### PR TITLE
chore: Generate iOS IPA for dev builds and test APK for Android builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,7 +424,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload iOS IPA
-        if: matrix.platform == 'ios' && env.IS_SIM_BUILD != 'true'
+        if: matrix.platform == 'ios'
         uses: actions/upload-artifact@v4
         with:
           name: ios-ipa-${{ inputs.build_name }}
@@ -447,7 +447,7 @@ jobs:
           path: ${{ steps.rename.outputs.ios_sourcemap_path }}
           if-no-files-found: warn
 
-      # Dev builds (CONFIGURATION=Debug): APK only
+      # Dev builds (CONFIGURATION=Debug): APK + test APK (for E2E)
       - name: Upload Android APK (dev)
         if: matrix.platform == 'android' && env.CONFIGURATION == 'Debug'
         uses: actions/upload-artifact@v4
@@ -455,6 +455,14 @@ jobs:
           name: android-apk-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_apk_path }}
           if-no-files-found: error
+
+      - name: Upload Android test APK (dev)
+        if: matrix.platform == 'android' && env.CONFIGURATION == 'Debug' && steps.rename.outputs.android_test_apk_path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-apk-${{ inputs.build_name }}
+          path: ${{ steps.rename.outputs.android_test_apk_path }}
+          if-no-files-found: warn
 
       # Release builds: APK and AAB as separate artifacts
       - name: Upload Android APK (release)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,7 +358,7 @@ jobs:
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
 
-      # Signing: uses role + secret from builds.yml (skip for dev builds - main-dev, flask-dev, qa-dev use debug/simulator)
+      # Signing: uses role + secret from builds.yml (skipped when builds.yml omits signing, e.g. simulator-only flask-dev / qa-dev)
       - name: Configure signing certificates
         if: needs.prepare.outputs.signing_aws_role != ''
         uses: ./.github/actions/configure-signing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,7 @@ jobs:
             SCRIPT_NAME="build:${{ matrix.platform }}:${BUILD_NAME//-/:}"
             yarn "$SCRIPT_NAME"
 
-      # Rename build artifacts (zips simulator .app and .xcarchive; writes ios_deploy_path / ios_archive_path / android_*_path outputs)
+      # Rename build artifacts (ios_simulator_path / ios_ipa_path / ios_archive_path / android_*_path outputs)
       - name: Rename ${{ matrix.platform }} artifacts
         if: success()
         id: rename
@@ -420,19 +420,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios-app-${{ inputs.build_name }}
-          path: ${{ steps.rename.outputs.ios_deploy_path }}
+          path: ${{ steps.rename.outputs.ios_simulator_path }}
           if-no-files-found: error
 
       - name: Upload iOS IPA
-        if: matrix.platform == 'ios'
+        if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
         uses: actions/upload-artifact@v4
         with:
           name: ios-ipa-${{ inputs.build_name }}
-          path: ${{ steps.rename.outputs.ios_deploy_path }}
+          path: ${{ steps.rename.outputs.ios_ipa_path }}
           if-no-files-found: error
 
       - name: Upload iOS xcarchive
-        if: matrix.platform == 'ios' && env.IS_SIM_BUILD != 'true'
+        if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
         uses: actions/upload-artifact@v4
         with:
           name: ios-xcarchive-${{ inputs.build_name }}
@@ -440,7 +440,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload iOS sourcemap
-        if: matrix.platform == 'ios' && env.IS_SIM_BUILD != 'true'
+        if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
         uses: actions/upload-artifact@v4
         with:
           name: ios-sourcemaps-${{ inputs.build_name }}

--- a/builds.yml
+++ b/builds.yml
@@ -291,6 +291,7 @@ builds:
       IS_TEST: 'false'
       MM_ENABLE_SETTINGS_PAGE_DEV_OPTIONS: 'true'
       IS_SIM_BUILD: 'true'
+      IS_DEVICE_BUILD: 'true'
       CONFIGURATION: 'Debug'
       DEV_OAUTH_CONFIG: 'true'
     secrets: *secrets

--- a/builds.yml
+++ b/builds.yml
@@ -273,9 +273,10 @@ builds:
     secrets: *secrets
     code_fencing: *code_fencing_experimental
 
-  # Local development / Expo development build (Runway .app for simulator)
+  # Local development / Expo development build (simulator .app + optional device IPA when IS_DEVICE_BUILD)
   main-dev:
     github_environment: build-exp
+    signing: *signing_uat
     env:
       <<: *public_envs
       METAMASK_ENVIRONMENT: 'dev'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -551,6 +551,14 @@ generateIosBinary() {
 	if [ "$IS_SIM_BUILD" = "true" ]; then
     	echo "Binary build type: Simulator"
 		xcodebuild -workspace MetaMask.xcworkspace -scheme $scheme -configuration $configuration -sdk iphonesimulator -derivedDataPath build
+
+		# Also generate an .ipa to run on devices
+		if [ "$IS_DEVICE_BUILD" = "true" ]; then
+			echo "Binary build type: Device"
+			xcodebuild -workspace MetaMask.xcworkspace -scheme $scheme -configuration $configuration archive -archivePath build/$scheme.xcarchive -destination generic/platform=ios
+			echo "Generating ipa for $scheme"
+			xcodebuild -exportArchive -archivePath build/$scheme.xcarchive -exportPath build/output -exportOptionsPlist $exportOptionsPlist
+		fi
 	else
 		echo "Binary build type: Device"
 		xcodebuild -workspace MetaMask.xcworkspace -scheme $scheme -configuration $configuration archive -archivePath build/$scheme.xcarchive -destination generic/platform=ios

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -198,11 +198,17 @@ function setGithubOutput(key, value) {
 
 /**
  * Rename iOS artifacts
+ *
+ * Simulator-only: ios_simulator_path (zipped .app).
+ * Device-only: ios_ipa_path, ios_archive_path, ios_sourcemap_path.
+ * Dual (IS_SIM_BUILD + IS_DEVICE_BUILD, e.g. main-dev): all of the above.
  */
 function renameIos() {
   console.log('📦 Renaming iOS artifacts...');
 
   const isSimBuild = process.env.IS_SIM_BUILD === 'true';
+  const isDeviceBuild = process.env.IS_DEVICE_BUILD === 'true';
+  const hasDeviceArtifacts = !isSimBuild || isDeviceBuild;
 
   // Determine app name based on build type
   let appName;
@@ -221,68 +227,56 @@ function renameIos() {
       process.exit(1);
   }
 
-  // Determine build paths based on simulator vs device
-  let buildDir, deviceType, binaryExtension;
+  const baseSuffix = `-${environment}-${buildType}-${appVersion}-${buildNumber}`;
+  const newSimBaseName = `metamask-simulator${baseSuffix}`;
+  const newDeviceBaseName = `metamask-device${baseSuffix}`;
+
+  const simProductsDir = path.join(
+    __dirname,
+    `../ios/build/Build/Products/${configuration || 'Release'}-iphonesimulator`,
+  );
+  const deviceOutputDir = path.join(__dirname, '../ios/build/output');
+
   if (isSimBuild) {
-    buildDir = path.join(
-      __dirname,
-      `../ios/build/Build/Products/${configuration || 'Release'}-iphonesimulator`,
-    );
-    deviceType = 'simulator';
-    binaryExtension = '.app';
-  } else {
-    buildDir = path.join(__dirname, '../ios/build/output');
-    deviceType = 'device';
-    binaryExtension = '.ipa';
-  }
+    console.log(`📝 Simulator artifact base name: ${newSimBaseName}`);
+    const oldApp = path.join(simProductsDir, `${appName}.app`);
+    if (fs.existsSync(oldApp)) {
+      const newApp = path.join(simProductsDir, `${newSimBaseName}.app`);
+      execSync(`cp -r "${oldApp}" "${newApp}"`);
+      console.log(`✅ Renamed simulator .app: ${newApp}`);
 
-  // Create new base name: metamask-{deviceType}-{environment}-{buildType}-{version}-{buildNumber}
-  const newBaseName = `metamask-${deviceType}-${environment}-${buildType}-${appVersion}-${buildNumber}`;
-  console.log(`📝 Renaming artifacts to: ${newBaseName}`);
-
-  // Rename binary (.app or .ipa)
-  const oldBinary = path.join(buildDir, `${appName}${binaryExtension}`);
-  if (fs.existsSync(oldBinary)) {
-    const newBinary = path.join(buildDir, `${newBaseName}${binaryExtension}`);
-    // Use cp -r for directories (.app), regular copy for files (.ipa)
-    if (binaryExtension === '.app') {
-      execSync(`cp -r "${oldBinary}" "${newBinary}"`);
-    } else {
-      fs.copyFileSync(oldBinary, newBinary);
-    }
-    console.log(`✅ Renamed binary: ${newBinary}`);
-
-    if (isSimBuild) {
-      // Zip the .app bundle for clean single-file download (mirrors Bitrise's is_compress: true)
-      const zipPath = path.join(buildDir, `${newBaseName}.zip`);
+      const zipPath = path.join(simProductsDir, `${newSimBaseName}.zip`);
       execSync(
-        `ditto -c -k --sequesterRsrc --keepParent "${newBinary}" "${zipPath}"`,
+        `ditto -c -k --sequesterRsrc --keepParent "${newApp}" "${zipPath}"`,
       );
       console.log(`✅ Zipped: ${zipPath}`);
-      setGithubOutput('ios_deploy_path', zipPath);
+      setGithubOutput('ios_simulator_path', zipPath);
     } else {
-      setGithubOutput('ios_deploy_path', newBinary);
+      console.log(`⚠️  Simulator .app not found: ${oldApp}`);
     }
-  } else {
-    console.log(`⚠️  Binary not found: ${oldBinary}`);
   }
 
-  // Expose sourcemap path for device builds (mirrors Bitrise's Deploy Source Map step)
-  if (!isSimBuild) {
+  if (hasDeviceArtifacts) {
+    console.log(`📝 Device artifact base name: ${newDeviceBaseName}`);
+    const oldIpa = path.join(deviceOutputDir, `${appName}.ipa`);
+    if (fs.existsSync(oldIpa)) {
+      const newIpa = path.join(deviceOutputDir, `${newDeviceBaseName}.ipa`);
+      fs.copyFileSync(oldIpa, newIpa);
+      console.log(`✅ Renamed IPA: ${newIpa}`);
+      setGithubOutput('ios_ipa_path', newIpa);
+    } else {
+      console.log(`⚠️  IPA not found: ${oldIpa}`);
+    }
+
     const sourcemapPath = path.join(__dirname, '../sourcemaps/ios/index.js.map');
     setGithubOutput('ios_sourcemap_path', sourcemapPath);
     console.log(`✅ Sourcemap path: ${sourcemapPath}`);
-  }
 
-  // Zip xcarchive into a single file (only for device builds)
-  // .xcarchive is a directory; zipping it produces a clean single-file artifact
-  // that Runway and other tools can match by extension.
-  if (!isSimBuild) {
     const oldArchive = path.join(__dirname, `../ios/build/${appName}.xcarchive`);
     if (fs.existsSync(oldArchive)) {
       const archiveZip = path.join(
         __dirname,
-        `../ios/build/${newBaseName}.xcarchive.zip`,
+        `../ios/build/${newDeviceBaseName}.xcarchive.zip`,
       );
       execSync(
         `ditto -c -k --sequesterRsrc --keepParent "${oldArchive}" "${archiveZip}"`,
@@ -297,7 +291,7 @@ function renameIos() {
   // List final artifacts
   console.log('📦 Final artifacts:');
   if (isSimBuild) {
-    const zips = findFiles(buildDir, '*.zip');
+    const zips = findFiles(simProductsDir, '*.zip');
     zips.forEach((zip) => {
       try {
         const stats = fs.statSync(zip);
@@ -307,8 +301,9 @@ function renameIos() {
         console.log(`  ${zip}`);
       }
     });
-  } else {
-    const ipas = findFiles(path.join(__dirname, '../ios/build/output'), '*.ipa');
+  }
+  if (hasDeviceArtifacts) {
+    const ipas = findFiles(deviceOutputDir, '*.ipa');
     const archives = findDirs(path.join(__dirname, '../ios/build'), '*.xcarchive');
     [...ipas, ...archives].forEach((file) => {
       try {

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -146,6 +146,24 @@ function renameAndroid() {
     console.log(`⚠️  APK not found: ${oldApk}`);
   }
 
+  // Instrumentation / Detox test APK (assemble*AndroidTest — see scripts/build.sh)
+  const testApkDir = path.join(
+    __dirname,
+    `../android/app/build/outputs/apk/androidTest/${appFlavor}/${buildConfig}`,
+  );
+  const oldTestApk = path.join(
+    testApkDir,
+    `app-${appFlavor}-${buildConfig}-androidTest.apk`,
+  );
+  if (fs.existsSync(oldTestApk)) {
+    const newTestApk = path.join(testApkDir, `${newBaseName}-androidTest.apk`);
+    fs.copyFileSync(oldTestApk, newTestApk);
+    console.log(`✅ Renamed Android test APK: ${newTestApk}`);
+    setGithubOutput('android_test_apk_path', newTestApk);
+  } else {
+    console.log(`⚠️  Android test APK not found: ${oldTestApk}`);
+  }
+
   // Rename AAB (only for Release builds — mirrors Bitrise's run_if: IS_DEV_BUILD != true)
   if (buildConfig === 'release') {
     const oldAab = path.join(bundleDir, `app-${appFlavor}-release.aab`);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

For `main-dev` configuration in `builds.yml`, we need to generate 4 artifacts when running the `Expo dev build` pipeline in Github actions:
1. iOS sim build
2. iOS device build
3. Android APK
4. Android test APK

The expo workflow is run whenever changes are merged into `main` and the builds are picked up by the buckets in Runway

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/build pipeline changes can break artifact publishing or downstream consumers (e.g., Runway) if naming/paths/conditions are incorrect, but they do not affect app runtime behavior.
> 
> **Overview**
> Enables the `main-dev` GitHub Actions pipeline to emit **both** iOS simulator and device artifacts by introducing `IS_DEVICE_BUILD` for dev builds, generating a device `.ipa`/`.xcarchive` even when `IS_SIM_BUILD=true`, and updating artifact renaming/output variables accordingly.
> 
> Adds support for Android Debug builds to rename and upload the instrumentation/test APK (`*-androidTest.apk`) as a separate artifact, and adjusts the workflow upload steps to use the new iOS output paths (`ios_simulator_path`, `ios_ipa_path`) and conditional uploads for dual sim+device builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a20167d6f0302e877a8d1f8464a20c401b6112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->