### PR TITLE
fix: include clientId and clientVersion in bridge token api requests

### DIFF
--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -71,7 +71,8 @@ describe('usePopularTokens', () => {
           headers: {
             'Content-Type': 'application/json',
             // Initial fetch may not have a bearer token
-            Authorization: 'Bearer ',
+            'Client-Version': expect.any(String),
+            'X-Client-Id': 'mobile',
           },
           body: JSON.stringify({
             chainIds: [MOCK_CHAIN_IDS.ethereum],

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
 import { CaipChainId, CaipAssetType } from '@metamask/utils';
+import { BridgeClientId, getClientHeaders } from '@metamask/bridge-controller';
 import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import { TokenRwaData } from '@metamask/assets-controllers';
 import Engine from '../../../../core/Engine';
+import { getBaseSemVerVersion } from '../../../../util/version';
 
 export interface PopularToken {
   assetId: CaipAssetType;
@@ -157,7 +159,11 @@ export const usePopularTokens = ({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              Authorization: `Bearer ${bearerToken ?? ''}`,
+              ...getClientHeaders({
+                clientId: BridgeClientId.MOBILE,
+                clientVersion: getBaseSemVerVersion(),
+                jwt: bearerToken ?? '',
+              }),
             },
             body: JSON.stringify({
               chainIds,

--- a/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
@@ -69,7 +69,8 @@ describe('useSearchTokens', () => {
           headers: {
             'Content-Type': 'application/json',
             // Initial fetch may not have a bearer token
-            Authorization: 'Bearer ',
+            'Client-Version': expect.any(String),
+            'X-Client-Id': 'mobile',
           },
           body: expect.stringContaining('test query'),
         }),

--- a/app/components/UI/Bridge/hooks/useSearchTokens.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.ts
@@ -1,9 +1,11 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import { debounce } from 'lodash';
 import { CaipChainId } from '@metamask/utils';
+import { BridgeClientId, getClientHeaders } from '@metamask/bridge-controller';
 import { PopularToken, IncludeAsset } from './usePopularTokens';
 import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import Engine from '../../../../core/Engine';
+import { getBaseSemVerVersion } from '../../../../util/version';
 
 const MIN_SEARCH_LENGTH = 3;
 
@@ -130,7 +132,11 @@ export const useSearchTokens = ({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              Authorization: `Bearer ${bearerToken ?? ''}`,
+              ...getClientHeaders({
+                clientId: BridgeClientId.MOBILE,
+                clientVersion: getBaseSemVerVersion(),
+                jwt: bearerToken ?? '',
+              }),
             },
             body: JSON.stringify(requestBody),
           },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds the client id and version to popular and search api calls so the backend can apply platform and version specific logic

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: include clientId and clientVersion in bridge token api requests


## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - no user facing changes

<!-- [screenshots/recordings] -->

### **After**

N/A - no user facing changes

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Bridge token API requests to change how auth/client metadata headers are constructed; if header formatting differs from backend expectations it could affect token search/popular results.
> 
> **Overview**
> Bridge token requests for `getTokens/popular` and `getTokens/search` now use `getClientHeaders` to send *client metadata* (`X-Client-Id: mobile` and `Client-Version` from `getBaseSemVerVersion()`), rather than manually setting only the `Authorization` bearer header.
> 
> Tests for both hooks were updated to assert the new header shape (including client headers even when the bearer token is empty).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047fa6a3d62861565e8094624cfff7711da0ae67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->