### PR TITLE
style(MUSD-629): green check icons and muted background for stablecoin feature tags

### DIFF
--- a/app/components/UI/Money/components/MoneyConvertStablecoins/MoneyConvertStablecoins.tsx
+++ b/app/components/UI/Money/components/MoneyConvertStablecoins/MoneyConvertStablecoins.tsx
@@ -24,6 +24,7 @@ import AvatarGroup from '../../../../../component-library/components/Avatars/Ava
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import { AvatarVariant } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
 import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
 import { buildTokenIconUrl } from '../../../Card/util/buildTokenIconUrl';
 import ConvertTokenRow from '../../../Earn/components/Musd/ConvertTokenRow';
 import { AssetType } from '../../../../Views/confirmations/types/token';
@@ -67,34 +68,43 @@ const STABLECOIN_AVATAR_PROPS = [
   },
 ];
 
-const FeatureTags = () => (
-  <Box
-    flexDirection={BoxFlexDirection.Row}
-    twClassName="flex-wrap gap-2 mt-4"
-    testID={MoneyConvertStablecoinsTestIds.FEATURE_TAGS}
-  >
-    {FEATURE_TAGS.map((tag) => (
-      <TagBase
-        key={tag}
-        shape={TagShape.Rectangle}
-        severity={TagSeverity.Neutral}
-        gap={4}
-        startAccessory={
-          <Icon
-            name={IconName.CheckBold}
-            size={IconSize.Sm}
-            color={IconColor.IconAlternative}
-          />
-        }
-        textProps={{
-          variant: ComponentTextVariant.BodySMMedium,
-        }}
-      >
-        {strings(tag)}
-      </TagBase>
-    ))}
-  </Box>
-);
+const FeatureTags = () => {
+  const { themeAppearance } = useTheme();
+  const tagBackgroundColor =
+    themeAppearance === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.04)';
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      twClassName="flex-wrap gap-2 mt-4"
+      testID={MoneyConvertStablecoinsTestIds.FEATURE_TAGS}
+    >
+      {FEATURE_TAGS.map((tag) => (
+        <TagBase
+          key={tag}
+          style={{ backgroundColor: tagBackgroundColor }}
+          shape={TagShape.Rectangle}
+          severity={TagSeverity.Neutral}
+          gap={4}
+          startAccessory={
+            <Icon
+              name={IconName.CheckBold}
+              size={IconSize.Sm}
+              color={IconColor.SuccessDefault}
+            />
+          }
+          textProps={{
+            variant: ComponentTextVariant.BodySMMedium,
+          }}
+        >
+          {strings(tag)}
+        </TagBase>
+      ))}
+    </Box>
+  );
+};
 
 const Description = () => (
   <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Convert your stablecoins" card on the Money screen had two visual issues compared to the design:

1. The check icons next to each feature tag (No lockups, No deposits, Daily payouts, Automatic bonus, No MetaMask fee) rendered in `IconColor.IconAlternative` (grey) instead of the success-green tone that matches the "3% annualized bonus" highlight in the description.
2. The tag background used `TagSeverity.Neutral`, which resolves to `theme.colors.background.alternative`. In dark mode this came out almost indistinguishable from the surrounding card surface.

The fix is scoped to the local usage of `TagBase` inside `MoneyConvertStablecoins` so it cannot regress any other consumer of `TagBase`:

- Check icons now use `IconColor.SuccessDefault`, matching the success-green token already used by the description's bonus highlight.
- The tag background is overridden via the `style` prop to a 4% white tint in dark mode (`rgba(255, 255, 255, 0.04)`) and a symmetric 4% black tint in light mode (`rgba(0, 0, 0, 0.04)`). `TagBase` merges the per-instance `style` prop after the severity-derived background, so neutral tags elsewhere in the app are unaffected. Only `backgroundColor` is touched (not `opacity`), so the icons and text inside the tag stay fully opaque.
- `useTheme()` reads `themeAppearance` so the override stays correct in both light and dark themes without hardcoding a single value.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Convert Stablecoins card so the feature tag check icons render in green and the tag background uses a subtle muted tint that matches the design.

## **Related issues**

Fixes: MUSD-629

## **Manual testing steps**

```gherkin
Feature: Convert Stablecoins feature tags styling

  Scenario: User views the Convert Stablecoins card in dark mode
    Given the app is set to dark theme
    And the user has no convertible stablecoin balance

    When the user opens the Money screen
    Then the "Convert your stablecoins" card is visible
    And each feature tag (No lockups, No deposits, Daily payouts, Automatic bonus, No MetaMask fee) shows a green check icon
    And each feature tag background is a subtle white tint, clearly distinguishable from the card surface
    And the tag label text remains fully opaque and legible

  Scenario: User views the Convert Stablecoins card in light mode
    Given the app is set to light theme

    When the user opens the Money screen
    Then each feature tag shows a green check icon
    And each feature tag background uses a subtle dark tint that remains distinguishable from the surrounding surface
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-10 at 12 08 28" src="https://github.com/user-attachments/assets/bdb68704-7a90-4e16-8a85-09636fd000d4" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change scoped to `MoneyConvertStablecoins` feature tags, adjusting icon and background colors without altering business logic or data flow.
> 
> **Overview**
> Updates the Money screen’s `MoneyConvertStablecoins` feature tags to better match design in both themes.
> 
> The checkmark icon color is changed to `IconColor.SuccessDefault`, and the tag background is overridden with a subtle theme-aware tint via `useTheme()` (light: `rgba(0, 0, 0, 0.04)`, dark: `rgba(255, 255, 255, 0.04)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a7b9ff88eba89463137d774e01d954c1bf4687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->