### PR TITLE
feat(predict): add TimeSlotPicker component for series time windows (PRED-788)

### DIFF
--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.constants.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.constants.ts
@@ -1,0 +1,4 @@
+export const PULSE_DURATION_MS = 1500;
+export const PULSE_DOT_SIZE = 8;
+export const PULSE_RING_SIZE = 16;
+export const COUNTDOWN_INTERVAL_MS = 1000;

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.test.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import TimeSlotPicker from './TimeSlotPicker';
+import { PredictMarket, Recurrence } from '../../types';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: (...classes: (string | boolean | undefined)[]) => ({
+      testStyle: classes.filter(Boolean).join(' '),
+    }),
+  }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const { View, Text: RNText } = jest.requireActual('react-native');
+  return {
+    Box: ({
+      children,
+      testID,
+      onLayout,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      onLayout?: (e: unknown) => void;
+      [key: string]: unknown;
+    }) => (
+      <View testID={testID} onLayout={onLayout} {...props}>
+        {children}
+      </View>
+    ),
+    BoxFlexDirection: { Row: 'row' },
+    BoxAlignItems: { Center: 'center' },
+    BoxBackgroundColor: {
+      ErrorMuted: 'bg-error-muted',
+      IconDefault: 'bg-icon-default',
+      BackgroundMuted: 'bg-muted',
+    },
+    BoxBorderColor: { ErrorDefault: 'border-error-default' },
+    Text: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) => <RNText {...props}>{children}</RNText>,
+    TextVariant: { BodySm: 'body-sm' },
+    TextColor: {
+      TextInverse: 'text-inverse',
+      TextDefault: 'text-default',
+    },
+    FontWeight: { Medium: 'medium', Regular: 'regular' },
+  };
+});
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: { View },
+    useSharedValue: (v: number) => ({ value: v }),
+    useAnimatedStyle: (fn: () => object) => fn(),
+    withRepeat: (v: number) => v,
+    withTiming: (v: number) => v,
+    Easing: { out: (fn: unknown) => fn, ease: {} },
+  };
+});
+
+jest.mock('./useCountdown', () => ({
+  useCountdown: jest.fn(() => null),
+}));
+
+const { useCountdown } = jest.requireMock('./useCountdown') as {
+  useCountdown: jest.Mock;
+};
+
+const createMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'btc-updown-5m',
+  title: 'BTC Up/Down 5m',
+  description: 'Will BTC go up?',
+  endDate: '2026-04-09T12:05:00.000Z',
+  image: '',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'crypto',
+  tags: ['up-or-down'],
+  outcomes: [],
+  liquidity: 1000,
+  volume: 5000,
+  ...overrides,
+});
+
+const createMarkets = (): PredictMarket[] => {
+  const now = Date.now();
+  return [
+    createMarket({
+      id: 'past-1',
+      endDate: new Date(now - 60_000).toISOString(),
+      status: 'closed',
+    }),
+    createMarket({
+      id: 'live-1',
+      endDate: new Date(now + 120_000).toISOString(),
+    }),
+    createMarket({
+      id: 'future-1',
+      endDate: new Date(now + 600_000).toISOString(),
+    }),
+    createMarket({
+      id: 'future-2',
+      endDate: new Date(now + 1_200_000).toISOString(),
+    }),
+  ];
+};
+
+describe('TimeSlotPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-09T12:00:00.000Z'));
+    useCountdown.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('renders a pill for each market', () => {
+      const markets = createMarkets();
+
+      const { getAllByText } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
+      );
+
+      const timeTexts = getAllByText(/.+/);
+      expect(timeTexts.length).toBeGreaterThanOrEqual(markets.length);
+    });
+
+    it('renders nothing when markets array is empty', () => {
+      const { toJSON } = render(
+        <TimeSlotPicker markets={[]} onMarketSelected={jest.fn()} />,
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+
+    it('displays "Live" text for the live market when countdown is active', () => {
+      useCountdown.mockReturnValue('02:00');
+      const markets = createMarkets();
+
+      const { getByText } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
+      );
+
+      expect(getByText('Live')).toBeTruthy();
+      expect(getByText('02:00')).toBeTruthy();
+    });
+  });
+
+  describe('selection', () => {
+    it('auto-selects the live market when no selectedMarketId is provided', () => {
+      useCountdown.mockReturnValue('02:00');
+      const markets = createMarkets();
+
+      const { getByText } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
+      );
+
+      expect(getByText('Live')).toBeTruthy();
+    });
+
+    it('selects the market matching selectedMarketId', () => {
+      const markets = createMarkets();
+      const onSelected = jest.fn();
+
+      render(
+        <TimeSlotPicker
+          markets={markets}
+          selectedMarketId="future-1"
+          onMarketSelected={onSelected}
+        />,
+      );
+
+      expect(useCountdown).toHaveBeenCalled();
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onMarketSelected with the tapped market', () => {
+      const markets = createMarkets();
+      const onSelected = jest.fn();
+
+      const { getAllByText } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={onSelected} />,
+      );
+
+      const timeTexts = getAllByText(/.+/);
+      fireEvent.press(timeTexts[0]);
+
+      expect(onSelected).toHaveBeenCalledTimes(1);
+      expect(onSelected).toHaveBeenCalledWith(
+        expect.objectContaining({ id: expect.any(String) }),
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('falls back to nearest market when no live market exists', () => {
+      const now = Date.now();
+      const markets = [
+        createMarket({
+          id: 'past-1',
+          endDate: new Date(now - 120_000).toISOString(),
+          status: 'closed',
+        }),
+        createMarket({
+          id: 'past-2',
+          endDate: new Date(now - 60_000).toISOString(),
+          status: 'closed',
+        }),
+      ];
+
+      const { toJSON } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
+      );
+
+      expect(toJSON()).not.toBeNull();
+    });
+
+    it('renders markets without endDate gracefully', () => {
+      const markets = [createMarket({ id: 'no-end', endDate: undefined })];
+
+      const { toJSON } = render(
+        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
+      );
+
+      expect(toJSON()).not.toBeNull();
+    });
+  });
+});

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.test.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, screen } from '@testing-library/react-native';
 import TimeSlotPicker from './TimeSlotPicker';
 import { PredictMarket, Recurrence } from '../../types';
 
@@ -39,18 +39,29 @@ jest.mock('@metamask/design-system-react-native', () => {
     BoxBorderColor: { ErrorDefault: 'border-error-default' },
     Text: ({
       children,
+      testID,
       ...props
     }: {
       children?: React.ReactNode;
+      testID?: string;
       [key: string]: unknown;
-    }) => <RNText {...props}>{children}</RNText>,
+    }) => (
+      <RNText testID={testID} {...props}>
+        {children}
+      </RNText>
+    ),
     TextVariant: { BodySm: 'body-sm' },
     TextColor: {
-      TextInverse: 'text-inverse',
+      PrimaryInverse: 'text-primary-inverse',
       TextDefault: 'text-default',
     },
     FontWeight: { Medium: 'medium', Regular: 'regular' },
   };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const { ScrollView } = jest.requireActual('react-native');
+  return { ScrollView };
 });
 
 jest.mock('react-native-reanimated', () => {
@@ -133,32 +144,33 @@ describe('TimeSlotPicker', () => {
     it('renders a pill for each market', () => {
       const markets = createMarkets();
 
-      const { getAllByText } = render(
-        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />);
 
-      const timeTexts = getAllByText(/.+/);
-      expect(timeTexts.length).toBeGreaterThanOrEqual(markets.length);
+      markets.forEach((market) => {
+        expect(
+          screen.getByTestId(`time-slot-pill-${market.id}`),
+        ).toBeOnTheScreen();
+      });
     });
 
     it('renders nothing when markets array is empty', () => {
-      const { toJSON } = render(
-        <TimeSlotPicker markets={[]} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={[]} onMarketSelected={jest.fn()} />);
 
-      expect(toJSON()).toBeNull();
+      expect(screen.queryByTestId('time-slot-picker')).not.toBeOnTheScreen();
     });
 
-    it('displays "Live" text for the live market when countdown is active', () => {
+    it('displays Live label and countdown for the live market when countdown is active', () => {
       useCountdown.mockReturnValue('02:00');
       const markets = createMarkets();
 
-      const { getByText } = render(
-        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />);
 
-      expect(getByText('Live')).toBeTruthy();
-      expect(getByText('02:00')).toBeTruthy();
+      expect(
+        screen.getByTestId('time-slot-live-label-live-1'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('time-slot-countdown-live-1'),
+      ).toBeOnTheScreen();
     });
   });
 
@@ -167,26 +179,25 @@ describe('TimeSlotPicker', () => {
       useCountdown.mockReturnValue('02:00');
       const markets = createMarkets();
 
-      const { getByText } = render(
-        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />);
 
-      expect(getByText('Live')).toBeTruthy();
+      expect(
+        screen.getByTestId('time-slot-live-label-live-1'),
+      ).toBeOnTheScreen();
     });
 
-    it('selects the market matching selectedMarketId', () => {
+    it('renders a pill for the explicitly selected market', () => {
       const markets = createMarkets();
-      const onSelected = jest.fn();
 
       render(
         <TimeSlotPicker
           markets={markets}
           selectedMarketId="future-1"
-          onMarketSelected={onSelected}
+          onMarketSelected={jest.fn()}
         />,
       );
 
-      expect(useCountdown).toHaveBeenCalled();
+      expect(screen.getByTestId('time-slot-pill-future-1')).toBeOnTheScreen();
     });
   });
 
@@ -195,16 +206,15 @@ describe('TimeSlotPicker', () => {
       const markets = createMarkets();
       const onSelected = jest.fn();
 
-      const { getAllByText } = render(
+      render(
         <TimeSlotPicker markets={markets} onMarketSelected={onSelected} />,
       );
 
-      const timeTexts = getAllByText(/.+/);
-      fireEvent.press(timeTexts[0]);
+      fireEvent.press(screen.getByTestId('time-slot-pill-past-1'));
 
       expect(onSelected).toHaveBeenCalledTimes(1);
       expect(onSelected).toHaveBeenCalledWith(
-        expect.objectContaining({ id: expect.any(String) }),
+        expect.objectContaining({ id: 'past-1' }),
       );
     });
   });
@@ -225,21 +235,17 @@ describe('TimeSlotPicker', () => {
         }),
       ];
 
-      const { toJSON } = render(
-        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />);
 
-      expect(toJSON()).not.toBeNull();
+      expect(screen.getByTestId('time-slot-picker')).toBeOnTheScreen();
     });
 
     it('renders markets without endDate gracefully', () => {
       const markets = [createMarket({ id: 'no-end', endDate: undefined })];
 
-      const { toJSON } = render(
-        <TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />,
-      );
+      render(<TimeSlotPicker markets={markets} onMarketSelected={jest.fn()} />);
 
-      expect(toJSON()).not.toBeNull();
+      expect(screen.getByTestId('time-slot-picker')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Pressable, ScrollView } from 'react-native';
+import { Pressable } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -27,52 +28,18 @@ import {
   PULSE_RING_SIZE,
 } from './TimeSlotPicker.constants';
 import { TimeSlotPickerProps } from './TimeSlotPicker.types';
+import {
+  formatTime,
+  findLiveMarket,
+  findNearestMarket,
+} from './TimeSlotPicker.utils';
 
-const formatTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return '';
-  return new Intl.DateTimeFormat(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(date);
-};
-
-const findLiveMarket = (
-  markets: PredictMarket[],
-): PredictMarket | undefined => {
-  const now = Date.now();
-  let closest: PredictMarket | undefined;
-  let closestDiff = Infinity;
-
-  for (const market of markets) {
-    if (!market.endDate) continue;
-    const diff = new Date(market.endDate).getTime() - now;
-    if (diff > 0 && diff < closestDiff) {
-      closestDiff = diff;
-      closest = market;
-    }
-  }
-  return closest;
-};
-
-const findNearestMarket = (
-  markets: PredictMarket[],
-): PredictMarket | undefined => {
-  if (markets.length === 0) return undefined;
-  const now = Date.now();
-  let nearest: PredictMarket | undefined;
-  let nearestDiff = Infinity;
-
-  for (const market of markets) {
-    if (!market.endDate) continue;
-    const diff = Math.abs(new Date(market.endDate).getTime() - now);
-    if (diff < nearestDiff) {
-      nearestDiff = diff;
-      nearest = market;
-    }
-  }
-  return nearest ?? markets[0];
-};
+interface PillStyle {
+  bg: BoxBackgroundColor | undefined;
+  border: BoxBorderColor | undefined;
+  textColor: TextColor;
+  bgClassName: string | undefined;
+}
 
 const PulseDot: React.FC = () => {
   const tw = useTailwind();
@@ -127,7 +94,7 @@ interface TimeSlotPillProps {
   market: PredictMarket;
   isSelected: boolean;
   isLive: boolean;
-  onPress: () => void;
+  onPress: (market: PredictMarket) => void;
 }
 
 const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
@@ -140,18 +107,18 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
   const countdown = useCountdown(isLive ? market.endDate : undefined);
   const timeLabel = market.endDate ? formatTime(market.endDate) : '';
 
-  const getPillStyle = () => {
+  const pillStyle = useMemo((): PillStyle => {
     if (isSelected && isLive) {
       return {
         bg: BoxBackgroundColor.ErrorMuted,
         border: BoxBorderColor.ErrorDefault,
         textColor: TextColor.PrimaryInverse,
-        bgClassName: undefined as string | undefined,
+        bgClassName: undefined,
       };
     }
     if (isSelected) {
       return {
-        bg: undefined as BoxBackgroundColor | undefined,
+        bg: undefined,
         border: undefined,
         textColor: TextColor.TextDefault,
         bgClassName: 'bg-icon-default',
@@ -161,15 +128,20 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
       bg: BoxBackgroundColor.BackgroundMuted,
       border: undefined,
       textColor: TextColor.PrimaryInverse,
-      bgClassName: undefined as string | undefined,
+      bgClassName: undefined,
     };
-  };
+  }, [isSelected, isLive]);
 
-  const { bg, border, textColor, bgClassName } = getPillStyle();
+  const { bg, border, textColor, bgClassName } = pillStyle;
+
+  const handlePress = useCallback(() => {
+    onPress(market);
+  }, [onPress, market]);
 
   return (
     <Pressable
-      onPress={onPress}
+      testID={`time-slot-pill-${market.id}`}
+      onPress={handlePress}
       style={({ pressed }) => tw.style(pressed && 'opacity-80')}
     >
       <Box
@@ -187,6 +159,7 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
             twClassName="gap-1"
           >
             <Text
+              testID={`time-slot-live-label-${market.id}`}
               variant={TextVariant.BodySm}
               color={textColor}
               fontWeight={FontWeight.Medium}
@@ -194,6 +167,7 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
               Live
             </Text>
             <Text
+              testID={`time-slot-countdown-${market.id}`}
               variant={TextVariant.BodySm}
               color={textColor}
               fontWeight={FontWeight.Medium}
@@ -203,6 +177,7 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
           </Box>
         ) : (
           <Text
+            testID={`time-slot-time-label-${market.id}`}
             variant={TextVariant.BodySm}
             color={textColor}
             fontWeight={isSelected ? FontWeight.Medium : FontWeight.Regular}
@@ -223,7 +198,7 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
   const tw = useTailwind();
   const scrollRef = useRef<ScrollView>(null);
   const pillPositions = useRef<Map<string, number>>(new Map());
-  const didAutoScroll = useRef(false);
+  const lastScrolledId = useRef<string | undefined>(undefined);
 
   const liveMarket = useMemo(() => findLiveMarket(markets), [markets]);
 
@@ -238,26 +213,21 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
   }, []);
 
   useEffect(() => {
-    if (didAutoScroll.current || !resolvedSelectedId) return;
+    if (!resolvedSelectedId) return;
+    if (lastScrolledId.current === resolvedSelectedId) return;
 
     const offset = pillPositions.current.get(resolvedSelectedId);
     if (offset !== undefined) {
       scrollRef.current?.scrollTo({ x: offset, animated: true });
-      didAutoScroll.current = true;
+      lastScrolledId.current = resolvedSelectedId;
     }
   }, [resolvedSelectedId, markets]);
-
-  const handlePress = useCallback(
-    (market: PredictMarket) => {
-      onMarketSelected(market);
-    },
-    [onMarketSelected],
-  );
 
   if (markets.length === 0) return null;
 
   return (
     <ScrollView
+      testID="time-slot-picker"
       ref={scrollRef}
       horizontal
       showsHorizontalScrollIndicator={false}
@@ -272,7 +242,7 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
             market={market}
             isSelected={market.id === resolvedSelectedId}
             isLive={market.id === liveMarket?.id}
-            onPress={() => handlePress(market)}
+            onPress={onMarketSelected}
           />
         </Box>
       ))}

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
@@ -200,13 +200,15 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
   const pillPositions = useRef<Map<string, number>>(new Map());
   const lastScrolledId = useRef<string | undefined>(undefined);
 
-  const liveMarket = useMemo(() => findLiveMarket(markets), [markets]);
+  const liveMarket = findLiveMarket(markets);
+  const liveMarketId = liveMarket?.id;
+  useCountdown(liveMarket?.endDate);
 
   const resolvedSelectedId = useMemo(() => {
     if (selectedMarketId) return selectedMarketId;
-    if (liveMarket) return liveMarket.id;
+    if (liveMarketId) return liveMarketId;
     return findNearestMarket(markets)?.id;
-  }, [selectedMarketId, liveMarket, markets]);
+  }, [selectedMarketId, liveMarketId, markets]);
 
   const handlePillLayout = useCallback((marketId: string, x: number) => {
     pillPositions.current.set(marketId, x);
@@ -216,11 +218,13 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
     if (!resolvedSelectedId) return;
     if (lastScrolledId.current === resolvedSelectedId) return;
 
-    const offset = pillPositions.current.get(resolvedSelectedId);
-    if (offset !== undefined) {
-      scrollRef.current?.scrollTo({ x: offset, animated: true });
-      lastScrolledId.current = resolvedSelectedId;
-    }
+    requestAnimationFrame(() => {
+      const offset = pillPositions.current.get(resolvedSelectedId);
+      if (offset !== undefined) {
+        scrollRef.current?.scrollTo({ x: offset, animated: true });
+        lastScrolledId.current = resolvedSelectedId;
+      }
+    });
   }, [resolvedSelectedId, markets]);
 
   if (markets.length === 0) return null;
@@ -241,7 +245,7 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
           <TimeSlotPill
             market={market}
             isSelected={market.id === resolvedSelectedId}
-            isLive={market.id === liveMarket?.id}
+            isLive={market.id === liveMarketId}
             onPress={onMarketSelected}
           />
         </Box>

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
@@ -1,0 +1,283 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Pressable, ScrollView } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  BoxBackgroundColor,
+  BoxBorderColor,
+} from '@metamask/design-system-react-native';
+import { PredictMarket } from '../../types';
+import { useCountdown } from './useCountdown';
+import {
+  PULSE_DURATION_MS,
+  PULSE_DOT_SIZE,
+  PULSE_RING_SIZE,
+} from './TimeSlotPicker.constants';
+import { TimeSlotPickerProps } from './TimeSlotPicker.types';
+
+const formatTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+};
+
+const findLiveMarket = (
+  markets: PredictMarket[],
+): PredictMarket | undefined => {
+  const now = Date.now();
+  let closest: PredictMarket | undefined;
+  let closestDiff = Infinity;
+
+  for (const market of markets) {
+    if (!market.endDate) continue;
+    const diff = new Date(market.endDate).getTime() - now;
+    if (diff > 0 && diff < closestDiff) {
+      closestDiff = diff;
+      closest = market;
+    }
+  }
+  return closest;
+};
+
+const findNearestMarket = (
+  markets: PredictMarket[],
+): PredictMarket | undefined => {
+  if (markets.length === 0) return undefined;
+  const now = Date.now();
+  let nearest: PredictMarket | undefined;
+  let nearestDiff = Infinity;
+
+  for (const market of markets) {
+    if (!market.endDate) continue;
+    const diff = Math.abs(new Date(market.endDate).getTime() - now);
+    if (diff < nearestDiff) {
+      nearestDiff = diff;
+      nearest = market;
+    }
+  }
+  return nearest ?? markets[0];
+};
+
+const PulseDot: React.FC = () => {
+  const tw = useTailwind();
+  const ringScale = useSharedValue(0.5);
+  const ringOpacity = useSharedValue(1);
+
+  useEffect(() => {
+    ringScale.value = withRepeat(
+      withTiming(1, {
+        duration: PULSE_DURATION_MS,
+        easing: Easing.out(Easing.ease),
+      }),
+      -1,
+      false,
+    );
+    ringOpacity.value = withRepeat(
+      withTiming(0, {
+        duration: PULSE_DURATION_MS,
+        easing: Easing.out(Easing.ease),
+      }),
+      -1,
+      false,
+    );
+  }, [ringScale, ringOpacity]);
+
+  const ringBaseStyle = useMemo(
+    () =>
+      tw.style(
+        `absolute w-[${PULSE_RING_SIZE}px] h-[${PULSE_RING_SIZE}px] rounded-full bg-icon-default/40`,
+      ),
+    [tw],
+  );
+
+  const ringAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: ringScale.value }],
+    opacity: ringOpacity.value,
+  }));
+
+  return (
+    <Box
+      twClassName={`w-[${PULSE_RING_SIZE}px] h-[${PULSE_RING_SIZE}px] items-center justify-center`}
+    >
+      <Animated.View style={[ringBaseStyle, ringAnimatedStyle]} />
+      <Box
+        twClassName={`w-[${PULSE_DOT_SIZE}px] h-[${PULSE_DOT_SIZE}px] rounded-full bg-error-default`}
+      />
+    </Box>
+  );
+};
+
+interface TimeSlotPillProps {
+  market: PredictMarket;
+  isSelected: boolean;
+  isLive: boolean;
+  onPress: () => void;
+}
+
+const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
+  market,
+  isSelected,
+  isLive,
+  onPress,
+}) => {
+  const tw = useTailwind();
+  const countdown = useCountdown(isLive ? market.endDate : undefined);
+  const timeLabel = market.endDate ? formatTime(market.endDate) : '';
+
+  const getPillStyle = () => {
+    if (isSelected && isLive) {
+      return {
+        bg: BoxBackgroundColor.ErrorMuted,
+        border: BoxBorderColor.ErrorDefault,
+        textColor: TextColor.PrimaryInverse,
+        bgClassName: undefined as string | undefined,
+      };
+    }
+    if (isSelected) {
+      return {
+        bg: undefined as BoxBackgroundColor | undefined,
+        border: undefined,
+        textColor: TextColor.TextDefault,
+        bgClassName: 'bg-icon-default',
+      };
+    }
+    return {
+      bg: BoxBackgroundColor.BackgroundMuted,
+      border: undefined,
+      textColor: TextColor.PrimaryInverse,
+      bgClassName: undefined as string | undefined,
+    };
+  };
+
+  const { bg, border, textColor, bgClassName } = getPillStyle();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => tw.style(pressed && 'opacity-80')}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        backgroundColor={bg}
+        borderColor={border}
+        twClassName={`px-3 py-2 rounded-full gap-2 ${border ? 'border' : ''} ${bgClassName ?? ''}`}
+      >
+        {isLive && <PulseDot />}
+        {isLive && countdown ? (
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-1"
+          >
+            <Text
+              variant={TextVariant.BodySm}
+              color={textColor}
+              fontWeight={FontWeight.Medium}
+            >
+              Live
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={textColor}
+              fontWeight={FontWeight.Medium}
+            >
+              {countdown}
+            </Text>
+          </Box>
+        ) : (
+          <Text
+            variant={TextVariant.BodySm}
+            color={textColor}
+            fontWeight={isSelected ? FontWeight.Medium : FontWeight.Regular}
+          >
+            {timeLabel}
+          </Text>
+        )}
+      </Box>
+    </Pressable>
+  );
+};
+
+const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
+  markets,
+  selectedMarketId,
+  onMarketSelected,
+}) => {
+  const tw = useTailwind();
+  const scrollRef = useRef<ScrollView>(null);
+  const pillPositions = useRef<Map<string, number>>(new Map());
+  const didAutoScroll = useRef(false);
+
+  const liveMarket = useMemo(() => findLiveMarket(markets), [markets]);
+
+  const resolvedSelectedId = useMemo(() => {
+    if (selectedMarketId) return selectedMarketId;
+    if (liveMarket) return liveMarket.id;
+    return findNearestMarket(markets)?.id;
+  }, [selectedMarketId, liveMarket, markets]);
+
+  const handlePillLayout = useCallback((marketId: string, x: number) => {
+    pillPositions.current.set(marketId, x);
+  }, []);
+
+  useEffect(() => {
+    if (didAutoScroll.current || !resolvedSelectedId) return;
+
+    const offset = pillPositions.current.get(resolvedSelectedId);
+    if (offset !== undefined) {
+      scrollRef.current?.scrollTo({ x: offset, animated: true });
+      didAutoScroll.current = true;
+    }
+  }, [resolvedSelectedId, markets]);
+
+  const handlePress = useCallback(
+    (market: PredictMarket) => {
+      onMarketSelected(market);
+    },
+    [onMarketSelected],
+  );
+
+  if (markets.length === 0) return null;
+
+  return (
+    <ScrollView
+      ref={scrollRef}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={tw.style('px-4 gap-2')}
+    >
+      {markets.map((market) => (
+        <Box
+          key={market.id}
+          onLayout={(e) => handlePillLayout(market.id, e.nativeEvent.layout.x)}
+        >
+          <TimeSlotPill
+            market={market}
+            isSelected={market.id === resolvedSelectedId}
+            isLive={market.id === liveMarket?.id}
+            onPress={() => handlePress(market)}
+          />
+        </Box>
+      ))}
+    </ScrollView>
+  );
+};
+
+export default TimeSlotPicker;

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
@@ -112,7 +112,7 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
       return {
         bg: BoxBackgroundColor.ErrorMuted,
         border: BoxBorderColor.ErrorDefault,
-        textColor: TextColor.PrimaryInverse,
+        textColor: TextColor.TextDefault,
         bgClassName: undefined,
       };
     }
@@ -120,14 +120,14 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
       return {
         bg: undefined,
         border: undefined,
-        textColor: TextColor.TextDefault,
+        textColor: TextColor.PrimaryInverse,
         bgClassName: 'bg-icon-default',
       };
     }
     return {
       bg: BoxBackgroundColor.BackgroundMuted,
       border: undefined,
-      textColor: TextColor.PrimaryInverse,
+      textColor: TextColor.TextDefault,
       bgClassName: undefined,
     };
   }, [isSelected, isLive]);
@@ -169,7 +169,7 @@ const TimeSlotPill: React.FC<TimeSlotPillProps> = ({
             <Text
               testID={`time-slot-countdown-${market.id}`}
               variant={TextVariant.BodySm}
-              color={textColor}
+              color={TextColor.ErrorDefault}
               fontWeight={FontWeight.Medium}
             >
               {countdown}

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.types.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.types.ts
@@ -1,0 +1,20 @@
+import { PredictMarket } from '../../types';
+
+/**
+ * Props for the TimeSlotPicker component.
+ *
+ * Displays a horizontal scrollable strip of pill-shaped items representing
+ * time windows (past, live, future) for crypto Up/Down prediction market series.
+ */
+export interface TimeSlotPickerProps {
+  /** Array of markets from usePredictSeries, ordered by endDate. */
+  markets: PredictMarket[];
+  /**
+   * Optional selected market ID.
+   * If provided, that market is selected.
+   * If omitted, the live market is auto-selected (or nearest to now).
+   */
+  selectedMarketId?: string;
+  /** Callback fired when the user taps a pill. */
+  onMarketSelected: (market: PredictMarket) => void;
+}

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.utils.test.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.utils.test.ts
@@ -1,0 +1,183 @@
+import {
+  formatTime,
+  findLiveMarket,
+  findNearestMarket,
+} from './TimeSlotPicker.utils';
+import { PredictMarket, Recurrence } from '../../types';
+
+const createMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'btc-updown-5m',
+  title: 'BTC Up/Down 5m',
+  description: 'Will BTC go up?',
+  endDate: '2026-04-09T12:05:00.000Z',
+  image: '',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'crypto',
+  tags: [],
+  outcomes: [],
+  liquidity: 1000,
+  volume: 5000,
+  ...overrides,
+});
+
+describe('formatTime', () => {
+  it('returns a non-empty string for a valid ISO date', () => {
+    const result = formatTime('2026-04-09T12:05:00.000Z');
+
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty string for an invalid date string', () => {
+    const result = formatTime('not-a-date');
+
+    expect(result).toBe('');
+  });
+
+  it('returns an empty string for an empty string', () => {
+    const result = formatTime('');
+
+    expect(result).toBe('');
+  });
+});
+
+describe('findLiveMarket', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-09T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the market with the soonest future endDate', () => {
+    const now = Date.now();
+    const markets = [
+      createMarket({
+        id: 'future-far',
+        endDate: new Date(now + 600_000).toISOString(),
+      }),
+      createMarket({
+        id: 'future-near',
+        endDate: new Date(now + 120_000).toISOString(),
+      }),
+      createMarket({
+        id: 'past',
+        endDate: new Date(now - 60_000).toISOString(),
+      }),
+    ];
+
+    const result = findLiveMarket(markets);
+
+    expect(result?.id).toBe('future-near');
+  });
+
+  it('returns undefined when all markets have past endDates', () => {
+    const now = Date.now();
+    const markets = [
+      createMarket({
+        id: 'past-1',
+        endDate: new Date(now - 120_000).toISOString(),
+      }),
+      createMarket({
+        id: 'past-2',
+        endDate: new Date(now - 60_000).toISOString(),
+      }),
+    ];
+
+    const result = findLiveMarket(markets);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when markets array is empty', () => {
+    const result = findLiveMarket([]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('skips markets without an endDate', () => {
+    const now = Date.now();
+    const markets = [
+      createMarket({ id: 'no-end', endDate: undefined }),
+      createMarket({
+        id: 'future',
+        endDate: new Date(now + 120_000).toISOString(),
+      }),
+    ];
+
+    const result = findLiveMarket(markets);
+
+    expect(result?.id).toBe('future');
+  });
+});
+
+describe('findNearestMarket', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-09T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the market whose endDate is closest to now', () => {
+    const now = Date.now();
+    const markets = [
+      createMarket({
+        id: 'far-future',
+        endDate: new Date(now + 600_000).toISOString(),
+      }),
+      createMarket({
+        id: 'near-past',
+        endDate: new Date(now - 30_000).toISOString(),
+      }),
+      createMarket({
+        id: 'near-future',
+        endDate: new Date(now + 45_000).toISOString(),
+      }),
+    ];
+
+    const result = findNearestMarket(markets);
+
+    expect(result?.id).toBe('near-past');
+  });
+
+  it('returns undefined when markets array is empty', () => {
+    const result = findNearestMarket([]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('falls back to first market when none have an endDate', () => {
+    const markets = [
+      createMarket({ id: 'first', endDate: undefined }),
+      createMarket({ id: 'second', endDate: undefined }),
+    ];
+
+    const result = findNearestMarket(markets);
+
+    expect(result?.id).toBe('first');
+  });
+
+  it('skips markets without endDate when others have one', () => {
+    const now = Date.now();
+    const markets = [
+      createMarket({ id: 'no-end', endDate: undefined }),
+      createMarket({
+        id: 'future',
+        endDate: new Date(now + 120_000).toISOString(),
+      }),
+    ];
+
+    const result = findNearestMarket(markets);
+
+    expect(result?.id).toBe('future');
+  });
+});

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.utils.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.utils.ts
@@ -1,0 +1,60 @@
+import { PredictMarket } from '../../types';
+
+/**
+ * Formats an ISO date string to a locale-aware "H:MM AM/PM" time string.
+ * Returns an empty string for invalid dates.
+ */
+export const formatTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+};
+
+/**
+ * Returns the market with the smallest positive time remaining (i.e. the
+ * market that is currently "live" — soonest to end but not yet ended).
+ * Returns `undefined` when no market has a future endDate.
+ */
+export const findLiveMarket = (
+  markets: PredictMarket[],
+): PredictMarket | undefined => {
+  const now = Date.now();
+  let closest: PredictMarket | undefined;
+  let closestDiff = Infinity;
+
+  for (const market of markets) {
+    if (!market.endDate) continue;
+    const diff = new Date(market.endDate).getTime() - now;
+    if (diff > 0 && diff < closestDiff) {
+      closestDiff = diff;
+      closest = market;
+    }
+  }
+  return closest;
+};
+
+/**
+ * Returns the market whose endDate is closest to now (past or future).
+ * Falls back to the first market in the array when none have an endDate.
+ */
+export const findNearestMarket = (
+  markets: PredictMarket[],
+): PredictMarket | undefined => {
+  if (markets.length === 0) return undefined;
+  const now = Date.now();
+  let nearest: PredictMarket | undefined;
+  let nearestDiff = Infinity;
+
+  for (const market of markets) {
+    if (!market.endDate) continue;
+    const diff = Math.abs(new Date(market.endDate).getTime() - now);
+    if (diff < nearestDiff) {
+      nearestDiff = diff;
+      nearest = market;
+    }
+  }
+  return nearest ?? markets[0];
+};

--- a/app/components/UI/Predict/components/TimeSlotPicker/index.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/index.ts
@@ -1,0 +1,3 @@
+export { default as TimeSlotPicker } from './TimeSlotPicker';
+export type { TimeSlotPickerProps } from './TimeSlotPicker.types';
+export { useCountdown } from './useCountdown';

--- a/app/components/UI/Predict/components/TimeSlotPicker/index.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/index.ts
@@ -1,3 +1,2 @@
 export { default as TimeSlotPicker } from './TimeSlotPicker';
 export type { TimeSlotPickerProps } from './TimeSlotPicker.types';
-export { useCountdown } from './useCountdown';

--- a/app/components/UI/Predict/components/TimeSlotPicker/useCountdown.test.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/useCountdown.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useCountdown } from './useCountdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-09T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns formatted MM:SS for a future target date', () => {
+    const target = new Date('2026-04-09T12:05:30.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBe('05:30');
+  });
+
+  it('returns null when target date is in the past', () => {
+    const target = new Date('2026-04-09T11:59:00.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when target date is undefined', () => {
+    const { result } = renderHook(() => useCountdown(undefined));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('decrements every second', () => {
+    const target = new Date('2026-04-09T12:00:03.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBe('00:03');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBe('00:02');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBe('00:01');
+  });
+
+  it('transitions to null when countdown reaches zero', () => {
+    const target = new Date('2026-04-09T12:00:01.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBe('00:01');
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBeNull();
+  });
+
+  it('pads single-digit minutes and seconds with leading zeros', () => {
+    const target = new Date('2026-04-09T12:01:05.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBe('01:05');
+  });
+
+  it('resets when targetDate changes', () => {
+    const target1 = new Date('2026-04-09T12:00:10.000Z').toISOString();
+    const target2 = new Date('2026-04-09T12:02:00.000Z').toISOString();
+
+    const { result, rerender } = renderHook(
+      ({ target }) => useCountdown(target),
+      { initialProps: { target: target1 } },
+    );
+
+    expect(result.current).toBe('00:10');
+
+    rerender({ target: target2 });
+
+    expect(result.current).toBe('02:00');
+  });
+
+  it('handles large countdown values', () => {
+    const target = new Date('2026-04-09T13:30:00.000Z').toISOString();
+
+    const { result } = renderHook(() => useCountdown(target));
+
+    expect(result.current).toBe('90:00');
+  });
+});

--- a/app/components/UI/Predict/components/TimeSlotPicker/useCountdown.ts
+++ b/app/components/UI/Predict/components/TimeSlotPicker/useCountdown.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { COUNTDOWN_INTERVAL_MS } from './TimeSlotPicker.constants';
+
+/**
+ * Returns the remaining time until `targetDate` as "MM:SS".
+ * Returns `null` when the target is in the past or undefined.
+ */
+export const useCountdown = (targetDate: string | undefined): string | null => {
+  const getRemainingSeconds = useCallback((): number => {
+    if (!targetDate) return 0;
+    const diff = new Date(targetDate).getTime() - Date.now();
+    return diff > 0 ? Math.floor(diff / 1000) : 0;
+  }, [targetDate]);
+
+  const [remaining, setRemaining] = useState<number>(getRemainingSeconds);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const seconds = getRemainingSeconds();
+    setRemaining(seconds);
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (seconds <= 0) return;
+
+    intervalRef.current = setInterval(() => {
+      const next = getRemainingSeconds();
+      setRemaining(next);
+      if (next <= 0 && intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }, COUNTDOWN_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [getRemainingSeconds]);
+
+  if (remaining <= 0) return null;
+
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+};


### PR DESCRIPTION
## **Description**

Add a new `TimeSlotPicker` component for the Predict feature that displays a horizontal scrollable strip of pill-shaped items representing time windows (past, live, future) for crypto Up/Down prediction market series.

This is a standalone reusable component built ahead of the series detail screen (PRED-786). It includes:
- Four visual pill states: default, selected, live, and selected+live
- Animated pulse dot indicator using Reanimated v3 for the live market
- Real-time countdown timer (MM:SS) for the live market's end time
- Auto-scroll on mount to bring the selected/live pill into view
- Locale-aware time formatting via `Intl.DateTimeFormat`
- Uncontrolled selection with optional `selectedMarketId` override

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-788](https://consensyssoftware.atlassian.net/browse/PRED-788)

## **Manual testing steps**

```gherkin
Feature: TimeSlotPicker for crypto Up/Down series

  Scenario: Component renders pills for series markets
    Given a crypto Up/Down market with series data is available
    When the TimeSlotPicker is rendered with the series markets
    Then a horizontal scrollable strip of pill-shaped items is displayed
    And each pill shows the market's end time in the device's locale format

  Scenario: Live market is auto-selected on mount
    Given the series contains a market whose endDate is in the future (live)
    When the TimeSlotPicker mounts without a selectedMarketId prop
    Then the live market pill is auto-selected
    And the strip auto-scrolls to bring the live pill into view

  Scenario: Live pill displays countdown and pulse animation
    Given a market is currently live (endDate in the future, soonest to end)
    When viewing the TimeSlotPicker
    Then the live pill shows a pulsing red dot, "Live" label, and a MM:SS countdown
    And the countdown ticks down every second

  Scenario: User taps a non-live pill
    Given the live market pill is currently selected
    When the user taps a different (future or past) pill
    Then the tapped pill becomes selected with a white background and dark text
    And the onMarketSelected callback fires with the tapped market
    And the live pill remains visible with its pulse dot and countdown (unselected style)

  Scenario: Countdown reaches zero
    Given the live market's countdown is ticking
    When the countdown reaches 00:00
    Then the live indicator moves to the next market in the series
    And the user's current selection does NOT change automatically
```

## **Screenshots/Recordings**

### **Before**

N/A — new component

### **After**

Demo: https://www.loom.com/share/a6ef4afae3ba4b7c83375b5ebc55971e

<img width="380" alt="Simulator Screenshot - mm-blue - 2026-04-09 at 16 02 23" src="https://github.com/user-attachments/assets/ef26e1f1-a288-4134-99e7-f207bbffc0c3" />
<img width="380" alt="Simulator Screenshot - mm-blue - 2026-04-09 at 16 02 35" src="https://github.com/user-attachments/assets/a5f9d685-87b4-4ab1-b566-03ac0a820d52" />
<img width="380"  alt="Simulator Screenshot - mm-blue - 2026-04-09 at 16 02 43" src="https://github.com/user-attachments/assets/24fa49ce-1231-4e90-bcbc-0d77cab2e550" />
<img width="380" alt="Simulator Screenshot - mm-blue - 2026-04-09 at 16 02 55" src="https://github.com/user-attachments/assets/ed8d1d09-68c2-4cdd-acc1-34827b40826e" />




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[PRED-788]: https://consensyssoftware.atlassian.net/browse/PRED-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a new, self-contained UI component with helper utilities and unit tests, with no changes to existing business logic, auth, or data flows.
> 
> **Overview**
> Adds a new `TimeSlotPicker` component that renders a horizontal list of selectable “time window” pills for a series, auto-selecting the *live* (soonest-ending future) market by default and auto-scrolling the strip to the resolved selection.
> 
> Live pills now show an animated pulse indicator (Reanimated) plus an `MM:SS` countdown driven by a new `useCountdown` hook, while non-live pills display a locale-formatted end time via `formatTime`.
> 
> Includes supporting constants/types, selection utilities (`findLiveMarket`, `findNearestMarket`), and comprehensive unit tests for the component, utilities, and countdown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ee540d194c4875f094f6c56287937cb54ef4f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->