### PR TITLE
fix: Ensure `AbortController` populates `reason` for `AbortSignal`

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -130,10 +130,31 @@ if (typeof global.CustomEvent === 'undefined') {
   };
 }
 
+// The ReactNative polyfill for AbortController does not populate `signal.reason`.
+class AbortControllerWithReason extends AbortController {
+  abort(reason) {
+    this.signal.reason = reason;
+    super.abort();
+  }
+}
+
+global.AbortController = AbortControllerWithReason;
+
 if (typeof global.AbortSignal.timeout === 'undefined') {
+  // In the browser this is a DOMException.
+  class TimeoutError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'TimeoutError';
+    }
+  }
+
   global.AbortSignal.timeout = function (delay) {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), delay);
+    setTimeout(
+      () => controller.abort(new TimeoutError('Signal timed out')),
+      delay,
+    );
     return controller.signal;
   };
 }

--- a/shim.js
+++ b/shim.js
@@ -130,10 +130,18 @@ if (typeof global.CustomEvent === 'undefined') {
   };
 }
 
+class AbortError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
 // The ReactNative polyfill for AbortController does not populate `signal.reason`.
 class AbortControllerWithReason extends AbortController {
   abort(reason) {
-    this.signal.reason = reason;
+    this.signal.reason =
+      reason ?? new AbortError('Signal is aborted without reason');
     super.abort();
   }
 }

--- a/shim.js
+++ b/shim.js
@@ -140,8 +140,14 @@ class AbortError extends Error {
 // The ReactNative polyfill for AbortController does not populate `signal.reason`.
 class AbortControllerWithReason extends AbortController {
   abort(reason) {
+    if (this.signal.aborted) {
+      return;
+    }
+
     this.signal.reason =
-      reason ?? new AbortError('Signal is aborted without reason');
+      reason === undefined
+        ? new AbortError('Signal is aborted without reason')
+        : reason;
     super.abort();
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

React Native uses a polyfill for `AbortController` that does not populate `signal.reason`. This causes errors derived from the signal in libraries such as `@nktkas/hyperliquid` to be thrown as `undefined`. This PR fixes that by populating `reason` onto the signal when it is passed. It mirrors the browser by defaulting to `AbortError` if no reason is passed.

Additionally this PR fixes an issue where our polyfill for `AbortSignal.timeout` had no error message.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overrides the global `AbortController` implementation to mutate `signal.reason`, which can subtly affect cancellation behavior across all consumers in React Native. Also changes `AbortSignal.timeout` to abort with a specific error object/message, potentially impacting code that inspects abort reasons.
> 
> **Overview**
> Ensures React Native abort signals behave closer to the browser by overriding `global.AbortController` with a wrapper that sets `signal.reason` when `abort(reason)` is called, defaulting to an `AbortError` when no reason is provided.
> 
> Updates the `AbortSignal.timeout` polyfill to abort with a `TimeoutError('Signal timed out')` instead of aborting without a reason/message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b652063b9f82357fb09c0eac3cc872f792322d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->