### PR TITLE
fix(snaps): Display account group names and balances in `SnapUIAccountSelector`

### DIFF
--- a/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
+++ b/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
@@ -30,11 +30,12 @@ import { stylesheet } from './SnapUIAccountSelector.styles';
 import I18n, { strings } from '../../../../locales/i18n';
 import { selectAvatarAccountType } from '../../../selectors/settings';
 import { selectAccountGroups } from '../../../selectors/multichainAccounts/accountTreeController';
-import { selectBalanceByAccountGroup } from '../../../selectors/assets/balances';
+import { selectMultichainNetworkAggregatedBalanceForAllAccounts } from '../../../selectors/multichain/multichain';
+import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { formatWithThreshold } from '../../../util/assets';
 
 export interface SnapUIAccountSelectorElementProps {
-  account: Account & { groupId: string };
+  account: Account & { fiatBalance: string };
   ensName?: string;
   privacyMode: boolean;
   avatarType: AvatarAccountType;
@@ -57,24 +58,6 @@ export const SnapUIAccountSelectorElement: FunctionComponent<
 
   const accountName = isDefaultAccountName(name) && ensName ? ensName : name;
   const shortAddress = formatAddress(address, 'short');
-
-  const selectBalanceForGroup = useMemo(
-    () => selectBalanceByAccountGroup(account.groupId),
-    [account.groupId],
-  );
-  const groupBalance = useSelector(selectBalanceForGroup);
-  const totalBalance = groupBalance?.totalBalanceInUserCurrency;
-  const userCurrency = groupBalance?.userCurrency;
-
-  const fiatBalance = useMemo(() => {
-    if (totalBalance == null || !userCurrency) {
-      return undefined;
-    }
-    return formatWithThreshold(totalBalance, 0.01, I18n.locale, {
-      style: 'currency',
-      currency: userCurrency.toUpperCase(),
-    });
-  }, [totalBalance, userCurrency]);
 
   const { styles } = useStyles(stylesheet, {});
 
@@ -116,7 +99,7 @@ export const SnapUIAccountSelectorElement: FunctionComponent<
           isHidden={privacyMode}
           variant={TextVariant.BodySMMedium}
         >
-          {fiatBalance}
+          {account.fiatBalance}
         </SensitiveText>
         <AccountNetworkIndicator partialAccount={{ address, scopes }} />
       </Box>
@@ -166,6 +149,10 @@ export const SnapUIAccountSelector: FunctionComponent<
   const avatarAccountType = useSelector(selectAvatarAccountType);
   const privacyMode = useSelector(selectPrivacyMode);
   const accountGroups = useSelector(selectAccountGroups);
+  const multichainBalances = useSelector(
+    selectMultichainNetworkAggregatedBalanceForAllAccounts,
+  );
+  const currentCurrency = useSelector(selectCurrentCurrency);
 
   const accounts = useMemo(() => {
     // Filter out the accounts that are not owned by the snap
@@ -191,13 +178,28 @@ export const SnapUIAccountSelector: FunctionComponent<
       );
       const name = group?.metadata.name ?? account.name;
 
+      const amount = multichainBalances[account.id]?.totalBalanceFiat ?? 0;
+
+      const fiatBalance = formatWithThreshold(amount, 0.01, I18n.locale, {
+        style: 'currency',
+        currency: currentCurrency.toUpperCase(),
+      });
+
       return {
         ...account,
         name,
-        groupId: group?.id ?? '',
+        fiatBalance,
       };
     });
-  }, [internalAccounts, chainIds, hideExternalAccounts, snapId, accountGroups]);
+  }, [
+    internalAccounts,
+    chainIds,
+    hideExternalAccounts,
+    snapId,
+    accountGroups,
+    currentCurrency,
+    multichainBalances,
+  ]);
 
   const options = accounts.map((account) => ({
     key: 'accountId',

--- a/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
+++ b/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
@@ -19,7 +19,6 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
-import { isDefaultAccountName } from '../../../util/ENSUtils';
 import { formatAddress } from '../../../util/address';
 import SensitiveText, {
   SensitiveTextLength,
@@ -36,7 +35,6 @@ import { formatWithThreshold } from '../../../util/assets';
 
 export interface SnapUIAccountSelectorElementProps {
   account: Account & { fiatBalance: string };
-  ensName?: string;
   privacyMode: boolean;
   avatarType: AvatarAccountType;
 }
@@ -46,17 +44,15 @@ export interface SnapUIAccountSelectorElementProps {
  *
  * @param props - The component props.
  * @param props.account - The account to display.
- * @param props.ensName - The ENS name of the account.
  * @param props.privacyMode - Whether the client is in privacy mode.
  * @param props.avatarType - The type of avatar to display.
  * @returns The AccountSelector element.
  */
 export const SnapUIAccountSelectorElement: FunctionComponent<
   SnapUIAccountSelectorElementProps
-> = ({ account, ensName, privacyMode, avatarType }) => {
-  const { name, address, scopes } = account;
+> = ({ account, privacyMode, avatarType }) => {
+  const { name, address, scopes, fiatBalance } = account;
 
-  const accountName = isDefaultAccountName(name) && ensName ? ensName : name;
   const shortAddress = formatAddress(address, 'short');
 
   const { styles } = useStyles(stylesheet, {});
@@ -79,7 +75,7 @@ export const SnapUIAccountSelectorElement: FunctionComponent<
           numberOfLines={1}
           ellipsizeMode="tail"
         >
-          {accountName}
+          {name}
         </Text>
         <Text
           variant={TextVariant.BodySM}
@@ -99,7 +95,7 @@ export const SnapUIAccountSelectorElement: FunctionComponent<
           isHidden={privacyMode}
           variant={TextVariant.BodySMMedium}
         >
-          {account.fiatBalance}
+          {fiatBalance}
         </SensitiveText>
         <AccountNetworkIndicator partialAccount={{ address, scopes }} />
       </Box>
@@ -142,7 +138,7 @@ export const SnapUIAccountSelector: FunctionComponent<
   ...props
 }) => {
   const { snapId } = useSnapInterfaceContext();
-  const { accounts: internalAccounts, ensByAccountAddress } = useAccounts({
+  const { accounts: internalAccounts } = useAccounts({
     fetchENS: false,
   });
 
@@ -217,7 +213,6 @@ export const SnapUIAccountSelector: FunctionComponent<
     <SnapUIAccountSelectorElement
       key={index}
       account={account}
-      ensName={ensByAccountAddress[account.address]}
       privacyMode={privacyMode}
       avatarType={avatarAccountType}
     />

--- a/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
+++ b/app/components/Snaps/SnapUIAccountSelector/SnapUIAccountSelector.tsx
@@ -27,11 +27,14 @@ import SensitiveText, {
 import AccountNetworkIndicator from '../../UI/AccountNetworkIndicator';
 import { useStyles } from '../../hooks/useStyles';
 import { stylesheet } from './SnapUIAccountSelector.styles';
-import { strings } from '../../../../locales/i18n';
+import I18n, { strings } from '../../../../locales/i18n';
 import { selectAvatarAccountType } from '../../../selectors/settings';
+import { selectAccountGroups } from '../../../selectors/multichainAccounts/accountTreeController';
+import { selectBalanceByAccountGroup } from '../../../selectors/assets/balances';
+import { formatWithThreshold } from '../../../util/assets';
 
 export interface SnapUIAccountSelectorElementProps {
-  account: Account;
+  account: Account & { groupId: string };
   ensName?: string;
   privacyMode: boolean;
   avatarType: AvatarAccountType;
@@ -50,14 +53,31 @@ export interface SnapUIAccountSelectorElementProps {
 export const SnapUIAccountSelectorElement: FunctionComponent<
   SnapUIAccountSelectorElementProps
 > = ({ account, ensName, privacyMode, avatarType }) => {
-  const { name, address, assets, scopes } = account;
+  const { name, address, scopes } = account;
 
   const accountName = isDefaultAccountName(name) && ensName ? ensName : name;
   const shortAddress = formatAddress(address, 'short');
 
-  const fiatBalance = assets?.fiatBalance.split('\n')[0] || '';
+  const selectBalanceForGroup = useMemo(
+    () => selectBalanceByAccountGroup(account.groupId),
+    [account.groupId],
+  );
+  const groupBalance = useSelector(selectBalanceForGroup);
+  const totalBalance = groupBalance?.totalBalanceInUserCurrency;
+  const userCurrency = groupBalance?.userCurrency;
+
+  const fiatBalance = useMemo(() => {
+    if (totalBalance == null || !userCurrency) {
+      return undefined;
+    }
+    return formatWithThreshold(totalBalance, 0.01, I18n.locale, {
+      style: 'currency',
+      currency: userCurrency.toUpperCase(),
+    });
+  }, [totalBalance, userCurrency]);
 
   const { styles } = useStyles(stylesheet, {});
+
   return (
     <Box
       flexDirection={FlexDirection.Row}
@@ -139,10 +159,13 @@ export const SnapUIAccountSelector: FunctionComponent<
   ...props
 }) => {
   const { snapId } = useSnapInterfaceContext();
-  const { accounts: internalAccounts, ensByAccountAddress } = useAccounts();
+  const { accounts: internalAccounts, ensByAccountAddress } = useAccounts({
+    fetchENS: false,
+  });
 
   const avatarAccountType = useSelector(selectAvatarAccountType);
   const privacyMode = useSelector(selectPrivacyMode);
+  const accountGroups = useSelector(selectAccountGroups);
 
   const accounts = useMemo(() => {
     // Filter out the accounts that are not owned by the snap
@@ -159,8 +182,22 @@ export const SnapUIAccountSelector: FunctionComponent<
       return filteredChainIds.length > 0;
     });
 
-    return filteredAccounts;
-  }, [internalAccounts, chainIds, hideExternalAccounts, snapId]);
+    // Get the name from the account group if it exists, otherwise use the account name
+    // This is necessary because the account name is empty now and the group name is used instead,
+    // but we still want to show the account name if the group name is not available.
+    return filteredAccounts.map((account) => {
+      const group = accountGroups.find(({ accounts: accountGroup }) =>
+        accountGroup.includes(account.id),
+      );
+      const name = group?.metadata.name ?? account.name;
+
+      return {
+        ...account,
+        name,
+        groupId: group?.id ?? '',
+      };
+    });
+  }, [internalAccounts, chainIds, hideExternalAccounts, snapId, accountGroups]);
 
   const options = accounts.map((account) => ({
     key: 'accountId',

--- a/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
@@ -73,6 +73,9 @@ describe('SnapUIAccountSelector', () => {
     AccountTreeController: {
       accountTree: [],
     },
+    CurrencyRateController: {
+      currentCurrency: 'usd',
+    },
     TokenBalancesController: {
       tokenBalances: {},
     },

--- a/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
@@ -47,7 +47,6 @@ jest.mock('../../../hooks/useAccounts', () => {
       },
     ],
     evmAccounts: [],
-    ensByAccountAddress: {},
   }));
   return {
     useAccounts: useAccountsMock,
@@ -76,12 +75,6 @@ describe('SnapUIAccountSelector', () => {
     CurrencyRateController: {
       currentCurrency: 'usd',
     },
-    TokenBalancesController: {
-      tokenBalances: {},
-    },
-    TokenRatesController: {
-      marketData: {},
-    },
     MultichainAssetsRatesController: {
       conversionRates: {},
     },
@@ -89,7 +82,7 @@ describe('SnapUIAccountSelector', () => {
       balances: {},
     },
     MultichainAssetsController: {
-      accountAssets: {},
+      accountsAssets: {},
     },
   };
 

--- a/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/account-selector.test.ts
@@ -26,10 +26,6 @@ jest.mock('../../../hooks/useAccounts', () => {
       {
         name: 'Account 1',
         address: '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272',
-        assets: {
-          fiatBalance: '$3200.00\n1 ETH',
-          tokens: [],
-        },
         type: 'HD Key Tree',
         yOffset: 0,
         scopes: ['eip155:0'],
@@ -40,10 +36,6 @@ jest.mock('../../../hooks/useAccounts', () => {
       {
         name: 'Solana Account 1',
         address: 'F9SpmMkV2rdbZoJxwpFQ192pCyZwcVDc8F9V6B1AWTbR',
-        assets: {
-          fiatBalance: '$6400.00\n1 SOL',
-          tokens: [],
-        },
         type: 'Snap Keyring',
         snapId: 'local:snap-id',
         yOffset: 0,
@@ -77,6 +69,24 @@ describe('SnapUIAccountSelector', () => {
           activeChains: [],
         },
       },
+    },
+    AccountTreeController: {
+      accountTree: [],
+    },
+    TokenBalancesController: {
+      tokenBalances: {},
+    },
+    TokenRatesController: {
+      marketData: {},
+    },
+    MultichainAssetsRatesController: {
+      conversionRates: {},
+    },
+    MultichainBalancesController: {
+      balances: {},
+    },
+    MultichainAssetsController: {
+      accountAssets: {},
     },
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a couple of issues in `SnapUIAccountSelector` caused by upstream changes. The assets metadata was removed and the account names are now unavailable via `useAccounts`. We adopt the same change as on extension to solve these problems.

Also removed ENS logic as it has been disabled in the main account selector as well.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-900


## **Screenshots/Recordings**

<img width="400" height="874" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-07 at 12 12 36" src="https://github.com/user-attachments/assets/ec2760d9-f95e-4626-aed3-a11089c981f8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the account selector to derive display names and fiat balances from account-tree and multichain balance selectors, which could regress rendering if those state slices are missing or inconsistent.
> 
> **Overview**
> Fixes `SnapUIAccountSelector` to stop relying on `useAccounts` ENS/asset metadata by **deriving display data from Redux**.
> 
> Accounts are now labeled using their **account group name** (fallback to `account.name`) and show a **formatted fiat balance** computed from `selectMultichainNetworkAggregatedBalanceForAllAccounts` and `selectCurrentCurrency` (with `formatWithThreshold`/locale). ENS fetching/override logic is removed, and tests are updated to reflect the new state dependencies and mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c27e7f6584b814e5fb1ef2ec2a104de8a910a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->