### PR TITLE
refactor: remove lingering ScreenComponent any-casts from route files

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -270,7 +270,7 @@ const OnboardingNav = () => {
       />
       <Stack.Screen
         name="AccountStatus"
-        component={AccountStatus as ScreenComponent}
+        component={AccountStatus}
         options={{ headerShown: false }}
       />
       <Stack.Screen
@@ -873,7 +873,7 @@ const MultichainAccountDetailsActions = () => {
       />
       <Stack.Screen
         name={Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SRP_REVEAL_QUIZ}
-        component={SRPQuiz as ScreenComponent}
+        component={SRPQuiz}
         initialParams={route?.params}
         options={commonScreenOptions}
       />
@@ -933,7 +933,7 @@ const ModalSwitchAccountType = () => (
   >
     <Stack.Screen
       name={Routes.CONFIRMATION_SWITCH_ACCOUNT_TYPE}
-      component={SwitchAccountTypeModal as ScreenComponent}
+      component={SwitchAccountTypeModal}
     />
   </Stack.Navigator>
 );

--- a/app/components/UI/Bridge/routes.tsx
+++ b/app/components/UI/Bridge/routes.tsx
@@ -15,9 +15,6 @@ import { PriceImpactModal } from './components/PriceImpactModal';
 import { clearStackNavigatorOptions } from '../../../constants/navigation/clearStackNavigatorOptions';
 import { TokenWarningModal } from './components/TokenWarningModal';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ScreenComponent = React.ComponentType<any>;
-
 const Stack = createStackNavigator();
 export const BridgeScreenStack = () => (
   <Stack.Navigator
@@ -58,7 +55,7 @@ export const BridgeModalStack = () => (
     />
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER}
-      component={BlockExplorersModal as ScreenComponent}
+      component={BlockExplorersModal}
     />
     <ModalStack.Screen
       name={Routes.BRIDGE.MODALS.BLOCKAID_MODAL}

--- a/app/components/UI/Ramp/Deposit/routes/index.tsx
+++ b/app/components/UI/Ramp/Deposit/routes/index.tsx
@@ -45,9 +45,6 @@ interface DepositParamList {
     | undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ScreenComponent = React.ComponentType<any>;
-
 const RootStack = createStackNavigator();
 const Stack = createStackNavigator<DepositParamList>();
 const ModalsStack = createStackNavigator();
@@ -193,10 +190,7 @@ const DepositRoutes = () => (
       initialRouteName={Routes.DEPOSIT.ROOT}
       screenOptions={{ headerShown: false }}
     >
-      <RootStack.Screen
-        name={Routes.DEPOSIT.ROOT}
-        component={MainRoutes as ScreenComponent}
-      />
+      <RootStack.Screen name={Routes.DEPOSIT.ROOT} component={MainRoutes} />
       <RootStack.Screen
         name={Routes.DEPOSIT.MODALS.ID}
         component={DepositModalsRoutes}

--- a/app/components/UI/Stake/routes/index.tsx
+++ b/app/components/UI/Stake/routes/index.tsx
@@ -21,9 +21,6 @@ import { clearStackNavigatorOptions } from '../../../../constants/navigation/cle
 const Stack = createStackNavigator();
 const ModalStack = createStackNavigator();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ScreenComponent = React.ComponentType<any>;
-
 // Regular Stack for Screens
 const StakeScreenStack = () => {
   const emptyNavHeaderOptions = useEmptyNavHeaderForConfirmations();
@@ -38,11 +35,11 @@ const StakeScreenStack = () => {
         />
         <Stack.Screen
           name={Routes.STAKING.STAKE_CONFIRMATION}
-          component={StakeConfirmationView as ScreenComponent}
+          component={StakeConfirmationView}
         />
         <Stack.Screen
           name={Routes.STAKING.UNSTAKE_CONFIRMATION}
-          component={UnstakeConfirmationView as ScreenComponent}
+          component={UnstakeConfirmationView}
         />
         <Stack.Screen
           name={Routes.STAKING.EARNINGS_HISTORY}
@@ -88,7 +85,7 @@ const StakeModalStack = () => (
       />
       <ModalStack.Screen
         name={Routes.STAKING.MODALS.GAS_IMPACT}
-        component={GasImpactModal as ScreenComponent}
+        component={GasImpactModal}
         options={{ headerShown: false }}
       />
       <ModalStack.Screen

--- a/app/components/Views/AccountStatus/index.test.tsx
+++ b/app/components/Views/AccountStatus/index.test.tsx
@@ -20,20 +20,20 @@ const mockNavigation = {
   dispatch: mockDispatch,
 };
 
+let mockRouteParams: Record<string, unknown> = {};
+
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => mockNavigation,
+  useRoute: () => ({
+    params: mockRouteParams,
+    key: 'AccountStatus',
+    name: 'AccountStatus',
+  }),
   StackActions: {
     replace: jest.fn(),
   },
 }));
-
-// Helper to create route props
-const createMockRoute = (params = {}) => ({
-  params,
-  key: 'AccountStatus',
-  name: 'AccountStatus' as const,
-});
 
 jest.mock('../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../util/theme');
@@ -57,6 +57,7 @@ jest.mock('../../../core/Analytics/MetricsEventBuilder', () => ({
 describe('AccountStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = {};
   });
 
   describe('Snapshots iOS', () => {
@@ -65,28 +66,20 @@ describe('AccountStatus', () => {
     });
 
     it('renders correctly with type="not_exist"', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-      );
+      mockRouteParams = { type: 'not_exist' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
 
     it('renders correctly with type="found"', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'found' })} />,
-      );
+      mockRouteParams = { type: 'found' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
 
     it('renders correctly with accountName in route params', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus
-          route={createMockRoute({
-            type: 'found',
-            accountName: 'test@example.com',
-          })}
-        />,
-      );
+      mockRouteParams = { type: 'found', accountName: 'test@example.com' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
   });
@@ -97,28 +90,20 @@ describe('AccountStatus', () => {
     });
 
     it('renders correctly with type="not_exist"', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-      );
+      mockRouteParams = { type: 'not_exist' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
 
     it('renders correctly with type="found"', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'found' })} />,
-      );
+      mockRouteParams = { type: 'found' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
 
     it('renders correctly with accountName in route params', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus
-          route={createMockRoute({
-            type: 'found',
-            accountName: 'test@example.com',
-          })}
-        />,
-      );
+      mockRouteParams = { type: 'found', accountName: 'test@example.com' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       expect(toJSON()).toMatchSnapshot();
     });
   });
@@ -126,12 +111,11 @@ describe('AccountStatus', () => {
   describe('Behavior Tests', () => {
     describe('Primary button interactions', () => {
       it('navigates to Rehydrate screen when type="found" and primary button is pressed', () => {
+        mockRouteParams = { type: 'found' };
         const mockReplace = jest.fn();
         (StackActions.replace as jest.Mock).mockReturnValue(mockReplace);
 
-        const { getByText } = renderWithProvider(
-          <AccountStatus route={createMockRoute({ type: 'found' })} />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const primaryButton = getByText(strings('account_status.log_in'));
 
         fireEvent.press(primaryButton);
@@ -145,12 +129,11 @@ describe('AccountStatus', () => {
       });
 
       it('navigates to ChoosePassword screen when type="not_exist" and primary button is pressed', () => {
+        mockRouteParams = { type: 'not_exist' };
         const mockReplace = jest.fn();
         (StackActions.replace as jest.Mock).mockReturnValue(mockReplace);
 
-        const { getByText } = renderWithProvider(
-          <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const primaryButton = getByText(
           strings('account_status.create_new_wallet'),
         );
@@ -166,14 +149,11 @@ describe('AccountStatus', () => {
       });
 
       it('passes oauthLoginSuccess from route params', () => {
+        mockRouteParams = { type: 'found', oauthLoginSuccess: true };
         const mockReplace = jest.fn();
         (StackActions.replace as jest.Mock).mockReturnValue(mockReplace);
 
-        const { getByText } = renderWithProvider(
-          <AccountStatus
-            route={createMockRoute({ type: 'found', oauthLoginSuccess: true })}
-          />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const primaryButton = getByText(strings('account_status.log_in'));
 
         fireEvent.press(primaryButton);
@@ -187,9 +167,7 @@ describe('AccountStatus', () => {
 
     describe('Secondary button interactions', () => {
       it('navigates back when secondary button is pressed', () => {
-        const { getByText } = renderWithProvider(
-          <AccountStatus route={createMockRoute()} />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const secondaryButton = getByText('Use a different login method');
 
         fireEvent.press(secondaryButton);
@@ -200,15 +178,14 @@ describe('AccountStatus', () => {
 
     describe('Analytics tracking', () => {
       it('tracks WALLET_IMPORT_STARTED event when type="found"', () => {
+        mockRouteParams = { type: 'found' };
         const mockBuild = jest.fn();
         const mockCreateEventBuilder = jest.fn(() => ({ build: mockBuild }));
         (
           MetricsEventBuilder.createEventBuilder as jest.Mock
         ).mockImplementation(mockCreateEventBuilder);
 
-        const { getByText } = renderWithProvider(
-          <AccountStatus route={createMockRoute({ type: 'found' })} />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const primaryButton = getByText('Log in');
 
         fireEvent.press(primaryButton);
@@ -221,15 +198,14 @@ describe('AccountStatus', () => {
       });
 
       it('tracks WALLET_SETUP_STARTED event when type="not_exist"', () => {
+        mockRouteParams = { type: 'not_exist' };
         const mockBuild = jest.fn();
         const mockCreateEventBuilder = jest.fn(() => ({ build: mockBuild }));
         (
           MetricsEventBuilder.createEventBuilder as jest.Mock
         ).mockImplementation(mockCreateEventBuilder);
 
-        const { getByText } = renderWithProvider(
-          <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-        );
+        const { getByText } = renderWithProvider(<AccountStatus />);
         const primaryButton = getByText('Create a new wallet');
 
         fireEvent.press(primaryButton);
@@ -245,9 +221,8 @@ describe('AccountStatus', () => {
 
   describe('Event Tracking', () => {
     it('calls trackOnboarding when primary button is pressed for existing account', () => {
-      const { getByText } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'found' })} />,
-      );
+      mockRouteParams = { type: 'found' };
+      const { getByText } = renderWithProvider(<AccountStatus />);
 
       const primaryButton = getByText(strings('account_status.log_in'));
       fireEvent.press(primaryButton);
@@ -256,9 +231,8 @@ describe('AccountStatus', () => {
     });
 
     it('calls trackOnboarding when primary button is pressed for new account', () => {
-      const { getByText } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-      );
+      mockRouteParams = { type: 'not_exist' };
+      const { getByText } = renderWithProvider(<AccountStatus />);
 
       const primaryButton = getByText(
         strings('account_status.create_new_wallet'),
@@ -271,9 +245,8 @@ describe('AccountStatus', () => {
 
   describe('SafeAreaView Configuration', () => {
     it('uses SafeAreaView with top and bottom edges', () => {
-      const { toJSON } = renderWithProvider(
-        <AccountStatus route={createMockRoute({ type: 'not_exist' })} />,
-      );
+      mockRouteParams = { type: 'not_exist' };
+      const { toJSON } = renderWithProvider(<AccountStatus />);
       const tree = toJSON();
 
       expect(tree).toBeTruthy();
@@ -284,9 +257,7 @@ describe('AccountStatus', () => {
 
   describe('Route params handling', () => {
     it('uses default type when route params are empty', () => {
-      const { getByText } = renderWithProvider(
-        <AccountStatus route={createMockRoute()} />,
-      );
+      const { getByText } = renderWithProvider(<AccountStatus />);
       // Default type is 'not_exist' which shows "Create a new wallet" button
       expect(
         getByText(strings('account_status.create_new_wallet')),
@@ -294,19 +265,9 @@ describe('AccountStatus', () => {
     });
 
     it('renders with undefined route params', () => {
-      const routeWithNoParams = {
-        params: undefined,
-        key: 'AccountStatus',
-        name: 'AccountStatus' as const,
-      };
+      mockRouteParams = undefined as unknown as Record<string, unknown>;
 
-      const { getByText } = renderWithProvider(
-        <AccountStatus
-          route={
-            routeWithNoParams as unknown as ReturnType<typeof createMockRoute>
-          }
-        />,
-      );
+      const { getByText } = renderWithProvider(<AccountStatus />);
       // Should render with default type 'not_exist'
       expect(
         getByText(strings('account_status.create_new_wallet')),
@@ -314,16 +275,13 @@ describe('AccountStatus', () => {
     });
 
     it('renders with all route params provided', () => {
-      const { getByText } = renderWithProvider(
-        <AccountStatus
-          route={createMockRoute({
-            type: 'found',
-            accountName: 'user@example.com',
-            oauthLoginSuccess: true,
-            provider: 'google',
-          })}
-        />,
-      );
+      mockRouteParams = {
+        type: 'found',
+        accountName: 'user@example.com',
+        oauthLoginSuccess: true,
+        provider: 'google',
+      };
+      const { getByText } = renderWithProvider(<AccountStatus />);
       expect(getByText(strings('account_status.log_in'))).toBeOnTheScreen();
     });
   });

--- a/app/components/Views/AccountStatus/index.tsx
+++ b/app/components/Views/AccountStatus/index.tsx
@@ -11,6 +11,7 @@ import {
 import {
   StackActions,
   useNavigation,
+  useRoute,
   RouteProp,
 } from '@react-navigation/native';
 import { strings } from '../../../../locales/i18n';
@@ -52,15 +53,18 @@ interface AccountStatusRouteParams {
 }
 
 interface AccountStatusProps {
-  route: RouteProp<
-    AccountStatusRouteParams,
-    'AccountStatus' | 'AccountAlreadyExists' | 'AccountNotFound'
-  >;
   saveOnboardingEvent: (...eventArgs: [ITrackingEvent]) => void;
 }
 
-const AccountStatus = ({ route, saveOnboardingEvent }: AccountStatusProps) => {
+const AccountStatus = ({ saveOnboardingEvent }: AccountStatusProps) => {
   const navigation = useNavigation();
+  const route =
+    useRoute<
+      RouteProp<
+        AccountStatusRouteParams,
+        'AccountStatus' | 'AccountAlreadyExists' | 'AccountNotFound'
+      >
+    >();
 
   const {
     type = 'not_exist',


### PR DESCRIPTION
## **Description**

Several route files (`App.tsx`, `Bridge/routes.tsx`, `Ramp/Deposit/routes/index.tsx`, `Stake/routes/index.tsx`) still defined a local `type ScreenComponent = React.ComponentType<any>` and cast screen components through it to silence type errors. Now that the underlying components have proper typings, these casts and the type alias are no longer needed.

This PR removes the `ScreenComponent` type alias and all `as ScreenComponent` casts, letting TypeScript infer the correct types directly.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — type-only cleanup, no runtime behavior change.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-safety refactor in navigation wiring plus a small `AccountStatus` API change to read params via `useRoute`; primary risk is a missed navigation prop/param typing mismatch causing runtime navigation issues.
> 
> **Overview**
> Removes several lingering React Navigation `ScreenComponent` (`React.ComponentType<any>`) casts in route definitions (App flow, Bridge modals, Deposit, and Stake), relying on inferred component types instead.
> 
> Refactors `AccountStatus` to stop accepting a `route` prop and instead read params via `useRoute`, and updates its tests to mock `useRoute` and render `<AccountStatus />` without passing route props.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13330e4e6faf64cfca78e3dcf574290ebbf8fdc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->