### PR TITLE
chore(ci): cherry-pick xmldom 0.8.12 bump (#28424) into release/7.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "@walletconnect/core": "^2.23.0",
     "@walletconnect/react-native-compat": "^2.23.0",
     "@walletconnect/utils": "^2.23.0",
-    "@xmldom/xmldom": "^0.8.10",
+    "@xmldom/xmldom": "^0.8.12",
     "asyncstorage-down": "4.2.0",
     "axios": "^1.13.5",
     "bignumber.js": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20811,7 +20811,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.10, @xmldom/xmldom@npm:^0.8.8, @xmldom/xmldom@npm:^0.x":
+"@xmldom/xmldom@npm:^0.8.12":
+  version: 0.8.12
+  resolution: "@xmldom/xmldom@npm:0.8.12"
+  checksum: 10/0fc20bc72a057a939ed17afc3fb35d6be2eb19e42aa9ba3c78aa8bdf471da0b4b17c2710581ce6a2cd68ce3995c2ee7d689593a70a26df1273c0c9c29dfca257
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.8.8, @xmldom/xmldom@npm:^0.x":
   version: 0.8.11
   resolution: "@xmldom/xmldom@npm:0.8.11"
   checksum: 10/f6d6ffdf71cf19d9b3c10e978fad40d2f85453bf5b2aa05be8aa0c5ad13f84690c3153316729213cc652d06ec12c605ddb0aa03886f1d73d51b974b4105d31e3
@@ -35740,7 +35747,7 @@ __metadata:
     "@walletconnect/utils": "npm:^2.23.0"
     "@wdio/protocols": "npm:^9.24.0"
     "@welldone-software/why-did-you-render": "npm:^8.0.1"
-    "@xmldom/xmldom": "npm:^0.8.10"
+    "@xmldom/xmldom": "npm:^0.8.12"
     appium: "npm:^2.12.1"
     appium-adb: "npm:^9.11.4"
     appium-chromium-driver: "npm:^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20811,17 +20811,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.12":
+"@xmldom/xmldom@npm:^0.8.12, @xmldom/xmldom@npm:^0.8.8, @xmldom/xmldom@npm:^0.x":
   version: 0.8.12
   resolution: "@xmldom/xmldom@npm:0.8.12"
   checksum: 10/0fc20bc72a057a939ed17afc3fb35d6be2eb19e42aa9ba3c78aa8bdf471da0b4b17c2710581ce6a2cd68ce3995c2ee7d689593a70a26df1273c0c9c29dfca257
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:^0.8.8, @xmldom/xmldom@npm:^0.x":
-  version: 0.8.11
-  resolution: "@xmldom/xmldom@npm:0.8.11"
-  checksum: 10/f6d6ffdf71cf19d9b3c10e978fad40d2f85453bf5b2aa05be8aa0c5ad13f84690c3153316729213cc652d06ec12c605ddb0aa03886f1d73d51b974b4105d31e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Cherry-picks [PR #28424](https://github.com/MetaMask/metamask-mobile/pull/28424) (`chore(deps): bump @xmldom/xmldom to 0.8.12` + lockfile dedupe) onto `release/7.72.0` for inclusion in the release train tracked by [PR #27990](https://github.com/MetaMask/metamask-mobile/pull/27990).

## Motivation
Addresses production dependency audit (`GHSA-wh4c-j3r5-mjhp`) by bumping `@xmldom/xmldom` to `0.8.12` and deduping `yarn.lock` so resolved versions align.

## Commits (cherry-picked)
- `46057e87e4` — chore(deps): bump @xmldom/xmldom to 0.8.12
- `776772ffcd` — chore(deps): dedupe lockfile after xmldom bump
CHANGELOG entry: null

## Testing
- [ ] CI green on this PR
- [ ] `yarn audit:ci` / audit expectations as appropriate for release branch

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change: bumps `@xmldom/xmldom` and updates the lockfile resolution/checksum, with no application code changes.
> 
> **Overview**
> Updates the `@xmldom/xmldom` dependency from `^0.8.10` to `^0.8.12` in `package.json`.
> 
> Refreshes `yarn.lock` to resolve `@xmldom/xmldom` to `0.8.12` (updated resolution key/checksum), aligning the lockfile with the bumped version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307083efc2de0b19e16399664c7789e9b5921537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->