### PR TITLE
chore: remove usage of tokensChainsCache from OndoPortfolio

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -70,10 +70,6 @@ jest.mock('../../../../../selectors/tokenBalancesController', () => ({
   selectAllTokenBalances: jest.fn(() => ({})),
 }));
 
-jest.mock('../../../../../selectors/tokenListController', () => ({
-  selectERC20TokensByChain: jest.fn(() => ({})),
-}));
-
 jest.mock('../../../../../selectors/tokensController', () => ({
   selectAllTokens: jest.fn(() => ({})),
 }));
@@ -391,11 +387,7 @@ describe('OndoPortfolio', () => {
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
-        const { selectERC20TokensByChain } = jest.requireMock(
-          '../../../../../selectors/tokenListController',
-        );
         if (selector === selectAllTokens) return {};
-        if (selector === selectERC20TokensByChain) return {};
         return null;
       });
     });
@@ -443,9 +435,6 @@ describe('OndoPortfolio', () => {
         const { selectAllTokenBalances } = jest.requireMock(
           '../../../../../selectors/tokenBalancesController',
         );
-        const { selectERC20TokensByChain } = jest.requireMock(
-          '../../../../../selectors/tokenListController',
-        );
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
@@ -460,7 +449,6 @@ describe('OndoPortfolio', () => {
               '0x1': { [TOKEN_ADDRESS]: rawHexBalance },
             },
           };
-        if (selector === selectERC20TokensByChain) return {};
         if (selector === selectAllTokens) return {};
         if (selector === selectInternalAccountByAddresses) return () => [];
         return null;
@@ -653,9 +641,6 @@ describe('OndoPortfolio', () => {
         const { selectAllTokenBalances } = jest.requireMock(
           '../../../../../selectors/tokenBalancesController',
         );
-        const { selectERC20TokensByChain } = jest.requireMock(
-          '../../../../../selectors/tokenListController',
-        );
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
@@ -675,7 +660,6 @@ describe('OndoPortfolio', () => {
               '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
             },
           };
-        if (selector === selectERC20TokensByChain) return {};
         if (selector === selectAllTokens) return {};
         if (selector === selectInternalAccountByAddresses)
           return () => [{ id: 'acc-1', address: ACCOUNT_1 }];
@@ -708,9 +692,6 @@ describe('OndoPortfolio', () => {
         const { selectAllTokenBalances } = jest.requireMock(
           '../../../../../selectors/tokenBalancesController',
         );
-        const { selectERC20TokensByChain } = jest.requireMock(
-          '../../../../../selectors/tokenListController',
-        );
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
@@ -733,7 +714,6 @@ describe('OndoPortfolio', () => {
               '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
             },
           };
-        if (selector === selectERC20TokensByChain) return {};
         if (selector === selectAllTokens) return {};
         if (selector === selectInternalAccountByAddresses)
           return () => [

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -49,7 +49,6 @@ import {
 import { formatComputedAt } from './OndoLeaderboard.utils';
 import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
 import { selectAllTokenBalances } from '../../../../../selectors/tokenBalancesController';
-import { selectERC20TokensByChain } from '../../../../../selectors/tokenListController';
 import { selectAllTokens } from '../../../../../selectors/tokensController';
 import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
 import {
@@ -169,7 +168,6 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
 
   const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
   const allTokenBalances = useSelector(selectAllTokenBalances);
-  const erc20TokensByChain = useSelector(selectERC20TokensByChain);
   const allTokens = useSelector(selectAllTokens);
   const accountToGroupMap = useSelector(selectAccountToGroupMap);
   const selectedGroup = useSelector(selectResolvedSelectedAccountGroup);
@@ -230,17 +228,12 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
         `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
       );
       const tokenHex = parsed.assetReference.toLowerCase() as Hex;
-      const tokenListDecimals =
-        erc20TokensByChain?.[chainHex]?.data?.[tokenHex]?.decimals;
-      const trackedDecimals =
-        tokenListDecimals === undefined
-          ? Object.values(allTokens[chainHex] ?? {})
-              .flat()
-              .find((t) => t.address.toLowerCase() === tokenHex)?.decimals
-          : undefined;
-      return tokenListDecimals ?? trackedDecimals ?? 18;
+      const trackedDecimals = Object.values(allTokens[chainHex] ?? {})
+        .flat()
+        .find((t) => t.address.toLowerCase() === tokenHex)?.decimals;
+      return trackedDecimals ?? 18;
     },
-    [erc20TokensByChain, allTokens],
+    [allTokens],
   );
 
   /** Returns the total token balance held across all accounts in the group, summed from raw hex values. */

--- a/app/selectors/tokenListController.ts
+++ b/app/selectors/tokenListController.ts
@@ -10,6 +10,7 @@ const selectTokenListConstrollerState = (state: RootState) =>
 /**
  * Return token list from TokenListController.
  * Can pass directly into useSelector.
+ * @deprecated tokensChainsCache will be removed from TokenListController
  */
 export const selectTokenList = createSelector(
   selectTokenListConstrollerState,
@@ -18,11 +19,17 @@ export const selectTokenList = createSelector(
     tokenListControllerState?.tokensChainsCache?.[chainId]?.data || [],
 );
 
+/**
+ * @deprecated tokensChainsCache will be removed from TokenListController
+ */
 const selectERC20TokensByChainInternal = createDeepEqualSelector(
   selectTokenListConstrollerState,
   (tokenListControllerState) => tokenListControllerState?.tokensChainsCache,
 );
 
+/**
+ * @deprecated tokensChainsCache will be removed from TokenListController
+ */
 export const selectERC20TokensByChain = createDeepEqualSelector(
   selectERC20TokensByChainInternal,
   (tokensChainsCache) => tokensChainsCache,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes the usage of `selectERC20TokensByChain` (which reads from `tokensChainsCache`) in `OndoPortfolio`. This is part of a broader effort to eliminate all usages of `tokensChainsCache` from the codebase so it can eventually be removed from `TokenListController`.

Previously, `resolveTokenDecimals` used `erc20TokensByChain` as the primary source for token decimals and `allTokens` (from `TokensController`) as a fallback. Since the tokens in Ondo portfolio positions are tokens the user holds in their wallet, they are already tracked in `TokensController.allTokens`, making the `tokensChainsCache` lookup redundant. The fallback of `18` is safe for any token not found in `allTokens`, and is also independently applied downstream in `OndoCampaignRwaSelectorView`.

Additionally marks `selectERC20TokensByChain` and `selectTokenList` as `@deprecated` in `tokenListController.ts` to signal their pending removal.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove usage of tokensChainsCache from OndoPortfolio

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3051

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a deprecated selector dependency and simplifies token-decimals resolution; behavior changes only affect how decimals are inferred when tracked tokens are missing.
> 
> **Overview**
> **Removes Ondo portfolio’s dependency on `TokenListController.tokensChainsCache`.** `OndoPortfolio` no longer reads `selectERC20TokensByChain` and now resolves token decimals solely from `selectAllTokens`, falling back to `18` when unknown.
> 
> Tests were updated to drop the `selectERC20TokensByChain` mocks, and `tokenListController` selectors were annotated as *deprecated* to reflect the planned removal of `tokensChainsCache`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803e4e8229baf307199c81b0ae1825cdd1759b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->