### PR TITLE
feat(predict): add extendedSportsMarketsLeagues version-gated feature flag

### DIFF
--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -1,4 +1,5 @@
 import {
+  PredictExtendedSportsMarketsFlag,
   PredictFeeCollection,
   PredictHotTabFlag,
   PredictLiveSportsFlag,
@@ -22,6 +23,13 @@ export const DEFAULT_LIVE_SPORTS_FLAG: PredictLiveSportsFlag = {
   enabled: false,
   leagues: [],
 };
+
+export const DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG: PredictExtendedSportsMarketsFlag =
+  {
+    enabled: false,
+    minimumVersion: '',
+    leagues: [],
+  };
 
 export const DEFAULT_MARKET_HIGHLIGHTS_FLAG: PredictMarketHighlightsFlag = {
   enabled: false,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -252,6 +252,7 @@ describe('PolymarketProvider', () => {
   const defaultFeatureFlags: PredictFeatureFlags = {
     feeCollection: DEFAULT_FEE_COLLECTION_FLAG,
     liveSportsLeagues: [],
+    extendedSportsMarketsLeagues: [],
     marketHighlightsFlag: {
       enabled: false,
       highlights: [],

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -174,6 +174,11 @@ export class PolymarketProvider implements PredictProvider {
     return filterSupportedLeagues(liveSportsLeagues);
   }
 
+  #hasExtendedMarketsForLeague(league: string): boolean {
+    const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
+    return extendedSportsMarketsLeagues.includes(league);
+  }
+
   #createTeamLookup(
     enabled: boolean,
   ):

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  selectExtendedSportsMarketsLeagues,
   selectPredictEnabledFlag,
   selectPredictFakOrdersEnabledFlag,
   selectPredictFeatureFlags,
@@ -1253,6 +1254,124 @@ describe('Predict Feature Flag Selectors', () => {
       const result = selectPredictUpDownEnabledFlag(state);
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('selectExtendedSportsMarketsLeagues', () => {
+    it('returns leagues when flag is enabled and version check passes', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictExtendedSportsMarkets: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                  leagues: ['nba', 'ucl'],
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectExtendedSportsMarketsLeagues(state);
+
+      expect(result).toEqual(['nba', 'ucl']);
+    });
+
+    it('returns empty array when flag is disabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictExtendedSportsMarkets: {
+                  enabled: false,
+                  minimumVersion: '1.0.0',
+                  leagues: ['nba', 'ucl'],
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectExtendedSportsMarketsLeagues(state);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when app version is below minimum required version', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictExtendedSportsMarkets: {
+                  enabled: true,
+                  minimumVersion: '99.0.0',
+                  leagues: ['nba'],
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectExtendedSportsMarketsLeagues(state);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when remote feature flags are empty', () => {
+      const result = selectExtendedSportsMarketsLeagues(mockedEmptyFlagsState);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when controller is undefined', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: undefined,
+          },
+        },
+      };
+
+      const result = selectExtendedSportsMarketsLeagues(state);
+
+      expect(result).toEqual([]);
+    });
+
+    it('filters out unsupported leagues', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictExtendedSportsMarkets: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                  leagues: ['nba', 'fake_league', 'ucl'],
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectExtendedSportsMarketsLeagues(state);
+
+      expect(result).toEqual(['nba', 'ucl']);
     });
   });
 });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -122,6 +122,11 @@ export const selectPredictFeatureFlags = createSelector(
     resolvePredictFeatureFlags({ remoteFeatureFlags, localOverrides }),
 );
 
+export const selectExtendedSportsMarketsLeagues = createSelector(
+  selectPredictFeatureFlags,
+  (flags) => flags.extendedSportsMarketsLeagues,
+);
+
 export const selectPredictFeeCollectionFlag = createSelector(
   selectPredictFeatureFlags,
   (flags) => flags.feeCollection,

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -18,9 +18,15 @@ export interface PredictMarketHighlightsFlag extends VersionGatedFeatureFlag {
   highlights: PredictMarketHighlight[];
 }
 
+export interface PredictExtendedSportsMarketsFlag
+  extends VersionGatedFeatureFlag {
+  leagues: string[];
+}
+
 export interface PredictFeatureFlags {
   feeCollection: PredictFeeCollection;
   liveSportsLeagues: string[];
+  extendedSportsMarketsLeagues: string[];
   marketHighlightsFlag: PredictMarketHighlightsFlag;
   fakOrdersEnabled: boolean;
   predictWithAnyTokenEnabled: boolean;

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -1,5 +1,6 @@
 import { validatedVersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
 import {
+  DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG,
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
 } from '../constants/flags';
@@ -25,6 +26,7 @@ describe('resolvePredictFeatureFlags', () => {
     expect(result).toEqual({
       feeCollection: DEFAULT_FEE_COLLECTION_FLAG,
       liveSportsLeagues: [],
+      extendedSportsMarketsLeagues: [],
       marketHighlightsFlag: DEFAULT_MARKET_HIGHLIGHTS_FLAG,
       fakOrdersEnabled: false,
       predictWithAnyTokenEnabled: false,
@@ -182,5 +184,124 @@ describe('resolvePredictFeatureFlags', () => {
 
     expect(result.fakOrdersEnabled).toBe(true);
     expect(result.predictWithAnyTokenEnabled).toBe(false);
+  });
+
+  describe('extendedSportsMarketsLeagues', () => {
+    it('returns empty array when flag is missing', () => {
+      const result = resolvePredictFeatureFlags({});
+
+      expect(result.extendedSportsMarketsLeagues).toEqual([]);
+    });
+
+    it('returns empty array when flag is disabled', () => {
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            ...DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG,
+            enabled: false,
+            leagues: ['nba', 'ucl'],
+          },
+        },
+      });
+
+      expect(result.extendedSportsMarketsLeagues).toEqual([]);
+    });
+
+    it('returns empty array when version check fails', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return false;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '99.0.0',
+            leagues: ['nba', 'ucl'],
+          },
+        },
+      });
+
+      expect(result.extendedSportsMarketsLeagues).toEqual([]);
+    });
+
+    it('returns filtered leagues when enabled and version check passes', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return true;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            leagues: ['nba', 'ucl', 'fake_league'],
+          },
+        },
+      });
+
+      expect(result.extendedSportsMarketsLeagues).toEqual(['nba', 'ucl']);
+    });
+
+    it('unwraps progressive rollout shape', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return true;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            name: 'group-a',
+            value: {
+              enabled: true,
+              minimumVersion: '1.0.0',
+              leagues: ['nba', 'epl'],
+            },
+          },
+        },
+      });
+
+      expect(result.extendedSportsMarketsLeagues).toEqual(['nba', 'epl']);
+    });
+
+    it('applies local override over remote flag', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) =>
+        Boolean(
+          flag &&
+            typeof flag === 'object' &&
+            'enabled' in flag &&
+            'leagues' in flag &&
+            (flag as { enabled: boolean }).enabled,
+        ),
+      );
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            leagues: ['nba', 'ucl'],
+          },
+        },
+        localOverrides: {
+          predictExtendedSportsMarkets: {
+            enabled: false,
+            minimumVersion: '1.0.0',
+            leagues: ['nba', 'ucl'],
+          },
+        },
+      });
+
+      expect(result.extendedSportsMarketsLeagues).toEqual([]);
+    });
   });
 });

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
@@ -3,6 +3,7 @@ import {
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 import {
+  DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG,
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
@@ -10,6 +11,7 @@ import {
 import { filterSupportedLeagues } from '../constants/sports';
 import { parse, PredictFeeCollectionSchema } from '../schemas';
 import {
+  PredictExtendedSportsMarketsFlag,
   PredictFeatureFlags,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
@@ -80,9 +82,23 @@ export function resolvePredictFeatureFlags(
       unwrapRemoteFeatureFlag<VersionGatedFeatureFlag>(flags.predictUpDown),
     ) ?? false;
 
+  const rawExtendedSportsFlag =
+    unwrapRemoteFeatureFlag<PredictExtendedSportsMarketsFlag>(
+      flags.predictExtendedSportsMarkets,
+    ) ?? DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG;
+
+  const isExtendedSportsEnabled = validatedVersionGatedFeatureFlag(
+    rawExtendedSportsFlag,
+  );
+
+  const extendedSportsMarketsLeagues = isExtendedSportsEnabled
+    ? filterSupportedLeagues(rawExtendedSportsFlag.leagues ?? [])
+    : [];
+
   return {
     feeCollection,
     liveSportsLeagues,
+    extendedSportsMarketsLeagues,
     marketHighlightsFlag,
     fakOrdersEnabled,
     predictWithAnyTokenEnabled,


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the `extendedSportsMarketsLeagues` feature flag infrastructure needed to control which sports leagues show extended market types (spreads, totals, player props, etc.) beyond moneyline.

The flag combines two existing patterns:
- **Version gating** (`VersionGatedFeatureFlag`) — ensures extended markets only activate on app versions that support the new UI
- **League-scoped filtering** (`filterSupportedLeagues`) — only leagues present in both the remote config and the hardcoded `SUPPORTED_SPORTS_LEAGUES` list are enabled

This is Phase 1 of the "Enable All Event Markets" epic (PRED-635). It lays the flag plumbing so that subsequent phases can conditionally render the extended markets UI on the game detail screen.

### Changes

| File | What |
|---|---|
| `types/flags.ts` | New `PredictExtendedSportsMarketsFlag` interface (extends `VersionGatedFeatureFlag` + `leagues[]`), added field to `PredictFeatureFlags` |
| `constants/flags.ts` | `DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG` default value |
| `utils/resolvePredictFeatureFlags.ts` | Resolution: unwrap progressive rollout → validate version gate → filter supported leagues |
| `selectors/featureFlags/index.ts` | `selectExtendedSportsMarketsLeagues` Redux selector |
| `providers/polymarket/PolymarketProvider.ts` | `#hasExtendedMarketsForLeague()` private method for downstream use |
| Test files | 12 new tests across resolver and selector test suites; provider mock updated |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-814](https://consensyssoftware.atlassian.net/browse/PRED-801) 

## **Manual testing steps**

```gherkin
Feature: extendedSportsMarketsLeagues feature flag

  Scenario: flag resolves to empty when remote config is absent
    Given the app launches without predictExtendedSportsMarkets in remote config
    When a selector reads extendedSportsMarketsLeagues
    Then it returns an empty array

  Scenario: flag resolves leagues when enabled and version passes
    Given predictExtendedSportsMarkets is set to { enabled: true, minimumVersion: "1.0.0", leagues: ["nba", "ucl"] }
    And the app version meets the minimum
    When a selector reads extendedSportsMarketsLeagues
    Then it returns ["nba", "ucl"]

  Scenario: flag resolves to empty when version check fails
    Given predictExtendedSportsMarkets is set to { enabled: true, minimumVersion: "99.0.0", leagues: ["nba"] }
    And the app version does not meet the minimum
    When a selector reads extendedSportsMarketsLeagues
    Then it returns an empty array
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new version-gated remote feature flag plumbing and selectors, with behavior defaulting to disabled/empty when missing or invalid.
> 
> **Overview**
> Adds a new version-gated remote feature flag (`predictExtendedSportsMarkets`) that resolves to an `extendedSportsMarketsLeagues` list, defaulting to empty unless enabled, the minimum app version is met, and leagues are supported.
> 
> Exposes the resolved leagues via `selectExtendedSportsMarketsLeagues`, wires the new field into `PredictFeatureFlags`, and adds a `PolymarketProvider` helper (`#hasExtendedMarketsForLeague`) for downstream conditional behavior. Includes comprehensive tests for progressive-rollout unwrapping, local overrides, version gating, and league filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c932efefc5bb22a0a273aa2e4a06a648541da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PRED-814]: https://consensyssoftware.atlassian.net/browse/PRED-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ