### PR TITLE
fix: prevent infinite provider alternation when all providers return empty payment methods

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -1312,10 +1312,9 @@ describe('BuildQuote', () => {
         mockUseParams.mockReturnValue({ assetId: BTC_ASSET });
 
         renderWithProvider(<BuildQuote />, { state: autoSelectedState });
-        act(() => {
-          jest.advanceTimersByTime(650);
-        });
 
+        // The effect should immediately switch to coinbase (which
+        // supports BTC) and return early — no modal timer started.
         expect(mockSetSelectedProvider).toHaveBeenCalledWith(coinbaseProvider, {
           autoSelected: true,
         });
@@ -1371,6 +1370,80 @@ describe('BuildQuote', () => {
         });
 
         expect(mockSetSelectedProvider).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(
+          'RampModals',
+          expect.objectContaining({
+            screen: 'RampTokenNotAvailableModal',
+          }),
+        );
+      });
+
+      it('switches at most once then shows modal when alternative also fails', () => {
+        const SOL_ASSET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+
+        const robinhoodProvider = {
+          id: '/providers/robinhood',
+          name: 'Robinhood',
+          supportedCryptoCurrencies: {
+            [TOKEN_ASSET]: true,
+            [SOL_ASSET]: true,
+          },
+          links: [],
+        };
+
+        const moonpayProvider = {
+          id: '/providers/moonpay',
+          name: 'Moonpay',
+          supportedCryptoCurrencies: {
+            [TOKEN_ASSET]: true,
+            [SOL_ASSET]: true,
+          },
+          links: [],
+        };
+
+        // First render: PayPal is selected, SOL token, empty payment methods.
+        mockUnavailableController({
+          selectedProvider: paypalProvider,
+          providers: [paypalProvider, robinhoodProvider, moonpayProvider],
+          selectedToken: {
+            assetId: SOL_ASSET,
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            symbol: 'SOL',
+          },
+        });
+        mockUseParams.mockReturnValue({ assetId: SOL_ASSET });
+
+        const { rerender } = renderWithProvider(<BuildQuote />, {
+          state: autoSelectedState,
+        });
+
+        // First (and only) switch: PayPal -> Robinhood
+        expect(mockSetSelectedProvider).toHaveBeenCalledWith(
+          robinhoodProvider,
+          { autoSelected: true },
+        );
+
+        // Simulate Robinhood also returning empty payment methods.
+        mockSetSelectedProvider.mockClear();
+        mockNavigate.mockClear();
+        mockUnavailableController({
+          selectedProvider: robinhoodProvider,
+          providers: [paypalProvider, robinhoodProvider, moonpayProvider],
+          selectedToken: {
+            assetId: SOL_ASSET,
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            symbol: 'SOL',
+          },
+        });
+        rerender(<BuildQuote />);
+
+        // Should NOT switch again — attempt already used.
+        expect(mockSetSelectedProvider).not.toHaveBeenCalled();
+
+        // Should fall through to the modal.
+        act(() => {
+          jest.advanceTimersByTime(650);
+        });
         expect(mockNavigate).toHaveBeenCalledWith(
           'RampModals',
           expect.objectContaining({

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -1378,7 +1378,7 @@ describe('BuildQuote', () => {
         );
       });
 
-      it('switches at most once then shows modal when alternative also fails', () => {
+      it('tries each provider once then shows modal when all return empty', () => {
         const SOL_ASSET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
 
         const robinhoodProvider = {
@@ -1401,7 +1401,7 @@ describe('BuildQuote', () => {
           links: [],
         };
 
-        // First render: PayPal is selected, SOL token, empty payment methods.
+        // First render: PayPal selected, SOL token, empty payment methods.
         mockUnavailableController({
           selectedProvider: paypalProvider,
           providers: [paypalProvider, robinhoodProvider, moonpayProvider],
@@ -1417,7 +1417,7 @@ describe('BuildQuote', () => {
           state: autoSelectedState,
         });
 
-        // First (and only) switch: PayPal -> Robinhood
+        // First switch: PayPal -> Robinhood
         expect(mockSetSelectedProvider).toHaveBeenCalledWith(
           robinhoodProvider,
           { autoSelected: true },
@@ -1425,7 +1425,6 @@ describe('BuildQuote', () => {
 
         // Simulate Robinhood also returning empty payment methods.
         mockSetSelectedProvider.mockClear();
-        mockNavigate.mockClear();
         mockUnavailableController({
           selectedProvider: robinhoodProvider,
           providers: [paypalProvider, robinhoodProvider, moonpayProvider],
@@ -1437,10 +1436,30 @@ describe('BuildQuote', () => {
         });
         rerender(<BuildQuote />);
 
-        // Should NOT switch again — attempt already used.
+        // Second switch: Robinhood -> Moonpay (PayPal already tried)
+        expect(mockSetSelectedProvider).toHaveBeenCalledTimes(1);
+        expect(mockSetSelectedProvider).toHaveBeenCalledWith(moonpayProvider, {
+          autoSelected: true,
+        });
+
+        // Simulate Moonpay also returning empty.
+        mockSetSelectedProvider.mockClear();
+        mockNavigate.mockClear();
+        mockUnavailableController({
+          selectedProvider: moonpayProvider,
+          providers: [paypalProvider, robinhoodProvider, moonpayProvider],
+          selectedToken: {
+            assetId: SOL_ASSET,
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            symbol: 'SOL',
+          },
+        });
+        rerender(<BuildQuote />);
+
+        // All exhausted — no further switch.
         expect(mockSetSelectedProvider).not.toHaveBeenCalled();
 
-        // Should fall through to the modal.
+        // Falls through to modal.
         act(() => {
           jest.advanceTimersByTime(650);
         });
@@ -1450,6 +1469,27 @@ describe('BuildQuote', () => {
             screen: 'RampTokenNotAvailableModal',
           }),
         );
+      });
+
+      it('hides powered-by text while auto-switching between providers', () => {
+        mockUnavailableController({
+          selectedProvider: paypalProvider,
+          providers: [paypalProvider, coinbaseProvider],
+          selectedToken: {
+            assetId: BTC_ASSET,
+            chainId: 'eip155:1',
+            symbol: 'BTC',
+          },
+        });
+        mockUseParams.mockReturnValue({ assetId: BTC_ASSET });
+
+        const { queryByText } = renderWithProvider(<BuildQuote />, {
+          state: autoSelectedState,
+        });
+
+        // While the token is unavailable and provider is auto-selected,
+        // the "Powered by" text should be suppressed to prevent flash.
+        expect(queryByText(/powered by/i)).toBeNull();
       });
     });
   });

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -252,6 +252,21 @@ function BuildQuote() {
   // when the combination changes.
   const lastShownUnavailableKeyRef = useRef<string>('');
 
+  // Caps the number of silent provider auto-switches per token.
+  // Without this, when every candidate provider claims static support
+  // but returns empty payment methods the effect would cycle through
+  // all of them (flashing "Powered by X" for each) before reaching
+  // the modal — or loop forever.  A single attempt is sufficient:
+  // if the best alternative also fails, the token is almost certainly
+  // unavailable in this region so we go straight to the modal.
+  const autoSwitchAttemptedRef = useRef(false);
+  const autoSwitchAssetRef = useRef<string | undefined>();
+
+  if (effectiveAssetId !== autoSwitchAssetRef.current) {
+    autoSwitchAttemptedRef.current = false;
+    autoSwitchAssetRef.current = effectiveAssetId;
+  }
+
   // Bump a counter on screen focus so the modal effect re-evaluates
   // when the user navigates away (e.g. token selection) and comes back.
   const [focusTrigger, setFocusTrigger] = useState(0);
@@ -297,13 +312,18 @@ function BuildQuote() {
       return;
     }
 
-    if (providerAutoSelected && effectiveAssetId) {
+    if (
+      providerAutoSelected &&
+      effectiveAssetId &&
+      !autoSwitchAttemptedRef.current
+    ) {
       const supportingProvider = providers.find(
         (p) =>
           p.id !== selectedProvider?.id &&
           providerSupportsAsset(p, effectiveAssetId),
       );
       if (supportingProvider) {
+        autoSwitchAttemptedRef.current = true;
         setSelectedProvider(supportingProvider, { autoSelected: true });
         return;
       }

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -252,19 +252,15 @@ function BuildQuote() {
   // when the combination changes.
   const lastShownUnavailableKeyRef = useRef<string>('');
 
-  // Caps the number of silent provider auto-switches per token.
-  // Without this, when every candidate provider claims static support
-  // but returns empty payment methods the effect would cycle through
-  // all of them (flashing "Powered by X" for each) before reaching
-  // the modal — or loop forever.  A single attempt is sufficient:
-  // if the best alternative also fails, the token is almost certainly
-  // unavailable in this region so we go straight to the modal.
-  const autoSwitchAttemptedRef = useRef(false);
-  const autoSwitchAssetRef = useRef<string | undefined>();
+  // Tracks providers already attempted for the current token during
+  // auto-switch.  Prevents an infinite loop when every candidate
+  // provider claims static support but returns empty payment methods.
+  const triedProvidersRef = useRef<Set<string>>(new Set());
+  const triedProvidersAssetRef = useRef<string | undefined>();
 
-  if (effectiveAssetId !== autoSwitchAssetRef.current) {
-    autoSwitchAttemptedRef.current = false;
-    autoSwitchAssetRef.current = effectiveAssetId;
+  if (effectiveAssetId !== triedProvidersAssetRef.current) {
+    triedProvidersRef.current = new Set();
+    triedProvidersAssetRef.current = effectiveAssetId;
   }
 
   // Bump a counter on screen focus so the modal effect re-evaluates
@@ -312,18 +308,18 @@ function BuildQuote() {
       return;
     }
 
-    if (
-      providerAutoSelected &&
-      effectiveAssetId &&
-      !autoSwitchAttemptedRef.current
-    ) {
+    if (providerAutoSelected && effectiveAssetId) {
+      if (selectedProvider?.id) {
+        triedProvidersRef.current.add(selectedProvider.id);
+      }
+
       const supportingProvider = providers.find(
         (p) =>
           p.id !== selectedProvider?.id &&
+          !triedProvidersRef.current.has(p.id) &&
           providerSupportsAsset(p, effectiveAssetId),
       );
       if (supportingProvider) {
-        autoSwitchAttemptedRef.current = true;
         setSelectedProvider(supportingProvider, { autoSelected: true });
         return;
       }
@@ -984,7 +980,8 @@ function BuildQuote() {
                       amount={amountAsNumber}
                     />
                   ) : (
-                    selectedProvider && (
+                    selectedProvider &&
+                    !(providerAutoSelected && isTokenUnavailable) && (
                       <Text
                         variant={TextVariant.BodySm}
                         style={styles.poweredByText}


### PR DESCRIPTION
## **Description**

When a user selects a token (e.g. SOL) where multiple providers claim static support via `supportedCryptoCurrencies` but all return empty payment methods from the API, the auto-switch effect in `BuildQuote` enters an infinite loop — cycling between providers every ~370ms.

1. **What is the reason for the change?**  The `isTokenUnavailable` effect silently switches to the next provider that statically supports the token, but never checks whether that candidate was already tried. When all candidates fail, it cycles back to the first one endlessly.

2. **What is the improvement/solution?** Track which providers have already been attempted for the current token via a ref (`triedProvidersRef`). Skip already-tried providers in the `providers.find()` call. Once all candidates are exhausted, fall through to the Token Not Available modal. The set resets when the token changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3435

## **Manual testing steps**

```gherkin
Feature: Provider auto-switch does not loop infinitely

  Scenario: User selects a token where all providers return empty payment methods
    Given the user is on the Build Quote screen
    And the provider was auto-selected by the system (not manually chosen)
    And the user is in US-CA region

    When the user changes the buy token from ETH to SOL
    Then the system tries each provider that claims SOL support at most once
    And after exhausting all candidates, the Token Not Available modal is shown
    And the provider does NOT alternate rapidly between Robinhood and Moonpay

  Scenario: User selects a token where an alternative provider has payment methods
    Given the user is on the Build Quote screen
    And the provider was auto-selected by the system

    When the user changes to a token unsupported by the current provider
    And another provider supports the token with valid payment methods
    Then the system silently switches to that provider
    And no modal is shown
```

## **Screenshots/Recordings**

### **Before**

https://www.loom.com/share/ef3f1307805646478e9e6ae3aa8a088a

### **After**

<!-- Recording to be added after testing this branch -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.