### PR TITLE
feat: add pull-to-refresh functionality to DeFiPositionsList component

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from '@testing-library/react-native';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import DeFiPositionsList from './DeFiPositionsList';
@@ -29,6 +30,8 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+const mockDeFiExecutePoll = jest.fn().mockResolvedValue(undefined);
+
 jest.mock('../../../core/Engine', () => ({
   context: {
     NetworkEnablementController: {
@@ -39,6 +42,9 @@ jest.mock('../../../core/Engine', () => ({
       disableNetwork: jest.fn(),
       enableNetworkInNamespace: jest.fn(),
       enableAllPopularNetworks: jest.fn(),
+    },
+    DeFiPositionsController: {
+      _executePoll: (...args: unknown[]) => mockDeFiExecutePoll(...args),
     },
   },
 }));
@@ -672,6 +678,31 @@ describe('DeFiPositionsList', () => {
       expect(mockAddProperties).not.toHaveBeenCalledWith(
         expect.objectContaining({ screen_type: 'defi', location: 'homepage' }),
       );
+    });
+  });
+
+  describe('Pull to refresh (full view)', () => {
+    beforeEach(() => {
+      mockDeFiExecutePoll.mockClear();
+    });
+
+    it('calls DeFiPositionsController._executePoll when refresh control fires', async () => {
+      const { findByTestId } = renderWithProvider(
+        <DeFiPositionsList tabLabel="DeFi" isFullView />,
+        { state: mockInitialState },
+      );
+
+      const scrollView = await findByTestId(
+        WalletViewSelectorsIDs.DEFI_POSITIONS_SCROLL_VIEW,
+      );
+      const { refreshControl } = scrollView.props;
+      expect(refreshControl).toBeTruthy();
+
+      await act(async () => {
+        await refreshControl.props.onRefresh();
+      });
+
+      expect(mockDeFiExecutePoll).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import { View } from 'react-native';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { RefreshControl, ScrollViewProps, View } from 'react-native';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
@@ -33,6 +39,9 @@ import { selectHomepageRedesignV1Enabled } from '../../../selectors/featureFlagC
 import ConditionalScrollView from '../../../component-library/components-temp/ConditionalScrollView';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import Engine from '../../../core/Engine';
+import { useTheme } from '../../../util/theme';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 export interface DeFiPositionsListProps {
   tabLabel: string;
@@ -54,6 +63,9 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = ({
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );
+  const { colors } = useTheme();
+  const tw = useTailwind();
+  const [refreshing, setRefreshing] = useState(false);
 
   const formattedDeFiPositions = useMemo(() => {
     if (!defiPositions) {
@@ -90,6 +102,49 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = ({
 
     return sortAssets(defiPositionsList, defiSortConfig);
   }, [defiPositions, tokenSortConfig, defiPositionsByEnabledNetworks]);
+
+  const handleDeFiRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await Engine.context.DeFiPositionsController._executePoll();
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const isScrollEnabled = isFullView || !isHomepageRedesignV1Enabled;
+
+  const scrollViewProps = useMemo((): ScrollViewProps => {
+    const base: ScrollViewProps = {
+      testID: WalletViewSelectorsIDs.DEFI_POSITIONS_SCROLL_VIEW,
+    };
+    if (!isFullView) {
+      return base;
+    }
+    const listLength = Array.isArray(formattedDeFiPositions)
+      ? formattedDeFiPositions.length
+      : 0;
+    return {
+      ...base,
+      refreshControl: (
+        <RefreshControl
+          colors={[colors.primary.default]}
+          tintColor={colors.icon.default}
+          refreshing={refreshing}
+          onRefresh={handleDeFiRefresh}
+        />
+      ),
+      ...(listLength === 0 ? { contentContainerStyle: tw`flex-grow` } : {}),
+    };
+  }, [
+    isFullView,
+    formattedDeFiPositions,
+    refreshing,
+    handleDeFiRefresh,
+    colors.primary.default,
+    colors.icon.default,
+    tw,
+  ]);
 
   useEffect(() => {
     if (
@@ -157,6 +212,13 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = ({
     </View>
   );
 
+  const listBody =
+    formattedDeFiPositions.length > 0 ? (
+      content
+    ) : (
+      <DefiEmptyState twClassName="mx-auto mt-4" />
+    );
+
   return (
     <View
       style={
@@ -165,18 +227,12 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = ({
       testID={WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER}
     >
       <DeFiPositionsControlBar />
-      {formattedDeFiPositions.length > 0 ? (
-        <ConditionalScrollView
-          isScrollEnabled={isFullView || !isHomepageRedesignV1Enabled}
-          scrollViewProps={{
-            testID: WalletViewSelectorsIDs.DEFI_POSITIONS_SCROLL_VIEW,
-          }}
-        >
-          {content}
-        </ConditionalScrollView>
-      ) : (
-        <DefiEmptyState twClassName="mx-auto mt-4" />
-      )}
+      <ConditionalScrollView
+        isScrollEnabled={isScrollEnabled}
+        scrollViewProps={isScrollEnabled ? scrollViewProps : undefined}
+      >
+        {listBody}
+      </ConditionalScrollView>
     </View>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The DeFi full view (opened from the homepage section) used a scrollable list but did not attach a RefreshControl, unlike the tokens and NFTs full views. Pull-to-refresh did not re-fetch DeFi positions.

DeFiPositionsList now adds RefreshControl when isFullView is true and calls DeFiPositionsController._executePoll() (aligned with homepage DeFi section refresh). When the list is empty, content stays inside the scroll view with contentContainerStyle flex-grow so pull-to-refresh still works. Tests cover that _executePoll runs when the refresh control fires.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed pull-to-refresh on the DeFi full view opened from the homepage

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/27968
https://consensyssoftware.atlassian.net/browse/TMCU-601

## **Manual testing steps**

```gherkin
Feature: DeFi full view pull-to-refresh

  Scenario: User refreshes DeFi positions from the homepage full view
    Given the user is on the homepage with DeFi enabled
    And the user opens the DeFi full view

    When the user pulls down to refresh on the DeFi list or empty state
    Then the refresh indicator appears and completes
    And DeFi position data is re-polled and the UI reflects updated data when the controller returns new state
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ecee8126-89a3-473f-b6b7-8b12b6f79a9d


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the DeFi full view; main risk is triggering the DeFi poll more often via the new `RefreshControl` integration.
> 
> **Overview**
> Adds pull-to-refresh support to `DeFiPositionsList` *when `isFullView` is true*, showing a native `RefreshControl` and invoking `Engine.context.DeFiPositionsController._executePoll()`.
> 
> Keeps pull-to-refresh usable even when the list is empty by applying a `flex-grow` content container style, and updates tests to mock the controller and assert `_executePoll` is called when the refresh handler fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0add9cced4a1afab1e1d1db56f78624320cd0317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->