### PR TITLE
chore(ci): RC cherry-pick changelog script and Slack integration

### DIFF
--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -146,12 +146,41 @@ jobs:
           ANDROID_BUILD_NUMBER: ${{ steps.build-meta.outputs.android_version_code }}
           BUILD_PIPELINE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  generate-rc-cherry-pick-changelog:
+    name: Generate RC cherry-pick changelog
+    runs-on: ubuntu-latest
+    needs:
+      - validate-and-check-label
+      - trigger-ios-rc-build
+      - trigger-android-rc-build
+    if: always() && needs.trigger-android-rc-build.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-and-check-label.outputs.branch-name }}
+          fetch-depth: 0
+      - name: Read build metadata from repo
+        id: build-meta
+        run: ./scripts/get-build-metadata.sh --ci
+      - name: Write rc-cherry-pick-changelog.md
+        env:
+          SEMVER: ${{ steps.build-meta.outputs.semantic_version }}
+          IOS_BUILD_NUMBER: ${{ steps.build-meta.outputs.ios_version_code }}
+          ANDROID_BUILD_NUMBER: ${{ steps.build-meta.outputs.android_version_code }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/write-rc-cherry-pick-changelog-artifact.sh rc-cherry-pick-changelog.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rc-cherry-pick-changelog-md
+          path: rc-cherry-pick-changelog.md
+
   slack-notification:
     name: Slack RC Notification
     needs:
       - validate-and-check-label
       - trigger-ios-rc-build
       - trigger-android-rc-build
+      - generate-rc-cherry-pick-changelog
     if: always() && needs.trigger-android-rc-build.result == 'success'
     uses: ./.github/workflows/slack-rc-notification.yml
     with:

--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -146,41 +146,12 @@ jobs:
           ANDROID_BUILD_NUMBER: ${{ steps.build-meta.outputs.android_version_code }}
           BUILD_PIPELINE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-  generate-rc-cherry-pick-changelog:
-    name: Generate RC cherry-pick changelog
-    runs-on: ubuntu-latest
-    needs:
-      - validate-and-check-label
-      - trigger-ios-rc-build
-      - trigger-android-rc-build
-    if: always() && needs.trigger-android-rc-build.result == 'success'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.validate-and-check-label.outputs.branch-name }}
-          fetch-depth: 0
-      - name: Read build metadata from repo
-        id: build-meta
-        run: ./scripts/get-build-metadata.sh --ci
-      - name: Write rc-cherry-pick-changelog.md
-        env:
-          SEMVER: ${{ steps.build-meta.outputs.semantic_version }}
-          IOS_BUILD_NUMBER: ${{ steps.build-meta.outputs.ios_version_code }}
-          ANDROID_BUILD_NUMBER: ${{ steps.build-meta.outputs.android_version_code }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: ./scripts/write-rc-cherry-pick-changelog-artifact.sh rc-cherry-pick-changelog.md
-      - uses: actions/upload-artifact@v4
-        with:
-          name: rc-cherry-pick-changelog-md
-          path: rc-cherry-pick-changelog.md
-
   slack-notification:
     name: Slack RC Notification
     needs:
       - validate-and-check-label
       - trigger-ios-rc-build
       - trigger-android-rc-build
-      - generate-rc-cherry-pick-changelog
     if: always() && needs.trigger-android-rc-build.result == 'success'
     uses: ./.github/workflows/slack-rc-notification.yml
     with:

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -3,8 +3,8 @@
 # Slack RC Notification (reusable)
 #
 # Posts an RC build notification to the release Slack channel.
-# Reads semver and build numbers directly from the checked-out branch so callers
-# only need to supply the source branch.
+# When build-rc-auto.yml uploads artifact `rc-cherry-pick-changelog-md`, it is downloaded
+# here and passed to slack-rc-notification.mjs as rc-cherry-pick-changelog.md.
 #
 ##############################################################################################
 name: Slack RC Notification
@@ -26,6 +26,12 @@ jobs:
         with:
           ref: ${{ inputs.source_branch }}
           fetch-depth: 1
+      - name: Download RC cherry-pick changelog (from build-rc-auto when present)
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: rc-cherry-pick-changelog-md
+          path: .
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -3,8 +3,9 @@
 # Slack RC Notification (reusable)
 #
 # Posts an RC build notification to the release Slack channel.
-# When build-rc-auto.yml uploads artifact `rc-cherry-pick-changelog-md`, it is downloaded
-# here and passed to slack-rc-notification.mjs as rc-cherry-pick-changelog.md.
+# Cherry-pick list: scripts/write-rc-cherry-pick-changelog-merge-base.sh runs
+# rc-cherry-pick-changelog.sh --from "$(git merge-base HEAD origin/main)" --to HEAD
+# and writes rc-cherry-pick-changelog.md for slack-rc-notification.mjs.
 #
 ##############################################################################################
 name: Slack RC Notification
@@ -25,13 +26,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_branch }}
-          fetch-depth: 1
-      - name: Download RC cherry-pick changelog (from build-rc-auto when present)
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: rc-cherry-pick-changelog-md
-          path: .
+          fetch-depth: 0
+      - name: Fetch main for merge-base
+        run: git fetch origin main
+      - name: Write RC cherry-pick changelog (merge-base main..HEAD)
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/write-rc-cherry-pick-changelog-merge-base.sh rc-cherry-pick-changelog.md
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/scripts/rc-cherry-pick-changelog.sh
+++ b/scripts/rc-cherry-pick-changelog.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Markdown list of RC cherry-pick commits between:
+#   • two build numbers (looks up "Bump version number to N"), or
+#   • two SHAs (--from / --to).
+#
+# Git behavior:
+#   • Build mode:  git log --first-parent --no-merges (release line).
+#   • Hash mode:   git log --ancestry-path --no-merges (see below).
+#
+# Why --ancestry-path for --from/--to:
+#   A plain range "A..B" lists every commit reachable from B but not from A.
+#   After merges, that often includes whole subtrees merged in from other
+#   branches—commits that are not on any single path from A to B. For an RC
+#   changelog between two explicit SHAs we want only commits that lie *between*
+#   those endpoints (ancestors of B and descendants of A on the same history).
+#   git log --ancestry-path A..B does exactly that (see git-log(1)).
+#   We do not add --first-parent here: combined with --ancestry-path it can
+#   produce an empty log on typical release merges; plain --ancestry-path matches
+#   the usual "what's between these two commits" intent.
+#
+# Subject filters: drop [skip ci]; keep only Runway / cherry-pick style messages.
+#
+set -euo pipefail
+
+readonly DEFAULT_REPO_URL='https://github.com/MetaMask/metamask-mobile'
+
+usage() {
+  cat <<'EOF'
+Usage:
+  rc-cherry-pick-changelog.sh <prev_build> <current_build> [--ref <ref>]
+  rc-cherry-pick-changelog.sh --from <sha> --to <sha> [--repo-url <url>]
+
+Options:
+  --ref <ref>     Ref for bump lookup (default: HEAD), e.g. release/7.73.0
+  --repo-url <u>  GitHub base URL for links (default: MetaMask metamask-mobile)
+  --full-graph    Build mode only: omit --first-parent
+  -h, --help      This help
+
+Examples:
+  ./scripts/rc-cherry-pick-changelog.sh 4380 4421 --ref release/7.73.0
+  ./scripts/rc-cherry-pick-changelog.sh --from 470307ed55 --to "$(git rev-parse release/7.73.0)"
+EOF
+  exit "${1:-0}"
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+# Commit subject filters (lowercase comparison)
+_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+# Bump / automation lines we skip after git log.
+subject_is_skip_ci() {
+  [[ "$(_lower "$1")" == *'[skip ci]'* ]]
+}
+
+# RC cherry-pick heuristics (Runway + manual cherry-picks).
+subject_is_cherry_pick() {
+  local s
+  s="$(_lower "$1")"
+  [[ "$s" == *'cherry-pick'* || "$s" == *'cherry pick'* ]] && return 0
+  [[ "$s" == chore\(runway\):* ]] && return 0
+  [[ "$s" == *'ci: cherry pick'* || "$s" == *'chore: cherry pick'* || "$s" == *'chore:cherry pick'* ]] && return 0
+  return 1
+}
+
+# Markdown line for one commit
+markdown_line() {
+  local sha="$1" subject="$2" base_url="$3"
+  local short
+  short="$(git rev-parse --short=7 "$sha" 2>/dev/null || echo "${sha:0:7}")"
+
+  if grep -E -q '\(#[[:digit:]]+\)' <<<"$subject"; then
+    local pr desc
+    pr="$(awk '{print $NF}' <<<"$subject" | tr -d '()')"
+    pr="${pr###}"
+    desc="$(awk '{NF--; print $0}' <<<"$subject")"
+    printf '%s\n' "- [#${pr}](${base_url}/pull/${pr}): ${desc}"
+  else
+    printf '%s\n' "- [\`${short}\`](${base_url}/commit/${sha}): ${subject}"
+  fi
+}
+
+main() {
+  local repo_url="${DEFAULT_REPO_URL}"
+  local git_ref='HEAD'
+  local from_sha='' to_sha=''
+  local prev_build='' cur_build=''
+  local full_graph=false
+  local hash_range=false
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h | --help) usage 0 ;;
+      --ref)
+        [[ $# -ge 2 ]] || die "--ref needs a value"
+        git_ref="$2"
+        shift 2
+        ;;
+      --repo-url)
+        [[ $# -ge 2 ]] || die "--repo-url needs a value"
+        repo_url="${2%/}"
+        shift 2
+        ;;
+      --from)
+        [[ $# -ge 2 ]] || die "--from needs a SHA"
+        from_sha="$2"
+        shift 2
+        ;;
+      --to)
+        [[ $# -ge 2 ]] || die "--to needs a SHA"
+        to_sha="$2"
+        shift 2
+        ;;
+      --full-graph) full_graph=true; shift ;;
+      *)
+        if [[ -z "${prev_build}" ]] && [[ "$1" =~ ^[0-9]+$ ]]; then
+          prev_build="$1"
+        elif [[ -z "${cur_build}" ]] && [[ "$1" =~ ^[0-9]+$ ]]; then
+          cur_build="$1"
+        else
+          die "unexpected argument: $1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Resolve endpoints to full SHAs
+  if [[ -n "${from_sha}" || -n "${to_sha}" ]]; then
+    [[ -n "${from_sha}" && -n "${to_sha}" ]] || die "use both --from and --to"
+    [[ "${from_sha}" =~ ^[0-9a-fA-F]{7,40}$ ]] || die "invalid --from SHA"
+    [[ "${to_sha}" =~ ^[0-9a-fA-F]{7,40}$ ]] || die "invalid --to SHA"
+    [[ -z "${prev_build}" && -z "${cur_build}" ]] || die "do not mix build numbers with --from/--to"
+    hash_range=true
+  else
+    [[ -n "${prev_build}" && -n "${cur_build}" ]] || usage 1
+    local bump_from bump_to
+    bump_from="$(git log "${git_ref}" --grep="Bump version number to ${prev_build}" -1 --format='%H' 2>/dev/null || true)"
+    bump_to="$(git log "${git_ref}" --grep="Bump version number to ${cur_build}" -1 --format='%H' 2>/dev/null || true)"
+    [[ -n "${bump_from}" ]] || die "no commit for build ${prev_build} (try --ref release/X.Y.Z)"
+    [[ -n "${bump_to}" ]] || die "no commit for build ${cur_build} (try --ref release/X.Y.Z)"
+    from_sha="${bump_from}"
+    to_sha="${bump_to}"
+  fi
+
+  [[ "${from_sha}" == "${to_sha}" ]] && {
+    echo "Nothing to list: from and to are the same commit."
+    exit 0
+  }
+
+  git merge-base --is-ancestor "${from_sha}" "${to_sha}" 2>/dev/null ||
+    die "--from must be an ancestor of --to"
+
+  # git log: traversal flags depend on mode
+  local -a log_args=(--reverse --no-merges --format='%H%n%s')
+  if [[ "${hash_range}" == true ]]; then
+    # Exclude merged-in subtrees that are not strictly between from..to (see file header).
+    log_args=(--ancestry-path "${log_args[@]}")
+  elif [[ "${full_graph}" != true ]]; then
+    log_args=(--first-parent "${log_args[@]}")
+  fi
+
+  local raw_log
+  raw_log="$(git log "${log_args[@]}" "${from_sha}..${to_sha}" 2>/dev/null || true)"
+  [[ -n "${raw_log}" ]] || {
+    echo "No commits in range ${from_sha:0:7}..${to_sha:0:7}."
+    exit 0
+  }
+
+  local left="commit ${from_sha:0:7}"
+  local right="commit ${to_sha:0:7}"
+  if [[ -n "${prev_build}" ]]; then
+    left="build ${prev_build}"
+    right="build ${cur_build}"
+  fi
+  echo "## RC cherry-picks: ${left} → ${right}"
+  echo ""
+
+  # Filter subjects and print
+  local count=0
+  local sha subject
+  while IFS= read -r sha && IFS= read -r subject; do
+    [[ -z "${sha}" ]] && continue
+    subject_is_skip_ci "${subject}" && continue
+    subject_is_cherry_pick "${subject}" || continue
+    markdown_line "${sha}" "${subject}" "${repo_url}"
+    count=$((count + 1))
+  done <<<"${raw_log}"
+
+  if [[ "${count}" -eq 0 ]]; then
+    echo "_No cherry-pick commits in this range (after filters)._"
+  fi
+}
+
+main "$@"

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -2,9 +2,8 @@
  * Slack RC Build Notification Script
  *
  * Cherry-pick section: reads markdown from rc-cherry-pick-changelog.sh (written in CI by
- * scripts/write-rc-cherry-pick-changelog-artifact.sh, e.g. build-rc-auto.yml → artifact).
- * If that file is missing, falls back to CHANGELOG.md via @metamask/auto-changelog (other
- * workflows that do not upload the artifact).
+ * scripts/write-rc-cherry-pick-changelog-merge-base.sh: --from merge-base(HEAD, origin/main),
+ * --to HEAD). If that file is missing, falls back to CHANGELOG.md via @metamask/auto-changelog.
  *
  * Required: SEMVER, SLACK_BOT_TOKEN, IOS_BUILD_NUMBER, ANDROID_BUILD_NUMBER
  * Optional: RC_CHERRY_PICK_CHANGELOG_PATH (defaults to rc-cherry-pick-changelog.md in repo root)

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -1,45 +1,101 @@
 /**
  * Slack RC Build Notification Script
  *
- * This script posts a notification to Slack after an RC build completes.
- * It reads the CHANGELOG.md using @metamask/auto-changelog to extract entries
- * for the current version and formats them into a Slack message with PR links.
+ * Cherry-pick section: reads markdown from rc-cherry-pick-changelog.sh (written in CI by
+ * scripts/write-rc-cherry-pick-changelog-artifact.sh, e.g. build-rc-auto.yml → artifact).
+ * If that file is missing, falls back to CHANGELOG.md via @metamask/auto-changelog (other
+ * workflows that do not upload the artifact).
  *
- * Required Environment Variables:
- *   - SEMVER: The semantic version (e.g., "7.40.0")
- *   - IOS_BUILD_NUMBER: iOS build number
- *   - ANDROID_BUILD_NUMBER: Android build number
- *   - SLACK_BOT_TOKEN: Slack Bot OAuth token for API calls
- *
- * Optional Environment Variables:
- *   - ANDROID_PUBLIC_URL: Public URL for Android APK download
- *   - IOS_PUBLIC_URL: Public URL for iOS build
- *   - BUILD_PIPELINE_URL: URL to the GitHub Actions pipeline
- *   - GITHUB_REPOSITORY: Repository in format "owner/repo"
- *   - TEST_CHANNEL: Override channel for testing (e.g., "#mm-test-channel")
+ * Required: SEMVER, SLACK_BOT_TOKEN, IOS_BUILD_NUMBER, ANDROID_BUILD_NUMBER
+ * Optional: RC_CHERRY_PICK_CHANGELOG_PATH (defaults to rc-cherry-pick-changelog.md in repo root)
  */
 
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import { parseChangelog } from '@metamask/auto-changelog';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..');
 
-// Configuration
 const REPO_URL = process.env.GITHUB_REPOSITORY
   ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
   : 'https://github.com/MetaMask/metamask-mobile';
 
+const MAX_SLACK_CHANGELOG_CHARS = 2800;
+const DEFAULT_CHERRY_PICK_FILE = 'rc-cherry-pick-changelog.md';
+
+function resolvePath(p) {
+  return isAbsolute(p) ? p : join(REPO_ROOT, p);
+}
+
 /**
- * Extract changelog entries for a specific version using auto-changelog
- * @param {string} version - The version to extract entries for
- * @returns {Object|null} The release changes or null if not found
+ * Convert rc-cherry-pick-changelog.sh markdown to Slack mrkdwn.
  */
+function cherryPickMarkdownToSlack(markdown) {
+  const body = markdown.replace(/^##[^\n]*\n\n?/m, '').trim();
+  if (
+    !body ||
+    /_No cherry-pick commits/i.test(body) ||
+    /Could not find a previous bump/i.test(body) ||
+    /range unavailable/i.test(body)
+  ) {
+    return { text: '', isEmpty: true };
+  }
+
+  const lines = body.split('\n').filter((line) => line.length > 0);
+  const slackLines = [];
+
+  for (const line of lines) {
+    const prLink = line.match(/^-\s*\[#(\d+)\]\(([^)]+)\):\s*(.*)$/);
+    if (prLink) {
+      slackLines.push(`• <${prLink[2]}|#${prLink[1]}>: ${prLink[3]}`);
+      continue;
+    }
+    const commitLink = line.match(/^-\s*\[`([^`]+)`\]\(([^)]+)\):\s*(.*)$/);
+    if (commitLink) {
+      slackLines.push(`• <${commitLink[2]}|\`${commitLink[1]}\`>: ${commitLink[3]}`);
+      continue;
+    }
+    slackLines.push(line);
+  }
+
+  let text = slackLines.join('\n');
+  if (text.length > MAX_SLACK_CHANGELOG_CHARS) {
+    text = `${text.slice(0, MAX_SLACK_CHANGELOG_CHARS - 40)}\n_…truncated_`;
+  }
+
+  return { text, isEmpty: false };
+}
+
+/**
+ * Load cherry-pick section from pre-generated file (CI artifact) if present.
+ */
+function loadCherryPickChangelogForSlack() {
+  const pathEnv = process.env.RC_CHERRY_PICK_CHANGELOG_PATH || DEFAULT_CHERRY_PICK_FILE;
+  const path = resolvePath(pathEnv);
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const markdown = readFileSync(path, 'utf8');
+    const converted = cherryPickMarkdownToSlack(markdown);
+    if (converted.isEmpty || !converted.text) {
+      console.log(`\n📖 Cherry-pick file ${pathEnv} present but empty after filters; trying CHANGELOG.md`);
+      return null;
+    }
+    console.log(`\n📖 Using cherry-pick changelog file: ${pathEnv}`);
+    return converted;
+  } catch (e) {
+    console.warn(`⚠️ Could not read ${path}: ${e.message}`);
+    return null;
+  }
+}
+
 function extractChangelogEntries(version) {
-  const changelogPath = join(__dirname, '..', 'CHANGELOG.md');
+  const changelogPath = join(REPO_ROOT, 'CHANGELOG.md');
 
   let changelogContent;
   try {
@@ -56,7 +112,6 @@ function extractChangelogEntries(version) {
       shouldExtractPrLinks: true,
     });
 
-    // Get changes for this specific version
     const releaseChanges = changelog.getReleaseChanges(version);
 
     if (!releaseChanges) {
@@ -71,16 +126,9 @@ function extractChangelogEntries(version) {
   }
 }
 
-/**
- * Format changelog entries for Slack
- * @param {Object} changes - The changelog changes object
- * @param {number} maxEntries - Maximum entries to display
- * @returns {string} Formatted changelog text for Slack
- */
 function formatChangesForSlack(changes, maxEntries = 15) {
   const formattedEntries = [];
 
-  // Priority order for categories
   const categoryOrder = [
     'Added',
     'Fixed',
@@ -97,10 +145,8 @@ function formatChangesForSlack(changes, maxEntries = 15) {
         break;
       }
 
-      // Build description with PR links
       let description = entry.description;
 
-      // If we have PR numbers from auto-changelog, format them for Slack
       if (entry.prNumbers && entry.prNumbers.length > 0) {
         const prLinks = entry.prNumbers
           .map((prNum) => `<${REPO_URL}/pull/${prNum}|#${prNum}>`)
@@ -112,7 +158,6 @@ function formatChangesForSlack(changes, maxEntries = 15) {
     }
   }
 
-  // Count remaining entries
   const allEntriesCount = Object.values(changes)
     .flat()
     .filter(Boolean).length;
@@ -125,11 +170,6 @@ function formatChangesForSlack(changes, maxEntries = 15) {
   return formattedEntries.join('\n');
 }
 
-/**
- * Check if a URL is valid
- * @param {string|undefined} url - The URL to check
- * @returns {boolean} Whether the URL is valid
- */
 function isValidUrl(url) {
   if (!url || typeof url !== 'string') {
     return false;
@@ -146,11 +186,6 @@ function isValidUrl(url) {
   }
 }
 
-/**
- * Build the Slack message payload
- * @param {Object} options - Message options
- * @returns {Object} Slack message payload
- */
 function buildSlackMessage(options) {
   const {
     version,
@@ -160,7 +195,13 @@ function buildSlackMessage(options) {
     pipelineUrl,
     changelogText,
     hasChangelog,
+    changelogSource,
   } = options;
+
+  const sectionTitle =
+    changelogSource === 'cherry-pick'
+      ? '*📋 Cherry-picks since last RC bump:*'
+      : '*📋 What\'s in this RC:*';
 
   const blocks = [
     {
@@ -210,7 +251,6 @@ function buildSlackMessage(options) {
     },
   ];
 
-  // Add changelog section if we have entries
   if (hasChangelog && changelogText) {
     blocks.push(
       {
@@ -220,7 +260,7 @@ function buildSlackMessage(options) {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*📋 What's in this RC:*\n${changelogText}`,
+          text: `${sectionTitle}\n${changelogText}`,
         },
       },
     );
@@ -229,12 +269,11 @@ function buildSlackMessage(options) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '_No changelog entries found for this version. Check CHANGELOG.md_',
+        text: '_No changelog entries found. See CHANGELOG.md or rc-cherry-pick-changelog output._',
       },
     });
   }
 
-  // Add pipeline link
   if (pipelineUrl) {
     blocks.push(
       {
@@ -245,7 +284,7 @@ function buildSlackMessage(options) {
         elements: [
           {
             type: 'mrkdwn',
-            text: `<${pipelineUrl}|View Build Pipeline> | <${REPO_URL}/blob/release/${version}/CHANGELOG.md|View Full Changelog>`,
+            text: `<${pipelineUrl}|View Build Pipeline> | <${REPO_URL}/blob/release/${version}/CHANGELOG.md|CHANGELOG.md>`,
           },
         ],
       },
@@ -254,17 +293,10 @@ function buildSlackMessage(options) {
 
   return {
     blocks,
-    text: `🚀 Mobile RC Build v${version} (${buildNumber}) is ready!`, // Fallback text
+    text: `🚀 Mobile RC Build v${version} (${buildNumber}) is ready!`,
   };
 }
 
-/**
- * Post message to Slack channel using Web API
- * @param {string} botToken - Slack bot token
- * @param {string} channelName - Channel name to post to
- * @param {Object} payload - Slack message payload
- * @returns {Promise<{success: boolean, channelNotFound: boolean}>}
- */
 async function postToSlack(botToken, channelName, payload) {
   try {
     const response = await fetch('https://slack.com/api/chat.postMessage', {
@@ -283,7 +315,6 @@ async function postToSlack(botToken, channelName, payload) {
     const data = await response.json();
 
     if (!data.ok) {
-      // Check if channel doesn't exist
       if (data.error === 'channel_not_found') {
         return { success: false, channelNotFound: true };
       }
@@ -298,21 +329,12 @@ async function postToSlack(botToken, channelName, payload) {
   }
 }
 
-/**
- * Get the Slack channel name for a release version
- * @param {string} version - The version string
- * @returns {string} The channel name
- */
 function getSlackChannel(version) {
   const formattedVersion = version.replace(/\./g, '-');
   return `#release-mobile-${formattedVersion}`;
 }
 
-/**
- * Main function
- */
 async function main() {
-  // Validate required environment variables (fail open - just log and return)
   const requiredEnvVars = ['SEMVER', 'SLACK_BOT_TOKEN'];
   const missingVars = requiredEnvVars.filter((v) => !process.env[v]);
 
@@ -331,7 +353,6 @@ async function main() {
   const pipelineUrl = process.env.BUILD_PIPELINE_URL;
   const botToken = process.env.SLACK_BOT_TOKEN;
 
-  // TEST_CHANNEL allows overriding the channel for local testing
   const testChannel = process.env.TEST_CHANNEL;
   const expectedChannelName = testChannel || getSlackChannel(version);
   const isTestMode = Boolean(testChannel);
@@ -343,28 +364,33 @@ async function main() {
     console.log(`📍 Target channel: ${expectedChannelName}`);
   }
 
-  // Extract changelog entries using auto-changelog
-  console.log('\n📖 Reading CHANGELOG.md...');
-  const changes = extractChangelogEntries(version);
-
   let changelogText = '';
   let hasChangelog = false;
+  let changelogSource = 'none';
 
-  if (changes) {
-    const totalChanges = Object.values(changes)
-      .flat()
-      .filter(Boolean).length;
-    console.log(`   Found ${totalChanges} changelog entries for v${version}`);
-
-    if (totalChanges > 0) {
-      hasChangelog = true;
-      changelogText = formatChangesForSlack(changes);
-    }
+  const cherry = loadCherryPickChangelogForSlack();
+  if (cherry && cherry.text) {
+    changelogText = cherry.text;
+    hasChangelog = true;
+    changelogSource = 'cherry-pick';
   } else {
-    console.log('   ⚠️ Could not read changelog');
+    console.log('\n📖 Reading CHANGELOG.md (no rc-cherry-pick-changelog.md in workspace)...');
+    const changes = extractChangelogEntries(version);
+    if (changes) {
+      const totalChanges = Object.values(changes)
+        .flat()
+        .filter(Boolean).length;
+      if (totalChanges > 0) {
+        hasChangelog = true;
+        changelogText = formatChangesForSlack(changes);
+        changelogSource = 'changelog-md';
+        console.log(`   Found ${totalChanges} changelog entries for v${version}`);
+      }
+    } else {
+      console.log('   ⚠️ Could not read changelog');
+    }
   }
 
-  // Build and send the message
   console.log('\n📤 Posting to Slack...');
 
   const payload = buildSlackMessage({
@@ -375,6 +401,7 @@ async function main() {
     pipelineUrl,
     changelogText,
     hasChangelog,
+    changelogSource,
   });
 
   const result = await postToSlack(botToken, expectedChannelName, payload);
@@ -383,20 +410,12 @@ async function main() {
     console.log(`\n✅ RC notification sent to ${expectedChannelName}`);
   } else if (result.channelNotFound) {
     console.warn(`\n⚠️ Channel ${expectedChannelName} not found in Slack workspace`);
-    console.warn('   This could mean:');
-    console.warn('   - The release channel has not been created yet');
-    console.warn('   - The bot does not have access to the channel');
-    console.warn('   - The channel name pattern is different');
     console.warn('Skipping Slack notification (non-critical)');
   } else {
-    // Fail open - log the error but don't exit with error code
     console.log('\n⚠️ RC notification failed but continuing (non-critical)');
   }
 }
 
-// Run - fail open on errors (non-critical notification)
 main().catch((error) => {
   console.error('⚠️ Unexpected error (non-critical):', error);
-  // Don't exit with error code - this is a non-critical notification
 });
-

--- a/scripts/write-rc-cherry-pick-changelog-artifact.sh
+++ b/scripts/write-rc-cherry-pick-changelog-artifact.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# CI helper: find previous "Bump version number" before current build on release/${SEMVER},
+# run rc-cherry-pick-changelog.sh, write markdown to the given file (default: rc-cherry-pick-changelog.md).
+#
+# Environment (required):
+#   SEMVER
+#   ANDROID_BUILD_NUMBER or IOS_BUILD_NUMBER
+#   GITHUB_REPOSITORY (owner/repo) for --repo-url
+#
+# Usage:
+#   ./scripts/write-rc-cherry-pick-changelog-artifact.sh [output-file]
+#
+set -euo pipefail
+
+OUT="${1:-rc-cherry-pick-changelog.md}"
+SEMVER="${SEMVER:?SEMVER is required}"
+REF="release/${SEMVER}"
+CUR="${ANDROID_BUILD_NUMBER:-${IOS_BUILD_NUMBER:-}}"
+[[ -n "${CUR}" ]] || {
+  echo "ANDROID_BUILD_NUMBER or IOS_BUILD_NUMBER is required" >&2
+  exit 1
+}
+
+REPO_URL="https://github.com/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+sorted="$(
+  git log "${REF}" --grep='Bump version number' --format='%s' 2>/dev/null |
+    sed -n 's/.*Bump version number to \([0-9][0-9]*\).*/\1/p' |
+    sort -n -u
+)"
+
+prev="$(
+  echo "${sorted}" | awk -v c="${CUR}" '{ a[NR] = $0 } END {
+    for (i = 1; i <= NR; i++) {
+      if (a[i] == c && i > 1) { print a[i - 1]; exit }
+    }
+  }'
+)"
+
+if [[ -z "${prev}" ]]; then
+  {
+    echo "## RC cherry-picks: (range unavailable)"
+    echo ""
+    echo "_Could not find a previous bump before build ${CUR} on ${REF}._"
+  } >"${OUT}"
+  exit 0
+fi
+
+echo "Writing ${OUT} (build ${prev} → ${CUR}, ${REF})" >&2
+if ! "${SCRIPT_DIR}/rc-cherry-pick-changelog.sh" "${prev}" "${CUR}" --ref "${REF}" --repo-url "${REPO_URL}" >"${OUT}"; then
+  {
+    echo "## RC cherry-picks: (generation failed)"
+    echo ""
+    echo "_rc-cherry-pick-changelog.sh exited with an error — see job logs._"
+  } >"${OUT}"
+fi

--- a/scripts/write-rc-cherry-pick-changelog-merge-base.sh
+++ b/scripts/write-rc-cherry-pick-changelog-merge-base.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# CI helper: merge-base(origin/main, HEAD) as --from, HEAD as --to — see rc-cherry-pick-changelog.sh.
+# Requires a full clone of the release branch; run `git fetch origin main` first if origin/main
+# is missing (e.g. shallow checkout of a single ref).
+#
+# Environment (required):
+#   GITHUB_REPOSITORY (owner/repo) for --repo-url
+#
+# Usage:
+#   ./scripts/write-rc-cherry-pick-changelog-merge-base.sh [output-file]
+#
+set -euo pipefail
+
+OUT="${1:-rc-cherry-pick-changelog.md}"
+REPO_URL="https://github.com/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+  echo "Fetching origin/main for merge-base..." >&2
+  git fetch origin main
+fi
+
+MERGE_BASE="$(git merge-base HEAD origin/main)" || {
+  {
+    echo "## RC cherry-picks: (merge-base unavailable)"
+    echo ""
+    echo "_Could not compute merge-base between HEAD and origin/main._"
+  } >"${OUT}"
+  exit 0
+}
+
+echo "Writing ${OUT} (merge-base ${MERGE_BASE:0:7} → HEAD, ${REPO_URL})" >&2
+if ! "${SCRIPT_DIR}/rc-cherry-pick-changelog.sh" \
+  --from "${MERGE_BASE}" \
+  --to "$(git rev-parse HEAD)" \
+  --repo-url "${REPO_URL}" >"${OUT}"; then
+  {
+    echo "## RC cherry-picks: (generation failed)"
+    echo ""
+    echo "_rc-cherry-pick-changelog.sh exited with an error — see job logs._"
+  } >"${OUT}"
+fi


### PR DESCRIPTION
## **Description**

This PR adds tooling to list **RC cherry-pick deltas** between release build bumps and wires that output into **Slack RC notifications** for **auto RC builds**.

**What shipped**

- **`scripts/rc-cherry-pick-changelog.sh`** — Markdown changelog of cherry-pick–style commits between two build numbers (resolved via `Bump version number to N`) or between two SHAs. Uses `--first-parent` / `--no-merges` in build mode and `--ancestry-path` for explicit hash ranges where appropriate; skips `[skip ci]` and filters to Runway/manual cherry-pick subjects.
- **`scripts/write-rc-cherry-pick-changelog-artifact.sh`** — CI helper: finds the previous bump vs current build on `release/${SEMVER}`, runs the script above, writes `rc-cherry-pick-changelog.md` (with stubs on missing range or script failure).
- **`build-rc-auto.yml`** — New job **`generate-rc-cherry-pick-changelog`** (full git history) runs the writer, uploads artifact **`rc-cherry-pick-changelog-md`**. **`slack-notification`** depends on it so the file exists before Slack runs.
- **`slack-rc-notification.yml`** — Downloads that artifact when present (`continue-on-error` so Runway callers without the artifact still work).
- **`scripts/slack-rc-notification.mjs`** — Prefers **`rc-cherry-pick-changelog.md`** (Slack mrkdwn conversion); if missing/empty after filters, falls back to **`CHANGELOG.md`** via `@metamask/auto-changelog`.
- **`package.json`** — `changelog:rc-cherry-picks` yarn script pointing at the shell script.

**Why**

Release managers need a reliable delta of cherry-picks between RC bumps; Slack should reflect that delta instead of only the static `CHANGELOG.md` section for the same semver.

---

## **Changelog**

CHANGELOG entry: null

---

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-442

---

## **Manual testing steps**

```gherkin
Feature: RC cherry-pick changelog script

  Scenario: Generate markdown between two build numbers on a release branch
    Given a clone with the release branch and full history
    When running yarn changelog:rc-cherry-picks <prev_build> <cur_build> --ref release/X.Y.Z
    Then markdown lists cherry-pick lines between those bumps or a clear empty/stub message

Feature: Slack RC notification consumes generated changelog

  Scenario: Auto RC workflow produces changelog artifact
    Given a draft or test run of the auto RC workflow on a release branch with auto-rc-builds
    When the generate-rc-cherry-pick-changelog job runs and slack-notification runs after it
    Then the Slack job downloads rc-cherry-pick-changelog-md and posts cherry-pick content (or falls back when artifact missing)
```

---

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

---

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

---

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
