### PR TITLE
fix: use event subscription for timeframe changing resolution for AC

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -225,6 +225,12 @@ const PriceAdvanced = ({
     }),
     [nextCursor, hasMore, assetId, currentCurrency],
   );
+  // This is to make sure we show only data relevant to selected timeframe even if api returns a lot more data than that
+  const visibleFromMs = useMemo(() => {
+    const lastBar = ohlcvData[ohlcvData.length - 1];
+    if (!lastBar) return undefined;
+    return lastBar.time - config.durationMs;
+  }, [ohlcvData, config.durationMs]);
 
   const dateLabel = strings(TIME_RANGE_LABELS[timeRange]);
 
@@ -346,6 +352,7 @@ const PriceAdvanced = ({
               lineChrome={advancedChartLineChromePresets.tokenOverview}
               isLoading={chartLoading}
               ohlcvPagination={ohlcvPagination}
+              visibleFromMs={visibleFromMs}
               onCrosshairMove={handleCrosshairMove}
               onChartInteracted={handleChartInteracted}
               onChartTradingViewClicked={handleChartTradingViewClicked}

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -91,6 +91,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       onChartTradingViewClicked,
       isLoading = false,
       lineChrome,
+      visibleFromMs,
     },
     ref,
   ) => {
@@ -181,11 +182,18 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     );
     paginationRef.current = ohlcvPagination;
 
+    const visibleFromMsRef = useRef<number | undefined>(visibleFromMs);
+    visibleFromMsRef.current = visibleFromMs;
+
     const sendOHLCVData = useCallback(
       (data: OHLCVBar[]) => {
         postMessage({
           type: 'SET_OHLCV_DATA',
-          payload: { data, pagination: paginationRef.current },
+          payload: {
+            data,
+            pagination: paginationRef.current,
+            visibleFromMs: visibleFromMsRef.current,
+          },
         });
       },
       [postMessage],
@@ -390,6 +398,17 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         ohlcvSeriesKey !== undefined &&
         ohlcvSeriesKey !== prevOhlcvSeriesKeyRef.current
       ) {
+        if (prevOhlcvSeriesKeyRef.current !== undefined) {
+          // Time range switch: ohlcvData is still stale from the previous
+          // period (fetch is in progress). Show skeleton, mark the key, and
+          // clear prevData so the fresh data triggers the length-diff branch
+          // on arrival — avoiding sending stale data to the WebView which
+          // causes a resolution race condition in TradingView.
+          beginFullOhlcvLayoutSettle();
+          prevOhlcvSeriesKeyRef.current = ohlcvSeriesKey;
+          prevOhlcvDataRef.current = [];
+          return;
+        }
         beginFullOhlcvLayoutSettle();
         sendOHLCVData(ohlcvData);
         prevOhlcvDataRef.current = ohlcvData;

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -197,6 +197,13 @@ export interface SetOHLCVDataPayload {
   data: OHLCVBar[];
   /** When provided, the WebView fetches older pages directly instead of round-tripping via RN. */
   pagination?: OHLCVPaginationConfig;
+  /**
+   * Expected visible-range start as a Unix timestamp in **milliseconds**.
+   * When set, the WebView calls `chart.setVisibleRange()` after `resetData()`
+   * so only the requested period (1H, 1D, 1W, 1M, 1Y) is shown initially —
+   * the user can still scroll left to reveal older data fetched via pagination.
+   */
+  visibleFromMs?: number;
 }
 
 export interface AddIndicatorPayload {
@@ -457,6 +464,13 @@ export interface AdvancedChartProps {
    * while the chart is not yet `CHART_READY`). Cleared when set false and the chart is ready.
    */
   isLoading?: boolean;
+
+  /**
+   * Expected visible-range start (Unix ms). After data loads the WebView constrains
+   * the viewport to `[visibleFromMs, lastBarTime]` via `chart.setVisibleRange()`.
+   * The user can still scroll left to reveal older/paginated data.
+   */
+  visibleFromMs?: number;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
+++ b/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
@@ -52,14 +52,16 @@ export interface TimeRangeConfig {
   timePeriod: OHLCVTimePeriod;
   /** Optional interval override. When undefined, API uses its default for the timePeriod. */
   interval?: string;
+  /** Duration of this time range in milliseconds (used to compute the initial visible viewport). */
+  durationMs: number;
 }
 
 export const TIME_RANGE_CONFIGS: Record<TimeRange, TimeRangeConfig> = {
-  '1H': { timePeriod: '1h' },
-  '1D': { timePeriod: '1d' },
-  '1W': { timePeriod: '1w' },
-  '1M': { timePeriod: '1m' },
-  '1Y': { timePeriod: '1y' },
+  '1H': { timePeriod: '1h', durationMs: 60 * 60 * 1000 },
+  '1D': { timePeriod: '1d', durationMs: 24 * 60 * 60 * 1000 },
+  '1W': { timePeriod: '1w', durationMs: 7 * 24 * 60 * 60 * 1000 },
+  '1M': { timePeriod: '1m', durationMs: 30 * 24 * 60 * 60 * 1000 },
+  '1Y': { timePeriod: '1y', durationMs: 365 * 24 * 60 * 60 * 1000 },
 };
 
 const TIME_RANGES: TimeRange[] = ['1H', '1D', '1W', '1M', '1Y'];

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -166,14 +166,18 @@ describe('AdvancedChart', () => {
     );
   });
 
-  it('sends SET_OHLCV_DATA when ohlcvSeriesKey changes even if bar count matches', () => {
-    const altBars: OHLCVBar[] = [
+  it('does not send stale data when ohlcvSeriesKey changes; waits for fresh data', () => {
+    const staleBars: OHLCVBar[] = [
+      { time: 1000000, open: 10, high: 12, low: 9, close: 11, volume: 100 },
+      { time: 1000300, open: 11, high: 13, low: 10, close: 12, volume: 200 },
+    ];
+    const freshBars: OHLCVBar[] = [
       { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
       { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
     ];
 
     const { getByTestId, rerender } = render(
-      <AdvancedChart ohlcvData={MOCK_BARS} ohlcvSeriesKey="range-a" />,
+      <AdvancedChart ohlcvData={staleBars} ohlcvSeriesKey="range-a" />,
     );
 
     const webView = getByTestId('mock-webview');
@@ -183,12 +187,28 @@ describe('AdvancedChart', () => {
 
     mockPostMessage.mockClear();
 
-    rerender(<AdvancedChart ohlcvData={altBars} ohlcvSeriesKey="range-b" />);
+    // Time range switch with stale data (same bars, new key) — should NOT send SET_OHLCV_DATA
+    rerender(<AdvancedChart ohlcvData={staleBars} ohlcvSeriesKey="range-b" />);
+
+    const setOhlcvCallsAfterKeyChange = mockPostMessage.mock.calls.filter(
+      (call) => {
+        try {
+          return JSON.parse(call[0] as string).type === 'SET_OHLCV_DATA';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(setOhlcvCallsAfterKeyChange).toHaveLength(0);
+
+    // Fresh data arrives (same key, different bars) — NOW it should send
+    mockPostMessage.mockClear();
+    rerender(<AdvancedChart ohlcvData={freshBars} ohlcvSeriesKey="range-b" />);
 
     expect(mockPostMessage).toHaveBeenCalledWith(
       JSON.stringify({
         type: 'SET_OHLCV_DATA',
-        payload: { data: altBars },
+        payload: { data: freshBars },
       }),
     );
 

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -428,9 +428,14 @@ function handleSetOHLCVData(payload) {
 
   function scheduleVisibleRangeAfterDataLoad(chart) {
     if (visibleFromMs == null) return;
+    var capturedGeneration = window.ohlcvGeneration;
     var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
+      // Discard stale callback if user switched timeframes before load completed
+      if (capturedGeneration !== window.ohlcvGeneration) {
+        return;
+      }
       var fromSec = Math.floor(visibleFromMs / 1000);
       var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
       var toSec = lastBar

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -38,6 +38,8 @@ window.ohlcvPagination = {
 };
 /** Bumped on each `SET_OHLCV_DATA` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
+/** Visible-range start (ms) from `SET_OHLCV_DATA`. Applied once after the first `getBars` load. */
+window.pendingVisibleFromMs = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -421,7 +423,32 @@ function handleSetOHLCVData(payload) {
     };
   }
 
+  var visibleFromMs =
+    payload.visibleFromMs != null ? payload.visibleFromMs : null;
+  window.pendingVisibleFromMs = null;
+
   var newResolution = detectResolution(window.ohlcvData);
+
+  function scheduleVisibleRangeAfterDataLoad(chart) {
+    if (visibleFromMs == null) return;
+    var sub = chart.onDataLoaded();
+    sub.subscribe(null, function onLoaded() {
+      sub.unsubscribe(null, onLoaded);
+      var fromSec = Math.floor(visibleFromMs / 1000);
+      var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+      var toSec = lastBar
+        ? Math.ceil(lastBar.time / 1000)
+        : Math.ceil(Date.now() / 1000);
+      try {
+        chart.setVisibleRange(
+          { from: fromSec, to: toSec },
+          { percentRightMargin: 5 },
+        );
+      } catch (e) {
+        // setVisibleRange can fail if chart is mid-teardown
+      }
+    });
+  }
 
   if (window.chartWidget && window.isChartReady) {
     var previousResolution = window.currentResolution;
@@ -434,6 +461,7 @@ function handleSetOHLCVData(payload) {
           try {
             chart.resetData();
             beginDeferredLayoutSettleAfterOhlcvReload();
+            scheduleVisibleRangeAfterDataLoad(chart);
           } catch (eR) {
             abortDeferredLayoutSettleAndNotify();
             return;
@@ -443,6 +471,7 @@ function handleSetOHLCVData(payload) {
         try {
           chart.resetData();
           beginDeferredLayoutSettleAfterOhlcvReload();
+          scheduleVisibleRangeAfterDataLoad(chart);
         } catch (e) {
           abortDeferredLayoutSettleAndNotify();
           return;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -38,8 +38,6 @@ window.ohlcvPagination = {
 };
 /** Bumped on each `SET_OHLCV_DATA` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
-/** Visible-range start (ms) from `SET_OHLCV_DATA`. Applied once after the first `getBars` load. */
-window.pendingVisibleFromMs = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -425,7 +423,6 @@ function handleSetOHLCVData(payload) {
 
   var visibleFromMs =
     payload.visibleFromMs != null ? payload.visibleFromMs : null;
-  window.pendingVisibleFromMs = null;
 
   var newResolution = detectResolution(window.ohlcvData);
 

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -47,6 +47,8 @@ window.ohlcvPagination = {
 };
 /** Bumped on each \`SET_OHLCV_DATA\` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
+/** Visible-range start (ms) from \`SET_OHLCV_DATA\`. Applied once after the first \`getBars\` load. */
+window.pendingVisibleFromMs = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -220,10 +222,7 @@ function handleMessage(event) {
     var message =
       typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
 
-    if (
-      !window.isChartReady &&
-      message.type !== 'SET_OHLCV_DATA'
-    ) {
+    if (!window.isChartReady && message.type !== 'SET_OHLCV_DATA') {
       window.pendingMessages.push(message);
       return;
     }
@@ -433,7 +432,29 @@ function handleSetOHLCVData(payload) {
     };
   }
 
+  var visibleFromMs = payload.visibleFromMs != null ? payload.visibleFromMs : null;
+  window.pendingVisibleFromMs = null;
+
   var newResolution = detectResolution(window.ohlcvData);
+
+  function scheduleVisibleRangeAfterDataLoad(chart) {
+    if (visibleFromMs == null) return;
+    var sub = chart.onDataLoaded();
+    sub.subscribe(null, function onLoaded() {
+      sub.unsubscribe(null, onLoaded);
+      var fromSec = Math.floor(visibleFromMs / 1000);
+      var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+      var toSec = lastBar ? Math.ceil(lastBar.time / 1000) : Math.ceil(Date.now() / 1000);
+      try {
+        chart.setVisibleRange(
+          { from: fromSec, to: toSec },
+          { percentRightMargin: 5 }
+        );
+      } catch (e) {
+        // setVisibleRange can fail if chart is mid-teardown
+      }
+    });
+  }
 
   if (window.chartWidget && window.isChartReady) {
     var previousResolution = window.currentResolution;
@@ -446,6 +467,7 @@ function handleSetOHLCVData(payload) {
           try {
             chart.resetData();
             beginDeferredLayoutSettleAfterOhlcvReload();
+            scheduleVisibleRangeAfterDataLoad(chart);
           } catch (eR) {
             abortDeferredLayoutSettleAndNotify();
             return;
@@ -455,6 +477,7 @@ function handleSetOHLCVData(payload) {
         try {
           chart.resetData();
           beginDeferredLayoutSettleAfterOhlcvReload();
+          scheduleVisibleRangeAfterDataLoad(chart);
         } catch (e) {
           abortDeferredLayoutSettleAndNotify();
           return;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -430,22 +430,30 @@ function handleSetOHLCVData(payload) {
     };
   }
 
-  var visibleFromMs = payload.visibleFromMs != null ? payload.visibleFromMs : null;
+  var visibleFromMs =
+    payload.visibleFromMs != null ? payload.visibleFromMs : null;
 
   var newResolution = detectResolution(window.ohlcvData);
 
   function scheduleVisibleRangeAfterDataLoad(chart) {
     if (visibleFromMs == null) return;
+    var capturedGeneration = window.ohlcvGeneration;
     var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
+      // Discard stale callback if user switched timeframes before load completed
+      if (capturedGeneration !== window.ohlcvGeneration) {
+        return;
+      }
       var fromSec = Math.floor(visibleFromMs / 1000);
       var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
-      var toSec = lastBar ? Math.ceil(lastBar.time / 1000) : Math.ceil(Date.now() / 1000);
+      var toSec = lastBar
+        ? Math.ceil(lastBar.time / 1000)
+        : Math.ceil(Date.now() / 1000);
       try {
         chart.setVisibleRange(
           { from: fromSec, to: toSec },
-          { percentRightMargin: 5 }
+          { percentRightMargin: 5 },
         );
       } catch (e) {
         // setVisibleRange can fail if chart is mid-teardown

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -47,8 +47,6 @@ window.ohlcvPagination = {
 };
 /** Bumped on each \`SET_OHLCV_DATA\` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
-/** Visible-range start (ms) from \`SET_OHLCV_DATA\`. Applied once after the first \`getBars\` load. */
-window.pendingVisibleFromMs = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -433,7 +431,6 @@ function handleSetOHLCVData(payload) {
   }
 
   var visibleFromMs = payload.visibleFromMs != null ? payload.visibleFromMs : null;
-  window.pendingVisibleFromMs = null;
 
   var newResolution = detectResolution(window.ohlcvData);
 


### PR DESCRIPTION


## **Description**

When switching between time ranges (e.g. 1M and 1Y) on the advanced chart, the charts appeared visually identical despite the API returning different data for each period. Two root causes were identified and fixed:

1. **Stale-data race condition**: When switching timeframes, the `useEffect` syncing OHLCV data to the WebView would immediately send the *previous* timeframe's data (still in React state) before the fresh fetch completed. If both timeframes happened to return similar data point counts, the chart would never receive the correct data at all.

2. **Missing visible range constraint**: TradingView auto-fits to *all* available data by default. Since the API returns similar amounts of daily-resolution data for 1M and 1Y, both timeframes displayed the full dataset — making them visually indistinguishable.

**Solution:**
- Defer sending stale data during timeframe switches by detecting when `ohlcvSeriesKey` changes but data hasn't refreshed yet. A skeleton is shown until fresh data arrives.
- Compute the expected viewport start timestamp (`visibleFromMs = lastBar.time - durationMs`) and pass it through to the WebView, where `chart.setVisibleRange()` constrains the initial viewport to only the selected period. Uses TradingView's `onDataLoaded()` event subscription to apply the range at the correct time.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed advanced chart timeframe switching (1H/1D/1W/1M/1Y) showing identical charts for different time periods


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3040

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RN↔WebView chart syncing and TradingView viewport logic; regressions could cause missing/incorrect chart data or loading skeletons during range switches.
> 
> **Overview**
> Fixes AdvancedChart timeframe switching issues where different ranges could appear identical.
> 
> On RN, `AdvancedChart` now *avoids pushing stale OHLCV* to the WebView when `ohlcvSeriesKey` changes by treating the first render after a key switch as a loading/skeleton state until fresh bars arrive.
> 
> Adds a `visibleFromMs` signal from the token price view (computed from the selected range duration) through `SET_OHLCV_DATA`, and updates the WebView `chartLogic` to apply `chart.setVisibleRange()` via a `onDataLoaded()` subscription so the initial viewport matches the selected timeframe while still allowing left-scroll/pagination. Tests were updated to assert the stale-data suppression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03b6d83bef824d5d5e923c5c4280b972d656636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->