### PR TITLE
chore: enable batched account creation for Solana

### DIFF
--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.test.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.test.ts
@@ -1,6 +1,9 @@
 import {
   MultichainAccountService,
   MultichainAccountServiceMessenger,
+  SOL_ACCOUNT_PROVIDER_NAME,
+  BTC_ACCOUNT_PROVIDER_NAME,
+  TRX_ACCOUNT_PROVIDER_NAME,
 } from '@metamask/multichain-account-service';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ControllerInitRequest } from '../../types';
@@ -84,5 +87,38 @@ describe('MultichainAccountServiceInit', () => {
 
     expect(callArgs.messenger).toBe(initRequestMock.controllerMessenger);
     expect(callArgs.providerConfigs).toBeDefined();
+  });
+
+  it('enables batched account creation for Solana', () => {
+    multichainAccountServiceInit(getInitRequestMock());
+
+    const callArgs = jest.mocked(MultichainAccountService).mock.calls[0][0];
+    const { providerConfigs } = callArgs;
+
+    expect(providerConfigs).toBeDefined();
+    expect(
+      providerConfigs?.[SOL_ACCOUNT_PROVIDER_NAME]?.createAccounts,
+    ).toMatchObject({
+      batched: true,
+    });
+  });
+
+  it('does not enable batched account creation for BTC and TRX', () => {
+    multichainAccountServiceInit(getInitRequestMock());
+
+    const callArgs = jest.mocked(MultichainAccountService).mock.calls[0][0];
+    const { providerConfigs } = callArgs;
+
+    expect(providerConfigs).toBeDefined();
+    expect(
+      providerConfigs?.[BTC_ACCOUNT_PROVIDER_NAME]?.createAccounts,
+    ).toMatchObject({
+      batched: false,
+    });
+    expect(
+      providerConfigs?.[TRX_ACCOUNT_PROVIDER_NAME]?.createAccounts,
+    ).toMatchObject({
+      batched: false,
+    });
   });
 });

--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
@@ -42,10 +42,18 @@ export const multichainAccountServiceInit: ControllerInitFunction<
     },
   };
 
+  const solanaSnapAccountProviderConfig = {
+    ...snapAccountProviderConfig,
+    createAccounts: {
+      ...snapAccountProviderConfig.createAccounts,
+      batched: true,
+    },
+  };
+
   const controller = new MultichainAccountService({
     messenger: controllerMessenger,
     providerConfigs: {
-      [SOL_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
+      [SOL_ACCOUNT_PROVIDER_NAME]: solanaSnapAccountProviderConfig,
       /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       [BTC_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
       /// END:ONLY_INCLUDE_IF

--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "@metamask/snaps-rpc-methods": "^15.0.1",
     "@metamask/snaps-sdk": "^11.0.0",
     "@metamask/snaps-utils": "^12.1.2",
-    "@metamask/solana-wallet-snap": "^2.7.4",
+    "@metamask/solana-wallet-snap": "^2.8.0",
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/stake-sdk": "^3.4.0",
     "@metamask/storage-service": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9836,10 +9836,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/solana-wallet-snap@npm:^2.7.4":
-  version: 2.7.4
-  resolution: "@metamask/solana-wallet-snap@npm:2.7.4"
-  checksum: 10/433f9baed0ed01d45c45b4434c3427925ff257c42dffd19c8f6d006e2955408fadd438d28a427453a78775afe6210aafb1a7206e0603ccc4d93560456b3a9333
+"@metamask/solana-wallet-snap@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@metamask/solana-wallet-snap@npm:2.8.0"
+  checksum: 10/5e26f28d585aa00c4da204a7311f15048de30ff336baa90df1ca82f0d151b25dcf7b3fc3daa8b9ab02914aca35f31eb7a2854bf167008f6e96f99e215f02767c
   languageName: node
   linkType: hard
 
@@ -35537,7 +35537,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^15.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/solana-wallet-snap": "npm:^2.7.4"
+    "@metamask/solana-wallet-snap": "npm:^2.8.0"
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@metamask/stake-sdk": "npm:^3.4.0"
     "@metamask/storage-service": "npm:^1.0.0"


### PR DESCRIPTION
## **Description**

<!-- What is the reason for the change? What is the improvement/solution? -->

Bumps `@metamask/solana-wallet-snap` from `^2.7.4` to `^2.8.0` and enables batch account creation for the Solana provider.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1651

## **Manual testing steps**

```gherkin
Feature: Solana batched account creation

  Scenario: user imports a power user SRP with multiple Solana accounts
    Given Backup & Sync is enabled
    And the user imports a new power user SRP

    When account discovery completes
    Then all multichain Solana accounts are correctly created
```

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multichain account creation behavior for the Solana provider (now batched), which could affect account discovery/creation flows; other providers remain unchanged. Also bumps the Solana snap dependency, introducing potential upstream behavior changes.
> 
> **Overview**
> Enables **batched account creation for Solana** by passing a Solana-specific provider config (`createAccounts.batched: true`) into `MultichainAccountService` initialization, while keeping BTC/TRX configs non-batched.
> 
> Adds unit coverage asserting the per-provider `batched` flag, and bumps `@metamask/solana-wallet-snap` from `^2.7.4` to `^2.8.0` (lockfile updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04c4ac5b16cccd32158fdd49e2933d130bdf7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->