### PR TITLE
fix(preidct): prioritize sport market type sorting over price sorting in feed

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1970,7 +1970,7 @@ describe('polymarket utils', () => {
       expect(result.map((m) => m.conditionId)).toEqual(['first', 'second']);
     });
 
-    it('prioritizes sortBy parameter over sport event sorting', () => {
+    it('prioritizes sport event sorting over sortBy parameter', () => {
       const markets = [
         createMarket('totals-low-price', '["0.3", "0.7"]', 100, 100, 'totals'),
         createMarket(
@@ -1986,10 +1986,80 @@ describe('polymarket utils', () => {
 
       const result = sortMarkets(event, 'price');
 
-      // Price sorting overrides sport sorting
+      // Sport sorting takes priority: moneyline first regardless of price
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-high-price',
         'totals-low-price',
+      ]);
+    });
+
+    it('places moneyline first for sport events even when moneyline has lower price', () => {
+      const markets = [
+        createMarket(
+          'spreads-high-price',
+          '["0.9", "0.1"]',
+          200,
+          200,
+          'spreads',
+        ),
+        createMarket('totals-mid-price', '["0.7", "0.3"]', 150, 150, 'totals'),
+        createMarket(
+          'moneyline-low-price',
+          '["0.3", "0.7"]',
+          100,
+          100,
+          'moneyline',
+        ),
+      ];
+      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
+      const event = createEvent(sportTags, markets);
+
+      const result = sortMarkets(event, 'price');
+
+      // Moneyline first despite having the lowest price
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-low-price',
+        'spreads-high-price',
+        'totals-mid-price',
+      ]);
+    });
+
+    it('uses sortBy parameter for non-sport events when sortBy is provided', () => {
+      const markets = [
+        createMarket('low-price', '["0.2", "0.8"]', 100, 100),
+        createMarket('high-price', '["0.8", "0.2"]', 100, 100),
+      ];
+      const event = createEvent([], markets);
+
+      const result = sortMarkets(event, 'price');
+
+      // Non-sport events still respect sortBy
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'high-price',
+        'low-price',
+      ]);
+    });
+
+    it('ignores event.sortBy for sport events', () => {
+      const markets = [
+        createMarket('totals-high-price', '["0.9", "0.1"]', 100, 100, 'totals'),
+        createMarket(
+          'moneyline-low-price',
+          '["0.2", "0.8"]',
+          100,
+          100,
+          'moneyline',
+        ),
+      ];
+      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
+      const event = createEvent(sportTags, markets, 'price');
+
+      const result = sortMarkets(event);
+
+      // Sport sorting wins over event.sortBy
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'moneyline-low-price',
+        'totals-high-price',
       ]);
     });
   });

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1972,10 +1972,10 @@ describe('polymarket utils', () => {
 
     it('prioritizes sport event sorting over sortBy parameter', () => {
       const markets = [
-        createMarket('totals-low-price', '["0.3", "0.7"]', 100, 100, 'totals'),
+        createMarket('totals-high-price', '["0.9", "0.1"]', 100, 100, 'totals'),
         createMarket(
-          'moneyline-high-price',
-          '["0.9", "0.1"]',
+          'moneyline-low-price',
+          '["0.3", "0.7"]',
           100,
           100,
           'moneyline',
@@ -1986,10 +1986,9 @@ describe('polymarket utils', () => {
 
       const result = sortMarkets(event, 'price');
 
-      // Sport sorting takes priority: moneyline first regardless of price
       expect(result.map((m) => m.conditionId)).toEqual([
-        'moneyline-high-price',
-        'totals-low-price',
+        'moneyline-low-price',
+        'totals-high-price',
       ]);
     });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -670,16 +670,16 @@ export const sortMarkets = (
   const markets = Array.isArray(event.markets) ? event.markets : [];
   const eventSortBy = event.sortBy;
 
+  if (isSportEvent(event)) {
+    return sortSportMarkets(markets);
+  }
+
   if (sortBy) {
     return sortMarketsByField(markets, sortBy);
   }
 
   if (eventSortBy) {
     return sortMarketsByField(markets, eventSortBy);
-  }
-
-  if (isSportEvent(event)) {
-    return sortSportMarkets(markets);
   }
 
   return markets;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sport cards on the Predict feed and carousel were displaying the wrong market type (e.g. spreads or totals) instead of moneyline. This happened because `sortMarkets()` checked the `sortBy` parameter **before** `isSportEvent()`. Since both `getMarkets()` and `getCarouselMarkets()` always pass `sortMarketsBy: 'price'`, the `sortSportMarkets()` branch — which enforces moneyline → spreads → totals ordering — was never reached. The sport card components (`PredictMarketSportCard`, `FeaturedCarouselSportCard`) all use `market.outcomes[0]` to select the displayed market, so whichever market had the highest price would show up instead of the moneyline market.

**Fix**: Move the `isSportEvent()` check above the `sortBy` check in `sortMarkets()` so sport events always use sport-type-based ordering regardless of the `sortBy` parameter. Non-sport events are unaffected and continue to respect `sortBy` as before.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-814](https://consensyssoftware.atlassian.net/browse/PRED-814)

## **Manual testing steps**

```gherkin
Feature: Sport card moneyline market display

  Scenario: sport cards on the feed show the moneyline market
    Given the user is on the Predict tab
    And the feed contains sport events with multiple market types (moneyline, spreads, totals)

    When the user views a sport card on the feed
    Then the card displays the moneyline market outcomes (team names with win probabilities)
    And the card does not display spread or total market outcomes

  Scenario: sport cards on the featured carousel show the moneyline market
    Given the user is on the Predict home screen
    And the featured carousel contains sport events

    When the user views a sport card in the carousel
    Then the card displays the moneyline market outcomes
    And the card does not display spread or total market outcomes

  Scenario: non-sport markets remain sorted by price
    Given the user is on the Predict tab
    And the feed contains non-sport prediction markets

    When the user views the market cards
    Then markets are sorted by price in descending order as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e93b1754-ba6d-4005-a17e-110b2173f1cf

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d5fcf806-5eae-44e3-af43-57218d81063a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[PRED-814]: https://consensyssoftware.atlassian.net/browse/PRED-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested change to market ordering logic that only affects how sport events choose their primary market in the feed/carousel.
> 
> **Overview**
> Fixes sport event market ordering so `sortMarkets()` always applies `sortSportMarkets()` (moneyline → spreads → totals) *before* any `sortBy`/`event.sortBy` price-based sorting.
> 
> Updates unit tests to reflect the new precedence, adding coverage that sport events ignore both passed-in and event-level `sortBy`, while non-sport events continue to respect price sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f885c7d279fd84b955d383977ec7b2d2189c028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->