### PR TITLE
feat: compliace tracking

### DIFF
--- a/app/components/UI/Compliance/contexts/AccessRestrictedContext.tsx
+++ b/app/components/UI/Compliance/contexts/AccessRestrictedContext.tsx
@@ -12,6 +12,12 @@ import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { METAMASK_SUPPORT_URL } from '../../../../constants/urls';
 import AccessRestrictedModal from '../AccessRestrictedModal';
+import { usePerpsEventTracking } from '../../Perps/hooks/usePerpsEventTracking';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller';
 
 interface AccessRestrictedContextType {
   showAccessRestrictedModal: () => void;
@@ -31,11 +37,16 @@ export const AccessRestrictedProvider = ({
 }: AccessRestrictedProviderProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const navigation = useNavigation();
+  const { track } = usePerpsEventTracking();
 
   const showAccessRestrictedModal = useCallback(() => {
     notificationAsync(NotificationFeedbackType.Warning);
     setIsVisible(true);
-  }, []);
+    track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+      [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+        PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF,
+    });
+  }, [track]);
 
   const hideAccessRestrictedModal = useCallback(() => {
     setIsVisible(false);

--- a/app/controllers/perps/constants/eventNames.ts
+++ b/app/controllers/perps/constants/eventNames.ts
@@ -388,6 +388,7 @@ export const PERPS_EVENT_VALUE = {
     ADD_MARGIN: 'add_margin',
     REMOVE_MARGIN: 'remove_margin',
     GEO_BLOCK_NOTIF: 'geo_block_notif',
+    COMPLIANCE_BLOCK_NOTIF: 'compliance_block_notif',
     // Deposit + order (pay-with token) cancel toast
     CANCEL_TRADE_WITH_TOKEN_TOAST: 'cancel_trade_with_token_toast',
   },

--- a/docs/perps/perps-metametrics-reference.md
+++ b/docs/perps/perps-metametrics-reference.md
@@ -74,7 +74,7 @@ this.#getMetrics().trackPerpsEvent(PerpsAnalyticsEvent.TradeTransaction, {
   - **Deposit screens:** `'deposit_input'` | `'deposit_review'`
   - **Market list screens:** `'market_list'` | `'market_list_all'` | `'market_list_crypto'` | `'market_list_stocks'`
   - **Position management:** `'close_all_positions'` | `'cancel_all_orders'` | `'increase_exposure'` | `'add_margin'` | `'remove_margin'`
-  - **Other screens:** `'pnl_hero_card'` | `'order_book'` | `'full_screen_chart'` | `'activity'` | `'geo_block_notif'`
+  - **Other screens:** `'pnl_hero_card'` | `'order_book'` | `'full_screen_chart'` | `'activity'` | `'geo_block_notif'` | `'compliance_block_notif'`
 - `asset` (optional): Asset symbol (e.g., `'BTC'`, `'ETH'`)
 - `direction` (optional): `'long' | 'short'`
 - `source` (optional): Where user came from
@@ -554,6 +554,52 @@ usePerpsEventTracking({
   },
 });
 ```
+
+---
+
+## Compliance (OFAC) Blocking Tracking
+
+When a wallet is blocked by an OFAC compliance check, the `compliance_block_notif` screen type is used. The event fires automatically via `AccessRestrictedContext` whenever `showAccessRestrictedModal()` is called — no per-action tracking is needed.
+
+### Properties
+
+- `screen_type`: `'compliance_block_notif'`
+
+### Constant
+
+```typescript
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller';
+
+// PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF === 'compliance_block_notif'
+```
+
+### Where the event fires
+
+The event is tracked in `showAccessRestrictedModal` inside `AccessRestrictedContext.tsx`. All call sites — `useComplianceGate` and every gated action handler — call this method, so coverage is automatic.
+
+```typescript
+// app/components/UI/Compliance/contexts/AccessRestrictedContext.tsx
+const showAccessRestrictedModal = useCallback(() => {
+  notificationAsync(NotificationFeedbackType.Warning);
+  setIsVisible(true);
+  track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+    [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+      PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF,
+  });
+}, [track]);
+```
+
+### Difference from geo-blocking
+
+|                    | Geo-blocking                       | Compliance blocking                            |
+| ------------------ | ---------------------------------- | ---------------------------------------------- |
+| `screen_type`      | `geo_block_notif`                  | `compliance_block_notif`                       |
+| Tracked per action | Yes — each handler tracks `source` | No — tracked once in context                   |
+| Source property    | Identifies the blocked action      | Not included (all routes share the same modal) |
+| Feature flag       | Geo eligibility                    | `complianceEnabled`                            |
 
 ---
 


### PR DESCRIPTION
## Description

Adds MetaMetrics tracking whenever the OFAC compliance-blocked modal is shown.

When a wallet address is sanctioned, `showAccessRestrictedModal()` is called from `useComplianceGate`. Until now this was a silent UI event — no analytics event was fired. This PR closes that gap by tracking `PERPS_SCREEN_VIEWED` with `screen_type: 'compliance_block_notif'` inside the context, so every call site is covered automatically with no per-handler changes.

### Changes

**`AccessRestrictedContext.tsx`**
Added `usePerpsEventTracking` and fires `MetaMetricsEvents.PERPS_SCREEN_VIEWED` with `PERPS_EVENT_PROPERTY.SCREEN_TYPE: PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF` inside `showAccessRestrictedModal`. Tracking is centralised here — all gated action handlers (`handleAddFunds`, `handleTradeAction`, `handleLongPress`, etc.) benefit automatically with no per-handler changes.

**`app/controllers/perps/constants/eventNames.ts`**
Added `COMPLIANCE_BLOCK_NOTIF: 'compliance_block_notif'` to `PERPS_EVENT_VALUE.SCREEN_TYPE`, following the same pattern as the existing `GEO_BLOCK_NOTIF` constant.

**`docs/perps/perps-metametrics-reference.md`**
- Added `'compliance_block_notif'` to the `screen_type` values list.
- Added a new **Compliance (OFAC) Blocking Tracking** section (mirroring the existing geo-blocking section) documenting the event, the constant, where it fires, and a comparison table with geo-blocking.

## Changelog

- **Added**: MetaMetrics tracking (`PERPS_SCREEN_VIEWED` / `compliance_block_notif`) fired automatically whenever the OFAC compliance-blocked modal is shown

CHANGELOG entry: Added compliance blocking analytics tracking

## Related issues

Refs: #28034

## Manual testing steps

**Feature**: Compliance blocking analytics

  Scenario: user with a blocked wallet address triggers a Perps action
    Given compliance is enabled via the `complianceEnabled` feature flag
    And the wallet address is OFAC-sanctioned (returns blocked from the API)

    When user taps any gated action (Add Funds, Long, Short, Close, Modify, etc.)
    Then the access-restricted modal appears with haptic feedback
    And a `Perp Screen Viewed` MetaMetrics event is sent with `screen_type: 'compliance_block_notif'`

  Scenario: user with an unblocked wallet address triggers a Perps action
    Given compliance is enabled
    And the wallet address is not sanctioned

    When user taps any gated action
    Then the action proceeds normally
    And no compliance tracking event is sent

  Scenario: compliance feature flag is disabled
    Given the `complianceEnabled` flag is off

    When user taps any gated action
    Then the action proceeds normally without any compliance check or tracking event

## Screenshots/Recordings

N/A — no UI change; tracking only.

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that adds a new `PERPS_SCREEN_VIEWED` screen type and emits it when the compliance access-restricted modal is shown; main risk is unintended extra event volume if the modal is triggered frequently.
> 
> **Overview**
> Adds MetaMetrics tracking for OFAC/compliance blocking by emitting `MetaMetricsEvents.PERPS_SCREEN_VIEWED` from `showAccessRestrictedModal()` in `AccessRestrictedContext`, with `screen_type` set to the new `PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF`.
> 
> Introduces the new `COMPLIANCE_BLOCK_NOTIF` screen type constant alongside existing Perps screen types, and updates the Perps MetaMetrics reference docs to include and describe this compliance-blocking tracking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fb2f10256bd3f655037a417d76151b9ce621c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->