### PR TITLE
fix(perps): show standard Order submitted toast for pay-with-any-token flow

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -1111,14 +1111,11 @@ describe('PerpsOrderView', () => {
     expect(mockGetPositions).toBeDefined();
   });
 
-  it('shows persistent submitting toast when custom token is selected (deposit flow)', async () => {
+  it('shows standard submitted toast when custom token is selected (deposit flow)', async () => {
     mockUseIsPerpsBalanceSelected.mockReturnValue(false);
 
     const mockShowToast = jest.fn();
     const mockSubmitted = jest.fn(() => ({ id: 'order-submitted-toast' }));
-    const mockSubmitting = jest.fn(() => ({
-      id: 'submitting-your-trade-toast',
-    }));
     (usePerpsToasts as jest.Mock).mockReturnValue({
       showToast: mockShowToast,
       PerpsToastOptions: {
@@ -1140,75 +1137,7 @@ describe('PerpsOrderView', () => {
             creationFailed: jest.fn(),
           },
           shared: {
-            submitting: mockSubmitting,
-          },
-        },
-        positionManagement: { tpsl: { updateTPSLError: jest.fn() } },
-        dataFetching: {
-          market: { error: { marketDataUnavailable: jest.fn() } },
-        },
-        accountManagement: {
-          deposit: {
-            inProgress: jest.fn(),
-            takingLonger: {},
-            tradeCanceled: {},
-            error: {},
-          },
-        },
-      },
-    });
-
-    (usePerpsOrderExecution as jest.Mock).mockImplementation(() => ({
-      placeOrder: jest.fn().mockResolvedValue({ success: true }),
-      isPlacing: false,
-    }));
-
-    render(<PerpsOrderView />, { wrapper: TestWrapper });
-
-    const placeOrderButton = await screen.findByTestId(
-      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
-    );
-    await act(async () => {
-      fireEvent.press(placeOrderButton);
-    });
-
-    await waitFor(() => {
-      expect(mockShowToast).toHaveBeenCalled();
-    });
-    expect(mockSubmitting).toHaveBeenCalled();
-    expect(mockSubmitted).not.toHaveBeenCalled();
-  });
-
-  it('shows standard submitted toast when using perps balance', async () => {
-    mockUseIsPerpsBalanceSelected.mockReturnValue(true);
-
-    const mockShowToast = jest.fn();
-    const mockSubmitted = jest.fn(() => ({ id: 'order-submitted-toast' }));
-    const mockSubmitting = jest.fn(() => ({
-      id: 'submitting-your-trade-toast',
-    }));
-    (usePerpsToasts as jest.Mock).mockReturnValue({
-      showToast: mockShowToast,
-      PerpsToastOptions: {
-        formValidation: {
-          orderForm: {
-            limitPriceRequired: {},
-            validationError: jest.fn(),
-          },
-        },
-        orderManagement: {
-          market: {
-            submitted: mockSubmitted,
-            confirmed: jest.fn(),
-            creationFailed: jest.fn(),
-          },
-          limit: {
-            submitted: jest.fn(),
-            confirmed: jest.fn(),
-            creationFailed: jest.fn(),
-          },
-          shared: {
-            submitting: mockSubmitting,
+            submitting: jest.fn(),
           },
         },
         positionManagement: { tpsl: { updateTPSLError: jest.fn() } },
@@ -1244,7 +1173,70 @@ describe('PerpsOrderView', () => {
       expect(mockShowToast).toHaveBeenCalled();
     });
     expect(mockSubmitted).toHaveBeenCalled();
-    expect(mockSubmitting).not.toHaveBeenCalled();
+  });
+
+  it('shows standard submitted toast when using perps balance', async () => {
+    mockUseIsPerpsBalanceSelected.mockReturnValue(true);
+
+    const mockShowToast = jest.fn();
+    const mockSubmitted = jest.fn(() => ({ id: 'order-submitted-toast' }));
+    (usePerpsToasts as jest.Mock).mockReturnValue({
+      showToast: mockShowToast,
+      PerpsToastOptions: {
+        formValidation: {
+          orderForm: {
+            limitPriceRequired: {},
+            validationError: jest.fn(),
+          },
+        },
+        orderManagement: {
+          market: {
+            submitted: mockSubmitted,
+            confirmed: jest.fn(),
+            creationFailed: jest.fn(),
+          },
+          limit: {
+            submitted: jest.fn(),
+            confirmed: jest.fn(),
+            creationFailed: jest.fn(),
+          },
+          shared: {
+            submitting: jest.fn(),
+          },
+        },
+        positionManagement: { tpsl: { updateTPSLError: jest.fn() } },
+        dataFetching: {
+          market: { error: { marketDataUnavailable: jest.fn() } },
+        },
+        accountManagement: {
+          deposit: {
+            inProgress: jest.fn(),
+            takingLonger: {},
+            tradeCanceled: {},
+            error: {},
+          },
+        },
+      },
+    });
+
+    (usePerpsOrderExecution as jest.Mock).mockImplementation(() => ({
+      placeOrder: jest.fn().mockResolvedValue({ success: true }),
+      isPlacing: false,
+    }));
+
+    render(<PerpsOrderView />, { wrapper: TestWrapper });
+
+    const placeOrderButton = await screen.findByTestId(
+      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+    );
+    await act(async () => {
+      fireEvent.press(placeOrderButton);
+    });
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalled();
+    });
+    expect(mockSubmitted).toHaveBeenCalled();
   });
 
   it('handles failed order placement', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -605,7 +605,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     [blockingPayAlerts],
   );
 
-  // Order execution hook. Perps balance: standard "Order submitted" toast. Custom token: persistent "Submitting your trade" toast during deposit.
+  // Order execution hook. Shows standard "Order submitted" toast for all order flows.
   const { placeOrder: executeOrder, isPlacing: isPlacingOrder } =
     usePerpsOrderExecution({
       onSuccess: (_position) => {
@@ -1084,19 +1084,13 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           },
         };
 
-        if (hasCustomTokenSelected) {
-          // Persistent "Submitting your trade" toast for deposit flow (user can dismiss via close button or swipe)
-          showToast(PerpsToastOptions.orderManagement.shared.submitting());
-        } else {
-          // Standard "Order submitted" toast for perps balance orders
-          showToast(
-            PerpsToastOptions.orderManagement[orderForm.type].submitted(
-              orderForm.direction,
-              positionSize,
-              orderForm.asset,
-            ),
-          );
-        }
+        showToast(
+          PerpsToastOptions.orderManagement[orderForm.type].submitted(
+            orderForm.direction,
+            positionSize,
+            orderForm.asset,
+          ),
+        );
 
         // Check if TP/SL should be handled separately (for new positions or position flips)
         const shouldHandleTPSLSeparately =


### PR DESCRIPTION
## **Description**

When placing a perps order through the "pay with any token" flow, a persistent "Submitting your trade" toast was shown instead of the standard "Order submitted" toast used in the normal (perps balance) flow. This inconsistency confused users since both flows ultimately submit the same type of order.

This PR removes the conditional toast logic in `PerpsOrderView` so that all order submissions — regardless of payment method — display the standard "Order submitted" toast with the order direction, size, and asset details.

## **Changelog**

CHANGELOG entry: Fixed perps "pay with any token" order flow to show the standard "Order submitted" toast instead of a different "Submitting your trade" toast

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2667

## **Manual testing steps**

```gherkin
Feature: Perps order toast consistency

  Scenario: User places an order using pay with any token
    Given the user is on the Perps order view
    And the user has selected a custom token (not perps balance) to pay with

    When the user places a market or limit order
    Then the standard "Order submitted" toast is displayed with direction, size, and asset
    And the persistent "Submitting your trade" toast is not shown

  Scenario: User places an order using perps balance
    Given the user is on the Perps order view
    And the user is paying with their perps balance

    When the user places a market or limit order
    Then the standard "Order submitted" toast is displayed with direction, size, and asset
```

## **Screenshots/Recordings**

N/A — toast content change only, no visual layout changes.

### **Before**

Pay with any token flow showed a persistent "Submitting your trade" toast.

### **After**

https://consensys.slack.com/archives/C092T3GPHQD/p1775635267124749

Pay with any token flow now shows the standard "Order submitted" toast, consistent with the perps balance flow.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI feedback change: removes a conditional toast in perps order submission and updates tests accordingly, without affecting order execution or funds handling logic.
> 
> **Overview**
> Makes perps order submission toasts consistent by always showing the standard `Order submitted` toast, even when using the *pay-with-any-token* (deposit) flow.
> 
> Removes the custom-token branch that previously displayed a persistent `Submitting your trade` toast, and updates `PerpsOrderView` tests to assert `submitted` is called for both payment paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26f0c717330849a0a320fcf74ddc30ea59f5814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->