### PR TITLE
fix(perps): extract payment token init into useInitPerpsPaymentToken hook and move it to the parent cp-7.73.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -149,6 +149,8 @@ import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/tran
 import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';
 import { useInsufficientPayTokenBalanceAlert } from '../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
 import { useNoPayTokenQuotesAlert } from '../../../../Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert';
+import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
+import { useInitPerpsPaymentToken } from './useInitPerpsPaymentToken';
 
 // Navigation params interface
 interface OrderRouteParams {
@@ -1229,6 +1231,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     setSelectedTooltip(null);
   }, []);
 
+  useInitPerpsPaymentToken(orderForm.asset ?? '');
+
   // Use the same calculation as handleMaxAmount in usePerpsOrderForm to avoid insufficient funds error
   const amountTimesLeverage = Math.floor(availableBalance * orderForm.leverage);
 
@@ -1330,6 +1334,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 const amount = Math.floor(value).toString();
                 setAmount(amount);
               }}
+              key={payToken?.symbol ?? ''}
               minimumValue={0}
               maximumValue={maxPossibleAmount}
               step={1}

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -149,7 +149,6 @@ import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/tran
 import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';
 import { useInsufficientPayTokenBalanceAlert } from '../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
 import { useNoPayTokenQuotesAlert } from '../../../../Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert';
-import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import { useInitPerpsPaymentToken } from './useInitPerpsPaymentToken';
 
 // Navigation params interface
@@ -1487,7 +1486,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               <View style={[styles.detailItem, styles.detailItemLast]}>
                 <PerpsPayRow
                   embeddedInStack
-                  initialAsset={orderForm.asset}
                   onPayWithInfoPress={() => handleTooltipPress('pay_with')}
                 />
               </View>

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -176,10 +176,7 @@ describe('PerpsPayRow', () => {
   it('calls onPayWithInfoPress when info icon is pressed', () => {
     const onPayWithInfoPress = jest.fn();
     const { getByTestId } = renderWithProvider(
-      <PerpsPayRow
-        initialAsset="BTC"
-        onPayWithInfoPress={onPayWithInfoPress}
-      />,
+      <PerpsPayRow onPayWithInfoPress={onPayWithInfoPress} />,
     );
 
     fireEvent.press(getByTestId('perps-pay-row-info'));

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { act, fireEvent } from '@testing-library/react-native';
+import { fireEvent } from '@testing-library/react-native';
 import { PerpsPayRow } from './PerpsPayRow';
 import { useNavigation } from '@react-navigation/native';
 import { useTransactionPayToken } from '../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
-import {
-  useIsPerpsBalanceSelected,
-  usePerpsPayWithToken,
-} from '../../hooks/useIsPerpsBalanceSelected';
+import { useIsPerpsBalanceSelected } from '../../hooks/useIsPerpsBalanceSelected';
 import { useTokenWithBalance } from '../../../../Views/confirmations/hooks/tokens/useTokenWithBalance';
 import { useConfirmationMetricEvents } from '../../../../Views/confirmations/hooks/metrics/useConfirmationMetricEvents';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { isHardwareAccount } from '../../../../../util/address';
-import Engine from '../../../../../core/Engine';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
 import {
@@ -20,8 +16,6 @@ import {
   PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { usePerpsSelector } from '../../hooks/usePerpsSelector';
-import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import {
   ConfirmationRowComponentIDs,
   TransactionPayComponentIDs,
@@ -42,16 +36,6 @@ jest.mock(
 );
 jest.mock('../../hooks/useIsPerpsBalanceSelected', () => ({
   useIsPerpsBalanceSelected: jest.fn(),
-  usePerpsPayWithToken: jest.fn(),
-}));
-jest.mock('../../hooks/usePerpsSelector');
-jest.mock('../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance');
-jest.mock('../../../../../core/Engine', () => ({
-  context: {
-    PerpsController: {
-      setSelectedPaymentToken: jest.fn(),
-    },
-  },
 }));
 jest.mock('../../../../Views/confirmations/hooks/tokens/useTokenWithBalance');
 jest.mock(
@@ -77,16 +61,6 @@ const mockUseTransactionMetadataRequest =
 const mockUseIsPerpsBalanceSelected =
   useIsPerpsBalanceSelected as jest.MockedFunction<
     typeof useIsPerpsBalanceSelected
-  >;
-const mockUsePerpsPayWithToken = usePerpsPayWithToken as jest.MockedFunction<
-  typeof usePerpsPayWithToken
->;
-const mockUsePerpsSelector = usePerpsSelector as jest.MockedFunction<
-  typeof usePerpsSelector
->;
-const mockUseDefaultPayWithTokenWhenNoPerpsBalance =
-  useDefaultPayWithTokenWhenNoPerpsBalance as jest.MockedFunction<
-    typeof useDefaultPayWithTokenWhenNoPerpsBalance
   >;
 const mockUseTokenWithBalance = useTokenWithBalance as jest.MockedFunction<
   typeof useTokenWithBalance
@@ -136,9 +110,6 @@ describe('PerpsPayRow', () => {
       track: trackMock,
     } as unknown as ReturnType<typeof usePerpsEventTracking>);
     mockIsHardwareAccount.mockReturnValue(false);
-    mockUsePerpsSelector.mockReturnValue({});
-    mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
   });
 
   it('renders pay with label', () => {
@@ -232,383 +203,5 @@ describe('PerpsPayRow', () => {
     );
 
     expect(getByTestId(ConfirmationRowComponentIDs.PAY_WITH)).toBeOnTheScreen();
-  });
-
-  it('syncs pay token from pending config when it differs from current', () => {
-    const setPayTokenMock = jest.fn();
-    const pendingToken = {
-      address: '0xPending',
-      chainId: '0x1',
-      description: 'Pending USDC',
-    };
-    mockUsePerpsSelector.mockReturnValue({
-      selectedPaymentToken: pendingToken,
-    });
-    mockUsePerpsPayWithToken.mockReturnValue({
-      address: pendingToken.address,
-      chainId: pendingToken.chainId,
-      description: pendingToken.description,
-    });
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'USDC' },
-      setPayToken: setPayTokenMock,
-    } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-    renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: '0xPending',
-      chainId: '0x1',
-    });
-    expect(
-      Engine.context.PerpsController?.setSelectedPaymentToken,
-    ).toHaveBeenCalledWith({
-      description: 'Pending USDC',
-      address: '0xPending',
-      chainId: '0x1',
-    });
-  });
-
-  it('does not call setPayToken when pay token already matches pending config', () => {
-    const setPayTokenMock = jest.fn();
-    const pendingToken = {
-      address: '0xSame',
-      chainId: '0x1',
-      description: 'Same USDC',
-    };
-    mockUsePerpsSelector.mockReturnValue({
-      selectedPaymentToken: pendingToken,
-    });
-    mockUsePerpsPayWithToken.mockReturnValue({
-      address: pendingToken.address,
-      chainId: pendingToken.chainId,
-      description: pendingToken.description,
-    });
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: {
-        address: pendingToken.address,
-        chainId: pendingToken.chainId,
-        symbol: 'USDC',
-      },
-      setPayToken: setPayTokenMock,
-    } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-    renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-    expect(setPayTokenMock).not.toHaveBeenCalled();
-  });
-
-  it('calls setSelectedPaymentToken(null) when pending config has no selected token', () => {
-    mockUsePerpsSelector.mockReturnValue({});
-    mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
-
-    renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-    expect(
-      Engine.context.PerpsController?.setSelectedPaymentToken,
-    ).toHaveBeenCalledWith(null);
-  });
-
-  it('preselects allowlist token with highest balance when no perps balance and pending has no token', () => {
-    const setPayTokenMock = jest.fn();
-    const defaultToken = {
-      address: '0xUSDC' as const,
-      chainId: '0xa4b1' as const,
-      description: 'USDC',
-    };
-    mockUsePerpsSelector.mockReturnValue({});
-    mockUsePerpsPayWithToken.mockReturnValue(null);
-    mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(defaultToken);
-    mockUseTransactionPayToken.mockReturnValue({
-      payToken: null,
-      setPayToken: setPayTokenMock,
-    } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-    renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: defaultToken.address,
-      chainId: defaultToken.chainId,
-    });
-    expect(
-      Engine.context.PerpsController?.setSelectedPaymentToken,
-    ).toHaveBeenCalledWith({
-      description: defaultToken.description,
-      address: defaultToken.address,
-      chainId: defaultToken.chainId,
-    });
-  });
-
-  describe('pending config sync (apply once per load)', () => {
-    it('does not overwrite pay token when user switches token after pending config was applied', () => {
-      const setPayTokenMock = jest.fn();
-      const pendingTokenA = {
-        address: '0xTokenA',
-        chainId: '0x1',
-        description: 'Token A',
-      };
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: pendingTokenA,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: pendingTokenA.address,
-        chainId: pendingTokenA.chainId,
-        description: pendingTokenA.description,
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'Other' },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      const { rerender } = renderWithProvider(
-        <PerpsPayRow initialAsset="BTC" />,
-      );
-
-      expect(setPayTokenMock).toHaveBeenCalledTimes(1);
-      expect(setPayTokenMock).toHaveBeenCalledWith({
-        address: '0xTokenA',
-        chainId: '0x1',
-      });
-
-      setPayTokenMock.mockClear();
-      (
-        Engine.context.PerpsController?.setSelectedPaymentToken as jest.Mock
-      ).mockClear();
-
-      const tokenB = {
-        address: '0xTokenB',
-        chainId: '0x1',
-        description: 'Token B',
-      };
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: tokenB.address,
-        chainId: tokenB.chainId,
-        description: tokenB.description,
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: {
-          address: tokenB.address,
-          chainId: tokenB.chainId,
-          symbol: 'B',
-        },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      act(() => {
-        rerender(<PerpsPayRow initialAsset="BTC" />);
-      });
-
-      expect(setPayTokenMock).not.toHaveBeenCalled();
-      expect(
-        Engine.context.PerpsController?.setSelectedPaymentToken,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('re-applies pending config when initialAsset changes', () => {
-      const setPayTokenMock = jest.fn();
-      const tokenA = {
-        address: '0xTokenA',
-        chainId: '0x1',
-        description: 'Token A',
-      };
-      const tokenB = {
-        address: '0xTokenB',
-        chainId: '0x1',
-        description: 'Token B',
-      };
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: tokenA,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: tokenA.address,
-        chainId: tokenA.chainId,
-        description: tokenA.description,
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'Other' },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      const { rerender } = renderWithProvider(
-        <PerpsPayRow initialAsset="BTC" />,
-      );
-
-      expect(setPayTokenMock).toHaveBeenCalledWith({
-        address: '0xTokenA',
-        chainId: '0x1',
-      });
-
-      setPayTokenMock.mockClear();
-
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: tokenB,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: tokenB.address,
-        chainId: tokenB.chainId,
-        description: tokenB.description,
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'Other' },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      act(() => {
-        rerender(<PerpsPayRow initialAsset="ETH" />);
-      });
-
-      expect(setPayTokenMock).toHaveBeenCalledWith({
-        address: '0xTokenB',
-        chainId: '0x1',
-      });
-    });
-
-    it('does not call setSelectedPaymentToken(null) again when pending has no token and already applied', () => {
-      mockUsePerpsSelector.mockReturnValue({});
-      mockUsePerpsPayWithToken.mockReturnValue(null);
-
-      const setSelectedPaymentTokenMock = Engine.context.PerpsController
-        ?.setSelectedPaymentToken as jest.Mock;
-
-      const { rerender } = renderWithProvider(
-        <PerpsPayRow initialAsset="BTC" />,
-      );
-
-      expect(setSelectedPaymentTokenMock).toHaveBeenCalledTimes(1);
-      expect(setSelectedPaymentTokenMock).toHaveBeenCalledWith(null);
-
-      setSelectedPaymentTokenMock.mockClear();
-      act(() => {
-        rerender(<PerpsPayRow initialAsset="BTC" />);
-      });
-
-      expect(setSelectedPaymentTokenMock).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('cleanup on asset change', () => {
-    it('resets selectedPaymentToken to null when initialAsset changes', () => {
-      const setSelectedPaymentTokenMock = Engine.context.PerpsController
-        ?.setSelectedPaymentToken as jest.Mock;
-
-      const { rerender } = renderWithProvider(
-        <PerpsPayRow initialAsset="BTC" />,
-      );
-
-      setSelectedPaymentTokenMock.mockClear();
-
-      act(() => {
-        rerender(<PerpsPayRow initialAsset="ETH" />);
-      });
-
-      expect(setSelectedPaymentTokenMock).toHaveBeenCalledWith(null);
-    });
-  });
-
-  describe('pending config sync when selectedPaymentToken is null', () => {
-    it('applies pending config even when selectedPaymentToken is null', () => {
-      const setPayTokenMock = jest.fn();
-      const pendingToken = {
-        address: '0xPending',
-        chainId: '0x1',
-        description: 'Pending Token',
-      };
-
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: pendingToken,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue(null);
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: { address: '0xOther', chainId: '0xa4b1', symbol: 'OTHER' },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-      expect(setPayTokenMock).toHaveBeenCalledWith({
-        address: '0xPending',
-        chainId: '0x1',
-      });
-      expect(
-        Engine.context.PerpsController?.setSelectedPaymentToken,
-      ).toHaveBeenCalledWith({
-        description: 'Pending Token',
-        address: '0xPending',
-        chainId: '0x1',
-      });
-    });
-  });
-
-  describe('sync when payToken matches but selectedPaymentToken differs', () => {
-    it('syncs when payToken matches pending but selectedPaymentToken does not', () => {
-      const setPayTokenMock = jest.fn();
-      const pendingToken = {
-        address: '0xPending',
-        chainId: '0x1',
-        description: 'Pending Token',
-      };
-
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: pendingToken,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: '0xDifferent',
-        chainId: '0x1',
-        description: 'Different Token',
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: {
-          address: pendingToken.address,
-          chainId: pendingToken.chainId,
-          symbol: 'PENDING',
-        },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-      expect(setPayTokenMock).toHaveBeenCalledWith({
-        address: '0xPending',
-        chainId: '0x1',
-      });
-      expect(
-        Engine.context.PerpsController?.setSelectedPaymentToken,
-      ).toHaveBeenCalledWith({
-        description: 'Pending Token',
-        address: '0xPending',
-        chainId: '0x1',
-      });
-    });
-
-    it('does not sync when both payToken and selectedPaymentToken match pending', () => {
-      const setPayTokenMock = jest.fn();
-      const pendingToken = {
-        address: '0xPending',
-        chainId: '0x1',
-        description: 'Pending Token',
-      };
-
-      mockUsePerpsSelector.mockReturnValue({
-        selectedPaymentToken: pendingToken,
-      });
-      mockUsePerpsPayWithToken.mockReturnValue({
-        address: pendingToken.address,
-        chainId: pendingToken.chainId,
-        description: pendingToken.description,
-      });
-      mockUseTransactionPayToken.mockReturnValue({
-        payToken: {
-          address: pendingToken.address,
-          chainId: pendingToken.chainId,
-          symbol: 'PENDING',
-        },
-        setPayToken: setPayTokenMock,
-      } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-      renderWithProvider(<PerpsPayRow initialAsset="BTC" />);
-
-      expect(setPayTokenMock).not.toHaveBeenCalled();
-    });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -113,9 +113,7 @@ describe('PerpsPayRow', () => {
   });
 
   it('renders pay with label', () => {
-    const { getByText } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" />,
-    );
+    const { getByText } = renderWithProvider(<PerpsPayRow />);
 
     expect(getByText('confirm.label.pay_with')).toBeOnTheScreen();
   });
@@ -123,9 +121,7 @@ describe('PerpsPayRow', () => {
   it('renders perps balance label when perps balance is selected', () => {
     mockUseIsPerpsBalanceSelected.mockReturnValue(true);
 
-    const { getByTestId } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" />,
-    );
+    const { getByTestId } = renderWithProvider(<PerpsPayRow />);
 
     expect(
       getByTestId(TransactionPayComponentIDs.PAY_WITH_SYMBOL),
@@ -139,9 +135,7 @@ describe('PerpsPayRow', () => {
       setPayToken: jest.fn(),
     } as unknown as ReturnType<typeof useTransactionPayToken>);
 
-    const { getByTestId } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" />,
-    );
+    const { getByTestId } = renderWithProvider(<PerpsPayRow />);
 
     expect(
       getByTestId(TransactionPayComponentIDs.PAY_WITH_SYMBOL),
@@ -149,9 +143,7 @@ describe('PerpsPayRow', () => {
   });
 
   it('navigates to pay with modal when row is pressed and not hardware account', () => {
-    const { getByTestId } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" />,
-    );
+    const { getByTestId } = renderWithProvider(<PerpsPayRow />);
 
     fireEvent.press(getByTestId(ConfirmationRowComponentIDs.PAY_WITH));
 
@@ -173,9 +165,7 @@ describe('PerpsPayRow', () => {
   it('does not navigate when hardware account', () => {
     mockIsHardwareAccount.mockReturnValue(true);
 
-    const { getByTestId } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" />,
-    );
+    const { getByTestId } = renderWithProvider(<PerpsPayRow />);
 
     fireEvent.press(getByTestId(ConfirmationRowComponentIDs.PAY_WITH));
 
@@ -198,9 +188,7 @@ describe('PerpsPayRow', () => {
   });
 
   it('renders with embedded style when embeddedInStack is true', () => {
-    const { getByTestId } = renderWithProvider(
-      <PerpsPayRow initialAsset="BTC" embeddedInStack />,
-    );
+    const { getByTestId } = renderWithProvider(<PerpsPayRow embeddedInStack />);
 
     expect(getByTestId(ConfirmationRowComponentIDs.PAY_WITH)).toBeOnTheScreen();
   });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -1,6 +1,6 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useNavigation } from '@react-navigation/native';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Badge, {
@@ -36,23 +36,16 @@ import { useTransactionMetadataRequest } from '../../../../Views/confirmations/h
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
-  selectPendingTradeConfiguration,
 } from '@metamask/perps-controller';
 import {
   PERPS_BALANCE_CHAIN_ID,
   PERPS_BALANCE_PLACEHOLDER_ADDRESS,
 } from '../../constants/perpsConfig';
 import { PERPS_BALANCE_ICON_URI } from '../../hooks/usePerpsBalanceTokenFilter';
-import {
-  useIsPerpsBalanceSelected,
-  usePerpsPayWithToken,
-} from '../../hooks/useIsPerpsBalanceSelected';
+import { useIsPerpsBalanceSelected } from '../../hooks/useIsPerpsBalanceSelected';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { Hex } from '@metamask/utils';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
-import { usePerpsSelector } from '../../hooks/usePerpsSelector';
-import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
-import Engine from '../../../../../core/Engine';
 
 const tokenIconStyles = StyleSheet.create({
   iconSmall: {
@@ -110,116 +103,9 @@ export const PerpsPayRow = ({
   const styles = createPayRowStyles(colors);
   const { setConfirmationMetric } = useConfirmationMetricEvents();
   const { track } = usePerpsEventTracking();
-  const { payToken, setPayToken } = useTransactionPayToken();
+  const { payToken } = useTransactionPayToken();
   const transactionMeta = useTransactionMetadataRequest();
   const matchesPerpsBalance = useIsPerpsBalanceSelected();
-  const pendingConfig = usePerpsSelector((state) =>
-    selectPendingTradeConfiguration(state, initialAsset),
-  );
-  const selectedPaymentToken = usePerpsPayWithToken();
-  const defaultPayTokenWhenNoPerpsBalance =
-    useDefaultPayWithTokenWhenNoPerpsBalance();
-
-  const pendingConfigSelectedPaymentToken = pendingConfig?.selectedPaymentToken;
-
-  // Track which pending config we've already applied so we don't overwrite the user's
-  // in-session token selection. Apply pending config only on initial load or when
-  // switching asset; otherwise switching tokens in the Pay With modal would flip back.
-  const appliedPendingTokenRef = useRef<
-    { address: string; chainId: string } | null | undefined
-  >(undefined);
-  const prevInitialAssetRef = useRef(initialAsset);
-  if (prevInitialAssetRef.current !== initialAsset) {
-    prevInitialAssetRef.current = initialAsset;
-    appliedPendingTokenRef.current = undefined;
-  }
-
-  // When pending config has no selected token: either set Perps balance (null)
-  // or preselect the allowlist token with highest USD balance when user has no perps balance.
-  useEffect(() => {
-    if (
-      pendingConfigSelectedPaymentToken != null ||
-      appliedPendingTokenRef.current != null
-    )
-      return;
-
-    const defaultToken = defaultPayTokenWhenNoPerpsBalance;
-    if (defaultToken != null) {
-      appliedPendingTokenRef.current = {
-        address: defaultToken.address,
-        chainId: defaultToken.chainId,
-      };
-      setPayToken({
-        address: defaultToken.address as Hex,
-        chainId: defaultToken.chainId as Hex,
-      });
-      Engine.context.PerpsController?.setSelectedPaymentToken?.({
-        description: defaultToken.description,
-        address: defaultToken.address as Hex,
-        chainId: defaultToken.chainId as Hex,
-      });
-
-      return;
-    }
-
-    if (appliedPendingTokenRef.current === null) return;
-    appliedPendingTokenRef.current = null;
-    Engine.context.PerpsController?.setSelectedPaymentToken?.(null);
-  }, [
-    pendingConfigSelectedPaymentToken,
-    defaultPayTokenWhenNoPerpsBalance,
-    setPayToken,
-  ]);
-
-  useEffect(
-    () => () => {
-      Engine.context.PerpsController?.setSelectedPaymentToken?.(null);
-    },
-    [initialAsset],
-  );
-
-  useEffect(() => {
-    if (!pendingConfigSelectedPaymentToken) return;
-
-    const pendingAddr = pendingConfigSelectedPaymentToken.address;
-    const pendingChainId = pendingConfigSelectedPaymentToken.chainId;
-    const alreadyApplied =
-      appliedPendingTokenRef.current !== undefined &&
-      (appliedPendingTokenRef.current === null
-        ? false
-        : appliedPendingTokenRef.current.address === pendingAddr &&
-          appliedPendingTokenRef.current.chainId === pendingChainId);
-    if (alreadyApplied) return;
-
-    appliedPendingTokenRef.current = {
-      address: pendingAddr,
-      chainId: pendingChainId,
-    };
-
-    if (
-      payToken?.address !== pendingAddr ||
-      payToken?.chainId !== pendingChainId ||
-      selectedPaymentToken?.address !== pendingAddr ||
-      selectedPaymentToken?.chainId !== pendingChainId
-    ) {
-      setPayToken({
-        address: pendingAddr as Hex,
-        chainId: pendingChainId as Hex,
-      });
-
-      Engine.context.PerpsController?.setSelectedPaymentToken?.({
-        description: pendingConfigSelectedPaymentToken.description,
-        address: pendingAddr as Hex,
-        chainId: pendingChainId as Hex,
-      });
-    }
-  }, [
-    initialAsset,
-    payToken,
-    pendingConfigSelectedPaymentToken,
-    setPayToken,
-    selectedPaymentToken,
-  ]);
 
   const {
     txParams: { from },

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -90,13 +90,11 @@ export interface PerpsPayRowProps {
   onPayWithInfoPress?: () => void;
   /** When true, row is stacked below another box (e.g. TP/SL); parent provides background and border radius */
   embeddedInStack?: boolean;
-  initialAsset: string;
 }
 
 export const PerpsPayRow = ({
   onPayWithInfoPress,
   embeddedInStack = false,
-  initialAsset,
 }: PerpsPayRowProps) => {
   const navigation = useNavigation();
   const { colors } = useTheme();

--- a/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.test.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.test.ts
@@ -37,7 +37,7 @@ const mockSetSelectedPaymentToken = Engine.context.PerpsController
   ?.setSelectedPaymentToken as jest.Mock;
 
 function setupDefaults({
-  payToken = null,
+  payToken = undefined,
   selectedPaymentToken = null,
   defaultPayToken = null,
   pendingConfig = undefined,
@@ -128,7 +128,7 @@ describe('useInitPerpsPaymentToken', () => {
 
   it('applies pending config payment token when it differs from current', () => {
     setupDefaults({
-      payToken: null,
+      payToken: undefined,
       selectedPaymentToken: null,
       pendingConfig: {
         selectedPaymentToken: {
@@ -159,7 +159,7 @@ describe('useInitPerpsPaymentToken', () => {
       description: 'DAI',
     };
     setupDefaults({
-      payToken: { address: '0xdai', chainId: '0x1' } as ReturnType<
+      payToken: { address: '0xdai', chainId: '0x1' } as unknown as ReturnType<
         typeof useTransactionPayToken
       >['payToken'],
       selectedPaymentToken: { address: '0xdai', chainId: '0x1' },
@@ -186,7 +186,7 @@ describe('useInitPerpsPaymentToken', () => {
       description: 'DAI',
     };
     setupDefaults({
-      payToken: null,
+      payToken: undefined,
       selectedPaymentToken: null,
       pendingConfig: { selectedPaymentToken: pendingToken },
     });

--- a/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.test.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.test.ts
@@ -1,0 +1,228 @@
+import { renderHook } from '@testing-library/react-native';
+import Engine from '../../../../../core/Engine';
+import { useTransactionPayToken } from '../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
+import { usePerpsPayWithToken } from '../../hooks/useIsPerpsBalanceSelected';
+import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
+import { usePerpsSelector } from '../../hooks/usePerpsSelector';
+import { useInitPerpsPaymentToken } from './useInitPerpsPaymentToken';
+
+jest.mock('../../../../Views/confirmations/hooks/pay/useTransactionPayToken');
+jest.mock('../../hooks/useIsPerpsBalanceSelected', () => ({
+  usePerpsPayWithToken: jest.fn(),
+}));
+jest.mock('../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance');
+jest.mock('../../hooks/usePerpsSelector');
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    PerpsController: {
+      setSelectedPaymentToken: jest.fn(),
+    },
+  },
+}));
+
+const mockSetPayToken = jest.fn();
+const mockUseTransactionPayToken =
+  useTransactionPayToken as jest.MockedFunction<typeof useTransactionPayToken>;
+const mockUsePerpsPayWithToken = usePerpsPayWithToken as jest.MockedFunction<
+  typeof usePerpsPayWithToken
+>;
+const mockUseDefaultPayToken =
+  useDefaultPayWithTokenWhenNoPerpsBalance as jest.MockedFunction<
+    typeof useDefaultPayWithTokenWhenNoPerpsBalance
+  >;
+const mockUsePerpsSelector = usePerpsSelector as jest.MockedFunction<
+  typeof usePerpsSelector
+>;
+const mockSetSelectedPaymentToken = Engine.context.PerpsController
+  ?.setSelectedPaymentToken as jest.Mock;
+
+function setupDefaults({
+  payToken = null,
+  selectedPaymentToken = null,
+  defaultPayToken = null,
+  pendingConfig = undefined,
+}: {
+  payToken?: ReturnType<typeof useTransactionPayToken>['payToken'];
+  selectedPaymentToken?: ReturnType<typeof usePerpsPayWithToken>;
+  defaultPayToken?: ReturnType<typeof useDefaultPayWithTokenWhenNoPerpsBalance>;
+  pendingConfig?:
+    | {
+        selectedPaymentToken?: {
+          address: string;
+          chainId: string;
+          description?: string;
+        };
+      }
+    | undefined;
+} = {}) {
+  mockUseTransactionPayToken.mockReturnValue({
+    payToken,
+    setPayToken: mockSetPayToken,
+  } as unknown as ReturnType<typeof useTransactionPayToken>);
+  mockUsePerpsPayWithToken.mockReturnValue(selectedPaymentToken);
+  mockUseDefaultPayToken.mockReturnValue(defaultPayToken);
+  mockUsePerpsSelector.mockReturnValue(pendingConfig);
+}
+
+describe('useInitPerpsPaymentToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaults();
+  });
+
+  it('clears selected payment token on unmount', () => {
+    const { unmount } = renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    mockSetSelectedPaymentToken.mockClear();
+
+    unmount();
+
+    expect(mockSetSelectedPaymentToken).toHaveBeenCalledWith(null);
+  });
+
+  it('sets default pay token when no pending config and no perps balance', () => {
+    const defaultToken = {
+      address: '0xusdc',
+      chainId: '0xa4b1',
+      description: 'USDC',
+    };
+    setupDefaults({ defaultPayToken: defaultToken });
+
+    renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    expect(mockSetPayToken).toHaveBeenCalledWith({
+      address: '0xusdc',
+      chainId: '0xa4b1',
+    });
+    expect(mockSetSelectedPaymentToken).toHaveBeenCalledWith({
+      description: 'USDC',
+      address: '0xusdc',
+      chainId: '0xa4b1',
+    });
+  });
+
+  it('does not set default token when pending config has a selected payment token', () => {
+    const defaultToken = {
+      address: '0xusdc',
+      chainId: '0xa4b1',
+      description: 'USDC',
+    };
+    setupDefaults({
+      defaultPayToken: defaultToken,
+      pendingConfig: {
+        selectedPaymentToken: {
+          address: '0xdai',
+          chainId: '0x1',
+          description: 'DAI',
+        },
+      },
+    });
+
+    renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    expect(mockSetPayToken).not.toHaveBeenCalledWith({
+      address: '0xusdc',
+      chainId: '0xa4b1',
+    });
+  });
+
+  it('applies pending config payment token when it differs from current', () => {
+    setupDefaults({
+      payToken: null,
+      selectedPaymentToken: null,
+      pendingConfig: {
+        selectedPaymentToken: {
+          address: '0xdai',
+          chainId: '0x1',
+          description: 'DAI',
+        },
+      },
+    });
+
+    renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    expect(mockSetPayToken).toHaveBeenCalledWith({
+      address: '0xdai',
+      chainId: '0x1',
+    });
+    expect(mockSetSelectedPaymentToken).toHaveBeenCalledWith({
+      description: 'DAI',
+      address: '0xdai',
+      chainId: '0x1',
+    });
+  });
+
+  it('does not reapply pending config when already matching', () => {
+    const pendingToken = {
+      address: '0xdai',
+      chainId: '0x1',
+      description: 'DAI',
+    };
+    setupDefaults({
+      payToken: { address: '0xdai', chainId: '0x1' } as ReturnType<
+        typeof useTransactionPayToken
+      >['payToken'],
+      selectedPaymentToken: { address: '0xdai', chainId: '0x1' },
+      pendingConfig: { selectedPaymentToken: pendingToken },
+    });
+
+    const { rerender } = renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    mockSetPayToken.mockClear();
+    mockSetSelectedPaymentToken.mockClear();
+
+    rerender({});
+
+    expect(mockSetPayToken).not.toHaveBeenCalled();
+    expect(mockSetSelectedPaymentToken).not.toHaveBeenCalledWith(
+      expect.objectContaining({ address: '0xdai' }),
+    );
+  });
+
+  it('resets applied pending token ref when initialAsset changes', () => {
+    const pendingToken = {
+      address: '0xdai',
+      chainId: '0x1',
+      description: 'DAI',
+    };
+    setupDefaults({
+      payToken: null,
+      selectedPaymentToken: null,
+      pendingConfig: { selectedPaymentToken: pendingToken },
+    });
+
+    const { rerender } = renderHook(
+      ({ asset }: { asset: string }) => useInitPerpsPaymentToken(asset),
+      { initialProps: { asset: 'BTC' } },
+    );
+
+    mockSetPayToken.mockClear();
+    mockSetSelectedPaymentToken.mockClear();
+
+    rerender({ asset: 'ETH' });
+
+    expect(mockSetPayToken).toHaveBeenCalledWith({
+      address: '0xdai',
+      chainId: '0x1',
+    });
+  });
+
+  it('clears controller token when no pending config and no default token', () => {
+    setupDefaults({
+      defaultPayToken: null,
+      pendingConfig: undefined,
+    });
+
+    renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    expect(mockSetPayToken).not.toHaveBeenCalled();
+  });
+
+  it('does not set default token when default is null', () => {
+    setupDefaults({ defaultPayToken: null });
+
+    renderHook(() => useInitPerpsPaymentToken('BTC'));
+
+    expect(mockSetPayToken).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from 'react';
+import { type Hex } from '@metamask/utils';
+import { selectPendingTradeConfiguration } from '@metamask/perps-controller';
+import Engine from '../../../../../core/Engine';
+import { usePerpsSelector } from '../../hooks/usePerpsSelector';
+import { useTransactionPayToken } from '../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
+import { usePerpsPayWithToken } from '../../hooks/useIsPerpsBalanceSelected';
+import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
+
+export function useInitPerpsPaymentToken(initialAsset: string) {
+  const { payToken, setPayToken } = useTransactionPayToken();
+  const selectedPaymentToken = usePerpsPayWithToken();
+  const defaultPayTokenWhenNoPerpsBalance =
+    useDefaultPayWithTokenWhenNoPerpsBalance();
+
+  const pendingConfig = usePerpsSelector((state) =>
+    selectPendingTradeConfiguration(state, initialAsset),
+  );
+  const pendingConfigSelectedPaymentToken = pendingConfig?.selectedPaymentToken;
+
+  const appliedPendingTokenRef = useRef<
+    { address: string; chainId: string } | null | undefined
+  >(undefined);
+  const prevInitialAssetRef = useRef(initialAsset);
+  if (prevInitialAssetRef.current !== initialAsset) {
+    prevInitialAssetRef.current = initialAsset;
+    appliedPendingTokenRef.current = undefined;
+  }
+
+  useEffect(
+    () => () => {
+      Engine.context.PerpsController?.setSelectedPaymentToken?.(null);
+    },
+    [initialAsset],
+  );
+
+  useEffect(() => {
+    if (
+      pendingConfigSelectedPaymentToken != null ||
+      appliedPendingTokenRef.current != null
+    )
+      return;
+
+    const defaultToken = defaultPayTokenWhenNoPerpsBalance;
+    if (defaultToken != null) {
+      appliedPendingTokenRef.current = {
+        address: defaultToken.address,
+        chainId: defaultToken.chainId,
+      };
+      setPayToken({
+        address: defaultToken.address as Hex,
+        chainId: defaultToken.chainId as Hex,
+      });
+      Engine.context.PerpsController?.setSelectedPaymentToken?.({
+        description: defaultToken.description,
+        address: defaultToken.address as Hex,
+        chainId: defaultToken.chainId as Hex,
+      });
+
+      return;
+    }
+
+    if (appliedPendingTokenRef.current === null) return;
+    appliedPendingTokenRef.current = null;
+    Engine.context.PerpsController?.setSelectedPaymentToken?.(null);
+  }, [
+    pendingConfigSelectedPaymentToken,
+    defaultPayTokenWhenNoPerpsBalance,
+    setPayToken,
+  ]);
+
+  useEffect(() => {
+    if (!pendingConfigSelectedPaymentToken) return;
+
+    const pendingAddr = pendingConfigSelectedPaymentToken.address;
+    const pendingChainId = pendingConfigSelectedPaymentToken.chainId;
+    const alreadyApplied =
+      appliedPendingTokenRef.current !== undefined &&
+      (appliedPendingTokenRef.current === null
+        ? false
+        : appliedPendingTokenRef.current.address === pendingAddr &&
+          appliedPendingTokenRef.current.chainId === pendingChainId);
+    if (alreadyApplied) return;
+
+    appliedPendingTokenRef.current = {
+      address: pendingAddr,
+      chainId: pendingChainId,
+    };
+
+    if (
+      payToken?.address !== pendingAddr ||
+      payToken?.chainId !== pendingChainId ||
+      selectedPaymentToken?.address !== pendingAddr ||
+      selectedPaymentToken?.chainId !== pendingChainId
+    ) {
+      setPayToken({
+        address: pendingAddr as Hex,
+        chainId: pendingChainId as Hex,
+      });
+
+      Engine.context.PerpsController?.setSelectedPaymentToken?.({
+        description: pendingConfigSelectedPaymentToken.description,
+        address: pendingAddr as Hex,
+        chainId: pendingChainId as Hex,
+      });
+    }
+  }, [
+    initialAsset,
+    payToken,
+    pendingConfigSelectedPaymentToken,
+    setPayToken,
+    selectedPaymentToken,
+  ]);
+}


### PR DESCRIPTION
## **Description**

The `PerpsPayRow` component contained ~110 lines of payment token initialization logic (pending config syncing, default token selection, asset-change resets) mixed in with its rendering concerns. This made the component harder to follow and impossible to unit-test the initialization behavior in isolation.

This PR extracts that logic into a dedicated `useInitPerpsPaymentToken` hook and calls it from `PerpsOrderViewContentBase` instead. The hook encapsulates:
- Syncing the pay token from `pendingTradeConfiguration` when resuming an order
- Falling back to the highest-balance allowlist token when the user has no perps balance
- Resetting state when the traded asset changes
- Cleaning up the controller's selected payment token on unmount

A `key` prop keyed on `payToken.symbol` was also added to the `PerpsSlider` so it recomputes width when the payment token changes, keeping the slider range in sync, allowing the user to use the slider

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28539

## **Manual testing steps**

```gherkin
Feature: Perps payment token initialization

  Scenario: user opens a perps order with some perps balance and other tokens
    Given the user selects USDC on Arbitrum
    When user navigates changes the amount to a different amount
    Then the USDC on Arbitrum should be still selected
    And user should be able to use slider if they have enough balance to cover the trade
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps payment-token selection/init logic and its interaction with `PerpsController`/confirmation pay-token state, which could affect default token selection and persisted pending configs if incorrect.
> 
> **Overview**
> Moves Perps “pay with” token initialization/sync logic out of `PerpsPayRow` into a new `useInitPerpsPaymentToken` hook, and runs it from `PerpsOrderView` so pending trade config, default-token fallback, asset-change resets, and unmount cleanup are handled at the screen level.
> 
> Simplifies `PerpsPayRow` to be a pure display/navigation row (dropping the `initialAsset` prop) and updates tests accordingly, while adding focused unit tests for `useInitPerpsPaymentToken`.
> 
> Adds a `key` to `PerpsSlider` based on `payToken.symbol` to force a re-mount when the payment token changes, keeping the slider’s range/width in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a7d10624018350f91a6322ce77eb808e87e508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->