### PR TITLE
fix(rewards): resolve TS errors from BottomSheet and IconSize breaking changes

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -86,7 +86,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   }, [optInToCampaign, campaign.id, showToast, RewardsToastOptions, onClose]);
 
   return (
-    <BottomSheet shouldNavigateBack={false} goBack={noop} onClose={onClose}>
+    <BottomSheet goBack={noop} onClose={onClose}>
       <Box twClassName="px-4 pb-4">
         {/* Header: centered title + close button */}
         <Box

--- a/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
@@ -54,12 +54,7 @@ const OndoAccountPickerSheet: React.FC<OndoAccountPickerSheetProps> = ({
   );
 
   return (
-    <BottomSheet
-      shouldNavigateBack={false}
-      onClose={onClose}
-      goBack={onClose}
-      ref={sheetRef}
-    >
+    <BottomSheet onClose={onClose} goBack={onClose} ref={sheetRef}>
       <BottomSheetHeader
         onClose={() => sheetRef.current?.onCloseBottomSheet(onClose)}
       >

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/index.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/index.tsx
@@ -2,15 +2,12 @@ import React, { useMemo } from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import Rive, { Alignment, Fit } from 'rive-react-native';
 import Animated from 'react-native-reanimated';
-import {
-  IconSize,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react-native';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { useTheme } from '../../../../../util/theme';
 import Icon, {
   IconName,
+  IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
 import {
   useRewardsAnimation,


### PR DESCRIPTION
## **Description**

Fixes TypeScript errors introduced by recent breaking changes in dependencies:

1. **`BottomSheet`** — `shouldNavigateBack` prop was removed. Removed from `CampaignOptInSheet` and `OndoAccountPickerSheet`.
2. **`IconSize`** — `RewardPointsAnimation` was importing `IconSize` from `@metamask/design-system-react-native`, but the local `Icon` component expects `IconSize` from the component library (`app/component-library/components/Icons/Icon`). Moved import to the correct source.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Rewards TypeScript compilation

  Scenario: user runs TypeScript lint
    Given the MetaMask mobile codebase
    When user runs yarn lint:tsc
    Then no TypeScript errors are reported in the Rewards components
```

## **Screenshots/Recordings**

### **Before**

3 TS errors in `CampaignOptInSheet.tsx`, `OndoAccountPickerSheet.tsx`, `RewardPointsAnimation/index.tsx`

### **After**

`yarn lint:tsc` exits with code 0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to prop/import updates to restore TypeScript compatibility, with minimal impact to runtime behavior aside from BottomSheet navigation-back handling.
> 
> **Overview**
> Resolves Rewards TypeScript build errors caused by upstream API changes.
> 
> Updates Rewards sheets to stop passing the removed `shouldNavigateBack` prop to `BottomSheet`, and adjusts `RewardPointsAnimation` to source `IconSize` from the local `Icon` component instead of `@metamask/design-system-react-native`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52025bffde8a02e4ef79df33d0ce3620fbaf2d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->