### PR TITLE
ci: fix Runway OTA core workflow reusable job layout

### DIFF
--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -144,13 +144,12 @@ jobs:
             echo "No OTA version bump (base: $BASE_OTA, current: $CURRENT_OTA) → will trigger build"
           fi
 
-  trigger-ota:
-    name: Trigger OTA update
+  # Reusable workflows must be job-level `uses:` (not a step). Steps only support actions (action.yml).
+  validate-ota-pr:
+    name: Validate PR for OTA
     needs: decide
     if: needs.decide.outputs.ota_bump == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.release_tag.outputs.release_tag }}
     steps:
       - name: Validate PR number
         run: |
@@ -161,20 +160,18 @@ jobs:
           fi
           echo "Using PR #${{ needs.decide.outputs.pr_number }}"
 
-      - name: Trigger Push OTA Update workflow
-        uses: ./.github/workflows/push-eas-update.yml
-        with:
-          pr_number: ${{ needs.decide.outputs.pr_number }}
-          base_branch: ${{ needs.decide.outputs.base_ref }}
-          message: ${{ needs.decide.outputs.ota_version }}
-          channel: ${{ inputs.ota_channel }}
-          platform: ${{ inputs.platform }}
-
-      - name: Export release tag for OTA follow-up jobs
-        id: release_tag
-        run: |
-          # Tag name must match OTA_VERSION (app/constants/ota.ts), not package.json semver
-          echo "release_tag=${{ needs.decide.outputs.ota_version }}" >> "$GITHUB_OUTPUT"
+  trigger-ota:
+    name: Trigger OTA update
+    needs: [decide, validate-ota-pr]
+    if: needs.decide.outputs.ota_bump == 'true'
+    uses: ./.github/workflows/push-eas-update.yml
+    with:
+      pr_number: ${{ needs.decide.outputs.pr_number }}
+      base_branch: ${{ needs.decide.outputs.base_ref }}
+      message: ${{ needs.decide.outputs.ota_version }}
+      channel: ${{ inputs.ota_channel }}
+      platform: ${{ inputs.platform }}
+    secrets: inherit
 
   trigger-build:
     name: Trigger build mobile app
@@ -191,11 +188,11 @@ jobs:
 
   create-ota-production-tag:
     name: Create OTA production release tag
-    needs: [trigger-ota]
+    needs: [decide, trigger-ota]
     if: ${{ inputs.create_production_ota_tag == true }}
     uses: ./.github/workflows/runway-create-ota-production-tag.yml
     with:
-      tag_name: ${{ needs.trigger-ota.outputs.release_tag }}
+      tag_name: ${{ needs.decide.outputs.ota_version }}
       checkout_ref: ${{ inputs.source_branch || github.ref_name }}
     secrets: inherit
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `trigger-ota` job mixed shell steps with a reusable workflow (`uses: ./.github/workflows/push-eas-update.yml`). In GitHub Actions, a job must either define `steps:` or call another workflow with job-level `uses:`, not both.
This splits that into:
1. **`validate-ota-pr`** — Validates a PR number exists before OTA (same guard as before).
2. **`trigger-ota`** — Only calls `push-eas-update.yml`, with `secrets: inherit` for caller secrets.
**`create-ota-production-tag`** now sets `tag_name` from `needs.decide.outputs.ota_version` (same value the old `release_tag` step echoed). It still `needs: trigger-ota` so tagging runs only after the OTA workflow finishes.

successful workflow run: https://github.com/MetaMask/metamask-mobile/actions/runs/23923283109

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the job graph for Runway OTA publishing/tagging; misconfigured `needs`/`uses`/secrets inheritance could block OTA releases or trigger the wrong follow-up jobs.
> 
> **Overview**
> Fixes `runway-ota-build-core.yml` to correctly invoke the reusable `push-eas-update.yml` workflow as a **job-level** `uses:` instead of mixing it with `steps:`.
> 
> Adds a separate `validate-ota-pr` job to guard OTA runs when no PR number is resolvable, updates `trigger-ota` to inherit secrets, and adjusts production tagging to use `needs.decide.outputs.ota_version` directly (removing the intermediate `release_tag` output).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b5c4c254009a0ad4f319adfb586028facebd59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->