### PR TITLE
chore: gitignore claude worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # task working directory (agent-local, not shipped)
 .task/
 
+# claude code worktrees (agent-local, not shipped)
+.claude/worktrees/
+
 # osx
 .DS_Store
 # don't save asdf tools-version config as nvm is prioritized.


### PR DESCRIPTION
## **Description**

Adds `.claude/worktrees/` to `.gitignore`. These are agent-local scratch directories created by Claude Code when working in worktrees and should not be tracked in the repository.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: gitignore claude worktrees

  Scenario: worktree directory is not tracked
    Given the .claude/worktrees/ directory exists locally
    When user runs git status
    Then the directory does not appear as untracked
```

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore`, preventing accidental commits of local Claude Code worktree files with no runtime impact.
> 
> **Overview**
> Adds `.claude/worktrees/` to `.gitignore` so Claude Code worktree scratch directories are not tracked or accidentally committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79cb9e7f15a0d7878b16483f55ce44d4af63561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->