### PR TITLE
fix: improve badge display for long name tokens and network name disp…

### DIFF
--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
@@ -52,6 +52,7 @@ import Cell, {
 import { AvatarVariant } from '../../../component-library/components/Avatars/Avatar/index.ts';
 import { IconName } from '../../../component-library/components/Icons/Icon/Icon.types';
 import AccountGroupBalancePerChain from '../Assets/components/Balance/AccountGroupBalancePerChain';
+import { resolveNetworkDisplayName } from './NetworkMultiSelectorUtils';
 
 interface ModalState {
   showPopularNetworkModal: boolean;
@@ -234,58 +235,13 @@ const NetworkMultiSelector = ({
   );
 
   const getNetworkName = useCallback(
-    (chainId: string | null): string => {
-      if (!chainId) return strings('network_information.unknown_network');
-
-      if (currentSelectedNetwork) {
-        if (currentSelectedNetwork.caipChainId === chainId) {
-          return currentSelectedNetwork.name;
-        }
-
-        try {
-          const parsed = parseCaipChainId(currentSelectedNetwork.caipChainId);
-          if (parsed.namespace === KnownCaipNamespace.Eip155) {
-            const networkHexChainId = toHex(parsed.reference);
-            if (networkHexChainId === chainId) {
-              return currentSelectedNetwork.name;
-            }
-          }
-        } catch {
-          // Continue to fallback logic
-        }
-      }
-
-      const isEvmChainId = chainId.startsWith('0x');
-      if (isEvmChainId) {
-        const networkConfig = networkConfigurations[chainId as Hex];
-        return (
-          networkConfig?.name || strings('network_information.unknown_network')
-        );
-      }
-
-      const nonEvmConfig = nonEvmNetworkConfigurations[chainId as CaipChainId];
-      if (nonEvmConfig) {
-        return (
-          nonEvmConfig.name || strings('network_information.unknown_network')
-        );
-      }
-
-      try {
-        const parsed = parseCaipChainId(chainId as CaipChainId);
-        if (parsed.namespace === KnownCaipNamespace.Eip155) {
-          const hexChainId = toHex(parsed.reference);
-          const networkConfig = networkConfigurations[hexChainId];
-          return (
-            networkConfig?.name ||
-            strings('network_information.unknown_network')
-          );
-        }
-      } catch {
-        // Not a valid CAIP chain ID
-      }
-
-      return strings('network_information.unknown_network');
-    },
+    (chainId: string | null): string =>
+      resolveNetworkDisplayName({
+        chainId,
+        evmNetworkConfigurations: networkConfigurations,
+        nonEvmNetworkConfigurations,
+        currentSelectedNetwork: currentSelectedNetwork ?? null,
+      }),
     [
       networkConfigurations,
       nonEvmNetworkConfigurations,

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.test.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.test.ts
@@ -90,7 +90,7 @@ describe('resolveNetworkDisplayName', () => {
       [solanaMainnet]: {
         chainId: solanaMainnet,
         name: 'Solana',
-      } as MultichainNetworkConfiguration,
+      } as unknown as MultichainNetworkConfiguration,
     };
 
     const result = resolveNetworkDisplayName({
@@ -107,7 +107,7 @@ describe('resolveNetworkDisplayName', () => {
     const nonEvm = {
       [solanaMainnet]: {
         chainId: solanaMainnet,
-      } as MultichainNetworkConfiguration,
+      } as unknown as MultichainNetworkConfiguration,
     };
 
     const result = resolveNetworkDisplayName({

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.test.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.test.ts
@@ -1,0 +1,166 @@
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import type { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
+import { SolScope } from '@metamask/keyring-api';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import {
+  resolveNetworkDisplayName,
+  type CurrentSelectedNetworkForDisplayName,
+} from './NetworkMultiSelectorUtils';
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+const UNKNOWN = 'network_information.unknown_network';
+
+describe('resolveNetworkDisplayName', () => {
+  const emptyEvm = {} as Record<Hex, NetworkConfiguration>;
+  const emptyNonEvm = {} as Record<CaipChainId, MultichainNetworkConfiguration>;
+
+  it('returns unknown_network when chainId is null', () => {
+    const result = resolveNetworkDisplayName({
+      chainId: null,
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+    });
+
+    expect(result).toBe(UNKNOWN);
+  });
+
+  it('returns currentSelectedNetwork name when chainId equals caipChainId', () => {
+    const current: CurrentSelectedNetworkForDisplayName = {
+      caipChainId: SolScope.Mainnet,
+      name: 'Solana Mainnet',
+    };
+
+    const result = resolveNetworkDisplayName({
+      chainId: SolScope.Mainnet,
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+      currentSelectedNetwork: current,
+    });
+
+    expect(result).toBe('Solana Mainnet');
+  });
+
+  it('returns currentSelectedNetwork name when chainId is hex matching selected eip155 caip', () => {
+    const current: CurrentSelectedNetworkForDisplayName = {
+      caipChainId: 'eip155:1' as CaipChainId,
+      name: 'Ethereum',
+    };
+
+    const result = resolveNetworkDisplayName({
+      chainId: '0x1',
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+      currentSelectedNetwork: current,
+    });
+
+    expect(result).toBe('Ethereum');
+  });
+
+  it('returns EVM network name for 0x chainId from configurations', () => {
+    const polygonHex = '0x89' as Hex;
+    const evm = {
+      [polygonHex]: { name: 'Polygon', chainId: polygonHex },
+    } as Record<Hex, NetworkConfiguration>;
+
+    const result = resolveNetworkDisplayName({
+      chainId: polygonHex,
+      evmNetworkConfigurations: evm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+    });
+
+    expect(result).toBe('Polygon');
+  });
+
+  it('returns unknown_network for 0x chainId missing from configurations', () => {
+    const result = resolveNetworkDisplayName({
+      chainId: '0x9999' as Hex,
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+    });
+
+    expect(result).toBe(UNKNOWN);
+  });
+
+  it('returns non-EVM network name for CAIP chainId from configurations', () => {
+    const solanaMainnet = SolScope.Mainnet;
+    const nonEvm = {
+      [solanaMainnet]: {
+        chainId: solanaMainnet,
+        name: 'Solana',
+      } as MultichainNetworkConfiguration,
+    };
+
+    const result = resolveNetworkDisplayName({
+      chainId: solanaMainnet,
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: nonEvm,
+    });
+
+    expect(result).toBe('Solana');
+  });
+
+  it('returns unknown_network when non-EVM configuration omits name', () => {
+    const solanaMainnet = SolScope.Mainnet;
+    const nonEvm = {
+      [solanaMainnet]: {
+        chainId: solanaMainnet,
+      } as MultichainNetworkConfiguration,
+    };
+
+    const result = resolveNetworkDisplayName({
+      chainId: solanaMainnet,
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: nonEvm,
+    });
+
+    expect(result).toBe(UNKNOWN);
+  });
+
+  it('returns EVM name when chainId is eip155 CAIP string', () => {
+    const mainnetHex = '0x1' as Hex;
+    const evm = {
+      [mainnetHex]: { name: 'Ethereum Mainnet', chainId: mainnetHex },
+    } as Record<Hex, NetworkConfiguration>;
+
+    const result = resolveNetworkDisplayName({
+      chainId: 'eip155:1',
+      evmNetworkConfigurations: evm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+    });
+
+    expect(result).toBe('Ethereum Mainnet');
+  });
+
+  it('returns unknown_network when chainId is not solvable', () => {
+    const result = resolveNetworkDisplayName({
+      chainId: 'not-a-caip-id',
+      evmNetworkConfigurations: emptyEvm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+    });
+
+    expect(result).toBe(UNKNOWN);
+  });
+
+  it('prefers currentSelectedNetwork over evm map when both match hex', () => {
+    const mainnetHex = '0x1' as Hex;
+    const evm = {
+      [mainnetHex]: { name: 'From Map', chainId: mainnetHex },
+    } as Record<Hex, NetworkConfiguration>;
+    const current: CurrentSelectedNetworkForDisplayName = {
+      caipChainId: 'eip155:1' as CaipChainId,
+      name: 'From Selection',
+    };
+
+    const result = resolveNetworkDisplayName({
+      chainId: mainnetHex,
+      evmNetworkConfigurations: evm,
+      nonEvmNetworkConfigurations: emptyNonEvm,
+      currentSelectedNetwork: current,
+    });
+
+    expect(result).toBe('From Selection');
+  });
+});

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelectorUtils.ts
@@ -1,0 +1,84 @@
+import {
+  KnownCaipNamespace,
+  type CaipChainId,
+  type Hex,
+  parseCaipChainId,
+} from '@metamask/utils';
+import { toHex } from '@metamask/controller-utils';
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import type { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
+import { strings } from '../../../../locales/i18n';
+
+const unknownNetwork = () => strings('network_information.unknown_network');
+
+export interface CurrentSelectedNetworkForDisplayName {
+  caipChainId: CaipChainId;
+  name: string;
+}
+
+export interface ResolveNetworkDisplayNameArgs {
+  chainId: string | null;
+  evmNetworkConfigurations: Record<Hex, NetworkConfiguration>;
+  nonEvmNetworkConfigurations: Record<
+    CaipChainId,
+    MultichainNetworkConfiguration
+  >;
+  currentSelectedNetwork?: CurrentSelectedNetworkForDisplayName | null;
+}
+
+/**
+ * Resolves a user-visible network name for EVM hex chain IDs, non-EVM CAIP chain
+ * IDs, and CAIP `eip155` strings — matching the NetworkMultiSelector sheet logic.
+ */
+export function resolveNetworkDisplayName({
+  chainId,
+  evmNetworkConfigurations,
+  nonEvmNetworkConfigurations,
+  currentSelectedNetwork,
+}: ResolveNetworkDisplayNameArgs): string {
+  if (!chainId) {
+    return unknownNetwork();
+  }
+
+  if (currentSelectedNetwork) {
+    if (currentSelectedNetwork.caipChainId === chainId) {
+      return currentSelectedNetwork.name;
+    }
+
+    try {
+      const parsed = parseCaipChainId(currentSelectedNetwork.caipChainId);
+      if (parsed.namespace === KnownCaipNamespace.Eip155) {
+        const networkHexChainId = toHex(parsed.reference);
+        if (networkHexChainId === chainId) {
+          return currentSelectedNetwork.name;
+        }
+      }
+    } catch {
+      // Continue to fallback logic
+    }
+  }
+
+  const isEvmChainId = chainId.startsWith('0x');
+  if (isEvmChainId) {
+    const networkConfig = evmNetworkConfigurations[chainId as Hex];
+    return networkConfig?.name ?? unknownNetwork();
+  }
+
+  const nonEvmConfig = nonEvmNetworkConfigurations[chainId as CaipChainId];
+  if (nonEvmConfig) {
+    return nonEvmConfig.name ?? unknownNetwork();
+  }
+
+  try {
+    const parsed = parseCaipChainId(chainId as CaipChainId);
+    if (parsed.namespace === KnownCaipNamespace.Eip155) {
+      const hexChainId = toHex(parsed.reference);
+      const networkConfig = evmNetworkConfigurations[hexChainId];
+      return networkConfig?.name ?? unknownNetwork();
+    }
+  } catch {
+    // Not a valid CAIP chain ID
+  }
+
+  return unknownNetwork();
+}

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
@@ -87,8 +87,26 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-jest.mock('../../../Views/confirmations/hooks/useNetworkName', () => ({
-  useNetworkName: () => 'Ethereum Mainnet',
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector: (state: unknown) => unknown) => {
+    const { selectEvmNetworkConfigurationsByChainId: selectEvm } =
+      jest.requireActual<
+        typeof import('../../../../selectors/networkController')
+      >('../../../../selectors/networkController');
+    const { selectNonEvmNetworkConfigurationsByChainId: selectNonEvm } =
+      jest.requireActual<
+        typeof import('../../../../selectors/multichainNetworkController')
+      >('../../../../selectors/multichainNetworkController');
+    if (selector === selectEvm) {
+      return {
+        '0x1': { name: 'Ethereum Mainnet', chainId: '0x1' },
+      };
+    }
+    if (selector === selectNonEvm) {
+      return {};
+    }
+    return undefined;
+  }),
 }));
 
 jest.mock('../../../hooks/useBlockExplorer', () => ({

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -25,9 +25,11 @@ import {
 } from '@metamask/design-system-react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
-import { useNetworkName } from '../../../Views/confirmations/hooks/useNetworkName';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
+import { selectNonEvmNetworkConfigurationsByChainId } from '../../../../selectors/multichainNetworkController';
+import { resolveNetworkDisplayName } from '../../NetworkMultiSelector/NetworkMultiSelectorUtils';
 import type { TokenDetailsRouteParams } from '../../TokenDetails/constants/constants';
 import {
   getFeatureTags,
@@ -60,7 +62,23 @@ const SecurityTrustScreen: React.FC = () => {
   const params = route.params as TokenDetailsRouteParams;
   const securityData = params?.securityData ?? null;
   const explorer = useBlockExplorer(params?.chainId);
-  const networkName = useNetworkName(params?.chainId as Hex);
+  const evmNetworkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+  const nonEvmNetworkConfigurations = useSelector(
+    selectNonEvmNetworkConfigurationsByChainId,
+  );
+  const networkName = React.useMemo(() => {
+    const chainId = params?.chainId;
+    if (!chainId) {
+      return undefined;
+    }
+    return resolveNetworkDisplayName({
+      chainId,
+      evmNetworkConfigurations,
+      nonEvmNetworkConfigurations,
+    });
+  }, [params?.chainId, evmNetworkConfigurations, nonEvmNetworkConfigurations]);
 
   // Get action handlers from hook (single source of truth)
   const { onBuy, handleStickySwapPress, hasEligibleSwapTokens, networkModal } =

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -662,7 +662,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            twClassName="gap-4 py-2 pr-[8px] pl-4"
+            twClassName="gap-4 py-2 pl-4 pr-[16px]"
           >
             <BadgeWrapper
               badgePosition={BadgePosition.BottomRight}
@@ -679,64 +679,72 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
               <AssetLogo asset={token} />
             </BadgeWrapper>
 
-            <Box twClassName="flex-1">
+            <Box twClassName="min-w-0 flex-1">
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
-                twClassName="gap-1.5"
+                twClassName="max-w-full min-w-0 gap-1.5 self-stretch"
               >
-                <Text
-                  variant={TextVariant.HeadingMd}
-                  color={TextColor.TextDefault}
-                  numberOfLines={1}
-                >
-                  {token.name || token.symbol}
-                </Text>
+                <Box twClassName="min-w-0 shrink grow-0">
+                  <Text
+                    variant={TextVariant.HeadingMd}
+                    color={TextColor.TextDefault}
+                    numberOfLines={1}
+                  >
+                    {token.name || token.symbol}
+                  </Text>
+                </Box>
                 {securityBadge && securityBadge.label === null && (
-                  <TouchableOpacity
-                    onPress={handleSecurityBadgePress}
-                    testID="security-badge-verified"
-                  >
-                    <Icon
-                      name={securityBadge.icon}
-                      size={IconSize.Md}
-                      color={securityBadge.iconColor}
-                    />
-                  </TouchableOpacity>
-                )}
-                {securityBadge && securityBadge.label !== null && (
-                  <TouchableOpacity
-                    onPress={handleSecurityBadgePress}
-                    testID={
-                      securityData?.resultType === 'Malicious'
-                        ? 'security-badge-malicious'
-                        : 'security-badge-warning'
-                    }
-                  >
-                    <Box
-                      flexDirection={BoxFlexDirection.Row}
-                      alignItems={BoxAlignItems.Center}
-                      twClassName={`rounded min-w-[22px] px-1.5 gap-1 ${securityBadge.bg}`}
+                  <Box twClassName="shrink-0">
+                    <TouchableOpacity
+                      onPress={handleSecurityBadgePress}
+                      testID="security-badge-verified"
                     >
                       <Icon
                         name={securityBadge.icon}
-                        size={IconSize.Sm}
+                        size={IconSize.Md}
                         color={securityBadge.iconColor}
                       />
-                      <Text
-                        variant={TextVariant.BodySm}
-                        color={securityBadge.textColor}
-                        fontWeight={FontWeight.Medium}
-                        numberOfLines={1}
-                        twClassName="overflow-hidden text-center"
+                    </TouchableOpacity>
+                  </Box>
+                )}
+                {securityBadge && securityBadge.label !== null && (
+                  <Box twClassName="shrink-0">
+                    <TouchableOpacity
+                      onPress={handleSecurityBadgePress}
+                      testID={
+                        securityData?.resultType === 'Malicious'
+                          ? 'security-badge-malicious'
+                          : 'security-badge-warning'
+                      }
+                    >
+                      <Box
+                        flexDirection={BoxFlexDirection.Row}
+                        alignItems={BoxAlignItems.Center}
+                        twClassName={`rounded min-w-[22px] px-1.5 gap-1 ${securityBadge.bg}`}
                       >
-                        {securityBadge.label}
-                      </Text>
-                    </Box>
-                  </TouchableOpacity>
+                        <Icon
+                          name={securityBadge.icon}
+                          size={IconSize.Sm}
+                          color={securityBadge.iconColor}
+                        />
+                        <Text
+                          variant={TextVariant.BodySm}
+                          color={securityBadge.textColor}
+                          fontWeight={FontWeight.Medium}
+                          numberOfLines={1}
+                          twClassName="overflow-hidden text-center"
+                        >
+                          {securityBadge.label}
+                        </Text>
+                      </Box>
+                    </TouchableOpacity>
+                  </Box>
                 )}
                 {!token.name && isStockToken(token as BridgeToken) && (
-                  <StockBadge token={token as BridgeToken} />
+                  <Box twClassName="shrink-0">
+                    <StockBadge token={token as BridgeToken} />
+                  </Box>
                 )}
               </Box>
               {token.name ? (


### PR DESCRIPTION

## **Description**

**Token details header (security badge)**  
Long token names used a flex row where the title did not shrink, so the row overflowed and the security badge was clipped at the screen edge. Short names did not hit this overflow path. The layout now constrains the heading with `min-w-0`, `shrink`, and `grow-0` on the text so it ellipsizes while the badge stays in a non-shrinking slot, and the header row uses **16px** right padding so the badge clears the edge.

**Network display name (Security & Trust + shared utility)**  
The confirmations `useNetworkName` hook only resolved EVM hex chain IDs and `NetworkList`, so non-EVM assets (e.g. Solana CAIP chain IDs) fell through to the raw id. `resolveNetworkDisplayName` was extracted from `NetworkMultiSelector` into `NetworkMultiSelectorUtils` and is now used from **Security & Trust** with **`selectEvmNetworkConfigurationsByChainId`** and **`selectNonEvmNetworkConfigurationsByChainId`**, so friendly names match the network filter sheet. **Unit tests** cover the util; **SecurityTrustScreen** tests mock `useSelector` accordingly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed token details so long asset names no longer clip the security badge, and fixed Security & Trust network labels for non-EVM chains to show the configured network name instead of the raw chain id

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout adjustments plus a small refactor of network display-name lookup with new unit coverage; main risk is minor regressions in displayed network labels.
> 
> **Overview**
> Improves the token details header layout so long asset names ellipsize and the security/stock badges remain visible (tweaked flex constraints and padding in `AssetOverviewContent`).
> 
> Extracts `resolveNetworkDisplayName` into `NetworkMultiSelectorUtils` and reuses it in `SecurityTrustScreen` (via `selectEvmNetworkConfigurationsByChainId`/`selectNonEvmNetworkConfigurationsByChainId`) so network labels resolve consistently for hex EVM, CAIP `eip155:*`, and non-EVM CAIP chain IDs. Adds dedicated unit tests for the resolver and updates `SecurityTrustScreen` tests to mock `useSelector` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ae0edef27a0eb08bb788bb0a7ea4499a96b49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->