### PR TITLE
chore: remove unused tokensChainsCache usage in useWithdrawTokens

### DIFF
--- a/app/components/UI/Perps/hooks/useWithdrawTokens.test.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawTokens.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useSelector } from 'react-redux';
 import { useWithdrawTokens } from './useWithdrawTokens';
 import {
   USDC_SYMBOL,
@@ -8,46 +7,7 @@ import {
   HYPERLIQUID_MAINNET_CHAIN_ID,
 } from '@metamask/perps-controller';
 
-// Mock react-redux
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
-// Mock token icon utils
-jest.mock('../utils/tokenIconUtils');
-
-import { enhanceTokenWithIcon } from '../utils/tokenIconUtils';
-
 describe('useWithdrawTokens', () => {
-  const mockTokenList = {
-    '0xa4b1_0x0000000000000000000000000000000000000000': {
-      symbol: USDC_SYMBOL,
-      decimals: USDC_DECIMALS,
-      name: USDC_NAME,
-      iconUrl: 'https://test.com/usdc.png',
-    },
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    // Mock enhanceTokenWithIcon to add image property
-    (enhanceTokenWithIcon as jest.Mock).mockImplementation(({ token }) => ({
-      ...token,
-      image: 'https://test.com/usdc.png',
-    }));
-
-    (useSelector as jest.Mock).mockImplementation((selector) => {
-      if (selector.name === 'selectTokenList') {
-        return mockTokenList;
-      }
-      if (selector.name === 'selectIsIpfsGatewayEnabled') {
-        return false;
-      }
-      return null;
-    });
-  });
-
   it('should return source and destination tokens', () => {
     const { result } = renderHook(() => useWithdrawTokens());
 
@@ -75,36 +35,5 @@ describe('useWithdrawTokens', () => {
     expect(result.current.destToken.name).toBe(USDC_NAME);
     expect(result.current.destToken.chainId).toBe('0xa4b1'); // Arbitrum mainnet
     expect(result.current.destToken.currencyExchangeRate).toBe(1);
-  });
-
-  it('should work with token list', () => {
-    // For this test, just verify that when tokenList is present,
-    // the tokens are still returned with the expected properties
-    const { result } = renderHook(() => useWithdrawTokens());
-
-    // The important thing is that tokens are returned with correct base properties
-    expect(result.current.sourceToken).toBeDefined();
-    expect(result.current.destToken).toBeDefined();
-    expect(result.current.sourceToken.symbol).toBe(USDC_SYMBOL);
-    expect(result.current.destToken.symbol).toBe(USDC_SYMBOL);
-  });
-
-  it('should handle missing token list', () => {
-    (useSelector as jest.Mock).mockImplementation((selector) => {
-      if (selector.name === 'selectTokenList') {
-        return null;
-      }
-      if (selector.name === 'selectIsIpfsGatewayEnabled') {
-        return false;
-      }
-      return null;
-    });
-
-    const { result } = renderHook(() => useWithdrawTokens());
-
-    expect(result.current.sourceToken).toBeDefined();
-    expect(result.current.destToken).toBeDefined();
-    expect(result.current.sourceToken.image).toBeUndefined();
-    expect(result.current.destToken.image).toBeUndefined();
   });
 });

--- a/app/components/UI/Perps/hooks/useWithdrawTokens.ts
+++ b/app/components/UI/Perps/hooks/useWithdrawTokens.ts
@@ -1,9 +1,6 @@
 import { toHex } from '@metamask/controller-utils';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
-import { selectIsIpfsGatewayEnabled } from '../../../../selectors/preferencesController';
-import { selectTokenList } from '../../../../selectors/tokenListController';
 import {
   ARBITRUM_MAINNET_CHAIN_ID,
   HYPERLIQUID_MAINNET_CHAIN_ID,
@@ -14,7 +11,6 @@ import {
   ZERO_ADDRESS,
   type PerpsToken,
 } from '@metamask/perps-controller';
-import { enhanceTokenWithIcon } from '../utils/tokenIconUtils';
 
 /**
  * TODO: make the hook dynamic once we manage multiple perps provider.
@@ -24,61 +20,31 @@ import { enhanceTokenWithIcon } from '../utils/tokenIconUtils';
  * @returns Source and destination token configurations
  */
 export const useWithdrawTokens = () => {
-  // Selectors
-  const tokenList = useSelector(selectTokenList);
-  const isIpfsGatewayEnabled = useSelector(selectIsIpfsGatewayEnabled);
-
   // Source token (Hyperliquid USDC)
-  const sourceToken = useMemo<PerpsToken>(() => {
-    // Always use mainnet chain ID for network image (like in deposit/order views)
-    const hyperliquidChainId = HYPERLIQUID_MAINNET_CHAIN_ID;
-    const baseToken: PerpsToken = {
+  const sourceToken = useMemo<PerpsToken>(
+    () => ({
       symbol: USDC_SYMBOL,
       address: ZERO_ADDRESS,
       decimals: USDC_DECIMALS,
       name: USDC_NAME,
-      chainId: hyperliquidChainId,
+      chainId: HYPERLIQUID_MAINNET_CHAIN_ID,
       currencyExchangeRate: 1,
-    };
-
-    // Enhance with icon from token list
-    if (tokenList) {
-      return enhanceTokenWithIcon({
-        token: baseToken,
-        tokenList,
-        isIpfsGatewayEnabled,
-      });
-    }
-
-    return baseToken;
-  }, [tokenList, isIpfsGatewayEnabled]);
+    }),
+    [],
+  );
 
   // Destination token (Arbitrum USDC)
-  const destToken = useMemo<PerpsToken>(() => {
-    const arbitrumChainId = toHex(
-      Number.parseInt(ARBITRUM_MAINNET_CHAIN_ID, 10),
-    );
-
-    const baseToken: PerpsToken = {
+  const destToken = useMemo<PerpsToken>(
+    () => ({
       symbol: USDC_SYMBOL,
       address: USDC_ARBITRUM_MAINNET_ADDRESS,
       decimals: USDC_DECIMALS,
       name: USDC_NAME,
-      chainId: arbitrumChainId,
+      chainId: toHex(Number.parseInt(ARBITRUM_MAINNET_CHAIN_ID, 10)),
       currencyExchangeRate: 1,
-    };
-
-    // Enhance with icon from token list
-    if (tokenList) {
-      return enhanceTokenWithIcon({
-        token: baseToken,
-        tokenList,
-        isIpfsGatewayEnabled,
-      });
-    }
-
-    return baseToken;
-  }, [tokenList, isIpfsGatewayEnabled]);
+    }),
+    [],
+  );
 
   return {
     sourceToken,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Removes the dependency on `selectTokenList` (backed by `tokensChainsCache`) from the `useWithdrawTokens` hook as part of the broader effort to stop using `tokensChainsCache` across the codebase.

The `tokenList` selector was used to call `enhanceTokenWithIcon` on both the source (Hyperliquid USDC) and destination (Arbitrum USDC) tokens. Investigation showed this was dead code:
- The `image` field populated by `enhanceTokenWithIcon` was never consumed — `PerpsWithdrawView` hardcodes `imageSource={{ uri: USDC_TOKEN_ICON_URL }}` directly with an explicit comment
- `sourceToken` is never destructured by any caller; only `destToken` is used
- The three fields actually read from `destToken` (`.chainId`, `.address`, `.symbol`) are fully determined by static constants from `@metamask/perps-controller`
Both tokens are now plain constant objects built from imported constants. The `useSelector` calls for `selectTokenList` and `selectIsIpfsGatewayEnabled` are removed entirely.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove unused tokensChainsCache usage in useWithdrawTokens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3047

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes Redux selector dependencies and icon-enhancement logic from a small hook; main potential impact is any caller that previously relied on `image` or other token-list-derived fields (now no longer provided).
> 
> **Overview**
> **Simplifies `useWithdrawTokens`** by removing `react-redux` selectors (`selectTokenList`, `selectIsIpfsGatewayEnabled`) and the `enhanceTokenWithIcon` path, returning memoized constant USDC token objects built purely from `@metamask/perps-controller` constants.
> 
> **Updates tests** to drop Redux/icon mocking and removes cases covering token-list presence/absence, keeping only assertions for the static token fields (symbol/decimals/name/chainId/exchange rate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966add9e1834321c2bf995f591cfdfeca53af012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->