### PR TITLE
feat(predict): adds RTDS WebSocket connection for live crypto price streaming

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController-method-action-types.ts
+++ b/app/components/UI/Predict/controllers/PredictController-method-action-types.ts
@@ -142,9 +142,21 @@ export type PredictControllerSubscribeToMarketPricesAction = {
 };
 
 /**
+ * Subscribes to real-time crypto price updates via RTDS WebSocket.
+ *
+ * @param symbols - Array of crypto symbols to subscribe to (e.g., ['btcusdt'])
+ * @param callback - Function invoked when a crypto price update is received
+ * @returns Unsubscribe function to clean up the subscription
+ */
+export type PredictControllerSubscribeToCryptoPricesAction = {
+  type: `PredictController:subscribeToCryptoPrices`;
+  handler: PredictController['subscribeToCryptoPrices'];
+};
+
+/**
  * Gets the current WebSocket connection status for live data feeds.
  *
- * @returns Connection status for sports and market data WebSocket channels
+ * @returns Connection status for sports, market, and RTDS data WebSocket channels
  */
 export type PredictControllerGetConnectionStatusAction = {
   type: `PredictController:getConnectionStatus`;
@@ -257,6 +269,7 @@ export type PredictControllerMethodActions =
   | PredictControllerRefreshEligibilityAction
   | PredictControllerSubscribeToGameUpdatesAction
   | PredictControllerSubscribeToMarketPricesAction
+  | PredictControllerSubscribeToCryptoPricesAction
   | PredictControllerGetConnectionStatusAction
   | PredictControllerClearOrderErrorAction
   | PredictControllerOnPlaceOrderSuccessAction

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -7482,6 +7482,7 @@ describe('PredictController', () => {
           expect(status).toEqual({
             sportsConnected: false,
             marketConnected: false,
+            rtdsConnected: false,
           });
         });
       });
@@ -7493,6 +7494,7 @@ describe('PredictController', () => {
           expect(status).toEqual({
             sportsConnected: false,
             marketConnected: false,
+            rtdsConnected: false,
           });
         });
       });

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -7452,6 +7452,44 @@ describe('PredictController', () => {
       });
     });
 
+    describe('subscribeToCryptoPrices', () => {
+      it('delegates to provider and returns unsubscribe function', () => {
+        withController(({ controller }) => {
+          const mockUnsubscribe = jest.fn();
+          const mockCallback = jest.fn();
+          mockPolymarketProvider.subscribeToCryptoPrices = jest
+            .fn()
+            .mockReturnValue(mockUnsubscribe);
+
+          const unsubscribe = controller.subscribeToCryptoPrices(
+            ['btcusdt', 'ethusdt'],
+            mockCallback,
+          );
+
+          expect(
+            mockPolymarketProvider.subscribeToCryptoPrices,
+          ).toHaveBeenCalledWith(['btcusdt', 'ethusdt'], mockCallback);
+          expect(unsubscribe).toBe(mockUnsubscribe);
+        });
+      });
+
+      it('returns no-op function when provider lacks method', () => {
+        withController(({ controller }) => {
+          delete (
+            mockPolymarketProvider as { subscribeToCryptoPrices?: unknown }
+          ).subscribeToCryptoPrices;
+
+          const unsubscribe = controller.subscribeToCryptoPrices(
+            ['btcusdt'],
+            jest.fn(),
+          );
+
+          expect(unsubscribe).toBeDefined();
+          expect(unsubscribe()).toBeUndefined();
+        });
+      });
+    });
+
     describe('getConnectionStatus', () => {
       it('returns connection status from provider', () => {
         withController(({ controller }) => {

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -67,6 +67,7 @@ import {
   ActiveOrderState,
   ClaimParams,
   ConnectionStatus,
+  CryptoPriceUpdateCallback,
   GameUpdateCallback,
   GetAccountStateParams,
   GetBalanceParams,
@@ -369,6 +370,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'refreshEligibility',
   'selectPaymentToken',
   'setSelectedPaymentToken',
+  'subscribeToCryptoPrices',
   'subscribeToGameUpdates',
   'subscribeToMarketPrices',
   'trackActivityViewed',
@@ -1548,14 +1550,36 @@ export class PredictController extends BaseController<
   }
 
   /**
+   * Subscribes to real-time crypto price updates via RTDS WebSocket.
+   *
+   * @param symbols - Array of crypto symbols to subscribe to (e.g., ['btcusdt'])
+   * @param callback - Function invoked when a crypto price update is received
+   * @returns Unsubscribe function to clean up the subscription
+   */
+  public subscribeToCryptoPrices(
+    symbols: string[],
+    callback: CryptoPriceUpdateCallback,
+  ): () => void {
+    const provider = this.provider;
+    if (!provider?.subscribeToCryptoPrices) {
+      return () => undefined;
+    }
+    return provider.subscribeToCryptoPrices(symbols, callback);
+  }
+
+  /**
    * Gets the current WebSocket connection status for live data feeds.
    *
-   * @returns Connection status for sports and market data WebSocket channels
+   * @returns Connection status for sports, market, and RTDS data WebSocket channels
    */
   public getConnectionStatus(): ConnectionStatus {
     const provider = this.provider;
     if (!provider?.getConnectionStatus) {
-      return { sportsConnected: false, marketConnected: false };
+      return {
+        sportsConnected: false,
+        marketConnected: false,
+        rtdsConnected: false,
+      };
     }
     return provider.getConnectionStatus();
   }

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrices.test.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrices.test.ts
@@ -1,0 +1,376 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useLiveCryptoPrices } from './useLiveCryptoPrices';
+import Engine from '../../../../core/Engine';
+import { CryptoPriceUpdate } from '../types';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      subscribeToCryptoPrices: jest.fn(),
+      getConnectionStatus: jest.fn(),
+    },
+  },
+}));
+
+describe('useLiveCryptoPrices', () => {
+  const mockSubscribeToCryptoPrices = Engine.context.PredictController
+    .subscribeToCryptoPrices as jest.Mock;
+  const mockGetConnectionStatus = Engine.context.PredictController
+    .getConnectionStatus as jest.Mock;
+  const mockUnsubscribe = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockSubscribeToCryptoPrices.mockReturnValue(mockUnsubscribe);
+    mockGetConnectionStatus.mockReturnValue({
+      rtdsConnected: true,
+      sportsConnected: false,
+      marketConnected: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('subscription management', () => {
+    it('subscribes to crypto price updates when symbols are provided', () => {
+      renderHook(() => useLiveCryptoPrices(['btcusdt', 'ethusdt']));
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledWith(
+        ['btcusdt', 'ethusdt'],
+        expect.any(Function),
+      );
+    });
+
+    it('does not subscribe when symbols is empty', () => {
+      renderHook(() => useLiveCryptoPrices([]));
+
+      expect(mockSubscribeToCryptoPrices).not.toHaveBeenCalled();
+    });
+
+    it('does not subscribe when enabled is false', () => {
+      renderHook(() =>
+        useLiveCryptoPrices(['btcusdt', 'ethusdt'], { enabled: false }),
+      );
+
+      expect(mockSubscribeToCryptoPrices).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribes on unmount', () => {
+      const { unmount } = renderHook(() =>
+        useLiveCryptoPrices(['btcusdt', 'ethusdt']),
+      );
+
+      unmount();
+
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+
+    it('resubscribes when symbols change', () => {
+      const { rerender } = renderHook(
+        ({ symbols }) => useLiveCryptoPrices(symbols),
+        { initialProps: { symbols: ['btcusdt'] } },
+      );
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(1);
+
+      rerender({ symbols: ['btcusdt', 'ethusdt'] });
+
+      expect(mockUnsubscribe).toHaveBeenCalled();
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not resubscribe when symbols order changes but content is same', () => {
+      const { rerender } = renderHook(
+        ({ symbols }) => useLiveCryptoPrices(symbols),
+        { initialProps: { symbols: ['ethusdt', 'btcusdt'] } },
+      );
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(1);
+
+      rerender({ symbols: ['btcusdt', 'ethusdt'] });
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('price update handling', () => {
+    it('updates prices map when callback is invoked', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.prices.size).toBe(0);
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      expect(result.current.prices.get('btcusdt')).toEqual({
+        symbol: 'btcusdt',
+        price: 67234.5,
+        timestamp: 1700000000,
+      });
+    });
+
+    it('accumulates prices from multiple updates', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const { result } = renderHook(() =>
+        useLiveCryptoPrices(['btcusdt', 'ethusdt']),
+      );
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      act(() => {
+        capturedCallback({
+          symbol: 'ethusdt',
+          price: 3500.0,
+          timestamp: 1700000001,
+        });
+      });
+
+      expect(result.current.prices.size).toBe(2);
+      expect(result.current.prices.get('btcusdt')?.price).toBe(67234.5);
+      expect(result.current.prices.get('ethusdt')?.price).toBe(3500.0);
+    });
+
+    it('overwrites previous price for same symbol', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 68000.0,
+          timestamp: 1700000005,
+        });
+      });
+
+      expect(result.current.prices.get('btcusdt')?.price).toBe(68000.0);
+    });
+
+    it('updates lastUpdateTime when price update is received', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const mockNow = 1704067200000;
+      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.lastUpdateTime).toBeNull();
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      expect(result.current.lastUpdateTime).toBe(mockNow);
+    });
+  });
+
+  describe('getPrice helper', () => {
+    it('returns price for existing symbol', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      expect(result.current.getPrice('btcusdt')?.price).toBe(67234.5);
+    });
+
+    it('returns undefined for non-existent symbol', () => {
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.getPrice('ethusdt')).toBeUndefined();
+    });
+  });
+
+  describe('connection status', () => {
+    it('reflects connected status from PredictController', () => {
+      mockGetConnectionStatus.mockReturnValue({
+        rtdsConnected: true,
+        sportsConnected: false,
+        marketConnected: false,
+      });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    it('reflects disconnected status from PredictController', () => {
+      mockGetConnectionStatus.mockReturnValue({
+        rtdsConnected: false,
+        sportsConnected: false,
+        marketConnected: false,
+      });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    it('updates connection status on interval', () => {
+      mockGetConnectionStatus
+        .mockReturnValueOnce({
+          rtdsConnected: true,
+          sportsConnected: false,
+          marketConnected: false,
+        })
+        .mockReturnValueOnce({
+          rtdsConnected: false,
+          sportsConnected: false,
+          marketConnected: false,
+        });
+
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.isConnected).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
+
+  describe('initial state', () => {
+    it('returns empty prices map initially', () => {
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.prices.size).toBe(0);
+    });
+
+    it('returns null lastUpdateTime initially', () => {
+      const { result } = renderHook(() => useLiveCryptoPrices(['btcusdt']));
+
+      expect(result.current.lastUpdateTime).toBeNull();
+    });
+
+    it('resets state when disabled', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const { result, rerender } = renderHook(
+        ({ enabled }) => useLiveCryptoPrices(['btcusdt'], { enabled }),
+        { initialProps: { enabled: true } },
+      );
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      expect(result.current.prices.size).toBe(1);
+
+      rerender({ enabled: false });
+
+      expect(result.current.prices.size).toBe(0);
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    it('resets lastUpdateTime when symbols change to different valid value', () => {
+      let capturedCallback: (update: CryptoPriceUpdate) => void = jest.fn();
+      mockSubscribeToCryptoPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+
+      const mockNow = 1704067200000;
+      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+      const { result, rerender } = renderHook(
+        ({ symbols }) => useLiveCryptoPrices(symbols),
+        { initialProps: { symbols: ['btcusdt'] } },
+      );
+
+      act(() => {
+        capturedCallback({
+          symbol: 'btcusdt',
+          price: 67234.5,
+          timestamp: 1700000000,
+        });
+      });
+
+      expect(result.current.lastUpdateTime).toBe(mockNow);
+
+      rerender({ symbols: ['ethusdt'] });
+
+      expect(result.current.lastUpdateTime).toBeNull();
+      expect(result.current.prices.size).toBe(0);
+    });
+
+    it('differentiates symbols with commas that could otherwise collide', () => {
+      const { rerender } = renderHook(
+        ({ symbols }) => useLiveCryptoPrices(symbols),
+        { initialProps: { symbols: ['a,b', 'c'] } },
+      );
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(1);
+
+      rerender({ symbols: ['a', 'b,c'] });
+
+      expect(mockSubscribeToCryptoPrices).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrices.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrices.ts
@@ -1,0 +1,96 @@
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import Engine from '../../../../core/Engine';
+import { CryptoPriceUpdate } from '../types';
+
+export interface UseLiveCryptoPricesOptions {
+  enabled?: boolean;
+}
+
+export interface UseLiveCryptoPricesResult {
+  prices: Map<string, CryptoPriceUpdate>;
+  getPrice: (symbol: string) => CryptoPriceUpdate | undefined;
+  isConnected: boolean;
+  lastUpdateTime: number | null;
+}
+
+export const useLiveCryptoPrices = (
+  symbols: string[],
+  options: UseLiveCryptoPricesOptions = {},
+): UseLiveCryptoPricesResult => {
+  const { enabled = true } = options;
+
+  const [prices, setPrices] = useState<Map<string, CryptoPriceUpdate>>(
+    new Map(),
+  );
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastUpdateTime, setLastUpdateTime] = useState<number | null>(null);
+
+  const isMountedRef = useRef(true);
+  const symbolsRef = useRef(symbols);
+
+  const symbolsKey = useMemo(
+    () => JSON.stringify([...symbols].sort((a, b) => a.localeCompare(b))),
+    [symbols],
+  );
+
+  useEffect(() => {
+    symbolsRef.current = symbols;
+  }, [symbols]);
+
+  const handlePriceUpdate = useCallback((update: CryptoPriceUpdate) => {
+    if (!isMountedRef.current) return;
+
+    setPrices((prevPrices) => {
+      const newPrices = new Map(prevPrices);
+      newPrices.set(update.symbol, update);
+      return newPrices;
+    });
+
+    setLastUpdateTime(Date.now());
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    setPrices(new Map());
+    setLastUpdateTime(null);
+
+    if (!enabled || symbolsRef.current.length === 0) {
+      setIsConnected(false);
+      return;
+    }
+
+    const { PredictController } = Engine.context;
+    const unsubscribe = PredictController.subscribeToCryptoPrices(
+      symbolsRef.current,
+      handlePriceUpdate,
+    );
+
+    const checkConnection = () => {
+      if (!isMountedRef.current) return;
+      const status = PredictController.getConnectionStatus();
+      setIsConnected(status.rtdsConnected);
+    };
+
+    checkConnection();
+    const intervalId = setInterval(checkConnection, 1000);
+
+    return () => {
+      isMountedRef.current = false;
+      unsubscribe();
+      clearInterval(intervalId);
+    };
+  }, [symbolsKey, enabled, handlePriceUpdate]);
+
+  const getPrice = useCallback(
+    (symbol: string): CryptoPriceUpdate | undefined => prices.get(symbol),
+    [prices],
+  );
+
+  return {
+    prices,
+    getPrice,
+    isConnected,
+    lastUpdateTime,
+  };
+};

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -186,6 +186,7 @@ jest.mock('./TeamsCache', () => ({
 const mockWebSocketManagerInstance = {
   subscribeToGame: jest.fn(),
   subscribeToMarketPrices: jest.fn(),
+  subscribeToCryptoPrices: jest.fn(),
   getConnectionStatus: jest.fn(),
   disconnect: jest.fn(),
   cleanup: jest.fn(),
@@ -7787,14 +7788,54 @@ describe('PolymarketProvider', () => {
       });
     });
 
+    describe('subscribeToCryptoPrices', () => {
+      it('delegates to WebSocketManager.subscribeToCryptoPrices', () => {
+        const provider = createProvider();
+        const mockCallback = jest.fn();
+        const mockUnsubscribeCrypto = jest.fn();
+        mockWebSocketManagerInstance.subscribeToCryptoPrices.mockReturnValue(
+          mockUnsubscribeCrypto,
+        );
+
+        const unsubscribe = provider.subscribeToCryptoPrices(
+          ['btcusdt', 'ethusdt'],
+          mockCallback,
+        );
+
+        expect(
+          mockWebSocketManagerInstance.subscribeToCryptoPrices,
+        ).toHaveBeenCalledWith(['btcusdt', 'ethusdt'], mockCallback);
+        expect(unsubscribe).toBe(mockUnsubscribeCrypto);
+      });
+
+      it('returns unsubscribe function from WebSocketManager', () => {
+        const provider = createProvider();
+        const mockUnsubscribeCrypto = jest.fn();
+        mockWebSocketManagerInstance.subscribeToCryptoPrices.mockReturnValue(
+          mockUnsubscribeCrypto,
+        );
+
+        const unsubscribe = provider.subscribeToCryptoPrices(
+          ['btcusdt'],
+          jest.fn(),
+        );
+
+        unsubscribe();
+
+        expect(mockUnsubscribeCrypto).toHaveBeenCalled();
+      });
+    });
+
     describe('getConnectionStatus', () => {
       it('returns connection status from WebSocketManager', () => {
         const provider = createProvider();
         mockWebSocketManagerInstance.getConnectionStatus.mockReturnValue({
           sportsConnected: true,
           marketConnected: false,
+          rtdsConnected: false,
           gameSubscriptionCount: 5,
           priceSubscriptionCount: 10,
+          cryptoPriceSubscriptionCount: 0,
         });
 
         const status = provider.getConnectionStatus();
@@ -7802,6 +7843,7 @@ describe('PolymarketProvider', () => {
         expect(status).toEqual({
           sportsConnected: true,
           marketConnected: false,
+          rtdsConnected: false,
         });
       });
 
@@ -7810,8 +7852,10 @@ describe('PolymarketProvider', () => {
         mockWebSocketManagerInstance.getConnectionStatus.mockReturnValue({
           sportsConnected: false,
           marketConnected: true,
+          rtdsConnected: true,
           gameSubscriptionCount: 0,
           priceSubscriptionCount: 3,
+          cryptoPriceSubscriptionCount: 1,
         });
 
         const status = provider.getConnectionStatus();

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -7821,6 +7821,7 @@ describe('PolymarketProvider', () => {
         expect(Object.keys(status)).toEqual([
           'sportsConnected',
           'marketConnected',
+          'rtdsConnected',
         ]);
       });
     });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -37,6 +37,7 @@ import {
   ClaimOrderParams,
   ClaimOrderResponse,
   ConnectionStatus,
+  CryptoPriceUpdateCallback,
   GameUpdateCallback,
   GeoBlockResponse,
   GetAccountStateParams,
@@ -2018,11 +2019,22 @@ export class PolymarketProvider implements PredictProvider {
     );
   }
 
+  public subscribeToCryptoPrices(
+    symbols: string[],
+    callback: CryptoPriceUpdateCallback,
+  ): () => void {
+    return WebSocketManager.getInstance().subscribeToCryptoPrices(
+      symbols,
+      callback,
+    );
+  }
+
   public getConnectionStatus(): ConnectionStatus {
     const status = WebSocketManager.getInstance().getConnectionStatus();
     return {
       sportsConnected: status.sportsConnected,
       marketConnected: status.marketConnected,
+      rtdsConnected: status.rtdsConnected,
     };
   }
 }

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -67,6 +67,10 @@ class MockWebSocket {
 let appStateCallback: ((state: AppStateStatus) => void) | null = null;
 const mockRemoveListener = jest.fn();
 
+const OriginalWebSocket = (
+  global as unknown as { WebSocket: typeof MockWebSocket }
+).WebSocket;
+
 (global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket =
   MockWebSocket;
 
@@ -78,6 +82,8 @@ jest.mock('react-native', () => ({
 
 describe('WebSocketManager', () => {
   beforeEach(() => {
+    (global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket =
+      MockWebSocket;
     WebSocketManager.resetInstance();
     mockWebSocketInstances = [];
     appStateCallback = null;
@@ -98,6 +104,8 @@ describe('WebSocketManager', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    (global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket =
+      OriginalWebSocket;
   });
 
   describe('singleton pattern', () => {

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -1083,6 +1083,293 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('RTDS connection edge cases', () => {
+    it('reuses existing connection for second subscriber', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      manager.subscribeToCryptoPrices(['ethusdt'], jest.fn());
+
+      const rtdsInstances = mockWebSocketInstances.filter(
+        (ws) => ws.url === 'wss://ws-live-data.polymarket.com',
+      );
+      expect(rtdsInstances).toHaveLength(1);
+    });
+
+    it('sends subscribe for new symbols on already-open connection', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.send.mockClear();
+
+      manager.subscribeToCryptoPrices(['ethusdt'], jest.fn());
+
+      expect(rtdsInstance.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'subscribe',
+          subscriptions: [
+            {
+              topic: 'crypto_prices',
+              type: 'update',
+              filters: 'ethusdt',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('does not create new connection when WS is in CONNECTING state', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const countAfterFirst = mockWebSocketInstances.length;
+
+      manager.subscribeToCryptoPrices(['ethusdt'], jest.fn());
+
+      expect(mockWebSocketInstances.length).toBe(countAfterFirst);
+    });
+
+    it('calls multiple subscriber callbacks for same symbol', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback1);
+      manager.subscribeToCryptoPrices(['btcusdt'], callback2);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: { symbol: 'btcusdt', timestamp: 1700000000, value: 67234.5 },
+      });
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback1).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+
+    it('delivers updates to multiple subscriptions with overlapping symbols', () => {
+      const manager = WebSocketManager.getInstance();
+      const callbackA = jest.fn();
+      const callbackB = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callbackA);
+      manager.subscribeToCryptoPrices(['btcusdt', 'ethusdt'], callbackB);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: { symbol: 'btcusdt', timestamp: 1700000000, value: 67234.5 },
+      });
+      jest.advanceTimersByTime(16);
+
+      expect(callbackA).toHaveBeenCalledTimes(1);
+      expect(callbackB).toHaveBeenCalledTimes(1);
+
+      callbackA.mockClear();
+      callbackB.mockClear();
+
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000001,
+        payload: { symbol: 'ethusdt', timestamp: 1700000001, value: 3500.0 },
+      });
+      jest.advanceTimersByTime(16);
+
+      expect(callbackA).not.toHaveBeenCalled();
+      expect(callbackB).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores messages with non-crypto_prices topic', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.simulateMessage({
+        topic: 'orderbook',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: { symbol: 'btcusdt', timestamp: 1700000000, value: 67234.5 },
+      });
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('ignores messages with missing payload', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+      });
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('handles onerror without crashing', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+
+      expect(() => rtdsInstance.simulateError()).not.toThrow();
+    });
+
+    it('does not send subscribe when WS is not open', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+
+      expect(rtdsInstance.send).not.toHaveBeenCalled();
+    });
+
+    it('does not send unsubscribe when WS is not open', () => {
+      const manager = WebSocketManager.getInstance();
+
+      const unsubscribe = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        jest.fn(),
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.send.mockClear();
+
+      unsubscribe();
+
+      expect(rtdsInstance.send).not.toHaveBeenCalled();
+    });
+
+    it('cleans up RTDS connection with throttle timer active', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: { symbol: 'btcusdt', timestamp: 1700000000, value: 67234.5 },
+      });
+
+      WebSocketManager.resetInstance();
+
+      expect(() => jest.advanceTimersByTime(100)).not.toThrow();
+    });
+
+    it('handles cleanup when rtdsWs is null', () => {
+      WebSocketManager.getInstance();
+
+      expect(() => WebSocketManager.resetInstance()).not.toThrow();
+    });
+
+    it('resubscribes all symbols on reconnect after close', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      manager.subscribeToCryptoPrices(['ethusdt'], jest.fn());
+      const firstInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      firstInstance.simulateOpen();
+      firstInstance.simulateClose();
+
+      jest.advanceTimersByTime(3000);
+
+      const secondInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      secondInstance.simulateOpen();
+
+      const subscribeCalls = secondInstance.send.mock.calls.filter(
+        (call: string[]) => {
+          try {
+            const msg = JSON.parse(call[0]);
+            return msg.action === 'subscribe';
+          } catch {
+            return false;
+          }
+        },
+      );
+
+      expect(subscribeCalls.length).toBeGreaterThan(0);
+    });
+
+    it('reconnectAll only connects RTDS when only RTDS has subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      const countBefore = mockWebSocketInstances.length;
+
+      if (appStateCallback) {
+        appStateCallback('background');
+        appStateCallback('active');
+      }
+
+      expect(mockWebSocketInstances.length).toBe(countBefore + 1);
+      expect(
+        mockWebSocketInstances[mockWebSocketInstances.length - 1].url,
+      ).toBe('wss://ws-live-data.polymarket.com');
+    });
+
+    it('clears throttle timer when buffer empties after flush', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: { symbol: 'btcusdt', timestamp: 1700000000, value: 67234.5 },
+      });
+
+      jest.advanceTimersByTime(16);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      callback.mockClear();
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getConnectionStatus', () => {
     it('returns connection status with all fields populated', () => {
       const manager = WebSocketManager.getInstance();

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -558,7 +558,6 @@ describe('WebSocketManager', () => {
             {
               topic: 'crypto_prices',
               type: 'update',
-              filters: 'btcusdt',
             },
           ],
         }),
@@ -657,7 +656,6 @@ describe('WebSocketManager', () => {
             {
               topic: 'crypto_prices',
               type: 'update',
-              filters: 'btcusdt',
             },
           ],
         }),
@@ -1122,7 +1120,6 @@ describe('WebSocketManager', () => {
             {
               topic: 'crypto_prices',
               type: 'update',
-              filters: 'ethusdt',
             },
           ],
         }),

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -519,6 +519,232 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('crypto price subscriptions', () => {
+    it('connects to RTDS WS when first subscription is made', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+
+      // Sports + Market WS instances may already exist from the singleton,
+      // but the RTDS one is the one with the RTDS URL
+      const rtdsInstance = mockWebSocketInstances.find(
+        (ws) => ws.url === 'wss://ws-live-data.polymarket.com',
+      );
+      expect(rtdsInstance).toBeDefined();
+    });
+
+    it('sends subscribe message after connection opens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      expect(rtdsInstance.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'subscribe',
+          subscriptions: [
+            {
+              topic: 'crypto_prices',
+              type: 'update',
+              filters: 'btcusdt',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('calls callback with crypto price update for subscribed symbol', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: {
+          symbol: 'btcusdt',
+          timestamp: 1700000001,
+          value: 67234.5,
+        },
+      });
+
+      // Throttled - advance timer to trigger flush
+      jest.advanceTimersByTime(16);
+
+      expect(callback).toHaveBeenCalledWith({
+        symbol: 'btcusdt',
+        price: 67234.5,
+        timestamp: 1700000001,
+      });
+    });
+
+    it('filters pong messages without calling callback', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      // Send pong as raw string (not JSON)
+      rtdsInstance.onmessage?.({ data: 'pong' } as MessageEvent);
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not call callback for unsubscribed symbols', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices',
+        type: 'update',
+        timestamp: 1700000000,
+        payload: {
+          symbol: 'ethusdt',
+          timestamp: 1700000001,
+          value: 3500.0,
+        },
+      });
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('sends unsubscribe message when all callbacks removed', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        callback,
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.send.mockClear();
+
+      unsubscribe();
+
+      expect(rtdsInstance.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'unsubscribe',
+          subscriptions: [
+            {
+              topic: 'crypto_prices',
+              type: 'update',
+              filters: 'btcusdt',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('disconnects when all subscribers unsubscribe', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      const unsubscribe1 = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        callback1,
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      const unsubscribe2 = manager.subscribeToCryptoPrices(
+        ['ethusdt'],
+        callback2,
+      );
+
+      expect(manager.getConnectionStatus().cryptoPriceSubscriptionCount).toBe(
+        2,
+      );
+
+      unsubscribe1();
+      expect(manager.getConnectionStatus().cryptoPriceSubscriptionCount).toBe(
+        1,
+      );
+
+      unsubscribe2();
+      expect(manager.getConnectionStatus().cryptoPriceSubscriptionCount).toBe(
+        0,
+      );
+      expect(rtdsInstance.close).toHaveBeenCalled();
+    });
+
+    it('throttles callbacks to configured interval', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      // Fire 5 rapid messages
+      for (let i = 0; i < 5; i++) {
+        rtdsInstance.simulateMessage({
+          topic: 'crypto_prices',
+          type: 'update',
+          timestamp: 1700000000 + i,
+          payload: {
+            symbol: 'btcusdt',
+            timestamp: 1700000000 + i,
+            value: 67234.5 + i,
+          },
+        });
+      }
+
+      // Before throttle flush: no callbacks yet (buffer is collecting)
+      expect(callback).not.toHaveBeenCalled();
+
+      // Advance past throttle interval
+      jest.advanceTimersByTime(16);
+
+      // Only latest value delivered (buffer overwrites per symbol)
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({
+        symbol: 'btcusdt',
+        price: 67238.5,
+        timestamp: 1700000004,
+      });
+    });
+
+    it('ignores malformed JSON messages without calling callback', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.onmessage?.({
+        data: 'not valid json',
+      } as MessageEvent);
+
+      jest.advanceTimersByTime(16);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
   describe('reconnection with exponential backoff', () => {
     it('reconnects with increasing delay after connection closes', () => {
       const manager = WebSocketManager.getInstance();
@@ -589,6 +815,89 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('RTDS reconnection', () => {
+    it('reconnects with increasing delay after RTDS connection closes', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const firstInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      firstInstance.simulateOpen();
+      const countAfterFirst = mockWebSocketInstances.length;
+
+      firstInstance.simulateClose();
+      jest.advanceTimersByTime(3000);
+      expect(mockWebSocketInstances.length).toBe(countAfterFirst + 1);
+
+      const secondInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      secondInstance.simulateClose();
+      jest.advanceTimersByTime(6000);
+      expect(mockWebSocketInstances.length).toBe(countAfterFirst + 2);
+    });
+
+    it('stops reconnecting after max attempts', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const initialCount = mockWebSocketInstances.length;
+
+      for (let i = 0; i < 5; i++) {
+        const idx = initialCount - 1 + i;
+        mockWebSocketInstances[idx].simulateClose();
+        jest.advanceTimersByTime((i + 1) * 3000);
+      }
+
+      const afterAttemptsCount = mockWebSocketInstances.length;
+      const lastIdx = afterAttemptsCount - 1;
+      mockWebSocketInstances[lastIdx].simulateClose();
+      jest.advanceTimersByTime(30000);
+
+      expect(mockWebSocketInstances.length).toBe(afterAttemptsCount);
+    });
+
+    it('resets reconnect attempts on successful connection', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const firstInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      firstInstance.simulateClose();
+      jest.advanceTimersByTime(3000);
+
+      const secondInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      secondInstance.simulateOpen();
+      secondInstance.simulateClose();
+      jest.advanceTimersByTime(3000);
+
+      expect(mockWebSocketInstances.length).toBeGreaterThan(2);
+    });
+
+    it('does not reconnect if no subscribers remain', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        callback,
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      unsubscribe();
+      const countAfterUnsubscribe = mockWebSocketInstances.length;
+      rtdsInstance.simulateClose();
+      jest.advanceTimersByTime(10000);
+
+      expect(mockWebSocketInstances.length).toBe(countAfterUnsubscribe);
+    });
+  });
+
   describe('AppState handling', () => {
     it('disconnects on app background when connected', () => {
       const manager = WebSocketManager.getInstance();
@@ -644,6 +953,69 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('RTDS AppState handling', () => {
+    it('disconnects RTDS on app background when connected', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      expect(appStateCallback).not.toBeNull();
+      if (appStateCallback) {
+        appStateCallback('background');
+      }
+
+      expect(rtdsInstance.readyState).toBe(MockWebSocket.CLOSED);
+    });
+
+    it('reconnects RTDS on app foreground with active subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      const countBeforeBackground = mockWebSocketInstances.length;
+
+      if (appStateCallback) {
+        appStateCallback('background');
+        appStateCallback('active');
+      }
+
+      expect(mockWebSocketInstances.length).toBeGreaterThan(
+        countBeforeBackground,
+      );
+    });
+
+    it('does not reconnect RTDS on foreground if no subscriptions', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        callback,
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      unsubscribe();
+      const countAfterUnsubscribe = mockWebSocketInstances.length;
+
+      if (appStateCallback) {
+        appStateCallback('background');
+        appStateCallback('active');
+      }
+
+      expect(mockWebSocketInstances.length).toBe(countAfterUnsubscribe);
+    });
+  });
+
   describe('ping/heartbeat', () => {
     it('sends ping at configured interval after connection opens', () => {
       const manager = WebSocketManager.getInstance();
@@ -674,6 +1046,43 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('RTDS ping/heartbeat', () => {
+    it('sends lowercase ping at 5-second interval after connection opens', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      manager.subscribeToCryptoPrices(['btcusdt'], callback);
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      rtdsInstance.send.mockClear();
+
+      jest.advanceTimersByTime(5000);
+
+      expect(rtdsInstance.send).toHaveBeenCalledWith('ping');
+    });
+
+    it('stops ping on disconnect', () => {
+      const manager = WebSocketManager.getInstance();
+      const callback = jest.fn();
+
+      const unsubscribe = manager.subscribeToCryptoPrices(
+        ['btcusdt'],
+        callback,
+      );
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+
+      unsubscribe();
+      rtdsInstance.send.mockClear();
+
+      jest.advanceTimersByTime(10000);
+
+      expect(rtdsInstance.send).not.toHaveBeenCalledWith('ping');
+    });
+  });
+
   describe('getConnectionStatus', () => {
     it('returns connection status with all fields populated', () => {
       const manager = WebSocketManager.getInstance();
@@ -681,8 +1090,10 @@ describe('WebSocketManager', () => {
       expect(manager.getConnectionStatus()).toEqual({
         sportsConnected: false,
         marketConnected: false,
+        rtdsConnected: false,
         gameSubscriptionCount: 0,
         priceSubscriptionCount: 0,
+        cryptoPriceSubscriptionCount: 0,
       });
 
       manager.subscribeToGame('123', jest.fn());
@@ -691,11 +1102,16 @@ describe('WebSocketManager', () => {
       manager.subscribeToMarketPrices(['token1'], jest.fn());
       mockWebSocketInstances[1].simulateOpen();
 
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      mockWebSocketInstances[2].simulateOpen();
+
       expect(manager.getConnectionStatus()).toEqual({
         sportsConnected: true,
         marketConnected: true,
+        rtdsConnected: true,
         gameSubscriptionCount: 1,
         priceSubscriptionCount: 1,
+        cryptoPriceSubscriptionCount: 1,
       });
     });
   });
@@ -719,10 +1135,14 @@ describe('WebSocketManager', () => {
       manager.subscribeToMarketPrices(['token1'], jest.fn());
       mockWebSocketInstances[1].simulateOpen();
 
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
+      mockWebSocketInstances[2].simulateOpen();
+
       WebSocketManager.resetInstance();
 
       expect(mockWebSocketInstances[0].close).toHaveBeenCalled();
       expect(mockWebSocketInstances[1].close).toHaveBeenCalled();
+      expect(mockWebSocketInstances[2].close).toHaveBeenCalled();
     });
 
     it('clears all subscriptions', () => {
@@ -730,15 +1150,22 @@ describe('WebSocketManager', () => {
 
       manager.subscribeToGame('123', jest.fn());
       manager.subscribeToMarketPrices(['token1'], jest.fn());
+      manager.subscribeToCryptoPrices(['btcusdt'], jest.fn());
 
       expect(manager.getConnectionStatus().gameSubscriptionCount).toBe(1);
       expect(manager.getConnectionStatus().priceSubscriptionCount).toBe(1);
+      expect(manager.getConnectionStatus().cryptoPriceSubscriptionCount).toBe(
+        1,
+      );
 
       WebSocketManager.resetInstance();
       const newManager = WebSocketManager.getInstance();
 
       expect(newManager.getConnectionStatus().gameSubscriptionCount).toBe(0);
       expect(newManager.getConnectionStatus().priceSubscriptionCount).toBe(0);
+      expect(
+        newManager.getConnectionStatus().cryptoPriceSubscriptionCount,
+      ).toBe(0);
     });
   });
 });

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -331,7 +331,7 @@ export class WebSocketManager {
     }
     callbacks.add(callback);
 
-    this.ensureRtdsConnection(symbols);
+    this.ensureRtdsConnection();
 
     return () => {
       const _callbacks = this.cryptoPriceSubscriptions.get(subscriptionKey);
@@ -339,7 +339,7 @@ export class WebSocketManager {
         _callbacks.delete(callback);
         if (_callbacks.size === 0) {
           this.cryptoPriceSubscriptions.delete(subscriptionKey);
-          this.sendRtdsUnsubscribe(symbols);
+          this.sendRtdsUnsubscribe();
         }
       }
 
@@ -521,9 +521,9 @@ export class WebSocketManager {
     this.marketReconnectAttempts = 0;
   }
 
-  private ensureRtdsConnection(symbols: string[]): void {
+  private ensureRtdsConnection(): void {
     if (this.rtdsWs?.readyState === WebSocket.OPEN) {
-      this.sendRtdsSubscribe(symbols);
+      this.sendRtdsSubscribe();
       return;
     }
     if (this.rtdsWs?.readyState === WebSocket.CONNECTING) {
@@ -622,26 +622,24 @@ export class WebSocketManager {
     this.cryptoPriceBuffer.clear();
   }
 
-  private sendRtdsSubscribe(symbols: string[]): void {
+  private sendRtdsSubscribe(): void {
     if (this.rtdsWs?.readyState !== WebSocket.OPEN) {
       return;
     }
 
-    this.rtdsWs.send(
-      JSON.stringify({
-        action: 'subscribe',
-        subscriptions: [
-          {
-            topic: 'crypto_prices',
-            type: 'update',
-            filters: symbols.join(','),
-          },
-        ],
-      }),
-    );
+    const msg = JSON.stringify({
+      action: 'subscribe',
+      subscriptions: [
+        {
+          topic: 'crypto_prices',
+          type: 'update',
+        },
+      ],
+    });
+    this.rtdsWs.send(msg);
   }
 
-  private sendRtdsUnsubscribe(symbols: string[]): void {
+  private sendRtdsUnsubscribe(): void {
     if (this.rtdsWs?.readyState !== WebSocket.OPEN) {
       return;
     }
@@ -653,7 +651,6 @@ export class WebSocketManager {
           {
             topic: 'crypto_prices',
             type: 'update',
-            filters: symbols.join(','),
           },
         ],
       }),
@@ -667,7 +664,7 @@ export class WebSocketManager {
     });
 
     if (allSymbols.size > 0) {
-      this.sendRtdsSubscribe(Array.from(allSymbols));
+      this.sendRtdsSubscribe();
     }
   }
 

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -1,5 +1,7 @@
 import { AppState, AppStateStatus } from 'react-native';
 import {
+  CryptoPriceUpdate,
+  CryptoPriceUpdateCallback,
   GameUpdate,
   PredictGamePeriod,
   PredictGameStatus,
@@ -14,6 +16,10 @@ const MARKET_WS_URL = 'wss://ws-subscriptions-clob.polymarket.com/ws/market';
 const RECONNECT_DELAY_MS = 3000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 const PING_INTERVAL_MS = 50000;
+
+const RTDS_WS_URL = 'wss://ws-live-data.polymarket.com';
+const RTDS_PING_INTERVAL_MS = 5000;
+const DEFAULT_THROTTLE_INTERVAL_MS = 16;
 
 type GameUpdateCallback = (update: GameUpdate) => void;
 type PriceUpdateCallback = (updates: PriceUpdate[]) => void;
@@ -41,6 +47,17 @@ interface MarketWebSocketEvent {
   timestamp: string;
 }
 
+interface RtdsWebSocketEvent {
+  topic: string;
+  type: string;
+  timestamp: number;
+  payload: {
+    symbol: string;
+    timestamp: number;
+    value: number;
+  };
+}
+
 export class WebSocketManager {
   private static instance: WebSocketManager | null = null;
 
@@ -57,6 +74,17 @@ export class WebSocketManager {
 
   private sportsPingInterval: ReturnType<typeof setInterval> | null = null;
   private marketPingInterval: ReturnType<typeof setInterval> | null = null;
+
+  private rtdsWs: WebSocket | null = null;
+  private cryptoPriceSubscriptions: Map<
+    string,
+    Set<CryptoPriceUpdateCallback>
+  > = new Map();
+  private rtdsReconnectAttempts = 0;
+  private rtdsReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private rtdsPingInterval: ReturnType<typeof setInterval> | null = null;
+  private cryptoPriceBuffer: Map<string, CryptoPriceUpdate> = new Map();
+  private throttleTimer: ReturnType<typeof setInterval> | null = null;
 
   private appStateSubscription: { remove: () => void } | null = null;
 
@@ -288,6 +316,39 @@ export class WebSocketManager {
     };
   }
 
+  subscribeToCryptoPrices(
+    symbols: string[],
+    callback: CryptoPriceUpdateCallback,
+  ): () => void {
+    const subscriptionKey = [...symbols]
+      .sort((a, b) => a.localeCompare(b))
+      .join(',');
+
+    let callbacks = this.cryptoPriceSubscriptions.get(subscriptionKey);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.cryptoPriceSubscriptions.set(subscriptionKey, callbacks);
+    }
+    callbacks.add(callback);
+
+    this.ensureRtdsConnection(symbols);
+
+    return () => {
+      const _callbacks = this.cryptoPriceSubscriptions.get(subscriptionKey);
+      if (_callbacks) {
+        _callbacks.delete(callback);
+        if (_callbacks.size === 0) {
+          this.cryptoPriceSubscriptions.delete(subscriptionKey);
+          this.sendRtdsUnsubscribe(symbols);
+        }
+      }
+
+      if (this.cryptoPriceSubscriptions.size === 0) {
+        this.disconnectRtds();
+      }
+    };
+  }
+
   private ensureMarketConnection(tokenIds: string[]): void {
     if (this.marketWs?.readyState === WebSocket.OPEN) {
       this.sendMarketSubscribe(tokenIds);
@@ -460,9 +521,227 @@ export class WebSocketManager {
     this.marketReconnectAttempts = 0;
   }
 
+  private ensureRtdsConnection(symbols: string[]): void {
+    if (this.rtdsWs?.readyState === WebSocket.OPEN) {
+      this.sendRtdsSubscribe(symbols);
+      return;
+    }
+    if (this.rtdsWs?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+
+    this.connectRtds();
+  }
+
+  private connectRtds(): void {
+    this.cleanupRtdsConnection();
+
+    try {
+      this.rtdsWs = new WebSocket(RTDS_WS_URL);
+
+      this.rtdsWs.onopen = () => {
+        this.rtdsReconnectAttempts = 0;
+        this.startRtdsPing();
+        this.resubscribeAllRtds();
+      };
+
+      this.rtdsWs.onclose = () => {
+        this.stopRtdsPing();
+        this.scheduleRtdsReconnect();
+      };
+
+      this.rtdsWs.onerror = () => {
+        // Error will trigger onclose
+      };
+
+      this.rtdsWs.onmessage = this.handleRtdsMessage;
+    } catch (error) {
+      DevLogger.log('WebSocketManager: Failed to connect to RTDS WebSocket', {
+        error,
+      });
+      this.scheduleRtdsReconnect();
+    }
+  }
+
+  private handleRtdsMessage = (event: WebSocketMessageEvent): void => {
+    try {
+      if (event.data === 'pong') {
+        return;
+      }
+
+      const data: RtdsWebSocketEvent = JSON.parse(event.data);
+
+      if (data.topic !== 'crypto_prices' || !data.payload) {
+        return;
+      }
+
+      const update: CryptoPriceUpdate = {
+        symbol: data.payload.symbol,
+        price: data.payload.value,
+        timestamp: data.payload.timestamp,
+      };
+
+      this.cryptoPriceBuffer.set(update.symbol, update);
+      this.ensureThrottleTimer();
+    } catch (error) {
+      DevLogger.log('WebSocketManager: Failed to parse RTDS message', {
+        error,
+      });
+    }
+  };
+
+  private ensureThrottleTimer(): void {
+    if (this.throttleTimer) {
+      return;
+    }
+
+    this.throttleTimer = setInterval(() => {
+      this.flushCryptoPriceBuffer();
+    }, DEFAULT_THROTTLE_INTERVAL_MS);
+  }
+
+  private flushCryptoPriceBuffer(): void {
+    if (this.cryptoPriceBuffer.size === 0) {
+      if (this.throttleTimer) {
+        clearInterval(this.throttleTimer);
+        this.throttleTimer = null;
+      }
+      return;
+    }
+
+    this.cryptoPriceSubscriptions.forEach((callbacks, key) => {
+      const subscribedSymbols = new Set(key.split(','));
+
+      this.cryptoPriceBuffer.forEach((update, symbol) => {
+        if (subscribedSymbols.has(symbol)) {
+          callbacks.forEach((callback) => callback(update));
+        }
+      });
+    });
+
+    this.cryptoPriceBuffer.clear();
+  }
+
+  private sendRtdsSubscribe(symbols: string[]): void {
+    if (this.rtdsWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.rtdsWs.send(
+      JSON.stringify({
+        action: 'subscribe',
+        subscriptions: [
+          {
+            topic: 'crypto_prices',
+            type: 'update',
+            filters: symbols.join(','),
+          },
+        ],
+      }),
+    );
+  }
+
+  private sendRtdsUnsubscribe(symbols: string[]): void {
+    if (this.rtdsWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.rtdsWs.send(
+      JSON.stringify({
+        action: 'unsubscribe',
+        subscriptions: [
+          {
+            topic: 'crypto_prices',
+            type: 'update',
+            filters: symbols.join(','),
+          },
+        ],
+      }),
+    );
+  }
+
+  private resubscribeAllRtds(): void {
+    const allSymbols = new Set<string>();
+    this.cryptoPriceSubscriptions.forEach((_, key) => {
+      key.split(',').forEach((symbol) => allSymbols.add(symbol));
+    });
+
+    if (allSymbols.size > 0) {
+      this.sendRtdsSubscribe(Array.from(allSymbols));
+    }
+  }
+
+  private scheduleRtdsReconnect(): void {
+    if (this.cryptoPriceSubscriptions.size === 0) {
+      return;
+    }
+
+    if (this.rtdsReconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      return;
+    }
+
+    this.rtdsReconnectAttempts++;
+    const delay = RECONNECT_DELAY_MS * this.rtdsReconnectAttempts;
+
+    this.rtdsReconnectTimeout = setTimeout(() => {
+      this.connectRtds();
+    }, delay);
+  }
+
+  private startRtdsPing(): void {
+    this.rtdsPingInterval = setInterval(() => {
+      if (this.rtdsWs?.readyState === WebSocket.OPEN) {
+        this.rtdsWs.send('ping');
+      }
+    }, RTDS_PING_INTERVAL_MS);
+  }
+
+  private stopRtdsPing(): void {
+    if (this.rtdsPingInterval) {
+      clearInterval(this.rtdsPingInterval);
+      this.rtdsPingInterval = null;
+    }
+  }
+
+  private cleanupRtdsConnection(): void {
+    this.stopRtdsPing();
+
+    if (this.throttleTimer) {
+      clearInterval(this.throttleTimer);
+      this.throttleTimer = null;
+    }
+    this.cryptoPriceBuffer.clear();
+
+    if (this.rtdsReconnectTimeout) {
+      clearTimeout(this.rtdsReconnectTimeout);
+      this.rtdsReconnectTimeout = null;
+    }
+
+    if (this.rtdsWs) {
+      this.rtdsWs.onopen = null;
+      this.rtdsWs.onclose = null;
+      this.rtdsWs.onerror = null;
+      this.rtdsWs.onmessage = null;
+
+      if (
+        this.rtdsWs.readyState === WebSocket.OPEN ||
+        this.rtdsWs.readyState === WebSocket.CONNECTING
+      ) {
+        this.rtdsWs.close();
+      }
+      this.rtdsWs = null;
+    }
+  }
+
+  private disconnectRtds(): void {
+    this.cleanupRtdsConnection();
+    this.rtdsReconnectAttempts = 0;
+  }
+
   private reconnectAll(): void {
     this.sportsReconnectAttempts = 0;
     this.marketReconnectAttempts = 0;
+    this.rtdsReconnectAttempts = 0;
 
     if (this.gameSubscriptions.size > 0) {
       this.connectSports();
@@ -470,17 +749,22 @@ export class WebSocketManager {
     if (this.priceSubscriptions.size > 0) {
       this.connectMarket();
     }
+    if (this.cryptoPriceSubscriptions.size > 0) {
+      this.connectRtds();
+    }
   }
 
   private disconnectAll(): void {
     this.disconnectSports();
     this.disconnectMarket();
+    this.disconnectRtds();
   }
 
   cleanup(): void {
     this.disconnectAll();
     this.gameSubscriptions.clear();
     this.priceSubscriptions.clear();
+    this.cryptoPriceSubscriptions.clear();
 
     if (this.appStateSubscription) {
       this.appStateSubscription.remove();
@@ -491,14 +775,18 @@ export class WebSocketManager {
   getConnectionStatus(): {
     sportsConnected: boolean;
     marketConnected: boolean;
+    rtdsConnected: boolean;
     gameSubscriptionCount: number;
     priceSubscriptionCount: number;
+    cryptoPriceSubscriptionCount: number;
   } {
     return {
       sportsConnected: this.sportsWs?.readyState === WebSocket.OPEN,
       marketConnected: this.marketWs?.readyState === WebSocket.OPEN,
+      rtdsConnected: this.rtdsWs?.readyState === WebSocket.OPEN,
       gameSubscriptionCount: this.gameSubscriptions.size,
       priceSubscriptionCount: this.priceSubscriptions.size,
+      cryptoPriceSubscriptionCount: this.cryptoPriceSubscriptions.size,
     };
   }
 }

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -2,6 +2,7 @@ import { KeyringController } from '@metamask/keyring-controller';
 import {
   AccountState,
   ConnectionStatus,
+  CryptoPriceUpdateCallback,
   GameUpdateCallback,
   GeoBlockResponse,
   GetBalanceParams,
@@ -31,6 +32,7 @@ import { PredictFeatureFlags } from '../types/flags';
 export type {
   AccountState,
   ConnectionStatus,
+  CryptoPriceUpdateCallback,
   GameUpdateCallback,
   GeoBlockResponse,
   GetBalanceParams,
@@ -168,6 +170,11 @@ export interface PredictProvider {
   subscribeToMarketPrices?(
     tokenIds: string[],
     callback: PriceUpdateCallback,
+  ): () => void;
+
+  subscribeToCryptoPrices?(
+    symbols: string[],
+    callback: CryptoPriceUpdateCallback,
   ): () => void;
 
   getMarketSeries?(params: GetSeriesParams): Promise<PredictMarket[]>;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -253,6 +253,12 @@ export interface PriceUpdate {
   bestAsk: number;
 }
 
+export interface CryptoPriceUpdate {
+  symbol: string;
+  price: number;
+  timestamp: number;
+}
+
 export type PredictOutcome = {
   id: string;
   providerId: string;
@@ -598,10 +604,12 @@ export interface GeoBlockResponse {
 export interface ConnectionStatus {
   sportsConnected: boolean;
   marketConnected: boolean;
+  rtdsConnected: boolean;
 }
 
 export type GameUpdateCallback = (update: GameUpdate) => void;
 export type PriceUpdateCallback = (updates: PriceUpdate[]) => void;
+export type CryptoPriceUpdateCallback = (update: CryptoPriceUpdate) => void;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PrepareDepositParams {}


### PR DESCRIPTION
## **Description**

Adds a third WebSocket connection type (RTDS) to the existing `WebSocketManager` singleton for Polymarket's real-time crypto price stream (`wss://ws-live-data.polymarket.com`), following the same lifecycle patterns as the existing sports and market connections.

This provides the live BTC/USD (and other crypto) price stream consumed by the `LiveScrollingChart`. The RTDS connection subscribes to the `crypto_prices` topic (server streams all symbols; filtering is done client-side by the subscription key), sends a heartbeat every 5 seconds per the RTDS protocol, and throttles price callbacks to ~60fps (~16ms intervals) to avoid overwhelming the chart renderer. The throttle rate is configurable via `DEFAULT_THROTTLE_INTERVAL_MS` for tuning on lower-end devices.

The connection is wired through the full provider → controller → hook stack: `WebSocketManager` → `PolymarketProvider` → `PredictController` → `useLiveCryptoPrices` hook.

**Key behaviors:**

- Reconnects on disconnect with exponential backoff (same pattern as sports/market)
- Pauses on app background via AppState listener, resumes on foreground — no RTDS traffic while backgrounded
- Cleans up subscriptions on unmount (no memory leaks)
- Throttle buffer overwrites per symbol, delivering only the latest price on each flush
- Client-side symbol filtering: server streams all crypto prices, subscribers only receive updates for their requested symbols

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: RTDS WebSocket crypto price streaming

  Scenario: Live crypto price updates appear on market detail chart
    Given the user is on a crypto market detail screen with a LiveScrollingChart
    And the device has network connectivity

    When the RTDS WebSocket connects to wss://ws-live-data.polymarket.com
    Then the chart receives throttled price updates at ~60fps
    And the displayed BTC/USD price reflects the live stream

  Scenario: RTDS connection pauses when app is backgrounded
    Given the user is viewing a crypto market detail screen with an active RTDS connection

    When the user backgrounds the app
    Then the RTDS WebSocket disconnects
    And no crypto price traffic is sent or received

    When the user foregrounds the app
    Then the RTDS WebSocket reconnects
    And live price updates resume on the chart

  Scenario: RTDS connection recovers after network interruption
    Given the user is viewing a crypto market detail screen with an active RTDS connection

    When the network connection drops
    Then the RTDS WebSocket attempts to reconnect with exponential backoff
    And the connection is restored when network returns within 5 attempts

  Scenario: RTDS connection cleans up on screen exit
    Given the user is viewing a crypto market detail screen with an active RTDS connection

    When the user navigates away from the market detail screen
    Then the RTDS WebSocket subscription is removed
    And the WebSocket disconnects if no other crypto price subscribers remain
```


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

(UI not shipped to production - just showing debug)
<img width="391" height="173" alt="Screenshot 2026-04-09 at 7 51 21 PM" src="https://github.com/user-attachments/assets/f456cd71-8627-4819-906f-8f2f46de5078" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new real-time WebSocket channel with reconnection, heartbeat, and throttled buffering; mistakes could impact live updates, resource usage, or connection lifecycle across the app.
> 
> **Overview**
> Adds end-to-end support for **live crypto price streaming** in Predict via a new RTDS WebSocket (`wss://ws-live-data.polymarket.com`) alongside the existing sports/market sockets.
> 
> `WebSocketManager` now manages RTDS connection lifecycle (subscribe/unsubscribe, background/foreground disconnect+reconnect, exponential backoff, 5s ping, and ~16ms throttled callback flush), plumbed through `PolymarketProvider`/`PredictController` with a new `subscribeToCryptoPrices` API and `ConnectionStatus.rtdsConnected`.
> 
> Introduces `useLiveCryptoPrices` hook to maintain a symbol→latest price map, expose `getPrice`, track last update time, and poll connection status; adds comprehensive unit tests across controller/provider/manager/hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e148dc24449f9eaa567be5bda1732f9c5be24324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->