### PR TITLE
fix: compliance env

### DIFF
--- a/app/core/Engine/controllers/compliance/compliance-service-init.test.ts
+++ b/app/core/Engine/controllers/compliance/compliance-service-init.test.ts
@@ -9,6 +9,16 @@ import {
 import { ControllerInitRequest } from '../../types';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
+jest.mock('../../../../util/environment', () => ({
+  isProduction: jest.fn(),
+}));
+
+import { isProduction } from '../../../../util/environment';
+
+const mockIsProduction = isProduction as jest.MockedFunction<
+  typeof isProduction
+>;
+
 function getInitRequestMock(): jest.Mocked<
   ControllerInitRequest<ComplianceServiceMessenger>
 > {
@@ -28,7 +38,20 @@ describe('complianceServiceInit', () => {
   });
 
   it('instantiates the ComplianceService', () => {
+    mockIsProduction.mockReturnValue(false);
     const { controller } = complianceServiceInit(getInitRequestMock());
     expect(controller).toBeInstanceOf(ComplianceService);
+  });
+
+  it('passes env=production when isProduction() returns true', () => {
+    mockIsProduction.mockReturnValue(true);
+    complianceServiceInit(getInitRequestMock());
+    expect(mockIsProduction).toHaveReturnedWith(true);
+  });
+
+  it('passes env=development when isProduction() returns false', () => {
+    mockIsProduction.mockReturnValue(false);
+    complianceServiceInit(getInitRequestMock());
+    expect(mockIsProduction).toHaveReturnedWith(false);
   });
 });

--- a/app/core/Engine/controllers/compliance/compliance-service-init.ts
+++ b/app/core/Engine/controllers/compliance/compliance-service-init.ts
@@ -3,6 +3,7 @@ import {
   type ComplianceServiceMessenger,
 } from '@metamask/compliance-controller';
 import type { ControllerInitFunction } from '../../types';
+import { isProduction } from '../../../../util/environment';
 
 /**
  * Initialize the ComplianceService.
@@ -18,7 +19,7 @@ export const complianceServiceInit: ControllerInitFunction<
   const controller = new ComplianceService({
     messenger: controllerMessenger,
     fetch,
-    env: __DEV__ ? 'development' : 'production',
+    env: isProduction() ? 'production' : 'development',
   });
 
   return { controller };


### PR DESCRIPTION
## **Description**

`ComplianceService` was initialised with `env` derived from React Native's `__DEV__` flag, which reflects the JS bundle mode rather than the actual build environment. On a `main-exp` release binary running a dev JS bundle, this silently routed compliance API calls to the wrong endpoint.

The fix replaces `__DEV__` with `isProduction()` (`METAMASK_ENVIRONMENT === 'production'`), so only App Store production builds hit the production compliance API — all other environments (`exp`, `beta`, `rc`, `dev`) use the development API.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Compliance API environment routing

  Scenario: production build routes to the production compliance API
    Given the app is built with METAMASK_ENVIRONMENT=production
    When ComplianceService is initialised
    Then env=production is passed to the service constructor

  Scenario: non-production build routes to the development compliance API
    Given the app is built with METAMASK_ENVIRONMENT=exp (or any non-production value)
    When ComplianceService is initialised
    Then env=development is passed to the service constructor
```

## **Screenshots/Recordings**

N/A — no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `ComplianceService` selects production vs development endpoints, which can affect where compliance requests are sent at runtime. Scope is small but impacts a network-facing service configuration.
> 
> **Overview**
> `ComplianceService` initialization now derives its `env` from `isProduction()` (based on `METAMASK_ENVIRONMENT`) instead of React Native’s `__DEV__` flag, preventing release builds running dev bundles from routing compliance calls to the wrong environment.
> 
> Updates the unit test to mock `isProduction()` and add coverage for the production/development selection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e66fc567abc03e312f99db396e4e1c05caabd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->