### PR TITLE
fix: track navbar location for trade swap clicks

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -110,6 +110,7 @@ export const useSwapBridgeNavigation = ({
   destToken: destTokenBase,
   abTestContext,
   skipLocationUpdate = false,
+  swapButtonEventLocationOverride,
 }: {
   location: SwapBridgeNavigationLocation;
   sourcePage: string;
@@ -126,6 +127,14 @@ export const useSwapBridgeNavigation = ({
    * bridge asset picker) to preserve the original entry-point location.
    */
   skipLocationUpdate?: boolean;
+  /**
+   * Override only the tracked location on the unified swap click event.
+   * This keeps bridge session source attribution intact while letting callers
+   * report the button tap from a more specific UI surface like the navbar.
+   */
+  swapButtonEventLocationOverride?:
+    | ActionLocation
+    | SwapBridgeNavigationLocation;
 }) => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -296,7 +305,7 @@ export const useSwapBridgeNavigation = ({
       trackActionButtonClick(trackEvent, createEventBuilder, actionButtonProps);
 
       const swapEventProperties = {
-        location,
+        location: swapButtonEventLocationOverride ?? location,
         chain_id_source: getDecimalChainId(sourceToken.chainId),
         token_symbol_source: sourceToken?.symbol,
         token_address_source: sourceToken?.address,
@@ -327,6 +336,7 @@ export const useSwapBridgeNavigation = ({
       currentNetworkInfo,
       getIsBridgeEnabledSource,
       skipLocationUpdate,
+      swapButtonEventLocationOverride,
     ],
   );
   const { networkModal } = useAddNetwork();

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -51,6 +51,7 @@ import { PredictEventValues } from '../../UI/Predict/constants/eventNames';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
 
 import BottomShape from './components/BottomShape';
 import OverlayWithHole from './components/OverlayWithHole';
@@ -118,6 +119,7 @@ function TradeWalletActions() {
   const { goToSwaps: goToSwapsBase } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'MainView',
+    swapButtonEventLocationOverride: ActionLocation.NAVBAR,
   });
 
   const handleNavigateBack = useCallback(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates swap analytics for the bottom trade navbar so tapping `Swap` emits `Unified SwapBridge Button Clicked` with `location: navbar`.

The change is intentionally scoped to the click event payload only. It preserves the existing bridge flow entry-point attribution for the rest of the swap session by leaving the controller and session location unchanged.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: SWAPS-4330

## **Manual testing steps**

```gherkin
Feature: swap navbar analytics attribution

  Scenario: user opens swap from the bottom trade navbar
    Given the wallet is open on the main wallet view

    When user taps the Trade tab
    And user taps Swap
    Then the unified swap flow opens
    And the "Unified SwapBridge Button Clicked" event is emitted with location set to "navbar"
    And the rest of the swap flow keeps its existing entry-point attribution
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
