### PR TITLE
feat: migrate to @metamask/messenger-cli for action types codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,8 @@
     "gem:bundle:install": "bundle install --gemfile=ios/Gemfile",
     "clean:android": "rm -rf android/app/build",
     "clean": "yarn clean:ios && yarn clean:android && yarn install --immutable",
-    "generate-method-action-types": "messenger-generate-action-types --fix app && prettier --write 'app/**/*-method-action-types.ts'",
-    "generate-method-action-types:check": "yarn generate-method-action-types && git diff --exit-code 'app/**/*-method-action-types.ts'",
-    "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --cache && yarn generate-method-action-types:check",
-    "lint:fix": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --fix --cache && yarn generate-method-action-types",
+    "lint": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --cache && yarn messenger-action-types:check",
+    "lint:fix": "NODE_OPTIONS='--max-old-space-size=8192' eslint '**/*.{js,ts,tsx}' --fix --cache && yarn messenger-action-types:generate",
     "lint:clean": "rm -f .eslintcache",
     "lint:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc --project ./tsconfig.json",
     "format": "prettier '**/*.{js,ts,tsx,json}' --write",
@@ -152,7 +150,9 @@
     "a:ios": "scripts/perps/agentic/preflight.sh --platform ios --wallet-setup",
     "a:android": "scripts/perps/agentic/preflight.sh --platform android --wallet-setup",
     "a:setup:ios": "scripts/perps/agentic/preflight.sh --platform ios --clean --wallet-setup",
-    "a:setup:android": "scripts/perps/agentic/preflight.sh --platform android --clean --wallet-setup"
+    "a:setup:android": "scripts/perps/agentic/preflight.sh --platform android --clean --wallet-setup",
+    "messenger-action-types:generate": "messenger-action-types --generate app && prettier --write \"app/**/*-method-action-types.ts\"",
+    "messenger-action-types:check": "yarn messenger-action-types:generate && git diff --exit-code \"app/**/*-method-action-types.ts\""
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -542,6 +542,7 @@
     "@metamask/eslint-config-typescript": "^13.0.0",
     "@metamask/eslint-plugin-design-tokens": "^1.0.0",
     "@metamask/foundryup": "1.0.0",
+    "@metamask/messenger-cli": "^0.1.0",
     "@metamask/mobile-provider": "^3.0.0",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/providers": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "a:setup:ios": "scripts/perps/agentic/preflight.sh --platform ios --clean --wallet-setup",
     "a:setup:android": "scripts/perps/agentic/preflight.sh --platform android --clean --wallet-setup",
     "messenger-action-types:generate": "messenger-action-types --generate app && prettier --write \"app/**/*-method-action-types.ts\"",
-    "messenger-action-types:check": "yarn messenger-action-types:generate && git diff --exit-code \"app/**/*-method-action-types.ts\""
+    "messenger-action-types:check": "messenger-action-types --generate app; prettier --write \"app/**/*-method-action-types.ts\" && git diff --exit-code \"app/**/*-method-action-types.ts\""
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8904,6 +8904,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/messenger-cli@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@metamask/messenger-cli@npm:0.1.0"
+  dependencies:
+    "@metamask/utils": "npm:^11.9.0"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    eslint: ">=8"
+    typescript: ">=5.0.0"
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  bin:
+    messenger-action-types: ./dist/cli.mjs
+  checksum: 10/dd359df00f2eba98dcfe5f3d8352d859f2e814220e709efe989ecb68c611ba32ea515fd6099a770a706066f1820abd07a134a2acf5fc6b883518c5d19991a8e2
+  languageName: node
+  linkType: hard
+
 "@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0, @metamask/messenger@npm:^1.1.1":
   version: 1.1.1
   resolution: "@metamask/messenger@npm:1.1.1"
@@ -35490,6 +35508,7 @@ __metadata:
     "@metamask/logging-controller": "npm:^8.0.0"
     "@metamask/message-signing-snap": "npm:^1.1.2"
     "@metamask/messenger": "npm:^1.1.0"
+    "@metamask/messenger-cli": "npm:^0.1.0"
     "@metamask/metamask-eth-abis": "npm:3.1.1"
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"


### PR DESCRIPTION
## **Description**

Migrates from the deprecated `messenger-generate-action-types` binary in `@metamask/messenger` to the new standalone `@metamask/messenger-cli` package.

- Add `@metamask/messenger-cli@^0.1.0` as devDependency
- Add `messenger-action-types:generate` script (generates action type files, scans `app/`, runs prettier)
- Add `messenger-action-types:check` script (generates and verifies no diff)
- Integrate into `lint` and `lint:fix`
- Remove old `generate-method-action-types` scripts

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to MetaMask/core#8378

## **Manual testing steps**

```gherkin
Feature: messenger action types codegen

  Scenario: developer generates action types
    Given the project has controllers with MESSENGER_EXPOSED_METHODS

    When developer runs yarn messenger-action-types:generate
    Then action type files are generated for all controllers

  Scenario: developer checks action types are up to date
    Given the project has controllers with MESSENGER_EXPOSED_METHODS

    When developer runs yarn messenger-action-types:check
    Then the check passes if files are up to date
```

## **Screenshots/Recordings**

N/A — developer tooling change, no UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk developer-tooling change that updates action-type codegen commands and lint wiring; main risk is CI/lint failures if the new CLI’s output differs or the check script behavior changes.
> 
> **Overview**
> Migrates messenger action-types code generation from the deprecated `messenger-generate-action-types` binary to the new `@metamask/messenger-cli`.
> 
> Updates `lint`/`lint:fix` to run the new `messenger-action-types:check`/`messenger-action-types:generate` scripts, removes the old `generate-method-action-types*` scripts, and adds `@metamask/messenger-cli@^0.1.0` to dependencies (with corresponding `yarn.lock` updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07085348eeb1a1fc85cf2c4527f7d62dd5dada47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->