### PR TITLE
fix(perps): avoid full reconnection on foreground return when WebSocket is still alive within grace period

### DIFF
--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1197,6 +1197,38 @@ describe('PerpsConnectionManager', () => {
       expect(state.isConnecting).toBe(false);
     });
 
+    it('skips cache clearing when preserveCaches is true', async () => {
+      // Arrange
+      const m = PerpsConnectionManager as unknown as {
+        connectionRefCount: number;
+        performActualDisconnection: (opts: {
+          force?: boolean;
+          preserveCaches?: boolean;
+        }) => Promise<void>;
+      };
+      m.connectionRefCount = 0;
+
+      // Act
+      await m.performActualDisconnection({ preserveCaches: true });
+
+      // Assert — caches must NOT be cleared when preserveCaches=true
+      expect(
+        mockStreamManagerInstance.positions.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.orders.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.account.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.prices.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.marketData.clearCache,
+      ).not.toHaveBeenCalled();
+    });
+
     it('skips disconnection when reference count is still positive', async () => {
       // Arrange — refCount > 0 means another consumer reconnected during grace period
       const m = PerpsConnectionManager as unknown as {
@@ -1453,17 +1485,49 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
-    it('reconnects when existing connection ping fails', async () => {
+    it('retries ping after delay and skips reconnect when retry succeeds', async () => {
       // Establish an initial connection
       await PerpsConnectionManager.connect();
 
-      // Make ping fail to simulate unhealthy connection
-      (
-        Engine.context.PerpsController.getActiveProvider as jest.Mock
-      ).mockReturnValueOnce({
-        ping: jest.fn().mockRejectedValueOnce(new Error('ping timeout')),
+      // First ping fails, retry succeeds — simulates JS thread sluggishness on foreground
+      const failPing = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('ping timeout'));
+      const succeedPing = jest.fn().mockResolvedValue(undefined);
+      (Engine.context.PerpsController.getActiveProvider as jest.Mock)
+        .mockReturnValueOnce({ ping: failPing })
+        .mockReturnValueOnce({ ping: succeedPing });
+
+      (Engine.context.PerpsController.init as jest.Mock).mockClear();
+
+      await PerpsConnectionManager.resumeFromForeground({
+        source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
       });
 
+      // Retry ping succeeded — no full reconnect needed
+      expect(Engine.context.PerpsController.init).not.toHaveBeenCalled();
+      expect(PerpsConnectionManager.getConnectionState().isConnected).toBe(
+        true,
+      );
+    });
+
+    it('soft-reconnects with preserveCaches when both pings fail', async () => {
+      // Establish an initial connection
+      await PerpsConnectionManager.connect();
+
+      // Both pings fail — truly unhealthy connection
+      (Engine.context.PerpsController.getActiveProvider as jest.Mock)
+        .mockReturnValueOnce({
+          ping: jest.fn().mockRejectedValueOnce(new Error('ping timeout')),
+        })
+        .mockReturnValueOnce({
+          ping: jest.fn().mockRejectedValueOnce(new Error('ping timeout')),
+        });
+
+      // Clear cache mocks to track preserveCaches behavior
+      Object.values(mockStreamManagerInstance).forEach(({ clearCache }) =>
+        clearCache.mockClear(),
+      );
       (Engine.context.PerpsController.init as jest.Mock).mockClear();
       (Engine.context.PerpsController.disconnect as jest.Mock).mockClear();
 
@@ -1471,8 +1535,18 @@ describe('PerpsConnectionManager', () => {
         source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
       });
 
-      // Should have fallen through to ensureConnected → reconnected
+      // Should have reconnected
       expect(Engine.context.PerpsController.init).toHaveBeenCalled();
+      // Caches must NOT be cleared — preserveCaches=true prevents skeleton flash
+      expect(
+        mockStreamManagerInstance.positions.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.orders.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.account.clearCache,
+      ).not.toHaveBeenCalled();
     });
 
     it('cancels grace period before resuming', async () => {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -458,6 +458,9 @@ class PerpsConnectionManagerClass {
         }
         return;
       } catch {
+        DevLogger.log(
+          '[TAT-2892] BUG_MARKER: ping failed in resumeFromForeground - falling through to full reconnect',
+        );
         // Fall through to reconnect below.
       }
     }

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -458,9 +458,6 @@ class PerpsConnectionManagerClass {
         }
         return;
       } catch {
-        DevLogger.log(
-          '[TAT-2892] BUG_MARKER: ping failed in resumeFromForeground - falling through to full reconnect',
-        );
         // Fall through to reconnect below.
       }
     }

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -40,6 +40,7 @@ import { PERPS_CONNECTION_SOURCE } from '../constants/perpsConfig';
 interface ConnectOptions {
   source?: string;
   suppressError?: boolean;
+  preserveCaches?: boolean;
 }
 
 /**
@@ -458,11 +459,31 @@ class PerpsConnectionManagerClass {
         }
         return;
       } catch {
-        // Fall through to reconnect below.
+        // First ping failed — JS thread may be sluggish right after foregrounding.
+        // Wait briefly and retry before triggering a full reconnection.
+        await wait(PERPS_CONSTANTS.ForegroundPingRetryDelayMs);
+        try {
+          const retryProvider =
+            Engine.context.PerpsController.getActiveProvider();
+          await retryProvider.ping();
+          DevLogger.log(
+            'PerpsConnectionManager: resumeFromForeground - retry ping succeeded, connection healthy',
+          );
+          if (!suppressError) {
+            this.clearError();
+          }
+          return;
+        } catch {
+          DevLogger.log(
+            'PerpsConnectionManager: resumeFromForeground - retry ping also failed, falling through to soft reconnect',
+          );
+        }
       }
     }
 
-    await this.ensureConnected({ source, suppressError });
+    // Soft reconnect: preserve cached data so no loading skeletons appear.
+    // The WebSocket was likely still alive — avoid a jarring skeleton flash.
+    await this.ensureConnected({ source, suppressError, preserveCaches: true });
   }
 
   /**
@@ -524,9 +545,10 @@ class PerpsConnectionManagerClass {
   /**
    * Perform the actual disconnection after grace period expires.
    * @param options.force - Bypass refCount guard (used by ensureConnected).
+   * @param options.preserveCaches - Skip clearing stream caches (used by soft foreground resume).
    */
   private async performActualDisconnection(
-    options: { force?: boolean } = {},
+    options: { force?: boolean; preserveCaches?: boolean } = {},
   ): Promise<void> {
     DevLogger.log(
       `PerpsConnectionManager: Grace period expired, performing disconnection (refCount: ${this.connectionRefCount})`,
@@ -552,17 +574,21 @@ class PerpsConnectionManagerClass {
             this.cleanupPreloadedSubscriptions();
 
             // Clear all stream caches so subscribers reset to loading state
-            // and hasReceivedFirstUpdate is reset for clean reconnection
-            const streamManager = getStreamManagerInstance();
-            streamManager.positions.clearCache();
-            streamManager.orders.clearCache();
-            streamManager.account.clearCache();
-            streamManager.prices.clearCache();
-            streamManager.marketData.clearCache();
-            streamManager.oiCaps.clearCache();
-            streamManager.fills.clearCache();
-            streamManager.topOfBook.clearCache();
-            streamManager.candles.clearCache();
+            // and hasReceivedFirstUpdate is reset for clean reconnection.
+            // Skip when preserveCaches=true (soft foreground resume): cached data
+            // is still valid and clearing it would cause unnecessary loading skeletons.
+            if (!options.preserveCaches) {
+              const streamManager = getStreamManagerInstance();
+              streamManager.positions.clearCache();
+              streamManager.orders.clearCache();
+              streamManager.account.clearCache();
+              streamManager.prices.clearCache();
+              streamManager.marketData.clearCache();
+              streamManager.oiCaps.clearCache();
+              streamManager.fills.clearCache();
+              streamManager.topOfBook.clearCache();
+              streamManager.candles.clearCache();
+            }
 
             // Reset state before disconnecting to prevent race conditions
             this.isConnected = false;
@@ -1153,6 +1179,7 @@ class PerpsConnectionManagerClass {
     this.ensureConnectedPromise = this.performEnsureConnected(
       options?.source,
       options?.suppressError,
+      options?.preserveCaches,
     );
     try {
       await this.ensureConnectedPromise;
@@ -1164,6 +1191,7 @@ class PerpsConnectionManagerClass {
   private async performEnsureConnected(
     source?: string,
     suppressError?: boolean,
+    preserveCaches?: boolean,
   ): Promise<void> {
     // Cancel grace period if still pending — we're taking over
     this.cancelGracePeriod();
@@ -1172,7 +1200,7 @@ class PerpsConnectionManagerClass {
     // Uses force: true to bypass the refCount guard — ensureConnected must
     // always tear down, regardless of how many components hold references.
     if (this.isConnected || this.isInitialized) {
-      await this.performActualDisconnection({ force: true });
+      await this.performActualDisconnection({ force: true, preserveCaches });
     }
 
     // Reset refCount so connect() brings it to exactly 1.

--- a/app/controllers/perps/constants/perpsConfig.ts
+++ b/app/controllers/perps/constants/perpsConfig.ts
@@ -29,6 +29,7 @@ export const PERPS_CONSTANTS = {
   ConnectionAttemptTimeoutMs: 30_000, // 30 seconds timeout for connection attempts to prevent indefinite hanging
   WebsocketPingTimeoutMs: 5_000, // 5 seconds timeout for WebSocket health check ping
   ConnectRetryDelayMs: 200, // Delay before retrying connect() when connection isn't ready yet
+  ForegroundPingRetryDelayMs: 500, // Delay before retrying ping in resumeFromForeground — JS thread may be sluggish right after foregrounding
   ReconnectionCleanupDelayMs: 500, // Platform-agnostic delay to ensure WebSocket is ready
   ReconnectionDelayAndroidMs: 300, // Android-specific reconnection delay for better reliability on slower devices
   ReconnectionDelayIosMs: 100, // iOS-specific reconnection delay for optimal performance


### PR DESCRIPTION
## **Description**

When the app returns to foreground within the 20 s grace period, `resumeFromForeground()` pinged the WebSocket to check health. The JS thread is often sluggish right after the AppState transition, so the ping could throw even though the socket was alive. The catch block fell through immediately to `ensureConnected()`, which tore down all 9 stream caches and triggered `isConnecting=true` — causing loading skeletons across all Perps UI despite the connection still being healthy.

**Fix:** Two-pronged:
1. **Ping retry** — wait 500 ms and retry `provider.ping()` before treating the connection as dead. Eliminates false positives from JS thread suspension.
2. **`preserveCaches` flag** — even if both pings fail, thread `preserveCaches: true` through `ensureConnected()` → `performEnsureConnected()` → `performActualDisconnection()` so stream caches survive the soft reconnect. Cached data is still valid (same account/network) — shows slightly stale data instead of skeletons.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2892](https://consensyssoftware.atlassian.net/browse/TAT-2892)

## **Manual testing steps**

```gherkin
Feature: Perps foreground reconnect

  Scenario: user returns app to foreground within grace period
    Given the Perps feature is enabled
      And the user has navigated to the Perps tab
      And the WebSocket is connected and initialized

    When the user backgrounds the app for less than 20 seconds
      And the user returns the app to the foreground

    Then the Perps tab must NOT show loading skeletons
      And the connection state remains isConnected=true, isInitialized=true
      And stream caches (positions, orders, account) are NOT cleared
```

## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json — automated validation for TAT-2892</summary>

```json
{
  "pr": "28592",
  "title": "Verify foreground reconnect does not clear caches when WebSocket is alive within grace period",
  "jira": "TAT-2892",
  "acceptance_criteria": [
    "Returning to foreground within grace period does not trigger full reconnection when WebSocket is healthy",
    "No loading skeletons during foreground return with healthy connection",
    "resumeFromForeground retries ping before falling through to full reconnect"
  ],
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "nav-perps",
      "nodes": {
        "nav-perps": {
          "action": "navigate",
          "target": "Perps",
          "next": "wait-initialized"
        },
        "wait-initialized": {
          "action": "wait_for",
          "expression": "JSON.stringify(Engine.context.PerpsController.state.initializationState)",
          "timeout_ms": 15000,
          "assert": { "operator": "contains", "value": "initialized" },
          "next": "check-state"
        },
        "check-state": {
          "action": "eval_ref",
          "ref": "perps/state",
          "assert": { "operator": "not_null" },
          "next": "watch-no-full-reconnect"
        },
        "watch-no-full-reconnect": {
          "action": "log_watch",
          "window_seconds": 5,
          "must_not_appear": [
            "BUG_MARKER: ping failed in resumeFromForeground",
            "Performing actual disconnection after grace period"
          ],
          "watch_for": ["Successfully connected", "connection healthy"],
          "next": "screenshot-connected"
        },
        "screenshot-connected": {
          "action": "screenshot",
          "filename": "evidence-perps-connected.png",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>


[TAT-2892]: https://consensyssoftware.atlassian.net/browse/TAT-2892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps WebSocket lifecycle and cache-clearing behavior on foreground resume; regressions could leave stale data visible or prevent proper reconnection if the socket is actually dead.
> 
> **Overview**
> Reduces unnecessary Perps UI reloads when the app returns to foreground by adding a short `provider.ping()` retry (`PERPS_CONSTANTS.ForegroundPingRetryDelayMs`) before deciding the connection is unhealthy.
> 
> Threads a new `preserveCaches` option through `ensureConnected()`/`performActualDisconnection()` so a foreground-triggered *soft reconnect* can skip clearing StreamManager caches, avoiding a loading-skeleton flash while still reinitializing the controller when needed.
> 
> Adds/updates Jest coverage for the ping-retry behavior and for skipping cache clears when `preserveCaches` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f39716b843991a7a79cf18ff9af7729bf1d95704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
