### PR TITLE
chore: remove redundant device/simulator label from iOS artifact names

### DIFF
--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -222,22 +222,20 @@ function renameIos() {
   }
 
   // Determine build paths based on simulator vs device
-  let buildDir, deviceType, binaryExtension;
+  let buildDir, binaryExtension;
   if (isSimBuild) {
     buildDir = path.join(
       __dirname,
       `../ios/build/Build/Products/${configuration || 'Release'}-iphonesimulator`,
     );
-    deviceType = 'simulator';
     binaryExtension = '.app';
   } else {
     buildDir = path.join(__dirname, '../ios/build/output');
-    deviceType = 'device';
     binaryExtension = '.ipa';
   }
 
-  // Create new base name: metamask-{deviceType}-{environment}-{buildType}-{version}-{buildNumber}
-  const newBaseName = `metamask-${deviceType}-${environment}-${buildType}-${appVersion}-${buildNumber}`;
+  // Create new base name: metamask-{environment}-{buildType}-{version}-{buildNumber}
+  const newBaseName = `metamask-${environment}-${buildType}-${appVersion}-${buildNumber}`;
   console.log(`📝 Renaming artifacts to: ${newBaseName}`);
 
   // Rename binary (.app or .ipa)


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `renameIos()` function in `scripts/rename-artifacts.js` was including either `device` or `simulator` in the renamed artifact base name. This label is redundant because the file extension already communicates this distinction: `.ipa` files are device builds and `.app` bundles are simulator builds.

Removing the `deviceType` segment simplifies artifact names from `metamask-device-main-main-x.y.z-NNN.ipa` to `metamask-main-main-x.y.z-NNN.ipa`, making them shorter without any loss of information.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes iOS CI artifact naming, with no runtime code impact. Risk is limited to any downstream tooling that assumes the old filename pattern.
> 
> **Overview**
> iOS artifact renaming now omits the redundant `device`/`simulator` segment from the generated base name, relying on `.ipa` vs `.app` to convey target.
> 
> The `renameIos()` script removes `deviceType` from the naming logic, producing shorter, consistent artifact filenames while leaving build paths and copy/zip behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21508a0c97970370fb0508fa8966f3cd56ef3bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->