### PR TITLE
fix(charts): coalesce advanced chart pagination requests

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -38,6 +38,8 @@ window.ohlcvPagination = {
 };
 /** Bumped on each `SET_OHLCV_DATA` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
+/** Tracks one in-flight older-history page fetch and coalesces duplicate callers. */
+window.pendingOlderBarsRequest = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -404,6 +406,7 @@ function handleSetOHLCVData(payload) {
   window.ohlcvData = payload.data;
   bumpLineChartOhlcvEpoch();
   window.ohlcvGeneration++;
+  window.pendingOlderBarsRequest = null;
 
   if (payload.pagination) {
     window.ohlcvPagination = {
@@ -2982,6 +2985,10 @@ function filterBarsForRange(fromMs, toMs, countBack) {
 
 var OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv-chart';
 
+function getOlderBarsErrorMessage(err) {
+  return err && err.message ? err.message : String(err);
+}
+
 /**
  * Fetches the next page of OHLCV history directly from the Price API inside the WebView.
  * Called from `getBars` when `window.ohlcvPagination` has a cursor, avoiding the RN round-trip.
@@ -2997,12 +3004,29 @@ function fetchOlderBars(pending) {
   }
 
   var gen = window.ohlcvGeneration;
+  var cursor = pag.nextCursor;
+  var existingRequest = window.pendingOlderBarsRequest;
+  if (
+    existingRequest &&
+    existingRequest.generation === gen &&
+    existingRequest.cursor === cursor
+  ) {
+    existingRequest.waiters.push(pending);
+    return;
+  }
+
+  var request = {
+    generation: gen,
+    cursor: cursor,
+    waiters: [pending],
+  };
+  window.pendingOlderBarsRequest = request;
   var url =
     OHLCV_BASE_URL +
     '/' +
     encodeURIComponent(pag.assetId) +
     '?nextCursor=' +
-    encodeURIComponent(pag.nextCursor);
+    encodeURIComponent(cursor);
   if (pag.vsCurrency) {
     url += '&vsCurrency=' + encodeURIComponent(pag.vsCurrency);
   }
@@ -3016,6 +3040,9 @@ function fetchOlderBars(pending) {
     })
     .then(function (result) {
       if (gen !== window.ohlcvGeneration) {
+        return;
+      }
+      if (window.pendingOlderBarsRequest !== request) {
         return;
       }
 
@@ -3043,14 +3070,19 @@ function fetchOlderBars(pending) {
         window.ohlcvData = newBars.concat(window.ohlcvData);
       }
 
-      var olderBars = [];
-      for (var j = 0; j < newBars.length; j++) {
-        if (newBars[j].time < pending.oldestAtDefer) {
-          olderBars.push(newBars[j]);
-        }
-      }
+      window.pendingOlderBarsRequest = null;
 
-      pending.onResult(olderBars, { noData: olderBars.length === 0 });
+      for (var w = 0; w < request.waiters.length; w++) {
+        var waiter = request.waiters[w];
+        var olderBars = [];
+        for (var j = 0; j < newBars.length; j++) {
+          if (newBars[j].time < waiter.oldestAtDefer) {
+            olderBars.push(newBars[j]);
+          }
+        }
+
+        waiter.onResult(olderBars, { noData: olderBars.length === 0 });
+      }
       if (window.__mmLayoutSettlePending) {
         queueTryCompleteLayoutSettleAfterData();
       }
@@ -3059,12 +3091,20 @@ function fetchOlderBars(pending) {
       if (gen !== window.ohlcvGeneration) {
         return;
       }
-      pending.onResult([], { noData: true });
+      if (window.pendingOlderBarsRequest !== request) {
+        return;
+      }
+      window.pendingOlderBarsRequest = null;
+
+      var errorMessage = getOlderBarsErrorMessage(err);
+      for (var w = 0; w < request.waiters.length; w++) {
+        request.waiters[w].onError(errorMessage);
+      }
       if (window.__mmLayoutSettlePending) {
         queueTryCompleteLayoutSettleAfterData();
       }
       sendToReactNative('DEBUG', {
-        message: 'fetchOlderBars error: ' + (err.message || String(err)),
+        message: 'fetchOlderBars error: ' + errorMessage,
       });
     });
 }
@@ -3172,6 +3212,7 @@ var customDatafeed = {
 
       fetchOlderBars({
         onResult: onResult,
+        onError: onError,
         oldestAtDefer: oldestTs,
       });
     } catch (error) {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.test.ts
@@ -1,0 +1,351 @@
+import chartLogicScript from './chartLogicString';
+
+type WebViewWindow = Window &
+  typeof globalThis & {
+    ReactNativeWebView: { postMessage: jest.Mock };
+    customDatafeed: {
+      getBars: (
+        symbolInfo: unknown,
+        resolution: string,
+        periodParams: {
+          from: number;
+          to: number;
+          countBack: number;
+          firstDataRequest: boolean;
+        },
+        onResult: jest.Mock,
+        onError: jest.Mock,
+      ) => void;
+    };
+    handleSetOHLCVData: (payload: unknown) => void;
+    ohlcvData: { time: number }[];
+  };
+
+const getTestWindow = () => window as unknown as WebViewWindow;
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const loadChartLogic = () => {
+  const win = getTestWindow();
+  const globalDocument = global.document as
+    | {
+        readyState?: string;
+        addEventListener?: jest.Mock;
+        getElementById?: jest.Mock;
+      }
+    | undefined;
+  if (!win.addEventListener) {
+    win.addEventListener = jest.fn() as unknown as typeof win.addEventListener;
+  }
+  if (!globalDocument) {
+    global.document = {
+      readyState: 'loading',
+      addEventListener: jest.fn(),
+      getElementById: jest.fn(() => ({
+        textContent: '',
+        innerHTML: '',
+        classList: { add: jest.fn() },
+      })),
+    } as Document;
+  } else {
+    globalDocument.readyState = 'loading';
+    if (!globalDocument.addEventListener) {
+      globalDocument.addEventListener = jest.fn();
+    }
+    globalDocument.getElementById = jest.fn(() => ({
+      textContent: '',
+      innerHTML: '',
+      classList: { add: jest.fn() },
+    }));
+  }
+  win.ReactNativeWebView = {
+    postMessage: jest.fn(),
+  };
+  win.eval(chartLogicScript);
+  return win;
+};
+
+describe('chartLogic older-history pagination', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('coalesces overlapping older-history getBars calls onto one fetch', async () => {
+    const win = loadChartLogic();
+    let resolveFetch: ((value: unknown) => void) | undefined;
+
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    ) as jest.Mock;
+
+    win.handleSetOHLCVData({
+      data: [
+        {
+          time: 1000,
+          open: 10,
+          high: 10,
+          low: 10,
+          close: 10,
+          volume: 10,
+        },
+      ],
+      pagination: {
+        nextCursor: 'cursor-1',
+        hasMore: true,
+        assetId: 'eip155:1/slip44:60',
+        vsCurrency: 'usd',
+      },
+    });
+
+    const onResultA = jest.fn();
+    const onResultB = jest.fn();
+    const onErrorA = jest.fn();
+    const onErrorB = jest.fn();
+
+    win.customDatafeed.getBars(
+      {},
+      '1',
+      { from: 2, to: 3, countBack: 0, firstDataRequest: false },
+      onResultA,
+      onErrorA,
+    );
+    win.customDatafeed.getBars(
+      {},
+      '1',
+      { from: 2, to: 3, countBack: 0, firstDataRequest: false },
+      onResultB,
+      onErrorB,
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              timestamp: 500,
+              open: 1,
+              high: 2,
+              low: 1,
+              close: 2,
+              volume: 100,
+            },
+          ],
+          hasNext: false,
+          nextCursor: null,
+        }),
+    });
+
+    await flushPromises();
+
+    expect(onResultA).toHaveBeenCalledWith(
+      [
+        {
+          time: 500,
+          open: 1,
+          high: 2,
+          low: 1,
+          close: 2,
+          volume: 100,
+        },
+      ],
+      { noData: false },
+    );
+    expect(onResultB).toHaveBeenCalledWith(
+      [
+        {
+          time: 500,
+          open: 1,
+          high: 2,
+          low: 1,
+          close: 2,
+          volume: 100,
+        },
+      ],
+      { noData: false },
+    );
+    expect(onErrorA).not.toHaveBeenCalled();
+    expect(onErrorB).not.toHaveBeenCalled();
+    expect(win.ohlcvData).toHaveLength(2);
+  });
+
+  it('reports older-history fetch failures through onError', async () => {
+    const win = loadChartLogic();
+
+    global.fetch = jest.fn(() =>
+      Promise.reject(new Error('network down')),
+    ) as jest.Mock;
+
+    win.handleSetOHLCVData({
+      data: [
+        {
+          time: 1000,
+          open: 10,
+          high: 10,
+          low: 10,
+          close: 10,
+          volume: 10,
+        },
+      ],
+      pagination: {
+        nextCursor: 'cursor-1',
+        hasMore: true,
+        assetId: 'eip155:1/slip44:60',
+        vsCurrency: 'usd',
+      },
+    });
+
+    const onResult = jest.fn();
+    const onError = jest.fn();
+
+    win.customDatafeed.getBars(
+      {},
+      '1',
+      { from: 2, to: 3, countBack: 0, firstDataRequest: false },
+      onResult,
+      onError,
+    );
+
+    await flushPromises();
+
+    expect(onResult).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith('network down');
+  });
+
+  it('clears pending older-history state when a new OHLCV series arrives', async () => {
+    const win = loadChartLogic();
+    let resolveFirstFetch: ((value: unknown) => void) | undefined;
+
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstFetch = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                timestamp: 1500,
+                open: 3,
+                high: 4,
+                low: 2,
+                close: 4,
+                volume: 50,
+              },
+            ],
+            hasNext: false,
+            nextCursor: null,
+          }),
+      });
+
+    win.handleSetOHLCVData({
+      data: [
+        {
+          time: 2000,
+          open: 20,
+          high: 20,
+          low: 20,
+          close: 20,
+          volume: 20,
+        },
+      ],
+      pagination: {
+        nextCursor: 'cursor-old',
+        hasMore: true,
+        assetId: 'eip155:1/slip44:60',
+        vsCurrency: 'usd',
+      },
+    });
+
+    win.customDatafeed.getBars(
+      {},
+      '1',
+      { from: 3, to: 4, countBack: 0, firstDataRequest: false },
+      jest.fn(),
+      jest.fn(),
+    );
+
+    win.handleSetOHLCVData({
+      data: [
+        {
+          time: 3000,
+          open: 30,
+          high: 30,
+          low: 30,
+          close: 30,
+          volume: 30,
+        },
+      ],
+      pagination: {
+        nextCursor: 'cursor-new',
+        hasMore: true,
+        assetId: 'eip155:1/slip44:60',
+        vsCurrency: 'usd',
+      },
+    });
+
+    const onResult = jest.fn();
+    const onError = jest.fn();
+    win.customDatafeed.getBars(
+      {},
+      '1',
+      { from: 4, to: 5, countBack: 0, firstDataRequest: false },
+      onResult,
+      onError,
+    );
+
+    await flushPromises();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    resolveFirstFetch?.({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              timestamp: 1000,
+              open: 1,
+              high: 1,
+              low: 1,
+              close: 1,
+              volume: 10,
+            },
+          ],
+          hasNext: false,
+          nextCursor: null,
+        }),
+    });
+
+    await flushPromises();
+
+    expect(onResult).toHaveBeenCalledWith(
+      [
+        {
+          time: 1500,
+          open: 3,
+          high: 4,
+          low: 2,
+          close: 4,
+          volume: 50,
+        },
+      ],
+      { noData: false },
+    );
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -47,6 +47,8 @@ window.ohlcvPagination = {
 };
 /** Bumped on each \`SET_OHLCV_DATA\` so in-flight fetches from a previous series are discarded. */
 window.ohlcvGeneration = 0;
+/** Tracks one in-flight older-history page fetch and coalesces duplicate callers. */
+window.pendingOlderBarsRequest = null;
 // Default line chart (ChartType.Line === 2); RN SET_CHART_TYPE overrides when chart mounts.
 window.currentChartType = 2;
 window.lineLastPriceShapeId = null;
@@ -220,10 +222,7 @@ function handleMessage(event) {
     var message =
       typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
 
-    if (
-      !window.isChartReady &&
-      message.type !== 'SET_OHLCV_DATA'
-    ) {
+    if (!window.isChartReady && message.type !== 'SET_OHLCV_DATA') {
       window.pendingMessages.push(message);
       return;
     }
@@ -416,6 +415,7 @@ function handleSetOHLCVData(payload) {
   window.ohlcvData = payload.data;
   bumpLineChartOhlcvEpoch();
   window.ohlcvGeneration++;
+  window.pendingOlderBarsRequest = null;
 
   if (payload.pagination) {
     window.ohlcvPagination = {
@@ -2994,6 +2994,10 @@ function filterBarsForRange(fromMs, toMs, countBack) {
 
 var OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv-chart';
 
+function getOlderBarsErrorMessage(err) {
+  return err && err.message ? err.message : String(err);
+}
+
 /**
  * Fetches the next page of OHLCV history directly from the Price API inside the WebView.
  * Called from \`getBars\` when \`window.ohlcvPagination\` has a cursor, avoiding the RN round-trip.
@@ -3009,12 +3013,29 @@ function fetchOlderBars(pending) {
   }
 
   var gen = window.ohlcvGeneration;
+  var cursor = pag.nextCursor;
+  var existingRequest = window.pendingOlderBarsRequest;
+  if (
+    existingRequest &&
+    existingRequest.generation === gen &&
+    existingRequest.cursor === cursor
+  ) {
+    existingRequest.waiters.push(pending);
+    return;
+  }
+
+  var request = {
+    generation: gen,
+    cursor: cursor,
+    waiters: [pending],
+  };
+  window.pendingOlderBarsRequest = request;
   var url =
     OHLCV_BASE_URL +
     '/' +
     encodeURIComponent(pag.assetId) +
     '?nextCursor=' +
-    encodeURIComponent(pag.nextCursor);
+    encodeURIComponent(cursor);
   if (pag.vsCurrency) {
     url += '&vsCurrency=' + encodeURIComponent(pag.vsCurrency);
   }
@@ -3028,6 +3049,9 @@ function fetchOlderBars(pending) {
     })
     .then(function (result) {
       if (gen !== window.ohlcvGeneration) {
+        return;
+      }
+      if (window.pendingOlderBarsRequest !== request) {
         return;
       }
 
@@ -3055,14 +3079,19 @@ function fetchOlderBars(pending) {
         window.ohlcvData = newBars.concat(window.ohlcvData);
       }
 
-      var olderBars = [];
-      for (var j = 0; j < newBars.length; j++) {
-        if (newBars[j].time < pending.oldestAtDefer) {
-          olderBars.push(newBars[j]);
-        }
-      }
+      window.pendingOlderBarsRequest = null;
 
-      pending.onResult(olderBars, { noData: olderBars.length === 0 });
+      for (var w = 0; w < request.waiters.length; w++) {
+        var waiter = request.waiters[w];
+        var olderBars = [];
+        for (var j = 0; j < newBars.length; j++) {
+          if (newBars[j].time < waiter.oldestAtDefer) {
+            olderBars.push(newBars[j]);
+          }
+        }
+
+        waiter.onResult(olderBars, { noData: olderBars.length === 0 });
+      }
       if (window.__mmLayoutSettlePending) {
         queueTryCompleteLayoutSettleAfterData();
       }
@@ -3071,12 +3100,20 @@ function fetchOlderBars(pending) {
       if (gen !== window.ohlcvGeneration) {
         return;
       }
-      pending.onResult([], { noData: true });
+      if (window.pendingOlderBarsRequest !== request) {
+        return;
+      }
+      window.pendingOlderBarsRequest = null;
+
+      var errorMessage = getOlderBarsErrorMessage(err);
+      for (var w = 0; w < request.waiters.length; w++) {
+        request.waiters[w].onError(errorMessage);
+      }
       if (window.__mmLayoutSettlePending) {
         queueTryCompleteLayoutSettleAfterData();
       }
       sendToReactNative('DEBUG', {
-        message: 'fetchOlderBars error: ' + (err.message || String(err)),
+        message: 'fetchOlderBars error: ' + errorMessage,
       });
     });
 }
@@ -3184,6 +3221,7 @@ var customDatafeed = {
 
       fetchOlderBars({
         onResult: onResult,
+        onError: onError,
         oldestAtDefer: oldestTs,
       });
     } catch (error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR tightens the WebView-owned pagination path for the advanced chart.

The motivation is that once pagination moved from the RN round-trip into the WebView, two correctness issues were introduced in the new history loading flow: overlapping getBars calls could fetch the same older page more than once, and transient fetch failures were being reported to TradingView as noData:true, which makes a network error look like end-of-history.

The fix coalesces overlapping older history requests onto a single in-flight fetch, resolves all waiting callers from that one result, and routes pagination fetch failures through the error path instead of reporting exhausted history. 

The PR also adds focused test coverage for request coalescing, failure handling, and resetting pending pagination state when a new OHLCV series arrives.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
