### PR TITLE
fix: persist chart type in state

### DIFF
--- a/app/actions/user/index.ts
+++ b/app/actions/user/index.ts
@@ -1,4 +1,5 @@
 import { type AppThemeKey } from '../../util/theme/models';
+import { type ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 import {
   type LockAppAction,
   type CheckForDeeplinkAction,
@@ -24,6 +25,7 @@ import {
   type SetMultichainAccountsIntroModalSeenAction,
   type SetMusdConversionEducationSeenAction,
   type SetMusdConversionAssetDetailCtaSeenAction,
+  type SetTokenOverviewChartTypeAction,
   UserActionType,
 } from './types';
 
@@ -211,5 +213,17 @@ export function setMusdConversionAssetDetailCtaSeen(
   return {
     type: UserActionType.SET_MUSD_CONVERSION_ASSET_DETAIL_CTA_SEEN,
     payload: { key },
+  };
+}
+
+/**
+ * Action to set token overview chart type preference
+ */
+export function setTokenOverviewChartType(
+  chartType: ChartType,
+): SetTokenOverviewChartTypeAction {
+  return {
+    type: UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE,
+    payload: { chartType },
   };
 }

--- a/app/actions/user/types.ts
+++ b/app/actions/user/types.ts
@@ -1,5 +1,6 @@
 import { type AppThemeKey } from '../../util/theme/models';
 import { type Action } from 'redux';
+import { type ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 
 // Action type enum
 export enum UserActionType {
@@ -27,6 +28,7 @@ export enum UserActionType {
   SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN = 'SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN',
   SET_MUSD_CONVERSION_EDUCATION_SEEN = 'SET_MUSD_CONVERSION_EDUCATION_SEEN',
   SET_MUSD_CONVERSION_ASSET_DETAIL_CTA_SEEN = 'SET_MUSD_CONVERSION_ASSET_DETAIL_CTA_SEEN',
+  SET_TOKEN_OVERVIEW_CHART_TYPE = 'SET_TOKEN_OVERVIEW_CHART_TYPE',
 }
 
 // User actions
@@ -107,6 +109,11 @@ export type SetMusdConversionAssetDetailCtaSeenAction =
     payload: { key: string };
   };
 
+export type SetTokenOverviewChartTypeAction =
+  Action<UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE> & {
+    payload: { chartType: ChartType };
+  };
+
 /**
  * User actions union type
  */
@@ -134,4 +141,5 @@ export type UserAction =
   | SetIsConnectionRemovedAction
   | SetMultichainAccountsIntroModalSeenAction
   | SetMusdConversionEducationSeenAction
-  | SetMusdConversionAssetDetailCtaSeenAction;
+  | SetMusdConversionAssetDetailCtaSeenAction
+  | SetTokenOverviewChartTypeAction;

--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -8,6 +8,15 @@ import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock'
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
 
+jest.mock('react-redux', () => {
+  const actual = jest.requireActual('react-redux');
+  return {
+    ...actual,
+    useSelector: jest.fn(() => 2), // ChartType.Line = 2
+    useDispatch: jest.fn(() => jest.fn()),
+  };
+});
+
 jest.mock('react-native-skeleton-placeholder', () => {
   const { View } = jest.requireActual('react-native');
   const MockSkeleton = ({ children }: { children: React.ReactNode }) => (

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { Dimensions, View } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import Svg, { Path } from 'react-native-svg';
 import { strings } from '../../../../../locales/i18n';
@@ -18,6 +19,7 @@ import { TokenOverviewSelectorsIDs } from '../TokenOverview.testIds';
 import { TokenI } from '../../Tokens/types';
 import { formatAddressToAssetId } from '@metamask/bridge-controller';
 import { Hex } from '@metamask/utils';
+import { normalizeTokenAddress } from '../../Bridge/utils/tokenUtils';
 import AdvancedChart from '../../Charts/AdvancedChart/AdvancedChart';
 import { advancedChartLineChromePresets } from '../../Charts/AdvancedChart/advancedChartLineChrome.presets';
 import {
@@ -41,6 +43,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { selectTokenOverviewChartType } from '../../../../reducers/user/selectors';
+import { setTokenOverviewChartType } from '../../../../actions/user';
 
 const EMPTY_INDICATORS: IndicatorType[] = [];
 
@@ -124,9 +128,10 @@ const PriceAdvanced = ({
   comparePrice,
   isLoading,
 }: PriceAdvancedProps) => {
+  const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const [timeRange, setTimeRange] = useState<TimeRange>('1D');
-  const [chartType, setChartType] = useState<ChartType>(ChartType.Line);
+  const chartType = useSelector(selectTokenOverviewChartType) ?? ChartType.Line;
   const [crosshairData, setCrosshairData] = useState<CrosshairData | null>(
     null,
   );
@@ -168,8 +173,8 @@ const PriceAdvanced = ({
         })
         .build(),
     );
-    setChartType(next);
-  }, [chartType, createEventBuilder, trackEvent]);
+    dispatch(setTokenOverviewChartType(next));
+  }, [chartType, createEventBuilder, trackEvent, dispatch]);
 
   const handleTimeRangeSelect = useCallback(
     (range: TimeRange) => {

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -130,7 +130,7 @@ const PriceAdvanced = ({
   const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const [timeRange, setTimeRange] = useState<TimeRange>('1D');
-  const chartType = useSelector(selectTokenOverviewChartType) ?? ChartType.Line;
+  const chartType = useSelector(selectTokenOverviewChartType);
   const [crosshairData, setCrosshairData] = useState<CrosshairData | null>(
     null,
   );

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -19,7 +19,6 @@ import { TokenOverviewSelectorsIDs } from '../TokenOverview.testIds';
 import { TokenI } from '../../Tokens/types';
 import { formatAddressToAssetId } from '@metamask/bridge-controller';
 import { Hex } from '@metamask/utils';
-import { normalizeTokenAddress } from '../../Bridge/utils/tokenUtils';
 import AdvancedChart from '../../Charts/AdvancedChart/AdvancedChart';
 import { advancedChartLineChromePresets } from '../../Charts/AdvancedChart/advancedChartLineChrome.presets';
 import {

--- a/app/components/UI/AssetOverview/Price/Price.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.test.tsx
@@ -5,6 +5,8 @@ import Price from './Price';
 import type { TokenI } from '../../Tokens/types';
 import { PriceChartProvider } from '../PriceChart/PriceChart.context';
 import { selectTokenOverviewAdvancedChartEnabled } from '../../../../selectors/featureFlagController/tokenOverviewAdvancedChart';
+import { selectTokenOverviewChartType } from '../../../../reducers/user/selectors';
+import { ChartType } from '../../Charts/AdvancedChart/AdvancedChart.types';
 
 jest.mock('../../Bridge/hooks/useRWAToken', () => ({
   useRWAToken: () => ({
@@ -18,6 +20,7 @@ jest.mock('react-redux', () => {
   return {
     ...actual,
     useSelector: jest.fn(),
+    useDispatch: jest.fn(() => jest.fn()),
   };
 });
 
@@ -94,6 +97,9 @@ describe('Price Component', () => {
       if (selector === selectTokenOverviewAdvancedChartEnabled) {
         return false;
       }
+      if (selector === selectTokenOverviewChartType) {
+        return ChartType.Line;
+      }
       return undefined;
     });
   });
@@ -102,6 +108,9 @@ describe('Price Component', () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectTokenOverviewAdvancedChartEnabled) {
         return true;
+      }
+      if (selector === selectTokenOverviewChartType) {
+        return ChartType.Line;
       }
       return undefined;
     });
@@ -116,6 +125,9 @@ describe('Price Component', () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectTokenOverviewAdvancedChartEnabled) {
         return true;
+      }
+      if (selector === selectTokenOverviewChartType) {
+        return ChartType.Line;
       }
       return undefined;
     });
@@ -137,6 +149,9 @@ describe('Price Component', () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectTokenOverviewAdvancedChartEnabled) {
         return true;
+      }
+      if (selector === selectTokenOverviewChartType) {
+        return ChartType.Line;
       }
       return undefined;
     });

--- a/app/reducers/user/index.test.ts
+++ b/app/reducers/user/index.test.ts
@@ -1,0 +1,63 @@
+import userReducer, { userInitialState } from './index';
+import {
+  UserActionType,
+  type SetTokenOverviewChartTypeAction,
+} from '../../actions/user/types';
+import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
+
+describe('user reducer', () => {
+  describe('initial state', () => {
+    it('should have ChartType.Line as default tokenOverviewChartType', () => {
+      expect(userInitialState.tokenOverviewChartType).toBe(ChartType.Line);
+    });
+  });
+
+  describe('SET_TOKEN_OVERVIEW_CHART_TYPE', () => {
+    it('should update tokenOverviewChartType to Candles', () => {
+      const action: SetTokenOverviewChartTypeAction = {
+        type: UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE,
+        payload: { chartType: ChartType.Candles },
+      };
+
+      const newState = userReducer(userInitialState, action);
+
+      expect(newState.tokenOverviewChartType).toBe(ChartType.Candles);
+    });
+
+    it('should update tokenOverviewChartType to Line', () => {
+      const currentState = {
+        ...userInitialState,
+        tokenOverviewChartType: ChartType.Candles,
+      };
+
+      const action: SetTokenOverviewChartTypeAction = {
+        type: UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE,
+        payload: { chartType: ChartType.Line },
+      };
+
+      const newState = userReducer(currentState, action);
+
+      expect(newState.tokenOverviewChartType).toBe(ChartType.Line);
+    });
+
+    it('should not modify other state properties', () => {
+      const currentState = {
+        ...userInitialState,
+        userLoggedIn: true,
+        seedphraseBackedUp: true,
+        tokenOverviewChartType: ChartType.Line,
+      };
+
+      const action: SetTokenOverviewChartTypeAction = {
+        type: UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE,
+        payload: { chartType: ChartType.Candles },
+      };
+
+      const newState = userReducer(currentState, action);
+
+      expect(newState.userLoggedIn).toBe(true);
+      expect(newState.seedphraseBackedUp).toBe(true);
+      expect(newState.tokenOverviewChartType).toBe(ChartType.Candles);
+    });
+  });
+});

--- a/app/reducers/user/index.test.ts
+++ b/app/reducers/user/index.test.ts
@@ -7,13 +7,13 @@ import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChar
 
 describe('user reducer', () => {
   describe('initial state', () => {
-    it('should have ChartType.Line as default tokenOverviewChartType', () => {
+    it('has ChartType.Line as default tokenOverviewChartType', () => {
       expect(userInitialState.tokenOverviewChartType).toBe(ChartType.Line);
     });
   });
 
   describe('SET_TOKEN_OVERVIEW_CHART_TYPE', () => {
-    it('should update tokenOverviewChartType to Candles', () => {
+    it('updates tokenOverviewChartType to Candles', () => {
       const action: SetTokenOverviewChartTypeAction = {
         type: UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE,
         payload: { chartType: ChartType.Candles },
@@ -24,7 +24,7 @@ describe('user reducer', () => {
       expect(newState.tokenOverviewChartType).toBe(ChartType.Candles);
     });
 
-    it('should update tokenOverviewChartType to Line', () => {
+    it('updates tokenOverviewChartType to Line', () => {
       const currentState = {
         ...userInitialState,
         tokenOverviewChartType: ChartType.Candles,
@@ -40,7 +40,7 @@ describe('user reducer', () => {
       expect(newState.tokenOverviewChartType).toBe(ChartType.Line);
     });
 
-    it('should not modify other state properties', () => {
+    it('does not modify other state properties', () => {
       const currentState = {
         ...userInitialState,
         userLoggedIn: true,

--- a/app/reducers/user/index.ts
+++ b/app/reducers/user/index.ts
@@ -1,6 +1,7 @@
 import { UserAction, UserActionType } from '../../actions/user/types';
 import { AppThemeKey } from '../../util/theme/models';
 import { UserState } from './types';
+import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 
 export * from './types';
 
@@ -28,6 +29,7 @@ export const userInitialState: UserState = {
   multichainAccountsIntroModalSeen: false,
   musdConversionEducationSeen: false,
   musdConversionAssetDetailCtasSeen: {},
+  tokenOverviewChartType: ChartType.Line,
 };
 
 /**
@@ -147,6 +149,11 @@ const userReducer = (
           ...state.musdConversionAssetDetailCtasSeen,
           [action.payload.key]: true,
         },
+      };
+    case UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE:
+      return {
+        ...state,
+        tokenOverviewChartType: action.payload.chartType,
       };
     default:
       return state;

--- a/app/reducers/user/selectors.test.ts
+++ b/app/reducers/user/selectors.test.ts
@@ -20,7 +20,7 @@ const mockState = {
     isConnectionRemoved: false,
     musdConversionEducationSeen: false,
     musdConversionAssetDetailCtasSeen: {} as Record<string, boolean>,
-    tokenOverviewChartType: ChartType.Line,
+    tokenOverviewChartType: ChartType.Line as ChartType,
   },
 };
 

--- a/app/reducers/user/selectors.test.ts
+++ b/app/reducers/user/selectors.test.ts
@@ -143,7 +143,7 @@ describe('user state selectors', () => {
       expect(result.current).toBe(ChartType.Candles);
     });
 
-    it('returns undefined when tokenOverviewChartType is not set', () => {
+    it('returns ChartType.Line default when tokenOverviewChartType is not set', () => {
       // @ts-expect-error - Testing undefined state
       mockState.user.tokenOverviewChartType = undefined;
 
@@ -151,7 +151,7 @@ describe('user state selectors', () => {
         useSelector(selectTokenOverviewChartType),
       );
 
-      expect(result.current).toBeUndefined();
+      expect(result.current).toBe(ChartType.Line);
     });
   });
 });

--- a/app/reducers/user/selectors.test.ts
+++ b/app/reducers/user/selectors.test.ts
@@ -8,7 +8,9 @@ import {
   selectUserState,
   selectMusdConversionEducationSeen,
   selectMusdConversionAssetDetailCtasSeen,
+  selectTokenOverviewChartType,
 } from './selectors';
+import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 
 // Mock the redux store state
 const mockState = {
@@ -18,6 +20,7 @@ const mockState = {
     isConnectionRemoved: false,
     musdConversionEducationSeen: false,
     musdConversionAssetDetailCtasSeen: {} as Record<string, boolean>,
+    tokenOverviewChartType: ChartType.Line,
   },
 };
 
@@ -116,6 +119,39 @@ describe('user state selectors', () => {
         '0x1-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': true,
         '0xe708-0xdac17f958d2ee523a2206206994597c13d831ec7': true,
       });
+    });
+  });
+
+  describe('selectTokenOverviewChartType', () => {
+    it('returns ChartType.Line when chart type is set to Line', () => {
+      mockState.user.tokenOverviewChartType = ChartType.Line;
+
+      const { result } = renderHook(() =>
+        useSelector(selectTokenOverviewChartType),
+      );
+
+      expect(result.current).toBe(ChartType.Line);
+    });
+
+    it('returns ChartType.Candles when chart type is set to Candles', () => {
+      mockState.user.tokenOverviewChartType = ChartType.Candles;
+
+      const { result } = renderHook(() =>
+        useSelector(selectTokenOverviewChartType),
+      );
+
+      expect(result.current).toBe(ChartType.Candles);
+    });
+
+    it('returns undefined when tokenOverviewChartType is not set', () => {
+      // @ts-expect-error - Testing undefined state
+      mockState.user.tokenOverviewChartType = undefined;
+
+      const { result } = renderHook(() =>
+        useSelector(selectTokenOverviewChartType),
+      );
+
+      expect(result.current).toBeUndefined();
     });
   });
 });

--- a/app/reducers/user/selectors.ts
+++ b/app/reducers/user/selectors.ts
@@ -55,3 +55,9 @@ export const selectMusdConversionEducationSeen = (state: RootState) =>
  */
 export const selectMusdConversionAssetDetailCtasSeen = (state: RootState) =>
   state.user?.musdConversionAssetDetailCtasSeen ?? {};
+
+/**
+ * Selects the token overview chart type preference
+ */
+export const selectTokenOverviewChartType = (state: RootState) =>
+  state.user?.tokenOverviewChartType;

--- a/app/reducers/user/selectors.ts
+++ b/app/reducers/user/selectors.ts
@@ -1,4 +1,5 @@
 import { RootState } from '..';
+import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 
 /**
  * Selects the user state
@@ -60,4 +61,4 @@ export const selectMusdConversionAssetDetailCtasSeen = (state: RootState) =>
  * Selects the token overview chart type preference
  */
 export const selectTokenOverviewChartType = (state: RootState) =>
-  state.user?.tokenOverviewChartType;
+  state.user?.tokenOverviewChartType ?? ChartType.Line;

--- a/app/reducers/user/types.ts
+++ b/app/reducers/user/types.ts
@@ -1,4 +1,5 @@
 import { AppThemeKey } from '../../util/theme/models';
+import { ChartType } from '../../components/UI/Charts/AdvancedChart/AdvancedChart.types';
 
 /**
  * User state
@@ -22,4 +23,5 @@ export interface UserState {
   multichainAccountsIntroModalSeen: boolean;
   musdConversionEducationSeen: boolean;
   musdConversionAssetDetailCtasSeen: Record<string, boolean>;
+  tokenOverviewChartType: ChartType;
 }


### PR DESCRIPTION


## **Description**

Implemented persistent chart type preference (Line vs Candlestick) for Advanced Charts across all asset pages using Redux user state with automatic persistence via redux-persist.

## Problem
When users switched between Line and Candlestick chart types, the preference was not saved. Upon navigating away and returning to any token details page, the chart would always default to Line chart.

## Solution
Store the chart type preference in Redux `user` state, which is automatically persisted to filesystem storage via `redux-persist`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Persist chart type upon switch in user state

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3034

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Redux state extension and wiring change; low risk aside from potential regressions in chart type toggle behavior and persisted-state defaults.
> 
> **Overview**
> Persists the Advanced Token Overview chart type (line vs candlestick) by moving `chartType` from local component state into Redux `user` state.
> 
> Adds `UserActionType.SET_TOKEN_OVERVIEW_CHART_TYPE`, `setTokenOverviewChartType`, `tokenOverviewChartType` in the user reducer (defaulting to `ChartType.Line`), plus `selectTokenOverviewChartType`; updates `Price.advanced` to read/write this preference via `useSelector`/`dispatch`, and adjusts/extends unit tests for the component, selector, and reducer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3991d04b9cc01c8a773525bbb55299e0aced82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->