### PR TITLE
fix(i18n): correct Turkish percent interpolation placeholders (TMCU-626)

### DIFF
--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -1057,7 +1057,7 @@
       "edit_button": "Düzenle"
     },
     "stop_loss_prompt": {
-      "near_liquidation_title": "Likidasyona yalnızca %{{distance}} uzaktasınız",
+      "near_liquidation_title": "Likidasyona yalnızca {{distance}}% uzaktasınız",
       "near_liquidation_subtitle": "Pozisyonunuzun riskini azaltmak için marj ekleyin",
       "add_margin_button": "Ekle",
       "protect_losses_title": "Daha fazla zarara karşı korunun",
@@ -1300,7 +1300,7 @@
         "current_price": "Mevcut fiyat",
         "liquidation_price": "Likidasyon fiyatı",
         "liquidation_distance": "Likidasyon mesafesi",
-        "liquidation_warning": "Fiyat %{{percentage}} {{direction}} yaşarsa pozisyonunuz likidasyona uğrar",
+        "liquidation_warning": "Fiyat {{percentage}}% {{direction}} yaşarsa pozisyonunuz likidasyona uğrar",
         "drops": "düşüş",
         "rises": "yükseliş",
         "set_leverage": "{{leverage}} kaldıraç ayarla"
@@ -1730,7 +1730,7 @@
         "provider_fee": "Sağlayıcı ücreti",
         "bridge_fee": "Köprü ücreti",
         "total": "Toplam ücretler",
-        "discount_message": "MetaMask Ödülleri ile %{{percentage}} tasarruf ediyorsunuz."
+        "discount_message": "MetaMask Ödülleri ile {{percentage}}% tasarruf ediyorsunuz."
       },
       "closing_fees": {
         "title": "Kapatma ücretleri",
@@ -2359,7 +2359,7 @@
       "slippage": "Kayma",
       "price_details": "Fiyat bilgileri",
       "prediction_order": "Tahmin emri",
-      "prediction_order_description": "Her biri {{price}} fiyatta ~{{count}} sözleşme. Son tutar, emir defteri kullanılabilirliğe göre değişiklik gösterebilir (%{{slippage}} orana kadar).",
+      "prediction_order_description": "Her biri {{price}} fiyatta ~{{count}} sözleşme. Son tutar, emir defteri kullanılabilirliğe göre değişiklik gösterebilir ({{slippage}}% orana kadar).",
       "metamask_fee_description": "Bu tahmin işlemine yönelik hizmet ücreti",
       "exchange_fee": "Borsa ücreti",
       "exchange_fee_description": "Borsaya veya piyasaya ödenen ücret",
@@ -5395,8 +5395,8 @@
     "included": "dahil",
     "max_gas_fee": "Maks. gaz ücreti",
     "edit": "Düzenle",
-    "quotes_include_fee": "%{{fee}} MetaMask ücreti tekliflere dahildir",
-    "quotes_include_gas_and_metamask_fee": "Gaz ve %{{fee}} MetaMask ücreti teklife dahildir",
+    "quotes_include_fee": "Tekliflere {{fee}}% MetaMask ücreti dahildir",
+    "quotes_include_gas_and_metamask_fee": "Teklife gaz ve {{fee}}% MetaMask ücreti dahildir",
     "tap_to_swap": "Takas işlemi gerçekleştirmek için dokunun",
     "swipe_to_swap": "Swap gerçekleştirmek için kaydır",
     "swipe_to": "Swap gerçekleştirmek için",
@@ -5999,16 +5999,16 @@
   },
   "earn": {
     "claimable_bonus_tooltip": "mUSD tuttuğunuz için kazandığınız yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
-    "earn_a_percentage_bonus": "%{{percentage}} bonus kazanın",
-    "percentage_bonus": "%{{percentage}} bonus",
+    "earn_a_percentage_bonus": "{{percentage}}% bonus kazanın",
+    "percentage_bonus": "{{percentage}}% bonus",
     "claimable_bonus": "Alınabilir bonus",
     "claim_bonus": "Bonusu al",
     "claim_bonus_with_fiat": "Claim {{amount}}",
     "claim_bonus_subtitle": "Bonus, {{networkName}} üzerinde ödenecektir.",
-    "percentage_bonus_on_linea": "Linea üzerinde %{{percentage}} bonus",
+    "percentage_bonus_on_linea": "Linea üzerinde {{percentage}}% bonus",
     "claim": "Al",
     "sounds_good": "Kulağa hoş geliyor",
-    "claimable_bonus_tooltip_with_percentage": "mUSD tuttuğunuz için kazandığınız %{{percentage}} yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
+    "claimable_bonus_tooltip_with_percentage": "mUSD tuttuğunuz için kazandığınız {{percentage}}% yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
     "empty_state_cta": {
       "heading": "{{tokenSymbol}} borç verin ve kazanın",
       "body": "{{protocol}} ile {{tokenSymbol}} token'ınızı borç verin ve",
@@ -6094,14 +6094,14 @@
     "musd_conversion": {
       "ok": "Tamam",
       "continue": "Devam et",
-      "convert_and_get_percentage_bonus": "Dönüştür ve %{{percentage}} al",
+      "convert_and_get_percentage_bonus": "Dönüştür ve {{percentage}}% al",
       "your_musd": "mUSD bakiyeniz",
       "balance_breakdown_title": "Ağa göre mUSD bakiyeleriniz",
       "balance_amount": "{{amount}} mUSD",
       "balance_amount_with_symbol": "{{amount}} {{symbol}}",
       "balance_fiat_unavailable": "—",
       "convert_to_musd": "mUSD'ye dönüştür",
-      "get_a_percentage_musd_bonus": "%{{percentage}} mUSD bonus al",
+      "get_a_percentage_musd_bonus": "{{percentage}}% mUSD bonus al",
       "convert": "Dönüştür",
       "fetching_quote": "Teklif alınıyor...",
       "you_convert": "Dönüştürdüğünüz tutar",
@@ -6117,16 +6117,16 @@
         "failed": "mUSD dönüştürme işlemi başarısız oldu"
       },
       "education": {
-        "heading": "STABİL KRİPTO PARALARDA\n%{{percentage}} AL",
-        "description": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz %{{percentage}} oranına varan yıllıklandırılmış bonus kazanın.",
+        "heading": "STABİL KRİPTO PARALARDA\n{{percentage}}% AL",
+        "description": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz {{percentage}}% oranına varan yıllıklandırılmış bonus kazanın.",
         "terms_apply": "Şartlar uygulanır.",
         "primary_button": "Başlarken",
         "secondary_button": "Şimdi değil"
       },
       "buy_musd": "mUSD al",
       "get_musd": "mUSD kazan",
-      "bonus_title": "Stabil kripto paranızda %{{percentage}} bonus kazanın",
-      "bonus_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve %{{percentage}} oranında yıllıklandırılmış bonus alın.",
+      "bonus_title": "Stabil kripto paranızda {{percentage}}% bonus kazanın",
+      "bonus_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve {{percentage}}% oranında yıllıklandırılmış bonus alın.",
       "powered_by_relay": "Destekleyen Relay",
       "max": "Maksimum",
       "quick_convert_button": "Dönüştür",
@@ -6134,14 +6134,14 @@
       "tooltip_title": "mUSD ile getiri elde et",
       "tooltip_content": "USDC, USDT veya DAI'nizi MetaMask'in dolar destekli stabil kripto parası olan mUSD'ye dönüştürün. Tuttuğunuz her dolar için {{apy}} getiri elde edin.",
       "quick_convert": {
-        "title": "Dönüştür ve %{{percentage}} al",
-        "subtitle": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz %{{percentage}} oranına varan yıllıklandırılmış bonus alın.",
+        "title": "Dönüştür ve {{percentage}}% al",
+        "subtitle": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz {{percentage}}% oranına varan yıllıklandırılmış bonus alın.",
         "inline_failed_message": "Dönüştürme işlemi başarısız oldu. Tekrar deneyin.",
         "confirmation": {
           "title": "Maksimumu dönüştür"
         }
       },
-      "percentage_bonus": "%{{percentage}} bonus",
+      "percentage_bonus": "{{percentage}}% bonus",
       "rate": "Oran"
     },
     "bonus_claim": {
@@ -6164,7 +6164,7 @@
   },
   "money": {
     "title": "Para",
-    "apy_label": "%{{percentage}} Yıllık Bileşik Getiri",
+    "apy_label": "{{percentage}}% Yıllık Bileşik Getiri",
     "action": {
       "add": "Ekle",
       "transfer": "Transfer Et",
@@ -6196,7 +6196,7 @@
       "subtitle": "Paranızı dilediğiniz yerde harcayın.",
       "virtual_card": "Sanal kart",
       "metal_card": "Metal kart",
-      "cashback": "%{{percentage}} para iadesi",
+      "cashback": "{{percentage}}% para iadesi",
       "get_now": "Hemen alın"
     },
     "why_metamask_money": {
@@ -6359,7 +6359,7 @@
     "you_could_earn_up_to": "Yılda",
     "per_year_on_your_tokens": "kazanabilirsiniz",
     "deposit": "Para Yatır",
-    "gas_cost_impact_warning": "Uyarı: İşlemin gaz maliyeti yatırdığınız paranın %{{percentOverDeposit}} fazlası olacaktır.",
+    "gas_cost_impact_warning": "Uyarı: İşlemin gaz maliyeti yatırdığınız paranın {{percentOverDeposit}}% fazlası olacaktır.",
     "earnings_history_title": "{{ticker}} kazançları",
     "apr": "APR",
     "interactive_chart": {
@@ -6719,7 +6719,7 @@
     "title": "Köprü",
     "submitting_transaction": "Gönderiliyor",
     "fetching_quote": "Teklif alınıyor",
-    "fee_disclaimer": "%{{feePercentage}} MetaMask ücreti dahildir.",
+    "fee_disclaimer": "{{feePercentage}}% MetaMask ücreti dahildir.",
     "no_mm_fee": "MM ücreti yok",
     "no_mm_fee_disclaimer": "{{destTokenSymbol}} takasında MetaMask ücreti yok.",
     "hardware_wallet_not_supported": "Donanım cüzdanları henüz desteklenmiyor. Devam etmek için sıcak cüzdan kullanın.",
@@ -6754,8 +6754,8 @@
     "confirm": "Onayla",
     "exceeding_upper_slippage_warning": "Yüksek kayma; bu durum istenmeyen bir takas ile sonuçlanabilir",
     "exceeding_lower_slippage_warning": "Düşük kayma; bu durum istenmeyen bir takas ile sonuçlanabilir",
-    "exceeding_lower_slippage_error": "%{{value}} değerin üzerinde olan bir değer girin",
-    "exceeding_upper_slippage_error": "%{{value}} değerin üzerinde olan bir değer giremezsiniz",
+    "exceeding_lower_slippage_error": "{{value}}% değerin üzerinde olan bir değer girin",
+    "exceeding_upper_slippage_error": "{{value}}% değerin üzerinde olan bir değer giremezsiniz",
     "custom": "Özel",
     "invalid_recipient_address": "Geçersiz adres",
     "select_quote": "Teklif Seç",


### PR DESCRIPTION
## **Description**

This PR fixes Turkish translations that used `%{{variable}}` patterns, which conflict with the i18n parser’s `%{...}` placeholder syntax and can render `[missing ... value]` text in UI.

Updated all affected `tr.json` strings to the safe/consistent form `{{variable}}%`, preserving meaning while preventing placeholder parsing collisions.

## **Changelog**

CHANGELOG entry: Fixed Turkish percentage strings that could render missing placeholder text on the homepage and related flows.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28412
Refs: [TMCU-626](https://consensyssoftware.atlassian.net/browse/TMCU-626)

## **Manual testing steps**

```gherkin
Feature: Turkish percentage translations render correctly

  Scenario: Turkish UI shows percentage values without missing placeholder errors
    Given the app language is set to Turkish
    And the user opens views that render percentage-based strings (e.g. Homepage/Earn/Bridge/Perps)

    When percentage-based localized copy is displayed
    Then text should render with a numeric percentage format like "{{value}}%"
    And no "[missing ... value]" placeholder text should appear
```

## **Screenshots/Recordings**

### **Before**
<img width="396" height="843" alt="Screenshot 2026-04-07 at 15 46 14" src="https://github.com/user-attachments/assets/e4fcd7c9-355a-4a06-af99-9936963ce469" />

### **After**
<img width="393" height="838" alt="Screenshot 2026-04-07 at 15 47 30" src="https://github.com/user-attachments/assets/8a46f42d-589d-4982-a177-c1cf709efd1e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Translation-only changes that adjust placeholder formatting; low functional risk, with the main risk being minor copy/format regressions if any string expects the old ordering.
> 
> **Overview**
> Fixes Turkish localization strings that embed percentage values by changing placeholders from `%{{var}}` to `{{var}}%` (and related word-order tweaks) across perps, swap/bridge quotes, slippage, fees, and Earn/mUSD copy.
> 
> This prevents i18n interpolation collisions that could display `[missing ... value]` in the UI while keeping the same meaning and formatting for percent-based messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaacb8e30a0033d0a639650b9e60bfbdf5fcb413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[TMCU-626]: https://consensyssoftware.atlassian.net/browse/TMCU-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ