### PR TITLE
fix: silent biometric cancel for react-native keychain errors

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -790,6 +790,9 @@ describe('Login', () => {
         availableBiometryType: 'TouchID',
       });
       (StorageWrapper.getItem as jest.Mock).mockReset();
+
+      mockUnlockWallet.mockReset();
+      mockUnlockWallet.mockResolvedValue(true);
     });
 
     it('authenticates with biometrics successfully', async () => {
@@ -873,6 +876,70 @@ describe('Login', () => {
       }
     });
 
+    it('does not show error UI for Android keychain biometric user cancel', async () => {
+      jest.useRealTimers();
+      try {
+        mockUnlockWallet.mockRejectedValueOnce(
+          new Error('code: 10, msg: Fingerprint operation canceled by user'),
+        );
+
+        const { getByTestId, queryByTestId } = renderWithProvider(<Login />);
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+        mockLogger.error.mockClear();
+
+        const biometryButton = getByTestId(
+          LoginViewSelectors.DEVICE_AUTHENTICATION_ICON,
+        );
+        await act(async () => {
+          fireEvent.press(biometryButton);
+        });
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        expect(
+          queryByTestId(LoginViewSelectors.PASSWORD_ERROR),
+        ).not.toBeOnTheScreen();
+        expect(mockLogger.error).not.toHaveBeenCalled();
+      } finally {
+        jest.useFakeTimers();
+      }
+    });
+
+    it('does not show error UI for iOS biometric user cancel', async () => {
+      jest.useRealTimers();
+      try {
+        mockUnlockWallet.mockRejectedValueOnce(
+          new Error(UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS),
+        );
+
+        const { getByTestId, queryByTestId } = renderWithProvider(<Login />);
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+        mockLogger.error.mockClear();
+
+        const biometryButton = getByTestId(
+          LoginViewSelectors.DEVICE_AUTHENTICATION_ICON,
+        );
+        await act(async () => {
+          fireEvent.press(biometryButton);
+        });
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        expect(
+          queryByTestId(LoginViewSelectors.PASSWORD_ERROR),
+        ).not.toBeOnTheScreen();
+        expect(mockLogger.error).not.toHaveBeenCalled();
+      } finally {
+        jest.useFakeTimers();
+      }
+    });
+
     it('silently cancels DENY_PIN_ERROR_ANDROID without error UI', async () => {
       jest.useRealTimers();
       try {
@@ -897,6 +964,7 @@ describe('Login', () => {
         await act(async () => {
           await new Promise((resolve) => setTimeout(resolve, 100));
         });
+        mockLogger.error.mockClear();
 
         const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
 
@@ -908,6 +976,7 @@ describe('Login', () => {
             queryByTestId(LoginViewSelectors.PASSWORD_ERROR),
           ).not.toBeOnTheScreen();
         });
+        expect(mockLogger.error).not.toHaveBeenCalled();
       } finally {
         jest.useFakeTimers();
       }
@@ -932,7 +1001,7 @@ describe('Login', () => {
           new Error(DENY_PIN_ERROR_ANDROID),
         );
 
-        const { getByTestId } = renderWithProvider(<Login />);
+        const { getByTestId, queryByTestId } = renderWithProvider(<Login />);
 
         await act(async () => {
           await new Promise((resolve) => setTimeout(resolve, 100));
@@ -948,12 +1017,15 @@ describe('Login', () => {
         });
 
         expect(mockLogger.error).not.toHaveBeenCalled();
+        expect(
+          queryByTestId(LoginViewSelectors.PASSWORD_ERROR),
+        ).not.toBeOnTheScreen();
       } finally {
         jest.useFakeTimers();
       }
     });
 
-    it('does not log error on iOS biometric cancellation', async () => {
+    it('does not show error UI on iOS biometric cancellation via password unlock', async () => {
       jest.useRealTimers();
       try {
         mockGetAuthType.mockReset();
@@ -972,7 +1044,7 @@ describe('Login', () => {
           new Error(UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS),
         );
 
-        const { getByTestId } = renderWithProvider(<Login />);
+        const { getByTestId, queryByTestId } = renderWithProvider(<Login />);
 
         await act(async () => {
           await new Promise((resolve) => setTimeout(resolve, 100));
@@ -988,6 +1060,9 @@ describe('Login', () => {
         });
 
         expect(mockLogger.error).not.toHaveBeenCalled();
+        expect(
+          queryByTestId(LoginViewSelectors.PASSWORD_ERROR),
+        ).not.toBeOnTheScreen();
       } finally {
         jest.useFakeTimers();
       }

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -68,7 +68,6 @@ import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
 import {
-  DENY_PIN_ERROR_ANDROID,
   JSON_PARSE_ERROR_UNEXPECTED_TOKEN,
   VAULT_ERROR,
   PASSCODE_NOT_SET_ERROR,
@@ -92,6 +91,7 @@ import { ScreenshotDeterrent } from '../../UI/ScreenshotDeterrent';
 import useAuthentication from '../../../core/Authentication/hooks/useAuthentication';
 import { SeedlessOnboardingControllerError } from '../../../core/Engine/controllers/seedless-onboarding-controller/error';
 import useAuthCapabilities from '../../../core/Authentication/hooks/useAuthCapabilities';
+import { isBiometricUnlockCancelledByUser } from '../../../core/Authentication/utils';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 
 interface LoginRouteParams {
@@ -230,11 +230,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
       }
 
       const isBiometricCancellation =
-        containsErrorMessage(loginError, DENY_PIN_ERROR_ANDROID) ||
-        containsErrorMessage(
-          loginError,
-          UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS,
-        );
+        isBiometricUnlockCancelledByUser(loginError);
 
       if (isBiometricCancellation) {
         setLoading(false);

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -75,7 +75,6 @@ import {
   WRONG_PASSWORD_ERROR_ANDROID,
   WRONG_PASSWORD_ERROR_ANDROID_2,
 } from './constants';
-import { UNLOCK_WALLET_ERROR_MESSAGES } from '../../../core/Authentication/constants';
 import {
   RouteProp,
   StackActions,

--- a/app/components/Views/OAuthRehydration/index.test.tsx
+++ b/app/components/Views/OAuthRehydration/index.test.tsx
@@ -946,6 +946,23 @@ describe('OAuthRehydration', () => {
       expect(rehydrationFailedCalls).toHaveLength(0);
     });
 
+    it('does not track REHYDRATION_PASSWORD_FAILED when Android keychain reports user cancel', async () => {
+      mockUnlockWallet.mockRejectedValue(
+        new Error('code: 10, msg: Fingerprint operation canceled by user'),
+      );
+      mockTrackOnboarding.mockClear();
+      const { getByTestId } = renderWithProvider(<OAuthRehydration />);
+      await enterPasswordAndSubmit(getByTestId, 'password123');
+
+      expect(Logger.error).not.toHaveBeenCalled();
+      const rehydrationFailedCalls = mockTrackOnboarding.mock.calls.filter(
+        (call) =>
+          call[0]?.properties?.name ===
+          MetaMetricsEvents.REHYDRATION_PASSWORD_FAILED.category,
+      );
+      expect(rehydrationFailedCalls).toHaveLength(0);
+    });
+
     it('sets biometryChoice to false on biometric cancellation', async () => {
       mockUnlockWallet.mockRejectedValue(new Error('Cancel'));
       const { getByTestId, queryByTestId } = renderWithProvider(

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -52,9 +52,8 @@ import {
   WRONG_PASSWORD_ERROR,
   WRONG_PASSWORD_ERROR_ANDROID,
   WRONG_PASSWORD_ERROR_ANDROID_2,
-  DENY_PIN_ERROR_ANDROID,
 } from '../Login/constants';
-import { UNLOCK_WALLET_ERROR_MESSAGES } from '../../../core/Authentication/constants';
+import { isBiometricUnlockCancelledByUser } from '../../../core/Authentication/utils';
 import {
   SeedlessOnboardingControllerErrorMessage,
   RecoveryError as SeedlessOnboardingControllerRecoveryError,
@@ -92,7 +91,7 @@ import TextField from '../../../component-library/components/Form/TextField';
 import HelpText, {
   HelpTextSeverity,
 } from '../../../component-library/components/Form/HelpText';
-import { useAuthentication } from '../../../core/Authentication';
+import useAuthentication from '../../../core/Authentication/hooks/useAuthentication';
 import { containsErrorMessage } from '../../../util/errorHandling';
 import { ensureError } from '../../../util/errorUtils';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
@@ -500,11 +499,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
       }
 
       const isBiometricCancellation =
-        containsErrorMessage(loginError, DENY_PIN_ERROR_ANDROID) ||
-        containsErrorMessage(
-          loginError,
-          UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS,
-        );
+        isBiometricUnlockCancelledByUser(loginError);
 
       if (isBiometricCancellation) {
         setBiometryChoice(false);

--- a/app/core/Authentication/utils.test.ts
+++ b/app/core/Authentication/utils.test.ts
@@ -12,6 +12,9 @@ import {
   getAuthLabel,
   getAuthType,
   getAuthIcon,
+  isAndroidKeychainBiometricUserCancellation,
+  isIosUserCancelledBiometricUnlock,
+  isBiometricUnlockCancelledByUser,
 } from './utils';
 import { IconName } from '@metamask/design-system-react-native';
 import { AuthenticationType } from 'expo-local-authentication';
@@ -96,6 +99,62 @@ describe('handlePasswordSubmissionError', () => {
     expect(() => handlePasswordSubmissionError(error)).toThrow(
       expectedThrownError,
     );
+  });
+});
+
+describe('isAndroidKeychainBiometricUserCancellation', () => {
+  it.each([
+    ['code: 10, msg: Fingerprint operation canceled by user', true],
+    ['code:5, msg: canceled', true],
+    ['code: 13, msg: negative button', true],
+    ['code: 7, msg: lockout', false],
+    ['User canceled the operation', false],
+  ])('returns %s -> %s', (message, expected) => {
+    expect(isAndroidKeychainBiometricUserCancellation(new Error(message))).toBe(
+      expected,
+    );
+  });
+});
+
+describe('isIosUserCancelledBiometricUnlock', () => {
+  it('returns true for the iOS LocalAuthentication cancel message', () => {
+    expect(
+      isIosUserCancelledBiometricUnlock(
+        new Error(UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isIosUserCancelledBiometricUnlock(new Error('Decrypt failed'))).toBe(
+      false,
+    );
+  });
+});
+
+describe('isBiometricUnlockCancelledByUser', () => {
+  it('returns true for Android keychain user-cancel shape', () => {
+    expect(
+      isBiometricUnlockCancelledByUser(
+        new Error('code: 10, msg: Fingerprint operation canceled by user'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for iOS user cancel message', () => {
+    expect(
+      isBiometricUnlockCancelledByUser(
+        new Error(UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for Android legacy Error: Cancel', () => {
+    expect(
+      isBiometricUnlockCancelledByUser(
+        new Error(UNLOCK_WALLET_ERROR_MESSAGES.ANDROID_PIN_DENIED),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/app/core/Authentication/utils.ts
+++ b/app/core/Authentication/utils.ts
@@ -8,6 +8,47 @@ import AUTHENTICATION_TYPE from '../../constants/userProperties';
 import { IconName } from '@metamask/design-system-react-native';
 
 /**
+ * Matches errors from react-native-keychain on Android (`ResultHandlerInteractiveBiometric`):
+ * `CryptoFailedException("code: $errorCode, msg: $errString")`.
+ */
+const ANDROID_KEYCHAIN_BIOMETRIC_USER_CANCEL_REGEX =
+  /code:\s*(?:5|10|13)\s*,\s*msg:/i;
+
+/**
+ * @param error - Error thrown during biometric unlock (SecureKeychain / react-native-keychain).
+ * @returns Whether the error is an Android keychain-formatted user cancellation.
+ */
+export const isAndroidKeychainBiometricUserCancellation = (
+  error: Error,
+): boolean => {
+  const message = error.message || error.toString();
+  return ANDROID_KEYCHAIN_BIOMETRIC_USER_CANCEL_REGEX.test(message);
+};
+
+/**
+ * iOS LocalAuthentication/expo-local-authentication user cancel.
+ */
+export const isIosUserCancelledBiometricUnlock = (error: Error): boolean =>
+  containsErrorMessage(
+    error,
+    UNLOCK_WALLET_ERROR_MESSAGES.IOS_USER_CANCELLED_BIOMETRICS,
+  );
+
+/**
+ * Android legacy cancel.
+ */
+export const isAndroidLegacyBiometricOrPinCancel = (error: Error): boolean =>
+  containsErrorMessage(error, UNLOCK_WALLET_ERROR_MESSAGES.ANDROID_PIN_DENIED);
+
+/**
+ * User dismissed the biometric/device-auth prompt on Android/iOS
+ */
+export const isBiometricUnlockCancelledByUser = (error: Error): boolean =>
+  isAndroidKeychainBiometricUserCancellation(error) ||
+  isIosUserCancelledBiometricUnlock(error) ||
+  isAndroidLegacyBiometricOrPinCancel(error);
+
+/**
  * Handles password submission errors by throwing the appropriate error.
  *
  * @param error - The error to handle.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Biometric unlock on Android can surface technical react-native-keychain errors (code/message), which were previously shown to users even when they simply dismissed the prompt.

This PR adds helpers to detect user-cancellation across Android and iOS, ensuring such cases don’t trigger errors or logs and only stop loading gracefully in Login.

Jira: https://consensyssoftware.atlassian.net/browse/TO-666
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the login screen showing a raw keychain error when users canceled fingerprint or device authentication.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-666

## **Manual testing steps**

```gherkin
Feature: Login biometric cancel

  Scenario: User cancels biometric unlock on Android
    Given the app is on the Login screen with biometric unlock available
    When the user starts device authentication and cancels the system prompt
    Then no red error text appears under the password field with a "code: …, msg: …" style message
    And the user can try again with password or biometric

  Scenario: User cancels biometric unlock on iOS
    Given the app is on the Login screen with Face ID or Touch ID unlock available
    When the user starts biometric unlock and cancels the system prompt
    Then no error line is shown for a normal user cancel
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/6c2a3fd4-5639-4264-ae2e-e66277edb501


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/5ad6a5d5-4fd1-4d36-8ab7-c56568ee972b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/authentication error-handling paths; a misclassification could hide real unlock failures or suppress useful error logging, though the change is narrowly scoped and covered by tests.
> 
> **Overview**
> Prevents user-dismissed biometric/device-auth prompts from surfacing as login errors by centralizing cancellation detection in `isBiometricUnlockCancelledByUser` (Android keychain `code: 5|10|13` format, iOS cancel message, and legacy Android cancel).
> 
> `Login` now uses this helper instead of ad-hoc string checks, and tests were expanded to assert **no error UI and no `Logger.error`** on Android keychain cancellation, iOS cancellation, and legacy `DENY_PIN_ERROR_ANDROID` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdb7e13248a559fb46a6abb50370853dfdf765fe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->