### PR TITLE
fix(Tron): transaction syncing failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "@ethereumjs/util@npm:^9.0.2": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",
     "@metamask/key-tree@npm:^10.1.1": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
-    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-8d73840",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-51f983e",
     "qs": "6.14.1",
     "viem": "2.31.3",
     "@metamask/core-backend": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "@ethereumjs/util@npm:^9.0.2": "patch:@ethereumjs/util@npm%3A9.1.0#~/.yarn/patches/@ethereumjs-util-npm-9.1.0-7e85509408.patch",
     "@metamask/key-tree@npm:^10.1.1": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
     "@metamask/key-tree@npm:^10.0.2": "patch:@metamask/key-tree@npm%3A10.1.1#~/.yarn/patches/@metamask-key-tree-npm-10.1.1-0bfab435ac.patch",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-8d73840",
     "qs": "6.14.1",
     "viem": "2.31.3",
     "@metamask/core-backend": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10085,10 +10085,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.25.0":
-  version: 1.25.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.25.0"
-  checksum: 10/f87a48d2c21b9ea72dfba368ef2a66c73e692d7dfadde60e2606d7f631defcf9b6481c23e2ce17404028c58906c9245e8a60e22921155dd0f747d8330dd2c118
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-8d73840":
+  version: 1.25.1-preview-8d73840
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.25.1-preview-8d73840"
+  checksum: 10/8d2d9df18310290b847905821e26231f98d8da90965a4f6808b3ab9c3af4fefd05d101283511bfef63182051b1699210e2959029b9fee7e7a20beca672d56438
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10085,10 +10085,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-8d73840":
-  version: 1.25.1-preview-8d73840
-  resolution: "@metamask-previews/tron-wallet-snap@npm:1.25.1-preview-8d73840"
-  checksum: 10/8d2d9df18310290b847905821e26231f98d8da90965a4f6808b3ab9c3af4fefd05d101283511bfef63182051b1699210e2959029b9fee7e7a20beca672d56438
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.25.1-preview-51f983e":
+  version: 1.25.1-preview-51f983e
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.25.1-preview-51f983e"
+  checksum: 10/42c4074dc23bdc3290f2fcc5b2092316b3d2e47c6fe93bb4be944207119cf2e25a93c747e8623eaadaebef50a859a5e30869eab61ed00a47ef23b644993f8f83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR overrides `@metamask/tron-wallet-snap` to use the latest preview package published from [MetaMask/snap-tron-wallet#289](https://github.com/MetaMask/snap-tron-wallet/pull/289): `@metamask-previews/tron-wallet-snap@1.25.1-preview-51f983e`.

The goal is to pull the upstream Tron transaction syncing fixes into Mobile without waiting for a stable snap release. The change is limited to Yarn resolution and lockfile updates so installs consistently resolve to the preview artifact.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Tron wallet snap to include the latest transaction syncing fixes.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Tron wallet snap preview override

  Scenario: user views Tron activity with the preview snap build
    Given I am running MetaMask Mobile from this branch
    And I have a wallet with a Tron account that has recent activity

    When user opens the Tron account
    And user views the activity list
    Then Tron transactions should sync successfully
    And the activity list should render without transaction sync failures

  Scenario: user loads a Tron account with TRC10 activity
    Given I am running MetaMask Mobile from this branch
    And I have a wallet with a Tron account that includes TRC10 token activity

    When user refreshes the Tron account activity
    Then the activity sync should complete successfully
    And TRC10 activity should load without malformed token identifier errors
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
