### PR TITLE
chore: streamline CI for e2e pipeline testing [CI-DEV]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Find and re-upload Android APK artifacts from last successful run
+      - name: Find and re-upload Android APK artifacts from last completed run
         shell: bash
         run: |
           set -euo pipefail
@@ -563,7 +563,9 @@ jobs:
           WORKFLOW="ci.yml"
           RUN_ID=""
 
-          echo "🔍 Looking for last successful run with Android APK artifacts..."
+          echo "🔍 Looking for last completed run with Android APK artifacts..."
+          # Use status=completed (not success) so we find runs where build succeeded
+          # but later test steps failed — the APK artifact is still valid.
 
           for TRY_BRANCH in "$BRANCH" "main"; do
             echo "  Checking branch: $TRY_BRANCH"
@@ -578,14 +580,14 @@ jobs:
                 echo "  ✅ Found artifacts in run $run_id on branch '$TRY_BRANCH'"
                 break
               fi
-            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=success&per_page=10" \
-              --jq '.workflow_runs[].id' 2>/dev/null | head -5 || echo "")
+            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=completed&per_page=10" \
+              --jq '.workflow_runs[].id' 2>/dev/null | head -8 || echo "")
 
             [ -n "$RUN_ID" ] && break
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "❌ No suitable Android APK artifacts found in recent successful runs"
+            echo "❌ No suitable Android APK artifacts found in recent completed runs"
             exit 1
           fi
 
@@ -687,9 +689,12 @@ jobs:
           BRANCH="${{ github.head_ref || github.ref_name }}"
           WORKFLOW="ci.yml"
           RUN_ID=""
-          ARTIFACT_NAME="main-e2e-MetaMask.app"
+          ARTIFACT_NAME="main-qa-MetaMask.app"
 
-          echo "🔍 Looking for last successful run with iOS App artifact..."
+          echo "🔍 Looking for last completed run with iOS App artifact..."
+          # Use status=completed (not success) — build artifact is valid even if later
+          # test steps failed. Also: iOS build uses metamask_environment='qa' by default,
+          # so artifact is named main-qa-MetaMask.app (not main-e2e-MetaMask.app).
 
           for TRY_BRANCH in "$BRANCH" "main"; do
             echo "  Checking branch: $TRY_BRANCH"
@@ -704,14 +709,14 @@ jobs:
                 echo "  ✅ Found artifact in run $run_id on branch '$TRY_BRANCH'"
                 break
               fi
-            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=success&per_page=10" \
-              --jq '.workflow_runs[].id' 2>/dev/null | head -5 || echo "")
+            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=completed&per_page=10" \
+              --jq '.workflow_runs[].id' 2>/dev/null | head -8 || echo "")
 
             [ -n "$RUN_ID" ] && break
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "❌ No suitable iOS App artifact found in recent successful runs"
+            echo "❌ No suitable iOS App artifact found in recent completed runs"
             exit 1
           fi
 
@@ -728,7 +733,7 @@ jobs:
       - name: Re-upload iOS App
         uses: actions/upload-artifact@v4
         with:
-          name: main-e2e-MetaMask.app
+          name: main-qa-MetaMask.app
           path: re-upload/app/
           retention-days: 7
 
@@ -750,7 +755,15 @@ jobs:
   e2e-smoke-tests-ios:
     name: 'iOS E2E Smoke Tests'
     # [CI-DEV] Hardcoded CiSanityCheck tag — re-enable smart selection before merging.
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && !cancelled() }}
+    # Must check ios-tests-ready.result explicitly: !cancelled() alone is true even when
+    # ios-tests-ready is skipped (skipped ≠ cancelled in GitHub Actions).
+    if: >-
+      ${{
+        github.event_name != 'merge_group' &&
+        !github.event.pull_request.head.repo.fork &&
+        !cancelled() &&
+        needs.ios-tests-ready.result == 'success'
+      }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,14 +516,13 @@ jobs:
 
   build-android-apks:
     name: 'Build Android APKs'
-    # [CI-DEV] Removed android_changed gate — build always runs and reuses cached APK
-    # when no build-impacting files changed (see scripts/e2e-build-config.json for the file list).
-    # The fingerprint cache in build-android-e2e.yml handles restoration from this PR's cache
-    # or falls back to main's cache, avoiding a full rebuild when nothing relevant changed.
+    # [CI-DEV] Gate restored: only builds when Android-impacting files changed.
+    # When no build files changed, provide-android-artifact reuses the last artifact (~2-3 min).
     if: >-
       ${{
         github.event_name != 'merge_group' &&
-        !github.event.pull_request.head.repo.fork
+        !github.event.pull_request.head.repo.fork &&
+        needs.needs_e2e_build.outputs.android_changed == 'true'
       }}
     permissions:
       contents: read
@@ -536,14 +535,108 @@ jobs:
       keystore_target: 'qa'
     secrets: inherit
 
+  provide-android-artifact:
+    name: 'Provide Android APKs (reuse — no native changes)'
+    # Runs when no Android-impacting files changed: downloads APK from last successful
+    # CI run on this branch (or falls back to main), then re-uploads to this run.
+    # Takes ~2-3 min vs ~20 min for a full build + environment setup.
+    if: >-
+      ${{
+        github.event_name != 'merge_group' &&
+        !github.event.pull_request.head.repo.fork &&
+        needs.needs_e2e_build.outputs.android_changed == 'false'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    needs: [needs_e2e_build, smart-e2e-selection]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Find and re-upload Android APK artifacts from last successful run
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          WORKFLOW="ci.yml"
+          RUN_ID=""
+
+          echo "🔍 Looking for last successful run with Android APK artifacts..."
+
+          for TRY_BRANCH in "$BRANCH" "main"; do
+            echo "  Checking branch: $TRY_BRANCH"
+
+            while IFS= read -r run_id; do
+              [ -z "$run_id" ] && continue
+              count=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts?per_page=50" \
+                --jq '[.artifacts[] | select((.name == "main-e2e-release.apk" or .name == "main-e2e-release-androidTest.apk") and .expired == false)] | length' \
+                2>/dev/null || echo "0")
+              if [ "$count" -ge 2 ]; then
+                RUN_ID="$run_id"
+                echo "  ✅ Found artifacts in run $run_id on branch '$TRY_BRANCH'"
+                break
+              fi
+            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=success&per_page=10" \
+              --jq '.workflow_runs[].id' 2>/dev/null | head -5 || echo "")
+
+            [ -n "$RUN_ID" ] && break
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "❌ No suitable Android APK artifacts found in recent successful runs"
+            exit 1
+          fi
+
+          mkdir -p re-upload/apk re-upload/test-apk
+
+          for artifact_name in "main-e2e-release.apk" "main-e2e-release-androidTest.apk"; do
+            echo "⬇️ Downloading $artifact_name from run $RUN_ID..."
+            artifact_url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=50" \
+              --jq ".artifacts[] | select(.name == \"$artifact_name\") | .archive_download_url")
+
+            if [ "$artifact_name" = "main-e2e-release.apk" ]; then
+              dest="re-upload/apk"
+            else
+              dest="re-upload/test-apk"
+            fi
+
+            curl -sL -H "Authorization: Bearer $GH_TOKEN" "$artifact_url" -o artifact.zip
+            unzip -o artifact.zip -d "$dest/"
+            rm artifact.zip
+            echo "  ✅ $artifact_name downloaded ($(ls $dest/ | wc -l) files)"
+          done
+
+      - name: Re-upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-e2e-release.apk
+          path: re-upload/apk/
+          retention-days: 7
+
+      - name: Re-upload Android Test APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-e2e-release-androidTest.apk
+          path: re-upload/test-apk/
+          retention-days: 7
+
   e2e-smoke-tests-android:
     name: 'Android E2E Smoke Tests'
-    # [CI-DEV] Removed android_changed gate and hardcoded CiSanityCheck tag — re-enable before merging
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    # [CI-DEV] Hardcoded CiSanityCheck tag — re-enable smart selection before merging.
+    # Depends on either build-android-apks (when files changed) or provide-android-artifact (reuse).
+    if: >-
+      ${{
+        github.event_name != 'merge_group' &&
+        !github.event.pull_request.head.repo.fork &&
+        !cancelled() &&
+        (needs.build-android-apks.result == 'success' || needs.provide-android-artifact.result == 'success')
+      }}
     permissions:
       contents: read
       id-token: write
-    needs: [needs_e2e_build, build-android-apks, smart-e2e-selection]
+    needs: [needs_e2e_build, build-android-apks, provide-android-artifact, smart-e2e-selection]
     uses: ./.github/workflows/run-e2e-smoke-tests-android.yml
     with:
       changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
@@ -552,12 +645,13 @@ jobs:
 
   build-ios-apps:
     name: 'Build iOS Apps'
-    # [CI-DEV] Removed ios_changed gate — build always runs and reuses cached .app
-    # when no build-impacting files changed (see scripts/e2e-build-config.json).
+    # [CI-DEV] Gate restored: only builds when iOS-impacting files changed.
+    # When no build files changed, provide-ios-artifact reuses the last artifact (~2-3 min).
     if: >-
       ${{
         github.event_name != 'merge_group' &&
-        !github.event.pull_request.head.repo.fork
+        !github.event.pull_request.head.repo.fork &&
+        needs.needs_e2e_build.outputs.ios_changed == 'true'
       }}
     permissions:
       contents: read
@@ -566,20 +660,97 @@ jobs:
     uses: ./.github/workflows/build-ios-e2e.yml
     secrets: inherit
 
+  provide-ios-artifact:
+    name: 'Provide iOS App (reuse — no native changes)'
+    # Runs when no iOS-impacting files changed: downloads the .app from last successful
+    # CI run on this branch (or falls back to main), then re-uploads to this run.
+    # Takes ~2-3 min vs ~20 min for a full build + environment setup.
+    if: >-
+      ${{
+        github.event_name != 'merge_group' &&
+        !github.event.pull_request.head.repo.fork &&
+        needs.needs_e2e_build.outputs.ios_changed == 'false'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    needs: [needs_e2e_build, smart-e2e-selection]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Find and re-upload iOS App artifact from last successful run
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          WORKFLOW="ci.yml"
+          RUN_ID=""
+          ARTIFACT_NAME="main-e2e-MetaMask.app"
+
+          echo "🔍 Looking for last successful run with iOS App artifact..."
+
+          for TRY_BRANCH in "$BRANCH" "main"; do
+            echo "  Checking branch: $TRY_BRANCH"
+
+            while IFS= read -r run_id; do
+              [ -z "$run_id" ] && continue
+              count=$(gh api "repos/$REPO/actions/runs/$run_id/artifacts?per_page=50" \
+                --jq "[.artifacts[] | select(.name == \"$ARTIFACT_NAME\" and .expired == false)] | length" \
+                2>/dev/null || echo "0")
+              if [ "$count" -ge 1 ]; then
+                RUN_ID="$run_id"
+                echo "  ✅ Found artifact in run $run_id on branch '$TRY_BRANCH'"
+                break
+              fi
+            done < <(gh api "repos/$REPO/actions/workflows/$WORKFLOW/runs?branch=$TRY_BRANCH&status=success&per_page=10" \
+              --jq '.workflow_runs[].id' 2>/dev/null | head -5 || echo "")
+
+            [ -n "$RUN_ID" ] && break
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "❌ No suitable iOS App artifact found in recent successful runs"
+            exit 1
+          fi
+
+          echo "⬇️ Downloading $ARTIFACT_NAME from run $RUN_ID..."
+          artifact_url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=50" \
+            --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\") | .archive_download_url")
+
+          curl -sL -H "Authorization: Bearer $GH_TOKEN" "$artifact_url" -o artifact.zip
+          mkdir -p re-upload/app
+          unzip -o artifact.zip -d re-upload/app/
+          rm artifact.zip
+          echo "✅ iOS artifact downloaded ($(ls re-upload/app/ | wc -l) top-level entries)"
+
+      - name: Re-upload iOS App
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-e2e-MetaMask.app
+          path: re-upload/app/
+          retention-days: 7
+
   ios-tests-ready:
     name: 'iOS Tests Ready'
     runs-on: ubuntu-latest
-    # [CI-DEV] Removed ios_changed gate — re-enable before merging
-    if: ${{ github.event_name != 'merge_group' }}
-    needs: [needs_e2e_build, build-ios-apps, smart-e2e-selection]
+    # [CI-DEV] Gate updated: waits for either build-ios-apps or provide-ios-artifact.
+    if: >-
+      ${{
+        github.event_name != 'merge_group' &&
+        !cancelled() &&
+        (needs.build-ios-apps.result == 'success' || needs.provide-ios-artifact.result == 'success')
+      }}
+    needs: [needs_e2e_build, build-ios-apps, provide-ios-artifact, smart-e2e-selection]
     steps:
       - name: iOS build complete
         run: echo "Dummy step to better visualize the Android and iOS E2E tests in Github workflow graph"
 
   e2e-smoke-tests-ios:
     name: 'iOS E2E Smoke Tests'
-    # [CI-DEV] Removed ios_changed gate and hardcoded CiSanityCheck tag — re-enable before merging
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    # [CI-DEV] Hardcoded CiSanityCheck tag — re-enable smart selection before merging.
+    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && !cancelled() }}
     permissions:
       contents: read
       id-token: write
@@ -797,6 +968,10 @@ jobs:
       - check-skip-merge-queue
       - all-jobs-pass
       - needs_e2e_build
+      - build-android-apks
+      - provide-android-artifact
+      - build-ios-apps
+      - provide-ios-artifact
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   check-diff:
     name: Check diff
     runs-on: macos-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     steps:
@@ -81,7 +81,7 @@ jobs:
   dedupe:
     name: Dedupe
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     steps:
@@ -117,7 +117,7 @@ jobs:
   git-safe-dependencies:
     name: Run `@lavamoat/git-safe-dependencies`
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     steps:
@@ -146,7 +146,7 @@ jobs:
   scripts:
     name: Run `${{ matrix.scripts }}`
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     strategy:
@@ -189,7 +189,7 @@ jobs:
   js-bundle-size-check:
     name: JS bundle size check
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     steps:
@@ -227,7 +227,7 @@ jobs:
     name: Ship JS bundle size check
     runs-on: ubuntu-latest
     needs: [js-bundle-size-check]
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     steps:
       - uses: actions/checkout@v4
 
@@ -246,7 +246,7 @@ jobs:
   check-workflows:
     name: Check workflows
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     steps:
@@ -262,7 +262,7 @@ jobs:
   unit-tests:
     name: Unit tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     strategy:
@@ -318,7 +318,7 @@ jobs:
   merge-unit-and-component-view-tests:
     runs-on: ubuntu-latest
     needs: [unit-tests, component-view-tests]
-    if: ${{ !cancelled() && github.event_name != 'merge_group' }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -425,7 +425,7 @@ jobs:
   component-view-tests:
     name: Component view tests
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-skip-merge-queue
     strategy:
@@ -516,12 +516,14 @@ jobs:
 
   build-android-apks:
     name: 'Build Android APKs'
+    # [CI-DEV] Removed android_changed gate — build always runs and reuses cached APK
+    # when no build-impacting files changed (see scripts/e2e-build-config.json for the file list).
+    # The fingerprint cache in build-android-e2e.yml handles restoration from this PR's cache
+    # or falls back to main's cache, avoiding a full rebuild when nothing relevant changed.
     if: >-
       ${{
         github.event_name != 'merge_group' &&
-        !github.event.pull_request.head.repo.fork &&
-        (needs.needs_e2e_build.outputs.android_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') &&
-        !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 80 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
+        !github.event.pull_request.head.repo.fork
       }}
     permissions:
       contents: read
@@ -536,7 +538,8 @@ jobs:
 
   e2e-smoke-tests-android:
     name: 'Android E2E Smoke Tests'
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.android_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    # [CI-DEV] Removed android_changed gate and hardcoded CiSanityCheck tag — re-enable before merging
+    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       id-token: write
@@ -544,21 +547,17 @@ jobs:
     uses: ./.github/workflows/run-e2e-smoke-tests-android.yml
     with:
       changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
-      selected_tags: >-
-        ${{
-          (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 80 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags) ||
-          '["ALL"]'
-        }}
+      selected_tags: '["CiSanityCheck"]'
     secrets: inherit
 
   build-ios-apps:
     name: 'Build iOS Apps'
+    # [CI-DEV] Removed ios_changed gate — build always runs and reuses cached .app
+    # when no build-impacting files changed (see scripts/e2e-build-config.json).
     if: >-
       ${{
         github.event_name != 'merge_group' &&
-        !github.event.pull_request.head.repo.fork &&
-        (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') &&
-        !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 80 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
+        !github.event.pull_request.head.repo.fork
       }}
     permissions:
       contents: read
@@ -570,7 +569,8 @@ jobs:
   ios-tests-ready:
     name: 'iOS Tests Ready'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    # [CI-DEV] Removed ios_changed gate — re-enable before merging
+    if: ${{ github.event_name != 'merge_group' }}
     needs: [needs_e2e_build, build-ios-apps, smart-e2e-selection]
     steps:
       - name: iOS build complete
@@ -578,7 +578,8 @@ jobs:
 
   e2e-smoke-tests-ios:
     name: 'iOS E2E Smoke Tests'
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    # [CI-DEV] Removed ios_changed gate and hardcoded CiSanityCheck tag — re-enable before merging
+    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       id-token: write
@@ -586,18 +587,14 @@ jobs:
     uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
     with:
       changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
-      selected_tags: >-
-        ${{
-          (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 80 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags) ||
-          '["ALL"]'
-        }}
+      selected_tags: '["CiSanityCheck"]'
     secrets: inherit
 
   # Flask E2E tests
 
   e2e-smoke-tests-android-flask:
     name: 'Android Flask E2E Smoke Tests'
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.android_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     permissions:
       contents: read
       id-token: write
@@ -614,7 +611,7 @@ jobs:
 
   e2e-smoke-tests-ios-flask:
     name: 'iOS Flask E2E Smoke Tests'
-    if: ${{ github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     permissions:
       contents: read
       id-token: write
@@ -632,7 +629,7 @@ jobs:
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && (needs.needs_e2e_build.outputs.ios_changed == 'true' || needs.smart-e2e-selection.outputs.force_run == 'true') }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     permissions:
       contents: read
       id-token: write
@@ -651,7 +648,7 @@ jobs:
   report-fixture-validation:
     name: 'Report Fixture Validation'
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs: [validate-e2e-fixtures]
     permissions:
       pull-requests: write
@@ -679,7 +676,7 @@ jobs:
     name: SonarCloud analysis
     runs-on: ubuntu-latest
     needs: merge-unit-and-component-view-tests
-    if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     steps:
       - uses: actions/checkout@v3
         with:
@@ -724,7 +721,7 @@ jobs:
     name: SonarCloud quality gate status
     runs-on: ubuntu-latest
     needs: sonar-cloud
-    if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -778,61 +775,21 @@ jobs:
           fi
 
   all-jobs-pass:
+    # [CI-DEV] Simplified — most non-e2e jobs are disabled for pipeline testing.
+    # Re-enable the full needs list and logic before merging.
     name: All jobs pass
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
-    needs:
-      [
-        check-diff,
-        dedupe,
-        scripts,
-        unit-tests,
-        component-view-tests,
-        check-workflows,
-        js-bundle-size-check,
-        sonar-cloud-quality-gate-status,
-      ]
     outputs:
       ALL_JOBS_PASSED: ${{ steps.jobs-passed-status.outputs.ALL_JOBS_PASSED }}
     steps:
       - name: Set jobs passed status
         id: jobs-passed-status
-        env:
-          NEEDS_CONTEXT: ${{ toJSON(needs) }}
-          EVENT_NAME: ${{ github.event_name }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          # Check results of all required jobs dynamically
-          # On merge_group events, "skipped" is acceptable (some jobs intentionally skip)
-          # On fork PRs, "skipped" is acceptable (secret-dependent jobs are intentionally skipped)
-          # On other events (push to main), all jobs must succeed
-
-          FAILED="false"
-
-          while read -r job_name result; do
-            if [[ "$result" == "failure" ]] || [[ "$result" == "cancelled" ]]; then
-              echo "::error::Job '$job_name' failed with result: $result"
-              FAILED="true"
-            elif [[ "$result" == "skipped" ]]; then
-              if [[ "$EVENT_NAME" == "merge_group" ]] || [[ "$IS_FORK" == "true" ]]; then
-                echo "Job '$job_name' was skipped (OK for merge_group events and fork PRs)"
-              else
-                echo "::error::Job '$job_name' was unexpectedly skipped on $EVENT_NAME event"
-                FAILED="true"
-              fi
-            else
-              echo "Job '$job_name' passed"
-            fi
-          done < <(echo "$NEEDS_CONTEXT" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
-
-          if [[ "$FAILED" == "true" ]]; then
-            echo "Some required jobs failed"
-            exit 1
-          fi
-
           echo "ALL_JOBS_PASSED=true" >> "$GITHUB_OUTPUT"
 
   check-all-jobs-pass:
+    # [CI-DEV] Flask tests removed from needs/checks — re-enable before merging.
     name: Check all jobs pass
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -842,8 +799,6 @@ jobs:
       - needs_e2e_build
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
-      - e2e-smoke-tests-android-flask
-      - e2e-smoke-tests-ios-flask
     env:
       SKIPPED: ${{ needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
     steps:
@@ -860,34 +815,17 @@ jobs:
             exit 1
           fi
 
-          # Check E2E jobs only if they should have run
-          if [[ "${{ needs.needs_e2e_build.outputs.builds }}" == "true" ]]; then
-            # Accept both 'success' and 'skipped' as valid results
-            # 'skipped' occurs during merge_group events or when jobs are intentionally skipped
-            # Only fail on 'failure' or 'cancelled'
-            ANDROID_RESULT="${{ needs.e2e-smoke-tests-android.result }}"
-            if [[ "$ANDROID_RESULT" == "failure" ]] || [[ "$ANDROID_RESULT" == "cancelled" ]]; then
-              echo "Android E2E tests failed (result: $ANDROID_RESULT)"
-              exit 1
-            fi
+          # [CI-DEV] Always check E2E results (android_changed gate removed)
+          ANDROID_RESULT="${{ needs.e2e-smoke-tests-android.result }}"
+          if [[ "$ANDROID_RESULT" == "failure" ]] || [[ "$ANDROID_RESULT" == "cancelled" ]]; then
+            echo "Android E2E tests failed (result: $ANDROID_RESULT)"
+            exit 1
+          fi
 
-            IOS_RESULT="${{ needs.e2e-smoke-tests-ios.result }}"
-            if [[ "$IOS_RESULT" == "failure" ]] || [[ "$IOS_RESULT" == "cancelled" ]]; then
-              echo "iOS E2E tests failed (result: $IOS_RESULT)"
-              exit 1
-            fi
-
-            ANDROID_FLASK_RESULT="${{ needs.e2e-smoke-tests-android-flask.result }}"
-            if [[ "$ANDROID_FLASK_RESULT" == "failure" ]] || [[ "$ANDROID_FLASK_RESULT" == "cancelled" ]]; then
-              echo "Android Flask E2E tests failed (result: $ANDROID_FLASK_RESULT)"
-              exit 1
-            fi
-
-            IOS_FLASK_RESULT="${{ needs.e2e-smoke-tests-ios-flask.result }}"
-            if [[ "$IOS_FLASK_RESULT" == "failure" ]] || [[ "$IOS_FLASK_RESULT" == "cancelled" ]]; then
-              echo "iOS Flask E2E tests failed (result: $IOS_FLASK_RESULT)"
-              exit 1
-            fi
+          IOS_RESULT="${{ needs.e2e-smoke-tests-ios.result }}"
+          if [[ "$IOS_RESULT" == "failure" ]] || [[ "$IOS_RESULT" == "cancelled" ]]; then
+            echo "iOS E2E tests failed (result: $IOS_RESULT)"
+            exit 1
           fi
 
           echo "All required jobs passed"
@@ -895,8 +833,7 @@ jobs:
   log-merge-group-failure:
     name: Log merge group failure
     runs-on: ubuntu-latest
-    # Only run this job if the merge group event fails, skip on forks
-    if: ${{ github.event_name == 'merge_group' && failure() }}
+    if: false # [CI-DEV] Disabled for e2e pipeline testing — re-enable before merging
     needs:
       - check-all-jobs-pass
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      checks: write
+      pull-requests: write
     needs: [needs_e2e_build, build-android-apks, provide-android-artifact, smart-e2e-selection]
     uses: ./.github/workflows/run-e2e-smoke-tests-android.yml
     with:
@@ -767,6 +769,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      checks: write
+      pull-requests: write
     needs: [needs_e2e_build, ios-tests-ready, smart-e2e-selection]
     uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
     with:

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -98,7 +98,6 @@ jobs:
               - 'babel.config.js'                  # Transpilation affects both
               - 'yarn.lock'                        # Dependency changes affect both
               - 'app/**'                           # Shared app files
-              - 'tests/**'                         # E2E test files (separate from mobile builds)
               - 'sentry*.properties*'              # Sentry configs
               - 'appwright/**'                     # Appwright test files
               - 'scripts/build.sh'                 # Build script changes
@@ -112,6 +111,7 @@ jobs:
               - 'docs/**'                          # Documentation directory
               - '**/*.yml'                         # Workflow files
               - '.github/**'                       # All .github files (workflows, scripts, actions — CI-only changes don't affect native builds)
+              - 'tests/**'                         # E2E test specs — run against the built app, don't require native rebuilds
               - 'LICENSE'                          # License file
               - 'README.md'                        # Main README
               - 'RELEASE.MD'                       # Release notes

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -70,7 +70,9 @@ jobs:
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
-          # Path filtering logic:
+          # Path filtering logic — mirrors scripts/e2e-build-config.json (authoritative reference).
+          # Keep both files in sync when adding/removing patterns.
+          #
           # - android: Files that require Android builds only
           # - ios: Files that require iOS builds only
           # - shared: Files that require both Android and iOS builds

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -105,15 +105,13 @@ jobs:
               - 'scripts/setup.mjs'                # Setup script changes
               - 'patches/**'                       # Legacy patch changes
               - '.yarn/patches/**'                 # Yarn patch changes
-              - '.github/workflows/**'             # GitHub workflow changes
-              - '.github/scripts/**'               # GitHub workflow script changes
               - 'react-native.config.js'           # React Native config changes
 
             ignore:
               - '**/*.md'                          # Documentation files
               - 'docs/**'                          # Documentation directory
               - '**/*.yml'                         # Workflow files
-              - '.github/**'                       # GitHub rest of .github directory changes
+              - '.github/**'                       # All .github files (workflows, scripts, actions — CI-only changes don't affect native builds)
               - 'LICENSE'                          # License file
               - 'README.md'                        # Main README
               - 'RELEASE.MD'                       # Release notes

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -246,6 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() && inputs.selected_tags != '[]' && inputs.selected_tags != '["FlaskBuildTests"]' }}
     needs:
+      - ci-sanity-check-android
       - trade-android-smoke
       - perps-android-smoke
       - wallet-platform-android-smoke

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -19,6 +19,20 @@ permissions:
   id-token: write
 
 jobs:
+  # CI pipeline sanity check — runs a single minimal navigation test.
+  # Only triggered when selected_tags contains 'CiSanityCheck'.
+  ci-sanity-check-android:
+    if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'CiSanityCheck')
+    uses: ./.github/workflows/run-e2e-workflow.yml
+    with:
+      test-suite-name: ci-sanity-check-android
+      platform: android
+      test_suite_tag: 'CiSanityCheck:'
+      split_number: 1
+      total_splits: 1
+      changed_files: ${{ inputs.changed_files }}
+    secrets: inherit
+
   trade-android-smoke:
     if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'SmokeTrade')
     strategy:

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       test-suite-name: ci-sanity-check-android
       platform: android
-      test_suite_tag: 'CiSanityCheck:'
+      test_suite_tag: 'CiSanityCheck'
       split_number: 1
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -274,6 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() && inputs.selected_tags != '[]' && inputs.selected_tags != '["FlaskBuildTests"]' }}
     needs:
+      - ci-sanity-check-ios
       - confirmations-ios-smoke
       - trade-ios-smoke
       - perps-ios-smoke

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -19,6 +19,22 @@ permissions:
   id-token: write
 
 jobs:
+  # CI pipeline sanity check — runs a single minimal navigation test.
+  # Only triggered when selected_tags contains 'CiSanityCheck'.
+  ci-sanity-check-ios:
+    if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'CiSanityCheck')
+    uses: ./.github/workflows/run-e2e-workflow.yml
+    with:
+      test-suite-name: ci-sanity-check-ios
+      platform: ios
+      test_suite_tag: 'CiSanityCheck:'
+      split_number: 1
+      total_splits: 1
+      changed_files: ${{ inputs.changed_files }}
+      build_type: 'main'
+      metamask_environment: 'qa'
+    secrets: inherit
+
   confirmations-ios-smoke:
     if: contains(fromJson(inputs.selected_tags), 'ALL') || contains(fromJson(inputs.selected_tags), 'SmokeConfirmations')
     strategy:

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       test-suite-name: ci-sanity-check-ios
       platform: ios
-      test_suite_tag: 'CiSanityCheck:'
+      test_suite_tag: 'CiSanityCheck'
       split_number: 1
       total_splits: 1
       changed_files: ${{ inputs.changed_files }}

--- a/scripts/e2e-build-config.json
+++ b/scripts/e2e-build-config.json
@@ -20,8 +20,6 @@
     "scripts/setup.mjs",
     "patches/**",
     ".yarn/patches/**",
-    ".github/workflows/**",
-    ".github/scripts/**",
     "react-native.config.js"
   ],
   "ignore": [

--- a/scripts/e2e-build-config.json
+++ b/scripts/e2e-build-config.json
@@ -13,7 +13,6 @@
     "babel.config.js",
     "yarn.lock",
     "app/**",
-    "tests/**",
     "sentry*.properties*",
     "appwright/**",
     "scripts/build.sh",

--- a/scripts/e2e-build-config.json
+++ b/scripts/e2e-build-config.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "Authoritative list of file patterns that trigger E2E build creation. If a push only touches files NOT in android/ios/shared below (or matches ignore), the CI will reuse the latest cached build from the PR branch or main instead of building fresh. Keep this in sync with the filters in .github/workflows/needs-e2e-build.yml.",
+  "android": [
+    "android/**"
+  ],
+  "ios": [
+    "ios/**"
+  ],
+  "shared": [
+    "package.json",
+    "metro.config.js",
+    "tsconfig.json",
+    "babel.config.js",
+    "yarn.lock",
+    "app/**",
+    "tests/**",
+    "sentry*.properties*",
+    "appwright/**",
+    "scripts/build.sh",
+    "scripts/setup.mjs",
+    "patches/**",
+    ".yarn/patches/**",
+    ".github/workflows/**",
+    ".github/scripts/**",
+    "react-native.config.js"
+  ],
+  "ignore": [
+    "**/*.md",
+    "docs/**",
+    "**/*.yml",
+    ".github/**",
+    "LICENSE",
+    "README.md",
+    "RELEASE.MD",
+    "CHANGELOG.md",
+    "attribution.txt",
+    "*.svg",
+    "*.png",
+    "codecov.yml",
+    "crowdin.yml",
+    "bitrise.yml",
+    "sonar-project.properties",
+    "scripts/*",
+    "scripts/*/**"
+  ]
+}

--- a/tests/smoke/wallet/ci-sanity-check.spec.ts
+++ b/tests/smoke/wallet/ci-sanity-check.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * CI Sanity Check — minimal navigation test.
+ *
+ * Purpose: verify that the app starts, logs in, and renders the Wallet view.
+ * This test is intentionally trivial; it is only used to validate the CI
+ * pipeline itself (build, download, device-boot) and is NOT a feature test.
+ *
+ * Tag: CiSanityCheck
+ * To revert: delete this file and remove the CiSanityCheck tag/job entries.
+ */
+import { CiSanityCheck } from '../../tags';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import WalletView from '../../page-objects/wallet/WalletView';
+import { loginToApp } from '../../flows/wallet.flow';
+import Assertions from '../../framework/Assertions';
+
+describe(CiSanityCheck('App navigation sanity check'), () => {
+  it('should open the app and show the Wallet view', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+        await Assertions.expectElementToBeVisible(WalletView.container);
+      },
+    );
+  });
+});

--- a/tests/tags.js
+++ b/tests/tags.js
@@ -146,6 +146,8 @@ const FlaskBuildTests = (testName) =>
 const SmokePerformance = (testName) => `${otherTags.performance} ${testName}`;
 const FixtureValidation = (testName) =>
   `${otherTags.fixtureValidation} ${testName}`;
+// CI sanity check — minimal navigation test used when validating the CI pipeline itself
+const CiSanityCheck = (testName) => `CiSanityCheck: ${testName}`;
 
 export {
   smokeTags,
@@ -176,4 +178,5 @@ export {
   FlaskBuildTests,
   SmokePerformance,
   FixtureValidation,
+  CiSanityCheck,
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


## Summary

> ⚠️ **[CI-DEV] Temporary branch — all `[CI-DEV]` changes must be reverted before merging to main.**
> This PR exists solely to validate the E2E CI pipeline in isolation (build reuse, device boot, test execution) without the cost of the full CI suite on every push.

- **Disable non-e2e CI jobs** — lint, unit tests, component view tests, SonarCloud, bundle size check, dedupe, `check-diff`, workflow validation, and fixture validation are all gated with `if: false` so only the e2e pipeline runs on push
- **Remove build gates** — the `android_changed` / `ios_changed` conditions that previously caused the build job to be skipped entirely are removed. The build job now always runs for non-fork PRs; the existing fingerprint cache in `build-android-e2e.yml` reuses the latest cached APK from the PR branch (or falls back to main) when no build-impacting files changed — so no full rebuild happens unless it's actually needed
- **Add `scripts/e2e-build-config.json`** — single authoritative reference listing every file pattern that triggers a new native build. Referenced from `needs-e2e-build.yml` and intended as the long-term home for this config
- **Single minimal e2e test** — new `CiSanityCheck` tag with `tests/smoke/wallet/ci-sanity-check.spec.ts`: boots the app, logs in, and asserts the Wallet view is visible. This is the only test that runs on this branch (`selected_tags` hardcoded to `["CiSanityCheck"]`)
- **Disable Flask, fixture-validation, and merge-group-logger jobs** for the same reason as above
- **Simplify `all-jobs-pass` / `check-all-jobs-pass`** to only depend on jobs that are actually active

## Test plan

- [ ] Push a commit that only changes a non-build-impacting file (e.g. a `*.md` or this PR description) and confirm the build job **restores from cache** rather than building from scratch
- [ ] Confirm the `ci-sanity-check-android` and `ci-sanity-check-ios` jobs run and pass
- [ ] Confirm all other jobs (`lint`, `unit-tests`, etc.) are correctly skipped
- [ ] Confirm `check-all-jobs-pass` is green

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Disable non-e2e jobs; remove build gates; hardcode `CiSanityCheck` tag |
| `.github/workflows/needs-e2e-build.yml` | Add reference comment to `e2e-build-config.json` |
| `.github/workflows/run-e2e-smoke-tests-android.yml` | Add `ci-sanity-check-android` job |
| `.github/workflows/run-e2e-smoke-tests-ios.yml` | Add `ci-sanity-check-ios` job |
| `scripts/e2e-build-config.json` | ✨ New — authoritative list of build-impacting file patterns |
| `tests/tags.js` | Add `CiSanityCheck` tag export |
| `tests/smoke/wallet/ci-sanity-check.spec.ts` | ✨ New — minimal navigation smoke test |

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
