### PR TITLE
ci(unit-tests): enable Jest cache and increase maxWorkers in CI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -60,7 +60,7 @@ const config = {
   ],
   coverageReporters: ['text-summary', 'lcov'],
   coverageDirectory: '<rootDir>/tests/coverage',
-  maxWorkers: process.env.NODE_ENV === 'production' ? '50%' : '20%',
+  maxWorkers: process.env.CI ? '50%' : '20%',
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/app/__mocks__/svgMock.js',
     '\\.(png)$': '<rootDir>/app/__mocks__/pngMock.js',
@@ -89,8 +89,10 @@ const config = {
       '<rootDir>/app/__mocks__/spinnerMock.js',
     '^rive-react-native$': '<rootDir>/app/__mocks__/rive-react-native.tsx',
   },
-  // Disable jest cache
-  cache: false,
+  cache: true,
+  ...(process.env.JEST_CACHE_DIRECTORY && {
+    cacheDirectory: process.env.JEST_CACHE_DIRECTORY,
+  }),
 };
 
 // eslint-disable-next-line import-x/no-commonjs


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Two low-risk, zero-infrastructure changes to `jest.config.js` that improve unit test performance on CI immediately:

### 1. Enable Jest transform cache (`cache: true`)

The previous `cache: false` forced babel-jest to re-parse and re-transform every source file on every test run from scratch. With `cache: true`, subsequent runs reuse cached transforms for unchanged files.

An optional `JEST_CACHE_DIRECTORY` env var is wired up so CI can pin the cache to a known path (`/tmp/jest_rs`) and persist it across runs via `actions/cache` (used in a follow-up PR).

### 2. Increase `maxWorkers` in CI (`process.env.CI ? '50%' : '20%'`)

The previous condition (`NODE_ENV === 'production'`) never triggered in CI, meaning Jest always used ~1 worker on the 4-vCPU `ubuntu-latest` runner (20% of 4 cores), leaving 3 cores idle during test execution.

Switching to `process.env.CI` (automatically set by GitHub Actions) gives Jest ~2 workers per shard in CI, while local development remains at `20%` to avoid overwhelming developer machines.

**Note:** If OOM failures appear (exit code 137, "JavaScript heap out of memory"), the first mitigation is lowering `--max_old_space_size` from `20480` to a more conservative value like `8192` to force more aggressive GC.

### Expected impact

| Metric | Before | After |
|---|---|---|
| Jest workers per shard (CI) | ~1 | ~2 |
| Transform cache | Disabled (full rebuild every run) | Enabled |
| Local dev workers | ~1 | unchanged (~1) |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — Jest config only. Verify by observing faster unit test shard times in this PR's CI run.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; main risk is CI instability from higher parallelism or stale cache behavior, which should surface quickly in test runs.
> 
> **Overview**
> Improves unit test performance by updating `jest.config.js` to run more workers in CI (`maxWorkers` now keyed off `process.env.CI`) while keeping local runs capped.
> 
> Re-enables Jest caching (`cache: true`) and optionally supports a custom cache location via `JEST_CACHE_DIRECTORY` to allow CI to persist/target the cache directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e147718155cea05d77580108d9d9b94a6f094bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->