### PR TITLE
fix: route aggregated mUSD row to Cash screen instead of asset detail page

### DIFF
--- a/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
@@ -97,7 +97,7 @@ describe('CashTokensFullView', () => {
 
   it('renders mUSD title', () => {
     renderWithProvider(<CashTokensFullView />);
-    expect(screen.getByText('Cash')).toBeOnTheScreen();
+    expect(screen.getByText('Money')).toBeOnTheScreen();
   });
 
   it('renders Get mUSD empty state when user has no mUSD', () => {

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
@@ -116,12 +116,12 @@ describe('CashSection', () => {
     expect(queryByText('Cash')).toBeNull();
   });
 
-  it('renders Cash title when enabled', () => {
+  it('renders Money title when enabled', () => {
     renderWithProvider(
       <CashSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('Cash')).toBeOnTheScreen();
+    expect(screen.getByText('Money')).toBeOnTheScreen();
   });
 
   it('navigates to CASH_TOKENS_FULL_VIEW when Money home screen flag is disabled', () => {
@@ -133,7 +133,7 @@ describe('CashSection', () => {
       <CashSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    fireEvent.press(screen.getByText('Cash'));
+    fireEvent.press(screen.getByText('Money'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.WALLET.CASH_TOKENS_FULL_VIEW,
@@ -149,7 +149,7 @@ describe('CashSection', () => {
       <CashSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    fireEvent.press(screen.getByText('Cash'));
+    fireEvent.press(screen.getByText('Money'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ROOT);
   });

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.test.tsx
@@ -103,7 +103,7 @@ describe('CashSection', () => {
       <CashSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(queryByText('Cash')).toBeNull();
+    expect(queryByText('Money')).toBeNull();
   });
 
   it('returns null when geo is ineligible', () => {
@@ -113,7 +113,7 @@ describe('CashSection', () => {
       <CashSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(queryByText('Cash')).toBeNull();
+    expect(queryByText('Money')).toBeNull();
   });
 
   it('renders Money title when enabled', () => {

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
@@ -53,9 +53,9 @@ const CashSection = forwardRef<SectionRefreshHandle, CashSectionProps>(
 
     const handleViewCashTokens = useCallback(() => {
       if (isMoneyHomeEnabled) {
-        navigation.navigate(Routes.MONEY.ROOT as never);
+        navigation.navigate(Routes.MONEY.ROOT);
       } else {
-        navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW as never);
+        navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW);
       }
     }, [navigation, isMoneyHomeEnabled]);
 

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -57,6 +57,12 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
+const mockSelectMoneyHomeScreenEnabledFlag = jest.fn().mockReturnValue(false);
+jest.mock('../../../../UI/Money/selectors/featureFlags', () => ({
+  selectMoneyHomeScreenEnabledFlag: (state: unknown) =>
+    mockSelectMoneyHomeScreenEnabledFlag(state),
+}));
+
 describe('MusdAggregatedRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -100,16 +106,6 @@ describe('MusdAggregatedRow', () => {
     expect(screen.getByTestId('cash-section-musd-row')).toBeOnTheScreen();
   });
 
-  it('navigates to Cash tokens full view when row is pressed', () => {
-    renderWithProvider(<MusdAggregatedRow />);
-
-    fireEvent.press(screen.getByTestId('cash-section-musd-row'));
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.WALLET.CASH_TOKENS_FULL_VIEW,
-    );
-  });
-
   it('shows Spinner when isClaiming is true', () => {
     mockUseMerklBonusClaim.mockReturnValue({
       claimableReward: '10',
@@ -141,12 +137,8 @@ describe('MusdAggregatedRow', () => {
   });
 
   describe('handleTokenRowPress', () => {
-    it('navigates to Cash tokens full view when row is pressed', () => {
-      mockUseMusdBalance.mockReturnValueOnce({
-        tokenBalanceAggregated: '1800.5',
-        fiatBalanceAggregatedFormatted: '$1,800.50',
-        hasMusdBalanceOnAnyChain: true,
-      });
+    it('navigates to Cash tokens full view when Money Home is disabled', () => {
+      mockSelectMoneyHomeScreenEnabledFlag.mockReturnValue(false);
 
       renderWithProvider(<MusdAggregatedRow />);
 
@@ -155,6 +147,16 @@ describe('MusdAggregatedRow', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.WALLET.CASH_TOKENS_FULL_VIEW,
       );
+    });
+
+    it('navigates to Money Home when Money Home is enabled', () => {
+      mockSelectMoneyHomeScreenEnabledFlag.mockReturnValue(true);
+
+      renderWithProvider(<MusdAggregatedRow />);
+
+      fireEvent.press(screen.getByTestId('cash-section-musd-row'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ROOT);
     });
   });
 

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -2,22 +2,21 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MusdAggregatedRow from './MusdAggregatedRow';
-import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
-import NavigationService from '../../../../../core/NavigationService';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
 
 const mockClaimRewards = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn(() => ({
   addProperties: jest.fn().mockReturnThis(),
   build: jest.fn(),
-}));
-jest.mock('../../../../../core/NavigationService', () => ({
-  __esModule: true,
-  default: {
-    navigation: {
-      navigate: jest.fn(),
-    },
-  },
 }));
 
 const mockUseMusdBalance = jest.fn(() => ({
@@ -101,17 +100,13 @@ describe('MusdAggregatedRow', () => {
     expect(screen.getByTestId('cash-section-musd-row')).toBeOnTheScreen();
   });
 
-  it('navigates to Asset with mobile_token_list_page source when row is pressed', () => {
+  it('navigates to Cash tokens full view when row is pressed', () => {
     renderWithProvider(<MusdAggregatedRow />);
 
     fireEvent.press(screen.getByTestId('cash-section-musd-row'));
 
-    const mockNavigate = jest.mocked(NavigationService.navigation.navigate);
     expect(mockNavigate).toHaveBeenCalledWith(
-      'Asset',
-      expect.objectContaining({
-        source: TokenDetailsSource.HomeSection,
-      }),
+      Routes.WALLET.CASH_TOKENS_FULL_VIEW,
     );
   });
 
@@ -146,7 +141,7 @@ describe('MusdAggregatedRow', () => {
   });
 
   describe('handleTokenRowPress', () => {
-    it('navigates to mUSD mainnet Asset details with mobile_token_list_page source when user has mUSD on a chain', () => {
+    it('navigates to Cash tokens full view when row is pressed', () => {
       mockUseMusdBalance.mockReturnValueOnce({
         tokenBalanceAggregated: '1800.5',
         fiatBalanceAggregatedFormatted: '$1,800.50',
@@ -157,24 +152,8 @@ describe('MusdAggregatedRow', () => {
 
       fireEvent.press(screen.getByTestId('cash-section-musd-row'));
 
-      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
-        'Asset',
-        expect.objectContaining({
-          source: TokenDetailsSource.HomeSection,
-        }),
-      );
-    });
-
-    it('navigates to mUSD mainnet Asset details when user has no mUSD balance on any chain', () => {
-      renderWithProvider(<MusdAggregatedRow />);
-
-      fireEvent.press(screen.getByTestId('cash-section-musd-row'));
-
-      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
-        'Asset',
-        expect.objectContaining({
-          source: TokenDetailsSource.HomeSection,
-        }),
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.WALLET.CASH_TOKENS_FULL_VIEW,
       );
     });
   });

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -36,16 +36,16 @@ import { useMerklBonusClaim } from '../../../../UI/Earn/components/MerklRewards/
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import {
-  LINEA_MUSD_ASSET_FOR_MERKL,
-  MUSD_MAINNET_ASSET_FOR_DETAILS,
-} from './CashGetMusdEmptyState.constants';
-import NavigationService from '../../../../../core/NavigationService';
-import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
+import { LINEA_MUSD_ASSET_FOR_MERKL } from './CashGetMusdEmptyState.constants';
+import { useNavigation } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+import { selectMoneyHomeScreenEnabledFlag } from '../../../../UI/Money/selectors/featureFlags';
 
 const MusdAggregatedRow = () => {
   const tw = useTailwind();
+  const navigation = useNavigation();
   const privacyMode = useSelector(selectPrivacyMode);
+  const isMoneyHomeEnabled = useSelector(selectMoneyHomeScreenEnabledFlag);
   const { tokenBalanceAggregated, fiatBalanceAggregatedFormatted } =
     useMusdBalance();
   const { claimableReward, hasPendingClaim, claimRewards, isClaiming } =
@@ -75,11 +75,12 @@ const MusdAggregatedRow = () => {
   }, [trackEvent, createEventBuilder, networkName, claimRewards]);
 
   const handleTokenRowPress = useCallback(() => {
-    NavigationService.navigation.navigate('Asset', {
-      ...MUSD_MAINNET_ASSET_FOR_DETAILS,
-      source: TokenDetailsSource.HomeSection,
-    });
-  }, []);
+    if (isMoneyHomeEnabled) {
+      navigation.navigate(Routes.MONEY.ROOT);
+    } else {
+      navigation.navigate(Routes.WALLET.CASH_TOKENS_FULL_VIEW);
+    }
+  }, [navigation, isMoneyHomeEnabled]);
 
   const tokenBalanceDisplay = `${getIntlNumberFormatter(I18n.locale, {
     minimumFractionDigits: 0,

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -477,6 +477,7 @@ export interface RootStackParamList extends ParamListBase {
   NftFullView: undefined;
   TokensFullView: undefined;
   CashTokensFullView: undefined;
+  MoneyScreens: undefined;
   TrendingTokensFullView: undefined;
   RWATokensFullView: undefined;
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8367,7 +8367,7 @@
   "homepage": {
     "sections": {
       "cash": "Money",
-      "cash_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Cash section on the homepage.",
+      "cash_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Money section on the homepage.",
       "cash_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",
       "tokens": "Tokens",
       "perpetuals": "Perpetuals",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8366,7 +8366,7 @@
   },
   "homepage": {
     "sections": {
-      "cash": "Cash",
+      "cash": "Money",
       "cash_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Cash section on the homepage.",
       "cash_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",
       "tokens": "Tokens",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tapping the aggregated mUSD row on the Home screen previously routed to the Mainnet-only asset detail page, showing a single-network balance that didn't match the aggregated total displayed on Home. This caused a confusing balance mismatch (e.g. Home: $33.15, Detail: $9.39).

Now, tapping the mUSD row navigates to the Cash screen (or Money Home when enabled), which shows a per-network breakdown of mUSD balances. This matches user expectations: aggregated view → breakdown view. Individual network rows on the Cash screen still navigate to the corresponding asset detail page as before.

Additionally, added `MoneyScreens` to `RootStackParamList` and removed unnecessary `as never` type casts from navigation calls in both `MusdAggregatedRow` and `CashSection`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed mUSD row on Home navigating to a single-network detail page instead of the network breakdown screen

## **Related issues**

Fixes: MUSD-283

## **Manual testing steps**

```gherkin
Feature: Aggregated mUSD navigation

  Scenario: User taps aggregated mUSD row on Home
    Given the user has mUSD on multiple networks (e.g. Ethereum Mainnet and Linea)
    And the Home screen shows an aggregated mUSD balance

    When user taps the "MetaMask USD" row in the Cash section
    Then the Cash screen is displayed showing mUSD balances per network
    And the sum of per-network balances matches the aggregated balance on Home

  Scenario: User taps a network row on the Cash screen
    Given the user is on the Cash screen showing mUSD per network

    When user taps an individual network row (e.g. "mUSD on Linea")
    Then the asset detail page for that specific network is displayed

  Scenario: User taps the Cash section header on Home
    Given the user is on the Home screen with the Cash section visible

    When user taps the Cash section header
    Then the Cash screen is displayed (unchanged behaviour)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation targets for the Home mUSD aggregated row and Cash/Money section header based on a feature flag, which could misroute users if route names or flags are misconfigured. Also updates i18n strings and navigation typings, which is low-risk but touches app-wide route definitions.
> 
> **Overview**
> Fixes the Home screen aggregated mUSD row so tapping it navigates to the mUSD breakdown view (`CashTokensFullView`) instead of the single-network asset details screen, and routes to `MoneyScreens` when the Money home feature flag is enabled.
> 
> Renames the homepage section label from **Cash** to **Money** (including empty-state copy) and updates/extends navigation typing (`RootStackParamList` adds `MoneyScreens`) while cleaning up navigation calls and adjusting tests to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3a78901e7eb005383d31a63e76489422049bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->