### PR TITLE
fix: initial seedless encryptor fix

### DIFF
--- a/app/core/Encryptor/Encryptor.test.ts
+++ b/app/core/Encryptor/Encryptor.test.ts
@@ -46,6 +46,41 @@ describe('Encryptor', () => {
 
       expect(decryptedObject).toEqual({ test: 'data' });
     });
+
+    describe('vault ciphertext under data field', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(QuickCryptoLib, 'decrypt')
+          .mockResolvedValue(JSON.stringify({ recovered: true }));
+        jest.spyOn(QuickCryptoLib, 'deriveKey').mockResolvedValue('mockedKey');
+      });
+
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it('decrypts payload that stores ciphertext under data instead of cipher', async () => {
+        const password = 'testPassword';
+        const mockVault = {
+          data: 'ciphertext-in-data',
+          iv: 'mockedIV',
+          salt: 'mockedSalt',
+          lib: ENCRYPTION_LIBRARY.original,
+        };
+
+        const decryptedObject = await encryptor.decrypt(
+          password,
+          JSON.stringify(mockVault),
+        );
+
+        expect(decryptedObject).toEqual({ recovered: true });
+        expect(QuickCryptoLib.decrypt).toHaveBeenCalledWith(
+          'ciphertext-in-data',
+          'mockedKey',
+          'mockedIV',
+        );
+      });
+    });
   });
 
   describe('isVaultUpdated', () => {
@@ -315,6 +350,28 @@ describe('Encryptor', () => {
 
       const importedKey = await encryptor.importKey(result.exportedKeyString);
       expect(importedKey.keyMetadata).toEqual(LEGACY_DERIVATION_OPTIONS);
+    });
+
+    it('decrypts vault that stores ciphertext under data instead of cipher', async () => {
+      const password = 'testPassword';
+      const mockVault = {
+        data: 'mockedCipher',
+        iv: 'mockedIV',
+        salt: 'mockedSalt',
+        lib: 'original',
+      };
+
+      const result = await encryptor.decryptWithDetail(
+        password,
+        JSON.stringify(mockVault),
+      );
+
+      expect(result.vault).toEqual({ test: 'data' });
+      expect(QuickCryptoLib.decrypt).toHaveBeenCalledWith(
+        'mockedCipher',
+        expect.any(String),
+        'mockedIV',
+      );
     });
   });
 });

--- a/app/core/Encryptor/Encryptor.ts
+++ b/app/core/Encryptor/Encryptor.ts
@@ -169,11 +169,9 @@ class Encryptor
     key: EncryptionKey,
     payload: EncryptionResult,
   ): Promise<unknown> => {
-    const result = await QuickCryptoLib.decrypt(
-      payload.cipher,
-      key.key,
-      payload.iv,
-    );
+    // @ts-expect-error - The payload type is not exported from the package
+    const cipher: string = payload.cipher ?? payload.data;
+    const result = await QuickCryptoLib.decrypt(cipher, key.key, payload.iv);
 
     return JSON.parse(result);
   };

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.test.ts
@@ -192,7 +192,7 @@ describe('seedless onboarding controller init', () => {
   });
 
   describe('encryptorAdapter', () => {
-    it('encryptWithKey maps cipher to data field', async () => {
+    it('encryptWithKey returns Encryptor result (cipher field)', async () => {
       const { mockEncryptWithKey } = getEncryptorMocks();
       seedlessOnboardingControllerInit(initRequestMock);
 
@@ -210,12 +210,12 @@ describe('seedless onboarding controller init', () => {
       const result = await encryptorAdapter.encryptWithKey(mockKey, testData);
 
       expect(mockEncryptWithKey).toHaveBeenCalledWith(mockKey, testData);
-      expect(result).toHaveProperty('data', mockEncryptResult.cipher);
+      expect(result).toHaveProperty('cipher', mockEncryptResult.cipher);
       expect(result).toHaveProperty('iv', mockEncryptResult.iv);
       expect(result).toHaveProperty('salt', mockEncryptResult.salt);
     });
 
-    it('decryptWithKey maps data to cipher field', async () => {
+    it('decryptWithKey forwards data-format vault; Encryptor reads cipher ?? data', async () => {
       const { mockDecryptWithKey } = getEncryptorMocks();
       seedlessOnboardingControllerInit(initRequestMock);
 
@@ -242,13 +242,7 @@ describe('seedless onboarding controller init', () => {
         encryptedObject,
       );
 
-      expect(mockDecryptWithKey).toHaveBeenCalledWith(mockKey, {
-        cipher: encryptedObject.data,
-        iv: encryptedObject.iv,
-        salt: encryptedObject.salt,
-        lib: encryptedObject.lib,
-        keyMetadata: encryptedObject.keyMetadata,
-      });
+      expect(mockDecryptWithKey).toHaveBeenCalledWith(mockKey, encryptedObject);
       expect(decrypted).toEqual({ test: 'decrypted-data' });
     });
 
@@ -283,7 +277,8 @@ describe('seedless onboarding controller init', () => {
       });
     });
 
-    it('decryptWithKey throws when both data and cipher are absent', async () => {
+    it('decryptWithKey forwards malformed vault to Encryptor (no adapter guard)', async () => {
+      const { mockDecryptWithKey } = getEncryptorMocks();
       seedlessOnboardingControllerInit(initRequestMock);
 
       const encryptorAdapter =
@@ -292,16 +287,12 @@ describe('seedless onboarding controller init', () => {
       const mockKey = { key: 'test-key', lib: 'test-lib', exportable: true };
       const malformedObject = { iv: 'test-iv', salt: 'test-salt' };
 
-      // Cast as never: the package type expects `data` (DefaultEncryptionResult), but we
-      // intentionally pass a malformed vault (missing both fields) to test the error path.
-      await expect(
-        encryptorAdapter.decryptWithKey(mockKey, malformedObject as never),
-      ).rejects.toThrow(
-        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
-      );
+      await encryptorAdapter.decryptWithKey(mockKey, malformedObject as never);
+
+      expect(mockDecryptWithKey).toHaveBeenCalledWith(mockKey, malformedObject);
     });
 
-    it('decrypt normalizes data-format vault before decryption', async () => {
+    it('decrypt passes data-format vault string through; Encryptor uses cipher ?? data', async () => {
       const { mockDecrypt } = getEncryptorMocks();
       seedlessOnboardingControllerInit(initRequestMock);
 
@@ -316,14 +307,7 @@ describe('seedless onboarding controller init', () => {
 
       await encryptorAdapter.decrypt('password', dataFormatVault);
 
-      // Should normalize 'data' → 'cipher' before passing to underlying encryptor
-      const expectedNormalized = JSON.stringify({
-        data: 'encrypted-data',
-        iv: 'test-iv',
-        salt: 'test-salt',
-        cipher: 'encrypted-data',
-      });
-      expect(mockDecrypt).toHaveBeenCalledWith('password', expectedNormalized);
+      expect(mockDecrypt).toHaveBeenCalledWith('password', dataFormatVault);
     });
 
     it('decrypt passes cipher-format vault through unchanged', async () => {
@@ -344,7 +328,7 @@ describe('seedless onboarding controller init', () => {
       expect(mockDecrypt).toHaveBeenCalledWith('password', cipherFormatVault);
     });
 
-    it('decryptWithDetail normalizes data-format vault before decryption', async () => {
+    it('decryptWithDetail passes data-format vault string through; Encryptor uses cipher ?? data', async () => {
       const { mockDecryptWithDetail } = getEncryptorMocks();
       seedlessOnboardingControllerInit(initRequestMock);
 
@@ -359,15 +343,9 @@ describe('seedless onboarding controller init', () => {
 
       await encryptorAdapter.decryptWithDetail('password', dataFormatVault);
 
-      const expectedNormalized = JSON.stringify({
-        data: 'encrypted-data',
-        iv: 'test-iv',
-        salt: 'test-salt',
-        cipher: 'encrypted-data',
-      });
       expect(mockDecryptWithDetail).toHaveBeenCalledWith(
         'password',
-        expectedNormalized,
+        dataFormatVault,
       );
     });
 
@@ -393,24 +371,13 @@ describe('seedless onboarding controller init', () => {
     });
 
     /**
-     * End-to-end bug reproduction scenario:
-     *
-     * Bug (pre-fix): While the wallet is unlocked, a background JWT token
-     * refresh triggers SeedlessOnboardingController#updateVault, which calls
-     * encryptWithKey via the adapter. The adapter returns { data, iv, salt }
-     * (browser-passworder format). This vault string (with `data`, no `cipher`)
-     * is persisted to state.
-     *
-     * On next unlock, the controller reads the persisted vault and calls
-     * decrypt / decryptWithDetail. The underlying mobile Encryptor reads
-     * `cipher` from the parsed vault — finds undefined — and crashes with
-     * "TypeError: The first argument must be one of type string, Buffer..."
-     *
-     * Fix: normalizeVaultFormat detects a vault that has `data` but no
-     * `cipher` and injects cipher = data before handing it to the Encryptor.
+     * End-to-end: persisted vault from encryptWithKey round-trips through
+     * decrypt / decryptWithDetail. Mobile Encryptor.decryptWithKey uses
+     * `payload.cipher ?? payload.data`, so vaults with only `data` still
+     * decrypt; encryptWithKey persists `cipher` from QuickCrypto.
      */
     describe('end-to-end: background token refresh followed by unlock', () => {
-      it('decrypt can read a vault written by encryptWithKey (data-format vault)', async () => {
+      it('decrypt can read a vault written by encryptWithKey', async () => {
         const { mockDecrypt } = getEncryptorMocks();
         seedlessOnboardingControllerInit(initRequestMock);
 
@@ -424,35 +391,23 @@ describe('seedless onboarding controller init', () => {
           keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
         };
 
-        // Step 1: background token refresh writes vault via encryptWithKey
-        // → adapter converts cipher → data, returning browser-passworder format
         const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
           secret: 'seed-phrase',
         });
-        expect(encryptedVault).toHaveProperty('data'); // data, not cipher
-        expect(encryptedVault).not.toHaveProperty('cipher');
+        expect(encryptedVault).toHaveProperty('cipher');
+        expect(encryptedVault).not.toHaveProperty('data');
 
-        // Step 2: controller serializes and persists the vault
         const persistedVaultString = JSON.stringify(encryptedVault);
 
-        // Step 3: wallet locks, vaultEncryptionKey is cleared (persist: false).
-        // On next unlock the controller calls decrypt with the persisted string.
-        // Without the fix this would crash because the Encryptor reads `cipher`
-        // (undefined here) and passes it to QuickCryptoLib.decrypt.
         await encryptorAdapter.decrypt('user-password', persistedVaultString);
 
-        // The underlying Encryptor must receive the vault with `cipher` injected
-        const expectedNormalized = JSON.stringify({
-          ...encryptedVault,
-          cipher: encryptedVault.data,
-        });
         expect(mockDecrypt).toHaveBeenCalledWith(
           'user-password',
-          expectedNormalized,
+          persistedVaultString,
         );
       });
 
-      it('decryptWithDetail can read a vault written by encryptWithKey (data-format vault)', async () => {
+      it('decryptWithDetail can read a vault written by encryptWithKey', async () => {
         const { mockDecryptWithDetail } = getEncryptorMocks();
         seedlessOnboardingControllerInit(initRequestMock);
 
@@ -466,27 +421,20 @@ describe('seedless onboarding controller init', () => {
           keyMetadata: { algorithm: 'PBKDF2', params: { iterations: 600000 } },
         };
 
-        // Step 1: background token refresh writes vault via encryptWithKey
         const encryptedVault = await encryptorAdapter.encryptWithKey(mockKey, {
           secret: 'seed-phrase',
         });
 
-        // Step 2: persist
         const persistedVaultString = JSON.stringify(encryptedVault);
 
-        // Step 3: unlock via decryptWithDetail (used when vaultEncryptionKey is absent)
         await encryptorAdapter.decryptWithDetail(
           'user-password',
           persistedVaultString,
         );
 
-        const expectedNormalized = JSON.stringify({
-          ...encryptedVault,
-          cipher: encryptedVault.data,
-        });
         expect(mockDecryptWithDetail).toHaveBeenCalledWith(
           'user-password',
-          expectedNormalized,
+          persistedVaultString,
         );
       });
     });

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
@@ -1,17 +1,12 @@
-import type { Json } from '@metamask/utils';
 import type { ControllerInitFunction } from '../../types';
 import {
   SeedlessOnboardingController,
-  SeedlessOnboardingControllerState,
   Web3AuthNetwork,
   getDefaultSeedlessOnboardingControllerState,
   type SeedlessOnboardingControllerMessenger,
 } from '@metamask/seedless-onboarding-controller';
 import { Encryptor, LEGACY_DERIVATION_OPTIONS } from '../../../Encryptor';
-import type {
-  EncryptionKey,
-  KeyDerivationOptions,
-} from '../../../Encryptor/types';
+import type { EncryptionKey } from '../../../Encryptor/types';
 import { web3AuthNetwork } from '../../../OAuthService/OAuthLoginHandlers/constants';
 import AuthTokenHandler from '../../../OAuthService/AuthTokenHandler';
 
@@ -44,8 +39,7 @@ export const seedlessOnboardingControllerInit: ControllerInitFunction<
 
   const controller = new SeedlessOnboardingController({
     messenger: controllerMessenger,
-    state:
-      seedlessOnboardingControllerState as SeedlessOnboardingControllerState,
+    state: seedlessOnboardingControllerState,
     encryptor,
     network: web3AuthNetwork as Web3AuthNetwork,
     passwordOutdatedCacheTTL: 15_000, // 15 seconds

--- a/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
+++ b/app/core/Engine/controllers/seedless-onboarding-controller/index.ts
@@ -20,88 +20,6 @@ const encryptor = new Encryptor({
 });
 
 /**
- * Encryption result interface expected by the SeedlessOnboardingController.
- * Uses 'data' instead of 'cipher' per @metamask/browser-passworder standard.
- */
-interface ControllerEncryptionResult {
-  data: string;
-  iv: string;
-  salt?: string;
-  lib?: string;
-  keyMetadata?: KeyDerivationOptions;
-}
-
-/**
- * Normalizes a serialized vault so the mobile Encryptor can decrypt it
- * regardless of whether the vault was written by the adapter (using 'data')
- * or by the original mobile Encryptor (using 'cipher').
- *
- * Background: the SeedlessOnboardingController stores vaults via
- * encryptWithKey (adapter, 'data' field) and via encryptWithDetail (mobile
- * Encryptor, 'cipher' field).  The mobile Encryptor's decrypt / decryptWithDetail
- * always reads 'cipher', so vaults produced by the adapter must be normalized
- * before being handed to those methods.
- */
-function normalizeVaultFormat(text: string): string {
-  const payload: Record<string, unknown> = JSON.parse(text);
-  if (payload.data !== undefined && payload.cipher === undefined) {
-    return JSON.stringify({ ...payload, cipher: payload.data });
-  }
-  return text;
-}
-
-/**
- * Adapter that wraps the mobile Encryptor to be compatible with
- * SeedlessOnboardingController's VaultEncryptor interface.
- * Maps 'cipher' <-> 'data' between mobile and controller formats.
- */
-const encryptorAdapter = {
-  ...encryptor,
-  encryptWithKey: async (
-    key: EncryptionKey,
-    data: Json,
-  ): Promise<ControllerEncryptionResult> => {
-    const result = await encryptor.encryptWithKey(key, data);
-    return {
-      data: result.cipher,
-      iv: result.iv,
-      salt: result.salt,
-      lib: result.lib,
-      keyMetadata: result.keyMetadata,
-    };
-  },
-  decryptWithKey: async (
-    key: EncryptionKey,
-    // Accept both adapter format ('data') and legacy mobile format ('cipher').
-    // 'data' is intentionally optional here: pre-adapter vaults only carry
-    // 'cipher', so making 'data' required would be a lie about the runtime
-    // shape and would allow the fallback to be silently removed.
-    encryptedObject: Omit<ControllerEncryptionResult, 'data'> & {
-      data?: string;
-      cipher?: string;
-    },
-  ): Promise<unknown> => {
-    const cipher = encryptedObject.data ?? encryptedObject.cipher;
-    if (!cipher) {
-      throw new Error(
-        'SeedlessOnboardingController encryptorAdapter: vault is missing both "data" and "cipher" fields',
-      );
-    }
-    return encryptor.decryptWithKey(key, {
-      cipher,
-      iv: encryptedObject.iv,
-      salt: encryptedObject.salt,
-      lib: encryptedObject.lib,
-      keyMetadata: encryptedObject.keyMetadata,
-    });
-  },
-  decrypt: async (password: string, text: string): Promise<unknown> =>
-    encryptor.decrypt(password, normalizeVaultFormat(text)),
-  decryptWithDetail: async (password: string, text: string) =>
-    encryptor.decryptWithDetail(password, normalizeVaultFormat(text)),
-};
-
-/**
  * Initialize the SeedlessOnboardingController.
  *
  * @param request - The request object.
@@ -128,7 +46,7 @@ export const seedlessOnboardingControllerInit: ControllerInitFunction<
     messenger: controllerMessenger,
     state:
       seedlessOnboardingControllerState as SeedlessOnboardingControllerState,
-    encryptor: encryptorAdapter,
+    encryptor,
     network: web3AuthNetwork as Web3AuthNetwork,
     passwordOutdatedCacheTTL: 15_000, // 15 seconds
     refreshJWTToken: AuthTokenHandler.refreshJWTToken,

--- a/app/store/migrations/132.test.ts
+++ b/app/store/migrations/132.test.ts
@@ -1,0 +1,168 @@
+import { captureException } from '@sentry/react-native';
+import migrate, { migrationVersion } from './132';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedCaptureException = jest.mocked(captureException);
+
+interface TestState {
+  engine: {
+    backgroundState: {
+      SeedlessOnboardingController?: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+  };
+  [key: string]: unknown;
+}
+
+describe(`Migration ${migrationVersion}: Seedless vault data → cipher`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
+  });
+
+  it('returns state unchanged if ensureValidState returns false', () => {
+    const testState = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const result = migrate(testState);
+
+    expect(result).toBe(testState);
+  });
+
+  it('returns state unchanged if SeedlessOnboardingController is missing', () => {
+    const testState: TestState = {
+      engine: {
+        backgroundState: {},
+      },
+    };
+
+    const result = migrate(testState);
+
+    expect(result).toBe(testState);
+  });
+
+  it('returns state unchanged if vault is null', () => {
+    const testState: TestState = {
+      engine: {
+        backgroundState: {
+          SeedlessOnboardingController: { vault: null },
+        },
+      },
+    };
+
+    const result = migrate(testState);
+
+    expect(result).toBe(testState);
+  });
+
+  it('copies data to cipher and removes data when cipher is absent', () => {
+    const vaultObj = {
+      data: 'encrypted-payload',
+      iv: 'iv-value',
+      salt: 'salt-value',
+    };
+    const testState: TestState = {
+      engine: {
+        backgroundState: {
+          SeedlessOnboardingController: {
+            vault: JSON.stringify(vaultObj),
+          },
+        },
+      },
+    };
+
+    migrate(testState);
+
+    const seedless = testState.engine.backgroundState
+      .SeedlessOnboardingController as Record<string, unknown>;
+    const parsed = JSON.parse(seedless.vault as string);
+    expect(parsed.cipher).toBe('encrypted-payload');
+    expect(parsed.iv).toBe('iv-value');
+    expect(parsed.data).toBeUndefined();
+  });
+
+  it('does not change vault when cipher is already present', () => {
+    const vaultString = JSON.stringify({
+      cipher: 'already-here',
+      data: 'ignored',
+      iv: 'iv',
+    });
+    const testState: TestState = {
+      engine: {
+        backgroundState: {
+          SeedlessOnboardingController: { vault: vaultString },
+        },
+      },
+    };
+
+    migrate(testState);
+
+    const seedless = testState.engine.backgroundState
+      .SeedlessOnboardingController as Record<string, unknown>;
+    expect(seedless.vault).toBe(vaultString);
+  });
+
+  it('does not throw on invalid vault JSON and leaves vault unchanged', () => {
+    const testState: TestState = {
+      engine: {
+        backgroundState: {
+          SeedlessOnboardingController: { vault: 'not-json{' },
+        },
+      },
+    };
+
+    const result = migrate(testState);
+
+    expect(result).toBe(testState);
+    expect(
+      (
+        testState.engine.backgroundState.SeedlessOnboardingController as Record<
+          string,
+          unknown
+        >
+      ).vault,
+    ).toBe('not-json{');
+  });
+
+  it('captures exceptions and returns state on unexpected errors', () => {
+    const seedless: Record<string, unknown> = {};
+    Object.defineProperty(seedless, 'vault', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return '{"data":"x","iv":"y"}';
+      },
+      set() {
+        throw new Error('Unexpected failure');
+      },
+    });
+
+    const testState: TestState = {
+      engine: {
+        backgroundState: {
+          SeedlessOnboardingController: seedless,
+        },
+      },
+    };
+
+    const result = migrate(testState);
+
+    expect(result).toBe(testState);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Migration 132: Failed to migrate seedless vault data to cipher',
+        ),
+      }),
+    );
+  });
+});

--- a/app/store/migrations/132.ts
+++ b/app/store/migrations/132.ts
@@ -1,0 +1,77 @@
+import { captureException } from '@sentry/react-native';
+import { hasProperty, isObject } from '@metamask/utils';
+
+import { ensureValidState } from './util';
+
+export const migrationVersion = 132;
+
+/**
+ * Normalizes a serialized seedless vault so the mobile Encryptor always sees `cipher`.
+ * Legacy vaults used browser-passworder's `data` field; mobile encryption uses `cipher`.
+ */
+function migrateSeedlessVaultPayload(vault: string): string {
+  try {
+    const payload: Record<string, unknown> = JSON.parse(vault);
+    if (
+      payload.data !== undefined &&
+      typeof payload.data === 'string' &&
+      payload.cipher === undefined
+    ) {
+      const { data, ...rest } = payload;
+      return JSON.stringify({ ...rest, cipher: data });
+    }
+    return vault;
+  } catch {
+    return vault;
+  }
+}
+
+/**
+ * Migration 132: Copy seedless vault `data` → `cipher` for persisted
+ * SeedlessOnboardingController state.
+ */
+const migration = (state: unknown): unknown => {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    if (
+      !hasProperty(
+        state.engine.backgroundState,
+        'SeedlessOnboardingController',
+      ) ||
+      !isObject(state.engine.backgroundState.SeedlessOnboardingController)
+    ) {
+      return state;
+    }
+
+    const seedless = state.engine.backgroundState.SeedlessOnboardingController;
+
+    if (!hasProperty(seedless, 'vault') || seedless.vault == null) {
+      return state;
+    }
+
+    const { vault } = seedless;
+    if (typeof vault !== 'string') {
+      return state;
+    }
+
+    const migrated = migrateSeedlessVaultPayload(vault);
+    if (migrated !== vault) {
+      seedless.vault = migrated;
+    }
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to migrate seedless vault data to cipher: ${String(
+          error,
+        )}`,
+      ),
+    );
+  }
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -132,6 +132,7 @@ import migration128 from './128';
 import migration129 from './129';
 import migration130 from './130';
 import migration131 from './131';
+import migration132 from './132';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -283,6 +284,7 @@ export const migrationList: MigrationsList = {
   129: migration129,
   130: migration130,
   131: migration131,
+  132: migration132,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "@metamask/scure-bip39": "^2.1.0",
     "@metamask/sdk-analytics": "0.0.5",
     "@metamask/sdk-communication-layer": "0.33.1",
-    "@metamask/seedless-onboarding-controller": "^9.0.0",
+    "@metamask/seedless-onboarding-controller": "npm:@metamask-previews/seedless-onboarding-controller@9.1.0-preview-26cb9fc",
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/signature-controller": "^39.1.2",
     "@metamask/slip44": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9670,22 +9670,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/seedless-onboarding-controller@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/seedless-onboarding-controller@npm:9.0.0"
+"@metamask/seedless-onboarding-controller@npm:@metamask-previews/seedless-onboarding-controller@9.1.0-preview-26cb9fc":
+  version: 9.1.0-preview-26cb9fc
+  resolution: "@metamask-previews/seedless-onboarding-controller@npm:9.1.0-preview-26cb9fc"
   dependencies:
     "@metamask/auth-network-utils": "npm:^0.3.0"
-    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/browser-passworder": "npm:^6.0.0"
-    "@metamask/keyring-controller": "npm:^25.1.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/toprf-secure-backup": "npm:^0.11.0"
+    "@metamask/keyring-controller": "npm:^25.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/toprf-secure-backup": "npm:^1.0.0"
     "@metamask/utils": "npm:^11.9.0"
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/curves": "npm:^1.9.2"
     "@noble/hashes": "npm:^1.8.0"
     async-mutex: "npm:^0.5.0"
-  checksum: 10/e547fc366c86ddef687e866e245a1895f174981dadbbdbf5250711555500305d0f33989be6ce95f48ff89e3aa31cb803c83cbdae8cb0608cebb9c08dbdb5c17f
+  checksum: 10/0cc732550fd852bfa79b4e1f47c4f2b932323a9354aa1388310fc970ff4e5d16597a62948e6dd98b1fc2c70a3b896d6244e60824c4540b357e9f787ba5d92ad1
   languageName: node
   linkType: hard
 
@@ -9993,9 +9993,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/toprf-secure-backup@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@metamask/toprf-secure-backup@npm:0.11.0"
+"@metamask/toprf-secure-backup@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/toprf-secure-backup@npm:1.0.0"
   dependencies:
     "@metamask/auth-network-utils": "npm:^0.4.0"
     "@noble/ciphers": "npm:^1.2.1"
@@ -10007,7 +10007,7 @@ __metadata:
     "@toruslabs/fetch-node-details": "npm:^15.0.0"
     "@toruslabs/http-helpers": "npm:^8.1.1"
     bn.js: "npm:^5.2.2"
-  checksum: 10/15ff309c59c978e4dc6939337d0384b914778e15f222fc52dac1b3b43705e741403e4648aadecb88c4c47a1c5e07fd2b97699757f79decd5a659e1968504ef7f
+  checksum: 10/f34d788c9f411fff45f9f1e38de0c91e01f23be014b60d6d8747f73c7352c14c38f9ce6cd435ba90375f298e6fc593061adbb33c1752d5717b54fda65cb1e9aa
   languageName: node
   linkType: hard
 
@@ -35645,7 +35645,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.1.0"
     "@metamask/sdk-analytics": "npm:0.0.5"
     "@metamask/sdk-communication-layer": "npm:0.33.1"
-    "@metamask/seedless-onboarding-controller": "npm:^9.0.0"
+    "@metamask/seedless-onboarding-controller": "npm:@metamask-previews/seedless-onboarding-controller@9.1.0-preview-26cb9fc"
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/signature-controller": "npm:^39.1.2"
     "@metamask/slip44": "npm:^4.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches seedless vault encryption/decryption paths and adds a state migration, so mistakes could prevent users from unlocking existing seedless vaults. Scope is contained and covered by new unit tests and a defensive migration.
> 
> **Overview**
> Updates `Encryptor.decryptWithKey` to accept legacy seedless vault payloads where ciphertext is stored under `data` (using `payload.cipher ?? payload.data`), with new unit coverage for both `decrypt` and `decryptWithDetail`.
> 
> Simplifies `SeedlessOnboardingController` initialization by removing the custom encryptor adapter/normalization logic and passing the mobile `Encryptor` directly; tests are updated accordingly. Adds migration `132` to rewrite persisted seedless vault strings from `data` → `cipher` (dropping `data`) and registers it in the migration manifest, with error reporting via Sentry. Also bumps `@metamask/seedless-onboarding-controller` to a preview `9.1.0` build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faadb905b37e5200c0fd8faf65d587365a2fa8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->