### PR TITLE
chore(deps): upgrade @metamask/design-system-react-native to v0.16.0 (design system v31.0.0)

### DIFF
--- a/app/component-library/components-temp/HeaderSearch/HeaderSearch.tsx
+++ b/app/component-library/components-temp/HeaderSearch/HeaderSearch.tsx
@@ -23,6 +23,10 @@ import {
 } from './HeaderSearch.types';
 
 /**
+ * @deprecated Please update your code to use `HeaderSearch` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/HeaderSearch/README.md}
+ *
  * HeaderSearch is a header component that combines a search field
  * with either a back button (screen variant) or cancel button (inline variant).
  *

--- a/app/component-library/components-temp/KeyValueRow/KeyValueRow.tsx
+++ b/app/component-library/components-temp/KeyValueRow/KeyValueRow.tsx
@@ -13,6 +13,11 @@ import KeyValueRowLabel from './KeyValueLabel/KeyValueLabel';
 import KeyValueRowRoot from './KeyValueRoot/KeyValueRoot';
 
 /**
+ * @deprecated Please update your code to use `KeyValueRow` from `@metamask/design-system-react-native`.
+ * The API has changed — the new component uses flat props (`keyLabel`, `value`, `variant`) instead of nested `field`/`value` objects.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/KeyValueRow/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#keyvaluerow-api Migration docs}
+ *
  * Prebuilt convenience component to format and render a key/value KeyValueRowLabel pair.
  * The KeyValueRowLabel component has props to display a tooltip and icon.
  *

--- a/app/component-library/components/Avatars/Avatar/Avatar.tsx
+++ b/app/component-library/components/Avatars/Avatar/Avatar.tsx
@@ -16,6 +16,12 @@ import { AvatarTokenProps } from './variants/AvatarToken/AvatarToken.types';
 // Internal dependencies.
 import { AvatarProps, AvatarVariant } from './Avatar.types';
 
+/**
+ * @deprecated Please update your code to use the individual avatar components from `@metamask/design-system-react-native`
+ * such as `AvatarAccount`, `AvatarFavicon`, `AvatarIcon`, `AvatarNetwork`, or `AvatarToken`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
+ */
 const Avatar = ({ variant, ...props }: AvatarProps) => {
   switch (variant) {
     case AvatarVariant.Account:

--- a/app/component-library/components/Avatars/Avatar/Avatar.tsx
+++ b/app/component-library/components/Avatars/Avatar/Avatar.tsx
@@ -20,7 +20,11 @@ import { AvatarProps, AvatarVariant } from './Avatar.types';
  * @deprecated Please update your code to use the individual avatar components from `@metamask/design-system-react-native`
  * such as `AvatarAccount`, `AvatarFavicon`, `AvatarIcon`, `AvatarNetwork`, or `AvatarToken`.
  * The API may have changed — compare props before migrating.
- * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md AvatarAccount}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarFavicon/README.md AvatarFavicon}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarIcon/README.md AvatarIcon}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarNetwork/README.md AvatarNetwork}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarToken/README.md AvatarToken}
  */
 const Avatar = ({ variant, ...props }: AvatarProps) => {
   switch (variant) {

--- a/app/component-library/components/Badges/Badge/Badge.tsx
+++ b/app/component-library/components/Badges/Badge/Badge.tsx
@@ -16,6 +16,12 @@ import {
   BADGE_BADGENOTIFICATIONS_TEST_ID,
 } from './Badge.constants';
 
+/**
+ * @deprecated Please update your code to use the individual badge components from `@metamask/design-system-react-native`
+ * such as `BadgeNetwork`, `BadgeStatus`, `BadgeCount`, or `BadgeIcon`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeNetwork/README.md}
+ */
 const Badge = ({ variant, ...props }: BadgeProps) => {
   switch (variant) {
     case BadgeVariant.Network:

--- a/app/component-library/components/Badges/Badge/variants/BadgeStatus/BadgeStatus.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeStatus/BadgeStatus.tsx
@@ -16,6 +16,11 @@ import {
   DEFAULT_BADGESTATUS_STATE,
 } from './BadgeStatus.constants';
 
+/**
+ * @deprecated Please update your code to use `BadgeStatus` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeStatus/README.md}
+ */
 const BadgeStatus = ({
   style,
   state = DEFAULT_BADGESTATUS_STATE,

--- a/app/component-library/components/Form/TextFieldSearch/TextFieldSearch.tsx
+++ b/app/component-library/components/Form/TextFieldSearch/TextFieldSearch.tsx
@@ -13,6 +13,11 @@ import { TextFieldSearchProps } from './TextFieldSearch.types';
 import { TEXTFIELDSEARCH_TEST_ID } from './TextFieldSearch.constants';
 import styles from './TextFieldSearch.styles';
 
+/**
+ * @deprecated Please update your code to use `TextFieldSearch` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/TextFieldSearch/README.md}
+ */
 const TextFieldSearch: React.FC<TextFieldSearchProps> = ({
   onPressClearButton,
   clearButtonProps,

--- a/app/component-library/components/Texts/SensitiveText/SensitiveText.tsx
+++ b/app/component-library/components/Texts/SensitiveText/SensitiveText.tsx
@@ -5,6 +5,11 @@ import Text from '../Text/Text';
 // internal dependencies
 import { SensitiveTextProps, SensitiveTextLength } from './SensitiveText.types';
 
+/**
+ * @deprecated Please update your code to use `SensitiveText` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/SensitiveText/README.md}
+ */
 const SensitiveText: React.FC<SensitiveTextProps> = ({
   isHidden = false,
   children = '',

--- a/app/components/UI/Bridge/hooks/useSlippageStepperDescription/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/Bridge/hooks/useSlippageStepperDescription/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`useSlippageStepperDescription complete snapshots for all states snapsho
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.lower_allowed_error [0.1]",
 }
@@ -18,7 +18,7 @@ exports[`useSlippageStepperDescription complete snapshots for all states snapsho
   "icon": {
     "color": "text-warning-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.lower_suggested_warning [0.5]",
 }
@@ -32,7 +32,7 @@ exports[`useSlippageStepperDescription complete snapshots for all states snapsho
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_allowed_error [50]",
 }
@@ -44,7 +44,7 @@ exports[`useSlippageStepperDescription complete snapshots for all states snapsho
   "icon": {
     "color": "text-warning-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_suggested_warning [5]",
 }
@@ -56,7 +56,7 @@ exports[`useSlippageStepperDescription complete snapshots for all states snapsho
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_allowed_error [50]",
 }
@@ -68,7 +68,7 @@ exports[`useSlippageStepperDescription lower_allowed_slippage_threshold (ERROR) 
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.lower_allowed_error [0.1]",
 }
@@ -80,7 +80,7 @@ exports[`useSlippageStepperDescription lower_allowed_slippage_threshold (ERROR) 
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.lower_allowed_error [0.1]",
 }
@@ -92,7 +92,7 @@ exports[`useSlippageStepperDescription lower_suggested_slippage_threshold (WARNI
   "icon": {
     "color": "text-warning-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.lower_suggested_warning [0.5]",
 }
@@ -104,7 +104,7 @@ exports[`useSlippageStepperDescription upper_allowed_slippage_threshold (ERROR) 
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_allowed_error [50]",
 }
@@ -116,7 +116,7 @@ exports[`useSlippageStepperDescription upper_allowed_slippage_threshold (ERROR) 
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_allowed_error [50]",
 }
@@ -128,7 +128,7 @@ exports[`useSlippageStepperDescription upper_allowed_slippage_threshold (ERROR) 
   "icon": {
     "color": "text-error-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_allowed_error [50]",
 }
@@ -140,7 +140,7 @@ exports[`useSlippageStepperDescription upper_suggested_slippage_threshold (WARNI
   "icon": {
     "color": "text-warning-default",
     "name": "Danger",
-    "size": "24",
+    "size": "lg",
   },
   "message": "bridge.upper_suggested_warning [5]",
 }

--- a/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
+++ b/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Box, IconSize } from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
+  IconSize,
 } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
 import type { ToastOptions } from '../../../../component-library/components/Toast/Toast.types';

--- a/app/components/Views/ManualBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ManualBackupStep1/__snapshots__/index.test.tsx.snap
@@ -394,8 +394,7 @@ exports[`ManualBackupStep1 matches snapshot 1`] = `
                       [
                         [
                           "text-icon-default",
-                          "w-[32px]",
-                          "h-[32px]",
+                          "w-8 h-8",
                           undefined,
                         ],
                         undefined,
@@ -946,8 +945,7 @@ exports[`ManualBackupStep1 theme appearance renders with dark theme 1`] = `
                       [
                         [
                           "text-icon-default",
-                          "w-[32px]",
-                          "h-[32px]",
+                          "w-8 h-8",
                           undefined,
                         ],
                         undefined,
@@ -1498,8 +1496,7 @@ exports[`ManualBackupStep1 theme appearance renders with light theme on Android 
                       [
                         [
                           "text-icon-default",
-                          "w-[32px]",
-                          "h-[32px]",
+                          "w-8 h-8",
                           undefined,
                         ],
                         undefined,

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "@metamask/core-backend": "^6.2.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.14.0",
+    "@metamask/design-system-react-native": "^0.16.0",
     "@metamask/design-system-twrnc-preset": "^0.4.1",
     "@metamask/design-tokens": "^8.3.0",
     "@metamask/earn-controller": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "@metamask/transaction-controller": "^64.2.0",
     "@metamask/transaction-pay-controller": "^19.1.1",
     "@metamask/tron-wallet-snap": "^1.25.2",
-    "@metamask/utils": "^11.8.1",
+    "@metamask/utils": "^11.11.0",
     "@myx-trade/sdk": "^0.1.265",
     "@ngraveio/bc-ur": "^1.1.6",
     "@nktkas/hyperliquid": "^0.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35699,7 +35699,7 @@ __metadata:
     "@metamask/transaction-controller": "npm:^64.2.0"
     "@metamask/transaction-pay-controller": "npm:^19.1.1"
     "@metamask/tron-wallet-snap": "npm:^1.25.2"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/utils": "npm:^11.11.0"
     "@myx-trade/sdk": "npm:^0.1.265"
     "@ngraveio/bc-ur": "npm:^1.1.6"
     "@nktkas/hyperliquid": "npm:^0.30.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10213,26 +10213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.10.0
-  resolution: "@metamask/utils@npm:11.10.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^11.11.0":
+"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
   version: 11.11.0
   resolution: "@metamask/utils@npm:11.11.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,11 +8181,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@metamask/design-system-react-native@npm:0.14.0"
+"@metamask/design-system-react-native@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@metamask/design-system-react-native@npm:0.16.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.7.0"
+    "@metamask/design-system-shared": "npm:^0.9.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8198,18 +8198,18 @@ __metadata:
     react-native-gesture-handler: ">=1.10.3"
     react-native-reanimated: ">=3.3.0"
     react-native-safe-area-context: ">=4.0.0"
-  checksum: 10/fce2e0c048af8e2918b4be9be90b86528d02a12021d7782c0c9b20a0499a2c3221f388e348ad5bfc8ffd3e1af59a1b787206c0d149e023afcf8d5095a1df2a15
+  checksum: 10/64693d417d266793d5ebc80c4e112913af1223a827ac670ff004b4664904c3cedbd14bd08f1929ddc8b5f07861cc26c22ad0b49da064b820ba546287e0e1f19b
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@metamask/design-system-shared@npm:0.7.0"
+"@metamask/design-system-shared@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@metamask/design-system-shared@npm:0.9.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
-  checksum: 10/6029af5621f4a80a1cdcfea226ab4391fce466ee8c0ed6259c0aa06e4ec4029c7b0049c93e6d53cf0bb0a77e630574c92242f80280d7a10e3fb1fdf0b9656a42
+  checksum: 10/d1c7d54fac099b119b9f4ad6580289abba3fdbc699db13ebceb23c17c1d162987237625e3bf67397bf869e286951cc8edf9879c600f74dfef50f5447b898d61f
   languageName: node
   linkType: hard
 
@@ -10213,7 +10213,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+  version: 11.10.0
+  resolution: "@metamask/utils@npm:11.10.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    "@types/lodash": "npm:^4.17.20"
+    debug: "npm:^4.3.4"
+    lodash: "npm:^4.17.21"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^11.11.0":
   version: 11.11.0
   resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
@@ -35581,7 +35600,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.2.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.14.0"
+    "@metamask/design-system-react-native": "npm:^0.16.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.4.1"
     "@metamask/design-tokens": "npm:^8.3.0"
     "@metamask/earn-controller": "npm:^12.0.0"


### PR DESCRIPTION
## **Description**

Upgrades `@metamask/design-system-react-native` from `^0.13.0` to `^0.16.0`, corresponding to the [MetaMask Design System v31.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v31.0.0).

### What changed in v31.0.0

**New components available:**
- `HeaderSearch` — search header component (we have a local version; the DSRN version can be evaluated for future migration)
- `KeyValueColumn` — vertical key/value layout component

**Breaking changes audited:**

| Breaking Change | Status |
|---|---|
| `BoxHorizontal` → `BoxRow` | No usages found in codebase — no action needed |
| `BoxVertical` → `BoxColumn` | No usages found in codebase — no action needed |
| `BoxHorizontalPropsShared` → `BoxRowPropsShared` | No usages found — no action needed |
| `BoxVerticalPropsShared` → `BoxColumnPropsShared` | No usages found — no action needed |
| `KeyValueRow` stub-based composition removed | Mobile uses local `KeyValueRow` in `components-temp/` — not affected |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Design system package upgrade

  Scenario: App builds and renders correctly after upgrade
    Given the updated design-system-react-native package is installed

    When the app is built and launched
    Then all screens using design system components render correctly
    And no TypeScript errors are introduced
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — dependency-only change -->

### **After**

<!-- N/A — dependency-only change -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core UI dependency (`@metamask/design-system-react-native`) and its shared package, which can cause subtle visual/behavior changes across the app despite limited local code changes.
> 
> **Overview**
> Upgrades `@metamask/design-system-react-native` to `^0.16.0` (and updates `yarn.lock`), along with bumping `@metamask/utils` to `^11.11.0`.
> 
> Adds **deprecation notices and migration links** to several in-repo component-library wrappers (`Avatar`, `Badge`, `BadgeStatus`, `TextFieldSearch`, and temp `HeaderSearch`/`KeyValueRow`) to steer usage toward the design-system equivalents.
> 
> Adjusts a Predict share toast utility to use the app’s local `Icon`/`IconSize` instead of importing `IconSize` from the design system, and updates Jest snapshots to match new icon sizing/tailwind class outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ff3f7bc1dcf476d3abbaf9b023eea15e52b240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->