### PR TITLE
refactor: remove redundant wallet_connection_user_approved/rejected V1 events

### DIFF
--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -67,8 +67,6 @@ enum EVENT_NAME {
 
   // Remote connection events (SDK v1 socket relay, MWP, and WalletConnect)
   REMOTE_CONNECT_REQUEST_RECEIVED = 'Remote Connect Request Received',
-  WALLET_CONNECTION_USER_APPROVED = 'wallet_connection_user_approved',
-  WALLET_CONNECTION_USER_REJECTED = 'wallet_connection_user_rejected',
 
   // Remote connection RPC events (all remote transports)
   REMOTE_CONNECTION_RPC_REQUEST_RECEIVED = 'Remote Connection RPC Request Received',
@@ -787,12 +785,6 @@ const events = {
   // Remote connection events (SDK v1 socket relay, MWP, and WalletConnect)
   REMOTE_CONNECT_REQUEST_RECEIVED: generateOpt(
     EVENT_NAME.REMOTE_CONNECT_REQUEST_RECEIVED,
-  ),
-  WALLET_CONNECTION_USER_APPROVED: generateOpt(
-    EVENT_NAME.WALLET_CONNECTION_USER_APPROVED,
-  ),
-  WALLET_CONNECTION_USER_REJECTED: generateOpt(
-    EVENT_NAME.WALLET_CONNECTION_USER_REJECTED,
   ),
 
   // Remote connection RPC events (all remote transports)

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.test.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.test.ts
@@ -288,62 +288,9 @@ describe('connectToChannel', () => {
       );
     });
 
-    it('should track wallet_connection_user_approved when checkPermissions resolves', async () => {
-      originatorInfo.anonId = 'test-anon-id';
-      (checkPermissions as jest.Mock).mockResolvedValue(true);
-
-      await connectToChannel({
-        instance: mockInstance,
-        id,
-        trigger,
-        otherPublicKey,
-        origin,
-        validUntil,
-        originatorInfo,
-        initialConnection: true,
-      });
-
-      expect(analytics.trackEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'wallet_connection_user_approved',
-          sensitiveProperties: expect.objectContaining({
-            anon_id: 'test-anon-id',
-          }),
-        }),
-      );
-    });
-
-    it('should track wallet_connection_user_rejected when checkPermissions rejects', async () => {
-      originatorInfo.anonId = 'test-anon-id';
-      (checkPermissions as jest.Mock).mockRejectedValue(
-        new Error('Permission denied'),
-      );
-
-      if (mockInstance.state.navigation) {
-        mockInstance.state.navigation.getCurrentRoute = jest
-          .fn()
-          .mockReturnValue({ name: 'rejection-test-route' });
-      }
-
-      await connectToChannel({
-        instance: mockInstance,
-        id,
-        trigger,
-        otherPublicKey,
-        origin,
-        validUntil,
-        originatorInfo,
-        initialConnection: true,
-      });
-
-      expect(analytics.trackEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'wallet_connection_user_rejected',
-          sensitiveProperties: expect.objectContaining({
-            anon_id: 'test-anon-id',
-          }),
-        }),
-      );
-    });
+    // wallet_connection_user_approved / wallet_connection_user_rejected are
+    // intentionally NOT tracked here — they are already covered by the
+    // MetaMetrics CONNECT_REQUEST_COMPLETED / CONNECT_REQUEST_CANCELLED events
+    // (with source: 'sdk') fired by the permission-system UI.
   });
 });

--- a/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
+++ b/app/core/SDKConnect/ConnectionManagement/connectToChannel.ts
@@ -183,44 +183,15 @@ async function connectToChannel({
           res,
         );
         authorized = true;
-
-        if (anonId) {
-          DevLogger.log(
-            `[MM SDK Analytics] event=wallet_connection_user_approved anonId=${anonId}`,
-          );
-          analytics.trackEvent(
-            AnalyticsEventBuilder.createEventBuilder(
-              MetaMetricsEvents.WALLET_CONNECTION_USER_APPROVED,
-            )
-              .addProperties({
-                transport_type: 'socket_relay',
-                sdk_version: originatorInfo?.apiVersion,
-              })
-              .addSensitiveProperties({ anon_id: anonId })
-              .build(),
-          );
-        }
       } catch (error) {
         DevLogger.log(
           `SDKConnect::connectToChannel - checkPermissions - error`,
           error,
         );
-        if (anonId) {
-          DevLogger.log(
-            `[MM SDK Analytics] event=wallet_connection_user_rejected anonId=${anonId}`,
-          );
-          analytics.trackEvent(
-            AnalyticsEventBuilder.createEventBuilder(
-              MetaMetricsEvents.WALLET_CONNECTION_USER_REJECTED,
-            )
-              .addProperties({
-                transport_type: 'socket_relay',
-                sdk_version: originatorInfo?.apiVersion,
-              })
-              .addSensitiveProperties({ anon_id: anonId })
-              .build(),
-          );
-        }
+        // User approval/rejection is already tracked by the MetaMetrics
+        // CONNECT_REQUEST_COMPLETED / CONNECT_REQUEST_CANCELLED events
+        // (with source: 'sdk') fired by the permission-system UI.
+
         // first needs to connect without key exchange to send the event
         await instance.state.connected[id].remote.reject({ channelId: id });
         // Send rejection event without awaiting


### PR DESCRIPTION
## Summary

Same rationale as the V2 cleanup (#28358): V1 connections flow through the connection approval UI, which already fires `CONNECT_REQUEST_COMPLETED` / `CONNECT_REQUEST_CANCELLED`. Adding `wallet_connection_user_approved` / `wallet_connection_user_rejected` in the relay layer re-implements the same signal.

**Removed:**

* `wallet_connection_user_approved` tracking from `connectToChannel.ts`
* `wallet_connection_user_rejected` tracking from `connectToChannel.ts`
* Both event definitions from `MetaMetrics.events.ts`
* Both test cases from `connectToChannel.test.ts`

**Kept** (no existing MetaMetrics event covers these):

* `Remote Connect Request Received` — fires before the permission check, needed to measure dapp-to-wallet drop-off
* `Remote Connection RPC Request *` events — track per-RPC-method confirmation lifecycle, separate concern from connection approval

**Renames in latest commit:**

The `SDK RPC Request *` events have been renamed to `Remote Connection RPC Request *` to reflect their intended cross-transport scope. Currently only SDKv1 is instrumented but the schema supports `socket_relay`, `mwp`, and `walletconnect` transports.

**Context:** The `useOriginSource` fix (WAPI-1380, #28290) ensures the `source` property is correct for both V1 and V2 connections on all permission events, so the existing events already carry the right attribution.

## Related schema PRs

- [Consensys/segment-schema#519](https://github.com/Consensys/segment-schema/pull/519) — `Remote Connect Request Received/Failed` schemas
- [Consensys/segment-schema#520](https://github.com/Consensys/segment-schema/pull/520) — `Remote Connection RPC Request Received/Approved/Rejected` schemas

## Test plan

* `connectToChannel.test.ts` — all remaining tests pass
* `handleConnectionMessage.test.ts` — updated for new event names
* `handleSendMessage.test.ts` — updated for new event names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes redundant MetaMetrics tracking and associated tests, with no changes to connection/permission behavior beyond analytics emission.
> 
> **Overview**
> Removes the SDK v1 relay-layer MetaMetrics events `wallet_connection_user_approved` and `wallet_connection_user_rejected`, including their definitions in `MetaMetrics.events.ts`.
> 
> `connectToChannel.ts` no longer emits these events on `checkPermissions` success/failure, relying instead on the permission UI’s existing `CONNECT_REQUEST_COMPLETED` / `CONNECT_REQUEST_CANCELLED` tracking. The corresponding unit tests asserting those emissions are deleted and replaced with a clarifying comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc8ab6bc3983f31535ca69118658bdfa17d13f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->