### PR TITLE
chore(rewards): improve Ondo campaign RWA position UX

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -81,6 +81,18 @@ jest.mock('./Views/OndoCampaignDetailsView', () => {
   };
 });
 
+jest.mock('./Views/OndoCampaignRwaSelectorView', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return function MockOndoCampaignRwaSelectorView() {
+    return ReactActual.createElement(
+      View,
+      { testID: 'ondo-campaign-rwa-selector-view' },
+      ReactActual.createElement(Text, null, 'Ondo Campaign RWA Selector View'),
+    );
+  };
+});
+
 jest.mock('./Views/SeasonOneCampaignDetailsView', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');
@@ -481,6 +493,18 @@ describe('RewardsNavigator', () => {
       mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
 
       // Rendering should not throw even with the new screens registered
+      const { getByTestId } = renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(getByTestId('rewards-dashboard-view')).toBeOnTheScreen();
+      });
+    });
+
+    it('registers REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR route when subscription exists', async () => {
+      // The RWA selector screen is registered inside the subscriptionId-guarded block
+      mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
+
+      // Rendering should not throw with the new screen registered
       const { getByTestId } = renderWithNavigation(<RewardsNavigator />);
 
       await waitFor(() => {

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -11,6 +11,7 @@ import SeasonOneCampaignDetailsView from './Views/SeasonOneCampaignDetailsView';
 import CampaignMechanicsView from './Views/CampaignMechanicsView';
 import MusdCalculatorView from './Views/MusdCalculatorView';
 import OndoLeaderboardView from './Views/OndoLeaderboardView';
+import OndoCampaignRwaSelectorView from './Views/OndoCampaignRwaSelectorView';
 import OndoCampaignPortfolioView from './Views/OndoCampaignPortfolioView';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
@@ -122,6 +123,11 @@ const RewardsNavigator: React.FC = () => {
           <Stack.Screen
             name={Routes.REWARDS_ONDO_CAMPAIGN_LEADERBOARD}
             component={OndoLeaderboardView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR}
+            component={OndoCampaignRwaSelectorView}
             options={{ headerShown: false }}
           />
           <Stack.Screen

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -154,27 +154,17 @@ jest.mock('../components/Campaigns/OndoLeaderboardPosition', () => {
   };
 });
 
-jest.mock('../components/Campaigns/OndoPortfolio', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      ReactActual.createElement(View, {
-        testID: 'ondo-campaign-portfolio',
-      }),
-  };
-});
-
 jest.mock('../components/RewardsInfoBanner', () => {
   const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+  const { View, Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: () =>
-      ReactActual.createElement(View, {
-        testID: 'competition-ended-banner',
-      }),
+    default: ({ title }: { title: string }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'competition-ended-banner' },
+        ReactActual.createElement(Text, null, title),
+      ),
   };
 });
 
@@ -262,6 +252,116 @@ const mockUseGetOndoPortfolioPosition =
     typeof useGetOndoPortfolioPosition
   >;
 
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => null),
+}));
+
+const mockIsTokenTradingOpen = jest.fn(() => true);
+jest.mock('../../Bridge/hooks/useRWAToken', () => ({
+  useRWAToken: () => ({
+    isTokenTradingOpen: mockIsTokenTradingOpen,
+    isStockToken: jest.fn(() => false),
+  }),
+}));
+
+jest.mock('../../Trending/hooks/useRwaTokens/useRwaTokens', () => ({
+  useRwaTokens: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock('../../Perps/utils/marketHours', () => ({
+  formatCountdown: jest.fn(() => '2h 30m'),
+  getMarketHoursStatus: jest.fn(() => ({
+    nextTransition: new Date(Date.now() + 1000 * 60 * 60 * 2),
+  })),
+}));
+
+// Mock the Engine file directly (imported as Engine/Engine, not Engine/index)
+jest.mock('../../../../core/Engine/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: { setSelectedAccountGroup: jest.fn() },
+    },
+    controllerMessenger: {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    },
+  },
+}));
+
+// Mock the new Balance import that triggers deep import chains
+jest.mock('../../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
+}));
+
+jest.mock('../../Trending/components/TrendingTokenLogo', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => ReactActual.createElement(View, null),
+  };
+});
+
+// OndoPortfolio named exports used by the account picker bottom sheet
+jest.mock('../components/Campaigns/OndoPortfolio', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onOpenAccountPicker,
+    }: {
+      marketOpen?: boolean;
+      onOpenAccountPicker?: (config: unknown) => void;
+    }) =>
+      ReactActual.createElement(Pressable, {
+        testID: 'ondo-campaign-portfolio',
+        onPress: () =>
+          onOpenAccountPicker?.({
+            row: {
+              tokenAsset: 'eip155:1/erc20:0xabc',
+              tokenSymbol: 'USDC',
+              tokenName: 'USD Coin',
+            },
+            entries: [
+              {
+                group: { id: 'group-1', metadata: { name: 'Account 1' } },
+                balance: '100',
+              },
+            ],
+            tokenDecimals: 6,
+          }),
+      }),
+    AccountGroupSelectRow: () => ReactActual.createElement(View, null),
+    getChainHex: jest.fn(() => '0x1'),
+  };
+});
+
+jest.mock('../components/Campaigns/OndoAccountPickerSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onClose,
+    }: {
+      pendingPicker: unknown;
+      sheetRef: unknown;
+      onClose: () => void;
+      onGroupSelect: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'account-picker-sheet' },
+        ReactActual.createElement(Pressable, {
+          testID: 'account-picker-sheet-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
@@ -320,6 +420,7 @@ const hookDefaults = {
 describe('OndoCampaignDetailsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsTokenTradingOpen.mockReturnValue(true);
     mockOndoLeaderboardPosition.mockReset();
     mockUseRewardCampaigns.mockReturnValue(hookDefaults);
     mockUseGetCampaignParticipantStatus.mockReturnValue({
@@ -477,9 +578,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByTestId('campaign-how-it-works')).toBeDefined();
     });
 
-    it('renders CampaignHowItWorks when campaign is active and entries are still open', () => {
-      // Any real-world date is "future" relative to the mocked Date.now() of 123ms,
-      // so opt-in is still allowed and HowItWorks should be visible.
+    it('does not render CampaignHowItWorks when user is opted in (even with entries still open)', () => {
       const nextWeek = new Date();
       nextWeek.setDate(nextWeek.getDate() + 7);
       mockUseRewardCampaigns.mockReturnValue({
@@ -497,8 +596,14 @@ describe('OndoCampaignDetailsView', () => {
           }),
         ],
       });
-      const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('campaign-how-it-works')).toBeDefined();
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      const { queryByTestId } = render(<OndoCampaignDetailsView />);
+      expect(queryByTestId('campaign-how-it-works')).toBeNull();
     });
 
     it('does not render CampaignHowItWorks when campaign has no details', () => {
@@ -874,27 +979,6 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByTestId('ondo-leaderboard')).toBeDefined();
     });
 
-    it('shows OndoLeaderboard when not opted in and campaign is active past cutoff date', () => {
-      // Date.now() is mocked to 123ms in testSetup.js; use epoch (0ms) as a "past" cutoff
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: {
-                title: 'How it works',
-                description: 'Description',
-                steps: [],
-              },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
-      });
-      const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('ondo-leaderboard')).toBeDefined();
-    });
-
     it('does not show leaderboard section header when campaign is complete and not opted in', () => {
       const lastMonth = new Date();
       lastMonth.setMonth(lastMonth.getMonth() - 1);
@@ -963,6 +1047,31 @@ describe('OndoCampaignDetailsView', () => {
           campaignId: 'campaign-1',
         },
       );
+    });
+  });
+
+  describe('account picker sheet', () => {
+    it('closes the account picker sheet when onClose is triggered', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [createTestCampaign()],
+      });
+      // Must be opted-in for portfolio section to render
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignDetailsView />,
+      );
+      // Open the account picker by pressing the portfolio mock
+      fireEvent.press(getByTestId('ondo-campaign-portfolio'));
+      expect(getByTestId('account-picker-sheet')).toBeDefined();
+      // Close it
+      fireEvent.press(getByTestId('account-picker-sheet-close'));
+      expect(queryByTestId('account-picker-sheet')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -370,7 +370,6 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.campaigns_view.retry_button': 'Retry',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
       'rewards.campaign_details.open_position': 'Open Position',
-      'rewards.campaign_details.swap_ondo_assets': 'Swap Ondo Assets',
       'rewards.campaign_details.entries_closed_title': 'Entries closed',
       'rewards.campaign_details.entries_closed_description':
         'You missed the opt-in window',
@@ -695,7 +694,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByText('Open Position')).toBeDefined();
     });
 
-    it('renders "Swap Ondo Assets" CTA when participant is opted in with positions', () => {
+    it('renders "Open Position" CTA when participant is opted in with positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -715,7 +714,7 @@ describe('OndoCampaignDetailsView', () => {
       });
       const { getByTestId, getByText } = render(<OndoCampaignDetailsView />);
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeDefined();
-      expect(getByText('Swap Ondo Assets')).toBeDefined();
+      expect(getByText('Open Position')).toBeDefined();
     });
 
     it('hides the CTA while participant status is loading', () => {

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -380,6 +380,27 @@ const OndoCampaignDetailsView: React.FC = () => {
                           )}
                         </Text>
                         <Icon name={IconName.ArrowRight} size={IconSize.Md} />
+                        {portfolioData?.computedAt &&
+                          portfolioData.positions.length > 0 && (
+                            <Box
+                              twClassName="flex-1"
+                              alignItems={BoxAlignItems.End}
+                            >
+                              <Text
+                                variant={TextVariant.BodyXs}
+                                color={TextColor.TextAlternative}
+                              >
+                                {strings(
+                                  'rewards.ondo_campaign_portfolio.updated_at',
+                                  {
+                                    time: formatComputedAt(
+                                      portfolioData.computedAt,
+                                    ),
+                                  },
+                                )}
+                              </Text>
+                            </Box>
+                          )}
                       </Box>
                     </Pressable>
                     <OndoPortfolio

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -411,6 +411,9 @@ const OndoCampaignDetailsView: React.FC = () => {
                       refetch={refetchPortfolio}
                       campaignId={campaignId}
                       onOpenAccountPicker={setPendingPicker}
+                      isCampaignComplete={
+                        getCampaignStatus(campaign) === 'complete'
+                      }
                     />
                   </Box>
                 </>

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -29,6 +29,7 @@ import CampaignHowItWorks from '../components/Campaigns/CampaignHowItWorks';
 import OndoLeaderboard from '../components/Campaigns/OndoLeaderboard';
 import OndoLeaderboardPosition from '../components/Campaigns/OndoLeaderboardPosition';
 import OndoPortfolio from '../components/Campaigns/OndoPortfolio';
+import OndoAccountPickerSheet from '../components/Campaigns/OndoAccountPickerSheet';
 import CampaignCTA from '../components/Campaigns/CampaignCTA';
 import {
   getCampaignStatus,
@@ -42,6 +43,7 @@ import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
 import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useOndoAccountPicker } from '../hooks/useOndoAccountPicker';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { OndoCampaignHowItWorks } from '../../../../core/Engine/controllers/rewards-controller/types';
@@ -65,11 +67,13 @@ export const CAMPAIGN_DETAILS_TEST_IDS = {
 
 const OndoCampaignDetailsView: React.FC = () => {
   const tw = useTailwind();
-  const navigation =
-    useNavigation<NavigationProp<RewardsCampaignStackParamList>>();
+  const navigation = useNavigation();
   const route =
     useRoute<RouteProp<OndoCampaignDetailsRouteParams, 'CampaignDetails'>>();
   const { campaignId } = route.params;
+
+  const { pendingPicker, setPendingPicker, sheetRef, handleGroupSelect } =
+    useOndoAccountPicker(campaignId);
 
   const {
     campaigns,
@@ -151,6 +155,7 @@ const OndoCampaignDetailsView: React.FC = () => {
 
     const showHowItWorksSection =
       Boolean(campaign.details?.howItWorks) &&
+      !isOptedIn &&
       !hasPositions &&
       !isPortfolioLoading &&
       getCampaignStatus(campaign) === 'active' &&
@@ -383,6 +388,8 @@ const OndoCampaignDetailsView: React.FC = () => {
                       hasError={hasPortfolioError}
                       hasFetched={portfolioHasFetched}
                       refetch={refetchPortfolio}
+                      campaignId={campaignId}
+                      onOpenAccountPicker={setPendingPicker}
                     />
                   </Box>
                 </>
@@ -443,6 +450,16 @@ const OndoCampaignDetailsView: React.FC = () => {
               isLoading: isParticipantStatusLoading,
             }}
             hasPositions={hasPositions}
+            campaignId={campaignId}
+          />
+        )}
+
+        {pendingPicker && (
+          <OndoAccountPickerSheet
+            pendingPicker={pendingPicker}
+            sheetRef={sheetRef}
+            onClose={() => setPendingPicker(null)}
+            onGroupSelect={handleGroupSelect}
           />
         )}
       </SafeAreaView>

--- a/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import OndoCampaignPortfolioView, {
   CAMPAIGN_PORTFOLIO_TEST_IDS,
 } from './OndoCampaignPortfolioView';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
 import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
 import { useGetOndoCampaignActivity } from '../hooks/useGetOndoCampaignActivity';
+import Routes from '../../../../constants/navigation/Routes';
 import {
   CampaignType,
   type CampaignDto,
@@ -13,11 +14,12 @@ import {
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     goBack: mockGoBack,
-    navigate: jest.fn(),
+    navigate: mockNavigate,
     addListener: jest.fn(() => jest.fn()),
     isFocused: () => true,
   }),
@@ -33,6 +35,12 @@ jest.mock('react-native-safe-area-context', () => {
       right: 0,
       bottom: 0,
       left: 0,
+    })),
+    useSafeAreaFrame: jest.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 390,
+      height: 844,
     })),
     SafeAreaView: ({
       children,
@@ -80,13 +88,89 @@ jest.mock('../../../Views/ErrorBoundary', () => {
   };
 });
 
+jest.mock('../components/Campaigns/OndoAccountPickerSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onClose,
+    }: {
+      pendingPicker: unknown;
+      sheetRef: unknown;
+      onClose: () => void;
+      onGroupSelect: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'account-picker-sheet' },
+        ReactActual.createElement(Pressable, {
+          testID: 'account-picker-sheet-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
+let capturedOnOpenAccountPicker: ((config: unknown) => void) | undefined;
+
 jest.mock('../components/Campaigns/OndoPortfolio', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onOpenAccountPicker,
+    }: {
+      onOpenAccountPicker?: (config: unknown) => void;
+    }) => {
+      capturedOnOpenAccountPicker = onOpenAccountPicker;
+      return ReactActual.createElement(Pressable, {
+        testID: 'ondo-portfolio',
+        onPress: () =>
+          onOpenAccountPicker?.({
+            row: {
+              tokenAsset: 'eip155:1/erc20:0xabc',
+              tokenSymbol: 'USDC',
+              tokenName: 'USD Coin',
+            },
+            entries: [
+              {
+                group: { id: 'group-1', name: 'Account 1' },
+                balance: '100',
+              },
+            ],
+          }),
+      });
+    },
+    AccountGroupSelectRow: () => ReactActual.createElement(View, null),
+    getChainHex: jest.fn(() => '0x1'),
+  };
+});
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => null),
+}));
+
+jest.mock('../../../../core/Engine/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: { setSelectedAccountGroup: jest.fn() },
+    },
+  },
+}));
+
+jest.mock('../../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
+}));
+
+jest.mock('../../Trending/components/TrendingTokenLogo', () => {
   const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: () =>
-      ReactActual.createElement(View, { testID: 'ondo-portfolio' }),
+    default: () => ReactActual.createElement(View, null),
   };
 });
 
@@ -275,5 +359,38 @@ describe('OndoCampaignPortfolioView', () => {
 
     const { getByTestId } = render(<OndoCampaignPortfolioView />);
     expect(getByTestId('error-banner')).toBeDefined();
+  });
+
+  it('opens account picker bottom sheet when OndoPortfolio triggers onOpenAccountPicker', () => {
+    const { getByTestId } = render(<OndoCampaignPortfolioView />);
+
+    fireEvent.press(getByTestId('ondo-portfolio'));
+
+    expect(getByTestId('account-picker-sheet')).toBeDefined();
+  });
+
+  it('captures onOpenAccountPicker callback from OndoPortfolio', () => {
+    render(<OndoCampaignPortfolioView />);
+    expect(capturedOnOpenAccountPicker).toBeDefined();
+  });
+
+  it('does not navigate before account picker is triggered', () => {
+    render(<OndoCampaignPortfolioView />);
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+      expect.anything(),
+    );
+  });
+
+  it('closes account picker sheet and clears pendingPicker when onClose is called', () => {
+    const { getByTestId, queryByTestId } = render(
+      <OndoCampaignPortfolioView />,
+    );
+    // Open the account picker
+    fireEvent.press(getByTestId('ondo-portfolio'));
+    expect(getByTestId('account-picker-sheet')).toBeDefined();
+    // Close it
+    fireEvent.press(getByTestId('account-picker-sheet-close'));
+    expect(queryByTestId('account-picker-sheet')).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
@@ -18,13 +18,16 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import OndoPortfolio from '../components/Campaigns/OndoPortfolio';
+import OndoAccountPickerSheet from '../components/Campaigns/OndoAccountPickerSheet';
 import OndoActivityRow from '../components/Campaigns/OndoActivityRow';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
 import { useGetOndoCampaignActivity } from '../hooks/useGetOndoCampaignActivity';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useOndoAccountPicker } from '../hooks/useOndoAccountPicker';
 import { strings } from '../../../../../locales/i18n';
+import Routes from '../../../../constants/navigation/Routes';
 import type { OndoGmActivityEntryDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -41,6 +44,9 @@ const OndoCampaignPortfolioView: React.FC = () => {
   const navigation = useNavigation<NavigationProp<ParamListBase>>();
   const route = useRoute<RouteProp<PortfolioRouteParams>>();
   const { campaignId } = route.params;
+
+  const { pendingPicker, setPendingPicker, sheetRef, handleGroupSelect } =
+    useOndoAccountPicker(campaignId);
 
   const { campaigns } = useRewardCampaigns();
   const campaign = useMemo(
@@ -149,6 +155,8 @@ const OndoCampaignPortfolioView: React.FC = () => {
             hasError={hasPortfolioError}
             hasFetched={portfolioHasFetched}
             refetch={refetchPortfolio}
+            campaignId={campaignId}
+            onOpenAccountPicker={setPendingPicker}
           />
         </Box>
 
@@ -175,6 +183,8 @@ const OndoCampaignPortfolioView: React.FC = () => {
     hasPortfolioError,
     portfolioHasFetched,
     refetchPortfolio,
+    campaignId,
+    setPendingPicker,
     isActivityLoading,
     activityEntries,
     tw,
@@ -211,6 +221,14 @@ const OndoCampaignPortfolioView: React.FC = () => {
           }
           showsVerticalScrollIndicator={false}
         />
+        {pendingPicker && (
+          <OndoAccountPickerSheet
+            pendingPicker={pendingPicker}
+            sheetRef={sheetRef}
+            onClose={() => setPendingPicker(null)}
+            onGroupSelect={handleGroupSelect}
+          />
+        )}
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -1,0 +1,312 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OndoCampaignRwaSelectorView from './OndoCampaignRwaSelectorView';
+import type { TrendingAsset } from '@metamask/assets-controllers';
+
+const mockGoBack = jest.fn();
+const mockGoToSwaps = jest.fn();
+
+let mockRouteParams: {
+  mode: 'open_position' | 'swap';
+  campaignId: string;
+  srcTokenAsset?: string;
+  srcTokenSymbol?: string;
+  srcTokenName?: string;
+  srcTokenDecimals?: number;
+} = { mode: 'open_position', campaignId: 'campaign-1' };
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+  useRoute: () => ({ params: mockRouteParams }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('react-native-safe-area-context');
+  return {
+    ...actual,
+    useSafeAreaInsets: jest.fn(() => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    })),
+    SafeAreaView: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children: React.ReactNode;
+      testID?: string;
+    }) => ReactActual.createElement(View, { ...props, testID }, children),
+  };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => {
+    const tw = () => ({});
+    tw.style = (..._args: unknown[]) => ({});
+    return tw;
+  },
+}));
+
+jest.mock(
+  '../../../../component-library/components-temp/HeaderCompactStandard',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { View, Pressable } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        title,
+        onBack,
+      }: {
+        title: React.ReactNode;
+        onBack: () => void;
+      }) =>
+        ReactActual.createElement(
+          View,
+          { testID: 'header' },
+          ReactActual.createElement(Pressable, {
+            onPress: onBack,
+            testID: 'header-back-button',
+          }),
+          typeof title === 'string'
+            ? ReactActual.createElement(
+                jest.requireActual('react-native').Text,
+                { testID: 'header-title' },
+                title,
+              )
+            : title,
+        ),
+    };
+  },
+);
+
+jest.mock('../../../Views/ErrorBoundary', () => {
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  };
+});
+
+const mockUseRwaTokens = jest.fn();
+jest.mock('../../Trending/hooks/useRwaTokens/useRwaTokens', () => ({
+  useRwaTokens: (...args: unknown[]) => mockUseRwaTokens(...args),
+}));
+
+jest.mock('../../Bridge/hooks/useSwapBridgeNavigation', () => ({
+  useSwapBridgeNavigation: () => ({ goToSwaps: mockGoToSwaps }),
+  SwapBridgeNavigationLocation: { Rewards: 'Rewards' },
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../utils/formatUtils', () => ({
+  ...jest.requireActual('../utils/formatUtils'),
+  parseCaip19: jest.fn(() => ({
+    namespace: 'eip155',
+    chainId: '1',
+    assetReference: '0xabc',
+  })),
+  caipChainIdToHex: jest.fn(() => '0x1'),
+}));
+
+jest.mock(
+  '../../Trending/components/TrendingTokenRowItem/TrendingTokenRowItem',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { TouchableOpacity, Text } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        token,
+        onPress,
+      }: {
+        token: TrendingAsset;
+        onPress: (t: TrendingAsset) => void;
+      }) =>
+        ReactActual.createElement(
+          TouchableOpacity,
+          {
+            testID: `token-row-${token.symbol}`,
+            onPress: () => onPress(token),
+          },
+          ReactActual.createElement(Text, null, token.symbol),
+        ),
+    };
+  },
+);
+
+jest.mock(
+  '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet',
+  () => ({
+    TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
+  }),
+);
+
+// Silence utility mocks
+jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
+  getTrendingTokenImageUrl: jest.fn(() => 'https://mock.image'),
+}));
+
+jest.mock('../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: { muted: 'muted-text' },
+      border: { muted: 'muted-border' },
+    },
+  }),
+}));
+
+jest.mock('../../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
+}));
+
+jest.mock('../../Trending/components/TrendingTokenLogo', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => ReactActual.createElement(View, null),
+  };
+});
+
+const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
+  ({
+    symbol,
+    name: `${symbol} Token`,
+    decimals: 18,
+    assetId: assetId ?? `eip155:1/erc20:0x${symbol.toLowerCase()}`,
+    rwaData: null,
+  }) as unknown as TrendingAsset;
+
+describe('OndoCampaignRwaSelectorView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+    mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
+  });
+
+  it('renders without crashing', () => {
+    const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+    expect(getByTestId('header')).toBeDefined();
+  });
+
+  it('renders skeleton when loading', () => {
+    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: true });
+    const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+    // When loading, FlatList is replaced by skeleton boxes — no token rows rendered
+    expect(queryByTestId('token-row-AAPL')).toBeNull();
+  });
+
+  it('renders empty state when no tokens and not loading', () => {
+    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+    const { getByText } = render(<OndoCampaignRwaSelectorView />);
+    expect(
+      getByText('rewards.ondo_rwa_asset_selector.no_results'),
+    ).toBeDefined();
+  });
+
+  it('renders token list items when tokens are available', () => {
+    mockUseRwaTokens.mockReturnValue({
+      data: [buildToken('AAPL'), buildToken('MSFT')],
+      isLoading: false,
+    });
+    const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+    expect(getByTestId('token-row-AAPL')).toBeDefined();
+    expect(getByTestId('token-row-MSFT')).toBeDefined();
+  });
+
+  it('in open_position mode, shows plain title string', () => {
+    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+    const { getByText } = render(<OndoCampaignRwaSelectorView />);
+    expect(
+      getByText('rewards.ondo_rwa_asset_selector.title_open_position'),
+    ).toBeDefined();
+  });
+
+  it('calls goToSwaps when a token item is pressed', () => {
+    const token = buildToken('AAPL');
+    mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+    const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+    fireEvent.press(getByTestId('token-row-AAPL'));
+    expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates back when back button is pressed', () => {
+    const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+    fireEvent.press(getByTestId('header-back-button'));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  describe('swap mode', () => {
+    beforeEach(() => {
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: 'eip155:1/erc20:0xabc',
+        srcTokenSymbol: 'USDC',
+        srcTokenName: 'USD Coin',
+        srcTokenDecimals: 6,
+      };
+    });
+
+    it('renders swap prefix title when srcTokenAsset and srcTokenSymbol are provided', () => {
+      const { getByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(
+        getByText('rewards.ondo_rwa_asset_selector.title_swap_prefix'),
+      ).toBeDefined();
+    });
+
+    it('does not show the open_position title in swap mode', () => {
+      const { queryByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(
+        queryByText('rewards.ondo_rwa_asset_selector.title_open_position'),
+      ).toBeNull();
+    });
+  });
+
+  describe('search interactions', () => {
+    it('shows the clear button when search query is not empty and clears it on press', () => {
+      const { getByPlaceholderText, getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      const input = getByPlaceholderText(
+        'rewards.ondo_rwa_asset_selector.search_placeholder',
+      );
+      fireEvent.changeText(input, 'AAPL');
+      expect(getByTestId('clear-search-button')).toBeDefined();
+      // Clear button appears as a TouchableOpacity wrapping the close icon
+      // Verify the input has the typed value and pressing clear resets it
+      fireEvent.changeText(input, '');
+      expect(
+        getByPlaceholderText(
+          'rewards.ondo_rwa_asset_selector.search_placeholder',
+        ),
+      ).toBeDefined();
+    });
+
+    it('displays skeleton after search query changes (isFiltering)', () => {
+      mockUseRwaTokens.mockReturnValue({
+        data: [buildToken('AAPL'), buildToken('MSFT')],
+        isLoading: false,
+      });
+      const { getByPlaceholderText, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      const input = getByPlaceholderText(
+        'rewards.ondo_rwa_asset_selector.search_placeholder',
+      );
+      // After changing text, isFiltering becomes true → skeleton shown
+      fireEvent.changeText(input, 'AAPL');
+      // Skeleton replaces the token list
+      expect(queryByTestId('token-row-MSFT')).toBeNull();
+    });
+  });
+});

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -1,0 +1,326 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Skeleton,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { Hex, type CaipChainId } from '@metamask/utils';
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
+import TrendingTokenLogo from '../../Trending/components/TrendingTokenLogo';
+import Badge, {
+  BadgeVariant,
+} from '../../../../component-library/components/Badges/Badge';
+import { AvatarSize } from '../../../../component-library/components/Avatars/Avatar';
+import { NetworkBadgeSource } from '../../AssetOverview/Balance/Balance';
+import ErrorBoundary from '../../../Views/ErrorBoundary';
+import { useRwaTokens } from '../../Trending/hooks/useRwaTokens/useRwaTokens';
+import TrendingTokenRowItem from '../../Trending/components/TrendingTokenRowItem/TrendingTokenRowItem';
+import { getTrendingTokenImageUrl } from '../../Trending/utils/getTrendingTokenImageUrl';
+import { parseCaip19, caipChainIdToHex } from '../utils/formatUtils';
+import {
+  useSwapBridgeNavigation,
+  SwapBridgeNavigationLocation,
+} from '../../Bridge/hooks/useSwapBridgeNavigation';
+import type { BridgeToken } from '../../Bridge/types';
+import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet';
+import { useTheme } from '../../../../util/theme';
+import { strings } from '../../../../../locales/i18n';
+
+// ParamListBase requires an index signature, which interfaces don't support
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type OndoCampaignRwaSelectorRouteParams = {
+  OndoCampaignRwaSelector: {
+    mode: 'swap' | 'open_position';
+    srcTokenAsset?: string;
+    srcTokenSymbol?: string;
+    srcTokenName?: string;
+    srcTokenDecimals?: number;
+    campaignId: string;
+  };
+};
+
+const styles = StyleSheet.create({
+  row: {
+    paddingHorizontal: 16,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+  },
+});
+
+const OndoCampaignRwaSelectorView: React.FC = () => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const route =
+    useRoute<
+      RouteProp<OndoCampaignRwaSelectorRouteParams, 'OndoCampaignRwaSelector'>
+    >();
+  const {
+    mode,
+    srcTokenAsset,
+    srcTokenSymbol,
+    srcTokenName,
+    srcTokenDecimals,
+  } = route.params;
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Build the source BridgeToken from route params (swap mode only)
+  const srcBridgeToken = useMemo((): BridgeToken | undefined => {
+    if (mode !== 'swap' || !srcTokenAsset || !srcTokenSymbol) return undefined;
+    const parsed = parseCaip19(srcTokenAsset);
+    if (!parsed) return undefined;
+    return {
+      address: parsed.assetReference,
+      symbol: srcTokenSymbol,
+      name: srcTokenName ?? srcTokenSymbol,
+      decimals: srcTokenDecimals ?? 18,
+      chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      image: getTrendingTokenImageUrl(srcTokenAsset),
+    };
+  }, [mode, srcTokenAsset, srcTokenSymbol, srcTokenName, srcTokenDecimals]);
+
+  const srcChainHex = useMemo(() => {
+    if (!srcTokenAsset) return undefined;
+    const parsed = parseCaip19(srcTokenAsset);
+    if (!parsed || parsed.namespace !== 'eip155') return undefined;
+    return caipChainIdToHex(
+      `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+    );
+  }, [srcTokenAsset]);
+
+  // In swap mode, filter to same chain as src asset
+  const chainIds = useMemo((): CaipChainId[] | undefined => {
+    if (mode !== 'swap' || !srcTokenAsset) return undefined;
+    const parsed = parseCaip19(srcTokenAsset);
+    if (!parsed) return undefined;
+    return [`${parsed.namespace}:${parsed.chainId}` as CaipChainId];
+  }, [mode, srcTokenAsset]);
+
+  const { data: rwaTokens, isLoading } = useRwaTokens({
+    searchQuery,
+    chainIds,
+  });
+
+  // Show skeleton while client-side filters are being applied.
+  // useRwaTokens applies search/sort synchronously but via useStableReference,
+  // which delays opts by one render cycle — so rwaTokens lags behind the inputs
+  // by exactly one render. isFiltering bridges that gap.
+  const [isFiltering, setIsFiltering] = useState(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setIsFiltering(true);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    setIsFiltering(false);
+  }, [rwaTokens]);
+
+  const showSkeleton = isLoading || isFiltering;
+
+  const { goToSwaps } = useSwapBridgeNavigation({
+    location: SwapBridgeNavigationLocation.Rewards,
+    sourcePage: 'OndoCampaignRwaSelector',
+    sourceToken: srcBridgeToken,
+  });
+
+  // Deduplicate by symbol so the same stock on multiple chains appears once.
+  const tokens = useMemo((): TrendingAsset[] => {
+    const seen = new Set<string>();
+    return rwaTokens.filter((token) => {
+      if (srcTokenSymbol && token.symbol === srcTokenSymbol) return false;
+      if (seen.has(token.symbol)) return false;
+      seen.add(token.symbol);
+      return true;
+    });
+  }, [rwaTokens, srcTokenSymbol]);
+
+  const handleAssetSelect = useCallback(
+    (asset: TrendingAsset) => {
+      const parsed = parseCaip19(asset.assetId);
+      if (!parsed) return;
+      const destToken: BridgeToken = {
+        address: parsed.assetReference,
+        symbol: asset.symbol,
+        name: asset.name,
+        decimals: asset.decimals,
+        chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+        image: getTrendingTokenImageUrl(asset.assetId),
+        rwaData: asset.rwaData as BridgeToken['rwaData'],
+      };
+
+      goToSwaps(undefined, destToken);
+    },
+    [goToSwaps],
+  );
+
+  const title =
+    mode === 'swap' && srcTokenSymbol && srcTokenAsset ? (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="gap-2"
+      >
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
+          {strings('rewards.ondo_rwa_asset_selector.title_swap_prefix')}
+        </Text>
+        <BadgeWrapper
+          position={BadgeWrapperPosition.BottomRight}
+          badge={
+            srcChainHex ? (
+              <Badge
+                variant={BadgeVariant.Network}
+                size={AvatarSize.Xs}
+                isScaled={false}
+                imageSource={NetworkBadgeSource(srcChainHex as Hex)}
+              />
+            ) : null
+          }
+        >
+          <TrendingTokenLogo
+            assetId={srcTokenAsset}
+            symbol={srcTokenSymbol}
+            size={28}
+          />
+        </BadgeWrapper>
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
+          {srcTokenSymbol}
+        </Text>
+      </Box>
+    ) : (
+      strings('rewards.ondo_rwa_asset_selector.title_open_position')
+    );
+
+  const renderItem = ({ item }: { item: TrendingAsset }) => (
+    <View style={styles.row}>
+      <TrendingTokenRowItem
+        token={item}
+        selectedTimeOption={TimeOption.TwentyFourHours}
+        onPress={handleAssetSelect}
+      />
+    </View>
+  );
+
+  const renderSkeleton = () => (
+    <Box twClassName="px-4 pt-4 gap-3">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Skeleton key={i} style={tw.style('h-14 rounded-xl')} />
+      ))}
+    </Box>
+  );
+
+  const renderEmpty = () => (
+    <Box twClassName="px-4 pt-8" alignItems={BoxAlignItems.Center}>
+      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+        {strings('rewards.ondo_rwa_asset_selector.no_results')}
+      </Text>
+    </Box>
+  );
+
+  return (
+    <ErrorBoundary navigation={navigation} view="OndoCampaignRwaSelectorView">
+      <SafeAreaView
+        edges={{ bottom: 'additive' }}
+        style={tw.style('flex-1 bg-default')}
+      >
+        <HeaderCompactStandard
+          title={title}
+          onBack={() => navigation.goBack()}
+          includesTopInset
+        />
+
+        {/* Sticky search bar */}
+        <View style={tw.style('px-4 py-2 bg-default')}>
+          <View
+            style={tw.style(
+              'flex-row items-center bg-muted rounded-xl px-3 py-2 gap-2',
+            )}
+          >
+            <Icon
+              name={IconName.Search}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+            <TextInput
+              style={tw.style('flex-1 text-default body-md')}
+              placeholder={strings(
+                'rewards.ondo_rwa_asset_selector.search_placeholder',
+              )}
+              placeholderTextColor={colors.text.muted}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+            />
+            {searchQuery.length > 0 && (
+              <TouchableOpacity
+                testID="clear-search-button"
+                onPress={() => setSearchQuery('')}
+              >
+                <Icon
+                  name={IconName.Close}
+                  size={IconSize.Sm}
+                  color={IconColor.IconAlternative}
+                />
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+
+        <View
+          style={[styles.divider, { backgroundColor: colors.border.muted }]}
+        />
+
+        {showSkeleton ? (
+          renderSkeleton()
+        ) : (
+          <FlatList<TrendingAsset>
+            data={tokens}
+            keyExtractor={(item) => item.assetId}
+            renderItem={renderItem}
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={tw.style('pt-2 pb-4')}
+            ListEmptyComponent={renderEmpty}
+          />
+        )}
+      </SafeAreaView>
+    </ErrorBoundary>
+  );
+};
+
+export default OndoCampaignRwaSelectorView;

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
@@ -82,6 +82,7 @@ function buildCampaign(overrides: Partial<CampaignDto> = {}): CampaignDto {
 
 const defaultProps = {
   hasPositions: false,
+  campaignId: 'campaign-1',
 };
 
 describe('CampaignCTA', () => {
@@ -234,7 +235,7 @@ describe('CampaignCTA', () => {
       expect(getByText('Open Position')).toBeOnTheScreen();
     });
 
-    it('navigates to RWA tokens view when pressed', () => {
+    it('navigates to RWA asset selector view when pressed', () => {
       const { getByTestId } = render(
         <CampaignCTA
           campaign={buildCampaign()}
@@ -246,7 +247,8 @@ describe('CampaignCTA', () => {
 
       fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.WALLET.RWA_TOKENS_FULL_VIEW,
+        Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+        { mode: 'open_position', campaignId: 'campaign-1' },
       );
     });
   });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
@@ -220,6 +220,44 @@ describe('CampaignCTA', () => {
     });
   });
 
+  describe('opted in, past deposit cutoff, no positions', () => {
+    it('renders nothing when deposit cutoff has passed and user has no positions', () => {
+      const { queryByTestId } = render(
+        <CampaignCTA
+          campaign={buildCampaign({
+            details: {
+              howItWorks: { title: 'How', description: 'Desc', steps: [] },
+              depositCutoffDate: '2025-08-01T00:00:00.000Z',
+            },
+          })}
+          participantStatus={optedIn}
+          {...defaultProps}
+          hasPositions={false}
+        />,
+      );
+
+      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
+    });
+
+    it('still renders swap button when deposit cutoff passed but user has positions', () => {
+      const { getByTestId } = render(
+        <CampaignCTA
+          campaign={buildCampaign({
+            details: {
+              howItWorks: { title: 'How', description: 'Desc', steps: [] },
+              depositCutoffDate: '2025-08-01T00:00:00.000Z',
+            },
+          })}
+          participantStatus={optedIn}
+          {...defaultProps}
+          hasPositions
+        />,
+      );
+
+      expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
+    });
+  });
+
   describe('opted in, no portfolio positions', () => {
     it('renders the "Open Position" button', () => {
       const { getByTestId, getByText } = render(

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.test.tsx
@@ -56,7 +56,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
     const map: Record<string, string> = {
       'rewards.campaign_details.join_campaign': 'Join Campaign',
       'rewards.campaign_details.open_position': 'Open Position',
-      'rewards.campaign_details.swap_ondo_assets': 'Swap Ondo Assets',
+
       'rewards.campaign_details.entries_closed_title': 'Entries closed',
       'rewards.campaign_details.entries_closed_description':
         'You missed the opt-in window',
@@ -254,7 +254,7 @@ describe('CampaignCTA', () => {
   });
 
   describe('opted in, with portfolio positions', () => {
-    it('renders the "Swap Ondo Assets" button', () => {
+    it('renders the "Open Position" button', () => {
       const { getByTestId, getByText } = render(
         <CampaignCTA
           campaign={buildCampaign()}
@@ -265,10 +265,10 @@ describe('CampaignCTA', () => {
       );
 
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-      expect(getByText('Swap Ondo Assets')).toBeOnTheScreen();
+      expect(getByText('Open Position')).toBeOnTheScreen();
     });
 
-    it('navigates to RWA tokens view when pressed', () => {
+    it('navigates to RWA asset selector in swap mode when pressed', () => {
       const { getByTestId } = render(
         <CampaignCTA
           campaign={buildCampaign()}
@@ -280,7 +280,8 @@ describe('CampaignCTA', () => {
 
       fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.WALLET.RWA_TOKENS_FULL_VIEW,
+        Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+        { mode: 'swap', campaignId: 'campaign-1' },
       );
     });
   });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
@@ -26,6 +26,7 @@ interface CampaignCTAProps {
     'status' | 'isLoading'
   >;
   hasPositions: boolean;
+  campaignId: string;
 }
 
 /**
@@ -42,14 +43,18 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
   campaign,
   participantStatus,
   hasPositions,
+  campaignId,
 }) => {
   const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
   const navigation = useNavigation();
   const { showToast, RewardsToastOptions } = useRewardsToast();
 
   const onOpenPosition = useCallback(() => {
-    navigation.navigate(Routes.WALLET.RWA_TOKENS_FULL_VIEW as never);
-  }, [navigation]);
+    navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
+      mode: 'open_position',
+      campaignId,
+    });
+  }, [navigation, campaignId]);
   const onSwapAssets = useCallback(() => {
     navigation.navigate(Routes.WALLET.RWA_TOKENS_FULL_VIEW as never);
   }, [navigation]);

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
@@ -129,6 +129,11 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
     );
   }
 
+  // Deposit window closed — can swap existing positions but cannot open new ones
+  if (!optinAllowed && !hasPositions) {
+    return null;
+  }
+
   if (hasPositions) {
     return (
       <Box twClassName="px-4 pt-2">

--- a/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignCTA.tsx
@@ -56,8 +56,11 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
     });
   }, [navigation, campaignId]);
   const onSwapAssets = useCallback(() => {
-    navigation.navigate(Routes.WALLET.RWA_TOKENS_FULL_VIEW as never);
-  }, [navigation]);
+    navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
+      mode: 'swap',
+      campaignId,
+    });
+  }, [navigation, campaignId]);
 
   const isActive =
     !participantStatus?.isLoading &&
@@ -136,7 +139,7 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
           onPress={onSwapAssets}
           testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
         >
-          {strings('rewards.campaign_details.swap_ondo_assets')}
+          {strings('rewards.campaign_details.open_position')}
         </Button>
       </Box>
     );

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -29,7 +29,18 @@ const setupSelectorMock = () => {
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
-  return { ...actual };
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    BottomSheet: ({
+      children,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+    }) => ReactActual.createElement(View, { testID }, children),
+  };
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
@@ -78,24 +89,6 @@ jest.mock('../../hooks/useRewardsToast', () => ({
     },
   }),
 }));
-
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    const { View } = jest.requireActual('react-native');
-    return {
-      __esModule: true,
-      default: ({
-        children,
-        testID,
-      }: {
-        children?: React.ReactNode;
-        testID?: string;
-      }) => ReactActual.createElement(View, { testID }, children),
-    };
-  },
-);
 
 jest.mock('../RewardsInfoBanner', () => {
   const ReactActual = jest.requireActual('react');

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -14,8 +14,8 @@ import {
   Text,
   TextVariant,
   FontWeight,
+  BottomSheet,
 } from '@metamask/design-system-react-native';
-import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import {
   type CampaignDto,
   CampaignType,

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { noop } from 'lodash';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -99,7 +100,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   }, [navigation]);
 
   return (
-    <BottomSheet shouldNavigateBack={false} onClose={onClose}>
+    <BottomSheet shouldNavigateBack={false} goBack={noop} onClose={onClose}>
       <Box twClassName="px-4 pb-4">
         {/* Header: centered title + close button */}
         <Box

--- a/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.test.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import OndoAccountPickerSheet from './OndoAccountPickerSheet';
+import type { AccountPickerConfig } from './OndoPortfolio';
+import type { BottomSheetRef } from '@metamask/design-system-react-native';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    BottomSheet: ({
+      children,
+      onClose,
+    }: {
+      children?: React.ReactNode;
+      onClose?: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'bottom-sheet' },
+        children,
+        ReactActual.createElement(Pressable, {
+          testID: 'sheet-backdrop-close',
+          onPress: onClose,
+        }),
+      ),
+    BottomSheetHeader: ({
+      children,
+      onClose,
+    }: {
+      children?: React.ReactNode;
+      onClose?: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'bottom-sheet-header' },
+        children,
+        ReactActual.createElement(Pressable, {
+          testID: 'sheet-header-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('../../../../../component-library/components/Badges/Badge', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => ReactActual.createElement(View, null),
+    BadgeVariant: { Network: 'Network' },
+  };
+});
+
+jest.mock('../../../../../component-library/components/Avatars/Avatar', () => ({
+  AvatarSize: { Xs: 'xs', Sm: 'sm', Md: 'md', Lg: 'lg' },
+}));
+
+jest.mock('../../../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
+}));
+
+jest.mock('../../../Trending/components/TrendingTokenLogo', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => ReactActual.createElement(View, null),
+  };
+});
+
+jest.mock(
+  '../../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectResolvedSelectedAccountGroup: jest.fn(),
+  }),
+);
+
+jest.mock('./OndoPortfolio', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Pressable, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    AccountGroupSelectRow: ({
+      group,
+      onPress,
+      isSelected,
+    }: {
+      group: { id: string };
+      onPress: () => void;
+      isSelected: boolean;
+    }) =>
+      ReactActual.createElement(
+        Pressable,
+        { testID: `account-row-${group.id}`, onPress },
+        ReactActual.createElement(
+          Text,
+          null,
+          isSelected ? 'selected' : 'unselected',
+        ),
+      ),
+    getChainHex: jest.fn(() => '0x1'),
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const translations: Record<string, string> = {
+      'rewards.ondo_campaign_portfolio.switch_account_sheet_prefix':
+        'Switch to',
+      'rewards.ondo_campaign_portfolio.switch_account_sheet_description':
+        'Select an account to swap with.',
+    };
+    return translations[key] ?? key;
+  },
+}));
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+const MOCK_GROUP_1 = {
+  id: 'group-1',
+  metadata: { name: 'Account 1' },
+} as never;
+const MOCK_GROUP_2 = {
+  id: 'group-2',
+  metadata: { name: 'Account 2' },
+} as never;
+
+const MOCK_PICKER_CONFIG: AccountPickerConfig = {
+  row: {
+    tokenAsset: 'eip155:1/erc20:0xabc',
+    tokenSymbol: 'USDC',
+    tokenName: 'USD Coin',
+  } as never,
+  entries: [
+    { group: MOCK_GROUP_1, balance: '100' },
+    { group: MOCK_GROUP_2, balance: '200' },
+  ],
+  tokenDecimals: 6,
+};
+
+const mockOnClose = jest.fn();
+const mockOnGroupSelect = jest.fn();
+const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
+const mockSheetRef = {
+  current: {
+    onOpenBottomSheet: jest.fn(),
+    onCloseBottomSheet: mockOnCloseBottomSheet,
+  },
+} as unknown as React.RefObject<BottomSheetRef>;
+
+const renderSheet = (
+  overrides?: Partial<React.ComponentProps<typeof OndoAccountPickerSheet>>,
+) =>
+  render(
+    <OndoAccountPickerSheet
+      pendingPicker={MOCK_PICKER_CONFIG}
+      sheetRef={mockSheetRef}
+      onClose={mockOnClose}
+      onGroupSelect={mockOnGroupSelect}
+      {...overrides}
+    />,
+  );
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('OndoAccountPickerSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(null);
+  });
+
+  it('renders the bottom sheet', () => {
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('bottom-sheet')).toBeDefined();
+  });
+
+  it('renders the sheet header', () => {
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('bottom-sheet-header')).toBeDefined();
+  });
+
+  it('renders the sheet prefix text', () => {
+    const { getByText } = renderSheet();
+    expect(getByText('Switch to', { exact: false })).toBeDefined();
+  });
+
+  it('renders the token symbol', () => {
+    const { getByText } = renderSheet();
+    expect(getByText('USDC', { exact: false })).toBeDefined();
+  });
+
+  it('renders a row for each entry', () => {
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('account-row-group-1')).toBeDefined();
+    expect(getByTestId('account-row-group-2')).toBeDefined();
+  });
+
+  it('calls onClose when the BottomSheet backdrop onClose fires', () => {
+    const { getByTestId } = renderSheet();
+    fireEvent.press(getByTestId('sheet-backdrop-close'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCloseBottomSheet(onClose) when the header close button is pressed', () => {
+    const { getByTestId } = renderSheet();
+    fireEvent.press(getByTestId('sheet-header-close'));
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledWith(mockOnClose);
+  });
+
+  it('invokes onClose after the sheet animation when header close is pressed', () => {
+    // mockOnCloseBottomSheet calls its callback immediately
+    const { getByTestId } = renderSheet();
+    fireEvent.press(getByTestId('sheet-header-close'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onGroupSelect with the correct group when a row is pressed', () => {
+    const { getByTestId } = renderSheet();
+    fireEvent.press(getByTestId('account-row-group-1'));
+    expect(mockOnGroupSelect).toHaveBeenCalledWith(MOCK_GROUP_1);
+  });
+
+  it('calls onGroupSelect with the second group when the second row is pressed', () => {
+    const { getByTestId } = renderSheet();
+    fireEvent.press(getByTestId('account-row-group-2'));
+    expect(mockOnGroupSelect).toHaveBeenCalledWith(MOCK_GROUP_2);
+  });
+
+  it('marks the currently selected group row as selected', () => {
+    mockUseSelector.mockReturnValue(MOCK_GROUP_2);
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('account-row-group-2')).toHaveTextContent('selected');
+    expect(getByTestId('account-row-group-1')).toHaveTextContent('unselected');
+  });
+
+  it('marks no row as selected when selectedGroup is null', () => {
+    mockUseSelector.mockReturnValue(null);
+    const { getByTestId } = renderSheet();
+    expect(getByTestId('account-row-group-1')).toHaveTextContent('unselected');
+    expect(getByTestId('account-row-group-2')).toHaveTextContent('unselected');
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
@@ -1,0 +1,128 @@
+import React, { useMemo } from 'react';
+import { ScrollView, useWindowDimensions } from 'react-native';
+import { useSelector } from 'react-redux';
+import {
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  BottomSheet,
+  BottomSheetHeader,
+  BottomSheetRef,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
+import { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import { NetworkBadgeSource } from '../../../AssetOverview/Balance/Balance';
+import TrendingTokenLogo from '../../../Trending/components/TrendingTokenLogo';
+import { selectResolvedSelectedAccountGroup } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import {
+  AccountGroupSelectRow,
+  getChainHex,
+  type AccountPickerConfig,
+} from './OndoPortfolio';
+import { strings } from '../../../../../../locales/i18n';
+
+interface OndoAccountPickerSheetProps {
+  pendingPicker: AccountPickerConfig;
+  sheetRef: React.RefObject<BottomSheetRef>;
+  onClose: () => void;
+  onGroupSelect: (group: AccountGroupObject) => void;
+}
+
+const OndoAccountPickerSheet: React.FC<OndoAccountPickerSheetProps> = ({
+  pendingPicker,
+  sheetRef,
+  onClose,
+  onGroupSelect,
+}) => {
+  const selectedGroup = useSelector(selectResolvedSelectedAccountGroup);
+  const { height: screenHeight } = useWindowDimensions();
+  const listStyle = useMemo(
+    () => ({ maxHeight: screenHeight * 0.4 }),
+    [screenHeight],
+  );
+
+  return (
+    <BottomSheet
+      shouldNavigateBack={false}
+      onClose={onClose}
+      goBack={onClose}
+      ref={sheetRef}
+    >
+      <BottomSheetHeader
+        onClose={() => sheetRef.current?.onCloseBottomSheet(onClose)}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-1"
+        >
+          <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+            {`${strings('rewards.ondo_campaign_portfolio.switch_account_sheet_prefix')} `}
+          </Text>
+          <BadgeWrapper
+            position={BadgeWrapperPosition.BottomRight}
+            badge={
+              getChainHex(pendingPicker.row.tokenAsset) ? (
+                <Badge
+                  variant={BadgeVariant.Network}
+                  size={AvatarSize.Xs}
+                  isScaled={false}
+                  imageSource={NetworkBadgeSource(
+                    getChainHex(pendingPicker.row.tokenAsset) as Hex,
+                  )}
+                />
+              ) : null
+            }
+          >
+            <TrendingTokenLogo
+              assetId={pendingPicker.row.tokenAsset}
+              symbol={pendingPicker.row.tokenSymbol}
+              size={28}
+            />
+          </BadgeWrapper>
+          <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+            {` ${pendingPicker.row.tokenSymbol} ${pendingPicker.entries
+              .reduce(
+                (sum, e) => sum.plus(new BigNumber(e.balance)),
+                new BigNumber(0),
+              )
+              .toFixed(2)}`}
+          </Text>
+        </Box>
+      </BottomSheetHeader>
+      <Box twClassName="px-4 pb-3">
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {strings(
+            'rewards.ondo_campaign_portfolio.switch_account_sheet_description',
+          )}
+        </Text>
+      </Box>
+      <ScrollView style={listStyle}>
+        {pendingPicker.entries.map(({ group, balance }) => (
+          <AccountGroupSelectRow
+            key={group.id}
+            group={group}
+            balance={balance}
+            tokenSymbol={pendingPicker.row.tokenSymbol}
+            isSelected={group.id === selectedGroup?.id}
+            onPress={() => onGroupSelect(group)}
+          />
+        ))}
+      </ScrollView>
+    </BottomSheet>
+  );
+};
+
+export default OndoAccountPickerSheet;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -612,6 +612,34 @@ describe('OndoPortfolio', () => {
       fireEvent.press(getByTestId('info-banner-confirm'));
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeOnTheScreen();
     });
+
+    it('does not render CTA button when campaign is complete', () => {
+      const { queryByTestId } = render(
+        <OndoPortfolio {...baseProps} hasFetched isCampaignComplete />,
+      );
+      expect(queryByTestId('info-banner-confirm')).toBeNull();
+    });
+  });
+
+  describe('campaign complete state', () => {
+    const loadedProps = {
+      ...baseProps,
+      portfolio: MOCK_PORTFOLIO,
+      hasFetched: true,
+      isCampaignComplete: true,
+    };
+
+    it('renders position rows without triggering navigation on press', () => {
+      const onOpenAccountPicker = jest.fn();
+      const { getByText } = render(
+        <OndoPortfolio
+          {...loadedProps}
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+      fireEvent.press(getByText('Apple Inc.'));
+      expect(onOpenAccountPicker).not.toHaveBeenCalled();
+    });
   });
 
   describe('AccountGroupSelectRow', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import OndoPortfolio, { ONDO_PORTFOLIO_TEST_IDS } from './OndoPortfolio';
+import { useSelector } from 'react-redux';
+import OndoPortfolio, {
+  ONDO_PORTFOLIO_TEST_IDS,
+  AccountGroupSelectRow,
+} from './OndoPortfolio';
 import type {
   OndoGmPortfolioDto,
   OndoGmPortfolioPositionDto,
@@ -19,6 +23,75 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn(), dispatch: jest.fn() }),
   StackActions: { push: jest.fn((name: string) => ({ type: 'push', name })) },
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => null),
+}));
+
+jest.mock('../../hooks/useRewardsToast', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: jest.fn(),
+    RewardsToastOptions: {
+      error: jest.fn((title: string, desc: string) => ({
+        type: 'error',
+        title,
+        desc,
+      })),
+    },
+  }),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: { setSelectedAccountGroup: jest.fn() },
+    },
+  },
+}));
+
+jest.mock('../../utils/formatUtils', () => ({
+  ...jest.requireActual('../../utils/formatUtils'),
+  parseCaip19: jest.fn(() => ({
+    namespace: 'eip155',
+    chainId: '1',
+    assetReference: '0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c',
+  })),
+  caipChainIdToHex: jest.fn(() => '0x1'),
+}));
+
+jest.mock('../../../../../selectors/rewards', () => ({
+  selectCurrentSubscriptionAccounts: jest.fn(() => []),
+}));
+
+jest.mock('../../../../../selectors/tokenBalancesController', () => ({
+  selectAllTokenBalances: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../selectors/tokenListController', () => ({
+  selectERC20TokensByChain: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../selectors/tokensController', () => ({
+  selectAllTokens: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../selectors/accountsController', () => ({
+  selectInternalAccountByAddresses: jest.fn(() => () => []),
+}));
+
+jest.mock(
+  '../../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectAccountToGroupMap: jest.fn(() => ({})),
+    selectResolvedSelectedAccountGroup: jest.fn(() => null),
+  }),
+);
+
+jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectIconSeedAddressByAccountGroupId: jest.fn(() => jest.fn(() => null)),
 }));
 
 jest.mock('../RewardsErrorBanner', () => {
@@ -100,21 +173,81 @@ jest.mock('../../../../../util/ondoGeoRestrictions', () => ({
   isGeoRestricted: jest.fn(() => false),
 }));
 
-jest.mock(
-  '../../../../../images/rewards/rewards-no-positions.svg',
-  () => 'NoPositionsImage',
-);
-
-jest.mock('../../../../../util/theme', () => {
-  const { mockTheme } = jest.requireActual('../../../../../util/theme');
-  return {
-    useTheme: () => mockTheme,
-  };
-});
-
 jest.mock('./OndoLeaderboard.utils', () => ({
   formatComputedAt: jest.fn(),
 }));
+
+jest.mock('../RewardsInfoBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      title,
+      onConfirm,
+      confirmButtonLabel,
+    }: {
+      title: string;
+      description: string;
+      onConfirm?: () => void;
+      confirmButtonLabel?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'rewards-info-banner' },
+        ReactActual.createElement(Text, null, title),
+        onConfirm &&
+          ReactActual.createElement(
+            Pressable,
+            { onPress: onConfirm, testID: 'info-banner-confirm' },
+            ReactActual.createElement(
+              Text,
+              null,
+              confirmButtonLabel ?? 'Confirm',
+            ),
+          ),
+      ),
+  };
+});
+
+jest.mock(
+  '../../../../../component-library/components/List/ListItemSelect',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { TouchableOpacity } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        children,
+        onPress,
+      }: {
+        children?: React.ReactNode;
+        onPress?: () => void;
+        isSelected?: boolean;
+        isDisabled?: boolean;
+        verticalAlignment?: string;
+      }) =>
+        ReactActual.createElement(
+          TouchableOpacity,
+          { onPress, testID: 'list-item-select' },
+          children,
+        ),
+    };
+  },
+);
+
+jest.mock(
+  '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: () =>
+        ReactActual.createElement(View, { testID: 'avatar-account' }),
+    };
+  },
+);
 
 const mockRefetch = jest.fn();
 
@@ -152,6 +285,8 @@ const baseProps = {
   hasError: false,
   hasFetched: false,
   refetch: mockRefetch,
+  campaignId: 'campaign-1',
+  onOpenAccountPicker: jest.fn(),
 };
 
 describe('OndoPortfolio', () => {
@@ -294,6 +429,24 @@ describe('OndoPortfolio', () => {
       hasFetched: true,
     };
 
+    beforeEach(() => {
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectERC20TokensByChain } = jest.requireMock(
+          '../../../../../selectors/tokenListController',
+        );
+        if (selector === selectAllTokens) return {};
+        if (selector === selectERC20TokensByChain) return {};
+        return null;
+      });
+    });
+
+    afterEach(() => {
+      (useSelector as jest.Mock).mockReturnValue(null);
+    });
+
     it('pressing a position row does not throw', () => {
       const { getByText } = render(<OndoPortfolio {...loadedProps} />);
       fireEvent.press(getByText('Apple Inc.'));
@@ -311,6 +464,97 @@ describe('OndoPortfolio', () => {
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeDefined();
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.CONTAINER)).toBeNull();
+    });
+  });
+
+  describe('zero balance filtering in getAccountsWithBalance', () => {
+    // Sets up useSelector so that one subscription account has the given raw hex
+    // balance for the mocked token, then presses the position row and asserts
+    // that onOpenAccountPicker is NOT called (the account is treated as zero).
+    const TOKEN_ADDRESS = '0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c';
+    const ACCOUNT_ADDRESS = '0xdeadbeef00000000000000000000000000000001';
+    const CAIP_ACCOUNT = `eip155:1:${ACCOUNT_ADDRESS}`;
+
+    const buildPropsWithBalance = (rawHexBalance: string) => {
+      const mockOnOpenAccountPicker = jest.fn();
+
+      // Set up two groups so that if balance leaks through the filter the
+      // component would open the account picker instead of navigating.
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectERC20TokensByChain } = jest.requireMock(
+          '../../../../../selectors/tokenListController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccountByAddresses } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_ACCOUNT }];
+        if (selector === selectAllTokenBalances)
+          return {
+            [ACCOUNT_ADDRESS.toLowerCase()]: {
+              '0x1': { [TOKEN_ADDRESS]: rawHexBalance },
+            },
+          };
+        if (selector === selectERC20TokensByChain) return {};
+        if (selector === selectAllTokens) return {};
+        if (selector === selectInternalAccountByAddresses) return () => [];
+        return null;
+      });
+
+      return {
+        ...baseProps,
+        portfolio: MOCK_PORTFOLIO,
+        hasFetched: true,
+        onOpenAccountPicker: mockOnOpenAccountPicker,
+      };
+    };
+
+    afterEach(() => {
+      // Restore the default useSelector mock for other tests
+      (useSelector as jest.Mock).mockReturnValue(null);
+    });
+
+    it.each([
+      ['0x0', 'single zero digit'],
+      ['0x00', 'two zero digits'],
+      ['0x', 'no digits after prefix'],
+      [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '64 zero digits (full 32-byte word)',
+      ],
+    ])(
+      'treats %s (%s) as zero and does not open account picker',
+      (rawHexBalance) => {
+        const props = buildPropsWithBalance(rawHexBalance);
+        const { getByText } = render(<OndoPortfolio {...props} />);
+
+        fireEvent.press(getByText('Apple Inc.'));
+
+        expect(props.onOpenAccountPicker).not.toHaveBeenCalled();
+      },
+    );
+
+    it('treats a non-zero hex balance as non-zero', () => {
+      const props = buildPropsWithBalance('0x1');
+      // With one account holding balance in one group, the component navigates
+      // directly (groups.length === 1) — picker is still not opened. What we
+      // want to confirm is that the account IS considered to have balance (i.e.
+      // selectInternalAccountByAddresses is called with a non-empty array).
+      // We verify this indirectly: if the account were filtered out the
+      // component would call navigateToSwap via the groups.length === 0 branch,
+      // which is the same observable outcome. So we just assert the render
+      // doesn't throw and the row is pressable.
+      const { getByText } = render(<OndoPortfolio {...props} />);
+      expect(() => fireEvent.press(getByText('Apple Inc.'))).not.toThrow();
     });
   });
 
@@ -357,6 +601,198 @@ describe('OndoPortfolio', () => {
         />,
       );
       expect(queryByText('—')).toBeNull();
+    });
+
+    it('navigates to RWA selector when section header is pressed with positions', () => {
+      const { getByText } = render(
+        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} hasFetched />,
+      );
+      fireEvent.press(getByText('rewards.ondo_campaign_portfolio.title'));
+      // Navigation called without throwing — the title is still on screen
+      expect(
+        getByText('rewards.ondo_campaign_portfolio.title'),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('empty state CTA', () => {
+    it('triggers navigate when empty state confirm button is pressed', () => {
+      const { getByTestId } = render(
+        <OndoPortfolio {...baseProps} hasFetched />,
+      );
+      fireEvent.press(getByTestId('info-banner-confirm'));
+      expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeOnTheScreen();
+    });
+  });
+
+  describe('AccountGroupSelectRow', () => {
+    it('renders group name and balance', () => {
+      const group = {
+        id: 'g1',
+        metadata: { name: 'My Group' },
+      } as never;
+      const onPress = jest.fn();
+      const { getByText } = render(
+        <AccountGroupSelectRow
+          group={group}
+          balance="12.500000"
+          tokenSymbol="AAPL"
+          isSelected={false}
+          onPress={onPress}
+        />,
+      );
+      expect(getByText('My Group')).toBeOnTheScreen();
+      expect(getByText('12.500000 AAPL')).toBeOnTheScreen();
+    });
+
+    it('calls onPress when the row is pressed', () => {
+      const group = { id: 'g1', metadata: { name: 'My Group' } } as never;
+      const onPress = jest.fn();
+      const { getByTestId } = render(
+        <AccountGroupSelectRow
+          group={group}
+          balance="0"
+          tokenSymbol="AAPL"
+          isSelected={false}
+          onPress={onPress}
+        />,
+      );
+      fireEvent.press(getByTestId('list-item-select'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleRowPress account group branching', () => {
+    const TOKEN_ADDRESS = '0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c';
+    const ACCOUNT_1 = '0xdeadbeef00000000000000000000000000000001';
+    const ACCOUNT_2 = '0xdeadbeef00000000000000000000000000000002';
+    const CAIP_1 = `eip155:1:${ACCOUNT_1}`;
+    const CAIP_2 = `eip155:1:${ACCOUNT_2}`;
+    const GROUP_1 = { id: 'group-1', metadata: { name: 'Account 1' } } as never;
+    const GROUP_2 = { id: 'group-2', metadata: { name: 'Account 2' } } as never;
+
+    afterEach(() => {
+      (useSelector as jest.Mock).mockReturnValue(null);
+    });
+
+    it('navigates directly when exactly one group has the token balance', () => {
+      const onOpenAccountPicker = jest.fn();
+
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectERC20TokensByChain } = jest.requireMock(
+          '../../../../../selectors/tokenListController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccountByAddresses } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+          jest.requireMock(
+            '../../../../../selectors/multichainAccounts/accountTreeController',
+          );
+
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_1 }];
+        if (selector === selectAllTokenBalances)
+          return {
+            [ACCOUNT_1]: {
+              '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
+            },
+          };
+        if (selector === selectERC20TokensByChain) return {};
+        if (selector === selectAllTokens) return {};
+        if (selector === selectInternalAccountByAddresses)
+          return () => [{ id: 'acc-1', address: ACCOUNT_1 }];
+        if (selector === selectAccountToGroupMap) return { 'acc-1': GROUP_1 };
+        if (selector === selectResolvedSelectedAccountGroup) return null;
+        return null;
+      });
+
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          hasFetched
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+
+      fireEvent.press(getByText('Apple Inc.'));
+
+      // Single group → navigates directly, picker NOT opened
+      expect(onOpenAccountPicker).not.toHaveBeenCalled();
+    });
+
+    it('opens account picker when multiple groups hold the token', () => {
+      const onOpenAccountPicker = jest.fn();
+
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectERC20TokensByChain } = jest.requireMock(
+          '../../../../../selectors/tokenListController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccountByAddresses } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+          jest.requireMock(
+            '../../../../../selectors/multichainAccounts/accountTreeController',
+          );
+
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_1 }, { account: CAIP_2 }];
+        if (selector === selectAllTokenBalances)
+          return {
+            [ACCOUNT_1]: {
+              '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
+            },
+            [ACCOUNT_2]: {
+              '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
+            },
+          };
+        if (selector === selectERC20TokensByChain) return {};
+        if (selector === selectAllTokens) return {};
+        if (selector === selectInternalAccountByAddresses)
+          return () => [
+            { id: 'acc-1', address: ACCOUNT_1 },
+            { id: 'acc-2', address: ACCOUNT_2 },
+          ];
+        if (selector === selectAccountToGroupMap)
+          return { 'acc-1': GROUP_1, 'acc-2': GROUP_2 };
+        if (selector === selectResolvedSelectedAccountGroup) return null;
+        return null;
+      });
+
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          hasFetched
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+
+      fireEvent.press(getByText('Apple Inc.'));
+
+      expect(onOpenAccountPicker).toHaveBeenCalledTimes(1);
+      const config = (onOpenAccountPicker as jest.Mock).mock.calls[0][0];
+      expect(config.entries).toHaveLength(2);
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -602,17 +602,6 @@ describe('OndoPortfolio', () => {
       );
       expect(queryByText('—')).toBeNull();
     });
-
-    it('navigates to RWA selector when section header is pressed with positions', () => {
-      const { getByText } = render(
-        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} hasFetched />,
-      );
-      fireEvent.press(getByText('rewards.ondo_campaign_portfolio.title'));
-      // Navigation called without throwing — the title is still on screen
-      expect(
-        getByText('rewards.ondo_campaign_portfolio.title'),
-      ).toBeOnTheScreen();
-    });
   });
 
   describe('empty state CTA', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -154,6 +154,7 @@ interface OndoPortfolioProps {
   refetch: () => Promise<void>;
   campaignId: string;
   onOpenAccountPicker: (config: AccountPickerConfig) => void;
+  isCampaignComplete?: boolean;
 }
 
 const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
@@ -397,50 +398,6 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
 
   return (
     <Box twClassName="gap-3" testID={ONDO_PORTFOLIO_TEST_IDS.CONTAINER}>
-      {/* Section header */}
-      <TouchableOpacity
-        onPress={
-          grouped.length > 0
-            ? () => {
-                navigation.navigate(
-                  Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
-                  { mode: 'open_position', campaignId },
-                );
-              }
-            : undefined
-        }
-        activeOpacity={grouped.length > 0 ? 0.7 : 1}
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="mb-4 gap-2"
-        >
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('rewards.ondo_campaign_portfolio.title')}
-          </Text>
-          {grouped.length > 0 && (
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Md}
-              color={IconColor.IconDefault}
-            />
-          )}
-          {portfolio.computedAt && portfolio.positions.length > 0 && (
-            <Box twClassName="flex-1" alignItems={BoxAlignItems.End}>
-              <Text
-                variant={TextVariant.BodyXs}
-                color={TextColor.TextAlternative}
-              >
-                {strings('rewards.ondo_campaign_portfolio.updated_at', {
-                  time: formatComputedAt(portfolio.computedAt),
-                })}
-              </Text>
-            </Box>
-          )}
-        </Box>
-      </TouchableOpacity>
-
       {/* Positions */}
       <Box twClassName="gap-3">
         {grouped.map((row) => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -165,6 +165,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   refetch,
   campaignId,
   onOpenAccountPicker,
+  isCampaignComplete = false,
 }) => {
   const navigation = useNavigation();
 
@@ -378,15 +379,17 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
           description={strings(
             'rewards.ondo_campaign_portfolio.empty_description',
           )}
-          onConfirm={() => {
-            navigation.navigate(
-              Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
-              { mode: 'open_position', campaignId },
-            );
-          }}
-          confirmButtonLabel={strings(
-            'rewards.ondo_campaign_portfolio.empty_cta',
-          )}
+          {...(!isCampaignComplete && {
+            onConfirm: () => {
+              navigation.navigate(
+                Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+                { mode: 'open_position', campaignId },
+              );
+            },
+            confirmButtonLabel: strings(
+              'rewards.ondo_campaign_portfolio.empty_cta',
+            ),
+          })}
         />
       </Box>
     );
@@ -409,10 +412,10 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
           return (
             <TouchableOpacity
               key={row.tokenAsset}
-              onPress={() => {
-                handleRowPress(row);
-              }}
-              activeOpacity={0.7}
+              onPress={
+                isCampaignComplete ? undefined : () => handleRowPress(row)
+              }
+              activeOpacity={isCampaignComplete ? 1 : 0.7}
             >
               <Box
                 flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { TouchableOpacity } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import {
   BadgeWrapper,
   BadgeWrapperPosition,
@@ -20,9 +20,10 @@ import {
   TextVariant,
   FontWeight,
 } from '@metamask/design-system-react-native';
-import { StackActions, useNavigation } from '@react-navigation/native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Hex } from '@metamask/utils';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { parseCaipAccountId, Hex, type CaipChainId } from '@metamask/utils';
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
 import { BigNumber } from 'bignumber.js';
 import { strings } from '../../../../../../locales/i18n';
 import formatFiat from '../../../../../util/formatFiat';
@@ -30,41 +31,49 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import { AvatarAccountType } from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.types';
 import { NetworkBadgeSource } from '../../../AssetOverview/Balance/Balance';
-import { parseCAIP19AssetId } from '../../../Ramp/Aggregator/utils/parseCaip19AssetId';
+import { parseCaip19, caipChainIdToHex } from '../../utils/formatUtils';
 import TrendingTokenLogo from '../../../Trending/components/TrendingTokenLogo';
-import { getTrendingTokenImageUrl } from '../../../Trending/utils/getTrendingTokenImageUrl';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
-import type { OndoGmPortfolioDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import type {
+  OndoGmPortfolioDto,
+  OndoGmPortfolioPositionDto,
+} from '../../../../../core/Engine/controllers/rewards-controller/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import NoPositionsImage from '../../../../../images/rewards/rewards-no-positions.svg';
-import { useTheme } from '../../../../../util/theme';
 import {
   groupPortfolioPositionsByAsset,
   formatPnlPercent,
   isPnlNonNegative,
-  getChainHex,
 } from './OndoPortfolio.utils';
 import { formatComputedAt } from './OndoLeaderboard.utils';
+import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
+import { selectAllTokenBalances } from '../../../../../selectors/tokenBalancesController';
+import { selectERC20TokensByChain } from '../../../../../selectors/tokenListController';
+import { selectAllTokens } from '../../../../../selectors/tokensController';
+import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
+import {
+  selectAccountToGroupMap,
+  selectResolvedSelectedAccountGroup,
+} from '../../../../../selectors/multichainAccounts/accountTreeController';
+import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
+import { VerticalAlignment } from '../../../../../component-library/components/List/ListItem';
+import AvatarAccount from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
+import { selectIconSeedAddressByAccountGroupId } from '../../../../../selectors/multichainAccounts/accounts';
+import Engine from '../../../../../core/Engine';
+import RewardsInfoBanner from '../RewardsInfoBanner';
 
-const getAssetNavParams = (
-  tokenAsset: string,
-  tokenSymbol: string,
-  tokenName: string,
-) => {
-  const parsed = parseCAIP19AssetId(tokenAsset);
-  if (!parsed || parsed.namespace !== 'eip155') return null;
-  const chainId = `0x${parseInt(parsed.chainId, 10).toString(16)}` as Hex;
-  return {
-    chainId,
-    address: parsed.assetReference,
-    symbol: tokenSymbol,
-    name: tokenName,
-    image: getTrendingTokenImageUrl(tokenAsset),
-    isFromTrending: true,
-    source: TokenDetailsSource.Trending,
-  };
+const styles = StyleSheet.create({
+  skeletonLg: { height: 128, borderRadius: 12 },
+  skeletonMd: { height: 96, borderRadius: 12 },
+});
+
+export const getChainHex = (caip19: string) => {
+  const parsed = parseCaip19(caip19);
+  if (!parsed || parsed.namespace !== 'eip155') return undefined;
+  return caipChainIdToHex(
+    `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+  );
 };
 
 export const ONDO_PORTFOLIO_TEST_IDS = {
@@ -82,12 +91,69 @@ const formatUsd = (value: string): string => {
   }
 };
 
+export interface AccountPickerConfig {
+  row: OndoGmPortfolioPositionDto;
+  entries: { group: AccountGroupObject; balance: string }[];
+  tokenDecimals: number;
+}
+
+interface AccountGroupSelectRowProps {
+  group: AccountGroupObject;
+  balance: string;
+  tokenSymbol: string;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+export const AccountGroupSelectRow: React.FC<AccountGroupSelectRowProps> = ({
+  group,
+  balance,
+  tokenSymbol,
+  isSelected,
+  onPress,
+}) => {
+  const selectEvmAddress = useMemo(
+    () => selectIconSeedAddressByAccountGroupId(group.id),
+    [group.id],
+  );
+  const evmAddress = useSelector(selectEvmAddress);
+
+  return (
+    <ListItemSelect
+      isSelected={isSelected}
+      isDisabled={false}
+      onPress={onPress}
+      verticalAlignment={VerticalAlignment.Center}
+    >
+      <AvatarAccount
+        accountAddress={evmAddress}
+        type={AvatarAccountType.Blockies}
+        size={AvatarSize.Md}
+      />
+      <Box twClassName="flex-1 min-w-0">
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          numberOfLines={1}
+        >
+          {group.metadata.name}
+        </Text>
+      </Box>
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {`${balance} ${tokenSymbol}`}
+      </Text>
+    </ListItemSelect>
+  );
+};
+
 interface OndoPortfolioProps {
   portfolio: OndoGmPortfolioDto | null;
   isLoading: boolean;
   hasError: boolean;
   hasFetched: boolean;
   refetch: () => Promise<void>;
+  campaignId: string;
+  onOpenAccountPicker: (config: AccountPickerConfig) => void;
 }
 
 const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
@@ -96,15 +162,178 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   hasError,
   hasFetched,
   refetch,
+  campaignId,
+  onOpenAccountPicker,
 }) => {
-  const tw = useTailwind();
   const navigation = useNavigation();
-  const theme = useTheme();
 
+  const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
+  const allTokenBalances = useSelector(selectAllTokenBalances);
+  const erc20TokensByChain = useSelector(selectERC20TokensByChain);
+  const allTokens = useSelector(selectAllTokens);
+  const accountToGroupMap = useSelector(selectAccountToGroupMap);
+  const selectedGroup = useSelector(selectResolvedSelectedAccountGroup);
+  const resolveAccountsByAddresses = useSelector(
+    selectInternalAccountByAddresses,
+  );
   const grouped = useMemo(
     () =>
       portfolio ? groupPortfolioPositionsByAsset(portfolio.positions) : [],
     [portfolio],
+  );
+
+  /** Returns InternalAccounts from the subscription that hold a non-zero balance of the given token. */
+  const getAccountsWithBalance = useCallback(
+    (row: OndoGmPortfolioPositionDto) => {
+      if (!subscriptionAccounts) return [];
+      const parsed = parseCaip19(row.tokenAsset);
+      if (!parsed || parsed.namespace !== 'eip155') return [];
+      const chainHex = caipChainIdToHex(
+        `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      );
+      const tokenHex = parsed.assetReference.toLowerCase() as Hex;
+      const addresses = subscriptionAccounts.flatMap((a) => {
+        const address = parseCaipAccountId(a.account).address;
+        const bal =
+          allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex]?.[
+            tokenHex
+          ];
+        return bal !== undefined && !!parseInt(bal, 16) ? [address] : [];
+      });
+      return resolveAccountsByAddresses(addresses);
+    },
+    [subscriptionAccounts, allTokenBalances, resolveAccountsByAddresses],
+  );
+
+  /** Returns unique AccountGroups from a pre-computed list of accounts. */
+  const getGroupsFromAccounts = useCallback(
+    (
+      accounts: ReturnType<typeof resolveAccountsByAddresses>,
+    ): AccountGroupObject[] => {
+      const seenGroups = new Map<string, AccountGroupObject>();
+      for (const account of accounts) {
+        const group = accountToGroupMap[account.id];
+        if (group && !seenGroups.has(group.id)) {
+          seenGroups.set(group.id, group);
+        }
+      }
+      return Array.from(seenGroups.values());
+    },
+    [accountToGroupMap],
+  );
+
+  const resolveTokenDecimals = useCallback(
+    (row: OndoGmPortfolioPositionDto): number => {
+      const parsed = parseCaip19(row.tokenAsset);
+      if (!parsed || parsed.namespace !== 'eip155') return 18;
+      const chainHex = caipChainIdToHex(
+        `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      );
+      const tokenHex = parsed.assetReference.toLowerCase() as Hex;
+      const tokenListDecimals =
+        erc20TokensByChain?.[chainHex]?.data?.[tokenHex]?.decimals;
+      const trackedDecimals =
+        tokenListDecimals === undefined
+          ? Object.values(allTokens[chainHex] ?? {})
+              .flat()
+              .find((t) => t.address.toLowerCase() === tokenHex)?.decimals
+          : undefined;
+      return tokenListDecimals ?? trackedDecimals ?? 18;
+    },
+    [erc20TokensByChain, allTokens],
+  );
+
+  /** Returns the total token balance held across all accounts in the group, summed from raw hex values. */
+  const getGroupBalance = useCallback(
+    (
+      group: AccountGroupObject,
+      accounts: ReturnType<typeof resolveAccountsByAddresses>,
+      row: OndoGmPortfolioPositionDto,
+      decimals: number,
+    ): string => {
+      const parsed = parseCaip19(row.tokenAsset);
+      if (!parsed || parsed.namespace !== 'eip155') return '0';
+      const chainHex = caipChainIdToHex(
+        `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      );
+      const tokenHex = parsed.assetReference.toLowerCase() as Hex;
+      const groupAccounts = accounts.filter(
+        (a) => accountToGroupMap[a.id]?.id === group.id,
+      );
+      let total = new BigNumber(0);
+      for (const account of groupAccounts) {
+        const hexBal =
+          allTokenBalances?.[account.address.toLowerCase() as Hex]?.[
+            chainHex
+          ]?.[tokenHex];
+        if (hexBal) {
+          try {
+            total = total.plus(new BigNumber(hexBal).shiftedBy(-decimals));
+          } catch {
+            // ignore malformed balance
+          }
+        }
+      }
+      return total.toFixed(6);
+    },
+    [accountToGroupMap, allTokenBalances],
+  );
+
+  const navigateToSwap = useCallback(
+    (row: OndoGmPortfolioPositionDto) => {
+      navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
+        mode: 'swap',
+        srcTokenAsset: row.tokenAsset,
+        srcTokenSymbol: row.tokenSymbol,
+        srcTokenName: row.tokenName,
+        srcTokenDecimals: resolveTokenDecimals(row),
+        campaignId,
+      });
+    },
+    [navigation, campaignId, resolveTokenDecimals],
+  );
+
+  const handleRowPress = useCallback(
+    (row: OndoGmPortfolioPositionDto) => {
+      const accountsForRow = getAccountsWithBalance(row);
+      const groupsForRow = getGroupsFromAccounts(accountsForRow);
+
+      if (groupsForRow.length === 0) {
+        // No group has balance — proceed directly; bridge will show correct state
+        navigateToSwap(row);
+        return;
+      }
+      if (groupsForRow.length === 1) {
+        const [group] = groupsForRow;
+        if (group.id !== selectedGroup?.id) {
+          Engine.context.AccountTreeController.setSelectedAccountGroup(
+            group.id,
+          );
+        }
+        navigateToSwap(row);
+        return;
+      }
+
+      // Multiple groups hold this token — delegate picker to parent
+      const decimals = resolveTokenDecimals(row);
+      onOpenAccountPicker({
+        row,
+        entries: groupsForRow.map((group) => ({
+          group,
+          balance: getGroupBalance(group, accountsForRow, row, decimals),
+        })),
+        tokenDecimals: decimals,
+      });
+    },
+    [
+      getAccountsWithBalance,
+      getGroupsFromAccounts,
+      getGroupBalance,
+      selectedGroup,
+      navigateToSwap,
+      onOpenAccountPicker,
+      resolveTokenDecimals,
+    ],
   );
 
   const showSkeleton =
@@ -128,9 +357,9 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   if (showSkeleton) {
     return (
       <Box twClassName="gap-3" testID={ONDO_PORTFOLIO_TEST_IDS.LOADING}>
-        <Skeleton style={tw.style('h-32 rounded-xl')} />
-        <Skeleton style={tw.style('h-24 rounded-xl')} />
-        <Skeleton style={tw.style('h-24 rounded-xl')} />
+        <Skeleton style={styles.skeletonLg} />
+        <Skeleton style={styles.skeletonMd} />
+        <Skeleton style={styles.skeletonMd} />
       </Box>
     );
   }
@@ -141,34 +370,23 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
         testID={ONDO_PORTFOLIO_TEST_IDS.EMPTY}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
-        twClassName="gap-2 py-4"
+        twClassName="gap-2"
       >
-        <NoPositionsImage
-          name="NoPositionsImage"
-          color={
-            theme.themeAppearance === 'dark'
-              ? theme.colors.background.default
-              : theme.colors.text.muted
-          }
-          width={80}
-          height={80}
+        <RewardsInfoBanner
+          title={strings('rewards.ondo_campaign_portfolio.empty')}
+          description={strings(
+            'rewards.ondo_campaign_portfolio.empty_description',
+          )}
+          onConfirm={() => {
+            navigation.navigate(
+              Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+              { mode: 'open_position', campaignId },
+            );
+          }}
+          confirmButtonLabel={strings(
+            'rewards.ondo_campaign_portfolio.empty_cta',
+          )}
         />
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="text-alternative max-w-xs text-center"
-        >
-          {strings('rewards.ondo_campaign_portfolio.empty')}
-        </Text>
-        <Button
-          variant={ButtonVariant.Tertiary}
-          size={ButtonSize.Sm}
-          twClassName="self-center"
-          onPress={() =>
-            navigation.navigate(Routes.WALLET.RWA_TOKENS_FULL_VIEW as never)
-          }
-        >
-          {strings('rewards.ondo_campaign_portfolio.empty_cta')}
-        </Button>
       </Box>
     );
   }
@@ -179,6 +397,50 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
 
   return (
     <Box twClassName="gap-3" testID={ONDO_PORTFOLIO_TEST_IDS.CONTAINER}>
+      {/* Section header */}
+      <TouchableOpacity
+        onPress={
+          grouped.length > 0
+            ? () => {
+                navigation.navigate(
+                  Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+                  { mode: 'open_position', campaignId },
+                );
+              }
+            : undefined
+        }
+        activeOpacity={grouped.length > 0 ? 0.7 : 1}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="mb-4 gap-2"
+        >
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('rewards.ondo_campaign_portfolio.title')}
+          </Text>
+          {grouped.length > 0 && (
+            <Icon
+              name={IconName.ArrowRight}
+              size={IconSize.Md}
+              color={IconColor.IconDefault}
+            />
+          )}
+          {portfolio.computedAt && portfolio.positions.length > 0 && (
+            <Box twClassName="flex-1" alignItems={BoxAlignItems.End}>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {strings('rewards.ondo_campaign_portfolio.updated_at', {
+                  time: formatComputedAt(portfolio.computedAt),
+                })}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </TouchableOpacity>
+
       {/* Positions */}
       <Box twClassName="gap-3">
         {grouped.map((row) => {
@@ -186,22 +448,14 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
             ? TextColor.SuccessDefault
             : TextColor.ErrorDefault;
           const rowPnlPercent = formatPnlPercent(row.unrealizedPnlPercent);
-          const assetNavParams = getAssetNavParams(
-            row.tokenAsset,
-            row.tokenSymbol,
-            row.tokenName,
-          );
+          const rowChainHex = getChainHex(row.tokenAsset);
           return (
             <TouchableOpacity
               key={row.tokenAsset}
               onPress={() => {
-                if (assetNavParams) {
-                  navigation.dispatch(
-                    StackActions.push('Asset', assetNavParams),
-                  );
-                }
+                handleRowPress(row);
               }}
-              activeOpacity={assetNavParams ? 0.7 : 1}
+              activeOpacity={0.7}
             >
               <Box
                 flexDirection={BoxFlexDirection.Row}
@@ -211,14 +465,12 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
                 <BadgeWrapper
                   position={BadgeWrapperPosition.BottomRight}
                   badge={
-                    getChainHex(row.tokenAsset) ? (
+                    rowChainHex ? (
                       <Badge
                         variant={BadgeVariant.Network}
                         size={AvatarSize.Xs}
                         isScaled={false}
-                        imageSource={NetworkBadgeSource(
-                          getChainHex(row.tokenAsset) as Hex,
-                        )}
+                        imageSource={NetworkBadgeSource(rowChainHex)}
                       />
                     ) : null
                   }

--- a/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
+++ b/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
@@ -1,6 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import type { MutableRefObject } from 'react';
+import type { BottomSheetRef } from '@metamask/design-system-react-native';
 import { useOndoAccountPicker } from './useOndoAccountPicker';
 import Engine from '../../../../core/Engine';
+import type { AccountPickerConfig } from '../components/Campaigns/OndoPortfolio';
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
 
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn(() => ({
@@ -67,9 +71,9 @@ const MOCK_PICKER = {
   },
   entries: [{ group: { id: 'group-1' }, balance: '100' }],
   tokenDecimals: 6,
-} as never;
+} as unknown as AccountPickerConfig;
 
-const MOCK_GROUP = { id: 'group-1' } as never;
+const MOCK_GROUP = { id: 'group-1' } as unknown as AccountGroupObject;
 
 describe('useOndoAccountPicker', () => {
   beforeEach(() => {
@@ -191,11 +195,14 @@ describe('useOndoAccountPicker', () => {
     it('defers navigation via onCloseBottomSheet when sheetRef is set', () => {
       const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
 
-      const mockOnCloseBottomSheet = jest.fn((cb: () => void) => cb());
+      const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
       act(() => {
-        result.current.sheetRef.current = {
+        (
+          result.current.sheetRef as MutableRefObject<BottomSheetRef | null>
+        ).current = {
+          onOpenBottomSheet: jest.fn(),
           onCloseBottomSheet: mockOnCloseBottomSheet,
-        } as never;
+        };
       });
       act(() => {
         result.current.setPendingPicker(MOCK_PICKER);

--- a/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
+++ b/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
@@ -1,0 +1,165 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useOndoAccountPicker } from './useOndoAccountPicker';
+import Engine from '../../../../core/Engine';
+
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn(() => ({
+  addProperties: jest.fn().mockReturnThis(),
+  build: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+jest.mock('../../../../core/Analytics', () => ({
+  MetaMetricsEvents: { SWITCHED_ACCOUNT: 'SWITCHED_ACCOUNT' },
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => [{ id: 'account-1' }, { id: 'account-2' }]),
+}));
+
+jest.mock('../../../../selectors/accountsController', () => ({
+  selectInternalAccounts: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+const mockUnsubscribe = jest.fn();
+let blurCallback: (() => void) | undefined;
+const mockAddListener = jest.fn((event: string, cb: () => void) => {
+  if (event === 'blur') blurCallback = cb;
+  return mockUnsubscribe;
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    addListener: mockAddListener,
+  }),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: { setSelectedAccountGroup: jest.fn() },
+    },
+    controllerMessenger: { subscribe: jest.fn(), unsubscribe: jest.fn() },
+  },
+}));
+
+const mockSetSelectedAccountGroup = Engine.context.AccountTreeController
+  .setSelectedAccountGroup as jest.MockedFunction<
+  typeof Engine.context.AccountTreeController.setSelectedAccountGroup
+>;
+
+const CAMPAIGN_ID = 'campaign-123';
+
+const MOCK_PICKER = {
+  row: {
+    tokenAsset: 'eip155:1/erc20:0xabc',
+    tokenSymbol: 'USDC',
+    tokenName: 'USD Coin',
+  },
+  entries: [{ group: { id: 'group-1' }, balance: '100' }],
+  tokenDecimals: 6,
+} as never;
+
+const MOCK_GROUP = { id: 'group-1' } as never;
+
+describe('useOndoAccountPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    blurCallback = undefined;
+  });
+
+  it('initializes pendingPicker as null', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+    expect(result.current.pendingPicker).toBeNull();
+  });
+
+  it('registers a blur listener on mount', () => {
+    renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+    expect(mockAddListener).toHaveBeenCalledWith('blur', expect.any(Function));
+  });
+
+  it('calls the unsubscribe function on unmount', () => {
+    const { unmount } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears pendingPicker when the screen blurs', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+    act(() => {
+      result.current.setPendingPicker(MOCK_PICKER);
+    });
+    expect(result.current.pendingPicker).toEqual(MOCK_PICKER);
+
+    act(() => {
+      blurCallback?.();
+    });
+    expect(result.current.pendingPicker).toBeNull();
+  });
+
+  it('setPendingPicker updates pendingPicker', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+    act(() => {
+      result.current.setPendingPicker(MOCK_PICKER);
+    });
+
+    expect(result.current.pendingPicker).toEqual(MOCK_PICKER);
+  });
+
+  it('handleGroupSelect is a no-op when pendingPicker is null', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+    act(() => {
+      result.current.handleGroupSelect(MOCK_GROUP);
+    });
+
+    expect(mockSetSelectedAccountGroup).not.toHaveBeenCalled();
+  });
+
+  it('handleGroupSelect calls setSelectedAccountGroup with the group id', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+    act(() => {
+      result.current.setPendingPicker(MOCK_PICKER);
+    });
+    act(() => {
+      result.current.handleGroupSelect(MOCK_GROUP);
+    });
+
+    expect(mockSetSelectedAccountGroup).toHaveBeenCalledWith('group-1');
+  });
+
+  it('handleGroupSelect fires SWITCHED_ACCOUNT trackEvent when a group is selected', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+    act(() => {
+      result.current.setPendingPicker(MOCK_PICKER);
+    });
+    act(() => {
+      result.current.handleGroupSelect(MOCK_GROUP);
+    });
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith('SWITCHED_ACCOUNT');
+    const builderInstance = mockCreateEventBuilder.mock.results[0].value;
+    expect(builderInstance.addProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'Rewards' }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a sheetRef that starts as null', () => {
+    const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+    expect(result.current.sheetRef.current).toBeNull();
+  });
+});

--- a/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
+++ b/app/components/UI/Rewards/hooks/useOndoAccountPicker.test.ts
@@ -162,4 +162,54 @@ describe('useOndoAccountPicker', () => {
     const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
     expect(result.current.sheetRef.current).toBeNull();
   });
+
+  describe('handleGroupSelect navigation', () => {
+    it('navigates and clears pendingPicker immediately when sheetRef is null', () => {
+      const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+      act(() => {
+        result.current.setPendingPicker(MOCK_PICKER);
+      });
+      act(() => {
+        result.current.handleGroupSelect(MOCK_GROUP);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'RewardsOndoRwaAssetSelector',
+        expect.objectContaining({
+          mode: 'swap',
+          srcTokenAsset: MOCK_PICKER.row.tokenAsset,
+          srcTokenSymbol: MOCK_PICKER.row.tokenSymbol,
+          srcTokenName: MOCK_PICKER.row.tokenName,
+          srcTokenDecimals: MOCK_PICKER.tokenDecimals,
+          campaignId: CAMPAIGN_ID,
+        }),
+      );
+      expect(result.current.pendingPicker).toBeNull();
+    });
+
+    it('defers navigation via onCloseBottomSheet when sheetRef is set', () => {
+      const { result } = renderHook(() => useOndoAccountPicker(CAMPAIGN_ID));
+
+      const mockOnCloseBottomSheet = jest.fn((cb: () => void) => cb());
+      act(() => {
+        result.current.sheetRef.current = {
+          onCloseBottomSheet: mockOnCloseBottomSheet,
+        } as never;
+      });
+      act(() => {
+        result.current.setPendingPicker(MOCK_PICKER);
+      });
+      act(() => {
+        result.current.handleGroupSelect(MOCK_GROUP);
+      });
+
+      expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'RewardsOndoRwaAssetSelector',
+        expect.objectContaining({ mode: 'swap', campaignId: CAMPAIGN_ID }),
+      );
+      expect(result.current.pendingPicker).toBeNull();
+    });
+  });
 });

--- a/app/components/UI/Rewards/hooks/useOndoAccountPicker.ts
+++ b/app/components/UI/Rewards/hooks/useOndoAccountPicker.ts
@@ -41,8 +41,8 @@ export const useOndoAccountPicker = (campaignId: string) => {
           })
           .build(),
       );
-      sheetRef.current?.onCloseBottomSheet(() => {
-        const { row, tokenDecimals } = pendingPicker;
+      const { row, tokenDecimals } = pendingPicker;
+      const afterClose = () => {
         setPendingPicker(null);
         navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
           mode: 'swap',
@@ -52,7 +52,12 @@ export const useOndoAccountPicker = (campaignId: string) => {
           srcTokenDecimals: tokenDecimals,
           campaignId,
         });
-      });
+      };
+      if (sheetRef.current) {
+        sheetRef.current.onCloseBottomSheet(afterClose);
+      } else {
+        afterClose();
+      }
     },
     [
       pendingPicker,

--- a/app/components/UI/Rewards/hooks/useOndoAccountPicker.ts
+++ b/app/components/UI/Rewards/hooks/useOndoAccountPicker.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  useNavigation,
+  type NavigationProp,
+  type ParamListBase,
+} from '@react-navigation/native';
+import type { AccountGroupObject } from '@metamask/account-tree-controller';
+import type { BottomSheetRef } from '@metamask/design-system-react-native';
+import Engine from '../../../../core/Engine';
+import Routes from '../../../../constants/navigation/Routes';
+import type { AccountPickerConfig } from '../components/Campaigns/OndoPortfolio';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { selectInternalAccounts } from '../../../../selectors/accountsController';
+
+export const useOndoAccountPicker = (campaignId: string) => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const [pendingPicker, setPendingPicker] =
+    useState<AccountPickerConfig | null>(null);
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const internalAccounts = useSelector(selectInternalAccounts);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('blur', () => {
+      setPendingPicker(null);
+    });
+    return unsubscribe;
+  }, [navigation]);
+
+  const handleGroupSelect = useCallback(
+    (group: AccountGroupObject) => {
+      if (!pendingPicker) return;
+      Engine.context.AccountTreeController.setSelectedAccountGroup(group.id);
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.SWITCHED_ACCOUNT)
+          .addProperties({
+            source: 'Rewards',
+            number_of_accounts: internalAccounts?.length,
+          })
+          .build(),
+      );
+      sheetRef.current?.onCloseBottomSheet(() => {
+        const { row, tokenDecimals } = pendingPicker;
+        setPendingPicker(null);
+        navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
+          mode: 'swap',
+          srcTokenAsset: row.tokenAsset,
+          srcTokenSymbol: row.tokenSymbol,
+          srcTokenName: row.tokenName,
+          srcTokenDecimals: tokenDecimals,
+          campaignId,
+        });
+      });
+    },
+    [
+      pendingPicker,
+      navigation,
+      campaignId,
+      trackEvent,
+      createEventBuilder,
+      internalAccounts?.length,
+    ],
+  );
+
+  return { pendingPicker, setPendingPicker, sheetRef, handleGroupSelect };
+};

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -17,6 +17,8 @@ import {
   formatComputedAt,
   getChainHex,
   getAssetReference,
+  parseCaip19,
+  caipChainIdToHex,
   shortenAddress,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
@@ -1288,6 +1290,58 @@ describe('formatUtils', () => {
 
     it('returns undefined for invalid CAIP-19', () => {
       expect(getChainHex('not-a-caip')).toBeUndefined();
+    });
+  });
+
+  describe('parseCaip19', () => {
+    it('parses a valid EIP-155 ERC-20 CAIP-19 identifier', () => {
+      expect(
+        parseCaip19(
+          'eip155:1/erc20:0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c',
+        ),
+      ).toEqual({
+        namespace: 'eip155',
+        chainId: '1',
+        assetReference: '0x14c3abf95cb9c93a8b82c1cdcb76d72cb87b2d4c',
+      });
+    });
+
+    it('parses a non-mainnet chain ID', () => {
+      expect(parseCaip19('eip155:137/erc20:0xdef')).toEqual({
+        namespace: 'eip155',
+        chainId: '137',
+        assetReference: '0xdef',
+      });
+    });
+
+    it('returns null for an invalid CAIP-19 string', () => {
+      expect(parseCaip19('not-a-caip')).toBeNull();
+    });
+
+    it('returns null for an empty string', () => {
+      expect(parseCaip19('')).toBeNull();
+    });
+  });
+
+  describe('caipChainIdToHex', () => {
+    it('converts eip155:1 to 0x1', () => {
+      expect(
+        caipChainIdToHex('eip155:1' as import('@metamask/utils').CaipChainId),
+      ).toBe('0x1');
+    });
+
+    it('converts eip155:137 to 0x89', () => {
+      expect(
+        caipChainIdToHex('eip155:137' as import('@metamask/utils').CaipChainId),
+      ).toBe('0x89');
+    });
+
+    it('converts eip155:42161 to 0xa4b1', () => {
+      expect(
+        caipChainIdToHex(
+          'eip155:42161' as import('@metamask/utils').CaipChainId,
+        ),
+      ).toBe('0xa4b1');
     });
   });
 

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -245,7 +245,7 @@ export const formatComputedAt = (isoString: string | null): string => {
  * Parses a CAIP-19 asset identifier into its components.
  * Returns `null` for invalid or unparseable identifiers.
  */
-const parseCaip19 = (
+export const parseCaip19 = (
   caip19: string,
 ): {
   namespace: string;
@@ -283,6 +283,17 @@ export const getChainHex = (caip19: string): Hex | undefined => {
 export const getAssetReference = (caip19: string): string => {
   const parsed = parseCaip19(caip19);
   return parsed?.assetReference ?? caip19;
+};
+
+/**
+ * Converts a CAIP chain ID (e.g. "eip155:1") to a hex chain ID (e.g. "0x1").
+ * For non-EVM chains the CAIP chain ID is returned as-is cast to Hex.
+ */
+export const caipChainIdToHex = (caipChainId: CaipChainId): Hex => {
+  const { namespace, reference } = parseCaipChainId(caipChainId);
+  return namespace === 'eip155'
+    ? (`0x${Number(reference).toString(16)}` as Hex)
+    : (caipChainId as Hex);
 };
 
 /**

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1676,4 +1676,55 @@ describe('TrendingTokenRowItem', () => {
       );
     });
   });
+
+  describe('custom onPress handler', () => {
+    it('calls custom onPress with the token when provided', () => {
+      const token = createMockToken();
+      const mockOnPress = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} onPress={mockOnPress} />,
+        { state: mockState },
+        false,
+      );
+
+      fireEvent.press(getByTestId(`trending-token-row-item-${token.assetId}`));
+
+      expect(mockOnPress).toHaveBeenCalledTimes(1);
+      expect(mockOnPress).toHaveBeenCalledWith(token);
+    });
+
+    it('does not navigate when custom onPress is provided', async () => {
+      const token = createMockToken();
+      const mockOnPress = jest.fn();
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} onPress={mockOnPress} />,
+        { state: mockState },
+        false,
+      );
+
+      fireEvent.press(getByTestId(`trending-token-row-item-${token.assetId}`));
+
+      await waitFor(() => {
+        expect(mockDispatch).not.toHaveBeenCalled();
+      });
+    });
+
+    it('does not call custom onPress when it is undefined (default behaviour)', () => {
+      const token = createMockToken();
+      const mockOnPress = jest.fn();
+
+      // Render without onPress — should not call the mock
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      fireEvent.press(getByTestId(`trending-token-row-item-${token.assetId}`));
+
+      expect(mockOnPress).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -17,11 +17,21 @@ import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
 import {
-  parseCaipChainId,
   CaipChainId,
   Hex,
   isCaipChainId,
+  parseCaipChainId,
 } from '@metamask/utils';
+
+/**
+ * Converts CAIP chain ID to hex chain ID
+ */
+const caipChainIdToHex = (caipChainId: CaipChainId): Hex => {
+  const { namespace, reference } = parseCaipChainId(caipChainId);
+  return namespace === 'eip155'
+    ? (`0x${Number(reference).toString(16)}` as Hex)
+    : (caipChainId as Hex);
+};
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../../constants/bridge';
 import {
   getDefaultNetworkByChainId,
@@ -50,16 +60,6 @@ import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
  */
 const getCaipChainIdFromAssetId = (assetId: string): CaipChainId =>
   assetId.split('/')[0] as CaipChainId;
-
-/**
- * Converts CAIP chain ID to hex chain ID
- */
-const caipChainIdToHex = (caipChainId: CaipChainId): Hex => {
-  const { namespace, reference } = parseCaipChainId(caipChainId);
-  return namespace === 'eip155'
-    ? (`0x${Number(reference).toString(16)}` as Hex)
-    : (caipChainId as Hex);
-};
 
 /**
  * Gets network badge image source for a given CAIP chain ID
@@ -136,6 +136,11 @@ interface TrendingTokenRowItemProps {
    * @default TokenDetailsSource.Trending
    */
   tokenDetailsSource?: TokenDetailsSource;
+  /**
+   * Custom press handler. When provided, bypasses default navigation to the
+   * asset details screen (including network-add logic and analytics tracking).
+   */
+  onPress?: (token: TrendingAsset) => void;
 }
 
 /**
@@ -181,6 +186,7 @@ const TrendingTokenRowItem = ({
   position,
   filterContext,
   tokenDetailsSource = TokenDetailsSource.Trending,
+  onPress,
 }: TrendingTokenRowItemProps) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation();
@@ -221,6 +227,11 @@ const TrendingTokenRowItem = ({
   const isPositiveChange = hasPercentageChange && pricePercentChange > 0;
 
   const handlePress = useCallback(async () => {
+    if (onPress) {
+      onPress(token);
+      return;
+    }
+
     if (!assetParams) return;
 
     // Track token click event BEFORE navigation to ensure capture
@@ -266,6 +277,7 @@ const TrendingTokenRowItem = ({
     // of navigating forward to the new token.
     navigation.dispatch(StackActions.push('Asset', assetParams));
   }, [
+    onPress,
     assetParams,
     caipChainId,
     navigation,

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -105,6 +105,7 @@ const Routes = {
   REWARDS_SEASON_ONE_CAMPAIGN_DETAILS_VIEW: 'RewardsSeasonOneCampaignDetails',
   REWARDS_CAMPAIGN_MECHANICS: 'RewardsCampaignMechanics',
   REWARDS_ONDO_CAMPAIGN_LEADERBOARD: 'RewardsOndoCampaignLeaderboard',
+  REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR: 'RewardsOndoRwaAssetSelector',
   REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW: 'RewardsOndoCampaignPortfolioView',
   TRENDING_VIEW: 'TrendingView',
   TRENDING_FEED: 'TrendingFeed',

--- a/app/selectors/rewards/index.test.ts
+++ b/app/selectors/rewards/index.test.ts
@@ -4,6 +4,7 @@ import {
   selectRewardsSubscriptionId,
   selectRewardsActiveAccountAddress,
   selectRewardsActiveAccountSubscriptionId,
+  selectCurrentSubscriptionAccounts,
 } from './index';
 // Mock rewards controller state
 const createMockRewardsControllerState = (overrides = {}) => ({
@@ -334,6 +335,89 @@ describe('Rewards Selectors', () => {
 
       // Assert
       expect(result).toBe(expectedAddress);
+    });
+  });
+
+  describe('selectCurrentSubscriptionAccounts', () => {
+    it('returns accounts belonging to the current subscription', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: {
+              activeAccount: { subscriptionId: 'sub-1' },
+              accounts: {
+                'acct-1': {
+                  subscriptionId: 'sub-1',
+                  account: 'eip155:1:0x123',
+                },
+                'acct-2': {
+                  subscriptionId: 'sub-2',
+                  account: 'eip155:1:0x456',
+                },
+              },
+              subscriptions: {
+                'sub-1': { id: 'sub-1' },
+              },
+            },
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      const result = selectCurrentSubscriptionAccounts(state);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        subscriptionId: 'sub-1',
+        account: 'eip155:1:0x123',
+      });
+    });
+
+    it('returns empty array when no current subscription', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: {
+              activeAccount: null,
+              accounts: {
+                'acct-1': {
+                  subscriptionId: 'sub-1',
+                  account: 'eip155:1:0x123',
+                },
+              },
+              subscriptions: {},
+            },
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      const result = selectCurrentSubscriptionAccounts(state);
+      expect(result).toHaveLength(0);
+    });
+
+    it('returns empty array when no accounts match subscription', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: {
+              activeAccount: { subscriptionId: 'sub-1' },
+              accounts: {
+                'acct-2': {
+                  subscriptionId: 'sub-2',
+                  account: 'eip155:1:0x456',
+                },
+              },
+              subscriptions: {
+                'sub-1': { id: 'sub-1' },
+              },
+            },
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      const result = selectCurrentSubscriptionAccounts(state);
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/app/selectors/rewards/index.ts
+++ b/app/selectors/rewards/index.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../../reducers';
+import { RewardsAccountState } from '../../core/Engine/controllers/rewards-controller/types';
 
 /**
  *
@@ -61,4 +62,21 @@ export const selectRewardsActiveAccountAddress = createSelector(
     const parts = account.split(':');
     return parts[parts.length - 1];
   },
+);
+
+export const selectCurrentSubscription = createSelector(
+  [selectRewardsSubscriptionId, selectRewardsControllerState],
+  (subscriptionId, rewardsState) =>
+    subscriptionId
+      ? (rewardsState.subscriptions[subscriptionId] ?? null)
+      : null,
+);
+
+export const selectCurrentSubscriptionAccounts = createSelector(
+  [selectRewardsControllerState, selectCurrentSubscription],
+  (rewardsState, subscription) =>
+    Object.values(rewardsState.accounts).filter(
+      (account: RewardsAccountState) =>
+        account.subscriptionId === subscription?.id,
+    ),
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8054,7 +8054,17 @@
       "empty_description": "Start earning rewards by opening a position in tokenized real-world assets.",
       "empty_cta": "Open a position",
       "position_units": "{{units}} shares",
-      "positions_title": "Positions"
+      "positions_title": "Positions",
+      "switch_account_title": "Switch account",
+      "switch_account_sheet_prefix": "Accounts with",
+      "switch_account_sheet_description": "Choose which balance to swap"
+    },
+    "ondo_rwa_asset_selector": {
+      "title_swap": "Swap {{symbol}}",
+      "title_swap_prefix": "Swap",
+      "title_open_position": "Open Position",
+      "search_placeholder": "Search assets",
+      "no_results": "No assets found"
     },
     "ondo_campaign_leaderboard": {
       "title": "Leaderboard",


### PR DESCRIPTION
## Description

Improves the Ondo campaign RWA position UX by introducing a dedicated RWA token selector flow and enriching the campaign details and portfolio views with richer position and market data.

## Changelog

CHANGELOG entry: null

## Screenshots

- Showing a sheet when tapping position & balance for position split between multiple accounts
<img width="1028" height="1954" alt="Screenshot from 2026-04-07 15-54-01" src="https://github.com/user-attachments/assets/9934804e-95bf-40df-b2ab-1da27b79ee30" />

---

- Open a position for open campaign & opted in

<img width="1008" height="1813" alt="Screenshot from 2026-04-07 15-37-05" src="https://github.com/user-attachments/assets/9abcccb3-611e-4e40-8a45-0f35a2f4c60f" />

---

- Showing our custom view/page for ondo assets 

<img width="1008" height="1813" alt="Screenshot from 2026-04-07 15-36-17" src="https://github.com/user-attachments/assets/81ec7d95-1e60-419c-9c7f-5595e55075ce" />

---

- Showing our custom view/page for swapping between ondo assets which presets both tokens on swap page

<img width="1008" height="1813" alt="Screenshot from 2026-04-07 15-35-59" src="https://github.com/user-attachments/assets/94089405-6a71-41d5-894f-de7298f62f34" />

<img width="1008" height="1813" alt="Screenshot from 2026-04-07 15-36-05" src="https://github.com/user-attachments/assets/0da85268-2b55-4c27-940d-87ef2b9d2cca" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new navigation routes and selection logic that changes how users enter the swaps/open-position flow and how account groups are switched, which could impact campaign UX and navigation state. Changes are mostly UI/selector-level but touch account selection via `Engine.context.AccountTreeController` and token-balance parsing.
> 
> **Overview**
> Adds a dedicated Ondo **RWA asset selector** screen (`RewardsOndoRwaAssetSelector`) and wires it into `RewardsNavigator`, `CampaignCTA`, and portfolio flows so “Open Position”/“Swap” now route through a Rewards-specific selector rather than the generic RWA tokens view.
> 
> Introduces an **account-group picker** bottom sheet (`OndoAccountPickerSheet`) plus `useOndoAccountPicker` to handle multi-account balances: `OndoPortfolio` now inspects subscription accounts’ token balances, switches account group when unambiguous, or prompts the user when multiple groups hold the token; campaign details/portfolio screens render and control this sheet.
> 
> Refines UX/logic around Ondo campaign states (e.g., hides “How it works” once opted-in, suppresses CTA when deposit window closed with no positions, shows “Last updated” in portfolio header) and expands unit tests accordingly; also exports CAIP helpers (`parseCaip19`, `caipChainIdToHex`) and adds a `TrendingTokenRowItem` custom `onPress` override for the selector list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0d1bae8f8b169dad662dfb28a0c8e2da5d994f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->