### PR TITLE
feat(rewards): campaign tour

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -138,6 +138,7 @@ import BonusCodeBottomSheet from '../../UI/Rewards/components/Tabs/OverviewTab/W
 import RewardsClaimBottomSheetModal from '../../UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal';
 import RewardOptInAccountGroupModal from '../../UI/Rewards/components/Settings/RewardOptInAccountGroupModal';
 import EndOfSeasonClaimBottomSheet from '../../UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet';
+import CampaignTourStepView from '../../UI/Rewards/Views/CampaignTourStepView';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import SitesFullView from '../../Views/SitesFullView/SitesFullView';
 import { TokenDetails } from '../../UI/TokenDetails/Views/TokenDetails';
@@ -1316,6 +1317,11 @@ const MainNavigator = () => {
         ///: END:ONLY_INCLUDE_IF
       }
       <Stack.Screen name={Routes.CARD.ROOT} component={CardRoutes} />
+      <Stack.Screen
+        name={Routes.REWARDS_CAMPAIGN_TOUR_STEP}
+        component={CampaignTourStepView}
+        options={{ headerShown: false }}
+      />
       <Stack.Screen
         name={Routes.RAMP.MODALS.PROCESSING_INFO}
         component={ProcessingInfoModal}

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -404,6 +404,15 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
   />
   <Screen
     component={[Function]}
+    name="RewardsCampaignTourStep"
+    options={
+      {
+        "headerShown": false,
+      }
+    }
+  />
+  <Screen
+    component={[Function]}
     name="RampProcessingInfoModal"
     options={
       {
@@ -823,6 +832,15 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
   />
   <Screen
     component={[Function]}
+    name="RewardsCampaignTourStep"
+    options={
+      {
+        "headerShown": false,
+      }
+    }
+  />
+  <Screen
+    component={[Function]}
     name="RampProcessingInfoModal"
     options={
       {
@@ -1239,6 +1257,15 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   <Screen
     component={[Function]}
     name="CardScreens"
+  />
+  <Screen
+    component={[Function]}
+    name="RewardsCampaignTourStep"
+    options={
+      {
+        "headerShown": false,
+      }
+    }
   />
   <Screen
     component={[Function]}

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import CampaignTourStepView from './CampaignTourStepView';
+import Routes from '../../../../constants/navigation/Routes';
+import { CAMPAIGN_TOUR_STEP_TEST_IDS } from '../components/Campaigns/tour/CampaignTourStep';
+import {
+  type CampaignDto,
+  CampaignType,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+  }),
+  useRoute: () => ({
+    params: { campaignId: 'campaign-1' },
+  }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return { ...actual };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock(
+  '../components/ThemeImageComponent/RewardsThemeImageComponent',
+  () => {
+    const { View } = jest.requireActual('react-native');
+    const ReactActual = jest.requireActual('react');
+    return {
+      __esModule: true,
+      default: () => ReactActual.createElement(View, { testID: 'theme-image' }),
+    };
+  },
+);
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const map: Record<string, string> = {
+      'rewards.onboarding.step_confirm': 'Next',
+      'rewards.onboarding.step_skip': 'Skip',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+jest.mock('../../../../util/device', () => ({
+  isLargeDevice: () => false,
+}));
+
+jest.mock('../components/Onboarding/ProgressIndicator', () => {
+  const { View } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({
+      totalSteps,
+      currentStep,
+    }: {
+      totalSteps: number;
+      currentStep: number;
+    }) =>
+      ReactActual.createElement(View, {
+        testID: 'progress-indicator-container',
+        accessibilityLabel: `${currentStep}/${totalSteps}`,
+      }),
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const mockGoToPage = jest.fn();
+jest.mock('@tommasini/react-native-scrollable-tab-view', () => {
+  const { View } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ReactActual.forwardRef(
+      (
+        {
+          children,
+          onChangeTab,
+        }: {
+          children: React.ReactNode;
+          onChangeTab: (obj: { i: number }) => void;
+        },
+        ref: React.Ref<unknown>,
+      ) => {
+        ReactActual.useImperativeHandle(ref, () => ({
+          goToPage: (page: number) => {
+            mockGoToPage(page);
+            onChangeTab({ i: page });
+          },
+        }));
+        return ReactActual.createElement(
+          View,
+          { testID: 'scrollable-tab-view' },
+          children,
+        );
+      },
+    ),
+  };
+});
+
+const tourSteps = [
+  {
+    title: 'Step 1 Title',
+    description: 'Step 1 Description',
+    image: null,
+    actions: { next: true, skip: true },
+  },
+  {
+    title: 'Step 2 Title',
+    description: 'Step 2 Description',
+    image: null,
+    actions: { next: true, skip: false },
+  },
+  {
+    title: 'Step 3 Title',
+    description: 'Step 3 Description',
+    image: null,
+    actions: { next: true },
+  },
+];
+
+const campaignWithTour: CampaignDto = {
+  id: 'campaign-1',
+  type: CampaignType.ONDO_HOLDING,
+  name: 'Test Campaign',
+  startDate: '2025-06-01T00:00:00.000Z',
+  endDate: '2025-12-31T23:59:59.999Z',
+  termsAndConditions: null,
+  excludedRegions: [],
+  featured: true,
+  details: {
+    howItWorks: {
+      title: 'How It Works',
+      description: 'Description',
+      steps: [],
+      tour: tourSteps,
+    },
+  },
+};
+
+const campaignWithoutTour: CampaignDto = {
+  ...campaignWithTour,
+  details: {
+    howItWorks: {
+      title: 'How It Works',
+      description: 'Description',
+      steps: [],
+    },
+  },
+};
+
+let mockCampaigns: CampaignDto[] = [campaignWithTour];
+
+jest.mock('../../../../reducers/rewards/selectors', () => ({
+  selectCampaigns: () => mockCampaigns,
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+describe('CampaignTourStepView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCampaigns = [campaignWithTour];
+  });
+
+  it('renders all tour steps', () => {
+    const { getByText } = render(<CampaignTourStepView />);
+
+    expect(getByText('Step 1 Title')).toBeOnTheScreen();
+    expect(getByText('Step 2 Title')).toBeOnTheScreen();
+    expect(getByText('Step 3 Title')).toBeOnTheScreen();
+  });
+
+  it('renders Next and Skip buttons for first step', () => {
+    const { getByTestId, getByText } = render(<CampaignTourStepView />);
+
+    expect(
+      getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON),
+    ).toBeOnTheScreen();
+    expect(getByText('Next')).toBeOnTheScreen();
+    expect(getByText('Skip')).toBeOnTheScreen();
+  });
+
+  it('calls goToPage when Next is pressed on a non-last step', () => {
+    const { getByTestId } = render(<CampaignTourStepView />);
+
+    fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
+
+    expect(mockGoToPage).toHaveBeenCalledWith(1);
+  });
+
+  it('navigates to campaign details when Next is pressed on last step', () => {
+    const { getByTestId } = render(<CampaignTourStepView />);
+
+    fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
+    fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
+    fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
+      { campaignId: 'campaign-1' },
+    );
+  });
+
+  it('navigates to campaign details when Skip is pressed', () => {
+    const { getByTestId } = render(<CampaignTourStepView />);
+
+    fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
+      { campaignId: 'campaign-1' },
+    );
+  });
+
+  it('navigates to details when campaign has no tour data', () => {
+    mockCampaigns = [campaignWithoutTour];
+
+    render(<CampaignTourStepView />);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
+      { campaignId: 'campaign-1' },
+    );
+  });
+
+  it('renders progress indicator', () => {
+    const { getByTestId } = render(<CampaignTourStepView />);
+
+    expect(getByTestId('progress-indicator-container')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
+import { useSelector } from 'react-redux';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+} from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+} from '@metamask/design-system-react-native';
+import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
+import { selectCampaigns } from '../../../../reducers/rewards/selectors';
+import Routes from '../../../../constants/navigation/Routes';
+import ProgressIndicator from '../components/Onboarding/ProgressIndicator';
+import CampaignTourStep, {
+  CAMPAIGN_TOUR_STEP_TEST_IDS,
+} from '../components/Campaigns/tour/CampaignTourStep';
+import { strings } from '../../../../../locales/i18n';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type CampaignTourStepRouteParams = {
+  CampaignTourStep: {
+    campaignId: string;
+  };
+};
+
+const CampaignTourStepView: React.FC = () => {
+  const tw = useTailwind();
+  const navigation = useNavigation();
+  const route =
+    useRoute<RouteProp<CampaignTourStepRouteParams, 'CampaignTourStep'>>();
+  const { campaignId } = route.params;
+  const safeAreaInsets = useSafeAreaInsets();
+
+  const campaigns = useSelector(selectCampaigns);
+  const campaign = useMemo(
+    () => campaigns.find((c) => c.id === campaignId),
+    [campaigns, campaignId],
+  );
+
+  const tour = campaign?.details?.howItWorks?.tour;
+  const [currentTab, setCurrentTab] = useState(0);
+  const scrollableTabViewRef = useRef<
+    typeof ScrollableTabView & { goToPage: (page: number) => void }
+  >(null);
+
+  const navigateToDetails = useCallback(() => {
+    navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+      campaignId,
+    });
+  }, [navigation, campaignId]);
+
+  const currentStep = tour?.[currentTab];
+  const isLastStep = tour ? currentTab === tour.length - 1 : false;
+  const showNext = currentStep?.actions?.next === true;
+  const showSkip = currentStep?.actions?.skip === true;
+
+  const handleTabChange = useCallback((obj: { i: number }) => {
+    setCurrentTab(obj.i);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    if (!tour) return;
+    if (isLastStep) {
+      navigateToDetails();
+    } else {
+      scrollableTabViewRef.current?.goToPage(currentTab + 1);
+    }
+  }, [tour, isLastStep, currentTab, navigateToDetails]);
+
+  const renderTabBar = useCallback(() => <View />, []);
+
+  if (!tour?.length) {
+    navigateToDetails();
+    return null;
+  }
+
+  return (
+    <Box
+      twClassName="flex-1 bg-default"
+      style={{ paddingTop: safeAreaInsets.top }}
+    >
+      <Box twClassName="items-center pt-4 pb-2">
+        <ProgressIndicator
+          totalSteps={tour.length}
+          currentStep={currentTab + 1}
+          variant="bars"
+        />
+      </Box>
+
+      <Box twClassName="flex-1">
+        <ScrollableTabView
+          ref={scrollableTabViewRef}
+          renderTabBar={renderTabBar}
+          onChangeTab={handleTabChange}
+          initialPage={0}
+        >
+          {tour.map((step, index) => (
+            <Box key={index} twClassName="flex-1">
+              <CampaignTourStep step={step} />
+            </Box>
+          ))}
+        </ScrollableTabView>
+      </Box>
+
+      <Box
+        twClassName="px-4 gap-2 pb-2"
+        style={{ paddingBottom: safeAreaInsets.bottom }}
+      >
+        {showNext && (
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            onPress={handleNext}
+            twClassName="w-full"
+            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON}
+          >
+            {strings('rewards.onboarding.step_confirm')}
+          </Button>
+        )}
+        {showSkip && (
+          <Button
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Lg}
+            onPress={navigateToDetails}
+            twClassName="w-full bg-gray-500 border-gray-500"
+            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON}
+          >
+            <Text twClassName="text-text-default">
+              {strings('rewards.onboarding.step_skip')}
+            </Text>
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default CampaignTourStepView;

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -26,7 +32,7 @@ import { strings } from '../../../../../locales/i18n';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CampaignTourStepRouteParams = {
-  CampaignTourStep: {
+  RewardsCampaignTourStep: {
     campaignId: string;
   };
 };
@@ -35,7 +41,9 @@ const CampaignTourStepView: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const route =
-    useRoute<RouteProp<CampaignTourStepRouteParams, 'CampaignTourStep'>>();
+    useRoute<
+      RouteProp<CampaignTourStepRouteParams, 'RewardsCampaignTourStep'>
+    >();
   const { campaignId } = route.params;
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -77,8 +85,13 @@ const CampaignTourStepView: React.FC = () => {
 
   const renderTabBar = useCallback(() => <View />, []);
 
+  useEffect(() => {
+    if (!tour?.length) {
+      navigateToDetails();
+    }
+  }, [tour, navigateToDetails]);
+
   if (!tour?.length) {
-    navigateToDetails();
     return null;
   }
 

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import OndoCampaignDetailsView, {
   CAMPAIGN_DETAILS_TEST_IDS,
 } from './OndoCampaignDetailsView';
-import { CAMPAIGN_CTA_TEST_IDS } from '../components/Campaigns/CampaignCTA';
+import { CAMPAIGN_CTA_TEST_IDS } from '../components/Campaigns/CampaignOptInCta';
 import {
   type CampaignDto,
   CampaignType,
@@ -151,20 +151,6 @@ jest.mock('../components/Campaigns/OndoLeaderboardPosition', () => {
         testID: 'ondo-leaderboard-position',
       });
     },
-  };
-});
-
-jest.mock('../components/RewardsInfoBanner', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ title }: { title: string }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'competition-ended-banner' },
-        ReactActual.createElement(Text, null, title),
-      ),
   };
 });
 
@@ -369,10 +355,10 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.campaigns_view.error_description': 'Please try again.',
       'rewards.campaigns_view.retry_button': 'Retry',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.open_position': 'Open Position',
-      'rewards.campaign_details.entries_closed_title': 'Entries closed',
-      'rewards.campaign_details.entries_closed_description':
-        'You missed the opt-in window',
+      'rewards.campaign_details.ondo.open_position': 'Open Position',
+      'rewards.campaign_details.ondo.entries_closed_title': 'Entries closed',
+      'rewards.campaign_details.ondo.entries_closed_description':
+        'You missed the opt-in window. Check back for more campaigns in the future.',
       'rewards.campaign_details.competition_closed_title':
         'Competition no longer open',
       'rewards.campaign_details.competition_closed_description':
@@ -531,9 +517,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByTestId('campaign-status')).toBeDefined();
     });
 
-    it('does not render CampaignHowItWorks when campaign is active and past the deposit cutoff date', () => {
-      // Date.now() is mocked to 123ms in testSetup.js; use epoch (0ms) as a "past" cutoff.
-      // HowItWorks is hidden once entries are closed so the user sees the leaderboard instead.
+    it('renders CampaignHowItWorks when campaign is active and user is not opted in', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -544,31 +528,6 @@ describe('OndoCampaignDetailsView', () => {
                 description: 'Description',
                 steps: [],
               },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
-      });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('campaign-how-it-works')).toBeNull();
-    });
-
-    it('renders CampaignHowItWorks when campaign is active and entries are still open', () => {
-      // Any real-world date is "future" relative to the mocked Date.now() of 123ms,
-      // so opt-in is still allowed and HowItWorks should be visible.
-      const nextWeek = new Date();
-      nextWeek.setDate(nextWeek.getDate() + 7);
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: {
-                title: 'How it works',
-                description: 'Description',
-                steps: [],
-              },
-              depositCutoffDate: nextWeek.toISOString(),
             },
           }),
         ],
@@ -577,9 +536,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByTestId('campaign-how-it-works')).toBeDefined();
     });
 
-    it('does not render CampaignHowItWorks when user is opted in (even with entries still open)', () => {
-      const nextWeek = new Date();
-      nextWeek.setDate(nextWeek.getDate() + 7);
+    it('renders CampaignHowItWorks when user is opted in but has no positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
@@ -590,7 +547,6 @@ describe('OndoCampaignDetailsView', () => {
                 description: 'Description',
                 steps: [],
               },
-              depositCutoffDate: nextWeek.toISOString(),
             },
           }),
         ],
@@ -599,6 +555,38 @@ describe('OndoCampaignDetailsView', () => {
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
         hasError: false,
+        refetch: jest.fn(),
+      });
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
+      expect(getByTestId('campaign-how-it-works')).toBeDefined();
+    });
+
+    it('does not render CampaignHowItWorks when user is opted in with positions', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            details: {
+              howItWorks: {
+                title: 'How it works',
+                description: 'Description',
+                steps: [],
+              },
+            },
+          }),
+        ],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
         refetch: jest.fn(),
       });
       const { queryByTestId } = render(<OndoCampaignDetailsView />);
@@ -766,131 +754,23 @@ describe('OndoCampaignDetailsView', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_CAMPAIGNS_VIEW);
     });
 
-    it('renders disabled CTA button when entries are closed (past deposit cutoff)', () => {
+    it('renders the entries-closed CTA when campaign is complete and user is not opted in', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [
           createTestCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
           }),
         ],
       });
-      const { getByTestId, getByText } = render(<OndoCampaignDetailsView />);
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeDefined();
-      expect(getByText('Entries closed')).toBeDefined();
-    });
-
-    it('does not render the CTA when campaign is complete', () => {
-      const lastMonth = new Date();
-      lastMonth.setMonth(lastMonth.getMonth() - 1);
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            startDate: lastMonth.toISOString(),
-            endDate: yesterday.toISOString(),
-          }),
-        ],
-      });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
-    });
-  });
-
-  describe('competition ended banner', () => {
-    it('shows the banner when campaign is active, past cutoff, and user is not opted in', () => {
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
-      });
-      const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('competition-ended-banner')).toBeDefined();
-    });
-
-    it('shows the banner when campaign is complete and user is not opted in', () => {
-      const lastMonth = new Date();
-      lastMonth.setMonth(lastMonth.getMonth() - 1);
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            startDate: lastMonth.toISOString(),
-            endDate: yesterday.toISOString(),
-          }),
-        ],
-      });
-      const { getByTestId } = render(<OndoCampaignDetailsView />);
-      expect(getByTestId('competition-ended-banner')).toBeDefined();
-    });
-
-    it('does not show the banner when entries are still open', () => {
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [createTestCampaign()],
-      });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('competition-ended-banner')).toBeNull();
-    });
-
-    it('does not show the banner when the user is opted in with portfolio fetching', () => {
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
-      });
-      mockUseGetCampaignParticipantStatus.mockReturnValue({
-        status: { optedIn: true, participantCount: 1 },
-        isLoading: false,
-        hasError: false,
-        refetch: jest.fn(),
-      });
-      // Portfolio not yet fetched — banner should be hidden while data loads
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('competition-ended-banner')).toBeNull();
-    });
-
-    it('does not show the banner while participant status is loading (entries closed)', () => {
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
-      });
-      mockUseGetCampaignParticipantStatus.mockReturnValue({
-        status: null,
-        isLoading: true,
-        hasError: false,
-        refetch: jest.fn(),
-      });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('competition-ended-banner')).toBeNull();
     });
   });
 
@@ -948,31 +828,10 @@ describe('OndoCampaignDetailsView', () => {
       expect(queryByTestId('ondo-leaderboard-position')).toBeNull();
     });
 
-    it('does not show OndoLeaderboard when not opted in and campaign is active with entries still open', () => {
+    it('shows OndoLeaderboard when not opted in and campaign is active', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
-      });
-      const { queryByTestId } = render(<OndoCampaignDetailsView />);
-      expect(queryByTestId('ondo-leaderboard')).toBeNull();
-    });
-
-    it('shows OndoLeaderboard when not opted in and campaign is active past cutoff date', () => {
-      // Date.now() is mocked to 123ms in testSetup.js; use epoch (0ms) as a "past" cutoff
-      mockUseRewardCampaigns.mockReturnValue({
-        ...hookDefaults,
-        campaigns: [
-          createTestCampaign({
-            details: {
-              howItWorks: {
-                title: 'How it works',
-                description: 'Description',
-                steps: [],
-              },
-              depositCutoffDate: new Date(0).toISOString(),
-            },
-          }),
-        ],
       });
       const { getByTestId } = render(<OndoCampaignDetailsView />);
       expect(getByTestId('ondo-leaderboard')).toBeDefined();
@@ -1055,7 +914,7 @@ describe('OndoCampaignDetailsView', () => {
         ...hookDefaults,
         campaigns: [createTestCampaign()],
       });
-      // Must be opted-in for portfolio section to render
+      // Opted-in so the portfolio mock triggers onOpenAccountPicker
       mockUseGetCampaignParticipantStatus.mockReturnValue({
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -101,7 +101,6 @@ const OndoCampaignDetailsView: React.FC = () => {
     portfolio: portfolioData,
     isLoading: isPortfolioLoading,
     hasError: hasPortfolioError,
-    hasFetched: portfolioHasFetched,
     refetch: refetchPortfolio,
   } = useGetOndoPortfolioPosition(isOptedIn ? campaignId : undefined);
 
@@ -343,7 +342,6 @@ const OndoCampaignDetailsView: React.FC = () => {
                       portfolio={portfolioData}
                       isLoading={isPortfolioLoading}
                       hasError={hasPortfolioError}
-                      hasFetched={portfolioHasFetched}
                       refetch={refetchPortfolio}
                       campaignId={campaignId}
                       onOpenAccountPicker={setPendingPicker}

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -30,14 +30,10 @@ import OndoLeaderboard from '../components/Campaigns/OndoLeaderboard';
 import OndoLeaderboardPosition from '../components/Campaigns/OndoLeaderboardPosition';
 import OndoPortfolio from '../components/Campaigns/OndoPortfolio';
 import OndoAccountPickerSheet from '../components/Campaigns/OndoAccountPickerSheet';
-import CampaignCTA from '../components/Campaigns/CampaignCTA';
-import {
-  getCampaignStatus,
-  isOptinAllowed,
-} from '../components/Campaigns/CampaignTile.utils';
+import OndoCampaignCTA from '../components/Campaigns/OndoCampaignCTA';
+import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
 import { formatComputedAt } from '../components/Campaigns/OndoLeaderboard.utils';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
-import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
@@ -100,8 +96,7 @@ const OndoCampaignDetailsView: React.FC = () => {
 
   const isOptedIn = participantStatusData?.optedIn === true;
 
-  // Single fetch point for portfolio — data is passed to both the portfolio section and
-  // used to gate the leaderboard rank section visibility
+  // Single fetch point for portfolio — only fetches when opted in
   const {
     portfolio: portfolioData,
     isLoading: isPortfolioLoading,
@@ -111,8 +106,6 @@ const OndoCampaignDetailsView: React.FC = () => {
   } = useGetOndoPortfolioPosition(isOptedIn ? campaignId : undefined);
 
   const hasPositions = Boolean(portfolioData?.positions.length);
-
-  const isOptinClosed = campaign !== null && !isOptinAllowed(campaign);
 
   const {
     tierNames,
@@ -138,7 +131,6 @@ const OndoCampaignDetailsView: React.FC = () => {
 
   const {
     showHowItWorksSection,
-    showCompetitionEndedBanner,
     showLeaderboardSection,
     showLeaderboardPositionSection,
     showPortfolioSection,
@@ -146,7 +138,6 @@ const OndoCampaignDetailsView: React.FC = () => {
     if (!campaign) {
       return {
         showHowItWorksSection: false,
-        showCompetitionEndedBanner: false,
         showLeaderboardSection: false,
         showLeaderboardPositionSection: false,
         showPortfolioSection: false,
@@ -155,54 +146,18 @@ const OndoCampaignDetailsView: React.FC = () => {
 
     const showHowItWorksSection =
       Boolean(campaign.details?.howItWorks) &&
-      !isOptedIn &&
       !hasPositions &&
-      !isPortfolioLoading &&
-      getCampaignStatus(campaign) === 'active' &&
-      isOptinAllowed(campaign);
-
-    const showCompetitionEndedBanner =
-      getCampaignStatus(campaign) === 'complete' ||
-      (!isParticipantStatusLoading &&
-        isOptinClosed &&
-        (!isOptedIn ||
-          (portfolioHasFetched && !hasPositions && !hasPortfolioError)));
+      getCampaignStatus(campaign) === 'active';
 
     const showLeaderboardPositionSection = isOptedIn && hasPositions;
 
-    const showPortfolioSection =
-      isOptedIn &&
-      (!showCompetitionEndedBanner ||
-        (hasPositions && getCampaignStatus(campaign) === 'complete') ||
-        isPortfolioLoading ||
-        (hasPortfolioError && !hasPositions));
-
-    const showLeaderboardSection =
-      (showCompetitionEndedBanner &&
-        !showLeaderboardPositionSection &&
-        !showPortfolioSection) ||
-      (isOptedIn &&
-        !showCompetitionEndedBanner &&
-        !hasPositions &&
-        !isPortfolioLoading);
-
     return {
       showHowItWorksSection,
-      showCompetitionEndedBanner,
       showLeaderboardPositionSection,
-      showLeaderboardSection,
-      showPortfolioSection,
+      showPortfolioSection: isOptedIn,
+      showLeaderboardSection: !showLeaderboardPositionSection,
     };
-  }, [
-    campaign,
-    isOptedIn,
-    hasPositions,
-    isParticipantStatusLoading,
-    isOptinClosed,
-    portfolioHasFetched,
-    hasPortfolioError,
-    isPortfolioLoading,
-  ]);
+  }, [campaign, isOptedIn, hasPositions]);
 
   return (
     <ErrorBoundary navigation={navigation} view="OndoCampaignDetailsView">
@@ -270,25 +225,6 @@ const OndoCampaignDetailsView: React.FC = () => {
                       howItWorks={
                         campaign.details?.howItWorks as OndoCampaignHowItWorks
                       }
-                    />
-                  </Box>
-                </>
-              )}
-
-              {/* Competition closed banner
-                  - for when cutoff date has passed and user is not opted in
-                  - or when the campaign is complete */}
-              {showCompetitionEndedBanner && (
-                <>
-                  <Box twClassName="border-b border-border-muted" />
-                  <Box twClassName="px-4 py-4 gap-4">
-                    <RewardsInfoBanner
-                      title={strings(
-                        'rewards.campaign_details.competition_closed_title',
-                      )}
-                      description={strings(
-                        'rewards.campaign_details.competition_closed_description',
-                      )}
                     />
                   </Box>
                 </>
@@ -467,7 +403,7 @@ const OndoCampaignDetailsView: React.FC = () => {
         </ScrollView>
 
         {campaign && (
-          <CampaignCTA
+          <OndoCampaignCTA
             campaign={campaign}
             participantStatus={{
               status: participantStatusData,

--- a/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
@@ -58,7 +58,6 @@ const OndoCampaignPortfolioView: React.FC = () => {
     portfolio,
     isLoading: isPortfolioLoading,
     hasError: hasPortfolioError,
-    hasFetched: portfolioHasFetched,
     refetch: refetchPortfolio,
   } = useGetOndoPortfolioPosition(campaignId);
 
@@ -153,7 +152,6 @@ const OndoCampaignPortfolioView: React.FC = () => {
             portfolio={portfolio}
             isLoading={isPortfolioLoading}
             hasError={hasPortfolioError}
-            hasFetched={portfolioHasFetched}
             refetch={refetchPortfolio}
             campaignId={campaignId}
             onOpenAccountPicker={setPendingPicker}
@@ -181,7 +179,6 @@ const OndoCampaignPortfolioView: React.FC = () => {
     portfolio,
     isPortfolioLoading,
     hasPortfolioError,
-    portfolioHasFetched,
     refetchPortfolio,
     campaignId,
     setPendingPicker,

--- a/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
@@ -15,6 +15,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { getIconName } from '../../utils/formatUtils';
 import ContentfulRichText, {
   isDocument,
+  documentToPlainText
 } from '../ContentfulRichText/ContentfulRichText';
 
 export const CAMPAIGN_HOW_IT_WORKS_TEST_IDS = {
@@ -64,7 +65,7 @@ const CampaignHowItWorks: React.FC<CampaignHowItWorksProps> = ({
             fontWeight={FontWeight.Medium}
             testID={`${CAMPAIGN_HOW_IT_WORKS_TEST_IDS.STEP_TITLE}-${stepIndex}`}
           >
-            {step.title}
+            {documentToPlainText(step.title)}
           </Text>
           {isDocument(step.description) && (
             <ContentfulRichText

--- a/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
@@ -15,7 +15,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { getIconName } from '../../utils/formatUtils';
 import ContentfulRichText, {
   isDocument,
-  documentToPlainText
+  documentToPlainText,
 } from '../ContentfulRichText/ContentfulRichText';
 
 export const CAMPAIGN_HOW_IT_WORKS_TEST_IDS = {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import CampaignOptInCta, { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
+import {
+  type CampaignDto,
+  CampaignType,
+} from '../../../../../core/Engine/controllers/rewards-controller/types';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return { ...actual };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('./CampaignOptInSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactActual.createElement(View, {
+        testID: 'campaign-opt-in-sheet',
+      }),
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const map: Record<string, string> = {
+      'rewards.campaign_details.join_campaign': 'Join Campaign',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+function buildCampaign(overrides: Partial<CampaignDto> = {}): CampaignDto {
+  return {
+    id: 'campaign-1',
+    type: CampaignType.ONDO_HOLDING,
+    name: 'Test Campaign',
+    startDate: '2025-06-01T00:00:00.000Z',
+    endDate: '2025-12-31T23:59:59.999Z',
+    termsAndConditions: null,
+    excludedRegions: [],
+    details: null,
+    featured: true,
+    ...overrides,
+  };
+}
+
+const notOptedIn = {
+  status: { optedIn: false, participantCount: 0 } as const,
+  isLoading: false,
+};
+
+const optedIn = {
+  status: { optedIn: true, participantCount: 1 } as const,
+  isLoading: false,
+};
+
+describe('CampaignOptInCta', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-08-15T12:00:00.000Z'));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('returns null', () => {
+    it('renders nothing when campaign is not active (upcoming)', () => {
+      const { queryByTestId } = render(
+        <CampaignOptInCta
+          campaign={buildCampaign({
+            startDate: '2026-01-01T00:00:00.000Z',
+            endDate: '2026-12-31T23:59:59.999Z',
+          })}
+          participantStatus={notOptedIn}
+        />,
+      );
+
+      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
+    });
+
+    it('renders nothing while participant status is loading', () => {
+      const { queryByTestId } = render(
+        <CampaignOptInCta
+          campaign={buildCampaign()}
+          participantStatus={{ status: null, isLoading: true }}
+        />,
+      );
+
+      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
+    });
+
+    it('renders nothing when user is already opted in', () => {
+      const { queryByTestId } = render(
+        <CampaignOptInCta
+          campaign={buildCampaign()}
+          participantStatus={optedIn}
+        />,
+      );
+
+      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
+    });
+  });
+
+  describe('opt-in flow', () => {
+    it('renders the opt-in CTA button when active and not yet opted in', () => {
+      const { getByTestId, getByText } = render(
+        <CampaignOptInCta
+          campaign={buildCampaign()}
+          participantStatus={notOptedIn}
+        />,
+      );
+
+      expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
+      expect(getByText('Join Campaign')).toBeOnTheScreen();
+    });
+
+    it('opens the opt-in sheet when the button is pressed', () => {
+      const { getByTestId, queryByTestId } = render(
+        <CampaignOptInCta
+          campaign={buildCampaign()}
+          participantStatus={notOptedIn}
+        />,
+      );
+
+      expect(queryByTestId('campaign-opt-in-sheet')).toBeNull();
+      fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+      expect(getByTestId('campaign-opt-in-sheet')).toBeOnTheScreen();
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
+import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import type { UseGetCampaignParticipantStatusResult } from '../../hooks/useGetCampaignParticipantStatus';
+import CampaignOptInSheet from './CampaignOptInSheet';
+import { getCampaignStatus } from './CampaignTile.utils';
+import { strings } from '../../../../../../locales/i18n';
+
+export const CAMPAIGN_CTA_TEST_IDS = {
+  CTA_BUTTON: 'campaign-details-cta-button',
+} as const;
+
+interface CampaignOptInCtaProps {
+  campaign: CampaignDto;
+  participantStatus: Pick<
+    UseGetCampaignParticipantStatusResult,
+    'status' | 'isLoading'
+  >;
+}
+
+/**
+ * General campaign opt-in CTA.
+ * Shows a "Join Campaign" button when the campaign is active, the user has not opted in,
+ * and the opt-in window is still open. Returns null in all other cases.
+ */
+const CampaignOptInCta: React.FC<CampaignOptInCtaProps> = ({
+  campaign,
+  participantStatus,
+}) => {
+  const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
+
+  const campaignStatus = getCampaignStatus(campaign);
+  const isLoading = participantStatus.isLoading;
+  const isOptedIn = participantStatus?.status?.optedIn === true;
+
+  const isActive = !isLoading && campaignStatus === 'active';
+
+  if (!isActive || isOptedIn) {
+    return null;
+  }
+
+  return (
+    <>
+      <Box twClassName="px-4 pt-2">
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={() => setIsOptInSheetOpen(true)}
+          testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
+        >
+          {strings('rewards.campaign_details.join_campaign')}
+        </Button>
+      </Box>
+
+      {isOptInSheetOpen && (
+        <CampaignOptInSheet
+          campaign={campaign}
+          onClose={() => setIsOptInSheetOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default CampaignOptInCta;

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.test.tsx
@@ -47,12 +47,6 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
 }));
 
-const mockNavigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({ navigate: mockNavigate }),
-}));
-
 jest.mock('../ContentfulRichText/ContentfulRichText', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text: RNText } = jest.requireActual('react-native');
@@ -136,19 +130,10 @@ jest.mock('../RewardsErrorBanner', () => {
   };
 });
 
-jest.mock('../Onboarding/constants', () => ({
-  REWARDS_ONBOARD_TERMS_URL: 'https://go.metamask.io/rewards-terms',
-}));
-
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
       'rewards.campaign.opt_in_sheet_title': 'Join Campaign',
-      'rewards.campaign.opt_in_sheet_description_pre_link':
-        'By joining you agree to the',
-      'rewards.campaign.opt_in_sheet_link_text': 'Terms',
-      'rewards.campaign.opt_in_sheet_description_post_link':
-        'You can opt out at any time.',
       'rewards.campaign_details.opt_in_error': 'Failed to join campaign',
       'rewards.campaign.opt_in_cta': 'Join',
       'rewards.campaign.geo_restriction_banner_title':
@@ -204,33 +189,24 @@ describe('CampaignOptInSheet', () => {
     );
   });
 
-  it('renders the description container', () => {
+  it('renders the description when termsAndConditions is a Contentful document', () => {
     const { getByTestId } = render(
-      <CampaignOptInSheet campaign={createTestCampaign()} />,
+      <CampaignOptInSheet
+        campaign={createTestCampaign({
+          termsAndConditions: { nodeType: 'document', content: [] },
+        })}
+      />,
     );
     expect(getByTestId('campaign-opt-in-sheet-description')).toBeDefined();
   });
 
-  it('renders the terms link with correct text', () => {
-    const { getByTestId } = render(
-      <CampaignOptInSheet campaign={createTestCampaign()} />,
+  it('does not render the description when termsAndConditions is null', () => {
+    const { queryByTestId } = render(
+      <CampaignOptInSheet
+        campaign={createTestCampaign({ termsAndConditions: null })}
+      />,
     );
-    expect(getByTestId('campaign-opt-in-sheet-terms-link')).toHaveTextContent(
-      'Terms',
-    );
-  });
-
-  it('navigates to the terms URL when terms link is pressed', () => {
-    const { getByTestId } = render(
-      <CampaignOptInSheet campaign={createTestCampaign()} />,
-    );
-    fireEvent.press(getByTestId('campaign-opt-in-sheet-terms-link'));
-    expect(mockNavigate).toHaveBeenCalledWith('BrowserTabHome', {
-      screen: 'BrowserView',
-      params: expect.objectContaining({
-        newTabUrl: 'https://go.metamask.io/rewards-terms',
-      }),
-    });
+    expect(queryByTestId('campaign-opt-in-sheet-description')).toBeNull();
   });
 
   it('renders the CTA button', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -24,7 +24,6 @@ import {
 import { useOptInToCampaign } from '../../hooks/useOptInToCampaign';
 import useRewardsToast from '../../hooks/useRewardsToast';
 import { strings } from '../../../../../../locales/i18n';
-import { REWARDS_ONBOARD_TERMS_URL } from '../Onboarding/constants';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import RewardsInfoBanner from '../RewardsInfoBanner';
 import { getDetectedGeolocation } from '../../../../../reducers/fiatOrders';
@@ -33,8 +32,6 @@ import { selectGeolocationStatus } from '../../../../../selectors/geolocationCon
 import ContentfulRichText, {
   isDocument,
 } from '../ContentfulRichText/ContentfulRichText';
-import { useNavigation } from '@react-navigation/native';
-import Routes from '../../../../../constants/navigation/Routes';
 
 interface CampaignOptInSheetProps {
   campaign: CampaignDto;
@@ -49,7 +46,6 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   campaign,
   onClose,
 }) => {
-  const navigation = useNavigation();
   const { optInToCampaign, isOptingIn, optInError } = useOptInToCampaign();
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const geolocation = useSelector(getDetectedGeolocation);
@@ -89,16 +85,6 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
     }
   }, [optInToCampaign, campaign.id, showToast, RewardsToastOptions, onClose]);
 
-  const handleTermsPress = useCallback(() => {
-    navigation.navigate(Routes.BROWSER.HOME, {
-      screen: Routes.BROWSER.VIEW,
-      params: {
-        newTabUrl: REWARDS_ONBOARD_TERMS_URL,
-        timestamp: Date.now(),
-      },
-    });
-  }, [navigation]);
-
   return (
     <BottomSheet shouldNavigateBack={false} goBack={noop} onClose={onClose}>
       <Box twClassName="px-4 pb-4">
@@ -115,7 +101,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
             justifyContent={BoxJustifyContent.Center}
           >
             <Text
-              variant={TextVariant.HeadingMd}
+              variant={TextVariant.HeadingSm}
               fontWeight={FontWeight.Bold}
               testID="campaign-opt-in-sheet-title"
             >
@@ -130,35 +116,17 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
           />
         </Box>
 
-        {/* Legal disclaimer – rich text from Contentful or static fallback */}
-        <Box twClassName="mb-6">
-          {isDocument(campaign.termsAndConditions) ? (
+        {/* Legal disclaimer – rich text from Contentful */}
+        {isDocument(campaign.termsAndConditions) && (
+          <Box twClassName="mb-6">
             <ContentfulRichText
               document={campaign.termsAndConditions}
               textVariant={TextVariant.BodySm}
-              bodyClassName="text-center text-alternative"
+              bodyClassName="text-center text-default"
               testID="campaign-opt-in-sheet-description"
             />
-          ) : (
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="text-alternative text-center"
-              testID="campaign-opt-in-sheet-description"
-            >
-              {strings('rewards.campaign.opt_in_sheet_description_pre_link')}{' '}
-              <Text
-                variant={TextVariant.BodySm}
-                twClassName="text-primary-default"
-                onPress={handleTermsPress}
-                testID="campaign-opt-in-sheet-terms-link"
-              >
-                {strings('rewards.campaign.opt_in_sheet_link_text')}
-              </Text>
-              {'. '}
-              {strings('rewards.campaign.opt_in_sheet_description_post_link')}
-            </Text>
-          )}
-        </Box>
+          </Box>
+        )}
 
         {optInError && (
           <Box twClassName="mb-4">

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatus.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatus.test.tsx
@@ -25,22 +25,6 @@ jest.mock('./CampaignTile.utils', () => ({
   }),
 }));
 
-jest.mock('../../utils/formatUtils', () => ({
-  ...jest.requireActual('../../utils/formatUtils'),
-  formatUTCDate: jest.fn((_date: string) => 'Fri, April 16'),
-}));
-
-jest.mock('../../../../../../locales/i18n', () => ({
-  strings: (key: string, params?: Record<string, string | number>) => {
-    const translations: Record<string, string> = {
-      'rewards.campaign_status.deposit_window': 'Deposit Window',
-      'rewards.campaign_status.deposit_closes': `Closes ${params?.date ?? ''}`,
-      'rewards.campaign_status.deposit_closed_on': `Closed on ${params?.date ?? ''}`,
-    };
-    return translations[key] ?? key;
-  },
-}));
-
 const createTestCampaign = (overrides = {}): CampaignDto => ({
   id: 'campaign-1',
   type: CampaignType.ONDO_HOLDING,
@@ -132,48 +116,6 @@ describe('CampaignStatus', () => {
     expect(
       queryByTestId(CAMPAIGN_STATUS_TEST_IDS.HOW_IT_WORKS_TITLE),
     ).toBeNull();
-  });
-
-  it('renders deposit window with "Closes" when cutoff is in the future', () => {
-    const campaign = createTestCampaign({
-      details: {
-        howItWorks: { title: '', description: '', phases: [] },
-        depositCutoffDate: '2099-12-31T00:00:00.000Z',
-      },
-    });
-    const { getByTestId } = render(<CampaignStatus campaign={campaign} />);
-    const depositWindow = getByTestId(CAMPAIGN_STATUS_TEST_IDS.DEPOSIT_WINDOW);
-    expect(depositWindow).toBeDefined();
-    expect(depositWindow).toHaveTextContent(/Deposit Window/);
-    expect(depositWindow).toHaveTextContent(/Closes Fri, April 16/);
-  });
-
-  it('renders deposit window with "Closed on" when cutoff is in the past', () => {
-    const campaign = createTestCampaign({
-      details: {
-        howItWorks: { title: '', description: '', phases: [] },
-        depositCutoffDate: '2000-01-01T00:00:00.000Z',
-      },
-    });
-    const { getByTestId } = render(<CampaignStatus campaign={campaign} />);
-    const depositWindow = getByTestId(CAMPAIGN_STATUS_TEST_IDS.DEPOSIT_WINDOW);
-    expect(depositWindow).toHaveTextContent(/Closed on Fri, April 16/);
-  });
-
-  it('does not render deposit window when depositCutoffDate is absent', () => {
-    const campaign = createTestCampaign({
-      details: {
-        howItWorks: { title: 'Title', description: '', phases: [] },
-      },
-    });
-    const { queryByTestId } = render(<CampaignStatus campaign={campaign} />);
-    expect(queryByTestId(CAMPAIGN_STATUS_TEST_IDS.DEPOSIT_WINDOW)).toBeNull();
-  });
-
-  it('does not render deposit window when details is null', () => {
-    const campaign = createTestCampaign({ details: null });
-    const { queryByTestId } = render(<CampaignStatus campaign={campaign} />);
-    expect(queryByTestId(CAMPAIGN_STATUS_TEST_IDS.DEPOSIT_WINDOW)).toBeNull();
   });
 
   it('calls getCampaignStatusInfo with campaign', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatus.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatus.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
-  BoxJustifyContent,
   Text,
   TextVariant,
   FontWeight,
@@ -13,8 +12,7 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { getCampaignStatusInfo } from './CampaignTile.utils';
-import { formatUTCDate } from '../../utils/formatUtils';
-import { strings } from '../../../../../../locales/i18n';
+import { documentToPlainText } from '../ContentfulRichText/ContentfulRichText';
 
 export const CAMPAIGN_STATUS_TEST_IDS = {
   CONTAINER: 'campaign-status-container',
@@ -22,7 +20,6 @@ export const CAMPAIGN_STATUS_TEST_IDS = {
   STATUS_LABEL: 'campaign-status-label',
   DATE_LABEL: 'campaign-status-date-label',
   HOW_IT_WORKS_TITLE: 'campaign-status-how-it-works-title',
-  DEPOSIT_WINDOW: 'campaign-status-deposit-window',
 } as const;
 
 interface CampaignStatusProps {
@@ -47,23 +44,9 @@ const CampaignStatus: React.FC<CampaignStatusProps> = ({
       ? campaign.image?.darkModeUrl
       : campaign.image?.lightModeUrl;
 
-  const howItWorksTitle = campaign.details?.howItWorks?.title;
-  const depositWindowLabel = useMemo(() => {
-    const rawDate = campaign.details?.depositCutoffDate;
-    if (!rawDate) return null;
-    const cutoff = new Date(rawDate);
-    const formatted = formatUTCDate(rawDate.split('T')[0], undefined, {
-      weekday: 'short',
-      month: 'long',
-      day: 'numeric',
-      year: undefined,
-    });
-    return cutoff < new Date()
-      ? strings('rewards.campaign_status.deposit_closed_on', {
-          date: formatted,
-        })
-      : strings('rewards.campaign_status.deposit_closes', { date: formatted });
-  }, [campaign.details?.depositCutoffDate]);
+  const howItWorksTitle = documentToPlainText(
+    campaign.details?.howItWorks?.title,
+  );
 
   return (
     <Box twClassName="gap-4 p-4" testID={CAMPAIGN_STATUS_TEST_IDS.CONTAINER}>
@@ -117,27 +100,6 @@ const CampaignStatus: React.FC<CampaignStatusProps> = ({
           >
             {howItWorksTitle}
           </Text>
-        ) : null}
-
-        {depositWindowLabel ? (
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="rounded-xl bg-muted px-3 py-2"
-            testID={CAMPAIGN_STATUS_TEST_IDS.DEPOSIT_WINDOW}
-          >
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.SuccessDefault}
-            >
-              {strings('rewards.campaign_status.deposit_window')}
-            </Text>
-            <Text variant={TextVariant.BodySm} twClassName="text-alternative">
-              {depositWindowLabel}
-            </Text>
-          </Box>
         ) : null}
       </Box>
     </Box>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -9,7 +9,6 @@ import {
 import {
   getCampaignStatusInfo,
   isCampaignTypeSupported,
-  isOptinAllowed,
 } from './CampaignTile.utils';
 import { selectCampaignParticipantCount } from '../../../../../reducers/rewards/selectors';
 import useGetCampaignParticipantStatus from '../../hooks/useGetCampaignParticipantStatus';
@@ -58,7 +57,6 @@ jest.mock('./CampaignTile.utils', () => ({
     dateLabelIcon: 'Clock',
   }),
   isCampaignTypeSupported: jest.fn().mockReturnValue(true),
-  isOptinAllowed: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../../../../reducers/rewards/selectors', () => ({
@@ -123,7 +121,6 @@ describe('CampaignTile', () => {
       dateLabelIcon: 'Clock',
     });
     (isCampaignTypeSupported as jest.Mock).mockReturnValue(true);
-    (isOptinAllowed as jest.Mock).mockReturnValue(true);
     setupParticipantCount(null);
     mockUseGetCampaignParticipantStatus.mockReturnValue({
       status: null,
@@ -193,16 +190,6 @@ describe('CampaignTile', () => {
         '•Enter now',
       );
       expect(queryByTestId('campaign-tile-participant-count')).toBeNull();
-    });
-
-    it('does not render enter-now when isOptinAllowed returns false (entries closed)', () => {
-      (isOptinAllowed as jest.Mock).mockReturnValue(false);
-      setupParticipantCount(null);
-      const campaign = createTestCampaign();
-
-      const { queryByTestId } = render(<CampaignTile campaign={campaign} />);
-
-      expect(queryByTestId('campaign-tile-enter-now')).toBeNull();
     });
 
     it('does not render enter-now when status is upcoming', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
@@ -65,11 +65,12 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
     dateLabelIcon, */
   } = useMemo(() => getCampaignStatusInfo(campaign), [campaign]);
 
-  const { status: participantStatus } = useGetCampaignParticipantStatus(
-    campaignStatus === 'active' && campaign.type === CampaignType.ONDO_HOLDING
-      ? campaign.id
-      : undefined,
-  );
+  const { status: participantStatus, isLoading: isParticipantStatusLoading } =
+    useGetCampaignParticipantStatus(
+      campaignStatus === 'active' && campaign.type === CampaignType.ONDO_HOLDING
+        ? campaign.id
+        : undefined,
+    );
 
   const isInteractive =
     campaignStatus !== 'upcoming' &&
@@ -80,15 +81,28 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
       ? campaign.image?.darkModeUrl
       : campaign.image?.lightModeUrl;
 
+  const hasTour = (campaign.details?.howItWorks?.tour?.length ?? 0) > 0;
+  const shouldShowTour =
+    hasTour &&
+    !isParticipantStatusLoading &&
+    participantStatus?.optedIn !== true &&
+    isOptinAllowed(campaign);
+
   const handlePress = () => {
     if (!isInteractive) return;
 
     if (onPress) {
       onPress();
     } else if (campaign.type === CampaignType.ONDO_HOLDING) {
-      navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
-        campaignId: campaign.id,
-      });
+      if (shouldShowTour) {
+        navigation.navigate(Routes.REWARDS_CAMPAIGN_TOUR_STEP, {
+          campaignId: campaign.id,
+        });
+      } else {
+        navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+          campaignId: campaign.id,
+        });
+      }
     } else if (campaign.type === CampaignType.SEASON_1) {
       navigation.navigate(Routes.REWARDS_SEASON_ONE_CAMPAIGN_DETAILS_VIEW, {
         campaignId: campaign.id,

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
@@ -25,7 +25,6 @@ import {
 import {
   getCampaignStatusInfo,
   isCampaignTypeSupported,
-  isOptinAllowed,
 } from './CampaignTile.utils';
 import { selectCampaignParticipantCount } from '../../../../../reducers/rewards/selectors';
 import { strings } from '../../../../../../locales/i18n';
@@ -86,7 +85,7 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
     hasTour &&
     !isParticipantStatusLoading &&
     participantStatus?.optedIn !== true &&
-    isOptinAllowed(campaign);
+    campaignStatus === 'active';
 
   const handlePress = () => {
     if (!isInteractive) return;
@@ -195,8 +194,7 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
                     </Text>
                   </Box>
                 ) : campaignStatus === 'active' &&
-                  participantStatus?.optedIn !== true &&
-                  isOptinAllowed(campaign) ? (
+                  participantStatus?.optedIn !== true ? (
                   <Box
                     flexDirection={BoxFlexDirection.Row}
                     alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.test.ts
@@ -8,7 +8,6 @@ import {
   getCampaignPillLabel,
   getCampaignStatusInfo,
   isCampaignTypeSupported,
-  isOptinAllowed,
 } from './CampaignTile.utils';
 import {
   type CampaignDto,
@@ -283,96 +282,6 @@ describe('CampaignTile.utils', () => {
         dateLabel: expect.stringContaining('rewards.campaign.ended_date'),
         dateLabelIcon: 'Confirmation',
       });
-    });
-  });
-
-  describe('isOptinAllowed', () => {
-    const minimalOndoDetails = {
-      howItWorks: { title: 'How', description: 'Desc', steps: [] },
-    };
-
-    /** Time within default buildCampaignDto start/end so status is `active`. */
-    const activeCampaignNow = new Date('2025-08-15T12:00:00.000Z');
-
-    beforeEach(() => {
-      jest.useFakeTimers();
-      jest.setSystemTime(activeCampaignNow);
-    });
-
-    it('returns true for non-ONDO_HOLDING campaigns even after a cutoff-like field', () => {
-      jest.setSystemTime(new Date('2025-10-15T12:00:00.000Z'));
-
-      const campaign = buildCampaignDto({
-        type: CampaignType.SEASON_1,
-        details: {
-          ...minimalOndoDetails,
-          depositCutoffDate: '2025-08-01T00:00:00.000Z',
-        },
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(true);
-    });
-
-    it('returns true for ONDO_HOLDING when depositCutoffDate is absent', () => {
-      const campaign = buildCampaignDto({
-        type: CampaignType.ONDO_HOLDING,
-        details: minimalOndoDetails,
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(true);
-    });
-
-    it('returns true when now is on or before depositCutoffDate', () => {
-      jest.setSystemTime(new Date('2025-08-01T12:00:00.000Z'));
-
-      const campaign = buildCampaignDto({
-        type: CampaignType.ONDO_HOLDING,
-        details: {
-          ...minimalOndoDetails,
-          depositCutoffDate: '2025-08-01T23:59:59.999Z',
-        },
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(true);
-    });
-
-    it('returns false when now is after depositCutoffDate', () => {
-      jest.setSystemTime(new Date('2025-08-02T12:00:00.000Z'));
-
-      const campaign = buildCampaignDto({
-        type: CampaignType.ONDO_HOLDING,
-        details: {
-          ...minimalOndoDetails,
-          depositCutoffDate: '2025-08-01T23:59:59.999Z',
-        },
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(false);
-    });
-
-    it('returns false when campaign status is upcoming', () => {
-      jest.setSystemTime(new Date('2025-05-01T12:00:00.000Z'));
-
-      const campaign = buildCampaignDto({
-        type: CampaignType.ONDO_HOLDING,
-        details: {
-          ...minimalOndoDetails,
-          depositCutoffDate: '2025-12-01T00:00:00.000Z',
-        },
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(false);
-    });
-
-    it('returns false when campaign status is complete', () => {
-      jest.setSystemTime(new Date('2026-01-15T12:00:00.000Z'));
-
-      const campaign = buildCampaignDto({
-        type: CampaignType.SEASON_1,
-        details: minimalOndoDetails,
-      });
-
-      expect(isOptinAllowed(campaign)).toBe(false);
     });
   });
 

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.utils.ts
@@ -52,34 +52,6 @@ export function getCampaignStatus(campaign: CampaignDto): CampaignStatus {
   return 'complete';
 }
 
-/**
- * Whether the user may still opt in to the campaign.
- * Opt-in is only possible while {@link getCampaignStatus} returns `'active'` (between
- * `startDate` and `endDate`). For {@link CampaignType.ONDO_HOLDING}, opt-in also closes after
- * `details.depositCutoffDate` (ISO 8601) when that date is present and valid.
- *
- * @param campaign - Campaign data from the API
- * @returns `true` if opt-in is allowed; `false` if the campaign is not active or the deposit cutoff has passed
- */
-export function isOptinAllowed(campaign: CampaignDto): boolean {
-  if (getCampaignStatus(campaign) !== 'active') {
-    return false;
-  }
-
-  if (campaign.type !== CampaignType.ONDO_HOLDING) {
-    return true;
-  }
-
-  const cutoff = campaign.details?.depositCutoffDate;
-  if (!cutoff) {
-    return true;
-  }
-
-  const cutoffMs = new Date(cutoff).getTime();
-
-  return Date.now() <= cutoffMs;
-}
-
 const MONTHS = [
   'January',
   'February',

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import CampaignCTA, { CAMPAIGN_CTA_TEST_IDS } from './CampaignCTA';
+import OndoCampaignCTA from './OndoCampaignCTA';
+import { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
 import {
   type CampaignDto,
   CampaignType,
@@ -55,11 +56,10 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.open_position': 'Open Position',
-
-      'rewards.campaign_details.entries_closed_title': 'Entries closed',
-      'rewards.campaign_details.entries_closed_description':
-        'You missed the opt-in window',
+      'rewards.campaign_details.ondo.open_position': 'Open Position',
+      'rewards.campaign_details.ondo.entries_closed_title': 'Entries closed',
+      'rewards.campaign_details.ondo.entries_closed_description':
+        'You missed the opt-in window. Check back for more campaigns in the future.',
     };
     return map[key] ?? key;
   },
@@ -85,7 +85,17 @@ const defaultProps = {
   campaignId: 'campaign-1',
 };
 
-describe('CampaignCTA', () => {
+const notOptedIn = {
+  status: { optedIn: false, participantCount: 0 } as const,
+  isLoading: false,
+};
+
+const optedIn = {
+  status: { optedIn: true, participantCount: 1 } as const,
+  isLoading: false,
+};
+
+describe('OndoCampaignCTA', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-08-15T12:00:00.000Z'));
@@ -96,20 +106,10 @@ describe('CampaignCTA', () => {
     jest.useRealTimers();
   });
 
-  const notOptedIn = {
-    status: { optedIn: false, participantCount: 0 } as const,
-    isLoading: false,
-  };
-
-  const optedIn = {
-    status: { optedIn: true, participantCount: 1 } as const,
-    isLoading: false,
-  };
-
   describe('visibility', () => {
     it('renders nothing when campaign is not active (upcoming)', () => {
       const { queryByTestId } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign({
             startDate: '2026-01-01T00:00:00.000Z',
             endDate: '2026-12-31T23:59:59.999Z',
@@ -122,24 +122,9 @@ describe('CampaignCTA', () => {
       expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
     });
 
-    it('renders nothing when campaign is complete', () => {
-      const { queryByTestId } = render(
-        <CampaignCTA
-          campaign={buildCampaign({
-            startDate: '2024-01-01T00:00:00.000Z',
-            endDate: '2025-01-01T00:00:00.000Z',
-          })}
-          participantStatus={notOptedIn}
-          {...defaultProps}
-        />,
-      );
-
-      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
-    });
-
     it('renders nothing while participant status is loading', () => {
       const { queryByTestId } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign()}
           participantStatus={{ status: null, isLoading: true }}
           {...defaultProps}
@@ -148,46 +133,13 @@ describe('CampaignCTA', () => {
 
       expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
     });
-  });
 
-  describe('not opted in, before deposit cutoff', () => {
-    it('renders the opt-in CTA button', () => {
+    it('renders "Entries closed" button when campaign is complete', () => {
       const { getByTestId, getByText } = render(
-        <CampaignCTA
-          campaign={buildCampaign()}
-          participantStatus={notOptedIn}
-          {...defaultProps}
-        />,
-      );
-
-      expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-      expect(getByText('Join Campaign')).toBeOnTheScreen();
-    });
-
-    it('opens the opt-in sheet when the button is pressed', () => {
-      const { getByTestId, queryByTestId } = render(
-        <CampaignCTA
-          campaign={buildCampaign()}
-          participantStatus={notOptedIn}
-          {...defaultProps}
-        />,
-      );
-
-      expect(queryByTestId('campaign-opt-in-sheet')).toBeNull();
-      fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
-      expect(getByTestId('campaign-opt-in-sheet')).toBeOnTheScreen();
-    });
-  });
-
-  describe('not opted in, past deposit cutoff', () => {
-    it('renders a disabled button with "Entries closed" text', () => {
-      const { getByTestId, getByText } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: '2025-08-01T00:00:00.000Z',
-            },
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2025-01-01T00:00:00.000Z',
           })}
           participantStatus={notOptedIn}
           {...defaultProps}
@@ -198,70 +150,47 @@ describe('CampaignCTA', () => {
       expect(getByText('Entries closed')).toBeOnTheScreen();
     });
 
-    it('shows the entries-closed toast', () => {
-      render(
-        <CampaignCTA
+    it('shows the entries-closed toast when the button is pressed on a complete campaign', () => {
+      const { getByTestId } = render(
+        <OndoCampaignCTA
           campaign={buildCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: '2025-08-01T00:00:00.000Z',
-            },
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2025-01-01T00:00:00.000Z',
           })}
           participantStatus={notOptedIn}
           {...defaultProps}
         />,
       );
 
+      fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+
       expect(mockEntriesClosed).toHaveBeenCalledWith(
         'Entries closed',
-        'You missed the opt-in window',
+        'You missed the opt-in window. Check back for more campaigns in the future.',
       );
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('opted in, past deposit cutoff, no positions', () => {
-    it('renders nothing when deposit cutoff has passed and user has no positions', () => {
-      const { queryByTestId } = render(
-        <CampaignCTA
-          campaign={buildCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: '2025-08-01T00:00:00.000Z',
-            },
-          })}
-          participantStatus={optedIn}
+  describe('not opted in', () => {
+    it('delegates to CampaignCTA and renders the opt-in button', () => {
+      const { getByTestId, getByText } = render(
+        <OndoCampaignCTA
+          campaign={buildCampaign()}
+          participantStatus={notOptedIn}
           {...defaultProps}
-          hasPositions={false}
-        />,
-      );
-
-      expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
-    });
-
-    it('still renders swap button when deposit cutoff passed but user has positions', () => {
-      const { getByTestId } = render(
-        <CampaignCTA
-          campaign={buildCampaign({
-            details: {
-              howItWorks: { title: 'How', description: 'Desc', steps: [] },
-              depositCutoffDate: '2025-08-01T00:00:00.000Z',
-            },
-          })}
-          participantStatus={optedIn}
-          {...defaultProps}
-          hasPositions
         />,
       );
 
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
+      expect(getByText('Join Campaign')).toBeOnTheScreen();
     });
   });
 
   describe('opted in, no portfolio positions', () => {
     it('renders the "Open Position" button', () => {
       const { getByTestId, getByText } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign()}
           participantStatus={optedIn}
           {...defaultProps}
@@ -273,9 +202,9 @@ describe('CampaignCTA', () => {
       expect(getByText('Open Position')).toBeOnTheScreen();
     });
 
-    it('navigates to RWA asset selector view when pressed', () => {
+    it('navigates to RWA asset selector in open_position mode when pressed', () => {
       const { getByTestId } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign()}
           participantStatus={optedIn}
           {...defaultProps}
@@ -294,7 +223,7 @@ describe('CampaignCTA', () => {
   describe('opted in, with portfolio positions', () => {
     it('renders the "Open Position" button', () => {
       const { getByTestId, getByText } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign()}
           participantStatus={optedIn}
           {...defaultProps}
@@ -308,7 +237,7 @@ describe('CampaignCTA', () => {
 
     it('navigates to RWA asset selector in swap mode when pressed', () => {
       const { getByTestId } = render(
-        <CampaignCTA
+        <OndoCampaignCTA
           campaign={buildCampaign()}
           participantStatus={optedIn}
           {...defaultProps}

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
   Box,
   Button,
@@ -8,18 +8,14 @@ import {
 } from '@metamask/design-system-react-native';
 import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import type { UseGetCampaignParticipantStatusResult } from '../../hooks/useGetCampaignParticipantStatus';
-import CampaignOptInSheet from './CampaignOptInSheet';
-import { getCampaignStatus, isOptinAllowed } from './CampaignTile.utils';
+import { getCampaignStatus } from './CampaignTile.utils';
 import { strings } from '../../../../../../locales/i18n';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import useRewardsToast from '../../hooks/useRewardsToast';
+import CampaignOptInCta, { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
 
-export const CAMPAIGN_CTA_TEST_IDS = {
-  CTA_BUTTON: 'campaign-details-cta-button',
-} as const;
-
-interface CampaignCTAProps {
+interface OndoCampaignCTAProps {
   campaign: CampaignDto;
   participantStatus: Pick<
     UseGetCampaignParticipantStatusResult,
@@ -32,20 +28,17 @@ interface CampaignCTAProps {
 /**
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
- * - "Opt In" button when the user has not opted in and the deposit cutoff has not passed
- * - Disabled "Entries closed" button (with Lock icon + toast) when cutoff has passed
+ * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, within deposit window)
+ * - "Entries closed" button (with Lock icon + toast) when cutoff has passed and user is not opted in
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
- *
- * Only visible when the campaign status is 'active'.
  */
-const CampaignCTA: React.FC<CampaignCTAProps> = ({
+const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   campaign,
   participantStatus,
   hasPositions,
   campaignId,
 }) => {
-  const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
   const navigation = useNavigation();
   const { showToast, RewardsToastOptions } = useRewardsToast();
 
@@ -55,6 +48,7 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
       campaignId,
     });
   }, [navigation, campaignId]);
+
   const onSwapAssets = useCallback(() => {
     navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
       mode: 'swap',
@@ -62,30 +56,22 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
     });
   }, [navigation, campaignId]);
 
-  const isActive =
-    !participantStatus?.isLoading &&
-    participantStatus &&
-    getCampaignStatus(campaign) === 'active';
+  const campaignStatus = getCampaignStatus(campaign);
+  const isLoading = participantStatus.isLoading;
   const isOptedIn = participantStatus?.status?.optedIn === true;
-  const optinAllowed = isOptinAllowed(campaign);
-  const isEntriesClosed = isActive && !isOptedIn && !optinAllowed;
-  const hasShownEntriesToast = useRef(false);
 
-  useEffect(() => {
-    if (isEntriesClosed && !hasShownEntriesToast.current) {
-      hasShownEntriesToast.current = true;
-      showToast(
-        RewardsToastOptions.entriesClosed(
-          strings('rewards.campaign_details.entries_closed_title'),
-          strings('rewards.campaign_details.entries_closed_description'),
-        ),
-      );
-    }
-  }, [isEntriesClosed, showToast, RewardsToastOptions]);
+  // Show "Entries closed" for complete campaigns when user has not opted in
+  const isEntriesClosed =
+    !isLoading && !isOptedIn && campaignStatus === 'complete';
 
-  if (!isActive) {
-    return null;
-  }
+  const handleEntriesClosedPress = useCallback(() => {
+    showToast(
+      RewardsToastOptions.entriesClosed(
+        strings('rewards.campaign_details.ondo.entries_closed_title'),
+        strings('rewards.campaign_details.ondo.entries_closed_description'),
+      ),
+    );
+  }, [showToast, RewardsToastOptions]);
 
   if (isEntriesClosed) {
     return (
@@ -94,44 +80,28 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           isFullWidth
-          isDisabled
           startIconName={IconName.Lock}
+          onPress={handleEntriesClosedPress}
           testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
         >
-          {strings('rewards.campaign_details.entries_closed_title')}
+          {strings('rewards.campaign_details.ondo.entries_closed_title')}
         </Button>
       </Box>
     );
   }
 
-  if (!isOptedIn) {
-    return (
-      <>
-        <Box twClassName="px-4 pt-2">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={() => setIsOptInSheetOpen(true)}
-            testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-          >
-            {strings('rewards.campaign_details.join_campaign')}
-          </Button>
-        </Box>
-
-        {isOptInSheetOpen && (
-          <CampaignOptInSheet
-            campaign={campaign}
-            onClose={() => setIsOptInSheetOpen(false)}
-          />
-        )}
-      </>
-    );
+  const isActive = !isLoading && campaignStatus === 'active';
+  if (!isActive) {
+    return null;
   }
 
-  // Deposit window closed — can swap existing positions but cannot open new ones
-  if (!optinAllowed && !hasPositions) {
-    return null;
+  if (!isOptedIn) {
+    return (
+      <CampaignOptInCta
+        campaign={campaign}
+        participantStatus={participantStatus}
+      />
+    );
   }
 
   if (hasPositions) {
@@ -144,7 +114,7 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
           onPress={onSwapAssets}
           testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
         >
-          {strings('rewards.campaign_details.open_position')}
+          {strings('rewards.campaign_details.ondo.open_position')}
         </Button>
       </Box>
     );
@@ -159,10 +129,10 @@ const CampaignCTA: React.FC<CampaignCTAProps> = ({
         onPress={onOpenPosition}
         testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
       >
-        {strings('rewards.campaign_details.open_position')}
+        {strings('rewards.campaign_details.ondo.open_position')}
       </Button>
     </Box>
   );
 };
 
-export default CampaignCTA;
+export default OndoCampaignCTA;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -177,37 +177,12 @@ jest.mock('./OndoLeaderboard.utils', () => ({
   formatComputedAt: jest.fn(),
 }));
 
-jest.mock('../RewardsInfoBanner', () => {
+jest.mock('../../../../../images/rewards/rewards-no-positions.svg', () => {
   const ReactActual = jest.requireActual('react');
-  const { View, Text, Pressable } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({
-      title,
-      onConfirm,
-      confirmButtonLabel,
-    }: {
-      title: string;
-      description: string;
-      onConfirm?: () => void;
-      confirmButtonLabel?: string;
-    }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'rewards-info-banner' },
-        ReactActual.createElement(Text, null, title),
-        onConfirm &&
-          ReactActual.createElement(
-            Pressable,
-            { onPress: onConfirm, testID: 'info-banner-confirm' },
-            ReactActual.createElement(
-              Text,
-              null,
-              confirmButtonLabel ?? 'Confirm',
-            ),
-          ),
-      ),
-  };
+  const { View } = jest.requireActual('react-native');
+  const RewardsNoPositionsImage = () =>
+    ReactActual.createElement(View, { testID: 'rewards-no-positions-image' });
+  return { __esModule: true, default: RewardsNoPositionsImage };
 });
 
 jest.mock(
@@ -390,12 +365,12 @@ describe('OndoPortfolio', () => {
   });
 
   describe('initial/unfetched state', () => {
-    it('renders nothing before any fetch has completed', () => {
+    it('renders the empty state before any fetch has completed', () => {
       const { queryByTestId } = render(<OndoPortfolio {...baseProps} />);
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeNull();
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeNull();
-      expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();
+      expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeDefined();
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.CONTAINER)).toBeNull();
     });
   });
@@ -605,19 +580,19 @@ describe('OndoPortfolio', () => {
   });
 
   describe('empty state CTA', () => {
-    it('triggers navigate when empty state confirm button is pressed', () => {
-      const { getByTestId } = render(
+    it('triggers navigate when empty state CTA is pressed', () => {
+      const { getByText, getByTestId } = render(
         <OndoPortfolio {...baseProps} hasFetched />,
       );
-      fireEvent.press(getByTestId('info-banner-confirm'));
+      fireEvent.press(getByText('Explore tokens'));
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeOnTheScreen();
     });
 
-    it('does not render CTA button when campaign is complete', () => {
-      const { queryByTestId } = render(
+    it('does not render CTA when campaign is complete', () => {
+      const { queryByText } = render(
         <OndoPortfolio {...baseProps} hasFetched isCampaignComplete />,
       );
-      expect(queryByTestId('info-banner-confirm')).toBeNull();
+      expect(queryByText('Explore tokens')).toBeNull();
     });
   });
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -258,7 +258,6 @@ const baseProps = {
   portfolio: null as OndoGmPortfolioDto | null,
   isLoading: false,
   hasError: false,
-  hasFetched: false,
   refetch: mockRefetch,
   campaignId: 'campaign-1',
   onOpenAccountPicker: jest.fn(),
@@ -280,12 +279,7 @@ describe('OndoPortfolio', () => {
 
     it('does not render skeleton when loading but portfolio data already present', () => {
       const { queryByTestId } = render(
-        <OndoPortfolio
-          {...baseProps}
-          portfolio={MOCK_PORTFOLIO}
-          isLoading
-          hasFetched
-        />,
+        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} isLoading />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeNull();
@@ -297,16 +291,15 @@ describe('OndoPortfolio', () => {
           {...baseProps}
           portfolio={{ ...MOCK_PORTFOLIO, positions: [] }}
           isLoading
-          hasFetched
         />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeDefined();
     });
 
-    it('renders skeleton during retry (isLoading=true, hasFetched=true, no portfolio)', () => {
+    it('renders skeleton during retry (isLoading=true, no portfolio)', () => {
       const { getByTestId, queryByTestId } = render(
-        <OndoPortfolio {...baseProps} isLoading hasFetched />,
+        <OndoPortfolio {...baseProps} isLoading />,
       );
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.LOADING)).toBeDefined();
@@ -316,16 +309,14 @@ describe('OndoPortfolio', () => {
 
   describe('error state', () => {
     it('renders error banner when has error and no data', () => {
-      const { getByTestId } = render(
-        <OndoPortfolio {...baseProps} hasError hasFetched />,
-      );
+      const { getByTestId } = render(<OndoPortfolio {...baseProps} hasError />);
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeDefined();
     });
 
     it('does not show empty banner on error even after fetch', () => {
       const { queryByTestId } = render(
-        <OndoPortfolio {...baseProps} hasError hasFetched />,
+        <OndoPortfolio {...baseProps} hasError />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();
@@ -333,12 +324,7 @@ describe('OndoPortfolio', () => {
 
     it('shows cached portfolio data instead of error banner when portfolio exists', () => {
       const { queryByTestId, getByTestId } = render(
-        <OndoPortfolio
-          {...baseProps}
-          portfolio={MOCK_PORTFOLIO}
-          hasError
-          hasFetched
-        />,
+        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} hasError />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.ERROR)).toBeNull();
@@ -348,16 +334,14 @@ describe('OndoPortfolio', () => {
 
   describe('empty state', () => {
     it('renders empty banner when fetch completed with no portfolio', () => {
-      const { getByTestId } = render(
-        <OndoPortfolio {...baseProps} hasFetched />,
-      );
+      const { getByTestId } = render(<OndoPortfolio {...baseProps} />);
 
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeDefined();
     });
 
     it('does not render empty banner when portfolio data is present', () => {
       const { queryByTestId } = render(
-        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} hasFetched />,
+        <OndoPortfolio {...baseProps} portfolio={MOCK_PORTFOLIO} />,
       );
 
       expect(queryByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeNull();
@@ -381,7 +365,6 @@ describe('OndoPortfolio', () => {
       portfolio: MOCK_PORTFOLIO,
       isLoading: false,
       hasError: false,
-      hasFetched: true,
     };
 
     it('renders portfolio container', () => {
@@ -401,7 +384,6 @@ describe('OndoPortfolio', () => {
     const loadedProps = {
       ...baseProps,
       portfolio: MOCK_PORTFOLIO,
-      hasFetched: true,
     };
 
     beforeEach(() => {
@@ -433,7 +415,6 @@ describe('OndoPortfolio', () => {
         <OndoPortfolio
           {...baseProps}
           portfolio={{ ...MOCK_PORTFOLIO, positions: [] }}
-          hasFetched
         />,
       );
 
@@ -488,7 +469,6 @@ describe('OndoPortfolio', () => {
       return {
         ...baseProps,
         portfolio: MOCK_PORTFOLIO,
-        hasFetched: true,
         onOpenAccountPicker: mockOnOpenAccountPicker,
       };
     };
@@ -537,7 +517,6 @@ describe('OndoPortfolio', () => {
     const loadedProps = {
       ...baseProps,
       portfolio: MOCK_PORTFOLIO,
-      hasFetched: true,
     };
 
     it('renders the units text', () => {
@@ -558,7 +537,6 @@ describe('OndoPortfolio', () => {
             ...MOCK_PORTFOLIO,
             positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '-0.05' }],
           }}
-          hasFetched
         />,
       );
       expect(getByText('-5.00%')).toBeDefined();
@@ -572,7 +550,6 @@ describe('OndoPortfolio', () => {
             ...MOCK_PORTFOLIO,
             positions: [{ ...MOCK_POSITION, unrealizedPnlPercent: '—' }],
           }}
-          hasFetched
         />,
       );
       expect(queryByText('—')).toBeNull();
@@ -582,7 +559,7 @@ describe('OndoPortfolio', () => {
   describe('empty state CTA', () => {
     it('triggers navigate when empty state CTA is pressed', () => {
       const { getByText, getByTestId } = render(
-        <OndoPortfolio {...baseProps} hasFetched />,
+        <OndoPortfolio {...baseProps} />,
       );
       fireEvent.press(getByText('Explore tokens'));
       expect(getByTestId(ONDO_PORTFOLIO_TEST_IDS.EMPTY)).toBeOnTheScreen();
@@ -590,7 +567,7 @@ describe('OndoPortfolio', () => {
 
     it('does not render CTA when campaign is complete', () => {
       const { queryByText } = render(
-        <OndoPortfolio {...baseProps} hasFetched isCampaignComplete />,
+        <OndoPortfolio {...baseProps} isCampaignComplete />,
       );
       expect(queryByText('Explore tokens')).toBeNull();
     });
@@ -600,7 +577,6 @@ describe('OndoPortfolio', () => {
     const loadedProps = {
       ...baseProps,
       portfolio: MOCK_PORTFOLIO,
-      hasFetched: true,
       isCampaignComplete: true,
     };
 
@@ -712,7 +688,6 @@ describe('OndoPortfolio', () => {
         <OndoPortfolio
           {...baseProps}
           portfolio={MOCK_PORTFOLIO}
-          hasFetched
           onOpenAccountPicker={onOpenAccountPicker}
         />,
       );
@@ -775,7 +750,6 @@ describe('OndoPortfolio', () => {
         <OndoPortfolio
           {...baseProps}
           portfolio={MOCK_PORTFOLIO}
-          hasFetched
           onOpenAccountPicker={onOpenAccountPicker}
         />,
       );

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -150,7 +150,6 @@ interface OndoPortfolioProps {
   portfolio: OndoGmPortfolioDto | null;
   isLoading: boolean;
   hasError: boolean;
-  hasFetched: boolean;
   refetch: () => Promise<void>;
   campaignId: string;
   onOpenAccountPicker: (config: AccountPickerConfig) => void;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -61,7 +61,7 @@ import { VerticalAlignment } from '../../../../../component-library/components/L
 import AvatarAccount from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { selectIconSeedAddressByAccountGroupId } from '../../../../../selectors/multichainAccounts/accounts';
 import Engine from '../../../../../core/Engine';
-import RewardsInfoBanner from '../RewardsInfoBanner';
+import RewardsNoPositionsImage from '../../../../../images/rewards/rewards-no-positions.svg';
 
 const styles = StyleSheet.create({
   skeletonLg: { height: 128, borderRadius: 12 },
@@ -161,7 +161,6 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   portfolio,
   isLoading,
   hasError,
-  hasFetched,
   refetch,
   campaignId,
   onOpenAccountPicker,
@@ -366,31 +365,45 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
     );
   }
 
-  if (hasFetched && (!portfolio || portfolio.positions.length === 0)) {
+  if (
+    !isLoading &&
+    !hasError &&
+    (!portfolio || portfolio.positions.length === 0)
+  ) {
     return (
       <Box
         testID={ONDO_PORTFOLIO_TEST_IDS.EMPTY}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
-        twClassName="gap-2"
+        twClassName="py-6 gap-3"
       >
-        <RewardsInfoBanner
-          title={strings('rewards.ondo_campaign_portfolio.empty')}
-          description={strings(
-            'rewards.ondo_campaign_portfolio.empty_description',
-          )}
-          {...(!isCampaignComplete && {
-            onConfirm: () => {
+        <RewardsNoPositionsImage
+          name="rewards-no-positions"
+          width={80}
+          height={80}
+        />
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+        >
+          {strings('rewards.ondo_campaign_portfolio.empty')}
+        </Text>
+        {!isCampaignComplete && (
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Bold}
+            twClassName="text-center"
+            onPress={() => {
               navigation.navigate(
                 Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
                 { mode: 'open_position', campaignId },
               );
-            },
-            confirmButtonLabel: strings(
-              'rewards.ondo_campaign_portfolio.empty_cta',
-            ),
-          })}
-        />
+            }}
+          >
+            {strings('rewards.ondo_campaign_portfolio.empty_cta')}
+          </Text>
+        )}
       </Box>
     );
   }

--- a/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CampaignTourStep, {
+  CAMPAIGN_TOUR_STEP_TEST_IDS,
+} from './CampaignTourStep';
+import type { OndoCampaignTourStepDto } from '../../../../../../core/Engine/controllers/rewards-controller/types';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return { ...actual };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('../../ThemeImageComponent/RewardsThemeImageComponent', () => {
+  const { View } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ themeImage }: { themeImage: { lightModeUrl: string } }) =>
+      ReactActual.createElement(View, {
+        testID: 'theme-image',
+        accessibilityLabel: themeImage.lightModeUrl,
+      }),
+  };
+});
+
+const baseStep: OndoCampaignTourStepDto = {
+  title: 'Welcome to the Campaign',
+  description: 'Learn how this works.',
+  image: {
+    lightModeUrl: 'https://example.com/light.png',
+    darkModeUrl: 'https://example.com/dark.png',
+  },
+  actions: { next: true, skip: true },
+};
+
+describe('CampaignTourStep', () => {
+  it('renders title and description', () => {
+    const { getByText } = render(<CampaignTourStep step={baseStep} />);
+
+    expect(getByText('Welcome to the Campaign')).toBeOnTheScreen();
+    expect(getByText('Learn how this works.')).toBeOnTheScreen();
+  });
+
+  it('renders image when provided', () => {
+    const { getByTestId } = render(<CampaignTourStep step={baseStep} />);
+
+    expect(getByTestId('theme-image')).toBeOnTheScreen();
+  });
+
+  it('does not render image when null', () => {
+    const { queryByTestId } = render(
+      <CampaignTourStep step={{ ...baseStep, image: null }} />,
+    );
+
+    expect(queryByTestId('theme-image')).toBeNull();
+  });
+
+  it('renders title with correct test ID', () => {
+    const { getByTestId } = render(<CampaignTourStep step={baseStep} />);
+
+    expect(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.TITLE)).toBeOnTheScreen();
+  });
+
+  it('renders description with correct test ID', () => {
+    const { getByTestId } = render(<CampaignTourStep step={baseStep} />);
+
+    expect(
+      getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.DESCRIPTION),
+    ).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Text,
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  BoxFlexDirection,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import RewardsThemeImageComponent from '../../ThemeImageComponent/RewardsThemeImageComponent';
+import type { OndoCampaignTourStepDto } from '../../../../../../core/Engine/controllers/rewards-controller/types';
+
+export const CAMPAIGN_TOUR_STEP_TEST_IDS = {
+  CONTAINER: 'campaign-tour-step-container',
+  TITLE: 'campaign-tour-step-title',
+  DESCRIPTION: 'campaign-tour-step-description',
+  NEXT_BUTTON: 'campaign-tour-step-next-button',
+  SKIP_BUTTON: 'campaign-tour-step-skip-button',
+} as const;
+
+interface CampaignTourStepProps {
+  step: OndoCampaignTourStepDto;
+}
+
+const CampaignTourStep: React.FC<CampaignTourStepProps> = ({ step }) => {
+  const tw = useTailwind();
+
+  return (
+    <ScrollView
+      contentContainerStyle={tw.style('flex-grow px-4 justify-center')}
+      showsVerticalScrollIndicator={false}
+    >
+      {step.image && (
+        <Box
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
+          flexDirection={BoxFlexDirection.Column}
+          twClassName="mb-6"
+        >
+          <RewardsThemeImageComponent
+            themeImage={step.image}
+            style={tw.style('w-64 h-64')}
+          />
+        </Box>
+      )}
+
+      <Box twClassName="w-full">
+        <Text
+          variant={TextVariant.HeadingLg}
+          twClassName="text-center"
+          testID={CAMPAIGN_TOUR_STEP_TEST_IDS.TITLE}
+        >
+          {step.title}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          twClassName="mt-2 text-center text-text-alternative"
+          testID={CAMPAIGN_TOUR_STEP_TEST_IDS.DESCRIPTION}
+        >
+          {step.description}
+        </Text>
+      </Box>
+    </ScrollView>
+  );
+};
+
+export default CampaignTourStep;

--- a/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
@@ -11,6 +11,7 @@ import {
 } from '@metamask/design-system-react-native';
 import RewardsThemeImageComponent from '../../ThemeImageComponent/RewardsThemeImageComponent';
 import type { OndoCampaignTourStepDto } from '../../../../../../core/Engine/controllers/rewards-controller/types';
+import { documentToPlainText } from '../../ContentfulRichText/ContentfulRichText';
 
 export const CAMPAIGN_TOUR_STEP_TEST_IDS = {
   CONTAINER: 'campaign-tour-step-container',
@@ -52,14 +53,14 @@ const CampaignTourStep: React.FC<CampaignTourStepProps> = ({ step }) => {
           twClassName="text-center"
           testID={CAMPAIGN_TOUR_STEP_TEST_IDS.TITLE}
         >
-          {step.title}
+          {documentToPlainText(step.title)}
         </Text>
         <Text
           variant={TextVariant.BodyMd}
           twClassName="mt-2 text-center text-text-alternative"
           testID={CAMPAIGN_TOUR_STEP_TEST_IDS.DESCRIPTION}
         >
-          {step.description}
+          {documentToPlainText(step.description)}
         </Text>
       </Box>
     </ScrollView>

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import type { Json } from '@metamask/utils';
-import ContentfulRichText from './ContentfulRichText';
+import ContentfulRichText, { documentToPlainText } from './ContentfulRichText';
 import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
@@ -193,5 +193,75 @@ describe('ContentfulRichText', () => {
       <ContentfulRichText document={doc} testID="rt" />,
     );
     expect(getByText('no marks')).toBeOnTheScreen();
+  });
+});
+
+describe('documentToPlainText', () => {
+  it('returns a clean plain string unchanged', () => {
+    expect(documentToPlainText('hello')).toBe('hello');
+  });
+
+  it('strips U+FFFD replacement character from a plain string', () => {
+    expect(
+      documentToPlainText('Trade tokenized stocks, \uFFFDETFs and more'),
+    ).toBe('Trade tokenized stocks, ETFs and more');
+  });
+
+  it('strips U+FFFC object replacement character from a plain string', () => {
+    expect(documentToPlainText('before\uFFFCafter')).toBe('beforeafter');
+  });
+
+  it('strips zero-width spaces from a plain string', () => {
+    expect(documentToPlainText('foo\u200Bbar')).toBe('foobar');
+  });
+
+  it('collapses multiple spaces after stripping special chars in a plain string', () => {
+    expect(documentToPlainText('foo  \uFFFD  bar')).toBe('foo bar');
+  });
+
+  it('returns empty string for null', () => {
+    expect(documentToPlainText(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(documentToPlainText(undefined)).toBe('');
+  });
+
+  it('returns empty string for a number', () => {
+    expect(documentToPlainText(42)).toBe('');
+  });
+
+  it('extracts value from a text node', () => {
+    expect(documentToPlainText({ nodeType: 'text', value: 'leaf' })).toBe(
+      'leaf',
+    );
+  });
+
+  it('returns empty string for a text node whose value is not a string', () => {
+    expect(documentToPlainText({ nodeType: 'text', value: 99 })).toBe('');
+  });
+
+  it('recursively extracts text from a document with nested content', () => {
+    const doc = {
+      nodeType: 'document',
+      content: [
+        {
+          nodeType: 'paragraph',
+          content: [
+            { nodeType: 'text', value: 'Hello' },
+            { nodeType: 'text', value: 'world' },
+          ],
+        },
+      ],
+    };
+    expect(documentToPlainText(doc)).toBe('Hello world');
+  });
+
+  it('returns empty string for an empty content array', () => {
+    expect(documentToPlainText({ nodeType: 'document', content: [] })).toBe('');
+  });
+
+  it('returns empty string for an object with no nodeType and no content', () => {
+    expect(documentToPlainText({ foo: 'bar' })).toBe('');
   });
 });

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
@@ -251,5 +251,51 @@ const ContentfulRichText: React.FC<ContentfulRichTextProps> = ({
   );
 };
 
-export { isDocument };
+// Returns a fresh RegExp each call so stateful `lastIndex` never leaks between uses.
+// Constructed via new RegExp() to avoid the no-control-regex lint rule firing on
+// intentional control-character matching (U+0000–U+001F, U+007F, etc.).
+const UNWANTED_CHARS_PATTERN =
+  '[\u0000-\u001F\u007F\u0080-\u009F\u200B-\u200F\u2028\u2029\uFEFF\uFFFC-\uFFFD]+';
+const UNWANTED_CHARS_RE = () => new RegExp(UNWANTED_CHARS_PATTERN, 'g');
+
+/**
+ * Recursively extracts plain text from a Contentful rich text document or node.
+ * If the value is already a string, it is returned as-is.
+ * Returns an empty string for null/undefined/non-object values.
+ */
+function documentToPlainText(value: unknown): string {
+  if (typeof value === 'string')
+    return value
+      .replace(UNWANTED_CHARS_RE(), ' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+  if (value === null || value === undefined || typeof value !== 'object')
+    return '';
+
+  const node = value as {
+    nodeType?: unknown;
+    value?: unknown;
+    content?: unknown[];
+  };
+
+  if (node.nodeType === 'text' && typeof node.value === 'string') {
+    return node.value
+      .replace(UNWANTED_CHARS_RE(), ' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+  }
+
+  if (Array.isArray(node.content)) {
+    return node.content
+      .map(documentToPlainText)
+      .join(' ')
+      .replace(/[\n\r\u2028\u2029]+/g, ' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+  }
+
+  return '';
+}
+
+export { isDocument, documentToPlainText };
 export default ContentfulRichText;

--- a/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
+++ b/app/components/UI/Rewards/components/ContentfulRichText/ContentfulRichText.tsx
@@ -266,7 +266,7 @@ const UNWANTED_CHARS_RE = () => new RegExp(UNWANTED_CHARS_PATTERN, 'g');
 function documentToPlainText(value: unknown): string {
   if (typeof value === 'string')
     return value
-      .replace(UNWANTED_CHARS_RE(), ' ')
+      .replace(UNWANTED_CHARS_RE(), '')
       .replace(/\s{2,}/g, ' ')
       .trim();
   if (value === null || value === undefined || typeof value !== 'object')
@@ -280,7 +280,7 @@ function documentToPlainText(value: unknown): string {
 
   if (node.nodeType === 'text' && typeof node.value === 'string') {
     return node.value
-      .replace(UNWANTED_CHARS_RE(), ' ')
+      .replace(UNWANTED_CHARS_RE(), '')
       .replace(/\s{2,}/g, ' ')
       .trim();
   }

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -181,7 +181,7 @@ describe('useRewardsToast', () => {
       expect(config).toMatchObject({
         variant: ToastVariants.Icon,
         iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.muted,
+        iconColor: mockTheme.colors.icon.default,
         backgroundColor: 'transparent',
         hapticsType: NotificationFeedbackType.Warning,
         hasNoTimeout: false,
@@ -200,20 +200,21 @@ describe('useRewardsToast', () => {
       const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.entriesClosed(
         'Entries closed',
-        'You missed the opt-in window',
+        'You missed the opt-in window. Check back for more campaigns in the future.',
       );
 
       expect(config).toMatchObject({
         variant: ToastVariants.Icon,
         iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.muted,
+        iconColor: mockTheme.colors.icon.default,
         hapticsType: NotificationFeedbackType.Warning,
       });
       expect(config.labelOptions).toEqual([
         { label: 'Entries closed', isBold: true },
       ]);
       expect(config.descriptionOptions).toEqual({
-        description: 'You missed the opt-in window',
+        description:
+          'You missed the opt-in window. Check back for more campaigns in the future.',
       });
     });
 

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -103,7 +103,7 @@ const useRewardsToast = (): {
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
         variant: ToastVariants.Icon,
         iconName: IconName.Lock,
-        iconColor: theme.colors.icon.muted,
+        iconColor: theme.colors.icon.default,
         backgroundColor: 'transparent',
         hapticsType: NotificationFeedbackType.Warning,
         labelOptions: getRewardsToastLabels(title),
@@ -121,7 +121,7 @@ const useRewardsToast = (): {
     [
       theme.colors.success.default,
       theme.colors.error.default,
-      theme.colors.icon.muted,
+      theme.colors.icon.default,
       toastRef,
     ],
   );

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -107,6 +107,7 @@ const Routes = {
   REWARDS_ONDO_CAMPAIGN_LEADERBOARD: 'RewardsOndoCampaignLeaderboard',
   REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR: 'RewardsOndoRwaAssetSelector',
   REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW: 'RewardsOndoCampaignPortfolioView',
+  REWARDS_CAMPAIGN_TOUR_STEP: 'RewardsCampaignTourStep',
   TRENDING_VIEW: 'TrendingView',
   TRENDING_FEED: 'TrendingFeed',
   WHATS_HAPPENING_DETAIL: 'WhatsHappeningDetailView',

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -213,7 +213,6 @@ export type ThemeImageState = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CampaignDetailsState = {
   howItWorks: OndoCampaignHowItWorksState;
-  depositCutoffDate?: string;
 };
 
 /**
@@ -700,7 +699,6 @@ export interface OndoCampaignHowItWorks {
 
 export interface OndoHoldingDetails {
   howItWorks: OndoCampaignHowItWorks;
-  depositCutoffDate?: string;
 }
 
 export type CampaignDetails = OndoHoldingDetails;

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -169,6 +169,23 @@ export type OndoCampaignStepState = {
   iconName: string;
 };
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type OndoCampaignTourActionsState = {
+  next?: boolean;
+  skip?: boolean;
+};
+
+/**
+ * Serializable version of OndoCampaignTourStepDto for state storage.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type OndoCampaignTourStepDtoState = {
+  title: string;
+  description: string;
+  image: ThemeImageState | null;
+  actions: OndoCampaignTourActionsState | null;
+};
+
 /**
  * Serializable version of OndoCampaignHowItWorks for state storage.
  */
@@ -178,6 +195,7 @@ export type OndoCampaignHowItWorksState = {
   description: string;
   steps: OndoCampaignStepState[];
   notes?: Json | null;
+  tour?: OndoCampaignTourStepDtoState[];
 };
 
 /**
@@ -660,11 +678,24 @@ export interface OndoCampaignStep {
   iconName: string;
 }
 
+export interface OndoCampaignTourActions {
+  next?: boolean;
+  skip?: boolean;
+}
+
+export interface OndoCampaignTourStepDto {
+  title: string;
+  description: string;
+  image: ThemeImage | null;
+  actions: OndoCampaignTourActions | null;
+}
+
 export interface OndoCampaignHowItWorks {
   title: string;
   description: string;
   steps: OndoCampaignStep[];
   notes?: Json | null;
+  tour?: OndoCampaignTourStepDto[];
 }
 
 export interface OndoHoldingDetails {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8011,9 +8011,6 @@
       "participant_count": "#{{count}}",
       "opt_in_cta": "Opt in",
       "opt_in_sheet_title": "Join the campaign",
-      "opt_in_sheet_description_pre_link": "By clicking 'Opt in' you agree to the MetaMask Rewards",
-      "opt_in_sheet_link_text": "Supplemental Terms of Use and Privacy Notice",
-      "opt_in_sheet_description_post_link": "We'll track onchain activity to reward you automatically.",
       "geo_restriction_banner_title": "Not available in your region",
       "geo_restriction_banner_description": "This campaign is not available in your region due to local regulations.",
       "opt_in_success_toast": "You're in!"
@@ -8029,15 +8026,17 @@
       "opted_in": "You're opted in to this campaign",
       "opt_in_error": "Failed to opt in. Please try again.",
       "join_campaign": "Join the campaign",
-      "entries_closed_title": "Entries closed",
-      "entries_closed_description": "You missed the opt-in window",
       "competition_closed_title": "Competition no longer open",
       "competition_closed_description": "Sorry, this competition is no longer open to join. You can follow the leaderboard below and check back for future campaigns.",
       "checking_opt_in_status": "Checking opt in status",
       "swap": "Swap",
-      "open_position": "Open Position",
       "swap_ondo_assets": "Swap Ondo Assets",
-      "how_it_works": "How it works"
+      "how_it_works": "How it works",
+      "ondo": {
+        "entries_closed_title": "Entries closed",
+        "entries_closed_description": "You missed the opt-in window. Check back for more campaigns in the future.",
+        "open_position": "Open Position"
+      }
     },
     "ondo_campaign_leaderboard_position": {
       "title": "Your Position",
@@ -8130,11 +8129,6 @@
       "error_description": "We couldn't load the campaigns. Please try again.",
       "retry_button": "Retry",
       "refreshing": "Refreshing..."
-    },
-    "campaign_status": {
-      "deposit_window": "Deposit Window",
-      "deposit_closes": "Closes {{date}}",
-      "deposit_closed_on": "Closed on {{date}}"
     }
   },
   "time": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Add campaign tour before use opts in 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add campaign tour before use opts into a new campaign

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/87bc981e-3dba-49e8-9a4e-1388adec7c0b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes rewards campaign navigation/CTA visibility and removes deposit-cutoff based gating, which can affect who can opt in and what screens are shown for active/complete campaigns.
> 
> **Overview**
> Adds a new `RewardsCampaignTourStep` route and `CampaignTourStepView` to present a multi-step, swipeable campaign tour with *Next/Skip* actions, and updates `CampaignTile` to route non-opted-in active Ondo users with tour data through this flow before landing on campaign details.
> 
> Refactors Ondo campaign details/CTA logic to remove `depositCutoffDate`/`isOptinAllowed` gating and the “competition ended” banner, splitting opt-in UI into reusable `CampaignOptInCta` + `CampaignOptInSheet`, and changing the “entries closed” behavior to apply to *complete* campaigns via a toast-triggering lock CTA.
> 
> Improves Contentful text robustness by adding `documentToPlainText` and using it for campaign titles/steps, updates Ondo portfolio empty-state UI (new illustration + “Explore tokens” link), and adjusts copy/translation keys and toast styling accordingly, with updated/added unit tests and navigation snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcf7ff6e203915238fad8a224a7ed3e8471579e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->