### PR TITLE
refactor(predict): move deposit amount to PredictPayWithAnyTokenInfo cp-7.73.0 

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -260,6 +260,7 @@ jest.mock('./components/PredictPayWithAnyTokenInfo', () => {
     currentValue,
   }: {
     currentValue: number;
+    isInputFocused: boolean;
   }) {
     return <Text testID="predict-pay-with-any-token-info">{currentValue}</Text>;
   };

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -130,7 +130,6 @@ jest.mock('./hooks/usePredictBuyInfo', () => ({
     providerFee: 2,
     total: 23,
     depositFee: 3,
-    depositAmount: 4,
     rewardsFeeAmount: 5,
     totalPayForPredictBalance: 20,
   }),
@@ -258,13 +257,11 @@ jest.mock('../../components/PredictOrderRetrySheet', () => {
 jest.mock('./components/PredictPayWithAnyTokenInfo', () => {
   const { Text } = jest.requireActual('react-native');
   return function MockPredictPayWithAnyTokenInfo({
-    depositAmount,
+    currentValue,
   }: {
-    depositAmount: number;
+    currentValue: number;
   }) {
-    return (
-      <Text testID="predict-pay-with-any-token-info">{depositAmount}</Text>
-    );
+    return <Text testID="predict-pay-with-any-token-info">{currentValue}</Text>;
   };
 });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -127,7 +127,6 @@ const PredictBuyWithAnyToken = () => {
     providerFee,
     total,
     depositFee,
-    depositAmount,
     rewardsFeeAmount,
     totalPayForPredictBalance,
   } = usePredictBuyInfo({
@@ -291,7 +290,10 @@ const PredictBuyWithAnyToken = () => {
         onDismiss={resetOrderNotFilled}
         isRetrying={isRetrying}
       />
-      <PredictPayWithAnyTokenInfo depositAmount={depositAmount} />
+      <PredictPayWithAnyTokenInfo
+        currentValue={currentValue}
+        preview={preview}
+      />
     </SafeAreaView>
   );
 };

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -293,6 +293,7 @@ const PredictBuyWithAnyToken = () => {
       <PredictPayWithAnyTokenInfo
         currentValue={currentValue}
         preview={preview}
+        isInputFocused={isInputFocused}
       />
     </SafeAreaView>
   );

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -128,11 +128,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
   });
 
   describe('render', () => {
-    it('returns null', () => {
+    it('returns null when transactionMeta is missing', () => {
       const { UNSAFE_root } = render(
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -141,34 +142,42 @@ describe('PredictPayWithAnyTokenInfo', () => {
   });
 
   describe('depositAmount computation', () => {
-    it('produces 0 when preview is null', () => {
-      mockActiveTransactionMeta = { id: 'tx-1' };
-
-      render(<PredictPayWithAnyTokenInfo currentValue={1} preview={null} />);
-
-      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
-    });
-
-    it('produces 0 when preview has no fees', () => {
+    it('produces empty when preview is null', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
 
       render(
         <PredictPayWithAnyTokenInfo
           currentValue={1}
-          preview={createMockPreview({ fees: undefined })}
+          preview={null}
+          isInputFocused={false}
         />,
       );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
-    it('produces 0 when currentValue is below minimum bet', () => {
+    it('produces empty when preview has no fees', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={1}
+          preview={createMockPreview({ fees: undefined })}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('produces empty when currentValue is below minimum bet', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
 
       render(
         <PredictPayWithAnyTokenInfo
           currentValue={0.5}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -191,6 +200,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -214,6 +224,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -237,6 +248,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -260,6 +272,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -284,6 +297,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -292,8 +306,118 @@ describe('PredictPayWithAnyTokenInfo', () => {
     });
   });
 
+  describe('deposit amount gating', () => {
+    it('does not commit deposit amount while input is focused', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('commits deposit amount when input loses focus', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      const { rerender } = render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+    });
+
+    it('does not re-trigger deposit update when value is unchanged after unfocus', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      const { rerender } = render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledTimes(1);
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+
+      mockUpdatePendingAmount.mockClear();
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused
+        />,
+      );
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('updates deposit amount when value changes after unfocus', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      const { rerender } = render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+      mockUpdatePendingAmount.mockClear();
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={200}
+          preview={defaultPreview}
+          isInputFocused
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={200}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('200');
+    });
+  });
+
   describe('updatePendingAmount effect', () => {
-    it('calls updatePendingAmount when depositAmount > 0, not isPredictBalanceSelected, and has transactionMeta', () => {
+    it('calls updatePendingAmount when depositAmount is valid and has transactionMeta', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
@@ -301,6 +425,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -315,13 +440,14 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
-    it('does not call updatePendingAmount when depositAmount is 0', () => {
+    it('does not call updatePendingAmount when depositAmount is empty', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
@@ -329,6 +455,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={0}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -343,6 +470,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -365,6 +493,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -382,6 +511,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -405,6 +535,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
+          isInputFocused={false}
         />,
       );
 
@@ -420,6 +551,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -435,6 +567,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -450,6 +583,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -465,6 +599,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -480,6 +615,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={0}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -503,6 +639,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -527,6 +664,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -545,6 +683,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -559,6 +698,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 
@@ -576,6 +716,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
+          isInputFocused={false}
         />,
       );
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import PredictPayWithAnyTokenInfo from './PredictPayWithAnyTokenInfo';
+import { OrderPreview, Side } from '../../../../types';
 
 let mockIsPredictBalanceSelected = false;
 let mockUpdatePendingAmount = jest.fn();
@@ -20,11 +21,18 @@ let mockPayToken:
     }
   | undefined;
 let mockSetPayToken = jest.fn();
+let mockPredictBalance = 0;
 
 jest.mock('../../../../hooks/usePredictPaymentToken', () => ({
   usePredictPaymentToken: () => ({
     isPredictBalanceSelected: mockIsPredictBalanceSelected,
     selectedPaymentToken: mockSelectedPaymentToken,
+  }),
+}));
+
+jest.mock('../../../../hooks/usePredictBalance', () => ({
+  usePredictBalance: () => ({
+    data: mockPredictBalance,
   }),
 }));
 
@@ -73,6 +81,38 @@ jest.mock('../../../../../../Views/confirmations/constants/predict', () => ({
   PREDICT_CURRENCY: 'USD',
 }));
 
+jest.mock('../../../../constants/transactions', () => ({
+  MINIMUM_BET: 1,
+}));
+
+const createMockPreview = (
+  overrides?: Partial<OrderPreview>,
+): OrderPreview => ({
+  marketId: 'market-1',
+  outcomeId: 'outcome-1',
+  outcomeTokenId: 'token-1',
+  timestamp: 1000000,
+  side: Side.BUY,
+  sharePrice: 0.5,
+  maxAmountSpent: 100,
+  minAmountReceived: 180,
+  slippage: 0.01,
+  tickSize: 0.01,
+  minOrderSize: 1,
+  negRisk: false,
+  rateLimited: false,
+  fees: {
+    totalFee: 0,
+    metamaskFee: 0,
+    providerFee: 0,
+    totalFeePercentage: 0,
+    collector: '0xCollector',
+  },
+  ...overrides,
+});
+
+const defaultPreview = createMockPreview();
+
 describe('PredictPayWithAnyTokenInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -84,15 +124,171 @@ describe('PredictPayWithAnyTokenInfo', () => {
     mockSelectedPaymentToken = undefined;
     mockPayToken = undefined;
     mockSetPayToken = jest.fn();
+    mockPredictBalance = 0;
   });
 
   describe('render', () => {
     it('returns null', () => {
       const { UNSAFE_root } = render(
-        <PredictPayWithAnyTokenInfo depositAmount={100} />,
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
       );
 
       expect(UNSAFE_root.children.length).toBe(0);
+    });
+  });
+
+  describe('depositAmount computation', () => {
+    it('produces 0 when preview is null', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(<PredictPayWithAnyTokenInfo currentValue={1} preview={null} />);
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('produces 0 when preview has no fees', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={1}
+          preview={createMockPreview({ fees: undefined })}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('produces 0 when currentValue is below minimum bet', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={0.5}
+          preview={defaultPreview}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+    });
+
+    it('computes the remaining amount needed after predict balance is applied', () => {
+      mockPredictBalance = 80;
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 5,
+              metamaskFee: 2,
+              providerFee: 3,
+              totalFeePercentage: 0.05,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
+
+      // totalPay = 100 + 3 + 2 = 105, remaining = 105 - 80 = 25
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('25');
+    });
+
+    it('rounds the remaining amount up to 2 decimals when a deposit is still needed', () => {
+      mockPredictBalance = 0;
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={2}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 0.075,
+              metamaskFee: 0.035,
+              providerFee: 0.04,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
+
+      // totalPay = 2 + 0.04 + 0.035 = 2.075, remaining = 2.075, ROUND_UP → 2.08
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('2.08');
+    });
+
+    it('rounds up even when the third decimal is below 5 so the deposit fully covers the shortfall', () => {
+      mockPredictBalance = 0;
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={2}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 0.074,
+              metamaskFee: 0.034,
+              providerFee: 0.04,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
+
+      // totalPay = 2 + 0.04 + 0.034 = 2.074, remaining = 2.074, ROUND_UP → 2.08
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('2.08');
+    });
+
+    it('rounds a tiny positive shortfall up to the minimum cent instead of zero', () => {
+      mockPredictBalance = 2.075889;
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={2}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 0.08,
+              metamaskFee: 0.04,
+              providerFee: 0.04,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
+
+      // totalPay = 2.08, remaining = 2.08 - 2.075889 ≈ 0.004111, ROUND_UP → 0.01
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('0.01');
+    });
+
+    it('computes the full preview total when predict balance already covers the bet', () => {
+      mockPredictBalance = 110;
+      mockActiveTransactionMeta = { id: 'tx-1' };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={1}
+          preview={createMockPreview({
+            maxAmountSpent: 1,
+            fees: {
+              totalFee: 0.04,
+              metamaskFee: 0.02,
+              providerFee: 0.02,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
+
+      // totalPay = 1 + 0.02 + 0.02 = 1.04, remaining = 1.04 - 110 < 0, returns totalPay ROUND_UP = 1.04
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('1.04');
     });
   });
 
@@ -101,7 +297,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
     });
@@ -110,16 +311,26 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockIsPredictBalanceSelected = true;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
-    it('does not call updatePendingAmount when depositAmount <= 0', () => {
+    it('does not call updatePendingAmount when depositAmount is 0', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={0} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={0}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
@@ -128,27 +339,37 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = null;
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
-    it('formats depositAmount with 2 decimal places using BigNumber', () => {
+    it('formats computed depositAmount to a string with 2 decimal places', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100.456} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={2}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 0.075,
+              metamaskFee: 0.035,
+              providerFee: 0.04,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
 
-      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100.46');
-    });
-
-    it('rounds depositAmount correctly using ROUND_HALF_UP', () => {
-      mockIsPredictBalanceSelected = false;
-      mockActiveTransactionMeta = { id: 'tx-1' };
-
-      render(<PredictPayWithAnyTokenInfo depositAmount={100.445} />);
-
-      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100.45');
+      // depositAmount = 2.08 → parsedDepositAmount = "2.08"
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('2.08');
     });
   });
 
@@ -158,7 +379,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '100.50';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100');
     });
@@ -168,8 +394,22 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '2.078803';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={2.08} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={2}
+          preview={createMockPreview({
+            fees: {
+              totalFee: 0.075,
+              metamaskFee: 0.035,
+              providerFee: 0.04,
+              totalFeePercentage: 4,
+              collector: '0xCollector',
+            },
+          })}
+        />,
+      );
 
+      // depositAmount = 2.08 → parsedDepositAmount = "2.08"
       expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('2.08');
     });
 
@@ -178,7 +418,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '0';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
@@ -188,7 +433,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
@@ -198,7 +448,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '100.50';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
@@ -208,17 +463,27 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = null;
       mockAmountHuman = '100.50';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
 
-    it('does not call updateTokenAmountCallback when depositAmount <= 0', () => {
+    it('does not call updateTokenAmountCallback when depositAmount is 0', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '100.50';
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={0} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={0}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
@@ -236,7 +501,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
         chainId: '0x1',
       };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockSetPayToken).toHaveBeenCalledWith({
         address: '0xabc123',
@@ -255,7 +525,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
         chainId: '0X1',
       };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockSetPayToken).not.toHaveBeenCalled();
     });
@@ -268,7 +543,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
         chainId: '0x1',
       };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockSetPayToken).not.toHaveBeenCalled();
     });
@@ -277,7 +557,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockSelectedPaymentToken = undefined;
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockSetPayToken).not.toHaveBeenCalled();
     });
@@ -289,7 +574,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
         chainId: '0x1',
       };
 
-      render(<PredictPayWithAnyTokenInfo depositAmount={100} />);
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+        />,
+      );
 
       expect(mockSetPayToken).not.toHaveBeenCalled();
     });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -368,13 +368,12 @@ describe('PredictPayWithAnyTokenInfo', () => {
         />,
       );
 
-      // depositAmount = 2.08 → parsedDepositAmount = "2.08"
       expect(mockUpdatePendingAmount).toHaveBeenCalledWith('2.08');
     });
   });
 
   describe('updateTokenAmountCallback effect', () => {
-    it('calls updateTokenAmountCallback with the parsed deposit amount when amountHuman is valid', () => {
+    it('calls updateTokenAmountCallback with amountHuman when deposit is valid', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '100.50';
@@ -386,10 +385,10 @@ describe('PredictPayWithAnyTokenInfo', () => {
         />,
       );
 
-      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100');
+      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100.50');
     });
 
-    it('uses the rounded parsed deposit amount instead of the fiat-converted amountHuman', () => {
+    it('passes amountHuman from useTransactionCustomAmount, not the raw depositAmount', () => {
       mockIsPredictBalanceSelected = false;
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '2.078803';
@@ -409,8 +408,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         />,
       );
 
-      // depositAmount = 2.08 → parsedDepositAmount = "2.08"
-      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('2.08');
+      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('2.078803');
     });
 
     it('does not call updateTokenAmountCallback when amountHuman is "0"', () => {
@@ -443,7 +441,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
       expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
     });
 
-    it('does not call updateTokenAmountCallback when parsedDepositAmount is empty', () => {
+    it('does not call updateTokenAmountCallback when depositAmount is empty', () => {
       mockIsPredictBalanceSelected = true;
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockAmountHuman = '100.50';

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -50,6 +50,9 @@ function PredictPayWithAnyTokenInfoInner({
   const { data: predictBalance = 0 } = usePredictBalance();
   const { updateTokenAmount: updateTokenAmountCallback } =
     useUpdateTokenAmount();
+  const { updatePendingAmount, amountHuman } = useTransactionCustomAmount({
+    currency: PREDICT_CURRENCY,
+  });
 
   const totalPayForPredictBalance = useMemo(
     () =>
@@ -98,10 +101,6 @@ function PredictPayWithAnyTokenInfoInner({
     () => depositAmount !== '' && transactionMeta,
     [depositAmount, transactionMeta],
   );
-
-  const { updatePendingAmount, amountHuman } = useTransactionCustomAmount({
-    currency: PREDICT_CURRENCY,
-  });
 
   const lastEmittedDepositRef = useRef('');
   const lastEmittedAmountHumanRef = useRef('');

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -5,15 +5,20 @@ import { useTransactionCustomAmount } from '../../../../../../Views/confirmation
 import { useTransactionMetadataRequest } from '../../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import { useUpdateTokenAmount } from '../../../../../../Views/confirmations/hooks/transactions/useUpdateTokenAmount';
 import { usePredictPaymentToken } from '../../../../hooks/usePredictPaymentToken';
+import { usePredictBalance } from '../../../../hooks/usePredictBalance';
 import { useTransactionPayToken } from '../../../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
+import { MINIMUM_BET } from '../../../../constants/transactions';
+import { OrderPreview } from '../../../../types';
 import { Hex } from '@metamask/utils';
 
 interface PredictPayWithAnyTokenInfoProps {
-  depositAmount: number;
+  currentValue: number;
+  preview?: OrderPreview | null;
 }
 
 const PredictPayWithAnyTokenInfo = ({
-  depositAmount,
+  currentValue,
+  preview,
 }: PredictPayWithAnyTokenInfoProps) => {
   const transactionMeta = useTransactionMetadataRequest();
 
@@ -21,19 +26,51 @@ const PredictPayWithAnyTokenInfo = ({
     return null;
   }
 
-  return <PredictPayWithAnyTokenInfoInner depositAmount={depositAmount} />;
+  return (
+    <PredictPayWithAnyTokenInfoInner
+      currentValue={currentValue}
+      preview={preview}
+    />
+  );
 };
 
 function PredictPayWithAnyTokenInfoInner({
-  depositAmount,
+  currentValue,
+  preview,
 }: PredictPayWithAnyTokenInfoProps) {
   const { isPredictBalanceSelected, selectedPaymentToken } =
     usePredictPaymentToken();
   const { setPayToken, payToken } = useTransactionPayToken();
   const transactionMeta = useTransactionMetadataRequest();
+  const { data: predictBalance = 0 } = usePredictBalance();
 
   const { updateTokenAmount: updateTokenAmountCallback } =
     useUpdateTokenAmount();
+
+  const totalPayForPredictBalance = useMemo(
+    () =>
+      currentValue +
+      (preview?.fees?.providerFee ?? 0) +
+      (preview?.fees?.metamaskFee ?? 0),
+    [currentValue, preview?.fees?.providerFee, preview?.fees?.metamaskFee],
+  );
+
+  const depositAmount = useMemo(() => {
+    if (!preview?.fees || currentValue < MINIMUM_BET) {
+      return 0;
+    }
+
+    const remainingAmount = new BigNumber(totalPayForPredictBalance)
+      .minus(predictBalance)
+      .decimalPlaces(2, BigNumber.ROUND_UP)
+      .toNumber();
+    if (remainingAmount <= 0) {
+      return new BigNumber(totalPayForPredictBalance)
+        .decimalPlaces(2, BigNumber.ROUND_UP)
+        .toNumber();
+    }
+    return remainingAmount;
+  }, [preview?.fees, currentValue, totalPayForPredictBalance, predictBalance]);
 
   const parsedDepositAmount = useMemo(() => {
     if (isPredictBalanceSelected || depositAmount <= 0) {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -10,6 +10,7 @@ import { useTransactionPayToken } from '../../../../../../Views/confirmations/ho
 import { MINIMUM_BET } from '../../../../constants/transactions';
 import { OrderPreview } from '../../../../types';
 import { Hex } from '@metamask/utils';
+import EngineService from '../../../../../../../core/EngineService';
 
 interface PredictPayWithAnyTokenInfoProps {
   currentValue: number;
@@ -114,6 +115,7 @@ function PredictPayWithAnyTokenInfoInner({
     }
     lastEmittedDepositRef.current = depositAmount;
     updatePendingAmount(depositAmount);
+    EngineService.flushState();
   }, [depositAmount, hasValidDepositAmount, updatePendingAmount]);
 
   useEffect(() => {
@@ -127,6 +129,7 @@ function PredictPayWithAnyTokenInfoInner({
     }
     lastEmittedAmountHumanRef.current = amountHuman;
     updateTokenAmountCallback(amountHuman);
+    EngineService.flushState();
   }, [
     amountHuman,
     updateTokenAmountCallback,
@@ -150,6 +153,7 @@ function PredictPayWithAnyTokenInfoInner({
         address: selectedPaymentToken.address as Hex,
         chainId: selectedPaymentToken.chainId as Hex,
       });
+      EngineService.flushState();
     }
   }, [
     transactionMeta,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { PREDICT_CURRENCY } from '../../../../../../Views/confirmations/constants/predict';
 import { useTransactionCustomAmount } from '../../../../../../Views/confirmations/hooks/transactions/useTransactionCustomAmount';
 import { useTransactionMetadataRequest } from '../../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
@@ -14,11 +14,13 @@ import { Hex } from '@metamask/utils';
 interface PredictPayWithAnyTokenInfoProps {
   currentValue: number;
   preview?: OrderPreview | null;
+  isInputFocused: boolean;
 }
 
 const PredictPayWithAnyTokenInfo = ({
   currentValue,
   preview,
+  isInputFocused,
 }: PredictPayWithAnyTokenInfoProps) => {
   const transactionMeta = useTransactionMetadataRequest();
 
@@ -30,6 +32,7 @@ const PredictPayWithAnyTokenInfo = ({
     <PredictPayWithAnyTokenInfoInner
       currentValue={currentValue}
       preview={preview}
+      isInputFocused={isInputFocused}
     />
   );
 };
@@ -37,13 +40,14 @@ const PredictPayWithAnyTokenInfo = ({
 function PredictPayWithAnyTokenInfoInner({
   currentValue,
   preview,
+  isInputFocused,
 }: PredictPayWithAnyTokenInfoProps) {
+  const [depositAmount, setDepositAmount] = useState('');
   const { isPredictBalanceSelected, selectedPaymentToken } =
     usePredictPaymentToken();
   const { setPayToken, payToken } = useTransactionPayToken();
   const transactionMeta = useTransactionMetadataRequest();
   const { data: predictBalance = 0 } = usePredictBalance();
-
   const { updateTokenAmount: updateTokenAmountCallback } =
     useUpdateTokenAmount();
 
@@ -55,12 +59,17 @@ function PredictPayWithAnyTokenInfoInner({
     [currentValue, preview?.fees?.providerFee, preview?.fees?.metamaskFee],
   );
 
-  const depositAmount = useMemo(() => {
-    if (
-      isPredictBalanceSelected ||
-      !preview?.fees ||
-      currentValue < MINIMUM_BET
-    ) {
+  const canTriggerDepositAmountCalculation = useMemo(
+    () =>
+      !isPredictBalanceSelected &&
+      !!preview?.fees &&
+      currentValue >= MINIMUM_BET &&
+      !isInputFocused,
+    [isPredictBalanceSelected, preview?.fees, currentValue, isInputFocused],
+  );
+
+  const computedDepositAmount = useMemo(() => {
+    if (!canTriggerDepositAmountCalculation) {
       return '';
     }
 
@@ -71,19 +80,22 @@ function PredictPayWithAnyTokenInfoInner({
       ? totalPay.decimalPlaces(2, BigNumber.ROUND_UP)
       : remaining.decimalPlaces(2, BigNumber.ROUND_UP);
 
-    const parsedDepositAmount = amount.toString(10);
-
-    return parsedDepositAmount;
+    return amount.toString(10);
   }, [
-    isPredictBalanceSelected,
-    preview?.fees,
-    currentValue,
+    canTriggerDepositAmountCalculation,
     totalPayForPredictBalance,
     predictBalance,
   ]);
 
+  useEffect(() => {
+    if (!canTriggerDepositAmountCalculation) return;
+    setDepositAmount((prev) =>
+      prev === computedDepositAmount ? prev : computedDepositAmount,
+    );
+  }, [canTriggerDepositAmountCalculation, computedDepositAmount]);
+
   const hasValidDepositAmount = useMemo(
-    () => depositAmount && depositAmount.trim() !== '' && transactionMeta,
+    () => depositAmount !== '' && transactionMeta,
     [depositAmount, transactionMeta],
   );
 
@@ -91,16 +103,31 @@ function PredictPayWithAnyTokenInfoInner({
     currency: PREDICT_CURRENCY,
   });
 
+  const lastEmittedDepositRef = useRef('');
+  const lastEmittedAmountHumanRef = useRef('');
+
   useEffect(() => {
-    if (hasValidDepositAmount) {
-      updatePendingAmount(depositAmount);
+    if (
+      !hasValidDepositAmount ||
+      depositAmount === lastEmittedDepositRef.current
+    ) {
+      return;
     }
+    lastEmittedDepositRef.current = depositAmount;
+    updatePendingAmount(depositAmount);
   }, [depositAmount, hasValidDepositAmount, updatePendingAmount]);
 
   useEffect(() => {
-    if (amountHuman && amountHuman !== '0' && hasValidDepositAmount) {
-      updateTokenAmountCallback(amountHuman);
+    if (
+      !amountHuman ||
+      amountHuman === '0' ||
+      !hasValidDepositAmount ||
+      amountHuman === lastEmittedAmountHumanRef.current
+    ) {
+      return;
     }
+    lastEmittedAmountHumanRef.current = amountHuman;
+    updateTokenAmountCallback(amountHuman);
   }, [
     amountHuman,
     updateTokenAmountCallback,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -56,60 +56,56 @@ function PredictPayWithAnyTokenInfoInner({
   );
 
   const depositAmount = useMemo(() => {
-    if (!preview?.fees || currentValue < MINIMUM_BET) {
-      return 0;
-    }
-
-    const remainingAmount = new BigNumber(totalPayForPredictBalance)
-      .minus(predictBalance)
-      .decimalPlaces(2, BigNumber.ROUND_UP)
-      .toNumber();
-    if (remainingAmount <= 0) {
-      return new BigNumber(totalPayForPredictBalance)
-        .decimalPlaces(2, BigNumber.ROUND_UP)
-        .toNumber();
-    }
-    return remainingAmount;
-  }, [preview?.fees, currentValue, totalPayForPredictBalance, predictBalance]);
-
-  const parsedDepositAmount = useMemo(() => {
-    if (isPredictBalanceSelected || depositAmount <= 0) {
+    if (
+      isPredictBalanceSelected ||
+      !preview?.fees ||
+      currentValue < MINIMUM_BET
+    ) {
       return '';
     }
-    return new BigNumber(depositAmount)
-      .decimalPlaces(2, BigNumber.ROUND_HALF_UP)
-      .toString(10);
-  }, [isPredictBalanceSelected, depositAmount]);
+
+    const totalPay = new BigNumber(totalPayForPredictBalance);
+    const remaining = totalPay.minus(predictBalance);
+
+    const amount = remaining.lte(0)
+      ? totalPay.decimalPlaces(2, BigNumber.ROUND_UP)
+      : remaining.decimalPlaces(2, BigNumber.ROUND_UP);
+
+    const parsedDepositAmount = amount.toString(10);
+
+    return parsedDepositAmount;
+  }, [
+    isPredictBalanceSelected,
+    preview?.fees,
+    currentValue,
+    totalPayForPredictBalance,
+    predictBalance,
+  ]);
+
+  const hasValidDepositAmount = useMemo(
+    () => depositAmount && depositAmount.trim() !== '' && transactionMeta,
+    [depositAmount, transactionMeta],
+  );
 
   const { updatePendingAmount, amountHuman } = useTransactionCustomAmount({
     currency: PREDICT_CURRENCY,
   });
 
   useEffect(() => {
-    if (
-      parsedDepositAmount &&
-      parsedDepositAmount.trim() !== '' &&
-      transactionMeta
-    ) {
-      updatePendingAmount(parsedDepositAmount);
+    if (hasValidDepositAmount) {
+      updatePendingAmount(depositAmount);
     }
-  }, [parsedDepositAmount, transactionMeta, updatePendingAmount]);
+  }, [depositAmount, hasValidDepositAmount, updatePendingAmount]);
 
   useEffect(() => {
-    if (
-      amountHuman &&
-      amountHuman !== '0' &&
-      parsedDepositAmount &&
-      parsedDepositAmount.trim() !== '' &&
-      transactionMeta
-    ) {
-      updateTokenAmountCallback(parsedDepositAmount);
+    if (amountHuman && amountHuman !== '0' && hasValidDepositAmount) {
+      updateTokenAmountCallback(amountHuman);
     }
   }, [
     amountHuman,
-    transactionMeta,
     updateTokenAmountCallback,
-    parsedDepositAmount,
+    depositAmount,
+    hasValidDepositAmount,
   ]);
 
   useEffect(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-native';
 import { usePredictBuyConditions } from './usePredictBuyConditions';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { ActiveOrderState, OrderPreview } from '../../../types';
 
 let mockIsBalanceLoading = false;
@@ -79,12 +78,6 @@ jest.mock(
   }),
 );
 
-jest.mock('@metamask/assets-controllers', () => ({
-  getNativeTokenAddress: jest.fn(
-    () => '0x0000000000000000000000000000000000001010',
-  ),
-}));
-
 const defaultParams = {
   currentValue: 10,
   depositFee: 0,
@@ -119,7 +112,7 @@ describe('usePredictBuyConditions', () => {
   });
 
   afterEach(() => {
-    jest.mocked(getNativeTokenAddress).mockClear();
+    jest.restoreAllMocks();
   });
 
   describe('isBelowMinimum', () => {
@@ -429,111 +422,6 @@ describe('usePredictBuyConditions', () => {
     it('returns false when source amount has not been set yet', () => {
       mockIsPredictBalanceSelected = false;
       mockSelectedPaymentToken = { address: '0xabc', chainId: '0x1' };
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(false);
-    });
-  });
-
-  describe('isQuotesStale', () => {
-    it('returns false when isPredictBalanceSelected', () => {
-      mockIsPredictBalanceSelected = true;
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(false);
-    });
-
-    it('returns false when no selectedPaymentToken', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = null;
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(false);
-    });
-
-    it('returns true when quote sourceTokenAddress differs from selectedPaymentToken', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = { address: '0xabc', chainId: '0x1' };
-      mockQuotes = [
-        { request: { sourceTokenAddress: '0xdef', sourceChainId: '0x1' } },
-      ];
-      mockPayTotals = { total: '100' };
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(true);
-    });
-
-    it('returns true when quote sourceChainId differs from selectedPaymentToken', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = { address: '0xabc', chainId: '0x1' };
-      mockQuotes = [
-        { request: { sourceTokenAddress: '0xabc', sourceChainId: '0x89' } },
-      ];
-      mockPayTotals = { total: '100' };
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(true);
-    });
-
-    it('returns false when Polygon native token quote uses zero address', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = {
-        address: '0x0000000000000000000000000000000000001010',
-        chainId: '0x89',
-      };
-      mockQuotes = [
-        {
-          request: {
-            sourceTokenAddress: '0x0000000000000000000000000000000000000000',
-            sourceChainId: '0x89',
-          },
-        },
-      ];
-      mockPayTotals = { total: '100' };
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(false);
-      expect(getNativeTokenAddress).toHaveBeenCalledWith('0x89');
-    });
-
-    it('returns false when requiredTokens include selected token and quotes are unavailable', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = { address: '0xabc', chainId: '0x1' };
-      mockQuotes = null;
-      mockPayTotals = { total: '100' };
-      mockRequiredTokens = [{ address: '0xABC', chainId: '0x1' }];
-
-      const { result } = renderHook(() =>
-        usePredictBuyConditions(defaultParams),
-      );
-
-      expect(result.current.isPayFeesLoading).toBe(false);
-    });
-
-    it('returns false when requiredTokens include selected token but quotes are empty', () => {
-      mockIsPredictBalanceSelected = false;
-      mockSelectedPaymentToken = { address: '0xabc', chainId: '0x1' };
-      mockQuotes = [];
-      mockPayTotals = { total: '100' };
-      mockRequiredTokens = [{ address: '0xABC', chainId: '0x1' }];
 
       const { result } = renderHook(() =>
         usePredictBuyConditions(defaultParams),

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -1,21 +1,17 @@
 import { useEffect, useMemo } from 'react';
+import { useInsufficientPayTokenBalanceAlert } from '../../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
 import {
   useIsTransactionPayLoading,
   useIsTransactionPayQuoteLoading,
   useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
 import { MINIMUM_BET } from '../../../constants/transactions';
+import { usePredictBalance } from '../../../hooks/usePredictBalance';
 import { usePredictDeposit } from '../../../hooks/usePredictDeposit';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { usePredictBuyAvailableBalance } from './usePredictBuyAvailableBalance';
-import { useInsufficientPayTokenBalanceAlert } from '../../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { Hex } from '@metamask/utils';
-import { EMPTY_ADDRESS } from '../../../../../../constants/transaction';
-import { usePredictBalance } from '../../../hooks/usePredictBalance';
 
 interface UsePredictBuyConditionsParams {
   currentValue: number;
@@ -26,21 +22,6 @@ interface UsePredictBuyConditionsParams {
   totalPayForPredictBalance: number;
   isInputFocused: boolean;
 }
-
-const normalizeQuoteComparableAddress = (
-  address?: string,
-  chainId?: string,
-) => {
-  if (!address || !chainId) {
-    return address?.toLowerCase();
-  }
-
-  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
-
-  return address.toLowerCase() === nativeTokenAddress.toLowerCase()
-    ? EMPTY_ADDRESS
-    : address.toLowerCase();
-};
 
 export const usePredictBuyConditions = ({
   preview,
@@ -58,12 +39,8 @@ export const usePredictBuyConditions = ({
   const { isDepositPending } = usePredictDeposit();
   const payTotals = useTransactionPayTotals();
   const quotes = useTransactionPayQuotes();
-  const requiredTokens = useTransactionPayRequiredTokens();
-  const {
-    isPredictBalanceSelected,
-    selectedPaymentToken,
-    resetSelectedPaymentToken,
-  } = usePredictPaymentToken();
+  const { isPredictBalanceSelected, resetSelectedPaymentToken } =
+    usePredictPaymentToken();
   const { data: predictBalance = 0 } = usePredictBalance();
 
   const [insufficientPayTokenBalanceAlert] =
@@ -105,76 +82,16 @@ export const usePredictBuyConditions = ({
 
   const isRateLimited = useMemo(() => preview?.rateLimited ?? false, [preview]);
 
-  const isPaymentTokenRequired = useMemo(() => {
-    if (!selectedPaymentToken || !requiredTokens?.length) {
-      return false;
-    }
-    return requiredTokens.some(
-      (token) =>
-        normalizeQuoteComparableAddress(token.address, token.chainId) ===
-          normalizeQuoteComparableAddress(
-            selectedPaymentToken.address,
-            selectedPaymentToken.chainId,
-          ) &&
-        token.chainId.toLowerCase() ===
-          selectedPaymentToken.chainId?.toLowerCase(),
-    );
-  }, [selectedPaymentToken, requiredTokens]);
-
-  // Workaround: TransactionPayController sets paymentToken and isLoading in
-  // separate state updates, causing a render with stale totals + loading=false.
-  // Compare quote source token with selected token to bridge the gap.
-  const isQuotesStale = useMemo(() => {
-    if (
-      !shouldWaitForPayFees ||
-      isPredictBalanceSelected ||
-      !selectedPaymentToken
-    ) {
-      return false;
-    }
-    if (!quotes && !payTotals) {
-      return false;
-    }
-    if (!quotes?.length) {
-      return !isPaymentTokenRequired;
-    }
-    const request = quotes[0]?.request;
-    if (!request) {
-      return false;
-    }
-    return (
-      normalizeQuoteComparableAddress(
-        request.sourceTokenAddress,
-        request.sourceChainId,
-      ) !==
-        normalizeQuoteComparableAddress(
-          selectedPaymentToken.address,
-          selectedPaymentToken.chainId,
-        ) ||
-      request.sourceChainId?.toLowerCase() !==
-        selectedPaymentToken.chainId?.toLowerCase()
-    );
-  }, [
-    shouldWaitForPayFees,
-    isPredictBalanceSelected,
-    selectedPaymentToken,
-    quotes,
-    payTotals,
-    isPaymentTokenRequired,
-  ]);
-
   const isPayFeesLoading = useMemo(
     () =>
       shouldWaitForPayFees &&
       (isPayTotalsLoading ||
         isPayQuoteLoading ||
-        isQuotesStale ||
         (quotes?.length === 0 && !payTotals)),
     [
       shouldWaitForPayFees,
       isPayTotalsLoading,
       isPayQuoteLoading,
-      isQuotesStale,
       payTotals,
       quotes?.length,
     ],

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
@@ -11,7 +11,6 @@ let mockPayTotals: {
   };
 } | null = null;
 let mockActiveOrder: { error?: string } | null = null;
-let mockPredictBalance = 0;
 let mockAvailableBalance = 1000;
 let mockIsBalanceLoading = false;
 let mockInsufficientPayTokenBalanceAlert: { message: string } | null = null;
@@ -32,13 +31,6 @@ jest.mock(
 jest.mock('../../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
     activeOrder: mockActiveOrder,
-  }),
-}));
-
-jest.mock('../../../hooks/usePredictBalance', () => ({
-  usePredictBalance: () => ({
-    data: mockPredictBalance,
-    isLoading: false,
   }),
 }));
 
@@ -75,10 +67,6 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 
 jest.mock('../../../utils/format', () => ({
   formatPrice: jest.fn((value: number) => `$${value.toFixed(2)}`),
-}));
-
-jest.mock('../../../constants/transactions', () => ({
-  MINIMUM_BET: 1,
 }));
 
 const createMockPreview = (
@@ -121,7 +109,6 @@ describe('usePredictBuyInfo', () => {
     mockIsPredictBalanceSelected = true;
     mockPayTotals = null;
     mockActiveOrder = null;
-    mockPredictBalance = 0;
     mockAvailableBalance = 1000;
     mockIsBalanceLoading = false;
     mockInsufficientPayTokenBalanceAlert = null;
@@ -324,136 +311,6 @@ describe('usePredictBuyInfo', () => {
       const { result } = renderHook(() => usePredictBuyInfo(params));
 
       expect(result.current.toWin).toBe(0);
-    });
-  });
-
-  describe('depositAmount', () => {
-    it('returns 0 when preview is null', () => {
-      mockPredictBalance = 0;
-      const params = { ...defaultParams, currentValue: 1, preview: null };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(0);
-    });
-
-    it('returns 0 when preview has no fees', () => {
-      mockPredictBalance = 0;
-      const params = {
-        ...defaultParams,
-        currentValue: 1,
-        preview: createMockPreview({ fees: undefined }),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(0);
-    });
-
-    it('returns 0 when currentValue is below minimum bet', () => {
-      mockPredictBalance = 0;
-      const params = {
-        ...defaultParams,
-        currentValue: 0.5,
-        preview: createMockPreview(),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(0);
-    });
-
-    it('returns the remaining amount needed after predict balance is applied', () => {
-      mockPredictBalance = 80;
-
-      const { result } = renderHook(() => usePredictBuyInfo(defaultParams));
-
-      expect(result.current.depositAmount).toBe(25);
-    });
-
-    it('rounds the remaining amount up to 2 decimals when a deposit is still needed', () => {
-      mockPredictBalance = 0;
-      const params = {
-        ...defaultParams,
-        currentValue: 2,
-        preview: createMockPreview({
-          fees: {
-            totalFee: 0.075,
-            metamaskFee: 0.035,
-            providerFee: 0.04,
-            totalFeePercentage: 4,
-            collector: '0xCollector',
-          },
-        }),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(2.08);
-    });
-
-    it('rounds up even when the third decimal is below 5 so the deposit fully covers the shortfall', () => {
-      mockPredictBalance = 0;
-      const params = {
-        ...defaultParams,
-        currentValue: 2,
-        preview: createMockPreview({
-          fees: {
-            totalFee: 0.074,
-            metamaskFee: 0.034,
-            providerFee: 0.04,
-            totalFeePercentage: 4,
-            collector: '0xCollector',
-          },
-        }),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(2.08);
-    });
-
-    it('rounds a tiny positive shortfall up to the minimum cent instead of zero', () => {
-      mockPredictBalance = 2.075889;
-      const params = {
-        ...defaultParams,
-        currentValue: 2,
-        preview: createMockPreview({
-          fees: {
-            totalFee: 0.08,
-            metamaskFee: 0.04,
-            providerFee: 0.04,
-            totalFeePercentage: 4,
-            collector: '0xCollector',
-          },
-        }),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(0.01);
-    });
-
-    it('returns the full preview total when predict balance already covers the bet', () => {
-      mockPredictBalance = 110;
-      const params = {
-        ...defaultParams,
-        currentValue: 1,
-        preview: createMockPreview({
-          maxAmountSpent: 1,
-          fees: {
-            totalFee: 0.04,
-            metamaskFee: 0.02,
-            providerFee: 0.02,
-            totalFeePercentage: 4,
-            collector: '0xCollector',
-          },
-        }),
-      };
-
-      const { result } = renderHook(() => usePredictBuyInfo(params));
-
-      expect(result.current.depositAmount).toBe(1.04);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
@@ -1,11 +1,9 @@
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
 import { useTransactionPayTotals } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
-import { usePredictBalance } from '../../../hooks/usePredictBalance';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { useInsufficientPayTokenBalanceAlert } from '../../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
-import { MINIMUM_BET } from '../../../constants/transactions';
 
 interface UsePredictBuyInfoParams {
   currentValue: number;
@@ -24,7 +22,6 @@ export const usePredictBuyInfo = ({
 }: UsePredictBuyInfoParams) => {
   const { isPredictBalanceSelected } = usePredictPaymentToken();
   const payTotals = useTransactionPayTotals();
-  const { data: predictBalance = 0 } = usePredictBalance();
 
   const [insufficientPayTokenBalanceAlert] =
     useInsufficientPayTokenBalanceAlert();
@@ -94,30 +91,11 @@ export const usePredictBuyInfo = ({
     ],
   );
 
-  const depositAmount = useMemo(() => {
-    // Only trigger deposit amount calculation when preview fees are available and current value is greater than minimum bet
-    if (!preview?.fees || currentValue < MINIMUM_BET) {
-      return 0;
-    }
-
-    const remainingAmount = new BigNumber(totalPayForPredictBalance)
-      .minus(predictBalance)
-      .decimalPlaces(2, BigNumber.ROUND_UP)
-      .toNumber();
-    if (remainingAmount <= 0) {
-      return new BigNumber(totalPayForPredictBalance)
-        .decimalPlaces(2, BigNumber.ROUND_UP)
-        .toNumber();
-    }
-    return remainingAmount;
-  }, [preview?.fees, currentValue, totalPayForPredictBalance, predictBalance]);
-
   return {
     toWin,
     metamaskFee,
     providerFee,
     depositFee,
-    depositAmount,
     total,
     rewardsFeeAmount,
     totalPayForPredictBalance,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refactors the deposit amount flow in the Predict buy-with-any-token feature to improve correctness, reduce redundant re-computations, and align the token amount update pattern with Perps.

**What changed:**

- **Moved `depositAmount` computation** from `usePredictBuyInfo` into `PredictPayWithAnyTokenInfo`, co-locating the calculation with the component that consumes it. This eliminates an unnecessary prop hop and keeps the headless component self-contained.
- **Gated deposit amount updates on input focus** — deposit amount is only committed when the user finishes editing (input blur), preventing redundant effect runs and state churn while the user is actively typing.
- **Removed `isQuotesStale` logic** from `usePredictBuyConditions` — this workaround for `TransactionPayController` timing gaps is no longer needed, simplifying the pay fees loading derivation.
- **Added `EngineService.flushState()`** after deposit amount, token amount, and pay token mutations to ensure immediate state consistency for the deposit-and-order batch flow.
- **Aligned token amount callback with `amountHuman`** — `updateTokenAmountCallback` now passes the fiat-converted `amountHuman` from `useTransactionCustomAmount` instead of the rounded deposit amount, matching the Perps pattern.

**Files changed (8):**

| File                                  | Change                                                                                        |
| ------------------------------------- | --------------------------------------------------------------------------------------------- |
| `PredictPayWithAnyTokenInfo.tsx`      | Major — owns deposit amount computation, input focus gating, state flush                      |
| `PredictPayWithAnyTokenInfo.test.tsx` | Major — new test sections for computation, gating, dedup behavior                             |
| `PredictBuyWithAnyToken.tsx`          | Minor — passes `currentValue`, `preview`, `isInputFocused` instead of `depositAmount`         |
| `PredictBuyWithAnyToken.test.tsx`     | Minor — updated mock interface                                                                |
| `usePredictBuyInfo.ts`                | Minor — removed `depositAmount` return, removed `usePredictBalance` and `MINIMUM_BET` imports |
| `usePredictBuyInfo.test.ts`           | Minor — removed `depositAmount` tests and related mocks                                       |
| `usePredictBuyConditions.ts`          | Moderate — removed `isQuotesStale`, simplified `isPayFeesLoading`                             |
| `usePredictBuyConditions.test.ts`     | Moderate — removed `isQuotesStale` tests and `getNativeTokenAddress` mock                     |


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28413

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict buy payment/deposit amount propagation into the confirmations flow, including new state-flush behavior; mistakes could cause incorrect amounts or extra state churn during order placement.
> 
> **Overview**
> Refactors the Predict buy-with-any-token flow so `PredictPayWithAnyTokenInfo` owns **deposit amount calculation and propagation** (based on `currentValue`, `preview` fees, and `usePredictBalance`) and only commits updates when the amount input is *not focused*.
> 
> Removes `depositAmount` from `usePredictBuyInfo` and updates the screen/component wiring accordingly; `updatePendingAmount`/`updateTokenAmount` now de-dupe repeated emissions, use `amountHuman` for token updates, and call `EngineService.flushState()` after mutating confirmation/payment state.
> 
> Simplifies pay-fee loading in `usePredictBuyConditions` by dropping the `isQuotesStale` workaround and associated native-token normalization logic, with tests updated/expanded to cover the new deposit gating and rounding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5526d807bad3ba1d39cb47c3b53e6a4965467a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->