### PR TITLE
feat(predict): scaffold Crypto Up/Down detail screen with header

### DIFF
--- a/app/components/UI/Predict/Predict.testIds.ts
+++ b/app/components/UI/Predict/Predict.testIds.ts
@@ -128,6 +128,19 @@ export const PredictMarketDetailsSelectorsIDs = {
     'predict-details-buttons-skeleton-button-1',
 } as const;
 
+// ========================================
+// PREDICT CRYPTO UP/DOWN DETAILS SELECTORS
+// ========================================
+
+export const PredictCryptoUpDownDetailsSelectorsIDs = {
+  SCREEN: 'predict-crypto-up-down-details-screen',
+  HEADER: 'predict-crypto-up-down-details-header',
+  BACK_BUTTON: 'predict-crypto-up-down-details-back-button',
+  SHARE_BUTTON: 'predict-crypto-up-down-details-share-button',
+  SCROLL_VIEW: 'predict-crypto-up-down-details-scroll-view',
+  TITLE_SECTION: 'predict-crypto-up-down-details-title-section',
+} as const;
+
 export const PredictMarketDetailsSelectorsText = {
   // Tab content containers
   ABOUT_TAB_TEXT: 'About',

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
@@ -1,0 +1,321 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import PredictCryptoUpDownDetails from './PredictCryptoUpDownDetails';
+import { PredictCryptoUpDownDetailsSelectorsIDs } from '../../Predict.testIds';
+import type { PredictMarket, PredictSeries } from '../../types';
+import usePredictShare from '../../hooks/usePredictShare';
+import { formatMarketEndDate } from '../../utils/format';
+
+const mockUsePredictShare = usePredictShare as jest.Mock;
+const mockFormatMarketEndDate = formatMarketEndDate as jest.Mock;
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: jest.fn(() => ({})),
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const { ScrollView } = jest.requireActual('react-native');
+  return {
+    ...jest.requireActual('react-native-reanimated'),
+    Animated: { ScrollView },
+    useSharedValue: jest.fn((initialValue: number) => ({
+      value: initialValue,
+    })),
+    useAnimatedScrollHandler: jest.fn(() => jest.fn()),
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    ...jest.requireActual('react-native-safe-area-context'),
+    SafeAreaView: View,
+  };
+});
+
+jest.mock(
+  '../../../../../component-library/components-temp/HeaderStandardAnimated',
+  () => {
+    const { View, Text } = jest.requireActual('react-native');
+    interface MockProps {
+      title?: string;
+      subtitle?: string;
+      testID?: string;
+      endButtonIconProps?: { testID?: string }[];
+    }
+    const MockHeaderStandardAnimated = ({
+      title,
+      subtitle,
+      testID,
+      endButtonIconProps,
+    }: MockProps) => (
+      <View testID={testID}>
+        {title && <Text>{title}</Text>}
+        {subtitle && <Text>{subtitle}</Text>}
+        {endButtonIconProps && endButtonIconProps.length > 0 && (
+          <View testID={endButtonIconProps[0].testID} />
+        )}
+      </View>
+    );
+    return MockHeaderStandardAnimated;
+  },
+);
+
+jest.mock(
+  '../../../../../component-library/components-temp/HeaderStandardAnimated/useHeaderStandardAnimated',
+  () => ({
+    __esModule: true,
+    default: () => ({
+      scrollY: { value: 0 },
+      titleSectionHeightSv: { value: 0 },
+      setTitleSectionHeight: jest.fn(),
+      onScroll: jest.fn(),
+    }),
+  }),
+);
+
+jest.mock(
+  '../../../../../component-library/components-temp/TitleSubpage',
+  () => {
+    const { View, Text } = jest.requireActual('react-native');
+    interface MockProps {
+      title?: string;
+      bottomLabel?: string;
+      startAccessory?: React.ReactNode;
+      twClassName?: string;
+      testID?: string;
+    }
+    const MockTitleSubpage = ({
+      title,
+      bottomLabel,
+      startAccessory,
+    }: MockProps) => (
+      <View>
+        {startAccessory}
+        {title && <Text>{title}</Text>}
+        {bottomLabel && <Text>{bottomLabel}</Text>}
+      </View>
+    );
+    return MockTitleSubpage;
+  },
+);
+
+jest.mock('../../hooks/usePredictShare', () => {
+  const mockUsePredictShare = jest.fn(
+    ({ marketId, marketSlug }: { marketId?: string; marketSlug?: string }) => ({
+      handleSharePress: jest.fn(),
+      marketId,
+      marketSlug,
+    }),
+  );
+  return {
+    __esModule: true,
+    default: mockUsePredictShare,
+  };
+});
+
+jest.mock('../../utils/format', () => ({
+  formatMarketEndDate: jest.fn((date: string) => 'April 9, 1:45 PM'),
+}));
+
+const createMockMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket & { series: PredictSeries } =>
+  ({
+    id: 'market-1',
+    providerId: 'polymarket',
+    slug: 'btc-up-or-down-5m',
+    title: 'BTC Up or Down - 5 Minutes',
+    description: 'Will BTC go up or down?',
+    image: 'https://example.com/btc.png',
+    status: 'open',
+    recurrence: 'NONE',
+    category: 'crypto',
+    tags: ['crypto', 'up-or-down'],
+    outcomes: [],
+    liquidity: 100,
+    volume: 200,
+    endDate: '2026-04-09T19:45:00Z',
+    series: {
+      id: 's1',
+      slug: 'btc-up-or-down-5m',
+      title: 'BTC Up or Down - 5 Minutes',
+      recurrence: '5m',
+    },
+    ...overrides,
+  }) as PredictMarket & { series: PredictSeries };
+
+describe('PredictCryptoUpDownDetails', () => {
+  const mockOnBack = jest.fn();
+  const mockOnRefresh = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the screen container with correct testID', () => {
+    const market = createMockMarket();
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    expect(
+      screen.getByTestId(PredictCryptoUpDownDetailsSelectorsIDs.SCREEN),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders HeaderStandardAnimated with series title as title prop', () => {
+    const market = createMockMarket({
+      series: {
+        id: 's1',
+        slug: 'btc-up-or-down-5m',
+        title: 'BTC Up or Down - 5 Minutes',
+        recurrence: '5m',
+      },
+    });
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    const header = screen.getByTestId(
+      PredictCryptoUpDownDetailsSelectorsIDs.HEADER,
+    );
+    expect(header).toBeOnTheScreen();
+  });
+
+  it('renders HeaderStandardAnimated with formatted endDate as subtitle prop', () => {
+    const market = createMockMarket({
+      endDate: '2026-04-09T19:45:00Z',
+    });
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    const header = screen.getByTestId(
+      PredictCryptoUpDownDetailsSelectorsIDs.HEADER,
+    );
+    expect(header).toBeOnTheScreen();
+  });
+
+  it('passes share button in endButtonIconProps', () => {
+    const market = createMockMarket();
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    expect(
+      screen.getByTestId(PredictCryptoUpDownDetailsSelectorsIDs.SHARE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('calls usePredictShare with market id and slug', () => {
+    const market = createMockMarket({
+      id: 'market-123',
+      slug: 'btc-up-or-down-5m',
+    });
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    expect(mockUsePredictShare).toHaveBeenCalledWith({
+      marketId: 'market-123',
+      marketSlug: 'btc-up-or-down-5m',
+    });
+  });
+
+  it('renders TitleSubpage with series title', () => {
+    const market = createMockMarket({
+      series: {
+        id: 's1',
+        slug: 'btc-up-or-down-5m',
+        title: 'BTC Up or Down - 5 Minutes',
+        recurrence: '5m',
+      },
+    });
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    const titleSection = screen.getByTestId(
+      PredictCryptoUpDownDetailsSelectorsIDs.TITLE_SECTION,
+    );
+    expect(titleSection).toBeOnTheScreen();
+  });
+
+  it('renders TitleSubpage with formatted endDate as bottomLabel', () => {
+    const market = createMockMarket({
+      endDate: '2026-04-09T19:45:00Z',
+    });
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    const titleSection = screen.getByTestId(
+      PredictCryptoUpDownDetailsSelectorsIDs.TITLE_SECTION,
+    );
+    expect(titleSection).toBeOnTheScreen();
+  });
+
+  it('omits subtitle when endDate is undefined', () => {
+    const market = createMockMarket({
+      endDate: undefined,
+    });
+
+    mockFormatMarketEndDate.mockClear();
+
+    render(
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={mockOnBack}
+        onRefresh={mockOnRefresh}
+        refreshing={false}
+      />,
+    );
+
+    expect(mockFormatMarketEndDate).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
@@ -4,10 +4,8 @@ import PredictCryptoUpDownDetails from './PredictCryptoUpDownDetails';
 import { PredictCryptoUpDownDetailsSelectorsIDs } from '../../Predict.testIds';
 import type { PredictMarket, PredictSeries } from '../../types';
 import usePredictShare from '../../hooks/usePredictShare';
-import { formatMarketEndDate } from '../../utils/format';
 
 const mockUsePredictShare = usePredictShare as jest.Mock;
-const mockFormatMarketEndDate = formatMarketEndDate as jest.Mock;
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
@@ -30,38 +28,17 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('react-native-safe-area-context', () => {
   const { View } = jest.requireActual('react-native');
   return {
-    ...jest.requireActual('react-native-safe-area-context'),
     SafeAreaView: View,
+    SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+    useSafeAreaInsets: jest.fn(() => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    })),
+    useSafeAreaFrame: () => ({ x: 0, y: 0, width: 375, height: 812 }),
   };
 });
-
-jest.mock(
-  '../../../../../component-library/components-temp/HeaderStandardAnimated',
-  () => {
-    const { View, Text } = jest.requireActual('react-native');
-    interface MockProps {
-      title?: string;
-      subtitle?: string;
-      testID?: string;
-      endButtonIconProps?: { testID?: string }[];
-    }
-    const MockHeaderStandardAnimated = ({
-      title,
-      subtitle,
-      testID,
-      endButtonIconProps,
-    }: MockProps) => (
-      <View testID={testID}>
-        {title && <Text>{title}</Text>}
-        {subtitle && <Text>{subtitle}</Text>}
-        {endButtonIconProps && endButtonIconProps.length > 0 && (
-          <View testID={endButtonIconProps[0].testID} />
-        )}
-      </View>
-    );
-    return MockHeaderStandardAnimated;
-  },
-);
 
 jest.mock(
   '../../../../../component-library/components-temp/HeaderStandardAnimated/useHeaderStandardAnimated',
@@ -76,34 +53,8 @@ jest.mock(
   }),
 );
 
-jest.mock(
-  '../../../../../component-library/components-temp/TitleSubpage',
-  () => {
-    const { View, Text } = jest.requireActual('react-native');
-    interface MockProps {
-      title?: string;
-      bottomLabel?: string;
-      startAccessory?: React.ReactNode;
-      twClassName?: string;
-      testID?: string;
-    }
-    const MockTitleSubpage = ({
-      title,
-      bottomLabel,
-      startAccessory,
-    }: MockProps) => (
-      <View>
-        {startAccessory}
-        {title && <Text>{title}</Text>}
-        {bottomLabel && <Text>{bottomLabel}</Text>}
-      </View>
-    );
-    return MockTitleSubpage;
-  },
-);
-
 jest.mock('../../hooks/usePredictShare', () => {
-  const mockUsePredictShare = jest.fn(
+  const mockUsePredictShareFn = jest.fn(
     ({ marketId, marketSlug }: { marketId?: string; marketSlug?: string }) => ({
       handleSharePress: jest.fn(),
       marketId,
@@ -112,12 +63,12 @@ jest.mock('../../hooks/usePredictShare', () => {
   );
   return {
     __esModule: true,
-    default: mockUsePredictShare,
+    default: mockUsePredictShareFn,
   };
 });
 
 jest.mock('../../utils/format', () => ({
-  formatMarketEndDate: jest.fn((date: string) => 'April 9, 1:45 PM'),
+  formatMarketEndDate: jest.fn(() => 'April 9, 1:45 PM'),
 }));
 
 const createMockMarket = (
@@ -172,7 +123,7 @@ describe('PredictCryptoUpDownDetails', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders HeaderStandardAnimated with series title as title prop', () => {
+  it('renders the header with the series title text', () => {
     const market = createMockMarket({
       series: {
         id: 's1',
@@ -191,13 +142,15 @@ describe('PredictCryptoUpDownDetails', () => {
       />,
     );
 
-    const header = screen.getByTestId(
-      PredictCryptoUpDownDetailsSelectorsIDs.HEADER,
-    );
-    expect(header).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PredictCryptoUpDownDetailsSelectorsIDs.HEADER),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getAllByText('BTC Up or Down - 5 Minutes').length,
+    ).toBeGreaterThan(0);
   });
 
-  it('renders HeaderStandardAnimated with formatted endDate as subtitle prop', () => {
+  it('renders the formatted endDate as subtitle in the header', () => {
     const market = createMockMarket({
       endDate: '2026-04-09T19:45:00Z',
     });
@@ -211,13 +164,10 @@ describe('PredictCryptoUpDownDetails', () => {
       />,
     );
 
-    const header = screen.getByTestId(
-      PredictCryptoUpDownDetailsSelectorsIDs.HEADER,
-    );
-    expect(header).toBeOnTheScreen();
+    expect(screen.getAllByText('April 9, 1:45 PM').length).toBeGreaterThan(0);
   });
 
-  it('passes share button in endButtonIconProps', () => {
+  it('renders the share button in the header end area', () => {
     const market = createMockMarket();
 
     render(
@@ -255,7 +205,7 @@ describe('PredictCryptoUpDownDetails', () => {
     });
   });
 
-  it('renders TitleSubpage with series title', () => {
+  it('renders the title section with the series title text', () => {
     const market = createMockMarket({
       series: {
         id: 's1',
@@ -278,9 +228,12 @@ describe('PredictCryptoUpDownDetails', () => {
       PredictCryptoUpDownDetailsSelectorsIDs.TITLE_SECTION,
     );
     expect(titleSection).toBeOnTheScreen();
+    expect(
+      screen.getAllByText('BTC Up or Down - 5 Minutes').length,
+    ).toBeGreaterThan(0);
   });
 
-  it('renders TitleSubpage with formatted endDate as bottomLabel', () => {
+  it('renders the title section with formatted endDate as bottom label', () => {
     const market = createMockMarket({
       endDate: '2026-04-09T19:45:00Z',
     });
@@ -298,14 +251,13 @@ describe('PredictCryptoUpDownDetails', () => {
       PredictCryptoUpDownDetailsSelectorsIDs.TITLE_SECTION,
     );
     expect(titleSection).toBeOnTheScreen();
+    expect(screen.getAllByText('April 9, 1:45 PM').length).toBeGreaterThan(0);
   });
 
-  it('omits subtitle when endDate is undefined', () => {
+  it('renders no subtitle text when endDate is undefined', () => {
     const market = createMockMarket({
       endDate: undefined,
     });
-
-    mockFormatMarketEndDate.mockClear();
 
     render(
       <PredictCryptoUpDownDetails
@@ -316,6 +268,6 @@ describe('PredictCryptoUpDownDetails', () => {
       />,
     );
 
-    expect(mockFormatMarketEndDate).not.toHaveBeenCalled();
+    expect(screen.queryByText('April 9, 1:45 PM')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -41,7 +41,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
   return (
     <SafeAreaView
       style={tw.style('flex-1 bg-default')}
-      edges={['left', 'right', 'bottom']}
+      edges={['left', 'right', 'top']}
       testID={PredictCryptoUpDownDetailsSelectorsIDs.SCREEN}
     >
       <HeaderStandardAnimated

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Image, RefreshControl } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Box, IconName } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import HeaderStandardAnimated from '../../../../../component-library/components-temp/HeaderStandardAnimated';
+import useHeaderStandardAnimated from '../../../../../component-library/components-temp/HeaderStandardAnimated/useHeaderStandardAnimated';
+import TitleSubpage from '../../../../../component-library/components-temp/TitleSubpage';
+import type { PredictMarket, PredictSeries } from '../../types';
+import { formatMarketEndDate } from '../../utils/format';
+import usePredictShare from '../../hooks/usePredictShare';
+import { PredictCryptoUpDownDetailsSelectorsIDs } from '../../Predict.testIds';
+
+export interface PredictCryptoUpDownDetailsProps {
+  market: PredictMarket & { series: PredictSeries };
+  onBack: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+}
+
+const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
+  market,
+  onBack,
+  onRefresh,
+  refreshing,
+}) => {
+  const tw = useTailwind();
+  const { scrollY, titleSectionHeightSv, setTitleSectionHeight, onScroll } =
+    useHeaderStandardAnimated();
+  const { handleSharePress } = usePredictShare({
+    marketId: market.id,
+    marketSlug: market.slug,
+  });
+
+  const title = market.series.title;
+  const subtitle = market.endDate
+    ? formatMarketEndDate(market.endDate)
+    : undefined;
+
+  return (
+    <SafeAreaView
+      style={tw.style('flex-1 bg-default')}
+      edges={['left', 'right', 'bottom']}
+      testID={PredictCryptoUpDownDetailsSelectorsIDs.SCREEN}
+    >
+      <HeaderStandardAnimated
+        scrollY={scrollY}
+        titleSectionHeight={titleSectionHeightSv}
+        title={title}
+        subtitle={subtitle}
+        onBack={onBack}
+        backButtonProps={{
+          testID: PredictCryptoUpDownDetailsSelectorsIDs.BACK_BUTTON,
+        }}
+        endButtonIconProps={[
+          {
+            iconName: IconName.Share,
+            onPress: handleSharePress,
+            testID: PredictCryptoUpDownDetailsSelectorsIDs.SHARE_BUTTON,
+          },
+        ]}
+        testID={PredictCryptoUpDownDetailsSelectorsIDs.HEADER}
+      />
+
+      <Animated.ScrollView
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+        testID={PredictCryptoUpDownDetailsSelectorsIDs.SCROLL_VIEW}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      >
+        <Box
+          testID={PredictCryptoUpDownDetailsSelectorsIDs.TITLE_SECTION}
+          onLayout={(e) => setTitleSectionHeight(e.nativeEvent.layout.height)}
+        >
+          <TitleSubpage
+            startAccessory={
+              <Box twClassName="w-10 h-10 rounded-lg bg-muted overflow-hidden">
+                {market.image ? (
+                  <Image
+                    source={{ uri: market.image }}
+                    style={tw.style('w-full h-full')}
+                    resizeMode="cover"
+                  />
+                ) : (
+                  <Box twClassName="w-full h-full bg-muted" />
+                )}
+              </Box>
+            }
+            title={title}
+            bottomLabel={subtitle}
+            twClassName="px-4 pt-1 pb-3"
+          />
+        </Box>
+      </Animated.ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default PredictCryptoUpDownDetails;

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/README.md
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/README.md
@@ -1,0 +1,29 @@
+# PredictCryptoUpDownDetails
+
+Full-screen detail view for Crypto Up/Down prediction markets (e.g., "BTC Up or Down - 5 Minutes").
+
+## When it renders
+
+`PredictMarketDetails` renders this screen instead of the default market view when **both** conditions are met:
+
+1. The `predict_up_down_enabled` feature flag is `true`.
+2. `isCryptoUpDown(market)` returns `true` — meaning the market has a `series`, an `up-or-down` tag, and a `crypto` tag.
+
+## Props
+
+| Prop         | Type                                        | Description                                  |
+| ------------ | ------------------------------------------- | -------------------------------------------- |
+| `market`     | `PredictMarket & { series: PredictSeries }` | The market to display. Must have a `series`. |
+| `onBack`     | `() => void`                                | Called when the back button is pressed.      |
+| `onRefresh`  | `() => void`                                | Called when the user pulls to refresh.       |
+| `refreshing` | `boolean`                                   | Whether a refresh is currently in progress.  |
+
+## Structure
+
+```
+SafeAreaView
+└── HeaderStandardAnimated   (animated compact header with share button)
+└── Animated.ScrollView
+    └── Box (title section — drives header animation threshold)
+        └── TitleSubpage     (market image + series title + end date)
+```

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/index.ts
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PredictCryptoUpDownDetails';
+export type { PredictCryptoUpDownDetailsProps } from './PredictCryptoUpDownDetails';

--- a/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.tsx
+++ b/app/components/UI/Predict/components/PredictShareButton/PredictShareButton.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useContext } from 'react';
-import { Pressable, Share } from 'react-native';
+import React from 'react';
+import { Pressable } from 'react-native';
 import Icon, {
   IconName,
   IconSize,
@@ -7,13 +7,7 @@ import Icon, {
 import { useTheme } from '../../../../../util/theme';
 import { PredictMarketDetailsSelectorsIDs } from '../../Predict.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
-import { Box } from '@metamask/design-system-react-native';
-import Engine from '../../../../../core/Engine';
-import { PredictShareStatus } from '../../constants/eventNames';
+import usePredictShare from '../../hooks/usePredictShare';
 
 interface PredictShareButtonProps {
   marketId?: string;
@@ -24,71 +18,8 @@ const PredictShareButton: React.FC<PredictShareButtonProps> = ({
   marketId,
   marketSlug,
 }) => {
-  const { toastRef } = useContext(ToastContext);
   const { colors } = useTheme();
-
-  const handleSharePress = useCallback(async () => {
-    Engine.context.PredictController.trackShareAction({
-      status: PredictShareStatus.INITIATED,
-      marketId,
-      marketSlug,
-    });
-
-    try {
-      const url = `https://link.metamask.io/predict?market=${marketId ?? ''}&utm_source=user_shared`;
-
-      const result = await Share.share(
-        {
-          url,
-          message: `Check out this prediction market on MetaMask:\n\n${url}`,
-        },
-        {},
-      );
-      if (result.action === Share.sharedAction) {
-        Engine.context.PredictController.trackShareAction({
-          status: PredictShareStatus.SUCCESS,
-          marketId,
-          marketSlug,
-        });
-
-        if (
-          result.activityType === 'com.apple.UIKit.activity.CopyToPasteboard'
-        ) {
-          return toastRef?.current?.showToast({
-            variant: ToastVariants.Icon,
-            labelOptions: [
-              {
-                label: strings('predict.toasts.copied_to_clipboard'),
-                isBold: true,
-              },
-            ],
-            iconName: IconName.Confirmation,
-            backgroundColor: 'transparent',
-            iconColor: colors.success.default,
-            hasNoTimeout: false,
-            customBottomOffset: -50,
-            startAccessory: (
-              <Box twClassName="items-center justify-center align-center pr-[12px]">
-                <Icon
-                  name={IconName.Confirmation}
-                  color={colors.success.default}
-                  size={IconSize.Lg}
-                />
-              </Box>
-            ),
-          });
-        }
-      } else {
-        throw new Error('Failed to share');
-      }
-    } catch (_error) {
-      Engine.context.PredictController.trackShareAction({
-        status: PredictShareStatus.FAILED,
-        marketId,
-        marketSlug,
-      });
-    }
-  }, [colors.success.default, marketId, marketSlug, toastRef]);
+  const { handleSharePress } = usePredictShare({ marketId, marketSlug });
 
   return (
     <Pressable

--- a/app/components/UI/Predict/hooks/usePredictShare.ts
+++ b/app/components/UI/Predict/hooks/usePredictShare.ts
@@ -1,9 +1,6 @@
 import { useCallback, useContext } from 'react';
 import { Share } from 'react-native';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
+import { ToastContext } from '../../../../component-library/components/Toast';
 import { useTheme } from '../../../../util/theme';
 import Engine from '../../../../core/Engine';
 import { PredictShareStatus } from '../constants/eventNames';

--- a/app/components/UI/Predict/hooks/usePredictShare.ts
+++ b/app/components/UI/Predict/hooks/usePredictShare.ts
@@ -1,7 +1,5 @@
-import React, { useCallback, useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import { Share } from 'react-native';
-import { Box, IconName, IconSize } from '@metamask/design-system-react-native';
-import Icon from '../../../../component-library/components/Icons/Icon';
 import {
   ToastContext,
   ToastVariants,
@@ -10,6 +8,7 @@ import { useTheme } from '../../../../util/theme';
 import Engine from '../../../../core/Engine';
 import { PredictShareStatus } from '../constants/eventNames';
 import { strings } from '../../../../../locales/i18n';
+import { buildShareCopiedToastOptions } from './usePredictShare.utils';
 
 interface UsePredictShareParams {
   marketId?: string;
@@ -47,29 +46,12 @@ const usePredictShare = ({ marketId, marketSlug }: UsePredictShareParams) => {
         if (
           result.activityType === 'com.apple.UIKit.activity.CopyToPasteboard'
         ) {
-          return toastRef?.current?.showToast({
-            variant: ToastVariants.Icon,
-            labelOptions: [
-              {
-                label: strings('predict.toasts.copied_to_clipboard'),
-                isBold: true,
-              },
-            ],
-            iconName: IconName.Confirmation,
-            backgroundColor: 'transparent',
-            iconColor: colors.success.default,
-            hasNoTimeout: false,
-            customBottomOffset: -50,
-            startAccessory: (
-              <Box twClassName="items-center justify-center align-center pr-[12px]">
-                <Icon
-                  name={IconName.Confirmation}
-                  color={colors.success.default}
-                  size={IconSize.Lg}
-                />
-              </Box>
-            ),
-          });
+          return toastRef?.current?.showToast(
+            buildShareCopiedToastOptions({
+              label: strings('predict.toasts.copied_to_clipboard'),
+              successColor: colors.success.default,
+            }),
+          );
         }
       } else {
         throw new Error('Failed to share');

--- a/app/components/UI/Predict/hooks/usePredictShare.tsx
+++ b/app/components/UI/Predict/hooks/usePredictShare.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback, useContext } from 'react';
+import { Share } from 'react-native';
+import { Box, IconName, IconSize } from '@metamask/design-system-react-native';
+import Icon from '../../../../component-library/components/Icons/Icon';
+import {
+  ToastContext,
+  ToastVariants,
+} from '../../../../component-library/components/Toast';
+import { useTheme } from '../../../../util/theme';
+import Engine from '../../../../core/Engine';
+import { PredictShareStatus } from '../constants/eventNames';
+import { strings } from '../../../../../locales/i18n';
+
+interface UsePredictShareParams {
+  marketId?: string;
+  marketSlug?: string;
+}
+
+const usePredictShare = ({ marketId, marketSlug }: UsePredictShareParams) => {
+  const { toastRef } = useContext(ToastContext);
+  const { colors } = useTheme();
+
+  const handleSharePress = useCallback(async () => {
+    Engine.context.PredictController.trackShareAction({
+      status: PredictShareStatus.INITIATED,
+      marketId,
+      marketSlug,
+    });
+
+    try {
+      const url = `https://link.metamask.io/predict?market=${marketId ?? ''}&utm_source=user_shared`;
+
+      const result = await Share.share(
+        {
+          url,
+          message: `Check out this prediction market on MetaMask:\n\n${url}`,
+        },
+        {},
+      );
+      if (result.action === Share.sharedAction) {
+        Engine.context.PredictController.trackShareAction({
+          status: PredictShareStatus.SUCCESS,
+          marketId,
+          marketSlug,
+        });
+
+        if (
+          result.activityType === 'com.apple.UIKit.activity.CopyToPasteboard'
+        ) {
+          return toastRef?.current?.showToast({
+            variant: ToastVariants.Icon,
+            labelOptions: [
+              {
+                label: strings('predict.toasts.copied_to_clipboard'),
+                isBold: true,
+              },
+            ],
+            iconName: IconName.Confirmation,
+            backgroundColor: 'transparent',
+            iconColor: colors.success.default,
+            hasNoTimeout: false,
+            customBottomOffset: -50,
+            startAccessory: (
+              <Box twClassName="items-center justify-center align-center pr-[12px]">
+                <Icon
+                  name={IconName.Confirmation}
+                  color={colors.success.default}
+                  size={IconSize.Lg}
+                />
+              </Box>
+            ),
+          });
+        }
+      } else {
+        throw new Error('Failed to share');
+      }
+    } catch (_error) {
+      Engine.context.PredictController.trackShareAction({
+        status: PredictShareStatus.FAILED,
+        marketId,
+        marketSlug,
+      });
+    }
+  }, [colors.success.default, marketId, marketSlug, toastRef]);
+
+  return { handleSharePress };
+};
+
+export default usePredictShare;

--- a/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
+++ b/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Box, IconName, IconSize } from '@metamask/design-system-react-native';
-import Icon from '../../../../component-library/components/Icons/Icon';
+import { Box, IconSize } from '@metamask/design-system-react-native';
+import Icon, {
+  IconName,
+} from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
 import type { ToastOptions } from '../../../../component-library/components/Toast/Toast.types';
 

--- a/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
+++ b/app/components/UI/Predict/hooks/usePredictShare.utils.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Box, IconName, IconSize } from '@metamask/design-system-react-native';
+import Icon from '../../../../component-library/components/Icons/Icon';
+import { ToastVariants } from '../../../../component-library/components/Toast';
+import type { ToastOptions } from '../../../../component-library/components/Toast/Toast.types';
+
+interface BuildShareCopiedToastOptionsParams {
+  label: string;
+  successColor: string;
+}
+
+/**
+ * Builds the ToastOptions payload for the "copied to clipboard" share feedback.
+ * Kept in a separate file so that the `usePredictShare` hook itself is JSX-free.
+ */
+export const buildShareCopiedToastOptions = ({
+  label,
+  successColor,
+}: BuildShareCopiedToastOptionsParams): ToastOptions => ({
+  variant: ToastVariants.Icon,
+  labelOptions: [{ label, isBold: true }],
+  iconName: IconName.Confirmation,
+  backgroundColor: 'transparent',
+  iconColor: successColor,
+  hasNoTimeout: false,
+  customBottomOffset: -50,
+  startAccessory: (
+    <Box twClassName="items-center justify-center pr-3">
+      <Icon
+        name={IconName.Confirmation}
+        color={successColor}
+        size={IconSize.Lg}
+      />
+    </Box>
+  ),
+});

--- a/app/components/UI/Predict/utils/cryptoUpDown.test.ts
+++ b/app/components/UI/Predict/utils/cryptoUpDown.test.ts
@@ -1,4 +1,4 @@
-import { isCryptoUpDown, UP_OR_DOWN_TAG } from './cryptoUpDown';
+import { isCryptoUpDown, UP_OR_DOWN_TAG, CRYPTO_TAG } from './cryptoUpDown';
 import { Recurrence, type PredictMarket } from '../types';
 
 const createMockMarket = (
@@ -25,6 +25,12 @@ describe('cryptoUpDown utilities', () => {
   describe('UP_OR_DOWN_TAG', () => {
     it('equals "up-or-down"', () => {
       expect(UP_OR_DOWN_TAG).toBe('up-or-down');
+    });
+  });
+
+  describe('CRYPTO_TAG', () => {
+    it('equals "crypto"', () => {
+      expect(CRYPTO_TAG).toBe('crypto');
     });
   });
 
@@ -113,6 +119,22 @@ describe('cryptoUpDown utilities', () => {
       const result = isCryptoUpDown(market);
 
       expect(result).toBe(true);
+    });
+
+    it('returns false when market has series and up-or-down tag but no crypto tag', () => {
+      const market = createMockMarket({
+        series: {
+          id: 's1',
+          slug: 'btc-up-or-down-5m',
+          title: 'BTC Up or Down',
+          recurrence: '5m',
+        },
+        tags: ['up-or-down', 'trending'],
+      });
+
+      const result = isCryptoUpDown(market);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/app/components/UI/Predict/utils/cryptoUpDown.test.ts
+++ b/app/components/UI/Predict/utils/cryptoUpDown.test.ts
@@ -35,7 +35,7 @@ describe('cryptoUpDown utilities', () => {
   });
 
   describe('isCryptoUpDown', () => {
-    it('returns true when market has series and up-or-down tag', () => {
+    it('returns true when market has series, up-or-down tag, and crypto tag', () => {
       const market = createMockMarket({
         series: {
           id: 's1',

--- a/app/components/UI/Predict/utils/cryptoUpDown.ts
+++ b/app/components/UI/Predict/utils/cryptoUpDown.ts
@@ -1,14 +1,20 @@
 import type { PredictMarket, PredictSeries } from '../types';
 
 export const UP_OR_DOWN_TAG = 'up-or-down';
+export const CRYPTO_TAG = 'crypto';
 
 /**
  * Type guard: narrows to a market with a guaranteed `series` field.
- * Returns true when a market has series metadata AND the "up-or-down" tag.
- * Regular series markets (e.g., recurring tweet counts) are excluded.
+ * Returns true when a market has series metadata AND both the "up-or-down"
+ * and "crypto" tags. Regular series markets (e.g., recurring tweet counts)
+ * and non-crypto up-or-down markets are excluded.
  */
 export function isCryptoUpDown(
   market: PredictMarket,
 ): market is PredictMarket & { series: PredictSeries } {
-  return market.series != null && market.tags.includes(UP_OR_DOWN_TAG);
+  return (
+    market.series != null &&
+    market.tags.includes(UP_OR_DOWN_TAG) &&
+    market.tags.includes(CRYPTO_TAG)
+  );
 }

--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -11,6 +11,7 @@ import {
   calculateNetAmount,
   formatPriceWithSubscriptNotation,
   formatGameStartTime,
+  formatMarketEndDate,
   formatPredictUnrealizedPnLStringParts,
 } from './format';
 import { Recurrence, PredictSeries } from '../types';
@@ -1387,6 +1388,35 @@ describe('format utils', () => {
       });
 
       expect(result).toBe('5');
+    });
+  });
+
+  describe('formatMarketEndDate', () => {
+    it('formats valid ISO date string to readable format', () => {
+      jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+        () =>
+          ({
+            format: () => 'April 9, 1:45 PM',
+            formatToParts: () => [],
+            resolvedOptions: () => ({}),
+          }) as unknown as Intl.DateTimeFormat,
+      );
+
+      const result = formatMarketEndDate('2026-04-09T19:45:00Z');
+
+      expect(result).toBe('April 9, 1:45 PM');
+    });
+
+    it('returns empty string for invalid date string', () => {
+      const result = formatMarketEndDate('not-a-date');
+
+      expect(result).toBe('');
+    });
+
+    it('returns empty string for completely unparseable input', () => {
+      const result = formatMarketEndDate('invalid-date-format');
+
+      expect(result).toBe('');
     });
   });
 

--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -1392,6 +1392,10 @@ describe('format utils', () => {
   });
 
   describe('formatMarketEndDate', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('formats valid ISO date string to readable format', () => {
       jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(
         () =>
@@ -1407,14 +1411,8 @@ describe('format utils', () => {
       expect(result).toBe('April 9, 1:45 PM');
     });
 
-    it('returns empty string for invalid date string', () => {
+    it('returns empty string for an unparseable date string', () => {
       const result = formatMarketEndDate('not-a-date');
-
-      expect(result).toBe('');
-    });
-
-    it('returns empty string for completely unparseable input', () => {
-      const result = formatMarketEndDate('invalid-date-format');
 
       expect(result).toBe('');
     });

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -430,13 +430,6 @@ export const estimateLineCount = (text: string | undefined): number => {
 };
 
 /**
- * Formats a game start time into separate date and time strings for display.
- * Uses locale-aware formatting via Intl.DateTimeFormat.
- * @param startTime - ISO 8601 datetime string (e.g., "2026-02-08T20:30:00Z")
- * @returns Object with formatted date ("Sun, Feb 8") and time ("3:30 PM")
- * @example formatGameStartTime("2026-02-08T20:30:00Z") => { date: "Sun, Feb 8", time: "3:30 PM" }
- */
-/**
  * Formats a market end date into a user-friendly date/time string
  * using the user's local timezone.
  * @param endDate - ISO 8601 datetime string (e.g., "2026-04-09T19:45:00Z")
@@ -458,6 +451,13 @@ export const formatMarketEndDate = (endDate: string): string => {
   }).format(dateObj);
 };
 
+/**
+ * Formats a game start time into separate date and time strings for display.
+ * Uses locale-aware formatting via Intl.DateTimeFormat.
+ * @param startTime - ISO 8601 datetime string (e.g., "2026-02-08T20:30:00Z")
+ * @returns Object with formatted date ("Sun, Feb 8") and time ("3:30 PM")
+ * @example formatGameStartTime("2026-02-08T20:30:00Z") => { date: "Sun, Feb 8", time: "3:30 PM" }
+ */
 export const formatGameStartTime = (
   startTime: string | undefined,
 ): { date: string; time: string } => {

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -436,6 +436,28 @@ export const estimateLineCount = (text: string | undefined): number => {
  * @returns Object with formatted date ("Sun, Feb 8") and time ("3:30 PM")
  * @example formatGameStartTime("2026-02-08T20:30:00Z") => { date: "Sun, Feb 8", time: "3:30 PM" }
  */
+/**
+ * Formats a market end date into a user-friendly date/time string
+ * using the user's local timezone.
+ * @param endDate - ISO 8601 datetime string (e.g., "2026-04-09T19:45:00Z")
+ * @returns Formatted string (e.g., "April 9, 1:45 PM" in MDT)
+ * @example formatMarketEndDate("2026-04-09T19:45:00Z") => "April 9, 1:45 PM"
+ */
+export const formatMarketEndDate = (endDate: string): string => {
+  const dateObj = new Date(endDate);
+
+  if (isNaN(dateObj.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(dateObj);
+};
+
 export const formatGameStartTime = (
   startTime: string | undefined,
 ): { date: string; time: string } => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -321,6 +321,39 @@ jest.mock('../../components/PredictGameDetailsContent', () => {
   };
 });
 
+jest.mock('../../components/PredictCryptoUpDownDetails', () => {
+  const { View } = jest.requireActual('react-native');
+  return function MockPredictCryptoUpDownDetails() {
+    return <View testID="predict-crypto-up-down-details" />;
+  };
+});
+
+jest.mock('../../utils/cryptoUpDown', () => ({
+  isCryptoUpDown: jest.fn(() => false),
+  UP_OR_DOWN_TAG: 'up-or-down',
+  CRYPTO_TAG: 'crypto',
+}));
+
+let mockSelectPredictUpDownEnabledFlag = false;
+const mockSelectPredictFeeCollectionFlag = {
+  enabled: true,
+  collector: '0xe6a2026d58eaff3c7ad7ba9386fb143388002382',
+  metamaskFee: 0.02,
+  providerFee: 0.02,
+  waiveList: ['middle-east'],
+  executors: [],
+  permit2Enabled: false,
+};
+
+jest.mock('../../selectors/featureFlags', () => ({
+  selectPredictUpDownEnabledFlag: jest.fn(
+    () => mockSelectPredictUpDownEnabledFlag,
+  ),
+  selectPredictFeeCollectionFlag: jest.fn(
+    () => mockSelectPredictFeeCollectionFlag,
+  ),
+}));
+
 jest.mock('../../../../Base/TabBar', () => {
   const { View, Text } = jest.requireActual('react-native');
   return function MockTabBar({ textStyle }: { textStyle: object }) {
@@ -483,6 +516,15 @@ function setupPredictMarketDetailsTest(
   jest.clearAllMocks();
   runAfterInteractionsCallbacks.length = 0;
   mockRunAfterInteractions.mockImplementation(runAfterInteractionsMockImpl);
+
+  const { selectPredictUpDownEnabledFlag, selectPredictFeeCollectionFlag } =
+    jest.requireMock('../../selectors/featureFlags');
+  selectPredictUpDownEnabledFlag.mockReturnValue(
+    mockSelectPredictUpDownEnabledFlag,
+  );
+  selectPredictFeeCollectionFlag.mockReturnValue(
+    mockSelectPredictFeeCollectionFlag,
+  );
 
   const mockNavigate = jest.fn();
   const mockSetOptions = jest.fn();
@@ -1750,6 +1792,57 @@ describe('PredictMarketDetails', () => {
       expect(buttonLabels).toEqual(
         expect.arrayContaining(['Yes•65¢', 'No•35¢']),
       );
+    });
+  });
+
+  describe('Crypto Up/Down Branching', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockSelectPredictUpDownEnabledFlag = false;
+      const { isCryptoUpDown } = jest.requireMock('../../utils/cryptoUpDown');
+      isCryptoUpDown.mockReturnValue(false);
+    });
+
+    it('renders PredictCryptoUpDownDetails when upDownEnabled and isCryptoUpDown are true', () => {
+      const { isCryptoUpDown } = jest.requireMock('../../utils/cryptoUpDown');
+      mockSelectPredictUpDownEnabledFlag = true;
+      isCryptoUpDown.mockReturnValue(true);
+
+      setupPredictMarketDetailsTest();
+
+      expect(
+        screen.getByTestId('predict-crypto-up-down-details'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders default market details when upDownEnabled is false', () => {
+      const { isCryptoUpDown } = jest.requireMock('../../utils/cryptoUpDown');
+      mockSelectPredictUpDownEnabledFlag = false;
+      isCryptoUpDown.mockReturnValue(true);
+
+      setupPredictMarketDetailsTest();
+
+      expect(
+        screen.getByTestId(PredictMarketDetailsSelectorsIDs.SCREEN),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('predict-crypto-up-down-details'),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders default market details when isCryptoUpDown returns false', () => {
+      const { isCryptoUpDown } = jest.requireMock('../../utils/cryptoUpDown');
+      mockSelectPredictUpDownEnabledFlag = true;
+      isCryptoUpDown.mockReturnValue(false);
+
+      setupPredictMarketDetailsTest();
+
+      expect(
+        screen.getByTestId(PredictMarketDetailsSelectorsIDs.SCREEN),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('predict-crypto-up-down-details'),
+      ).not.toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -42,7 +42,10 @@ import PredictDetailsContentSkeleton from '../../components/PredictDetailsConten
 import PredictGameDetailsContent from '../../components/PredictGameDetailsContent';
 import PredictCryptoUpDownDetails from '../../components/PredictCryptoUpDownDetails';
 import { isCryptoUpDown } from '../../utils/cryptoUpDown';
-import { selectPredictUpDownEnabledFlag , selectPredictFeeCollectionFlag } from '../../selectors/featureFlags';
+import {
+  selectPredictUpDownEnabledFlag,
+  selectPredictFeeCollectionFlag,
+} from '../../selectors/featureFlags';
 import PredictMarketDetailsStatus from './components/PredictMarketDetailsStatus';
 import PredictMarketDetailsHeader from './components/PredictMarketDetailsHeader';
 import PredictMarketDetailsTabBar from './components/PredictMarketDetailsTabBar';

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -40,6 +40,9 @@ import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { usePredictNavigation } from '../../hooks/usePredictNavigation';
 import PredictDetailsContentSkeleton from '../../components/PredictDetailsContentSkeleton';
 import PredictGameDetailsContent from '../../components/PredictGameDetailsContent';
+import PredictCryptoUpDownDetails from '../../components/PredictCryptoUpDownDetails';
+import { isCryptoUpDown } from '../../utils/cryptoUpDown';
+import { selectPredictUpDownEnabledFlag , selectPredictFeeCollectionFlag } from '../../selectors/featureFlags';
 import PredictMarketDetailsStatus from './components/PredictMarketDetailsStatus';
 import PredictMarketDetailsHeader from './components/PredictMarketDetailsHeader';
 import PredictMarketDetailsTabBar from './components/PredictMarketDetailsTabBar';
@@ -49,7 +52,6 @@ import { useChartData } from './hooks/useChartData';
 import { useOutcomeResolution } from './hooks/useOutcomeResolution';
 import { useOpenOutcomes } from './hooks/useOpenOutcomes';
 import { useSelector } from 'react-redux';
-import { selectPredictFeeCollectionFlag } from '../../selectors/featureFlags';
 
 // Use theme tokens instead of hex values for multi-series charts
 
@@ -70,6 +72,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
 
+  const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
   const { marketId, entryPoint, title, image } = route.params || {};
   const resolvedMarketId = marketId;
 
@@ -346,6 +349,16 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const hasPositivePnl = claimablePositions.some(
     (position) => position.percentPnl > 0,
   );
+  if (upDownEnabled && market && isCryptoUpDown(market)) {
+    return (
+      <PredictCryptoUpDownDetails
+        market={market}
+        onBack={handleBackPress}
+        onRefresh={handleRefresh}
+        refreshing={isRefreshing}
+      />
+    );
+  }
   if (market?.game) {
     return (
       <PredictGameDetailsContent


### PR DESCRIPTION
## **Description**

Scaffolds the new Crypto Up/Down detail screen (`PredictCryptoUpDownDetails`) with an animated header, laying the groundwork for the full experience in future tickets.

**What changed:**

- **New `PredictCryptoUpDownDetails` component** — Uses `HeaderStandardAnimated` + `TitleSubpage` + `Animated.ScrollView` to match the Perps header pattern. Displays the market's series title, formatted end date, market image, and a share button.
- **Updated `isCryptoUpDown()`** — Now requires both `up-or-down` AND `crypto` tags, filtering out non-crypto up-or-down markets.
- **Feature-flagged routing** — `PredictMarketDetails` branches to the new screen only when `predictUpDown` flag is enabled and `isCryptoUpDown(market)` is true.
- **Extracted `usePredictShare` hook** — Pulled share logic (tracking, native share sheet, clipboard toast) out of `PredictShareButton` into a reusable hook for use with `endButtonIconProps`.
- **Added `formatMarketEndDate`** — Intl-based date formatter using the user's local timezone.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-786](https://consensyssoftware.atlassian.net/browse/PRED-786)

## **Manual testing steps**

```gherkin
Feature: Crypto Up/Down detail screen scaffold

  Scenario: user navigates to a crypto up-or-down market with the flag enabled
    Given the predictUpDown feature flag is enabled
    And there is a market with series, "up-or-down" tag, and "crypto" tag

    When user taps on that market from the feed
    Then the new Crypto Up/Down detail screen renders
    And the header shows the series title and formatted end date
    And the share button is visible in the header
    And pull-to-refresh works on the scroll view

  Scenario: user navigates to a crypto up-or-down market with the flag disabled
    Given the predictUpDown feature flag is disabled
    And there is a market with series, "up-or-down" tag, and "crypto" tag

    When user taps on that market from the feed
    Then the default market details screen renders

  Scenario: user navigates to a non-crypto up-or-down market
    Given the predictUpDown feature flag is enabled
    And there is a market with series and "up-or-down" tag but no "crypto" tag

    When user taps on that market from the feed
    Then the default market details screen renders
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A - new screen -->

### **After**

<!-- Screenshots to be added -->

DEMO: https://www.loom.com/share/95cf9d133e35439dac7da42ab2ea32a7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[PRED-786]: https://consensyssoftware.atlassian.net/browse/PRED-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new feature-flagged navigation branch in `PredictMarketDetails` and refactors share behavior into a reusable hook, which could affect which details screen renders and how share events/toasts are triggered.
> 
> **Overview**
> Introduces a new `PredictCryptoUpDownDetails` screen scaffold with an animated header, pull-to-refresh scroll view, market image/title, and header share action, plus new test IDs and component/unit tests.
> 
> Updates `PredictMarketDetails` to **conditionally route** crypto up/down markets to this new screen when `selectPredictUpDownEnabledFlag` is enabled and `isCryptoUpDown()` matches (now requiring both `up-or-down` and `crypto` tags).
> 
> Refactors share handling by extracting the native share + analytics + clipboard toast logic from `PredictShareButton` into a reusable `usePredictShare` hook (with a JSX helper util), and adds `formatMarketEndDate` for localized end-date display (with tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eaad98b14b860e5eb25955064013fa9a0fe18cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->