### PR TITLE
fix(bridge): harden token hooks against malformed API responses cp-7.73.0

### DIFF
--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { usePopularTokens, clearPopularTokensCache } from './usePopularTokens';
 import {
   createMockPopularToken,
@@ -101,6 +101,81 @@ describe('usePopularTokens', () => {
           }),
         }),
       );
+    });
+
+    it('falls back to an empty array for malformed responses', async () => {
+      const mockedEngine = jest.requireMock('../../../../core/Engine');
+      mockedEngine.context.AuthenticationController.getBearerToken.mockReturnValue(
+        new Promise(() => undefined),
+      );
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        json: async () => ({
+          data: mockPopularTokens,
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        usePopularTokens({
+          chainIds: [MOCK_CHAIN_IDS.ethereum],
+          includeAssets: '[]',
+        }),
+      );
+
+      await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+      expect(result.current.popularTokens).toEqual([]);
+    });
+
+    it('does not cache malformed top-level responses', async () => {
+      const mockedEngine = jest.requireMock('../../../../core/Engine');
+      mockedEngine.context.AuthenticationController.getBearerToken.mockReturnValue(
+        new Promise(() => undefined),
+      );
+
+      let resolveFirstFetch:
+        | ((value: { json: () => Promise<unknown> }) => void)
+        | undefined;
+
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveFirstFetch = resolve;
+            }),
+        )
+        .mockResolvedValueOnce({
+          json: async () => mockPopularTokens,
+        });
+
+      const params = {
+        chainIds: [MOCK_CHAIN_IDS.ethereum],
+        includeAssets: '[]',
+      };
+
+      const { result: firstResult, unmount } = renderHook(() =>
+        usePopularTokens(params),
+      );
+
+      await act(async () => {
+        resolveFirstFetch?.({
+          json: async () => ({
+            data: mockPopularTokens,
+          }),
+        });
+      });
+
+      expect(firstResult.current.popularTokens).toEqual([]);
+      unmount();
+
+      const { result: secondResult } = renderHook(() =>
+        usePopularTokens(params),
+      );
+
+      await waitFor(() => expect(secondResult.current.isLoading).toBe(false));
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(secondResult.current.popularTokens).toEqual(mockPopularTokens);
     });
   });
 

--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -16,6 +16,8 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+const mockedEngine = jest.requireMock('../../../../core/Engine');
+
 const mockPopularTokens = [
   createMockPopularToken({
     symbol: 'TEST',
@@ -33,6 +35,9 @@ describe('usePopularTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     clearPopularTokensCache();
+    mockedEngine.context.AuthenticationController.getBearerToken.mockResolvedValue(
+      'mock-bearer-token',
+    );
   });
 
   afterEach(() => {
@@ -104,7 +109,6 @@ describe('usePopularTokens', () => {
     });
 
     it('falls back to an empty array for malformed responses', async () => {
-      const mockedEngine = jest.requireMock('../../../../core/Engine');
       mockedEngine.context.AuthenticationController.getBearerToken.mockReturnValue(
         new Promise(() => undefined),
       );
@@ -128,7 +132,6 @@ describe('usePopularTokens', () => {
     });
 
     it('does not cache malformed top-level responses', async () => {
-      const mockedEngine = jest.requireMock('../../../../core/Engine');
       mockedEngine.context.AuthenticationController.getBearerToken.mockReturnValue(
         new Promise(() => undefined),
       );

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -166,13 +166,26 @@ export const usePopularTokens = ({
             signal: abortController.signal,
           },
         );
-        const popularAssets: PopularToken[] = await response.json();
+        if (response.ok === false) {
+          throw new Error(
+            `Failed to fetch popular tokens with status ${response.status}`,
+          );
+        }
 
-        // Store in cache with current timestamp
-        popularTokensCache.set(cacheKey, {
-          data: popularAssets,
-          timestamp: Date.now(),
-        });
+        const popularAssetsResponse: unknown = await response.json();
+        const isValidTopLevelPayload = Array.isArray(popularAssetsResponse);
+        const popularAssets: PopularToken[] = isValidTopLevelPayload
+          ? popularAssetsResponse
+          : [];
+
+        if (isValidTopLevelPayload) {
+          // Cache only valid top-level API payloads so malformed responses do
+          // not suppress retries for the full cache TTL.
+          popularTokensCache.set(cacheKey, {
+            data: popularAssets,
+            timestamp: Date.now(),
+          });
+        }
 
         if (!isCancelled) {
           setPopularTokens(popularAssets);

--- a/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
@@ -129,6 +129,27 @@ describe('useSearchTokens', () => {
         }),
       );
     });
+
+    it('falls back to an empty array for malformed responses', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: async () => ({
+          pageInfo: {
+            hasNextPage: false,
+          },
+        }),
+      });
+
+      const { result } = renderHook(() => useSearchTokens(defaultParams));
+
+      await act(async () => {
+        await result.current.searchTokens('test query');
+      });
+
+      await waitFor(() => expect(result.current.isSearchLoading).toBe(false));
+
+      expect(result.current.searchResults).toEqual([]);
+      expect(result.current.searchCursor).toBeUndefined();
+    });
   });
 
   describe('debouncing', () => {

--- a/app/components/UI/Bridge/hooks/useSearchTokens.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.ts
@@ -135,11 +135,20 @@ export const useSearchTokens = ({
             body: JSON.stringify(requestBody),
           },
         );
-        const searchData: SearchTokensResponse = await response.json();
+        if (response.ok === false) {
+          throw new Error(
+            `Failed to search tokens with status ${response.status}`,
+          );
+        }
+
+        const searchData: Partial<SearchTokensResponse> = await response.json();
+        const searchResultData: PopularToken[] = Array.isArray(searchData.data)
+          ? searchData.data
+          : [];
 
         // Store the cursor for pagination if there's a next page
         setSearchCursor(
-          searchData.pageInfo.hasNextPage
+          searchData.pageInfo?.hasNextPage
             ? searchData.pageInfo.endCursor
             : undefined,
         );
@@ -149,10 +158,10 @@ export const useSearchTokens = ({
         if (isPagination) {
           setSearchResults((prevResults) => [
             ...prevResults,
-            ...searchData.data,
+            ...searchResultData,
           ]);
         } else {
-          setSearchResults(searchData.data);
+          setSearchResults(searchResultData);
         }
       } catch (error) {
         console.error('Error searching tokens:', error);

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.test.ts
@@ -130,6 +130,12 @@ describe('useTokensWithBalances', () => {
       expect(result.current).toEqual([]);
     });
 
+    it('handles undefined token arrays', () => {
+      const { result } = renderHook(() => useTokensWithBalances(undefined, {}));
+
+      expect(result.current).toEqual([]);
+    });
+
     it('handles multiple tokens with partial balance data', () => {
       const token1AssetId =
         'eip155:1/erc20:0x1111111111111111111111111111111111111111' as CaipAssetType;

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
@@ -14,9 +14,9 @@ import { BalancesByAssetId } from './useBalancesByAssetId';
  * based on whether the chain is EVM or non-EVM
  */
 const convertAPITokensToBridgeTokens = (
-  apiTokens: PopularToken[],
+  apiTokens?: PopularToken[] | null,
 ): (BridgeToken & { assetId: CaipAssetType })[] =>
-  apiTokens.map((token) => {
+  (Array.isArray(apiTokens) ? apiTokens : []).map((token) => {
     const { assetReference, chainId, assetNamespace } = parseCaipAssetType(
       token.assetId,
     );
@@ -57,7 +57,7 @@ const convertAPITokensToBridgeTokens = (
  * @returns Tokens with merged balance information
  */
 export const useTokensWithBalances = (
-  apiTokens: PopularToken[],
+  apiTokens: PopularToken[] | null | undefined,
   balancesByAssetId: BalancesByAssetId,
 ): BridgeToken[] =>
   useMemo(() => {


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR hardens Bridge token hooks against malformed API responses that could leave the token selector vulnerable to render-time crashes or stale empty state. It guards `useTokensWithBalances` against missing token arrays, normalizes malformed search and popular token payloads to empty results, and skips caching malformed top-level popular-token responses so the app can retry on the next request.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that could leave Bridge token lists empty or unstable when the Bridge API returned malformed token payloads.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28519

## **Manual testing steps**

```gherkin
Feature: Bridge token list resiliency

  Scenario: user opens the Bridge token selector
    Given the user has opened the Bridge flow
    When the user opens the source or destination token selector
    Then the token list loads without crashing

  Scenario: user searches for a token
    Given the Bridge token selector is open
    When the user enters a token search query
    Then the app shows matching results or an empty state without crashing
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token list fetching/parsing and caching behavior in Bridge hooks; while defensive, it can affect when requests retry and what users see in token selectors/search under API or network errors.
> 
> **Overview**
> **Hardens Bridge token hooks against malformed or non-OK API responses.** `usePopularTokens` and `useSearchTokens` now validate `response.ok`, coerce unexpected JSON shapes to empty result arrays, and avoid crashing on missing fields.
> 
> **Adjusts caching semantics for popular tokens.** `usePopularTokens` now caches responses only when the top-level payload is a valid array, so malformed payloads won’t poison the 15-minute cache and will retry on subsequent renders.
> 
> **Improves null/undefined tolerance when merging balances.** `useTokensWithBalances` now accepts `null`/`undefined` token arrays and treats them as empty, with added test coverage for these edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2efbf4e52334cd118f7b5f40384c875db9f4764e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->