### PR TITLE
chore: increase Check bundle size CI step from 54 to 55

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=12288
 
       - name: Check bundle size
-        run: ./scripts/js-bundle-stats.sh ios/main.jsbundle 54
+        run: ./scripts/js-bundle-stats.sh ios/main.jsbundle 55
 
       - name: Upload iOS bundle
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## **Description**

Increases the JS bundle size CI threshold from 54 MB to 55 MB to unblock https://github.com/MetaMask/metamask-mobile/pull/28495/, which is failing the bundle size check.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/28495/ (failing JS bundle size check)

## **Manual testing steps**

N/A — CI-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that relaxes a size gate by 1MB; main impact is reduced sensitivity to bundle growth, which could mask small regressions.
> 
> **Overview**
> Updates the `ci.yml` **JS bundle size check** to allow the generated iOS `main.jsbundle` to be up to *55MB* (previously 54MB), unblocking CI when the bundle size slightly increases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2725d697ea2fb7ed3426fe18e17b9ba6871a5234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->