### PR TITLE
chore(rewards): render rich text for campaign step description

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import type { Json } from '@metamask/utils';
 import CampaignHowItWorks, {
   CAMPAIGN_HOW_IT_WORKS_TEST_IDS,
 } from './CampaignHowItWorks';
@@ -11,8 +12,6 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { View } = jest.requireActual('react-native');
   return {
     ...actual,
-    // Icon maps its name prop to an SVG component via enum lookup; mock it to
-    // avoid "type is invalid" errors when getIconName returns a plain string.
     Icon: ({ testID }: { testID?: string }) =>
       ReactActual.createElement(View, { testID }),
   };
@@ -35,6 +34,22 @@ jest.mock('../../../../../../locales/i18n', () => ({
   },
 }));
 
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const makeRichText = (text: string): Json => ({
+  nodeType: 'document',
+  data: {},
+  content: [
+    {
+      nodeType: 'paragraph',
+      data: {},
+      content: [{ nodeType: 'text', value: text, marks: [], data: {} }],
+    },
+  ],
+});
+
 const createHowItWorks = (
   overrides: Partial<OndoCampaignHowItWorks> = {},
 ): OndoCampaignHowItWorks => ({
@@ -44,7 +59,7 @@ const createHowItWorks = (
     {
       iconName: 'star',
       title: 'Step 1',
-      description: 'Do step 1',
+      description: makeRichText('Do step 1'),
     },
   ],
   ...overrides,
@@ -79,11 +94,31 @@ describe('CampaignHowItWorks', () => {
     ).toHaveTextContent('Do step 1');
   });
 
+  it('does not render description when it is null', () => {
+    const howItWorks = createHowItWorks({
+      steps: [{ iconName: 'star', title: 'Step 1', description: null }],
+    });
+    const { queryByTestId } = render(
+      <CampaignHowItWorks howItWorks={howItWorks} />,
+    );
+    expect(
+      queryByTestId(`${CAMPAIGN_HOW_IT_WORKS_TEST_IDS.STEP_DESCRIPTION}-0`),
+    ).toBeNull();
+  });
+
   it('renders multiple steps', () => {
     const howItWorks = createHowItWorks({
       steps: [
-        { iconName: 'star', title: 'Step A', description: 'Desc A' },
-        { iconName: 'circle', title: 'Step B', description: 'Desc B' },
+        {
+          iconName: 'star',
+          title: 'Step A',
+          description: makeRichText('Desc A'),
+        },
+        {
+          iconName: 'circle',
+          title: 'Step B',
+          description: makeRichText('Desc B'),
+        },
       ],
     });
     const { getByTestId } = render(

--- a/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignHowItWorks.tsx
@@ -13,6 +13,9 @@ import {
 import type { OndoCampaignHowItWorks } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../locales/i18n';
 import { getIconName } from '../../utils/formatUtils';
+import ContentfulRichText, {
+  isDocument,
+} from '../ContentfulRichText/ContentfulRichText';
 
 export const CAMPAIGN_HOW_IT_WORKS_TEST_IDS = {
   CONTAINER: 'campaign-how-it-works-container',
@@ -63,13 +66,12 @@ const CampaignHowItWorks: React.FC<CampaignHowItWorksProps> = ({
           >
             {step.title}
           </Text>
-          <Text
-            variant={TextVariant.BodyMd}
-            twClassName="text-alternative"
-            testID={`${CAMPAIGN_HOW_IT_WORKS_TEST_IDS.STEP_DESCRIPTION}-${stepIndex}`}
-          >
-            {step.description}
-          </Text>
+          {isDocument(step.description) && (
+            <ContentfulRichText
+              document={step.description}
+              testID={`${CAMPAIGN_HOW_IT_WORKS_TEST_IDS.STEP_DESCRIPTION}-${stepIndex}`}
+            />
+          )}
         </Box>
       </Box>
     ))}

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -165,7 +165,7 @@ export interface CampaignDto {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type OndoCampaignStepState = {
   title: string;
-  description: string;
+  description: Json | null;
   iconName: string;
 };
 
@@ -656,7 +656,7 @@ export type CampaignParticipantStatusState = {
 
 export interface OndoCampaignStep {
   title: string;
-  description: string;
+  description: Json | null;
   iconName: string;
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Render rich text for campaign step description
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null 

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-04-07 at 16 56 03" src="https://github.com/user-attachments/assets/ba9b7257-ccf6-4756-b690-8ab3c06a0085" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the campaign step `description` type from `string` to `Json | null`, which can affect serialization/state and any code consuming these types. UI rendering now depends on `ContentfulRichText` and will silently omit non-document values, so mismatched backend payloads could hide content.
> 
> **Overview**
> **Campaign “How it works” steps now render Contentful rich text** instead of plain strings. `CampaignHowItWorks` switches step description rendering to `ContentfulRichText` gated by `isDocument`, allowing `description` to be `null`/non-document without rendering.
> 
> The rewards campaign types are updated so `OndoCampaignStep.description` (and its state variant) becomes `Json | null`. Tests are updated to build rich-text documents for step descriptions and add coverage for the `null` description case (including mocking navigation for `ContentfulRichText`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9438245f4f82b8a551e4950ec22f3e4864ea5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->