### PR TITLE
feat: `ButtonBase` pilot migration

### DIFF
--- a/app/components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx
+++ b/app/components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Animated, Easing, ViewProps, ViewStyle } from 'react-native';
-import ButtonBase from '../../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
 import {
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
-import { TextVariant } from '../../../../../../component-library/components/Texts/Text';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
+  ButtonBase,
+  ButtonBaseSize,
+  FontWeight,
+  IconName,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './ResourceToggle.styles';
 
@@ -31,7 +31,7 @@ const ResourceToggle = ({
   style,
   ...rest
 }: ResourceToggleProps) => {
-  const { styles, theme } = useStyles(styleSheet, {
+  const { styles } = useStyles(styleSheet, {
     style: style as ViewStyle,
   });
   const isBandwidth = value === 'bandwidth';
@@ -69,30 +69,36 @@ const ResourceToggle = ({
           <View style={styles.buttonWrapper}>
             <ButtonBase
               onPress={() => onChange('energy')}
-              label={energyLabel}
               startIconName={IconName.Flash}
-              size={ButtonSize.Md}
-              width={ButtonWidthTypes.Full}
-              labelTextVariant={TextVariant.BodyMDMedium}
-              labelColor={theme.colors.text.default}
+              size={ButtonBaseSize.Md}
+              isFullWidth
+              textProps={{
+                variant: TextVariant.BodyMd,
+                fontWeight: FontWeight.Medium,
+              }}
               style={styles.buttonBase}
               testID={testIDEnergy}
               accessibilityLabel={energyLabel}
-            />
+            >
+              {energyLabel}
+            </ButtonBase>
           </View>
           <View style={styles.buttonWrapper}>
             <ButtonBase
               onPress={() => onChange('bandwidth')}
-              label={bandwidthLabel}
               startIconName={IconName.Connect}
-              size={ButtonSize.Md}
-              width={ButtonWidthTypes.Full}
-              labelTextVariant={TextVariant.BodyMDMedium}
-              labelColor={theme.colors.text.default}
+              size={ButtonBaseSize.Md}
+              isFullWidth
+              textProps={{
+                variant: TextVariant.BodyMd,
+                fontWeight: FontWeight.Medium,
+              }}
               style={styles.buttonBase}
               testID={testIDBandwidth}
               accessibilityLabel={bandwidthLabel}
-            />
+            >
+              {bandwidthLabel}
+            </ButtonBase>
           </View>
         </View>
       </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated `ButtonBase` as part of pilot migration.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-637

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b70ab92d-aa28-4e43-8b6e-a53526fe2f7d

### **After**

https://github.com/user-attachments/assets/e72a2968-d8a9-47d7-b937-8f3bd5b79681

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only refactor that swaps the underlying button component/props; main risk is minor visual/regression differences in button labeling and styling.
> 
> **Overview**
> Migrates the Tron Earn `ResourceToggle` buttons from the legacy component-library `ButtonBase` API to `@metamask/design-system-react-native`.
> 
> This updates button props (e.g., `size`, full-width, text styling via `textProps`) and switches from the `label` prop to children-based labels, while removing direct theme color wiring from the component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec5887f4b15d08350722fda43458adff21098bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->