### PR TITLE
chore: use push EAS directly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@ fingerprint.config.js                                       @MetaMask/mobile-pla
 builds.yml                                                  @MetaMask/mobile-platform
 .github/workflows/create-build-branch.yml                   @MetaMask/mobile-platform
 .github/workflows/push-eas-update.yml                       @MetaMask/mobile-admins
+.github/workflows/build-and-upload-to-testflight.yml        @MetaMask/mobile-admins
 .github/workflows/upload-to-testflight.yml                  @MetaMask/mobile-admins
 scripts/update-expo-channel.js                              @MetaMask/mobile-admins
 certs/certificate.pem                                       @MetaMask/mobile-admins

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -34,6 +34,31 @@ on:
           - android
         default: all
 
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to publish (uses PR branch HEAD commit)'
+        type: string
+        required: true
+      base_branch:
+        description: 'Base ref to compare fingerprints against (branch name like "main" or tag name like "v7.61.6")'
+        type: string
+        required: true
+      message:
+        description: 'EAS update message'
+        type: string
+        required: true
+      channel:
+        description: 'OTA channel to push update to (exp, rc, production)'
+        type: string
+        required: false
+        default: exp
+      platform:
+        description: 'Platform to update (all, ios, android)'
+        type: string
+        required: false
+        default: all
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -99,9 +99,10 @@ jobs:
           echo "Resolving PR for branch: $BRANCH (repo: $GITHUB_REPOSITORY)"
 
           # Try same-repo head first, then owner:branch (required by API when listing pulls)
-          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          # jq '.[0].number' on an empty array outputs the literal string "null", so normalise to empty
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
           if [[ -z "$PR_NUMBER" ]]; then
-            PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+            PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
           fi
 
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -161,25 +161,13 @@ jobs:
           echo "Using PR #${{ needs.decide.outputs.pr_number }}"
 
       - name: Trigger Push OTA Update workflow
-        uses: actions/github-script@v7
+        uses: ./.github/workflows/push-eas-update.yml
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const ref = '${{ inputs.source_branch || github.ref_name }}'.replace(/^refs\/heads\//, '');
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'push-eas-update.yml',
-              ref: ref,
-              inputs: {
-                pr_number: '${{ needs.decide.outputs.pr_number }}',
-                base_branch: '${{ needs.decide.outputs.base_ref }}',
-                message: '${{ needs.decide.outputs.ota_version }}',
-                channel: '${{ inputs.ota_channel }}',
-                platform: '${{ inputs.platform }}'
-              }
-            });
-            core.notice(`Triggered Push OTA Update on ${ref} (PR #${{ needs.decide.outputs.pr_number }}, base: ${{ needs.decide.outputs.base_ref }}, message: ${{ needs.decide.outputs.ota_version }})`);
+          pr_number: ${{ needs.decide.outputs.pr_number }}
+          base_branch: ${{ needs.decide.outputs.base_ref }}
+          message: ${{ needs.decide.outputs.ota_version }}
+          channel: ${{ inputs.ota_channel }}
+          platform: ${{ inputs.platform }}
 
       - name: Export release tag for OTA follow-up jobs
         id: release_tag


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Use push EAS update in the Runway workflow directly
- Fix PR number null issue

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/OTA GitHub Actions orchestration by switching from API dispatch to a reusable workflow and tweaking PR-number resolution; mistakes here could block OTA publishing or target the wrong ref.
> 
> **Overview**
> Updates the OTA publishing pipeline to call `push-eas-update.yml` as a *reusable workflow* (`workflow_call`) instead of dispatching it via `actions/github-script`, simplifying `runway-ota-build-core.yml`.
> 
> Also fixes PR-number discovery to treat `gh pr list` returning `null` as empty (avoiding false positives), and updates `CODEOWNERS` to include the new `build-and-upload-to-testflight.yml` workflow under `@MetaMask/mobile-admins`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633c2ac5ddcab83bf6422788f96026790acd48e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->