### PR TITLE
fix(predict): wires homepage_positions entry_point on Predict Feed Viewed event

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -4,6 +4,7 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictionsSection from './PredictionsSection';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PREDICT_CLAIM_BUTTON_TEST_IDS } from '../../../../UI/Predict/components/PredictActionButtons/PredictClaimButton.testIds';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 
 const mockNavigate = jest.fn();
 const mockClaim = jest.fn();
@@ -231,6 +232,33 @@ describe('PredictionsSection', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
+    });
+  });
+
+  it('navigates with homepage_positions entry_point when positions section title is pressed', () => {
+    mockUsePredictPositionsForHomepage.mockImplementation(
+      ({
+        claimable = false,
+      }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+        positions: claimable ? [] : mockActivePositions,
+        isLoading: false,
+        error: null,
+        totalClaimableValue: 0,
+        refetch: jest.fn(),
+      }),
+    );
+
+    renderWithProvider(
+      <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    fireEvent.press(screen.getByText('Predictions'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+      },
     });
   });
 
@@ -637,6 +665,32 @@ describe('PredictionsSection', () => {
       );
 
       expect(screen.getByText('Test Position 1')).toBeOnTheScreen();
+    });
+
+    it('navigates with homepage_positions entry_point on title press', () => {
+      mockUsePredictPositionsForHomepage.mockReturnValue({
+        positions: mockActivePositions,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictionsSection
+          sectionIndex={0}
+          totalSectionsLoaded={5}
+          mode="positions-only"
+        />,
+      );
+
+      fireEvent.press(screen.getByText('Predictions'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+        },
+      });
     });
 
     it('returns null when no positions after loading', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -241,6 +241,15 @@ const usePredictNavigationHandlers = () => {
     });
   }, [navigation]);
 
+  const handleViewAllFromPositions = useCallback(() => {
+    navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+      },
+    });
+  }, [navigation]);
+
   const handlePositionPress = useCallback(
     (position: PredictPosition) => {
       navigation.navigate(Routes.PREDICT.ROOT, {
@@ -255,7 +264,11 @@ const usePredictNavigationHandlers = () => {
     [navigation],
   );
 
-  return { handleViewAllPredictions, handlePositionPress };
+  return {
+    handleViewAllPredictions,
+    handleViewAllFromPositions,
+    handlePositionPress,
+  };
 };
 
 const usePredictPositionsSectionData = () => {
@@ -333,8 +346,11 @@ const PredictionsSectionDefault = forwardRef<
     const queryClient = useQueryClient();
     const title = titleOverride ?? strings('homepage.sections.predictions');
     const analyticsName = sectionNameOverride ?? HomeSectionNames.PREDICT;
-    const { handleViewAllPredictions, handlePositionPress } =
-      usePredictNavigationHandlers();
+    const {
+      handleViewAllPredictions,
+      handleViewAllFromPositions,
+      handlePositionPress,
+    } = usePredictNavigationHandlers();
     const {
       privacyMode,
       positions,
@@ -397,7 +413,7 @@ const PredictionsSectionDefault = forwardRef<
         <View ref={sectionViewRef} onLayout={onLayout}>
           <HomepagePredictPositions
             title={title}
-            onViewAll={handleViewAllPredictions}
+            onViewAll={handleViewAllFromPositions}
             privacyMode={privacyMode}
             isLoadingPositions={isLoadingPositions}
             positions={positions}
@@ -447,7 +463,7 @@ const PredictionsSectionPositionsOnly = forwardRef<
     const queryClient = useQueryClient();
     const title = titleOverride ?? strings('homepage.sections.predictions');
     const analyticsName = sectionNameOverride ?? HomeSectionNames.PREDICT;
-    const { handleViewAllPredictions, handlePositionPress } =
+    const { handleViewAllFromPositions, handlePositionPress } =
       usePredictNavigationHandlers();
     const {
       privacyMode,
@@ -494,7 +510,7 @@ const PredictionsSectionPositionsOnly = forwardRef<
       <View ref={sectionViewRef} onLayout={onLayout}>
         <HomepagePredictPositions
           title={title}
-          onViewAll={handleViewAllPredictions}
+          onViewAll={handleViewAllFromPositions}
           privacyMode={privacyMode}
           isLoadingPositions={isLoadingPositions}
           positions={positions}


### PR DESCRIPTION
## **Description**

The `Predict Feed Viewed` event's `entry_point` property was never populated with `homepage_positions` because the homepage `PredictionsSection` navigated to the PredictFeed without passing an `entryPoint` param. The "View All" button in the positions section called `handleViewAllPredictions` which omitted the entry point, so all feed navigations from the positions section fired with an undefined `entry_point`.

Added a dedicated `handleViewAllFromPositions` navigation handler that passes `entryPoint: HOMEPAGE_POSITIONS` when "View All" is tapped from the positions section. Applied to both `default` and `positions-only` section modes. The trending markets "View All" remains unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict Feed Viewed entry_point tracking from homepage positions

  Scenario: View All from positions section fires Predict Feed Viewed with homepage_positions
    Given the user is on the homepage
    And the user has active predict positions visible in the Predictions section

    When the user taps "View All" on the Predictions positions section header
    Then the Predict Feed screen opens
    And a "Predict Feed Viewed" event fires with entry_point = "homepage_positions"

  Scenario: View All from trending markets section fires Predict Feed Viewed without positions entry_point
    Given the user is on the homepage
    And the user has no active predict positions
    And trending prediction markets are visible

    When the user taps "View All" on the Predictions trending section header
    Then the Predict Feed screen opens
    And a "Predict Feed Viewed" event fires without entry_point = "homepage_positions"
```


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
