### PR TITLE
test: add file download E2E tests with local HTML fixtures

### DIFF
--- a/tests/fixtures/download/File.txt
+++ b/tests/fixtures/download/File.txt
@@ -1,0 +1,1 @@
+This is a test file for download E2E tests.

--- a/tests/fixtures/download/download_base64_file.html
+++ b/tests/fixtures/download/download_base64_file.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Download Base64 File</title>
+</head>
+<body>
+  <h1>Download File document</h1>
+  <button id="download_button">Download</button>
+  <a id="hidden_download_link" style="display:none;"></a>
+
+  <script>
+    document.getElementById("download_button").addEventListener("click", async () => {
+      try {
+        const response = await fetch("File.txt");
+        const blob = await response.blob();
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const base64DataUrl = reader.result;
+          const link = document.getElementById("hidden_download_link");
+          link.href = base64DataUrl;
+          link.download = "file.txt";
+          link.click();
+        };
+        reader.readAsDataURL(blob);
+      } catch (error) {
+        console.error("Download failed:", error);
+        alert("Failed to download file.");
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/download/download_blob_file.html
+++ b/tests/fixtures/download/download_blob_file.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Download Blob file</title>
+</head>
+<body>
+  <h1>Download File document</h1>
+  <button id="download_button">Download</button>
+
+  <script>
+    document.getElementById("download_button").addEventListener("click", async () => {
+      try {
+        const response = await fetch("File.txt");
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "file.txt";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error("Download failed:", error);
+        alert("Failed to download file.");
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/smoke/wallet/browser/browser-download.spec.ts
+++ b/tests/smoke/wallet/browser/browser-download.spec.ts
@@ -1,0 +1,55 @@
+// eslint-disable-next-line import-x/no-nodejs-modules
+import path from 'path';
+import { SmokeWalletPlatform } from '../../../tags.js';
+import { loginToApp } from '../../../flows/wallet.flow';
+import { navigateToBrowserView } from '../../../flows/browser.flow';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import { getDappUrl } from '../../../framework/fixtures/FixtureUtils';
+import { DappVariants } from '../../../framework/Constants';
+import Browser from '../../../page-objects/Browser/BrowserView';
+import DownloadFileWebsite from '../../../page-objects/Browser/ExternalWebsites/DownloadFileWebsite';
+import DownloadFile from '../../../page-objects/Browser/DownloadFile';
+
+const DOWNLOAD_FIXTURES_PATH = path.resolve(
+  __dirname,
+  '../../../fixtures/download',
+);
+
+async function testDownloadFile(filename: string) {
+  await withFixtures(
+    {
+      dapps: [
+        {
+          dappVariant: DappVariants.TEST_DAPP,
+          dappPath: DOWNLOAD_FIXTURES_PATH,
+        },
+      ],
+      fixture: new FixtureBuilder().build(),
+      restartDevice: true,
+    },
+    async () => {
+      await loginToApp();
+      await navigateToBrowserView();
+      await Browser.tapUrlInputBox();
+      await Browser.navigateToURL(`${getDappUrl(0)}/${filename}`);
+      await DownloadFileWebsite.tapDownloadFileButton();
+      await DownloadFile.verifyTapjackingAndClickDownloadButton();
+      await DownloadFile.verifySuccessStateVisible();
+    },
+  );
+}
+
+describe(SmokeWalletPlatform('Browser File Download'), () => {
+  beforeEach(() => {
+    jest.setTimeout(150000);
+  });
+
+  it('downloads a blob file', async () => {
+    await testDownloadFile('download_blob_file.html');
+  });
+
+  it('downloads a base64 file', async () => {
+    await testDownloadFile('download_base64_file.html');
+  });
+});


### PR DESCRIPTION
## **Description**

Migrates the two file download E2E tests from the quarantined `browser-tests.failing.ts` into a new `browser-download.spec.ts` file. Replaces live external URL navigation (`tyschenko.github.io`) with local HTML fixtures served by DappServer, eliminating external network dependencies and improving test reliability.

Part of the effort to increase API mocking coverage for E2E tests ([MMQA-1368](https://consensyssoftware.atlassian.net/browse/MMQA-1368)).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1705](https://consensyssoftware.atlassian.net/browse/MMQA-1705)

## **Manual testing steps**

```gherkin
Feature: Browser File Download

  Scenario: user downloads a blob file from a local fixture page
    Given the app is launched and user is logged in
    And the browser view is open

    When user navigates to the local blob download fixture page
    And user taps the Download button
    And user confirms the download in the tapjacking dialog
    Then the download success state is displayed

  Scenario: user downloads a base64 file from a local fixture page
    Given the app is launched and user is logged in
    And the browser view is open

    When user navigates to the local base64 download fixture page
    And user taps the Download button
    And user confirms the download in the tapjacking dialog
    Then the download success state is displayed
```

## **Screenshots/Recordings**

### **Before**

N/A — tests were quarantined in `browser-tests.failing.ts` due to reliance on external URLs.

### **After**

Both tests passing locally on iOS simulator:

```
PASS tests/smoke/wallet/browser/browser-download.spec.ts (222.23 s)
  SmokeWalletPlatform: Browser File Download
    ✓ downloads a blob file (121368 ms)
    ✓ downloads a base64 file (92885 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-1368]: https://consensyssoftware.atlassian.net/browse/MMQA-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1705]: https://consensyssoftware.atlassian.net/browse/MMQA-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to E2E smoke tests and static HTML/text fixtures, with no production code paths affected.
> 
> **Overview**
> Adds a new smoke spec `browser-download.spec.ts` that exercises in-app browser file downloads for both *blob* and *base64 data URL* flows.
> 
> Replaces reliance on external download pages by introducing local DappServer-served fixtures (`tests/fixtures/download/*`) that fetch a bundled `File.txt` and trigger downloads via `URL.createObjectURL` or `FileReader.readAsDataURL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca245f7a7d842ede0c7dd0973062dfe49a4d483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->