### PR TITLE
fix: perps withdraw metrics, UI, and fee display improvements

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -290,6 +290,16 @@ describe('TransactionDetails', () => {
       expect(navOptions.headerLeft()).not.toBeNull();
       expect(navOptions.headerRight()).toBeNull();
     });
+
+    it('overrides headerTintColor to text.default instead of primary', () => {
+      render();
+
+      const navOptions = mockSetOptions.mock.calls[0][0];
+      expect(navOptions.headerTintColor).not.toEqual(
+        expect.stringContaining('primary'),
+      );
+      expect(navOptions.headerTintColor).toBeDefined();
+    });
   });
 
   describe('SUMMARY_SECTION_TYPES', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -42,9 +42,10 @@ export function TransactionDetails() {
   const title = getTitle(transactionMeta);
 
   useEffect(() => {
-    navigation.setOptions(
-      getNavigationOptionsTitle(title, navigation, false, colors),
-    );
+    navigation.setOptions({
+      ...getNavigationOptionsTitle(title, navigation, false, colors),
+      headerTintColor: colors.text.default,
+    });
   }, [colors, navigation, theme, title]);
 
   const showSummarySection = hasTransactionType(

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -138,6 +138,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       isMoneyAccountWithdraw && !selectedRecipientAddress;
 
     const isResultReady = useIsResultReady({ isKeyboardVisible });
+    const quotes = useTransactionPayQuotes();
+    const isQuotesLoading = useIsTransactionPayLoading();
+    const hasQuoteResults = isQuotesLoading || Boolean(quotes?.length);
 
     const {
       amountFiat,
@@ -204,6 +207,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           {!overrideContent && children}
         </Box>
         <Box gap={16}>
+          <AlertMessage alertMessage={alertMessage} />
           {!overrideContent && (
             <>
               {isMoneyAccountWithdraw && (
@@ -215,15 +219,18 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {disablePay !== true && hasTokens && <PayWithRow />}
             </>
           )}
-          <AlertMessage alertMessage={alertMessage} />
           {isResultReady && (
             <Box>
-              <BridgeFeeRow />
-              <BridgeTimeRow />
-              {canSelectWithdrawToken ? (
-                <ReceiveRow inputAmountUsd={amountFiat} />
-              ) : (
-                <TotalRow />
+              {hasQuoteResults && (
+                <>
+                  <BridgeFeeRow />
+                  <BridgeTimeRow />
+                  {canSelectWithdrawToken ? (
+                    <ReceiveRow inputAmountUsd={amountFiat} />
+                  ) : (
+                    <TotalRow />
+                  )}
+                </>
               )}
               <PercentageRow />
             </Box>

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -106,10 +106,10 @@ describe('BridgeFeeRow', () => {
     expect(queryByTestId('metamask-fee-row-skeleton')).toBeNull();
   });
 
-  it('does not render tooltip if no quotes', async () => {
+  it('renders empty fee when there are no quotes', () => {
     useTransactionPayQuotesMock.mockReturnValue([]);
-    const { queryByTestId } = render();
-    expect(queryByTestId('info-row-tooltip-open-btn')).toBeNull();
+    const { getByTestId } = render();
+    expect(getByTestId('bridge-fee-row')).toBeDefined();
   });
 
   it('includes metamask fee in transaction fee total', () => {

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -64,8 +64,10 @@ function TransactionFeeRow({
 }) {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
 
+  const hasQuotes = Boolean(quotes?.length);
+
   const feeTotalUsd = useMemo(() => {
-    if (!totals?.fees) return '';
+    if (!totals?.fees || !hasQuotes) return '';
 
     const metaMask = totals.fees.metaMask.usd ?? 0;
     const provider = totals.fees.provider.usd;
@@ -78,11 +80,9 @@ function TransactionFeeRow({
         .plus(sourceNetwork)
         .plus(targetNetwork),
     );
-  }, [totals, formatFiat]);
+  }, [totals, formatFiat, hasQuotes]);
 
   if (isLoading) return <InfoRowSkeleton testId="bridge-fee-row-skeleton" />;
-
-  const hasQuotes = Boolean(quotes?.length);
 
   return (
     <AlertRow

--- a/app/components/Views/confirmations/components/rows/receive-row/receive-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/receive-row/receive-row.test.tsx
@@ -6,9 +6,14 @@ import { simpleSendTransactionControllerMock } from '../../../__mocks__/controll
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayQuotes,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
-import { TransactionPayTotals } from '@metamask/transaction-pay-controller';
+import {
+  TransactionPayQuote,
+  TransactionPayTotals,
+} from '@metamask/transaction-pay-controller';
+import { Json } from '@metamask/utils';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
@@ -35,6 +40,7 @@ describe('ReceiveRow', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,6 +54,9 @@ describe('ReceiveRow', () => {
     } as unknown as TransactionPayTotals);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useTransactionPayQuotesMock.mockReturnValue([
+      {} as TransactionPayQuote<Json>,
+    ]);
   });
 
   it('renders the receive amount (input minus all fees)', () => {
@@ -86,5 +95,12 @@ describe('ReceiveRow', () => {
 
     const { queryByText } = render();
     expect(queryByText(EXPECTED_RECEIVE_MOCK)).toBeNull();
+  });
+
+  it('renders empty receive amount when there are no quotes', () => {
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { getByTestId } = render();
+    expect(getByTestId('receive-row')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/receive-row/receive-row.tsx
+++ b/app/components/Views/confirmations/components/rows/receive-row/receive-row.tsx
@@ -9,6 +9,7 @@ import { View } from 'react-native';
 import { BigNumber } from 'bignumber.js';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayQuotes,
   useTransactionPayTotals,
 } from '../../../hooks/pay/useTransactionPayData';
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
@@ -30,9 +31,11 @@ export function ReceiveRow({ inputAmountUsd }: ReceiveRowProps) {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const totals = useTransactionPayTotals();
+  const quotes = useTransactionPayQuotes();
+  const hasQuotes = Boolean(quotes?.length);
 
   const receiveUsd = useMemo(() => {
-    if (!totals || inputAmountUsd == null) return '';
+    if (!totals || inputAmountUsd == null || !hasQuotes) return '';
 
     const inputUsd = new BigNumber(inputAmountUsd);
     const providerFee = new BigNumber(totals.fees?.provider?.usd ?? 0);
@@ -50,7 +53,7 @@ export function ReceiveRow({ inputAmountUsd }: ReceiveRowProps) {
       .plus(metaMaskFee);
     const youReceive = inputUsd.minus(totalFees);
     return formatFiat(youReceive.isPositive() ? youReceive : new BigNumber(0));
-  }, [totals, formatFiat, inputAmountUsd]);
+  }, [totals, formatFiat, inputAmountUsd, hasQuotes]);
 
   if (isLoading) {
     return <InfoRowSkeleton testId="receive-row-skeleton" />;

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.test.ts
@@ -175,6 +175,10 @@ describe('useInsufficientPerpsBalanceAlert', () => {
   });
 
   it('does not trigger fee check during pending input even when fees exceed amount', () => {
+    jest
+      .mocked(useTransactionPayQuotes)
+      .mockReturnValue([{} as TransactionPayQuote<Json>]);
+
     useTransactionPayTotalsMock.mockReturnValue({
       fees: {
         provider: { usd: '100' },
@@ -193,6 +197,10 @@ describe('useInsufficientPerpsBalanceAlert', () => {
     useTokenAmountMock.mockReturnValue({
       amountPrecise: '40',
     } as ReturnType<typeof useTokenAmount>);
+
+    jest
+      .mocked(useTransactionPayQuotes)
+      .mockReturnValue([{} as TransactionPayQuote<Json>]);
 
     useTransactionPayTotalsMock.mockReturnValue({
       fees: {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.test.ts
@@ -9,10 +9,20 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { useTokenAmount } from '../useTokenAmount';
+import {
+  useTransactionPayQuotes,
+  useTransactionPayTotals,
+} from '../pay/useTransactionPayData';
+import {
+  TransactionPayQuote,
+  TransactionPayTotals,
+} from '@metamask/transaction-pay-controller';
+import { Json } from '@metamask/utils';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../useTokenAmount');
+jest.mock('../pay/useTransactionPayData');
 
 const mockPerpsState = (availableBalance: string | null = '45.31') => ({
   engine: {
@@ -39,6 +49,7 @@ function runHook({
 
 describe('useInsufficientPerpsBalanceAlert', () => {
   const useTokenAmountMock = jest.mocked(useTokenAmount);
+  const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
 
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
@@ -55,6 +66,8 @@ describe('useInsufficientPerpsBalanceAlert', () => {
     } as unknown as TransactionMeta);
 
     useTokenAmountMock.mockReturnValue({} as ReturnType<typeof useTokenAmount>);
+    useTransactionPayTotalsMock.mockReturnValue(undefined);
+    jest.mocked(useTransactionPayQuotes).mockReturnValue(undefined);
   });
 
   it('returns alert if perps balance less than pending amount', () => {
@@ -133,6 +146,64 @@ describe('useInsufficientPerpsBalanceAlert', () => {
       pendingAmount: '50',
       availableBalance: null,
     });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns alert on confirmation screen when fees exceed withdraw amount', () => {
+    useTokenAmountMock.mockReturnValue({
+      amountPrecise: '10',
+    } as ReturnType<typeof useTokenAmount>);
+
+    jest
+      .mocked(useTransactionPayQuotes)
+      .mockReturnValue([{} as TransactionPayQuote<Json>]);
+
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        provider: { usd: '5' },
+        sourceNetwork: { estimate: { usd: '3' } },
+        targetNetwork: { usd: '4' },
+        metaMask: { usd: '1' },
+      },
+    } as unknown as TransactionPayTotals);
+
+    const { result } = runHook();
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].key).toBe(AlertKeys.InsufficientPerpsBalance);
+  });
+
+  it('does not trigger fee check during pending input even when fees exceed amount', () => {
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        provider: { usd: '100' },
+        sourceNetwork: { estimate: { usd: '0' } },
+        targetNetwork: { usd: '0' },
+        metaMask: { usd: '0' },
+      },
+    } as unknown as TransactionPayTotals);
+
+    const { result } = runHook({ pendingAmount: '10' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert on confirmation screen when fees are less than amount', () => {
+    useTokenAmountMock.mockReturnValue({
+      amountPrecise: '40',
+    } as ReturnType<typeof useTokenAmount>);
+
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        provider: { usd: '0.05' },
+        sourceNetwork: { estimate: { usd: '0' } },
+        targetNetwork: { usd: '0' },
+        metaMask: { usd: '0.003' },
+      },
+    } as unknown as TransactionPayTotals);
+
+    const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
   });

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
@@ -12,6 +12,10 @@ import {
 } from '@metamask/transaction-controller';
 import { useTokenAmount } from '../useTokenAmount';
 import { hasTransactionType } from '../../utils/transaction';
+import {
+  useTransactionPayQuotes,
+  useTransactionPayTotals,
+} from '../pay/useTransactionPayData';
 import type { RootState } from '../../../../../reducers';
 
 export function useInsufficientPerpsBalanceAlert({
@@ -22,6 +26,9 @@ export function useInsufficientPerpsBalanceAlert({
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
   const { amountPrecise } = useTokenAmount();
   const amountHuman = pendingAmount ?? amountPrecise ?? '0';
+  const totals = useTransactionPayTotals();
+  const quotes = useTransactionPayQuotes();
+  const hasQuotes = Boolean(quotes?.length);
 
   const availableBalance = useSelector(
     (state: RootState) =>
@@ -33,14 +40,47 @@ export function useInsufficientPerpsBalanceAlert({
     TransactionType.perpsWithdraw,
   ]);
 
-  const isInsufficient = useMemo(
-    () =>
-      isPerpsWithdraw &&
+  const isPendingInput = pendingAmount !== undefined;
+
+  const isInsufficient = useMemo(() => {
+    if (!isPerpsWithdraw) return false;
+
+    if (
       availableBalance !== undefined &&
       availableBalance !== null &&
-      new BigNumber(availableBalance).isLessThan(amountHuman),
-    [amountHuman, isPerpsWithdraw, availableBalance],
-  );
+      new BigNumber(availableBalance).isLessThan(amountHuman)
+    ) {
+      return true;
+    }
+
+    // On the confirmation screen (not while typing), check if fees
+    // exceed the withdraw amount — user would receive nothing.
+    // Skipped during input because totals may be stale.
+    if (
+      !isPendingInput &&
+      hasQuotes &&
+      totals?.fees &&
+      new BigNumber(amountHuman).isGreaterThan(0)
+    ) {
+      const totalFees = new BigNumber(totals.fees.provider?.usd ?? 0)
+        .plus(totals.fees.sourceNetwork?.estimate?.usd ?? 0)
+        .plus(totals.fees.targetNetwork?.usd ?? 0)
+        .plus(totals.fees.metaMask?.usd ?? 0);
+
+      if (totalFees.isGreaterThanOrEqualTo(amountHuman)) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [
+    amountHuman,
+    hasQuotes,
+    isPendingInput,
+    isPerpsWithdraw,
+    availableBalance,
+    totals,
+  ]);
 
   return useMemo(() => {
     if (!isInsufficient) {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -18,6 +18,7 @@ import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalanc
 import {
   useTransactionPayTotals,
   useTransactionPayIsMaxAmount,
+  useTransactionPayIsPostQuote,
 } from '../pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import {
@@ -100,6 +101,9 @@ describe('useTransactionCustomAmount', () => {
   const useTransactionPayIsMaxAmountMock = jest.mocked(
     useTransactionPayIsMaxAmount,
   );
+  const useTransactionPayIsPostQuoteMock = jest.mocked(
+    useTransactionPayIsPostQuote,
+  );
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
   );
@@ -140,6 +144,7 @@ describe('useTransactionCustomAmount', () => {
     } as unknown as ReturnType<typeof useConfirmationMetricEvents>);
     useTransactionPayTotalsMock.mockReturnValue(undefined);
     useTransactionPayIsMaxAmountMock.mockReturnValue(false);
+    useTransactionPayIsPostQuoteMock.mockReturnValue(false);
     useTransactionPayHasSourceAmountMock.mockReturnValue(true);
   });
 
@@ -271,6 +276,29 @@ describe('useTransactionCustomAmount', () => {
 
     await act(async () => {
       rerender({});
+    });
+
+    expect(setConfirmationMetricMock).toHaveBeenCalledWith({
+      properties: {
+        mm_pay_quote_requested: true,
+      },
+    });
+  });
+
+  it('sets mm_pay_quote_requested metric when isPostQuote is true even if hasSourceAmount is false', async () => {
+    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
+    useTransactionPayIsPostQuoteMock.mockReturnValue(true);
+
+    const { result } = runHook();
+
+    await act(async () => {
+      result.current.updatePendingAmount('123.45');
+    });
+
+    setConfirmationMetricMock.mockClear();
+
+    await act(async () => {
+      result.current.updateTokenAmount();
     });
 
     expect(setConfirmationMetricMock).toHaveBeenCalledWith({

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -16,6 +16,7 @@ import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalanc
 import Engine from '../../../../../core/Engine';
 import {
   useTransactionPayIsMaxAmount,
+  useTransactionPayIsPostQuote,
   useTransactionPayTotals,
 } from '../pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
@@ -34,6 +35,7 @@ export function useTransactionCustomAmount({
   const [amountHumanDebounced, setAmountHumanDebounced] = useState('0');
   const totals = useTransactionPayTotals();
   const hasSourceAmount = useTransactionPayHasSourceAmount();
+  const isPostQuote = useTransactionPayIsPostQuote();
   const { setConfirmationMetric } = useConfirmationMetricEvents();
   const [isTokenAmountUpdated, setIsTokenAmountUpdated] = useState(false);
 
@@ -161,7 +163,7 @@ export function useTransactionCustomAmount({
   }, [amountHuman, updateTokenAmountCallback]);
 
   useEffect(() => {
-    if (isTokenAmountUpdated && hasSourceAmount) {
+    if (isTokenAmountUpdated && (hasSourceAmount || isPostQuote)) {
       setConfirmationMetric({
         properties: {
           mm_pay_quote_requested: true,
@@ -169,7 +171,12 @@ export function useTransactionCustomAmount({
       });
       setIsTokenAmountUpdated(false);
     }
-  }, [hasSourceAmount, isTokenAmountUpdated, setConfirmationMetric]);
+  }, [
+    hasSourceAmount,
+    isPostQuote,
+    isTokenAmountUpdated,
+    setConfirmationMetric,
+  ]);
 
   return {
     amountFiat,

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -693,6 +693,22 @@ describe('Metamask Pay Metrics', () => {
       expect(result.properties).not.toHaveProperty('mm_pay_time_to_complete_s');
     });
 
+    it('falls back to parent submittedTime when no children have submittedTime', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1060500);
+
+      request.transactionMeta.type = TransactionType.perpsWithdraw;
+      request.transactionMeta.submittedTime = 1000000;
+      request.transactionMeta.requiredTransactionIds = [];
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties).toStrictEqual(
+        expect.objectContaining({
+          mm_pay_time_to_complete_s: 60.5,
+        }),
+      );
+    });
+
     it('does not add mm_pay_time_to_complete_s when submittedTime is undefined', () => {
       request.transactionMeta.type = TransactionType.perpsDeposit;
 

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -148,10 +148,9 @@ function addTimeToComplete(
     return;
   }
 
-  const submittedTime = getLatestChildSubmittedTime(
-    transactionMeta,
-    allTransactions,
-  );
+  const submittedTime =
+    getLatestChildSubmittedTime(transactionMeta, allTransactions) ??
+    transactionMeta.submittedTime;
 
   if (typeof submittedTime !== 'number') {
     return;


### PR DESCRIPTION
## **Description**

Fixes several things with the Perps Withdraw to any token flow:

- **mm_pay_quote_requested metric always false**: The metric relied on `hasSourceAmount` which is never true for post-quote flows. Now uses `isPostQuote` as an alternative gate.
- **mm_pay_time_to_complete_s missing**: Falls back to the parent's `submittedTime` when no child transactions exist (gasless HyperLiquid withdrawals).
- **Insufficient funds alert for excessive fees**: On the confirmation screen, shows insufficient funds when total fees exceed the withdraw amount (gated on quotes being available).
- **Unrealistic fallback fee displayed**: Hides fee, time, and receive rows when no relay quotes exist, since the controller's raw gas fallback produces unrealistic values.
- **Alert message positioning**: Moved "This payment route isn't available" above the Receive token selector.
- **Blue activity title**: Overrides `headerTintColor` to `text.default` so the transaction details title is no longer blue.

## **Changelog**

CHANGELOG entry: Fixed perps withdraw metrics tracking, hide rows when no quotes are available, and fixed blue title in transaction details

## **Related issues**

Fixes: CONF-1159

## **Manual testing steps**

Feature: Perps Withdraw

Scenario: user withdraws to BNB
- Given user has a perps balance
- When user initiates a perps withdraw to BNB
- Then transaction fee and receive amount display correctly
- Then mm_pay_quote_requested is true in the finalized event
- Then mm_pay_time_to_complete_s is present in the finalized event

Scenario: user enters tiny amount
- Given user is on the perps withdraw confirmation screen
- When user selects MUSD on Ethereum as receive token and enters $0.05 with withdraw
- Then fee and receive rows are hidden
- Then "No quotes" button is shown
- Then alert message appears above the Receive selector

Scenario: user views completed withdrawal in activity
- Given user has a completed perps withdrawal
- When user opens the transaction details
- Then the "Withdrawal" title is default text color, not blue

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation-screen fee/receive rendering and blocking alert logic for withdraws, plus metrics emission paths, which could affect user-visible values and analytics if quote/totals availability is misdetected.
> 
> **Overview**
> Fixes Perps Withdraw confirmation UX by **only showing fee/time/receive totals when relay quotes are loading or available**, avoiding misleading fallback fee values; it also moves the inline `AlertMessage` above the receive/account selector.
> 
> Tightens quote-dependent calculations by returning empty values for `BridgeFeeRow` and `ReceiveRow` when there are no quotes, and adds a confirmation-only insufficient-funds check that blocks when total fees would consume the entire withdraw amount.
> 
> Improves MetaMask Pay metrics: `mm_pay_quote_requested` now triggers for post-quote flows (via `useTransactionPayIsPostQuote`), and `mm_pay_time_to_complete_s` falls back to the parent transaction `submittedTime` when no child submitted times exist. Also fixes the activity details header color by overriding `headerTintColor` to `colors.text.default` (with updated tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33f62944bb6347ed0a96a646370d369c67d5161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->