### PR TITLE
refactor: rename Controller types to MessengerClient types

### DIFF
--- a/app/core/Engine/controllers/account-tracker-controller-init.test.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.test.ts
@@ -2,7 +2,7 @@ import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getAccountTrackerControllerMessenger } from '../messengers/account-tracker-controller-messenger';
 
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { accountTrackerControllerInit } from './account-tracker-controller-init';
 import {
   AccountTrackerController,
@@ -28,7 +28,7 @@ jest.mock('../../../selectors/settings', () => ({
 }));
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<AccountTrackerControllerMessenger>
+  MessengerClientInitRequest<AccountTrackerControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/account-tracker-controller-init.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   AccountTrackerController,
   AccountTrackerControllerMessenger,
@@ -14,7 +14,7 @@ import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagC
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const accountTrackerControllerInit: ControllerInitFunction<
+export const accountTrackerControllerInit: MessengerClientInitFunction<
   AccountTrackerController,
   AccountTrackerControllerMessenger
 > = ({ controllerMessenger, persistedState, getController, getState }) => {

--- a/app/core/Engine/controllers/accounts-controller/index.test.ts
+++ b/app/core/Engine/controllers/accounts-controller/index.test.ts
@@ -2,7 +2,7 @@ import {
   AccountsController,
   type AccountsControllerMessenger,
 } from '@metamask/accounts-controller';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { accountsControllerInit } from '.';
 import { defaultAccountsControllerState } from './constants';
@@ -23,7 +23,7 @@ jest.mock('@metamask/accounts-controller');
 describe('accounts controller init', () => {
   const accountsControllerClassMock = jest.mocked(AccountsController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<AccountsControllerMessenger>
+    MessengerClientInitRequest<AccountsControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/accounts-controller/index.ts
+++ b/app/core/Engine/controllers/accounts-controller/index.ts
@@ -3,7 +3,7 @@ import {
   type AccountsControllerMessenger,
   type AccountsControllerState,
 } from '@metamask/accounts-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { logAccountsControllerCreation } from './utils';
 import { defaultAccountsControllerState } from './constants';
 
@@ -16,7 +16,7 @@ export * from './constants';
  * @param request - The request object.
  * @returns The AccountsController.
  */
-export const accountsControllerInit: ControllerInitFunction<
+export const accountsControllerInit: MessengerClientInitFunction<
   AccountsController,
   AccountsControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/address-book-controller-init.test.ts
+++ b/app/core/Engine/controllers/address-book-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getAddressBookControllerMessenger } from '../messengers/address-book-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { addressBookControllerInit } from './address-book-controller-init';
 import {
   AddressBookController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/address-book-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<AddressBookControllerMessenger>
+  MessengerClientInitRequest<AddressBookControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/address-book-controller-init.ts
+++ b/app/core/Engine/controllers/address-book-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   AddressBookController,
   type AddressBookControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const addressBookControllerInit: ControllerInitFunction<
+export const addressBookControllerInit: MessengerClientInitFunction<
   AddressBookController,
   AddressBookControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/ai-digest-controller-init.test.ts
+++ b/app/core/Engine/controllers/ai-digest-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getAiDigestControllerMessenger } from '../messengers/ai-digest-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { aiDigestControllerInit } from './ai-digest-controller-init';
 import {
   AiDigestController,
@@ -14,7 +14,7 @@ import AppConstants from '../../AppConstants';
 jest.mock('@metamask/ai-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<AiDigestControllerMessenger>
+  MessengerClientInitRequest<AiDigestControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/ai-digest-controller-init.ts
+++ b/app/core/Engine/controllers/ai-digest-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   AiDigestController,
   AiDigestService,
@@ -14,7 +14,7 @@ import AppConstants from '../../AppConstants';
  * @param request.persistedState - The persisted state to hydrate from.
  * @returns The initialized controller.
  */
-export const aiDigestControllerInit: ControllerInitFunction<
+export const aiDigestControllerInit: MessengerClientInitFunction<
   AiDigestController,
   AiDigestControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   AnalyticsController,
   AnalyticsControllerMessenger,
@@ -18,7 +18,7 @@ import { isE2E } from '../../../../util/test/utils';
  * @param request.persistedState - The persisted state for all controllers.
  * @returns The initialized controller.
  */
-export const analyticsControllerInit: ControllerInitFunction<
+export const analyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
   AnalyticsControllerMessenger
 > = ({ controllerMessenger, analyticsId, persistedState }) => {

--- a/app/core/Engine/controllers/app-metadata-controller/index.ts
+++ b/app/core/Engine/controllers/app-metadata-controller/index.ts
@@ -4,11 +4,11 @@ import {
 } from '@metamask/app-metadata-controller';
 import { getVersion } from 'react-native-device-info';
 import { version as migrationVersion } from '../../../../store/migrations';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { logAppMetadataControllerCreation } from './utils';
 
 export function appMetadataControllerInit(
-  initRequest: ControllerInitRequest<AppMetadataControllerMessenger>,
+  initRequest: MessengerClientInitRequest<AppMetadataControllerMessenger>,
 ) {
   const currentVersion = getVersion();
   const currentState = initRequest.persistedState?.AppMetadataController || {

--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.test.ts
@@ -6,7 +6,7 @@ import { ApprovalType } from '@metamask/controller-utils';
 
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { ApprovalControllerInit } from './approval-controller-init';
 import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
@@ -16,7 +16,7 @@ jest.mock('@metamask/approval-controller');
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
-): jest.Mocked<ControllerInitRequest<ApprovalControllerMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<ApprovalControllerMessenger>> {
   const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,
   });

--- a/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
+++ b/app/core/Engine/controllers/approval-controller/approval-controller-init.ts
@@ -7,9 +7,9 @@ import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 
 import Logger from '../../../../util/Logger';
 import { ApprovalTypes } from '../../../RPCMethods/RPCMethodMiddleware';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
-export const ApprovalControllerInit: ControllerInitFunction<
+export const ApprovalControllerInit: MessengerClientInitFunction<
   ApprovalController,
   ApprovalControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/assets-contract-controller-init.test.ts
+++ b/app/core/Engine/controllers/assets-contract-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getAssetsContractControllerMessenger } from '../messengers/assets-contract-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { assetsContractControllerInit } from './assets-contract-controller-init';
 import {
   AssetsContractController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<AssetsContractControllerMessenger>
+  MessengerClientInitRequest<AssetsContractControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/assets-contract-controller-init.ts
+++ b/app/core/Engine/controllers/assets-contract-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   AssetsContractController,
   type AssetsContractControllerMessenger,
@@ -12,7 +12,7 @@ import { getGlobalChainId } from '../../../util/networks/global-network';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const assetsContractControllerInit: ControllerInitFunction<
+export const assetsContractControllerInit: MessengerClientInitFunction<
   AssetsContractController,
   AssetsContractControllerMessenger
 > = ({ controllerMessenger, getController }) => {

--- a/app/core/Engine/controllers/assets-controller/assets-controller-init.test.ts
+++ b/app/core/Engine/controllers/assets-controller/assets-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   type AssetsControllerInitMessenger,
   type AssetsControllerMessenger,
 } from '../../messengers/assets-controller';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { assetsControllerInit } from './assets-controller-init';
 import { AssetsController } from '@metamask/assets-controller';
@@ -113,7 +113,7 @@ function getInitRequestMock(overrides?: {
   remoteFeatureFlagState?: RemoteFeatureFlagState;
   remoteFeatureFlagGetStateThrows?: boolean;
 }): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     AssetsControllerMessenger,
     AssetsControllerInitMessenger
   >
@@ -129,7 +129,7 @@ function getInitRequestMock(overrides?: {
     initMessenger,
     persistedState: {},
   } as jest.Mocked<
-    ControllerInitRequest<
+    MessengerClientInitRequest<
       AssetsControllerMessenger,
       AssetsControllerInitMessenger
     >

--- a/app/core/Engine/controllers/assets-controller/assets-controller-init.ts
+++ b/app/core/Engine/controllers/assets-controller/assets-controller-init.ts
@@ -8,7 +8,7 @@ import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
 } from '../../../../selectors/featureFlagController/assetsUnifyState';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   type AssetsControllerMessenger,
   type AssetsControllerInitMessenger,
@@ -87,7 +87,7 @@ function getApiClient(
  * @param request.getController - Function to get a controller by name.
  * @returns The initialized controller.
  */
-export const assetsControllerInit: ControllerInitFunction<
+export const assetsControllerInit: MessengerClientInitFunction<
   AssetsController,
   AssetsControllerMessenger,
   AssetsControllerInitMessenger

--- a/app/core/Engine/controllers/bridge-controller/bridge-controller-init.test.ts
+++ b/app/core/Engine/controllers/bridge-controller/bridge-controller-init.test.ts
@@ -12,7 +12,7 @@ import {
   getBridgeControllerMessenger,
   BridgeControllerInitMessenger,
 } from '../../messengers/bridge-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   bridgeControllerInit,
   handleBridgeFetch,
@@ -59,7 +59,7 @@ function buildTransactionControllerMock(
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
 ): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     BridgeControllerMessenger,
     BridgeControllerInitMessenger
   >

--- a/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
+++ b/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
@@ -5,7 +5,10 @@ import {
 } from '@metamask/bridge-controller';
 import { fetch as expoFetch } from 'expo/fetch';
 
-import { ControllerInitFunction, ControllerInitRequest } from '../../types';
+import {
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
+} from '../../types';
 import type { BridgeControllerInitMessenger } from '../../messengers/bridge-controller-messenger';
 import { TransactionParams } from '@metamask/transaction-controller';
 import { buildAndTrackEvent } from '../../utils/analytics';
@@ -33,7 +36,7 @@ export const handleBridgeFetch = async (
   return handleFetch(url, options);
 };
 
-export const bridgeControllerInit: ControllerInitFunction<
+export const bridgeControllerInit: MessengerClientInitFunction<
   BridgeController,
   BridgeControllerMessenger,
   BridgeControllerInitMessenger
@@ -82,7 +85,7 @@ export const bridgeControllerInit: ControllerInitFunction<
 };
 
 function getControllers(
-  request: ControllerInitRequest<
+  request: MessengerClientInitRequest<
     BridgeControllerMessenger,
     BridgeControllerInitMessenger
   >,

--- a/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.test.ts
+++ b/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.test.ts
@@ -9,7 +9,7 @@ import { handleFetch } from '@metamask/controller-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { getBridgeStatusControllerMessenger } from '../../messengers/bridge-status-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { bridgeStatusControllerInit } from './bridge-status-controller-init';
 import { trace } from '../../../../util/trace';
 import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
@@ -41,7 +41,7 @@ function buildTransactionControllerMock(
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
-): jest.Mocked<ControllerInitRequest<BridgeStatusControllerMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<BridgeStatusControllerMessenger>> {
   const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,
   });

--- a/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.ts
+++ b/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.ts
@@ -5,12 +5,15 @@ import {
 } from '@metamask/bridge-status-controller';
 import { handleFetch, TraceCallback } from '@metamask/controller-utils';
 
-import { ControllerInitFunction, ControllerInitRequest } from '../../types';
+import {
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
+} from '../../types';
 import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import { trace } from '../../../../util/trace';
 import Logger from '../../../../util/Logger';
 
-export const bridgeStatusControllerInit: ControllerInitFunction<
+export const bridgeStatusControllerInit: MessengerClientInitFunction<
   BridgeStatusController,
   BridgeStatusControllerMessenger
 > = (request) => {
@@ -41,7 +44,7 @@ export const bridgeStatusControllerInit: ControllerInitFunction<
 };
 
 function getControllers(
-  request: ControllerInitRequest<BridgeStatusControllerMessenger>,
+  request: MessengerClientInitRequest<BridgeStatusControllerMessenger>,
 ) {
   return {
     transactionController: request.getController('TransactionController'),

--- a/app/core/Engine/controllers/card-controller/index.test.ts
+++ b/app/core/Engine/controllers/card-controller/index.test.ts
@@ -1,6 +1,6 @@
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { CardController, defaultCardControllerState } from './CardController';
 import {
   type CardControllerMessenger,
@@ -20,7 +20,7 @@ jest.mock('./CardController', () => {
 describe('cardControllerInit', () => {
   const cardControllerClassMock = jest.mocked(CardController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<CardControllerMessenger>
+    MessengerClientInitRequest<CardControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/card-controller/index.ts
+++ b/app/core/Engine/controllers/card-controller/index.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { CardController, defaultCardControllerState } from './CardController';
 import type { CardControllerMessenger } from './types';
 import { BaanxService } from './services/BaanxService';
@@ -11,7 +11,7 @@ import { resolveBaanxConfig } from './services/baanx-config';
  * @param request - The request object.
  * @returns The CardController.
  */
-export const cardControllerInit: ControllerInitFunction<
+export const cardControllerInit: MessengerClientInitFunction<
   CardController,
   CardControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/compliance/compliance-controller-init.test.ts
+++ b/app/core/Engine/controllers/compliance/compliance-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getComplianceControllerMessenger } from '../../messengers/compliance/compliance-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { complianceControllerInit } from './compliance-controller-init';
 import {
   ComplianceController,
@@ -13,7 +13,7 @@ function getInitRequestMock(
   overrides: {
     persistedState?: Record<string, unknown>;
   } = {},
-): jest.Mocked<ControllerInitRequest<ComplianceControllerMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<ComplianceControllerMessenger>> {
   const { persistedState = {} } = overrides;
 
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({

--- a/app/core/Engine/controllers/compliance/compliance-controller-init.ts
+++ b/app/core/Engine/controllers/compliance/compliance-controller-init.ts
@@ -2,7 +2,7 @@ import {
   ComplianceController,
   type ComplianceControllerMessenger,
 } from '@metamask/compliance-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the ComplianceController.
@@ -17,7 +17,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request.persistedState - Persisted state to hydrate from.
  * @returns The initialized ComplianceController.
  */
-export const complianceControllerInit: ControllerInitFunction<
+export const complianceControllerInit: MessengerClientInitFunction<
   ComplianceController,
   ComplianceControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/compliance/compliance-service-init.test.ts
+++ b/app/core/Engine/controllers/compliance/compliance-service-init.test.ts
@@ -6,7 +6,7 @@ import {
   ComplianceService,
   type ComplianceServiceMessenger,
 } from '@metamask/compliance-controller';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
 jest.mock('../../../../util/environment', () => ({
@@ -20,7 +20,7 @@ const mockIsProduction = isProduction as jest.MockedFunction<
 >;
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<ComplianceServiceMessenger>
+  MessengerClientInitRequest<ComplianceServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/compliance/compliance-service-init.ts
+++ b/app/core/Engine/controllers/compliance/compliance-service-init.ts
@@ -2,7 +2,7 @@ import {
   ComplianceService,
   type ComplianceServiceMessenger,
 } from '@metamask/compliance-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { isProduction } from '../../../../util/environment';
 
 /**
@@ -12,7 +12,7 @@ import { isProduction } from '../../../../util/environment';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized ComplianceService.
  */
-export const complianceServiceInit: ControllerInitFunction<
+export const complianceServiceInit: MessengerClientInitFunction<
   ComplianceService,
   ComplianceServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getConnectivityControllerMessenger } from '../../messengers/connectivity-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { connectivityControllerInit } from './connectivity-controller-init';
 import {
   ConnectivityController,
@@ -15,7 +15,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('./netinfo-connectivity-adapter');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<ConnectivityControllerMessenger>
+  MessengerClientInitRequest<ConnectivityControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.ts
@@ -3,7 +3,7 @@ import {
   type ConnectivityControllerMessenger,
 } from '@metamask/connectivity-controller';
 
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 
 import { NetInfoConnectivityAdapter } from './netinfo-connectivity-adapter';
 
@@ -18,7 +18,7 @@ import { NetInfoConnectivityAdapter } from './netinfo-connectivity-adapter';
  * @param request.controllerMessenger - The messenger for the controller.
  * @returns The controller init result.
  */
-export const connectivityControllerInit: ControllerInitFunction<
+export const connectivityControllerInit: MessengerClientInitFunction<
   ConnectivityController,
   ConnectivityControllerMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/core-backend/account-activity-service-init.ts
+++ b/app/core/Engine/controllers/core-backend/account-activity-service-init.ts
@@ -2,7 +2,7 @@ import {
   AccountActivityService,
   AccountActivityServiceMessenger,
 } from '@metamask/core-backend';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { trace } from '../../../../util/trace';
 import Logger from '../../../../util/Logger';
 
@@ -13,7 +13,7 @@ import Logger from '../../../../util/Logger';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const accountActivityServiceInit: ControllerInitFunction<
+export const accountActivityServiceInit: MessengerClientInitFunction<
   AccountActivityService,
   AccountActivityServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/core-backend/backend-websocket-service-init.ts
+++ b/app/core/Engine/controllers/core-backend/backend-websocket-service-init.ts
@@ -1,5 +1,5 @@
 import { BackendWebSocketService } from '@metamask/core-backend';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   BackendWebSocketServiceMessenger,
   BackendWebSocketServiceInitMessenger,
@@ -23,7 +23,7 @@ import Logger from '../../../../util/Logger';
  * @param request.initMessenger - The messenger for accessing other controllers.
  * @returns The initialized service.
  */
-export const backendWebSocketServiceInit: ControllerInitFunction<
+export const backendWebSocketServiceInit: MessengerClientInitFunction<
   BackendWebSocketService,
   BackendWebSocketServiceMessenger,
   BackendWebSocketServiceInitMessenger

--- a/app/core/Engine/controllers/currency-rate-controller/currency-rate-controller-init.test.ts
+++ b/app/core/Engine/controllers/currency-rate-controller/currency-rate-controller-init.test.ts
@@ -2,7 +2,7 @@ import {
   CurrencyRateController,
   CurrencyRateMessenger,
 } from '@metamask/assets-controllers';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { currencyRateControllerInit } from './currency-rate-controller-init';
 import { defaultCurrencyRateState } from './constants';
@@ -14,7 +14,7 @@ jest.mock('@metamask/assets-controllers');
 describe('currency rate controller init', () => {
   const currencyRateControllerClassMock = jest.mocked(CurrencyRateController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<CurrencyRateMessenger>
+    MessengerClientInitRequest<CurrencyRateMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/currency-rate-controller/currency-rate-controller-init.ts
+++ b/app/core/Engine/controllers/currency-rate-controller/currency-rate-controller-init.ts
@@ -2,7 +2,7 @@ import {
   CurrencyRateController,
   CurrencyRateMessenger,
 } from '@metamask/assets-controllers';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { defaultCurrencyRateState } from './constants';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
 
@@ -20,7 +20,7 @@ interface CurrencyRateEntry {
   usdConversionRate: number | null;
 }
 
-export const currencyRateControllerInit: ControllerInitFunction<
+export const currencyRateControllerInit: MessengerClientInitFunction<
   CurrencyRateController,
   CurrencyRateMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.test.ts
+++ b/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.test.ts
@@ -1,4 +1,4 @@
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import {
@@ -27,7 +27,7 @@ function getInitRequestMock(
     namespace: MOCK_ANY_NAMESPACE,
   }),
 ): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     DeFiPositionsControllerMessenger,
     DeFiPositionsControllerInitMessenger
   >

--- a/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.ts
+++ b/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.ts
@@ -2,7 +2,7 @@ import {
   DeFiPositionsController,
   DeFiPositionsControllerMessenger,
 } from '@metamask/assets-controllers';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { DeFiPositionsControllerInitMessenger } from '../../messengers/defi-positions-controller-messenger/defi-positions-controller-messenger';
 import { store } from '../../../../store';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
@@ -18,7 +18,7 @@ import {
  * @param request - The request object.
  * @returns The DeFiPositionsController.
  */
-export const defiPositionsControllerInit: ControllerInitFunction<
+export const defiPositionsControllerInit: MessengerClientInitFunction<
   DeFiPositionsController,
   DeFiPositionsControllerMessenger,
   DeFiPositionsControllerInitMessenger

--- a/app/core/Engine/controllers/delegation/delegation-controller-init.test.ts
+++ b/app/core/Engine/controllers/delegation/delegation-controller-init.test.ts
@@ -16,7 +16,7 @@ import {
   DelegationControllerInit,
   awaitDeleteDelegationEntry,
 } from './delegation-controller-init';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   DelegationControllerInitMessenger,
   getDelegationControllerInitMessenger,
@@ -29,7 +29,7 @@ import { Hex } from '@metamask/utils';
 jest.mock('@metamask/delegation-controller');
 
 function buildInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     DelegationControllerMessenger,
     DelegationControllerInitMessenger
   >

--- a/app/core/Engine/controllers/delegation/delegation-controller-init.ts
+++ b/app/core/Engine/controllers/delegation/delegation-controller-init.ts
@@ -13,7 +13,7 @@ import {
   getDeleGatorEnvironment,
 } from '../../../Delegation';
 import { Hex } from '@metamask/utils';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { DelegationControllerInitMessenger } from '../../messengers/delegation/delegation-controller-messenger';
 
 const getDelegationEnvironment = (chainId: Hex) =>
@@ -28,7 +28,7 @@ const getDelegationEnvironment = (chainId: Hex) =>
  * @param request.initMessenger - The initialization messenger for the controller.
  * @returns The initialized controller.
  */
-export const DelegationControllerInit: ControllerInitFunction<
+export const DelegationControllerInit: MessengerClientInitFunction<
   DelegationController,
   DelegationControllerMessenger,
   DelegationControllerInitMessenger

--- a/app/core/Engine/controllers/earn-controller-init.test.ts
+++ b/app/core/Engine/controllers/earn-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   EarnControllerInitMessenger,
   getEarnControllerInitMessenger,
 } from '../messengers/earn-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { earnControllerInit } from './earn-controller-init';
 import {
   EarnController,
@@ -16,7 +16,10 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/earn-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<EarnControllerMessenger, EarnControllerInitMessenger>
+  MessengerClientInitRequest<
+    EarnControllerMessenger,
+    EarnControllerInitMessenger
+  >
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/earn-controller-init.ts
+++ b/app/core/Engine/controllers/earn-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   EarnController,
   EarnControllerMessenger,
@@ -12,7 +12,7 @@ import { EarnControllerInitMessenger } from '../messengers/earn-controller-messe
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const earnControllerInit: ControllerInitFunction<
+export const earnControllerInit: MessengerClientInitFunction<
   EarnController,
   EarnControllerMessenger,
   EarnControllerInitMessenger

--- a/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.test.ts
+++ b/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.test.ts
@@ -10,7 +10,7 @@ import { isMainnetByChainId } from '../../../../util/networks';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import AppConstants from '../../../AppConstants';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { GasFeeControllerInit } from './gas-fee-controller-init';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
@@ -42,7 +42,7 @@ function buildControllerMock(
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
-): jest.Mocked<ControllerInitRequest<GasFeeMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<GasFeeMessenger>> {
   const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,
   });

--- a/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts
+++ b/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts
@@ -5,8 +5,8 @@ import {
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 import type {
-  ControllerInitFunction,
-  ControllerInitRequest,
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
 } from '../../types';
 import AppConstants from '../../../AppConstants';
 import Logger from '../../../../util/Logger';
@@ -17,7 +17,7 @@ const LEGACY_GAS_API_ENDPOINT =
 const EIP1559_API_ENDPOINT =
   'https://gas.api.cx.metamask.io/networks/<chain_id>/suggestedGasFees';
 
-export const GasFeeControllerInit: ControllerInitFunction<
+export const GasFeeControllerInit: MessengerClientInitFunction<
   GasFeeController,
   GasFeeMessenger
 > = (request) => {
@@ -53,7 +53,7 @@ export const GasFeeControllerInit: ControllerInitFunction<
   }
 };
 
-function getControllers(request: ControllerInitRequest<GasFeeMessenger>) {
+function getControllers(request: MessengerClientInitRequest<GasFeeMessenger>) {
   return {
     networkController: request.getController('NetworkController'),
   };

--- a/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.test.ts
+++ b/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.test.ts
@@ -3,7 +3,7 @@ import {
   type GatorPermissionsControllerState,
 } from '@metamask/gator-permissions-controller';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import {
   getGatorPermissionsControllerMessenger,
   GatorPermissionsControllerMessenger,
@@ -15,7 +15,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/gator-permissions-controller');
 
 function buildInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<GatorPermissionsControllerMessenger>
+  MessengerClientInitRequest<GatorPermissionsControllerMessenger>
 > {
   const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.ts
+++ b/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   type GatorPermissionsControllerMessenger,
   GatorPermissionsController,
@@ -32,7 +32,7 @@ const createGatorPermissionsConfig = (): GatorPermissionsControllerConfig => {
   return config;
 };
 
-export const GatorPermissionsControllerInit: ControllerInitFunction<
+export const GatorPermissionsControllerInit: MessengerClientInitFunction<
   GatorPermissionsController,
   GatorPermissionsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/geolocation-api-service-init.test.ts
+++ b/app/core/Engine/controllers/geolocation-api-service-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getGeolocationApiServiceMessenger } from '../messengers/geolocation-api-service-messenger';
-import type { ControllerInitRequest } from '../types';
+import type { MessengerClientInitRequest } from '../types';
 import { geolocationApiServiceInit } from './geolocation-api-service-init';
 import {
   GeolocationApiService,
@@ -21,7 +21,7 @@ import { SdkEnvironment } from '@consensys/native-ramps-sdk';
 const mockGetSdkEnvironment = jest.mocked(getSdkEnvironment);
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<GeolocationApiServiceMessenger>
+  MessengerClientInitRequest<GeolocationApiServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/geolocation-api-service-init.ts
+++ b/app/core/Engine/controllers/geolocation-api-service-init.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/geolocation-controller';
 import { SdkEnvironment } from '@consensys/native-ramps-sdk';
 import { getSdkEnvironment } from '../../../components/UI/Ramp/Deposit/sdk/getSdkEnvironment';
-import type { ControllerInitFunction } from '../types';
+import type { MessengerClientInitFunction } from '../types';
 
 /**
  * Initialize the GeolocationApiService.
@@ -14,7 +14,7 @@ import type { ControllerInitFunction } from '../types';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const geolocationApiServiceInit: ControllerInitFunction<
+export const geolocationApiServiceInit: MessengerClientInitFunction<
   GeolocationApiService,
   GeolocationApiServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/geolocation-controller/index.test.ts
+++ b/app/core/Engine/controllers/geolocation-controller/index.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getGeolocationControllerMessenger } from '../../messengers/geolocation-controller-messenger';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { geolocationControllerInit } from './index';
 import {
   GeolocationController,
@@ -24,8 +24,10 @@ jest.mock('@metamask/geolocation-controller', () => {
 });
 
 function getInitRequestMock(
-  overrides?: Partial<ControllerInitRequest<GeolocationControllerMessenger>>,
-): jest.Mocked<ControllerInitRequest<GeolocationControllerMessenger>> {
+  overrides?: Partial<
+    MessengerClientInitRequest<GeolocationControllerMessenger>
+  >,
+): jest.Mocked<MessengerClientInitRequest<GeolocationControllerMessenger>> {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,
   });
@@ -35,7 +37,7 @@ function getInitRequestMock(
     controllerMessenger: getGeolocationControllerMessenger(baseMessenger),
     initMessenger: undefined,
     ...overrides,
-  } as jest.Mocked<ControllerInitRequest<GeolocationControllerMessenger>>;
+  } as jest.Mocked<MessengerClientInitRequest<GeolocationControllerMessenger>>;
 }
 
 describe('geolocationControllerInit', () => {

--- a/app/core/Engine/controllers/geolocation-controller/index.ts
+++ b/app/core/Engine/controllers/geolocation-controller/index.ts
@@ -4,7 +4,7 @@ import {
   UNKNOWN_LOCATION,
   type GeolocationControllerMessenger,
 } from '@metamask/geolocation-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the GeolocationController.
@@ -14,7 +14,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request.persistedState - The persisted state to hydrate from.
  * @returns The initialized controller.
  */
-export const geolocationControllerInit: ControllerInitFunction<
+export const geolocationControllerInit: MessengerClientInitFunction<
   GeolocationController,
   GeolocationControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
+++ b/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getAuthenticationControllerMessenger } from '../../messengers/identity/authentication-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { authenticationControllerInit } from './authentication-controller-init';
 import {
   Controller as AuthenticationController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/profile-sync-controller/auth');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<AuthenticationControllerMessenger>
+  MessengerClientInitRequest<AuthenticationControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/identity/authentication-controller-init.ts
+++ b/app/core/Engine/controllers/identity/authentication-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   Controller as AuthenticationController,
   type AuthenticationControllerMessenger,
@@ -12,7 +12,7 @@ import { Platform } from '@metamask/profile-sync-controller/sdk';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const authenticationControllerInit: ControllerInitFunction<
+export const authenticationControllerInit: MessengerClientInitFunction<
   AuthenticationController,
   AuthenticationControllerMessenger
 > = ({ controllerMessenger, persistedState, analyticsId }) => {

--- a/app/core/Engine/controllers/identity/user-storage-controller-init.test.ts
+++ b/app/core/Engine/controllers/identity/user-storage-controller-init.test.ts
@@ -4,7 +4,7 @@ import {
   getUserStorageControllerMessenger,
   getUserStorageControllerInitMessenger,
 } from '../../messengers/identity/user-storage-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { userStorageControllerInit } from './user-storage-controller-init';
 import {
   Controller as UserStorageController,
@@ -21,7 +21,7 @@ jest.mock('../../utils/analytics');
 jest.mock('../../../../util/analytics/AnalyticsEventBuilder');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     UserStorageControllerMessenger,
     ReturnType<typeof getUserStorageControllerInitMessenger>
   >

--- a/app/core/Engine/controllers/identity/user-storage-controller-init.ts
+++ b/app/core/Engine/controllers/identity/user-storage-controller-init.ts
@@ -1,5 +1,5 @@
 import { scrypt } from 'react-native-fast-crypto';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   Controller as UserStorageController,
   UserStorageControllerMessenger,
@@ -16,7 +16,7 @@ import { buildAndTrackEvent } from '../../utils/analytics';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const userStorageControllerInit: ControllerInitFunction<
+export const userStorageControllerInit: MessengerClientInitFunction<
   UserStorageController,
   UserStorageControllerMessenger,
   UserStorageControllerInitMessenger

--- a/app/core/Engine/controllers/keyring-controller/keyring-controller-init.test.ts
+++ b/app/core/Engine/controllers/keyring-controller/keyring-controller-init.test.ts
@@ -9,7 +9,7 @@ const mockIsMoneyAccountEnabled = jest.requireMock(
 ).isMoneyAccountEnabled as jest.Mock;
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getKeyringControllerMessenger } from '../../messengers/keyring-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { keyringControllerInit } from './keyring-controller-init';
 import {
   KeyringController,
@@ -31,7 +31,7 @@ jest.mock('@metamask/eth-money-keyring', () => {
 const mockWithKeyringUnsafe = jest.fn();
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<KeyringControllerMessenger>
+  MessengerClientInitRequest<KeyringControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/keyring-controller/keyring-controller-init.ts
+++ b/app/core/Engine/controllers/keyring-controller/keyring-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { isMoneyAccountEnabled } from '../../../../lib/Money/feature-flags';
 import { CryptographicFunctions } from '@metamask/key-tree';
 import { encodeMnemonic } from '@metamask/keyring-sdk';
@@ -34,7 +34,7 @@ const encryptor = new Encryptor({
  * @param request.persistedState - The persisted state of the client.
  * @returns The initialized controller.
  */
-export const keyringControllerInit: ControllerInitFunction<
+export const keyringControllerInit: MessengerClientInitFunction<
   KeyringController,
   KeyringControllerMessenger
 > = ({

--- a/app/core/Engine/controllers/logging-controller-init.test.ts
+++ b/app/core/Engine/controllers/logging-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getLoggingControllerMessenger } from '../messengers/logging-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { loggingControllerInit } from './logging-controller-init';
 import {
   LoggingController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/logging-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<LoggingControllerMessenger>
+  MessengerClientInitRequest<LoggingControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/logging-controller-init.ts
+++ b/app/core/Engine/controllers/logging-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   LoggingController,
   LoggingControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const loggingControllerInit: ControllerInitFunction<
+export const loggingControllerInit: MessengerClientInitFunction<
   LoggingController,
   LoggingControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/money-account-controller-init.test.ts
+++ b/app/core/Engine/controllers/money-account-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getMoneyAccountControllerMessenger } from '../messengers/money-account-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { moneyAccountControllerInit } from './money-account-controller-init';
 import {
   MoneyAccountController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/money-account-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<MoneyAccountControllerMessenger>
+  MessengerClientInitRequest<MoneyAccountControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/money-account-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   MoneyAccountController,
   MoneyAccountControllerMessenger,
@@ -13,7 +13,7 @@ import {
  * @param request.persistedState - The persisted state to restore.
  * @returns The initialized controller.
  */
-export const moneyAccountControllerInit: ControllerInitFunction<
+export const moneyAccountControllerInit: MessengerClientInitFunction<
   MoneyAccountController,
   MoneyAccountControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.test.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.test.ts
@@ -6,7 +6,7 @@ import {
   TRX_ACCOUNT_PROVIDER_NAME,
 } from '@metamask/multichain-account-service';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { multichainAccountServiceInit } from './multichain-account-service-init';
 import {
   MultichainAccountServiceInitMessenger,
@@ -43,7 +43,7 @@ function getInitRequestMock({
 }: {
   messenger?: MockInitMessenger;
 } = {}): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     MultichainAccountServiceMessenger,
     MultichainAccountServiceInitMessenger
   >

--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
@@ -5,7 +5,7 @@ import {
   BTC_ACCOUNT_PROVIDER_NAME,
   TRX_ACCOUNT_PROVIDER_NAME,
 } from '@metamask/multichain-account-service';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import Engine from '../../Engine';
 import { forwardSelectedAccountGroupToSnapKeyring } from '../../../SnapKeyring/utils/forwardSelectedAccountGroupToSnapKeyring';
 import { MultichainAccountServiceInitMessenger } from '../../messengers/multichain-account-service-messenger/multichain-account-service-messenger';
@@ -17,7 +17,7 @@ import { MultichainAccountServiceInitMessenger } from '../../messengers/multicha
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const multichainAccountServiceInit: ControllerInitFunction<
+export const multichainAccountServiceInit: MessengerClientInitFunction<
   MultichainAccountService,
   MultichainAccountServiceMessenger,
   MultichainAccountServiceInitMessenger

--- a/app/core/Engine/controllers/multichain-assets-controller/multichain-assets-controller-init.test.ts
+++ b/app/core/Engine/controllers/multichain-assets-controller/multichain-assets-controller-init.test.ts
@@ -3,7 +3,7 @@ import {
   type MultichainAssetsControllerMessenger,
   MultichainAssetsControllerState,
 } from '@metamask/assets-controllers';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { multichainAssetsControllerInit } from './multichain-assets-controller-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
@@ -16,7 +16,7 @@ describe('multichain assets controller init', () => {
     MultichainAssetsController,
   );
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<MultichainAssetsControllerMessenger>
+    MessengerClientInitRequest<MultichainAssetsControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/multichain-assets-controller/multichain-assets-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-assets-controller/multichain-assets-controller-init.ts
@@ -3,7 +3,7 @@ import {
   type MultichainAssetsControllerMessenger,
   MultichainAssetsControllerState,
 } from '@metamask/assets-controllers';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the MultichainAssetsController.
@@ -11,7 +11,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request - The request object.
  * @returns The MultichainAssetsController.
  */
-export const multichainAssetsControllerInit: ControllerInitFunction<
+export const multichainAssetsControllerInit: MessengerClientInitFunction<
   MultichainAssetsController,
   MultichainAssetsControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.test.ts
+++ b/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.test.ts
@@ -3,7 +3,7 @@ import {
   type MultichainAssetsRatesControllerMessenger,
   MultichainAssetsRatesControllerState,
 } from '@metamask/assets-controllers';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { multichainAssetsRatesControllerInit } from './multichain-assets-rates-controller-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
@@ -16,7 +16,7 @@ describe('multichain assets rates controller init', () => {
     MultichainAssetsRatesController,
   );
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<MultichainAssetsRatesControllerMessenger>
+    MessengerClientInitRequest<MultichainAssetsRatesControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.ts
@@ -3,7 +3,7 @@ import {
   type MultichainAssetsRatesControllerMessenger,
   MultichainAssetsRatesControllerState,
 } from '@metamask/assets-controllers';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the MultichainAssetsRatesController.
@@ -11,7 +11,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request - The request object.
  * @returns The MultichainAssetsRatesController.
  */
-export const multichainAssetsRatesControllerInit: ControllerInitFunction<
+export const multichainAssetsRatesControllerInit: MessengerClientInitFunction<
   MultichainAssetsRatesController,
   MultichainAssetsRatesControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/multichain-balances-controller/multichain-balances-controller-init.test.ts
+++ b/app/core/Engine/controllers/multichain-balances-controller/multichain-balances-controller-init.test.ts
@@ -3,7 +3,7 @@ import {
   MultichainBalancesControllerMessenger,
   MultichainBalancesControllerState,
 } from '@metamask/assets-controllers';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { multichainBalancesControllerInit } from './multichain-balances-controller-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
@@ -16,7 +16,7 @@ describe('multichain balances controller init', () => {
     MultichainBalancesController,
   );
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<MultichainBalancesControllerMessenger>
+    MessengerClientInitRequest<MultichainBalancesControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/multichain-balances-controller/multichain-balances-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-balances-controller/multichain-balances-controller-init.ts
@@ -3,7 +3,7 @@ import {
   MultichainBalancesControllerState,
   MultichainBalancesControllerMessenger,
 } from '@metamask/assets-controllers';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the MultichainBalancesController.
@@ -11,7 +11,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request - The request object.
  * @returns The MultichainBalancesController.
  */
-export const multichainBalancesControllerInit: ControllerInitFunction<
+export const multichainBalancesControllerInit: MessengerClientInitFunction<
   MultichainBalancesController,
   MultichainBalancesControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/multichain-network-controller/multichain-network-controller-init.test.ts
+++ b/app/core/Engine/controllers/multichain-network-controller/multichain-network-controller-init.test.ts
@@ -7,7 +7,7 @@ import {
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { multichainNetworkControllerInit } from './multichain-network-controller-init';
 import { BtcScope } from '@metamask/keyring-api';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
@@ -17,7 +17,7 @@ describe('multichain network controller init', () => {
   const multichainNetworkControllerClassMock = jest.mocked(
     MultichainNetworkController,
   );
-  let initRequestMock: ControllerInitRequest<MultichainNetworkControllerMessenger> & {
+  let initRequestMock: MessengerClientInitRequest<MultichainNetworkControllerMessenger> & {
     fetchFunction: typeof fetch;
   };
 

--- a/app/core/Engine/controllers/multichain-network-controller/multichain-network-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-network-controller/multichain-network-controller-init.ts
@@ -3,7 +3,10 @@ import {
   MultichainNetworkControllerMessenger,
   MultichainNetworkControllerState,
 } from '@metamask/multichain-network-controller';
-import { ControllerInitFunction, ControllerInitRequest } from '../../types';
+import {
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
+} from '../../types';
 import { MultichainNetworkServiceInit } from './multichain-network-service-init';
 
 /**
@@ -15,8 +18,8 @@ import { MultichainNetworkServiceInit } from './multichain-network-service-init'
 export const multichainNetworkControllerInit = ({
   controllerMessenger,
   persistedState,
-}: ControllerInitRequest<MultichainNetworkControllerMessenger>): ReturnType<
-  ControllerInitFunction<
+}: MessengerClientInitRequest<MultichainNetworkControllerMessenger>): ReturnType<
+  MessengerClientInitFunction<
     MultichainNetworkController,
     MultichainNetworkControllerMessenger
   >

--- a/app/core/Engine/controllers/multichain-routing-service-init.test.ts
+++ b/app/core/Engine/controllers/multichain-routing-service-init.test.ts
@@ -5,7 +5,7 @@ import {
   getMultichainRoutingServiceMessenger,
   MultichainRoutingServiceInitMessenger,
 } from '../messengers/multichain-routing-service-messenger.ts';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { multichainRoutingServiceInit } from './multichain-routing-service-init.ts';
 import {
   MultichainRoutingService,
@@ -16,7 +16,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/snaps-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     MultichainRoutingServiceMessenger,
     MultichainRoutingServiceInitMessenger
   >

--- a/app/core/Engine/controllers/multichain-routing-service-init.ts
+++ b/app/core/Engine/controllers/multichain-routing-service-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   MultichainRoutingService,
   type MultichainRoutingServiceMessenger,
@@ -14,7 +14,7 @@ import { KeyringTypes } from '@metamask/keyring-controller';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const multichainRoutingServiceInit: ControllerInitFunction<
+export const multichainRoutingServiceInit: MessengerClientInitFunction<
   MultichainRoutingService,
   MultichainRoutingServiceMessenger,
   MultichainRoutingServiceInitMessenger

--- a/app/core/Engine/controllers/multichain-transactions-controller/multichain-transactions-controller-init.test.ts
+++ b/app/core/Engine/controllers/multichain-transactions-controller/multichain-transactions-controller-init.test.ts
@@ -3,7 +3,7 @@ import {
   MultichainTransactionsController,
   MultichainTransactionsControllerState,
 } from '@metamask/multichain-transactions-controller';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { multichainTransactionsControllerInit } from './multichain-transactions-controller-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
@@ -18,7 +18,7 @@ describe('multichain transactions controller init', () => {
     MultichainTransactionsController,
   );
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<MultichainTransactionsControllerMessenger>
+    MessengerClientInitRequest<MultichainTransactionsControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/multichain-transactions-controller/multichain-transactions-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-transactions-controller/multichain-transactions-controller-init.ts
@@ -2,7 +2,7 @@ import {
   MultichainTransactionsController,
   MultichainTransactionsControllerState,
 } from '@metamask/multichain-transactions-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import { MultichainTransactionsControllerMessenger } from '../../messengers/multichain-transactions-controller-messenger/types';
 
 /**
@@ -13,7 +13,7 @@ import { MultichainTransactionsControllerMessenger } from '../../messengers/mult
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const multichainTransactionsControllerInit: ControllerInitFunction<
+export const multichainTransactionsControllerInit: MessengerClientInitFunction<
   MultichainTransactionsController,
   MultichainTransactionsControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/network-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getNetworkControllerMessenger,
   NetworkControllerInitMessenger,
 } from '../messengers/network-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import {
   ADDITIONAL_DEFAULT_NETWORKS,
   getInitialNetworkControllerState,
@@ -44,7 +44,7 @@ function getInitRequestMock(
     namespace: MOCK_ANY_NAMESPACE,
   }),
 ): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     NetworkControllerMessenger,
     NetworkControllerInitMessenger
   >

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   getDefaultNetworkControllerState,
   NetworkController,
@@ -114,7 +114,7 @@ export function getInitialNetworkControllerState(persistedState: {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const networkControllerInit: ControllerInitFunction<
+export const networkControllerInit: MessengerClientInitFunction<
   NetworkController,
   NetworkControllerMessenger,
   NetworkControllerInitMessenger

--- a/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/network-enablement-controller';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { networkEnablementControllerInit } from './network-enablement-controller-init';
-import type { ControllerInitRequest } from '../../types';
+import type { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { KnownCaipNamespace } from '@metamask/utils';
 import { ChainId } from '@metamask/controller-utils';
@@ -18,7 +18,7 @@ describe('networkEnablementControllerInit', () => {
   const networkEnablementControllerClassMock = jest.mocked(
     NetworkEnablementController,
   );
-  let initRequestMock: ControllerInitRequest<NetworkEnablementControllerMessenger>;
+  let initRequestMock: MessengerClientInitRequest<NetworkEnablementControllerMessenger>;
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.ts
+++ b/app/core/Engine/controllers/network-enablement-controller/network-enablement-controller-init.ts
@@ -3,7 +3,7 @@ import {
   type NetworkEnablementControllerMessenger,
   NetworkEnablementControllerState,
 } from '@metamask/network-enablement-controller';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 
 /**
  * Initialize the NetworkEnablementController.
@@ -11,7 +11,7 @@ import type { ControllerInitFunction } from '../../types';
  * @param request - The request object.
  * @returns The NetworkEnablementController.
  */
-export const networkEnablementControllerInit: ControllerInitFunction<
+export const networkEnablementControllerInit: MessengerClientInitFunction<
   NetworkEnablementController,
   NetworkEnablementControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/nft-controller-init.test.ts
+++ b/app/core/Engine/controllers/nft-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getNftControllerMessenger } from '../messengers/nft-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { nftControllerInit } from './nft-controller-init';
 import {
   NftController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<NftControllerMessenger>
+  MessengerClientInitRequest<NftControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/nft-controller-init.ts
+++ b/app/core/Engine/controllers/nft-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   NftController,
   type NftControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const nftControllerInit: ControllerInitFunction<
+export const nftControllerInit: MessengerClientInitFunction<
   NftController,
   NftControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/nft-detection-controller-init.test.ts
+++ b/app/core/Engine/controllers/nft-detection-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getNftDetectionControllerMessenger } from '../messengers/nft-detection-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { nftDetectionControllerInit } from './nft-detection-controller-init';
 import {
   NftDetectionController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<NftDetectionControllerMessenger>
+  MessengerClientInitRequest<NftDetectionControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/nft-detection-controller-init.ts
+++ b/app/core/Engine/controllers/nft-detection-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   NftDetectionController,
   type NftDetectionControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const nftDetectionControllerInit: ControllerInitFunction<
+export const nftDetectionControllerInit: MessengerClientInitFunction<
   NftDetectionController,
   NftDetectionControllerMessenger
 > = ({ controllerMessenger, getController }) => {

--- a/app/core/Engine/controllers/notifications/notification-services-controller-init.ts
+++ b/app/core/Engine/controllers/notifications/notification-services-controller-init.ts
@@ -4,7 +4,7 @@ import {
   Controller as NotificationServicesController,
   defaultState,
 } from '@metamask/notification-services-controller/notification-services';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import Logger from '../../../../util/Logger';
 import { createNotificationServicesController } from './create-notification-services-controller';
 
@@ -20,7 +20,7 @@ const logControllerCreation = (
   }
 };
 
-export const notificationServicesControllerInit: ControllerInitFunction<
+export const notificationServicesControllerInit: MessengerClientInitFunction<
   NotificationServicesController,
   NotificationServicesControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/notifications/notification-services-push-controller-init.ts
+++ b/app/core/Engine/controllers/notifications/notification-services-push-controller-init.ts
@@ -4,7 +4,7 @@ import {
   Controller as NotificationServicesPushController,
   defaultState,
 } from '@metamask/notification-services-controller/push-services';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import Logger from '../../../../util/Logger';
 import { createNotificationServicesPushController } from './create-notification-services-push-controller';
 
@@ -25,7 +25,7 @@ const logControllerCreation = (
   }
 };
 
-export const notificationServicesPushControllerInit: ControllerInitFunction<
+export const notificationServicesPushControllerInit: MessengerClientInitFunction<
   NotificationServicesPushController,
   NotificationServicesPushControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/permission-controller-init.test.ts
+++ b/app/core/Engine/controllers/permission-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getPermissionControllerInitMessenger,
   PermissionControllerInitMessenger,
 } from '../messengers/permission-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { permissionControllerInit } from './permission-controller-init';
 import {
   PermissionController,
@@ -16,7 +16,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/permission-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     PermissionControllerMessenger,
     PermissionControllerInitMessenger
   >

--- a/app/core/Engine/controllers/permission-controller-init.ts
+++ b/app/core/Engine/controllers/permission-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   PermissionController,
   type PermissionSpecificationConstraint,
@@ -23,7 +23,7 @@ import { CaipChainId } from '@metamask/utils';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const permissionControllerInit: ControllerInitFunction<
+export const permissionControllerInit: MessengerClientInitFunction<
   PermissionController<
     PermissionSpecificationConstraint,
     CaveatSpecificationConstraint

--- a/app/core/Engine/controllers/perps-controller/index.test.ts
+++ b/app/core/Engine/controllers/perps-controller/index.test.ts
@@ -1,6 +1,6 @@
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   PerpsController,
   PerpsControllerMessenger,
@@ -47,7 +47,7 @@ jest.mock('@metamask/perps-controller', () => {
 describe('perps controller init', () => {
   const perpsControllerClassMock = jest.mocked(PerpsController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<PerpsControllerMessenger>
+    MessengerClientInitRequest<PerpsControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/perps-controller/index.ts
+++ b/app/core/Engine/controllers/perps-controller/index.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   PerpsController,
   PerpsControllerMessenger,
@@ -16,7 +16,7 @@ import {
  * @param request - The request object.
  * @returns The PerpsController.
  */
-export const perpsControllerInit: ControllerInitFunction<
+export const perpsControllerInit: MessengerClientInitFunction<
   PerpsController,
   PerpsControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/phishing-controller-init.test.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getPhishingControllerMessenger } from '../messengers/phishing-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { phishingControllerInit } from './phishing-controller-init';
 import {
   PhishingController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/phishing-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<PhishingControllerMessenger>
+  MessengerClientInitRequest<PhishingControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/phishing-controller-init.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   PhishingController,
   type PhishingControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const phishingControllerInit: ControllerInitFunction<
+export const phishingControllerInit: MessengerClientInitFunction<
   PhishingController,
   PhishingControllerMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -1,6 +1,6 @@
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   PredictController,
   PredictControllerMessenger,
@@ -29,7 +29,7 @@ jest.mock(
 describe('predict controller init', () => {
   const predictControllerClassMock = jest.mocked(PredictController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<PredictControllerMessenger>
+    MessengerClientInitRequest<PredictControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/predict-controller/index.ts
+++ b/app/core/Engine/controllers/predict-controller/index.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   PredictController,
   PredictControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request - The request object.
  * @returns The PredictController.
  */
-export const predictControllerInit: ControllerInitFunction<
+export const predictControllerInit: MessengerClientInitFunction<
   PredictController,
   PredictControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/preferences-controller-init.test.ts
+++ b/app/core/Engine/controllers/preferences-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getPreferencesControllerMessenger } from '../messengers/preferences-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { preferencesControllerInit } from './preferences-controller-init';
 import {
   PreferencesController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/preferences-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<PreferencesControllerMessenger>
+  MessengerClientInitRequest<PreferencesControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/preferences-controller-init.ts
+++ b/app/core/Engine/controllers/preferences-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   PreferencesController,
   type PreferencesControllerMessenger,
@@ -12,7 +12,7 @@ import AppConstants from '../../AppConstants';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const preferencesControllerInit: ControllerInitFunction<
+export const preferencesControllerInit: MessengerClientInitFunction<
   PreferencesController,
   PreferencesControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.test.ts
@@ -2,7 +2,7 @@ import {
   ProfileMetricsController,
   ProfileMetricsControllerMessenger,
 } from '@metamask/profile-metrics-controller';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { profileMetricsControllerInit } from './profile-metrics-controller-init';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
@@ -22,7 +22,7 @@ function getInitRequestMock({
   analyticsEnabled: boolean;
   pna25Acknowledged: boolean;
 }): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     ProfileMetricsControllerMessenger,
     ProfileMetricsControllerInitMessenger
   >

--- a/app/core/Engine/controllers/profile-metrics-controller-init.ts
+++ b/app/core/Engine/controllers/profile-metrics-controller-init.ts
@@ -3,7 +3,7 @@ import {
   ProfileMetricsControllerMessenger,
 } from '@metamask/profile-metrics-controller';
 import { analyticsControllerSelectors } from '@metamask/analytics-controller';
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import { ProfileMetricsControllerInitMessenger } from '../messengers/profile-metrics-controller-messenger';
 
 /**
@@ -16,7 +16,7 @@ import { ProfileMetricsControllerInitMessenger } from '../messengers/profile-met
  * @param request.getController - A function to get other initialized controllers.
  * @returns The initialized controller.
  */
-export const profileMetricsControllerInit: ControllerInitFunction<
+export const profileMetricsControllerInit: MessengerClientInitFunction<
   ProfileMetricsController,
   ProfileMetricsControllerMessenger,
   ProfileMetricsControllerInitMessenger

--- a/app/core/Engine/controllers/profile-metrics-service-init.test.ts
+++ b/app/core/Engine/controllers/profile-metrics-service-init.test.ts
@@ -3,7 +3,7 @@ import {
   ProfileMetricsServiceMessenger,
 } from '@metamask/profile-metrics-controller';
 import { SDK } from '@metamask/profile-sync-controller';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { profileMetricsServiceInit } from './profile-metrics-service-init';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
@@ -13,7 +13,7 @@ import { getProfileMetricsServiceMessenger } from '../messengers/profile-metrics
 jest.mock('@metamask/profile-metrics-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<ProfileMetricsServiceMessenger>
+  MessengerClientInitRequest<ProfileMetricsServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/profile-metrics-service-init.ts
+++ b/app/core/Engine/controllers/profile-metrics-service-init.ts
@@ -2,7 +2,7 @@ import {
   ProfileMetricsService,
   ProfileMetricsServiceMessenger,
 } from '@metamask/profile-metrics-controller';
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import { SDK } from '@metamask/profile-sync-controller';
 
 /**
@@ -12,7 +12,7 @@ import { SDK } from '@metamask/profile-sync-controller';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized controller.
  */
-export const profileMetricsServiceInit: ControllerInitFunction<
+export const profileMetricsServiceInit: MessengerClientInitFunction<
   ProfileMetricsService,
   ProfileMetricsServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react-native';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   RampsController,
   RampsControllerMessenger,
@@ -101,7 +101,7 @@ const createMockInitMessenger = (
 describe('ramps controller init', () => {
   const rampsControllerClassMock = jest.mocked(RampsController);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<
+    MessengerClientInitRequest<
       RampsControllerMessenger,
       RampsControllerInitMessenger
     >
@@ -118,7 +118,7 @@ describe('ramps controller init', () => {
       ...buildControllerInitRequestMock(baseControllerMessenger),
       initMessenger: createMockInitMessenger(),
     } as jest.Mocked<
-      ControllerInitRequest<
+      MessengerClientInitRequest<
         RampsControllerMessenger,
         RampsControllerInitMessenger
       >

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   RampsController,
   RampsControllerMessenger,
@@ -48,7 +48,7 @@ function getIsRampsUnifiedBuyV2Enabled(
  * @param request.initMessenger - The init messenger for reading feature flags.
  * @returns The initialized controller.
  */
-export const rampsControllerInit: ControllerInitFunction<
+export const rampsControllerInit: MessengerClientInitFunction<
   RampsController,
   RampsControllerMessenger,
   RampsControllerInitMessenger

--- a/app/core/Engine/controllers/ramps-controller/ramps-service-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-service-init.test.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   RampsService,
   RampsServiceMessenger,
@@ -150,7 +150,7 @@ describe('getRampsContext', () => {
 describe('rampsServiceInit', () => {
   const rampsServiceClassMock = jest.mocked(RampsService);
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<RampsServiceMessenger>
+    MessengerClientInitRequest<RampsServiceMessenger>
   >;
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
   const originalOS = Platform.OS;

--- a/app/core/Engine/controllers/ramps-controller/ramps-service-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-service-init.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   RampsService,
   RampsServiceMessenger,
@@ -48,7 +48,7 @@ export function getRampsContext(): string {
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const rampsServiceInit: ControllerInitFunction<
+export const rampsServiceInit: MessengerClientInitFunction<
   RampsService,
   RampsServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/ramps-controller/transak-service-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/transak-service-init.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   TransakService,
   TransakServiceMessenger,
@@ -27,7 +27,7 @@ function getTransakContext(): string {
   return Platform.OS === 'ios' ? 'mobile-ios' : 'mobile-android';
 }
 
-export const transakServiceInit: ControllerInitFunction<
+export const transakServiceInit: MessengerClientInitFunction<
   TransakService,
   TransakServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
@@ -4,7 +4,7 @@ import {
   RemoteFeatureFlagController,
   RemoteFeatureFlagControllerMessenger,
 } from '@metamask/remote-feature-flag-controller';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { getRemoteFeatureFlagControllerMessenger } from '../messengers/remote-feature-flag-controller-messenger';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../utils/test-utils';
@@ -23,7 +23,7 @@ jest.mock('@metamask/remote-feature-flag-controller', () => ({
 }));
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<RemoteFeatureFlagControllerMessenger>
+  MessengerClientInitRequest<RemoteFeatureFlagControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   ClientConfigApiService,
   ClientType,
@@ -22,7 +22,7 @@ import { getBaseSemVerVersion } from '../../../util/version';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const remoteFeatureFlagControllerInit: ControllerInitFunction<
+export const remoteFeatureFlagControllerInit: MessengerClientInitFunction<
   RemoteFeatureFlagController,
   RemoteFeatureFlagControllerMessenger
 > = ({ controllerMessenger, persistedState, getState, analyticsId }) => {

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -1,6 +1,6 @@
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   RewardsController,
   RewardsControllerMessenger,
@@ -41,7 +41,7 @@ describe('rewardsControllerInit', () => {
   const isVersionGatedFeatureFlagMock = jest.mocked(isVersionGatedFeatureFlag);
 
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<RewardsControllerMessenger>
+    MessengerClientInitRequest<RewardsControllerMessenger>
   >;
   let mockControllerInstance: jest.Mocked<RewardsController>;
   let mockControllerMessenger: jest.Mocked<RewardsControllerMessenger>;

--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -3,7 +3,7 @@ import {
   selectBitcoinRewardsEnabledFlag,
   selectTronRewardsEnabledFlag,
 } from '../../../../selectors/featureFlagController/rewards/rewardsEnabled';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   RewardsController,
   RewardsControllerMessenger,
@@ -16,7 +16,7 @@ import {
  * @param request - The request object.
  * @returns The RewardsController.
  */
-export const rewardsControllerInit: ControllerInitFunction<
+export const rewardsControllerInit: MessengerClientInitFunction<
   RewardsController,
   RewardsControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/rewards-data-service-init.test.ts
+++ b/app/core/Engine/controllers/rewards-data-service-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getRewardsDataServiceMessenger } from '../messengers/rewards-data-service-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { rewardsDataServiceInit } from './rewards-data-service-init';
 import {
   RewardsDataService,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('./rewards-controller/services');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<RewardsDataServiceMessenger>
+  MessengerClientInitRequest<RewardsDataServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/rewards-data-service-init.ts
+++ b/app/core/Engine/controllers/rewards-data-service-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   RewardsDataService,
   type RewardsDataServiceMessenger,
@@ -14,7 +14,7 @@ import type { RewardsControllerState } from './rewards-controller/types';
  * @param request.persistedState - The full persisted state for all controllers.
  * @returns The initialized controller.
  */
-export const rewardsDataServiceInit: ControllerInitFunction<
+export const rewardsDataServiceInit: MessengerClientInitFunction<
   RewardsDataService,
   RewardsDataServiceMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
@@ -1,7 +1,7 @@
 import { seedlessOnboardingControllerInit } from '.';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   SeedlessOnboardingController,
   SeedlessOnboardingControllerMessenger,
@@ -118,7 +118,7 @@ describe('seedless onboarding controller init', () => {
     SeedlessOnboardingController,
   );
   let initRequestMock: jest.Mocked<
-    ControllerInitRequest<SeedlessOnboardingControllerMessenger>
+    MessengerClientInitRequest<SeedlessOnboardingControllerMessenger>
   >;
 
   beforeEach(() => {

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
@@ -1,5 +1,5 @@
 import type { Json } from '@metamask/utils';
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import {
   SeedlessOnboardingController,
   SeedlessOnboardingControllerState,
@@ -107,7 +107,7 @@ const encryptorAdapter = {
  * @param request - The request object.
  * @returns The SeedlessOnboardingController.
  */
-export const seedlessOnboardingControllerInit: ControllerInitFunction<
+export const seedlessOnboardingControllerInit: MessengerClientInitFunction<
   SeedlessOnboardingController<EncryptionKey>,
   SeedlessOnboardingControllerMessenger
 > = (request) => {

--- a/app/core/Engine/controllers/selected-network-controller-init.test.ts
+++ b/app/core/Engine/controllers/selected-network-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getSelectedNetworkControllerMessenger } from '../messengers/selected-network-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { selectedNetworkControllerInit } from './selected-network-controller-init';
 import {
   SelectedNetworkController,
@@ -13,7 +13,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/selected-network-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<SelectedNetworkControllerMessenger>
+  MessengerClientInitRequest<SelectedNetworkControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/selected-network-controller-init.ts
+++ b/app/core/Engine/controllers/selected-network-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   SelectedNetworkController,
   type SelectedNetworkControllerMessenger,
@@ -13,7 +13,7 @@ import DomainProxyMap from '../../../lib/DomainProxyMap/DomainProxyMap';
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const selectedNetworkControllerInit: ControllerInitFunction<
+export const selectedNetworkControllerInit: MessengerClientInitFunction<
   SelectedNetworkController,
   SelectedNetworkControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/signature-controller/signature-controller-init.test.ts
+++ b/app/core/Engine/controllers/signature-controller/signature-controller-init.test.ts
@@ -9,7 +9,7 @@ import {
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import AppConstants from '../../../AppConstants';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { SignatureControllerInit } from './signature-controller-init';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
@@ -41,7 +41,7 @@ function buildControllerMock(
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
-): jest.Mocked<ControllerInitRequest<SignatureControllerMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<SignatureControllerMessenger>> {
   const baseControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,
   });

--- a/app/core/Engine/controllers/signature-controller/signature-controller-init.ts
+++ b/app/core/Engine/controllers/signature-controller/signature-controller-init.ts
@@ -4,14 +4,14 @@ import {
   type SignatureControllerOptions,
 } from '@metamask/signature-controller';
 import type {
-  ControllerInitFunction,
-  ControllerInitRequest,
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
 } from '../../types';
 import { trace } from '../../../../util/trace';
 import AppConstants from '../../../AppConstants';
 import Logger from '../../../../util/Logger';
 
-export const SignatureControllerInit: ControllerInitFunction<
+export const SignatureControllerInit: MessengerClientInitFunction<
   SignatureController,
   SignatureControllerMessenger
 > = (request) => {
@@ -37,7 +37,7 @@ export const SignatureControllerInit: ControllerInitFunction<
 };
 
 function getControllers(
-  request: ControllerInitRequest<SignatureControllerMessenger>,
+  request: MessengerClientInitRequest<SignatureControllerMessenger>,
 ) {
   return {
     preferencesController: request.getController('PreferencesController'),

--- a/app/core/Engine/controllers/smart-transactions-controller-init.test.ts
+++ b/app/core/Engine/controllers/smart-transactions-controller-init.test.ts
@@ -4,7 +4,7 @@ import {
   getSmartTransactionsControllerMessenger,
   getSmartTransactionsControllerInitMessenger,
 } from '../messengers/smart-transactions-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { smartTransactionsControllerInit } from './smart-transactions-controller-init';
 import {
   SmartTransactionsController,
@@ -15,7 +15,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/smart-transactions-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     SmartTransactionsControllerMessenger,
     ReturnType<typeof getSmartTransactionsControllerInitMessenger>
   >

--- a/app/core/Engine/controllers/smart-transactions-controller-init.ts
+++ b/app/core/Engine/controllers/smart-transactions-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   getSmartTransactionMetricsProperties,
   SmartTransactionsController,
@@ -21,7 +21,7 @@ import { setSentinelApiAuth } from '../../../util/transactions/sentinel-api';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const smartTransactionsControllerInit: ControllerInitFunction<
+export const smartTransactionsControllerInit: MessengerClientInitFunction<
   SmartTransactionsController,
   SmartTransactionsControllerMessenger,
   SmartTransactionsControllerInitMessenger

--- a/app/core/Engine/controllers/snap-keyring/snap-keyring-builder-init.test.ts
+++ b/app/core/Engine/controllers/snap-keyring/snap-keyring-builder-init.test.ts
@@ -5,13 +5,13 @@ import {
   getSnapKeyringBuilderMessenger,
   SnapKeyringBuilderInitMessenger,
 } from '../../messengers/snap-keyring-builder-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { snapKeyringBuilderInit } from './snap-keyring-builder-init';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { SnapKeyringBuilderMessenger } from '../../../SnapKeyring/types';
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     SnapKeyringBuilderMessenger,
     SnapKeyringBuilderInitMessenger
   >

--- a/app/core/Engine/controllers/snap-keyring/snap-keyring-builder-init.ts
+++ b/app/core/Engine/controllers/snap-keyring/snap-keyring-builder-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { SnapKeyringBuilderInitMessenger } from '../../messengers/snap-keyring-builder-messenger';
 import {
   snapKeyringBuilder,
@@ -13,7 +13,7 @@ import { SnapKeyringBuilderMessenger } from '../../../SnapKeyring/types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const snapKeyringBuilderInit: ControllerInitFunction<
+export const snapKeyringBuilderInit: MessengerClientInitFunction<
   SnapKeyringBuilder,
   SnapKeyringBuilderMessenger,
   SnapKeyringBuilderInitMessenger

--- a/app/core/Engine/controllers/snaps/cronjob-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/cronjob-controller-init.test.ts
@@ -1,5 +1,5 @@
 import { CronjobController } from '@metamask/snaps-controllers';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   CronjobControllerMessenger,
   getCronjobControllerMessenger,
@@ -12,7 +12,7 @@ import configureStore from '../../../../util/test/configureStore';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<CronjobControllerMessenger>
+  MessengerClientInitRequest<CronjobControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/snaps/cronjob-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/cronjob-controller-init.ts
@@ -1,5 +1,5 @@
 import { CronjobController } from '@metamask/snaps-controllers';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { CronjobControllerMessenger } from '../../messengers/snaps';
 import { CronjobControllerStorageManager } from '../../../CronjobControllerStorageManager/CronjobControllerStorageManager';
 
@@ -11,7 +11,7 @@ import { CronjobControllerStorageManager } from '../../../CronjobControllerStora
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const cronjobControllerInit: ControllerInitFunction<
+export const cronjobControllerInit: MessengerClientInitFunction<
   CronjobController,
   CronjobControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/snaps/execution-service-init.test.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.test.ts
@@ -1,5 +1,5 @@
 import { WebViewExecutionService } from '@metamask/snaps-controllers/react-native';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { getExecutionServiceMessenger } from '../../messengers/snaps';
 import { executionServiceInit } from './execution-service-init';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
@@ -15,7 +15,7 @@ jest.mock('@metamask/snaps-controllers/react-native');
 jest.mock('../../../Snaps');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<ExecutionServiceMessenger>
+  MessengerClientInitRequest<ExecutionServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/snaps/execution-service-init.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.ts
@@ -4,7 +4,7 @@ import {
 } from '@metamask/snaps-controllers';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import { Duplex } from 'stream';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { WebViewExecutionService } from '@metamask/snaps-controllers/react-native';
 import { createWebView, removeWebView } from '../../../../lib/snaps';
 import Logger from '../../../../util/Logger';
@@ -19,7 +19,7 @@ import { SnapId } from '@metamask/snaps-sdk';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized controller.
  */
-export const executionServiceInit: ControllerInitFunction<
+export const executionServiceInit: MessengerClientInitFunction<
   ExecutionService,
   ExecutionServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -2,7 +2,7 @@ import {
   SnapController,
   SnapControllerMessenger,
 } from '@metamask/snaps-controllers';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   getSnapControllerInitMessenger,
   getSnapControllerMessenger,
@@ -39,7 +39,10 @@ function getInitRequestMock(
     namespace: MOCK_ANY_NAMESPACE,
   }),
 ): jest.Mocked<
-  ControllerInitRequest<SnapControllerMessenger, SnapControllerInitMessenger>
+  MessengerClientInitRequest<
+    SnapControllerMessenger,
+    SnapControllerInitMessenger
+  >
 > {
   const requestMock = {
     ...buildControllerInitRequestMock(baseMessenger),

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -4,7 +4,7 @@ import {
 } from '@metamask/snaps-controllers';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import { hmacSha512 } from '@metamask/native-utils';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { SnapControllerInitMessenger } from '../../messengers/snaps';
 import {
   EndowmentPermissions,
@@ -42,7 +42,7 @@ import { getMnemonicSeed } from '../../../Snaps/permissions/utils';
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const snapControllerInit: ControllerInitFunction<
+export const snapControllerInit: MessengerClientInitFunction<
   SnapController,
   SnapControllerMessenger,
   SnapControllerInitMessenger

--- a/app/core/Engine/controllers/snaps/snap-interface-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-interface-controller-init.test.ts
@@ -1,5 +1,5 @@
 import { SnapInterfaceController } from '@metamask/snaps-controllers';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import {
   getSnapInterfaceControllerMessenger,
   SnapInterfaceControllerMessenger,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/snaps-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<SnapInterfaceControllerMessenger>
+  MessengerClientInitRequest<SnapInterfaceControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/snaps/snap-interface-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-interface-controller-init.ts
@@ -1,5 +1,5 @@
 import { SnapInterfaceController } from '@metamask/snaps-controllers';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { SnapInterfaceControllerMessenger } from '../../messengers/snaps';
 
 /**
@@ -10,7 +10,7 @@ import { SnapInterfaceControllerMessenger } from '../../messengers/snaps';
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const snapInterfaceControllerInit: ControllerInitFunction<
+export const snapInterfaceControllerInit: MessengerClientInitFunction<
   SnapInterfaceController,
   SnapInterfaceControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/snaps/snap-registry-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-registry-controller-init.test.ts
@@ -2,7 +2,7 @@ import {
   SnapRegistryController,
   SnapRegistryControllerMessenger,
 } from '@metamask/snaps-controllers';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { getSnapRegistryControllerMessenger } from '../../messengers/snaps';
 import { snapRegistryControllerInit } from './snap-registry-controller-init';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
@@ -16,7 +16,7 @@ jest.mock('react-native-device-info', () => ({
 }));
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<SnapRegistryControllerMessenger>
+  MessengerClientInitRequest<SnapRegistryControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/snaps/snap-registry-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-registry-controller-init.ts
@@ -2,7 +2,7 @@ import {
   SnapRegistryController,
   SnapRegistryControllerMessenger,
 } from '@metamask/snaps-controllers';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { getVersion } from 'react-native-device-info';
 import { SemVerVersion } from '@metamask/utils';
 
@@ -14,7 +14,7 @@ import { SemVerVersion } from '@metamask/utils';
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const snapRegistryControllerInit: ControllerInitFunction<
+export const snapRegistryControllerInit: MessengerClientInitFunction<
   SnapRegistryController,
   SnapRegistryControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/snaps/websocket-service-init.test.ts
+++ b/app/core/Engine/controllers/snaps/websocket-service-init.test.ts
@@ -1,5 +1,5 @@
 import { WebSocketService } from '@metamask/snaps-controllers';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import {
   getWebSocketServiceMessenger,
@@ -10,7 +10,7 @@ import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<WebSocketServiceMessenger>
+  MessengerClientInitRequest<WebSocketServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/snaps/websocket-service-init.ts
+++ b/app/core/Engine/controllers/snaps/websocket-service-init.ts
@@ -1,5 +1,5 @@
 import { WebSocketService } from '@metamask/snaps-controllers';
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import { WebSocketServiceMessenger } from '../../messengers/snaps';
 
 /**
@@ -9,7 +9,7 @@ import { WebSocketServiceMessenger } from '../../messengers/snaps';
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const WebSocketServiceInit: ControllerInitFunction<
+export const WebSocketServiceInit: MessengerClientInitFunction<
   WebSocketService,
   WebSocketServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/storage-service/storage-service-init.test.ts
+++ b/app/core/Engine/controllers/storage-service/storage-service-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getStorageServiceMessenger } from '../../messengers/storage-service-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { storageServiceInit } from './storage-service-init';
 import {
   StorageService,
@@ -23,7 +23,7 @@ const mockDevice = jest.mocked(Device);
 const mockLogger = jest.mocked(Logger);
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<StorageServiceMessenger>
+  MessengerClientInitRequest<StorageServiceMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/storage-service/storage-service-init.ts
+++ b/app/core/Engine/controllers/storage-service/storage-service-init.ts
@@ -1,7 +1,7 @@
 import type { Json } from '@metamask/utils';
 import FilesystemStorage from 'redux-persist-filesystem-storage';
 
-import { ControllerInitFunction } from '../../types';
+import { MessengerClientInitFunction } from '../../types';
 import {
   StorageService,
   StorageServiceMessenger,
@@ -188,7 +188,7 @@ const mobileStorageAdapter: StorageAdapter = {
  * @param request.controllerMessenger - The messenger to use for the service.
  * @returns The initialized service.
  */
-export const storageServiceInit: ControllerInitFunction<
+export const storageServiceInit: MessengerClientInitFunction<
   StorageService,
   StorageServiceMessenger
 > = ({ controllerMessenger }) => {

--- a/app/core/Engine/controllers/subject-metadata-controller-init.test.ts
+++ b/app/core/Engine/controllers/subject-metadata-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getSubjectMetadataControllerMessenger } from '../messengers/subject-metadata-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { subjectMetadataControllerInit } from './subject-metadata-controller-init';
 import {
   SubjectMetadataController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/permission-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<SubjectMetadataControllerMessenger>
+  MessengerClientInitRequest<SubjectMetadataControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/subject-metadata-controller-init.ts
+++ b/app/core/Engine/controllers/subject-metadata-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   SubjectMetadataController,
   type SubjectMetadataControllerMessenger,
@@ -12,7 +12,7 @@ import {
  * @param request.persistedState - The persisted state of the extension.
  * @returns The initialized controller.
  */
-export const subjectMetadataControllerInit: ControllerInitFunction<
+export const subjectMetadataControllerInit: MessengerClientInitFunction<
   SubjectMetadataController,
   SubjectMetadataControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {

--- a/app/core/Engine/controllers/token-balances-controller-init.test.ts
+++ b/app/core/Engine/controllers/token-balances-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getTokenBalancesControllerMessenger,
   TokenBalancesControllerInitMessenger,
 } from '../messengers/token-balances-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokenBalancesControllerInit } from './token-balances-controller-init';
 import {
   TokenBalancesController,
@@ -16,7 +16,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TokenBalancesControllerMessenger,
     TokenBalancesControllerInitMessenger
   >

--- a/app/core/Engine/controllers/token-balances-controller-init.ts
+++ b/app/core/Engine/controllers/token-balances-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokenBalancesController,
   type TokenBalancesControllerMessenger,
@@ -15,7 +15,7 @@ import { selectCompletedOnboarding } from '../../../selectors/onboarding';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokenBalancesControllerInit: ControllerInitFunction<
+export const tokenBalancesControllerInit: MessengerClientInitFunction<
   TokenBalancesController,
   TokenBalancesControllerMessenger,
   TokenBalancesControllerInitMessenger

--- a/app/core/Engine/controllers/token-detection-controller-init.test.ts
+++ b/app/core/Engine/controllers/token-detection-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getTokenDetectionControllerMessenger,
   TokenDetectionControllerInitMessenger,
 } from '../messengers/token-detection-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokenDetectionControllerInit } from './token-detection-controller-init';
 import {
   TokenDetectionController,
@@ -16,7 +16,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TokenDetectionControllerMessenger,
     TokenDetectionControllerInitMessenger
   >

--- a/app/core/Engine/controllers/token-detection-controller-init.ts
+++ b/app/core/Engine/controllers/token-detection-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokenDetectionController,
   type TokenDetectionControllerMessenger,
@@ -19,7 +19,7 @@ import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokenDetectionControllerInit: ControllerInitFunction<
+export const tokenDetectionControllerInit: MessengerClientInitFunction<
   TokenDetectionController,
   TokenDetectionControllerMessenger,
   TokenDetectionControllerInitMessenger

--- a/app/core/Engine/controllers/token-list-controller-init.test.ts
+++ b/app/core/Engine/controllers/token-list-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getTokenListControllerInitMessenger,
   TokenListControllerInitMessenger,
 } from '../messengers/token-list-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokenListControllerInit } from './token-list-controller-init';
 import {
   TokenListController,
@@ -27,7 +27,7 @@ jest.mock('@metamask/assets-controllers', () => {
 });
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TokenListControllerMessenger,
     TokenListControllerInitMessenger
   >

--- a/app/core/Engine/controllers/token-list-controller-init.ts
+++ b/app/core/Engine/controllers/token-list-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokenListController,
   type TokenListControllerMessenger,
@@ -13,7 +13,7 @@ import { getGlobalChainId } from '../../../util/networks/global-network';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokenListControllerInit: ControllerInitFunction<
+export const tokenListControllerInit: MessengerClientInitFunction<
   TokenListController,
   TokenListControllerMessenger,
   TokenListControllerInitMessenger

--- a/app/core/Engine/controllers/token-rates-controller-init.test.ts
+++ b/app/core/Engine/controllers/token-rates-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getTokenRatesControllerMessenger } from '../messengers/token-rates-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokenRatesControllerInit } from './token-rates-controller-init';
 import {
   TokenRatesController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<TokenRatesControllerMessenger>
+  MessengerClientInitRequest<TokenRatesControllerMessenger>
 > {
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/token-rates-controller-init.ts
+++ b/app/core/Engine/controllers/token-rates-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokenRatesController,
   type TokenRatesControllerMessenger,
@@ -12,7 +12,7 @@ import { Duration, inMilliseconds } from '@metamask/utils';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokenRatesControllerInit: ControllerInitFunction<
+export const tokenRatesControllerInit: MessengerClientInitFunction<
   TokenRatesController,
   TokenRatesControllerMessenger
 > = ({ controllerMessenger, persistedState, codefiTokenApiV2 }) => {

--- a/app/core/Engine/controllers/token-search-discovery-data-controller-init.test.ts
+++ b/app/core/Engine/controllers/token-search-discovery-data-controller-init.test.ts
@@ -1,7 +1,7 @@
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getTokenSearchDiscoveryDataControllerMessenger } from '../messengers/token-search-discovery-data-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokenSearchDiscoveryDataControllerInit } from './token-search-discovery-data-controller-init';
 import {
   TokenSearchDiscoveryDataController,
@@ -12,7 +12,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<TokenSearchDiscoveryDataControllerMessenger>
+  MessengerClientInitRequest<TokenSearchDiscoveryDataControllerMessenger>
 > {
   const rootMessenger = new ExtendedMessenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,

--- a/app/core/Engine/controllers/token-search-discovery-data-controller-init.ts
+++ b/app/core/Engine/controllers/token-search-discovery-data-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokenSearchDiscoveryDataController,
   type TokenSearchDiscoveryDataControllerMessenger,
@@ -11,7 +11,7 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokenSearchDiscoveryDataControllerInit: ControllerInitFunction<
+export const tokenSearchDiscoveryDataControllerInit: MessengerClientInitFunction<
   TokenSearchDiscoveryDataController,
   TokenSearchDiscoveryDataControllerMessenger
 > = ({ controllerMessenger, codefiTokenApiV2 }) => {

--- a/app/core/Engine/controllers/tokens-controller-init.test.ts
+++ b/app/core/Engine/controllers/tokens-controller-init.test.ts
@@ -5,7 +5,7 @@ import {
   getTokensControllerInitMessenger,
   TokensControllerInitMessenger,
 } from '../messengers/tokens-controller-messenger';
-import { ControllerInitRequest } from '../types';
+import { MessengerClientInitRequest } from '../types';
 import { tokensControllerInit } from './tokens-controller-init';
 import {
   TokensController,
@@ -16,7 +16,7 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 jest.mock('@metamask/assets-controllers');
 
 function getInitRequestMock(): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TokensControllerMessenger,
     TokensControllerInitMessenger
   >

--- a/app/core/Engine/controllers/tokens-controller-init.ts
+++ b/app/core/Engine/controllers/tokens-controller-init.ts
@@ -1,4 +1,4 @@
-import { ControllerInitFunction } from '../types';
+import { MessengerClientInitFunction } from '../types';
 import {
   TokensController,
   type TokensControllerMessenger,
@@ -14,7 +14,7 @@ import { assert } from '@metamask/utils';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @returns The initialized controller.
  */
-export const tokensControllerInit: ControllerInitFunction<
+export const tokensControllerInit: MessengerClientInitFunction<
   TokensController,
   TokensControllerMessenger,
   TokensControllerInitMessenger

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -24,7 +24,7 @@ import { Delegation7702PublishHook } from '../../../../util/transactions/hooks/d
 import { isSendBundleSupported } from '../../../../util/transactions/sentinel-api';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { TransactionControllerInitMessenger } from '../../messengers/transaction-controller-messenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import {
   handleTransactionAddedEventForMetrics,
@@ -103,7 +103,7 @@ function buildControllerMock(
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
 ): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TransactionControllerMessenger,
     TransactionControllerInitMessenger
   >

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -33,8 +33,8 @@ import { getTransactionById } from '../../../../util/transactions';
 import type { RootState } from '../../../../reducers';
 import { TransactionControllerInitMessenger } from '../../messengers/transaction-controller-messenger';
 import type {
-  ControllerInitFunction,
-  ControllerInitRequest,
+  MessengerClientInitFunction,
+  MessengerClientInitRequest,
 } from '../../types';
 import AppConstants from '../../../../core/AppConstants';
 import type { TransactionEventHandlerRequest } from './types';
@@ -68,7 +68,7 @@ const TRANSACTION_SUBMISSION_METHOD = {
   SENTINEL_RELAY: 'sentinel_relay',
 } as const;
 
-export const TransactionControllerInit: ControllerInitFunction<
+export const TransactionControllerInit: MessengerClientInitFunction<
   TransactionController,
   TransactionControllerMessenger,
   TransactionControllerInitMessenger
@@ -424,7 +424,7 @@ function isFirstTimeInteractionEnabled(
 }
 
 function getControllers(
-  request: ControllerInitRequest<
+  request: MessengerClientInitRequest<
     TransactionControllerMessenger,
     TransactionControllerInitMessenger
   >,
@@ -442,7 +442,7 @@ function getControllers(
 
 function beforeSign(
   hookRequest: { transactionMeta: TransactionMeta },
-  request: ControllerInitRequest<
+  request: MessengerClientInitRequest<
     TransactionControllerMessenger,
     TransactionControllerInitMessenger
   >,

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
@@ -1,6 +1,6 @@
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
-import { ControllerInitRequest } from '../../types';
+import { MessengerClientInitRequest } from '../../types';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import {
   TransactionPayController,
@@ -15,7 +15,7 @@ jest.mock('@metamask/transaction-pay-controller');
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
 ): jest.Mocked<
-  ControllerInitRequest<
+  MessengerClientInitRequest<
     TransactionPayControllerMessenger,
     TransactionPayControllerInitMessenger
   >

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../types';
+import type { MessengerClientInitFunction } from '../../types';
 import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
@@ -9,7 +9,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
 
-export const TransactionPayControllerInit: ControllerInitFunction<
+export const TransactionPayControllerInit: MessengerClientInitFunction<
   TransactionPayController,
   TransactionPayControllerMessenger,
   TransactionPayControllerInitMessenger

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -439,7 +439,7 @@ import { captureException } from '@sentry/react-native';
  * Controllers that area always instantiated
  */
 type RequiredControllers = Omit<
-  Controllers,
+  MessengerClients,
   | 'GeolocationApiService'
   | 'MultichainRoutingService'
   | 'RewardsDataService'
@@ -452,7 +452,7 @@ type RequiredControllers = Omit<
  * Controllers that are sometimes not instantiated
  */
 type OptionalControllers = Pick<
-  Controllers,
+  MessengerClients,
   | 'GeolocationApiService'
   | 'MultichainRoutingService'
   | 'RewardsDataService'
@@ -676,7 +676,7 @@ export const getRootMessenger = (): RootMessenger =>
 // Interfaces are incompatible with our controllers and state types by default.
 // Adding an index signature fixes this, but at the cost of widening the type unnecessarily.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type Controllers = {
+export type MessengerClients = {
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   SamplePetnamesController: SamplePetnamesController;
   ///: END:ONLY_INCLUDE_IF
@@ -849,17 +849,17 @@ export type EngineState = {
   ComplianceController: ComplianceControllerState;
 };
 
-/** Controller names */
-export type ControllerName = keyof Controllers;
+/** Messenger client names */
+export type MessengerClientName = keyof MessengerClients;
 
 /**
- * Controller type
+ * Messenger client type
  */
-export type Controller = Controllers[ControllerName];
+export type MessengerClient = MessengerClients[MessengerClientName];
 
-/** Map of controllers by name. */
-export type ControllerByName = {
-  [Name in ControllerName]: Controllers[Name];
+/** Map of messenger clients by name. */
+export type MessengerClientsByName = {
+  [Name in MessengerClientName]: MessengerClients[Name];
 };
 
 /**
@@ -872,9 +872,9 @@ export type ControllerMessenger = Messenger<
 >;
 
 /**
- * Specify controllers to initialize.
+ * Specify messenger clients to initialize.
  */
-export type ControllersToInitialize =
+export type MessengerClientsToInitialize =
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   | 'SamplePetnamesController'
   ///: END:ONLY_INCLUDE_IF
@@ -969,27 +969,27 @@ export type ControllerMessengerCallback = (
 ) => ControllerMessenger;
 
 /**
- * Persisted state for all controllers.
+ * Persisted state for all messenger clients.
  * e.g. `{ TransactionController: { transactions: [] } }`.
  */
-type ControllerPersistedState = Partial<{
+type MessengerClientPersistedState = Partial<{
   [Name in Exclude<
-    ControllerName,
+    MessengerClientName,
     (typeof STATELESS_NON_CONTROLLER_NAMES)[number]
-  >]: Partial<ControllerByName[Name]['state']>;
+  >]: Partial<MessengerClientsByName[Name]['state']>;
 }>;
 
 /**
- * Map of controller messengers by controller name.
+ * Map of messenger client messengers by name.
  */
-export type ControllerMessengerByControllerName = typeof CONTROLLER_MESSENGERS;
+export type MessengerClientMessengersByName = typeof CONTROLLER_MESSENGERS;
 
 /**
  * Request to initialize and return a controller instance.
  * Includes standard data and methods not coupled to any specific controller.
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type ControllerInitRequest<
+export type MessengerClientInitRequest<
   ControllerMessengerType extends ControllerMessenger,
   InitMessengerType extends void | ControllerMessenger = void,
 > = {
@@ -1010,9 +1010,9 @@ export type ControllerInitRequest<
    *
    * @param name - The name of the controller to retrieve.
    */
-  getController<Name extends ControllerName>(
+  getController<Name extends MessengerClientName>(
     name: Name,
-  ): ControllerByName[Name];
+  ): MessengerClientsByName[Name];
 
   /**
    * Retrieve the chain ID of the globally selected network.
@@ -1064,37 +1064,40 @@ export type ControllerInitRequest<
    * Includes controller name properties.
    * e.g. `{ TransactionController: { transactions: [] } }`.
    */
-  persistedState: ControllerPersistedState;
+  persistedState: MessengerClientPersistedState;
 };
 
 /**
  * Function to initialize a controller instance and return associated data.
  */
-export type ControllerInitFunction<
-  ControllerType extends Controller,
+export type MessengerClientInitFunction<
+  MessengerClientType extends MessengerClient,
   ControllerMessengerType extends ControllerMessenger,
   InitMessengerType extends void | ControllerMessenger = void,
 > = (
-  request: ControllerInitRequest<ControllerMessengerType, InitMessengerType>,
+  request: MessengerClientInitRequest<
+    ControllerMessengerType,
+    InitMessengerType
+  >,
 ) => {
-  controller: ControllerType;
+  controller: MessengerClientType;
 };
 
 /**
- * Map of controller init functions by controller name.
+ * Map of messenger client init functions by messenger client name.
  */
-export type ControllerInitFunctionByControllerName = {
-  [Name in ControllersToInitialize]: ControllerInitFunction<
-    ControllerByName[Name],
+export type MessengerClientInitFunctionsByMessengerClientName = {
+  [Name in MessengerClientsToInitialize]: MessengerClientInitFunction<
+    MessengerClientsByName[Name],
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getMessenger']>,
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getInitMessenger']>
   >;
 };
 
-export interface InitModularizedControllersFunctionRequest {
+export interface InitMessengerClientsFunctionRequest {
   baseControllerMessenger: RootExtendedMessenger;
-  controllerInitFunctions: ControllerInitFunctionByControllerName;
-  existingControllersByName?: Partial<ControllerByName>;
+  controllerInitFunctions: MessengerClientInitFunctionsByMessengerClientName;
+  existingControllersByName?: Partial<MessengerClientsByName>;
   getGlobalChainId: () => Hex;
   getState: () => RootState;
   analyticsId: string;
@@ -1104,14 +1107,14 @@ export interface InitModularizedControllersFunctionRequest {
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   removeAccount: (address: string) => Promise<void>;
   ///: END:ONLY_INCLUDE_IF
-  persistedState: ControllerPersistedState;
+  persistedState: MessengerClientPersistedState;
 }
 
 /**
- * Function to initialize the controllers in the engine.
+ * Function to initialize the messenger clients in the engine.
  */
-export type InitModularizedControllersFunction = (
-  request: InitModularizedControllersFunctionRequest,
+export type InitMessengerClientsFunction = (
+  request: InitMessengerClientsFunctionRequest,
 ) => {
-  controllersByName: ControllerByName;
+  controllersByName: MessengerClientsByName;
 };

--- a/app/core/Engine/utils/test-utils.ts
+++ b/app/core/Engine/utils/test-utils.ts
@@ -1,22 +1,22 @@
 import {
   ControllerMessenger,
   RootExtendedMessenger,
-  ControllerInitFunction,
-  Controller,
-  ControllerName,
-  ControllerInitRequest,
+  MessengerClientInitFunction,
+  MessengerClient,
+  MessengerClientName,
+  MessengerClientInitRequest,
 } from '../types';
 import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 import { CodefiTokenPricesServiceV2 } from '@metamask/assets-controllers';
 
 /**
- * Build a mock for the ControllerInitRequest.
+ * Build a mock for the MessengerClientInitRequest.
  *
- * @returns A mocked ControllerInitRequest.
+ * @returns A mocked MessengerClientInitRequest.
  */
 export function buildControllerInitRequestMock(
   controllerMessenger: RootExtendedMessenger,
-): jest.Mocked<ControllerInitRequest<ControllerMessenger>> {
+): jest.Mocked<MessengerClientInitRequest<ControllerMessenger>> {
   return {
     codefiTokenApiV2: jest.fn() as unknown as CodefiTokenPricesServiceV2,
     controllerMessenger: controllerMessenger as unknown as ControllerMessenger,
@@ -39,14 +39,14 @@ export function buildControllerInitRequestMock(
  * @returns A mock controller init function
  */
 export function createMockControllerInitFunction<
-  T extends Controller,
+  T extends MessengerClient,
   M extends ControllerMessenger,
->(requiredController?: string): ControllerInitFunction<T, M> {
+>(requiredController?: string): MessengerClientInitFunction<T, M> {
   return (request) => {
     const { getController } = request;
 
     if (requiredController) {
-      getController(requiredController as unknown as ControllerName);
+      getController(requiredController as unknown as MessengerClientName);
     }
 
     return {

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -18,7 +18,7 @@ import {
   PermissionController,
   PermissionSpecificationConstraint,
 } from '@metamask/permission-controller';
-import { InitModularizedControllersFunctionRequest } from '../types';
+import { InitMessengerClientsFunctionRequest } from '../types';
 import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
@@ -34,7 +34,7 @@ describe('initModularizedControllers', () => {
 
   function buildModularizedControllerRequest(
     overrides?: Record<string, unknown>,
-  ): InitModularizedControllersFunctionRequest {
+  ): InitMessengerClientsFunctionRequest {
     const partialRequest = merge(
       {
         existingControllersByName: {},
@@ -60,7 +60,7 @@ describe('initModularizedControllers', () => {
 
     // @ts-expect-error: Intentionally only providing a subset of all
     // controllers, to avoid excessive boilerplate in tests.
-    return partialRequest as InitModularizedControllersFunctionRequest;
+    return partialRequest as InitMessengerClientsFunctionRequest;
   }
 
   beforeEach(() => {

--- a/app/core/Engine/utils/utils.ts
+++ b/app/core/Engine/utils/utils.ts
@@ -1,26 +1,26 @@
 import { createProjectLogger } from '@metamask/utils';
 import type {
   ControllerMessenger,
-  ControllerByName,
+  MessengerClientsByName,
   ControllerMessengerCallback,
-  ControllerName,
-  ControllersToInitialize,
-  InitModularizedControllersFunction,
-  ControllerInitRequest,
-  ControllerInitFunction,
+  MessengerClientName,
+  MessengerClientsToInitialize,
+  InitMessengerClientsFunction,
+  MessengerClientInitRequest,
+  MessengerClientInitFunction,
 } from '../types';
 import { CONTROLLER_MESSENGERS } from '../messengers';
 
 const log = createProjectLogger('controller-init');
 
-type BaseControllerInitRequest = ControllerInitRequest<
+type BaseControllerInitRequest = MessengerClientInitRequest<
   ControllerMessenger,
   ControllerMessenger | void
 >;
 
-type InitFunction<Name extends ControllersToInitialize> =
-  ControllerInitFunction<
-    ControllerByName[Name],
+type InitFunction<Name extends MessengerClientsToInitialize> =
+  MessengerClientInitFunction<
+    MessengerClientsByName[Name],
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getMessenger']>,
     ReturnType<(typeof CONTROLLER_MESSENGERS)[Name]['getInitMessenger']>
   >;
@@ -37,7 +37,7 @@ type InitFunction<Name extends ControllersToInitialize> =
  * @param options.persistedState - The full persisted state for all controllers.
  * @returns The initialized controllers and associated data.
  */
-export const initModularizedControllers: InitModularizedControllersFunction = ({
+export const initModularizedControllers: InitMessengerClientsFunction = ({
   baseControllerMessenger,
   controllerInitFunctions,
   existingControllersByName,
@@ -46,9 +46,9 @@ export const initModularizedControllers: InitModularizedControllersFunction = ({
   log('Initializing controllers', Object.keys(controllerInitFunctions).length);
 
   // Used by other controllers to get dependent controllers
-  const getController = <Name extends ControllerName>(
+  const getController = <Name extends MessengerClientName>(
     name: Name,
-  ): ControllerByName[Name] =>
+  ): MessengerClientsByName[Name] =>
     getControllerOrThrow({
       controller: existingControllersByName?.[name],
       name,
@@ -57,7 +57,7 @@ export const initModularizedControllers: InitModularizedControllersFunction = ({
   for (const [key, controllerInitFunction] of Object.entries(
     controllerInitFunctions,
   )) {
-    const controllerName = key as ControllersToInitialize;
+    const controllerName = key as MessengerClientsToInitialize;
 
     const initFunction = controllerInitFunction as InitFunction<
       typeof controllerName
@@ -98,7 +98,7 @@ export const initModularizedControllers: InitModularizedControllersFunction = ({
   }
 
   return {
-    controllersByName: existingControllersByName as ControllerByName,
+    controllersByName: existingControllersByName as MessengerClientsByName,
   };
 };
 
@@ -111,13 +111,13 @@ export const initModularizedControllers: InitModularizedControllersFunction = ({
  * @param options.name - The name of the controller.
  * @returns The controller.
  */
-export function getControllerOrThrow<Name extends ControllerName>({
+export function getControllerOrThrow<Name extends MessengerClientName>({
   controller,
   name,
 }: {
-  controller: Partial<ControllerByName>[Name];
+  controller: Partial<MessengerClientsByName>[Name];
   name: Name;
-}): ControllerByName[Name] {
+}): MessengerClientsByName[Name] {
   if (!controller) {
     throw new Error(`Controller requested before it was initialized: ${name}`);
   }

--- a/app/features/SampleFeature/controllers/sample-petnames-controller-init.ts
+++ b/app/features/SampleFeature/controllers/sample-petnames-controller-init.ts
@@ -1,4 +1,4 @@
-import type { ControllerInitFunction } from '../../../core/Engine/types';
+import type { MessengerClientInitFunction } from '../../../core/Engine/types';
 import {
   SamplePetnamesController,
   SamplePetnamesControllerMessenger,
@@ -7,7 +7,7 @@ import { createProjectLogger } from '@metamask/utils';
 
 const log = createProjectLogger('sample-petnames-controller');
 
-export const samplePetnamesControllerInit: ControllerInitFunction<
+export const samplePetnamesControllerInit: MessengerClientInitFunction<
   SamplePetnamesController,
   SamplePetnamesControllerMessenger
 > = (request) => {

--- a/app/multichain-accounts/controllers/account-tree-controller/index.ts
+++ b/app/multichain-accounts/controllers/account-tree-controller/index.ts
@@ -2,7 +2,7 @@ import {
   AccountTreeController,
   AccountTreeControllerMessenger,
 } from '@metamask/account-tree-controller';
-import type { ControllerInitFunction } from '../../../core/Engine/types';
+import type { MessengerClientInitFunction } from '../../../core/Engine/types';
 import { trace } from '../../../util/trace';
 import { forwardSelectedAccountGroupToSnapKeyring } from '../../../core/SnapKeyring/utils/forwardSelectedAccountGroupToSnapKeyring';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -16,7 +16,7 @@ import { AccountTreeControllerInitMessenger } from '../../messengers/account-tre
  * @param request - The request object.
  * @returns The AccountTreeController.
  */
-export const accountTreeControllerInit: ControllerInitFunction<
+export const accountTreeControllerInit: MessengerClientInitFunction<
   AccountTreeController,
   AccountTreeControllerMessenger,
   AccountTreeControllerInitMessenger


### PR DESCRIPTION
## **Description**

Rename type definitions in `Engine/types.ts` to reflect that the init system handles all messenger clients (controllers + services), not just controllers. All consumer imports updated accordingly.

**PR 1 of 4** in a series that updates the init system API to use "messenger client" terminology:
- **PR 1 (this):** Core type renames (`Controller` → `MessengerClient`, `ControllerInitFunction` → `MessengerClientInitFunction`, etc.)
- PR 2: `CONTROLLER_MESSENGERS` → `MESSENGER_FACTORIES`
- PR 3: `initModularizedControllers` → `initMessengerClients` + utils/Engine.ts renames
- PR 4: Property renames (`controller` → `messengerClient`, `getController` → `getMessengerClient`) in all init files + tests

Relates to [WPC-916](https://consensyssoftware.atlassian.net/browse/WPC-916).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-916

## **Manual testing steps**

N/A — no runtime behavior change.

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WPC-916]: https://consensyssoftware.atlassian.net/browse/WPC-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad mechanical type renames across many engine init modules and tests; low behavioral risk but moderate integration risk if any downstream code still expects the old `Controller*` types.
> 
> **Overview**
> Updates the Engine init type API to use *messenger client* terminology: `Controllers`  `MessengerClients`, `ControllerName`  `MessengerClientName`, `ControllerInitRequest`/`ControllerInitFunction`  `MessengerClientInitRequest`/`MessengerClientInitFunction`, and related mapping/request types in `app/core/Engine/types.ts`.
> 
> Propagates the rename through all affected init implementations and unit tests (e.g., `accountsControllerInit`, `bridgeControllerInit`, `TransactionControllerInit`, etc.) plus test utilities, without changing initialization logic beyond updated type annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97d56cc47c55bfcb6d8ab78b55a04166aeee7ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->