### PR TITLE
ci: Fix "Install Android System Images" retry

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -54,7 +54,6 @@ jobs:
           command: |
             echo "📱 Installing Android system images for AVD..."
             "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
-            echo "✅ System images installed"
 
       - name: Setup Android Build Environment
         timeout-minutes: 15

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -54,7 +54,6 @@ jobs:
           command: |
             echo "📱 Installing Android system images for AVD..."
             rm -rf "$ANDROID_SDK_ROOT"/.temp "$ANDROID_SDK_ROOT"/system-images
-            df -h
             "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
 
       - name: Setup Android Build Environment

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -54,6 +54,7 @@ jobs:
           command: |
             echo "📱 Installing Android system images for AVD..."
             rm -rf "$ANDROID_SDK_ROOT"/.temp "$ANDROID_SDK_ROOT"/system-images
+            df -h
             "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
 
       - name: Setup Android Build Environment

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -53,6 +53,7 @@ jobs:
           retry_wait_seconds: 30
           command: |
             echo "📱 Installing Android system images for AVD..."
+            rm -rf "$ANDROID_SDK_ROOT"/.temp "$ANDROID_SDK_ROOT"/system-images
             "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager "system-images;android-34;google_apis;x86_64"
 
       - name: Setup Android Build Environment


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the retry logic for "Install Android System Images" by omitting the final `echo`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

