### PR TITLE
fix(perps): Incorrect PnL and order size displayed in perp market page after SL execution

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -16,7 +16,10 @@ import {
   type SortField,
 } from '@metamask/perps-controller';
 import type { PerpsTransaction } from '../types/transactionHistory';
-import { transformFillsToTransactions } from '../utils/transactionTransforms';
+import {
+  transformFillsToTransactions,
+  mergeOrderFills,
+} from '../utils/transactionTransforms';
 import Engine from '../../../../core/Engine';
 import { HOME_SCREEN_CONFIG } from '../constants/perpsConfig';
 import { selectPerpsWatchlistMarkets } from '../selectors/perpsController';
@@ -123,40 +126,10 @@ export const usePerpsHomeData = ({
     };
   }, [isConnected, isInitialized]);
 
-  // Merge REST + WebSocket fills with deduplication
-  // Live fills take precedence over REST fills (more up-to-date)
-  const mergedFills = useMemo(() => {
-    // Use Map for efficient deduplication
-    const fillsMap = new Map<string, OrderFill>();
-
-    // Add REST fills first
-    for (const fill of restFills) {
-      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-      fillsMap.set(key, fill);
-    }
-
-    // Add live fills (overwrites duplicates from REST - live data is fresher)
-    // Preserve detailedOrderType from REST fills since WS fills lack it
-    for (const fill of liveFills) {
-      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-      const existing = fillsMap.get(key);
-      if (existing?.detailedOrderType && !fill.detailedOrderType) {
-        fillsMap.set(key, {
-          ...fill,
-          detailedOrderType: existing.detailedOrderType,
-          ...(existing.liquidation &&
-            !fill.liquidation && { liquidation: existing.liquidation }),
-        });
-      } else {
-        fillsMap.set(key, fill);
-      }
-    }
-
-    // Convert back to array and sort by timestamp descending (newest first)
-    return Array.from(fillsMap.values()).sort(
-      (a, b) => b.timestamp - a.timestamp,
-    );
-  }, [restFills, liveFills]);
+  const mergedFills = useMemo(
+    () => mergeOrderFills(restFills, liveFills),
+    [restFills, liveFills],
+  );
 
   // Transform merged fills to PerpsTransaction format for activity display
   const tradesOnly = useMemo(

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { usePerpsLiveFills } from './stream';
 import { PERPS_CONSTANTS, type OrderFill } from '@metamask/perps-controller';
+import { mergeOrderFills } from '../utils/transactionTransforms';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { ensureError } from '../../../../util/errorUtils';
@@ -133,34 +134,14 @@ export const usePerpsMarketFills = ({
   }, [fetchRestFills]);
 
   // Merge REST + WebSocket fills with deduplication, filtered by symbol
-  // Live fills take precedence over REST fills (more up-to-date)
-  const fills = useMemo(() => {
-    // Use Map for efficient deduplication
-    const fillsMap = new Map<string, OrderFill>();
-
-    // Add REST fills first
-    for (const fill of restFills) {
-      // Only add fills for the requested symbol
-      if (fill.symbol === symbol) {
-        const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-        fillsMap.set(key, fill);
-      }
-    }
-
-    // Add live fills (overwrites duplicates from REST - live data is fresher)
-    for (const fill of liveFills) {
-      // Only add fills for the requested symbol
-      if (fill.symbol === symbol) {
-        const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-        fillsMap.set(key, fill);
-      }
-    }
-
-    // Convert back to array and sort by timestamp descending (newest first)
-    return Array.from(fillsMap.values()).sort(
-      (a, b) => b.timestamp - a.timestamp,
-    );
-  }, [restFills, liveFills, symbol]);
+  const fills = useMemo(
+    () =>
+      mergeOrderFills(
+        restFills.filter((f) => f.symbol === symbol),
+        liveFills.filter((f) => f.symbol === symbol),
+      ),
+    [restFills, liveFills, symbol],
+  );
 
   return {
     fills,

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -1045,10 +1045,11 @@ describe('usePerpsTransactionHistory', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
+      // mergedTransactions sorts fills descending by timestamp before transforming
       expect(mockTransformFillsToTransactions).toHaveBeenCalledWith([
-        { ...partialFills[0], detailedOrderType: 'Stop Loss' },
-        { ...partialFills[1], detailedOrderType: 'Stop Loss' },
         { ...partialFills[2], detailedOrderType: 'Stop Loss' },
+        { ...partialFills[1], detailedOrderType: 'Stop Loss' },
+        { ...partialFills[0], detailedOrderType: 'Stop Loss' },
       ]);
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -11,6 +11,7 @@ import {
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
+  mergeOrderFills,
 } from '../utils/transactionTransforms';
 import { FillType } from '../types/transactionHistory';
 import type { CaipAccountId } from '@metamask/utils';
@@ -53,6 +54,9 @@ const mockTransformWalletPerpsDepositsToTransactions =
   transformWalletPerpsDepositsToTransactions as jest.MockedFunction<
     typeof transformWalletPerpsDepositsToTransactions
   >;
+const mockMergeOrderFills = mergeOrderFills as jest.MockedFunction<
+  typeof mergeOrderFills
+>;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 describe('usePerpsTransactionHistory', () => {
@@ -209,6 +213,13 @@ describe('usePerpsTransactionHistory', () => {
     mockTransformFundingToTransactions.mockReturnValue([]);
     mockTransformUserHistoryToTransactions.mockReturnValue([]);
     mockTransformWalletPerpsDepositsToTransactions.mockReturnValue([]);
+    // Use real mergeOrderFills so dedup, sort, and detailedOrderType preservation
+    // are exercised correctly in hook-level tests. Unit tests for the function
+    // itself live in transactionTransforms.test.ts.
+    const actualTransforms = jest.requireActual(
+      '../utils/transactionTransforms',
+    ) as typeof import('../utils/transactionTransforms');
+    mockMergeOrderFills.mockImplementation(actualTransforms.mergeOrderFills);
   });
 
   describe('initial state', () => {

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -492,41 +492,43 @@ describe('usePerpsTransactionHistory', () => {
     });
 
     it('sorts transactions by timestamp descending', async () => {
-      const mockTransactions = [
-        {
-          id: 'tx1',
-          timestamp: 1000,
-          type: 'deposit' as const,
-          category: 'deposit' as const,
-          title: 'Deposit',
-          subtitle: '100 USDC',
-          asset: 'USDC',
-        },
-        {
-          id: 'tx2',
-          timestamp: 2000,
-          type: 'trade' as const,
-          category: 'position_open' as const,
-          title: 'Trade',
-          subtitle: '1 ETH',
-          asset: 'ETH',
-        },
-        {
-          id: 'tx3',
-          timestamp: 1500,
-          type: 'withdrawal' as const,
-          category: 'withdrawal' as const,
-          title: 'Withdrawal',
-          subtitle: '50 USDC',
-          asset: 'USDC',
-        },
-      ];
+      const tradeTx = {
+        id: 'tx2',
+        timestamp: 2000,
+        type: 'trade' as const,
+        category: 'position_open' as const,
+        title: 'Trade',
+        subtitle: '1 ETH',
+        asset: 'ETH',
+      };
+      const depositTx = {
+        id: 'tx1',
+        timestamp: 1000,
+        type: 'deposit' as const,
+        category: 'deposit' as const,
+        title: 'Deposit',
+        subtitle: '100 USDC',
+        asset: 'USDC',
+      };
+      const withdrawalTx = {
+        id: 'tx3',
+        timestamp: 1500,
+        type: 'withdrawal' as const,
+        category: 'withdrawal' as const,
+        title: 'Withdrawal',
+        subtitle: '50 USDC',
+        asset: 'USDC',
+      };
 
-      // Use mockImplementation to return transactions only for non-empty fills
-      // Empty fills (from WebSocket) should return empty array
+      // fills transform returns only trade transactions (realistic)
       mockTransformFillsToTransactions.mockImplementation((fills) =>
-        fills.length > 0 ? mockTransactions : [],
+        fills.length > 0 ? [tradeTx] : [],
       );
+      // Non-trade transactions come from user history
+      mockTransformUserHistoryToTransactions.mockReturnValue([
+        depositTx,
+        withdrawalTx,
+      ]);
 
       const { result } = renderHook(() => usePerpsTransactionHistory());
 
@@ -540,43 +542,45 @@ describe('usePerpsTransactionHistory', () => {
     });
 
     it('removes duplicate transactions', async () => {
-      const duplicateTransactions = [
-        {
-          id: 'tx1',
-          timestamp: 1000,
-          type: 'deposit' as const,
-          category: 'deposit' as const,
-          title: 'Deposit',
-          subtitle: '100 USDC',
-          asset: 'USDC',
-        },
-        {
-          id: 'tx1',
-          timestamp: 1000,
-          type: 'deposit' as const,
-          category: 'deposit' as const,
-          title: 'Deposit',
-          subtitle: '100 USDC',
-          asset: 'USDC',
-        },
-        {
-          id: 'tx2',
-          timestamp: 2000,
-          type: 'trade' as const,
-          category: 'position_open' as const,
-          title: 'Trade',
-          subtitle: '1 ETH',
-          asset: 'ETH',
-        },
-      ];
+      // Two deposits with same ID (duplicate) + one unique deposit
+      const duplicateDeposit1 = {
+        id: 'tx1',
+        timestamp: 1000,
+        type: 'deposit' as const,
+        category: 'deposit' as const,
+        title: 'Deposit',
+        subtitle: '100 USDC',
+        asset: 'USDC',
+      };
+      const duplicateDeposit2 = {
+        id: 'tx1',
+        timestamp: 1000,
+        type: 'deposit' as const,
+        category: 'deposit' as const,
+        title: 'Deposit',
+        subtitle: '100 USDC',
+        asset: 'USDC',
+      };
+      const uniqueDeposit = {
+        id: 'tx2',
+        timestamp: 2000,
+        type: 'deposit' as const,
+        category: 'deposit' as const,
+        title: 'Deposit 2',
+        subtitle: '50 USDC',
+        asset: 'USDC',
+      };
 
-      // Ensure all other transform functions return empty arrays for this test
+      // fills return empty (no trade transactions)
       mockTransformFillsToTransactions.mockReturnValue([]);
       mockTransformOrdersToTransactions.mockReturnValue([]);
       mockTransformFundingToTransactions.mockReturnValue([]);
-      mockTransformUserHistoryToTransactions.mockReturnValue(
-        duplicateTransactions,
-      );
+      // user history has duplicates — fetchAllTransactions dedupes by ID
+      mockTransformUserHistoryToTransactions.mockReturnValue([
+        duplicateDeposit1,
+        duplicateDeposit2,
+        uniqueDeposit,
+      ]);
 
       const { result } = renderHook(() => usePerpsTransactionHistory());
 
@@ -1077,64 +1081,111 @@ describe('usePerpsTransactionHistory', () => {
     });
   });
 
-  describe('WS fill merge preserves fillType from REST', () => {
-    it('preserves non-standard fillType when WS fill has standard', async () => {
-      // Arrange — REST returns a trade with stop_loss fillType
-      const restTrade = {
-        ...mockTransformedTransactions[0],
-        id: 'rest-sl-1',
-        asset: 'BTC',
+  describe('WS fill merge preserves detailedOrderType from REST', () => {
+    it('preserves detailedOrderType from REST fill when WS fill lacks it', async () => {
+      // REST fill has detailedOrderType set (enriched from orders API)
+      const restRawFill = {
+        orderId: 'sl-order-123',
         timestamp: 1641000000000,
-        fill: {
-          ...mockTransformedTransactions[0].fill,
-          fillType: FillType.StopLoss,
-        },
+        symbol: 'BTC',
+        side: 'sell',
+        size: '0.1',
+        price: '50000',
+        pnl: '100',
+        fee: '5',
+        feeToken: 'USDC',
+        direction: 'Close Long',
+        detailedOrderType: 'Stop Loss',
+        startPosition: '0.1',
+        success: true,
       };
-      // Live fill with same asset+timestamp(seconds) but standard fillType
-      const wsFill = {
-        ...mockTransformedTransactions[0],
-        id: 'ws-sl-1',
-        asset: 'BTC',
+      // WS fill with same orderId-timestamp-size-price but no detailedOrderType
+      const wsRawFill = {
+        orderId: 'sl-order-123',
         timestamp: 1641000000000,
-        fill: {
-          ...mockTransformedTransactions[0].fill,
-          fillType: FillType.Standard,
-        },
+        symbol: 'BTC',
+        side: 'sell',
+        size: '0.1',
+        price: '50000',
+        pnl: '100',
+        fee: '5',
+        feeToken: 'USDC',
+        direction: 'Close Long',
+        startPosition: '0.1',
+        success: true,
       };
 
-      // Call order: (1) useMemo on initial render with liveFills,
-      // (2) fetchAllTransactions with REST fills (sets state),
-      // (3) useMemo re-runs with liveFills after state update
-      mockTransformFillsToTransactions
-        .mockReturnValueOnce([wsFill]) // initial render: live fills
-        .mockReturnValueOnce([restTrade]) // fetchAllTransactions: REST fills
-        .mockReturnValue([wsFill]); // re-render: live fills again
+      mockProvider.getOrderFills.mockResolvedValue([restRawFill]);
+      // Provide order so fetchAllTransactions enriches the fill with detailedOrderType
+      mockProvider.getOrders.mockResolvedValue([
+        {
+          orderId: 'sl-order-123',
+          symbol: 'BTC',
+          side: 'sell',
+          orderType: 'Stop',
+          detailedOrderType: 'Stop Loss',
+          size: '0',
+          originalSize: '0.1',
+          price: '50000',
+          status: 'filled',
+          timestamp: 1641000000000,
+        },
+      ]);
 
       mockUsePerpsLiveFills.mockReturnValue({
-        fills: [
-          {
-            orderId: 'ws-1',
-            timestamp: 1641000000000,
-            symbol: 'BTC',
-            side: 'buy',
-            size: '0.1',
-            price: '50000',
-            pnl: '0',
-            direction: 'Open Long',
-            fee: '5',
-            feeToken: 'USDC',
-          },
-        ],
+        fills: [wsRawFill],
         isInitialLoading: false,
       });
 
-      // Act
+      // Pass-through mock: returns a trade with fillType based on detailedOrderType
+      mockTransformFillsToTransactions.mockImplementation((fills) =>
+        fills.map((f) => ({
+          id: `fill-${f.orderId}-${f.timestamp}`,
+          type: 'trade' as const,
+          category: 'position_close' as const,
+          title: f.detailedOrderType ?? 'Trade',
+          subtitle: '',
+          timestamp: f.timestamp,
+          asset: f.symbol,
+          fill: {
+            shortTitle: f.detailedOrderType ?? 'Trade',
+            amount: '+$100',
+            amountNumber: 100,
+            isPositive: true,
+            size: f.size,
+            entryPrice: f.price,
+            pnl: f.pnl,
+            fee: f.fee,
+            points: '0',
+            feeToken: f.feeToken,
+            action: 'Closed',
+            liquidation: undefined,
+            isLiquidation: false,
+            isTakeProfit: f.detailedOrderType === 'Take Profit',
+            isStopLoss: f.detailedOrderType === 'Stop Loss',
+            fillType:
+              f.detailedOrderType === 'Stop Loss'
+                ? FillType.StopLoss
+                : FillType.Standard,
+          },
+        })),
+      );
+
       const { result } = renderHook(() => usePerpsTransactionHistory());
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      // Assert — merged trade preserves the stop_loss fillType
+      // The mergedTransactions call receives the fill with detailedOrderType preserved
+      const mergedFillsCallArg =
+        mockTransformFillsToTransactions.mock.calls[
+          mockTransformFillsToTransactions.mock.calls.length - 1
+        ][0];
+      expect(mergedFillsCallArg[0]).toMatchObject({
+        detailedOrderType: 'Stop Loss',
+      });
+
+      // The resulting trade should reflect the Stop Loss fillType
       const trades = result.current.transactions.filter(
         (tx) => tx.type === 'trade',
       );

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -3,13 +3,14 @@ import { useSelector } from 'react-redux';
 import usePrevious from '../../../hooks/usePrevious';
 import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
+import type { OrderFill } from '@metamask/perps-controller';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import type { CaipAccountId } from '@metamask/utils';
 import { areAddressesEqual } from '../../../../util/address';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
-import { FillType, PerpsTransaction } from '../types/transactionHistory';
+import { PerpsTransaction } from '../types/transactionHistory';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream/usePerpsLiveFills';
 import {
@@ -46,6 +47,7 @@ export const usePerpsTransactionHistory = ({
   skipInitialFetch = false,
 }: UsePerpsTransactionHistoryParams = {}): UsePerpsTransactionHistoryResult => {
   const [transactions, setTransactions] = useState<PerpsTransaction[]>([]);
+  const [restFills, setRestFills] = useState<OrderFill[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -140,6 +142,10 @@ export const usePerpsTransactionHistory = ({
         }
       }
 
+      // Store raw enriched fills so mergedTransactions can merge at fill level
+      // (prevents WS partial-snapshot from overwriting correctly aggregated REST data)
+      setRestFills(enrichedFills);
+
       // Transform each data type to PerpsTransaction format
       const fillTransactions = transformFillsToTransactions(enrichedFills);
       const orderTransactions = transformOrdersToTransactions(
@@ -223,34 +229,48 @@ export const usePerpsTransactionHistory = ({
     return null;
   }, [error, userHistoryError]);
 
-  // Merge live WebSocket fills with REST transactions for instant updates
-  // Live fills take precedence for recent trades
-  // IMPORTANT: Deduplicate trades using asset+timestamp (truncated to seconds), not tx.id,
-  // because:
-  // 1. The ID includes array index which differs between REST and WebSocket arrays
-  // 2. Aggregated fills (from split stop loss/TP) may have slightly different first-fill
-  //    timestamps between REST and WebSocket if fills arrive in different order
+  // Merge live WebSocket fills with REST fills at the raw OrderFill level first,
+  // then transform once. This ensures multi-fill trades (e.g. SL split into 10
+  // sub-fills) are aggregated from the complete fill set rather than from the WS
+  // partial snapshot, which would produce an incorrect (lower) PnL and size.
   const mergedTransactions = useMemo(() => {
-    // Transform live fills to PerpsTransaction format
-    // Note: transformFillsToTransactions now aggregates split stop loss/TP fills
-    const liveTransactions = transformFillsToTransactions(liveFills);
+    // Merge raw fills: REST fills first, then WS fills overwrite duplicates.
+    // Dedup key matches usePerpsHomeData pattern: orderId-timestamp-size-price.
+    const fillsMap = new Map<string, OrderFill>();
 
-    // If no REST transactions yet, return live fills plus wallet deposits (sorted)
-    if (transactions.length === 0) {
-      const combined = [...liveTransactions, ...walletDepositTransactions].sort(
-        (a, b) => b.timestamp - a.timestamp,
-      );
-      return combined;
+    for (const fill of restFills) {
+      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
+      fillsMap.set(key, fill);
     }
 
-    // Separate trade transactions from non-trade transactions (orders, funding, deposits)
-    // Non-trade transactions use their ID directly (no index issue)
-    const restTradeTransactions = transactions.filter(
-      (tx) => tx.type === 'trade',
+    // WS fills overwrite REST duplicates (live data is fresher).
+    // Preserve detailedOrderType and liquidation from REST when WS fill lacks them
+    // so TP/SL pills remain visible.
+    for (const fill of liveFills) {
+      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
+      const existing = fillsMap.get(key);
+      if (existing?.detailedOrderType && !fill.detailedOrderType) {
+        fillsMap.set(key, {
+          ...fill,
+          detailedOrderType: existing.detailedOrderType,
+          ...(existing.liquidation &&
+            !fill.liquidation && { liquidation: existing.liquidation }),
+        });
+      } else {
+        fillsMap.set(key, fill);
+      }
+    }
+
+    // Transform once on the complete merged fill set
+    const mergedFillTransactions = transformFillsToTransactions(
+      Array.from(fillsMap.values()).sort((a, b) => b.timestamp - a.timestamp),
     );
+
+    // Separate non-trade transactions (orders, funding, user history deposits)
     const nonTradeTransactions = transactions.filter(
       (tx) => tx.type !== 'trade',
     );
+
     // Deduplicate wallet deposits against REST (user history) deposits by txHash.
     // When a wallet-originated deposit is bridged and recorded by the perps backend,
     // it appears in both sources; we keep the REST version and drop the wallet duplicate.
@@ -269,69 +289,15 @@ export const usePerpsTransactionHistory = ({
         return h === '' || !restDepositTxHashes.has(h);
       },
     );
-    const nonTradeIncludingWalletDeposits = [
+
+    const allTransactions = [
+      ...mergedFillTransactions,
       ...nonTradeTransactions,
       ...walletDepositsDeduplicated,
     ];
 
-    // Merge trades using asset+timestamp(seconds) as dedup key
-    // Use seconds-truncated timestamp to handle cases where REST and WebSocket
-    // aggregated fills have slightly different first-fill timestamps
-    const tradeMap = new Map<string, PerpsTransaction>();
-
-    // Add REST trade transactions first
-    for (const tx of restTradeTransactions) {
-      // Use asset + timestamp (truncated to seconds) as key
-      const timestampSeconds = Math.floor(tx.timestamp / 1000);
-      const dedupKey = `${tx.asset}-${timestampSeconds}`;
-      tradeMap.set(dedupKey, tx);
-    }
-
-    // Add live fills (overwrites REST duplicates - live data is fresher)
-    // Preserve fillType from REST when WS fill lacks enrichment (TP/SL pills)
-    for (const tx of liveTransactions) {
-      const timestampSeconds = Math.floor(tx.timestamp / 1000);
-      const dedupKey = `${tx.asset}-${timestampSeconds}`;
-      const existing = tradeMap.get(dedupKey);
-      if (existing) {
-        DevLogger.log('[PR-28593] BUG_MARKER: WS overwrites REST trade', {
-          key: dedupKey,
-          restPnl: existing.fill?.pnl,
-          wsPnl: tx.fill?.pnl,
-          restAmount: existing.fill?.amount,
-          wsAmount: tx.fill?.amount,
-        });
-      }
-      if (
-        existing?.fill?.fillType &&
-        existing.fill.fillType !== FillType.Standard &&
-        tx.fill?.fillType === FillType.Standard
-      ) {
-        tradeMap.set(dedupKey, {
-          ...tx,
-          fill: {
-            ...tx.fill,
-            fillType: existing.fill.fillType,
-            ...(existing.fill.liquidation &&
-              !tx.fill.liquidation && {
-                liquidation: existing.fill.liquidation,
-              }),
-          },
-        });
-      } else {
-        tradeMap.set(dedupKey, tx);
-      }
-    }
-
-    // Combine deduplicated trades with non-trade transactions (including wallet deposits)
-    const allTransactions = [
-      ...Array.from(tradeMap.values()),
-      ...nonTradeIncludingWalletDeposits,
-    ];
-
-    // Sort by timestamp descending
     return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
-  }, [liveFills, transactions, walletDepositTransactions]);
+  }, [liveFills, restFills, transactions, walletDepositTransactions]);
 
   return {
     transactions: mergedTransactions,

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -293,6 +293,15 @@ export const usePerpsTransactionHistory = ({
       const timestampSeconds = Math.floor(tx.timestamp / 1000);
       const dedupKey = `${tx.asset}-${timestampSeconds}`;
       const existing = tradeMap.get(dedupKey);
+      if (existing) {
+        DevLogger.log('[PR-28593] BUG_MARKER: WS overwrites REST trade', {
+          key: dedupKey,
+          restPnl: existing.fill?.pnl,
+          wsPnl: tx.fill?.pnl,
+          restAmount: existing.fill?.amount,
+          wsAmount: tx.fill?.amount,
+        });
+      }
       if (
         existing?.fill?.fillType &&
         existing.fill.fillType !== FillType.Standard &&

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -147,7 +147,8 @@ export const usePerpsTransactionHistory = ({
       setRestFills(enrichedFills);
 
       // Transform each data type to PerpsTransaction format
-      const fillTransactions = transformFillsToTransactions(enrichedFills);
+      // Note: fill transactions are derived in mergedTransactions from restFills,
+      // so we only need orders, funding, and user history here.
       const orderTransactions = transformOrdersToTransactions(
         orders,
         fillSizeByOrderId,
@@ -157,9 +158,8 @@ export const usePerpsTransactionHistory = ({
         userHistoryRef.current,
       );
 
-      // Combine all transactions (no Arbitrum withdrawals - using user history as single source of truth)
+      // Combine all non-trade transactions (no Arbitrum withdrawals - using user history as single source of truth)
       const allTransactions = [
-        ...fillTransactions,
         ...orderTransactions,
         ...fundingTransactions,
         ...userHistoryTransactions,
@@ -187,6 +187,7 @@ export const usePerpsTransactionHistory = ({
       DevLogger.log('Error fetching transaction history:', errorMessage);
       setError(errorMessage);
       setTransactions([]);
+      setRestFills([]);
     } finally {
       setIsLoading(false);
     }

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -19,6 +19,7 @@ import {
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
+  mergeOrderFills,
 } from '../utils/transactionTransforms';
 
 interface UsePerpsTransactionHistoryParams {
@@ -235,36 +236,9 @@ export const usePerpsTransactionHistory = ({
   // sub-fills) are aggregated from the complete fill set rather than from the WS
   // partial snapshot, which would produce an incorrect (lower) PnL and size.
   const mergedTransactions = useMemo(() => {
-    // Merge raw fills: REST fills first, then WS fills overwrite duplicates.
-    // Dedup key matches usePerpsHomeData pattern: orderId-timestamp-size-price.
-    const fillsMap = new Map<string, OrderFill>();
-
-    for (const fill of restFills) {
-      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-      fillsMap.set(key, fill);
-    }
-
-    // WS fills overwrite REST duplicates (live data is fresher).
-    // Preserve detailedOrderType and liquidation from REST when WS fill lacks them
-    // so TP/SL pills remain visible.
-    for (const fill of liveFills) {
-      const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
-      const existing = fillsMap.get(key);
-      if (existing?.detailedOrderType && !fill.detailedOrderType) {
-        fillsMap.set(key, {
-          ...fill,
-          detailedOrderType: existing.detailedOrderType,
-          ...(existing.liquidation &&
-            !fill.liquidation && { liquidation: existing.liquidation }),
-        });
-      } else {
-        fillsMap.set(key, fill);
-      }
-    }
-
     // Transform once on the complete merged fill set
     const mergedFillTransactions = transformFillsToTransactions(
-      Array.from(fillsMap.values()).sort((a, b) => b.timestamp - a.timestamp),
+      mergeOrderFills(restFills, liveFills),
     );
 
     // Separate non-trade transactions (orders, funding, user history deposits)

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -191,6 +191,50 @@ export function aggregateFillsByTimestamp(fills: OrderFill[]): OrderFill[] {
   return allFills;
 }
 
+/**
+ * Merges REST and WebSocket fill arrays into a single deduplicated, sorted array.
+ *
+ * REST fills are added first; WS fills overwrite duplicates (fresher data).
+ * When a WS fill lacks `detailedOrderType` or `liquidation` that the REST fill has,
+ * the REST metadata is preserved so TP/SL pills remain visible on all screens.
+ *
+ * Dedup key: `orderId-timestamp-size-price`
+ *
+ * @param restFills - Historical fills from the REST API
+ * @param liveFills - Real-time fills from the WebSocket
+ * @returns Merged, deduplicated fills sorted by timestamp descending
+ */
+export function mergeOrderFills(
+  restFills: OrderFill[],
+  liveFills: OrderFill[],
+): OrderFill[] {
+  const fillsMap = new Map<string, OrderFill>();
+
+  for (const fill of restFills) {
+    const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
+    fillsMap.set(key, fill);
+  }
+
+  for (const fill of liveFills) {
+    const key = `${fill.orderId}-${fill.timestamp}-${fill.size}-${fill.price}`;
+    const existing = fillsMap.get(key);
+    if (existing?.detailedOrderType && !fill.detailedOrderType) {
+      fillsMap.set(key, {
+        ...fill,
+        detailedOrderType: existing.detailedOrderType,
+        ...(existing.liquidation &&
+          !fill.liquidation && { liquidation: existing.liquidation }),
+      });
+    } else {
+      fillsMap.set(key, fill);
+    }
+  }
+
+  return Array.from(fillsMap.values()).sort(
+    (a, b) => b.timestamp - a.timestamp,
+  );
+}
+
 export interface WithdrawalRequest {
   id: string;
   timestamp: number;


### PR DESCRIPTION
## **Description**

The Activity page showed incorrect (lower) PnL and size for trades executed via multiple sub-fills (e.g. a Stop Loss split into 10 partial fills). The `mergedTransactions` useMemo in `usePerpsTransactionHistory` aggregated WebSocket fills into `PerpsTransaction` objects before merging with REST data, allowing the WS partial snapshot to overwrite the correctly aggregated REST result. The fix merges raw `OrderFill` objects at the fill level first (same pattern as `usePerpsHomeData`), then transforms once on the complete set.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Activity page showed incorrect PnL and order size for trades executed via multiple partial fills (e.g. Stop Loss).

## **Related issues**

Fixes: [TAT-2483](https://consensyssoftware.atlassian.net/browse/TAT-2483)

## **Manual testing steps**

```gherkin
Feature: Activity page PnL correctness after multi-fill trade

  Scenario: Stop Loss execution with multiple sub-fills shows correct aggregated PnL
    Given wallet is unlocked and perps feature is enabled
    And a Stop Loss order was executed via multiple partial sub-fills

    When user navigates to Activity page → Trades tab

    Then the trade row PnL matches the value shown on the market detail page
    And no TypeError appears in Metro logs
    And no BUG_MARKER fires in Metro logs
```

## **Screenshots/Recordings**


### **Before**

<!-- before.mp4 — Activity page showing incorrect PnL (WS partial snapshot overwrites REST aggregate) -->

### **After**

<!-- after.mp4 — Activity page showing correct PnL after raw-fill-level merge -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json — TAT-2483: Activity page shows correct aggregated PnL after multi-fill trade</summary>

```json
{
  "title": "TAT-2483: Activity page shows correct aggregated PnL after multi-fill trade",
  "jira": "TAT-2483",
  "acceptance_criteria": [
    "Activity page Trades tab loads without error",
    "Trade transactions are present in the Trades tab",
    "No BUG_MARKER fires in metro logs (WS overwrite does not corrupt aggregated data)",
    "No TypeError or undefined errors in metro logs during Activity page render"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "nav-activity",
      "nodes": {
        "nav-activity": {
          "action": "navigate",
          "target": "PerpsActivity",
          "params": { "redirectToPerpsTransactions": true },
          "next": "wait-render"
        },
        "wait-render": {
          "action": "wait_for",
          "route": "PerpsActivity",
          "next": "check-no-errors"
        },
        "check-no-errors": {
          "action": "log_watch",
          "window_seconds": 5,
          "must_not_appear": ["BUG_MARKER", "TypeError", "undefined is not an object"],
          "watch_for": ["User fills received"],
          "next": "check-state"
        },
        "check-state": {
          "action": "eval_sync",
          "expression": "JSON.stringify(Engine.context.PerpsController.state.accountState)",
          "assert": { "operator": "not_null" },
          "next": "screenshot-activity"
        },
        "screenshot-activity": {
          "action": "screenshot",
          "filename": "evidence-activity-trades.png",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

[TAT-2483]: https://consensyssoftware.atlassian.net/browse/TAT-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the perps activity/trade merging logic to merge raw REST and WebSocket fills before transforming, which affects user-facing PnL/size calculations and deduplication across multiple screens.
> 
> **Overview**
> Fixes incorrect trade PnL/size for multi-subfill executions (e.g., Stop Loss/Take Profit) by **merging REST and WebSocket data at the raw `OrderFill` level before transforming into `PerpsTransaction`s** in `usePerpsTransactionHistory`.
> 
> Extracts the fill dedupe/merge behavior into a shared `mergeOrderFills` helper (preserving REST `detailedOrderType`/`liquidation` when WS lacks it) and reuses it in `usePerpsHomeData` and `usePerpsMarketFills`. Updates transaction history tests to exercise the real merge behavior and to assert ordering and `detailedOrderType` preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66451081350b850bf36b4cc50ac61c62a0f6d5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

