### PR TITLE
fix: show perps withdraw transactions in Perps activity Deposits tab

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.test.ts
@@ -11,6 +11,8 @@ import {
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
+  transformWithdrawalRequestsToTransactions,
+  walletPerpsWithdrawalsToRequests,
   mergeOrderFills,
 } from '../utils/transactionTransforms';
 import { FillType } from '../types/transactionHistory';
@@ -53,6 +55,14 @@ const mockTransformUserHistoryToTransactions =
 const mockTransformWalletPerpsDepositsToTransactions =
   transformWalletPerpsDepositsToTransactions as jest.MockedFunction<
     typeof transformWalletPerpsDepositsToTransactions
+  >;
+const mockTransformWithdrawalRequestsToTransactions =
+  transformWithdrawalRequestsToTransactions as jest.MockedFunction<
+    typeof transformWithdrawalRequestsToTransactions
+  >;
+const mockWalletPerpsWithdrawalsToRequests =
+  walletPerpsWithdrawalsToRequests as jest.MockedFunction<
+    typeof walletPerpsWithdrawalsToRequests
   >;
 const mockMergeOrderFills = mergeOrderFills as jest.MockedFunction<
   typeof mergeOrderFills
@@ -213,6 +223,8 @@ describe('usePerpsTransactionHistory', () => {
     mockTransformFundingToTransactions.mockReturnValue([]);
     mockTransformUserHistoryToTransactions.mockReturnValue([]);
     mockTransformWalletPerpsDepositsToTransactions.mockReturnValue([]);
+    mockWalletPerpsWithdrawalsToRequests.mockReturnValue([]);
+    mockTransformWithdrawalRequestsToTransactions.mockReturnValue([]);
     // Use real mergeOrderFills so dedup, sort, and detailedOrderType preservation
     // are exercised correctly in hook-level tests. Unit tests for the function
     // itself live in transactionTransforms.test.ts.
@@ -380,6 +392,157 @@ describe('usePerpsTransactionHistory', () => {
       );
       expect(depositsWithSameTxHash).toHaveLength(1);
       expect(depositsWithSameTxHash[0].id).toBe('deposit-rest-1');
+    });
+
+    it('includes wallet perps withdrawals in merged transactions', async () => {
+      mockTransformFillsToTransactions.mockReturnValue([]);
+      mockTransformUserHistoryToTransactions.mockReturnValue([]);
+      const walletWithdrawalTx = {
+        id: 'wallet-withdrawal-tx-1',
+        type: 'withdrawal' as const,
+        category: 'withdrawal' as const,
+        title: 'Withdrew 0.26 USDC',
+        subtitle: 'Completed',
+        timestamp: 1640995204000,
+        asset: 'USDC',
+        depositWithdrawal: {
+          amount: '-$0.26',
+          amountNumber: -0.26,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: '0xwithdraw1',
+          status: 'completed' as const,
+          type: 'withdrawal' as const,
+        },
+      };
+      mockWalletPerpsWithdrawalsToRequests.mockReturnValue([
+        {
+          id: 'wallet-w1',
+          timestamp: 1640995204000,
+          amount: '0.26',
+          asset: 'USDC',
+          txHash: '0xwithdraw1',
+          status: 'completed',
+        },
+      ]);
+      mockTransformWithdrawalRequestsToTransactions.mockReturnValue([
+        walletWithdrawalTx,
+      ]);
+      const selectedAddr = '0x1234567890123456789012345678901234567890';
+      mockUseSelector.mockImplementation(() => {
+        const len = mockUseSelector.mock.calls.length;
+        return len % 2 === 1
+          ? [
+              {
+                id: 'w1',
+                type: 'perpsWithdraw',
+                txParams: { from: selectedAddr },
+                nestedTransactions: [{ type: 'perpsWithdraw' }],
+              },
+            ]
+          : selectedAddr;
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.transactions).toContainEqual(walletWithdrawalTx);
+      expect(mockWalletPerpsWithdrawalsToRequests).toHaveBeenCalled();
+      expect(mockTransformWithdrawalRequestsToTransactions).toHaveBeenCalled();
+    });
+
+    it('deduplicates wallet withdrawals against REST withdrawals by txHash', async () => {
+      const sameTxHash = '0xwithdraw123';
+      const restWithdrawal = {
+        id: 'withdrawal-rest-1',
+        type: 'withdrawal' as const,
+        category: 'withdrawal' as const,
+        title: 'Withdrew 0.50 USDC',
+        subtitle: 'Completed',
+        timestamp: 1640995200000,
+        asset: 'USDC',
+        depositWithdrawal: {
+          amount: '-$0.50',
+          amountNumber: -0.5,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: sameTxHash,
+          status: 'completed' as const,
+          type: 'withdrawal' as const,
+        },
+      };
+      const walletWithdrawalSameTx = {
+        id: 'wallet-withdrawal-tx-1',
+        type: 'withdrawal' as const,
+        category: 'withdrawal' as const,
+        title: 'Withdrew 0.50 USDC',
+        subtitle: 'Pending',
+        timestamp: 1640995201000,
+        asset: 'USDC',
+        depositWithdrawal: {
+          amount: '-$0.50',
+          amountNumber: -0.5,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: sameTxHash,
+          status: 'pending' as const,
+          type: 'withdrawal' as const,
+        },
+      };
+      mockTransformFillsToTransactions.mockReturnValue([]);
+      mockTransformUserHistoryToTransactions.mockReturnValue([restWithdrawal]);
+      mockWalletPerpsWithdrawalsToRequests.mockReturnValue([
+        {
+          id: 'wallet-w1',
+          timestamp: 1640995201000,
+          amount: '0.50',
+          asset: 'USDC',
+          txHash: sameTxHash,
+          status: 'pending',
+        },
+      ]);
+      mockTransformWithdrawalRequestsToTransactions.mockReturnValue([
+        walletWithdrawalSameTx,
+      ]);
+      const selectedAddr = '0x1234567890123456789012345678901234567890';
+      mockUseSelector.mockImplementation(() => {
+        const len = mockUseSelector.mock.calls.length;
+        return len % 2 === 1
+          ? [
+              {
+                id: 'w1',
+                type: 'perpsWithdraw',
+                txParams: { from: selectedAddr },
+                nestedTransactions: [{ type: 'perpsWithdraw' }],
+              },
+            ]
+          : selectedAddr;
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: false }),
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      const withdrawalsWithSameTxHash = result.current.transactions.filter(
+        (tx) =>
+          tx.type === 'withdrawal' &&
+          tx.depositWithdrawal?.txHash?.toLowerCase() ===
+            sameTxHash.toLowerCase(),
+      );
+      expect(withdrawalsWithSameTxHash).toHaveLength(1);
+      expect(withdrawalsWithSameTxHash[0].id).toBe('withdrawal-rest-1');
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -13,7 +13,10 @@ import type { CaipAccountId } from '@metamask/utils';
 import { areAddressesEqual } from '../../../../util/address';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
-import { PerpsTransaction } from '../types/transactionHistory';
+import {
+  PerpsTransaction,
+  PerpsTransactionType,
+} from '../types/transactionHistory';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream/usePerpsLiveFills';
@@ -33,8 +36,9 @@ function deduplicateByTxHash(
   restHashes: Set<string>,
 ) {
   return walletTxs.filter((tx) => {
-    const h = tx.depositWithdrawal?.txHash?.toLowerCase?.()?.trim() ?? '';
-    return h === '' || !restHashes.has(h);
+    const walletTxHash =
+      tx.depositWithdrawal?.txHash?.toLowerCase?.()?.trim() ?? '';
+    return walletTxHash === '' || !restHashes.has(walletTxHash);
   });
 }
 
@@ -285,7 +289,7 @@ export const usePerpsTransactionHistory = ({
 
     // Separate non-trade transactions (orders, funding, user history deposits)
     const nonTradeTransactions = transactions.filter(
-      (tx) => tx.type !== 'trade',
+      (tx) => tx.type !== PerpsTransactionType.Trade,
     );
 
     // Deduplicate wallet deposits/withdrawals against REST (user history) by txHash.
@@ -294,13 +298,13 @@ export const usePerpsTransactionHistory = ({
     const restDepositTxHashes = new Set<string>();
     const restWithdrawalTxHashes = new Set<string>();
     for (const tx of nonTradeTransactions) {
-      const h = tx.depositWithdrawal?.txHash?.trim();
-      if (!h) continue;
-      const normalized = h.toLowerCase();
-      if (tx.type === 'deposit') {
-        restDepositTxHashes.add(normalized);
-      } else if (tx.type === 'withdrawal') {
-        restWithdrawalTxHashes.add(normalized);
+      const restTxHash = tx.depositWithdrawal?.txHash?.trim();
+      if (!restTxHash) continue;
+      const normalizedHash = restTxHash.toLowerCase();
+      if (tx.type === PerpsTransactionType.Deposit) {
+        restDepositTxHashes.add(normalizedHash);
+      } else if (tx.type === PerpsTransactionType.Withdrawal) {
+        restWithdrawalTxHashes.add(normalizedHash);
       }
     }
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import usePrevious from '../../../hooks/usePrevious';
 import { BigNumber } from 'bignumber.js';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { OrderFill } from '@metamask/perps-controller';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
@@ -11,6 +14,7 @@ import { areAddressesEqual } from '../../../../util/address';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { PerpsTransaction } from '../types/transactionHistory';
+import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream/usePerpsLiveFills';
 import {
@@ -19,8 +23,20 @@ import {
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
   transformWalletPerpsDepositsToTransactions,
+  transformWithdrawalRequestsToTransactions,
+  walletPerpsWithdrawalsToRequests,
   mergeOrderFills,
 } from '../utils/transactionTransforms';
+
+function deduplicateByTxHash(
+  walletTxs: PerpsTransaction[],
+  restHashes: Set<string>,
+) {
+  return walletTxs.filter((tx) => {
+    const h = tx.depositWithdrawal?.txHash?.toLowerCase?.()?.trim() ?? '';
+    return h === '' || !restHashes.has(h);
+  });
+}
 
 interface UsePerpsTransactionHistoryParams {
   startTime?: number;
@@ -64,21 +80,47 @@ export const usePerpsTransactionHistory = ({
   // This ensures new trades appear immediately without waiting for REST refetch
   const { fills: liveFills } = usePerpsLiveFills({ throttleMs: 0 });
 
-  // Wallet perps deposits (TransactionType.perpsDeposit / perpsDepositAndOrder) for the Deposits tab
+  // Wallet perps deposits and withdrawals for the Deposits tab
   const walletTransactions = useSelector(selectNonReplacedTransactions);
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
-  const walletDepositTransactions = useMemo(() => {
-    const filtered = walletTransactions.filter(
-      (tx) =>
-        selectedAddress &&
-        areAddressesEqual(tx.txParams?.from ?? '', selectedAddress) &&
-        (tx.type === TransactionType.perpsDeposit ||
-          tx.type === TransactionType.perpsDepositAndOrder),
-    );
-    return transformWalletPerpsDepositsToTransactions(filtered);
-  }, [walletTransactions, selectedAddress]);
+  const { walletDepositTransactions, walletWithdrawalTransactions } =
+    useMemo(() => {
+      if (!selectedAddress) {
+        return {
+          walletDepositTransactions: [] as PerpsTransaction[],
+          walletWithdrawalTransactions: [] as PerpsTransaction[],
+        };
+      }
+
+      const deposits: TransactionMeta[] = [];
+      const withdrawals: TransactionMeta[] = [];
+
+      for (const tx of walletTransactions) {
+        if (!areAddressesEqual(tx.txParams?.from ?? '', selectedAddress)) {
+          continue;
+        }
+        if (
+          hasTransactionType(tx, [
+            TransactionType.perpsDeposit,
+            TransactionType.perpsDepositAndOrder,
+          ])
+        ) {
+          deposits.push(tx);
+        } else if (hasTransactionType(tx, [TransactionType.perpsWithdraw])) {
+          withdrawals.push(tx);
+        }
+      }
+
+      return {
+        walletDepositTransactions:
+          transformWalletPerpsDepositsToTransactions(deposits),
+        walletWithdrawalTransactions: transformWithdrawalRequestsToTransactions(
+          walletPerpsWithdrawalsToRequests(withdrawals),
+        ),
+      };
+    }, [walletTransactions, selectedAddress]);
 
   // Store userHistory in ref to avoid recreating fetchAllTransactions callback
   const userHistoryRef = useRef(userHistory);
@@ -246,33 +288,46 @@ export const usePerpsTransactionHistory = ({
       (tx) => tx.type !== 'trade',
     );
 
-    // Deduplicate wallet deposits against REST (user history) deposits by txHash.
-    // When a wallet-originated deposit is bridged and recorded by the perps backend,
+    // Deduplicate wallet deposits/withdrawals against REST (user history) by txHash.
+    // When a wallet-originated transaction is bridged and recorded by the perps backend,
     // it appears in both sources; we keep the REST version and drop the wallet duplicate.
-    const restDepositTxHashes = new Set(
-      nonTradeTransactions
-        .filter(
-          (tx) =>
-            tx.type === 'deposit' &&
-            tx.depositWithdrawal?.txHash?.trim() !== '',
-        )
-        .map((tx) => (tx.depositWithdrawal?.txHash ?? '').toLowerCase().trim()),
+    const restDepositTxHashes = new Set<string>();
+    const restWithdrawalTxHashes = new Set<string>();
+    for (const tx of nonTradeTransactions) {
+      const h = tx.depositWithdrawal?.txHash?.trim();
+      if (!h) continue;
+      const normalized = h.toLowerCase();
+      if (tx.type === 'deposit') {
+        restDepositTxHashes.add(normalized);
+      } else if (tx.type === 'withdrawal') {
+        restWithdrawalTxHashes.add(normalized);
+      }
+    }
+
+    const walletDepositsDeduplicated = deduplicateByTxHash(
+      walletDepositTransactions,
+      restDepositTxHashes,
     );
-    const walletDepositsDeduplicated = walletDepositTransactions.filter(
-      (tx) => {
-        const h = tx.depositWithdrawal?.txHash?.toLowerCase?.()?.trim() ?? '';
-        return h === '' || !restDepositTxHashes.has(h);
-      },
+    const walletWithdrawalsDeduplicated = deduplicateByTxHash(
+      walletWithdrawalTransactions,
+      restWithdrawalTxHashes,
     );
 
     const allTransactions = [
       ...mergedFillTransactions,
       ...nonTradeTransactions,
       ...walletDepositsDeduplicated,
+      ...walletWithdrawalsDeduplicated,
     ];
 
     return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
-  }, [liveFills, restFills, transactions, walletDepositTransactions]);
+  }, [
+    liveFills,
+    restFills,
+    transactions,
+    walletDepositTransactions,
+    walletWithdrawalTransactions,
+  ]);
 
   return {
     transactions: mergedTransactions,

--- a/app/components/UI/Perps/types/transactionHistory.ts
+++ b/app/components/UI/Perps/types/transactionHistory.ts
@@ -24,9 +24,17 @@ export enum FillType {
   AutoDeleveraging = 'auto_deleveraging',
 }
 
+export enum PerpsTransactionType {
+  Trade = 'trade',
+  Order = 'order',
+  Funding = 'funding',
+  Deposit = 'deposit',
+  Withdrawal = 'withdrawal',
+}
+
 export interface PerpsTransaction {
   id: string;
-  type: 'trade' | 'order' | 'funding' | 'deposit' | 'withdrawal';
+  type: `${PerpsTransactionType}`;
   category:
     | 'position_open'
     | 'position_close'

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -1628,7 +1628,7 @@ describe('transactionTransforms', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        id: 'withdrawal-withdrawal1',
+        id: 'withdrawal1',
         type: 'withdrawal' as const,
         category: 'withdrawal',
         title: 'Withdrew 500 USDC',
@@ -1969,7 +1969,7 @@ describe('transactionTransforms', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        id: 'wallet-tx-1',
+        id: 'wallet-withdrawal-tx-1',
         timestamp: 1640995200000,
         amount: '0.26',
         asset: 'USDC',
@@ -2018,7 +2018,7 @@ describe('transactionTransforms', () => {
         createMockWithdrawTx({ id: 'my-tx-id' }),
       ] as never);
 
-      expect(result[0].id).toBe('wallet-my-tx-id');
+      expect(result[0].id).toBe('wallet-withdrawal-my-tx-id');
     });
   });
 });

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -8,6 +8,7 @@ import {
   transformWithdrawalRequestsToTransactions,
   transformDepositRequestsToTransactions,
   transformWalletPerpsDepositsToTransactions,
+  walletPerpsWithdrawalsToRequests,
   aggregateFillsByTimestamp,
 } from './transactionTransforms';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
@@ -1637,7 +1638,7 @@ describe('transactionTransforms', () => {
         depositWithdrawal: {
           amount: '-$500.00',
           amountNumber: -500,
-          isPositive: true,
+          isPositive: false,
           asset: 'USDC',
           txHash: '0x456',
           status: 'completed' as const,
@@ -1646,7 +1647,7 @@ describe('transactionTransforms', () => {
       });
     });
 
-    it('filters out non-completed withdrawal requests', () => {
+    it('transforms pending withdrawal with Pending subtitle', () => {
       const pendingRequest = {
         ...mockWithdrawalRequest,
         status: 'pending' as const,
@@ -1656,7 +1657,31 @@ describe('transactionTransforms', () => {
         pendingRequest,
       ]);
 
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Pending');
+    });
+
+    it('transforms failed withdrawal with Failed subtitle', () => {
+      const failedRequest = {
+        ...mockWithdrawalRequest,
+        status: 'failed' as const,
+      };
+
+      const result = transformWithdrawalRequestsToTransactions([failedRequest]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Failed');
+    });
+
+    it('uses Withdrawal title when amount is zero', () => {
+      const zeroRequest = {
+        ...mockWithdrawalRequest,
+        amount: '0',
+      };
+
+      const result = transformWithdrawalRequestsToTransactions([zeroRequest]);
+
+      expect(result[0].title).toBe('Withdrawal');
     });
 
     it('handles missing txHash', () => {
@@ -1827,14 +1852,13 @@ describe('transactionTransforms', () => {
       } as unknown as ReturnType<typeof parseStandardTokenTransactionData>);
     });
 
-    it('filters to only perpsDeposit and perpsDepositAndOrder types', () => {
+    it('transforms all provided transactions (filtering is done by the hook)', () => {
       const txs = [
         createMockTx({ type: TransactionType.perpsDeposit }),
         createMockTx({
           id: 'tx-2',
           type: TransactionType.perpsDepositAndOrder,
         }),
-        createMockTx({ id: 'tx-3', type: 'swap' }),
       ];
 
       const result = transformWalletPerpsDepositsToTransactions(txs as never);
@@ -1912,6 +1936,89 @@ describe('transactionTransforms', () => {
 
       expect(result[0].title).toBe('Deposit');
       expect(result[0].depositWithdrawal?.amountNumber).toBe(0);
+    });
+  });
+
+  describe('walletPerpsWithdrawalsToRequests', () => {
+    const createMockWithdrawTx = (overrides: Record<string, unknown> = {}) => ({
+      id: 'tx-1',
+      type: TransactionType.perpsWithdraw,
+      status: 'confirmed',
+      time: 1640995200000,
+      hash: '0xwithdraw1',
+      txParams: { from: '0x123' },
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetTokenTransferData.mockReturnValue({
+        data: '0xa9059cbb0000000000000000000000000000000000000000000000000000000000000001' as `0x${string}`,
+        to: '0x0' as `0x${string}`,
+      });
+      mockParseStandardTokenTransactionData.mockReturnValue({
+        name: 'transfer',
+        args: { _value: { toString: () => '260000' } },
+      } as unknown as ReturnType<typeof parseStandardTokenTransactionData>);
+    });
+
+    it('converts wallet TransactionMeta to WithdrawalRequest format', () => {
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx(),
+      ] as never);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: 'wallet-tx-1',
+        timestamp: 1640995200000,
+        amount: '0.26',
+        asset: 'USDC',
+        txHash: '0xwithdraw1',
+        status: 'completed',
+      });
+    });
+
+    it('maps wallet status to withdrawal request status', () => {
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx({ status: 'failed' }),
+      ] as never);
+
+      expect(result[0].status).toBe('failed');
+    });
+
+    it('maps submitted status to pending', () => {
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx({ status: 'submitted' }),
+      ] as never);
+
+      expect(result[0].status).toBe('pending');
+    });
+
+    it('returns zero amount when getTokenTransferData returns undefined', () => {
+      mockGetTokenTransferData.mockReturnValue(undefined);
+
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx(),
+      ] as never);
+
+      expect(result[0].amount).toBe('0.00');
+    });
+
+    it('uses tx.time and tx.hash', () => {
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx({ time: 1700000000000, hash: '0xdef' }),
+      ] as never);
+
+      expect(result[0].timestamp).toBe(1700000000000);
+      expect(result[0].txHash).toBe('0xdef');
+    });
+
+    it('prefixes id with wallet-', () => {
+      const result = walletPerpsWithdrawalsToRequests([
+        createMockWithdrawTx({ id: 'my-tx-id' }),
+      ] as never);
+
+      expect(result[0].id).toBe('wallet-my-tx-id');
     });
   });
 });

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -670,109 +670,137 @@ const WALLET_STATUS_TO_DEPOSIT_STATUS: Record<
 export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
-  return transactions
-    .filter(
-      (tx) =>
-        tx.type === TransactionType.perpsDeposit ||
-        tx.type === TransactionType.perpsDepositAndOrder,
-    )
-    .map((tx) => {
-      const tokenData = getTokenTransferData(tx);
-      const decoded = tokenData?.data
-        ? parseStandardTokenTransactionData(tokenData.data)
-        : undefined;
-      const amountWei = decoded?.args?._value?.toString?.();
-      const amountBN =
-        amountWei !== undefined
-          ? new BigNumber(
-              calcTokenAmount(amountWei, ARBITRUM_USDC.decimals).toString(),
-            )
-          : new BigNumber(0);
+  return transactions.map((tx) => {
+    const tokenData = getTokenTransferData(tx);
+    const decoded = tokenData?.data
+      ? parseStandardTokenTransactionData(tokenData.data)
+      : undefined;
+    const amountWei = decoded?.args?._value?.toString?.();
+    const amountBN =
+      amountWei !== undefined
+        ? new BigNumber(
+            calcTokenAmount(amountWei, ARBITRUM_USDC.decimals).toString(),
+          )
+        : new BigNumber(0);
 
-      const displayAmount = `+$${amountBN.toFixed(2)}`;
-      const status = WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] ?? 'pending';
-      const statusText =
-        status === 'completed'
-          ? strings('perps.transactions.activity.status_completed')
-          : status === 'failed'
-            ? strings('perps.transactions.activity.status_failed')
-            : strings('perps.transactions.activity.status_pending');
+    const displayAmount = `+$${amountBN.toFixed(2)}`;
+    const status = WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] ?? 'pending';
+    const statusText =
+      status === 'completed'
+        ? strings('perps.transactions.activity.status_completed')
+        : status === 'failed'
+          ? strings('perps.transactions.activity.status_failed')
+          : strings('perps.transactions.activity.status_pending');
 
-      const title =
-        amountBN.isZero() || !amountWei
-          ? strings('perps.transactions.activity.deposit_title')
-          : strings('perps.transactions.activity.deposited_amount', {
-              amount: amountBN.toFixed(2),
-              symbol: ARBITRUM_USDC.symbol,
-            });
+    const title =
+      amountBN.isZero() || !amountWei
+        ? strings('perps.transactions.activity.deposit_title')
+        : strings('perps.transactions.activity.deposited_amount', {
+            amount: amountBN.toFixed(2),
+            symbol: ARBITRUM_USDC.symbol,
+          });
 
-      return {
-        id: `wallet-deposit-${tx.id}`,
-        type: 'deposit' as const,
-        category: 'deposit' as const,
-        title,
-        subtitle: statusText,
-        timestamp: tx.time ?? 0,
+    return {
+      id: `wallet-deposit-${tx.id}`,
+      type: 'deposit' as const,
+      category: 'deposit' as const,
+      title,
+      subtitle: statusText,
+      timestamp: tx.time ?? 0,
+      asset: ARBITRUM_USDC.symbol,
+      depositWithdrawal: {
+        amount: displayAmount,
+        amountNumber: amountBN.toNumber(),
+        isPositive: true,
         asset: ARBITRUM_USDC.symbol,
-        depositWithdrawal: {
-          amount: displayAmount,
-          amountNumber: amountBN.toNumber(),
-          isPositive: true,
-          asset: ARBITRUM_USDC.symbol,
-          txHash: tx.hash ?? '',
-          status,
-          type: 'deposit' as const,
-        },
-      };
-    });
+        txHash: tx.hash ?? '',
+        status,
+        type: 'deposit' as const,
+      },
+    };
+  });
 }
 
 /**
  * Transform WithdrawalRequest objects to PerpsTransaction format
- * Only shows completed withdrawals (txHash not displayed in UI)
  * @param withdrawalRequests - Array of WithdrawalRequest objects
  * @returns Array of PerpsTransaction objects
  */
 export function transformWithdrawalRequestsToTransactions(
   withdrawalRequests: WithdrawalRequest[],
 ): PerpsTransaction[] {
-  return withdrawalRequests
-    .filter((request) => request.status === 'completed')
-    .map((request) => {
-      const { id, timestamp, amount, asset, txHash, status } = request;
+  return withdrawalRequests.map((request) => {
+    const { id, timestamp, amount, asset, txHash, status } = request;
 
-      // Format amount with negative sign for withdrawals
-      const amountBN = BigNumber(amount);
-      const displayAmount = `-$${amountBN.toFixed(2)}`;
+    const amountBN = BigNumber(amount);
+    const displayAmount = `-$${amountBN.toFixed(2)}`;
 
-      // For completed withdrawals, status is always positive (green)
-      const statusText = strings(
-        'perps.transactions.activity.status_completed',
-      );
-      const isPositive = true;
+    const statusText =
+      status === 'completed'
+        ? strings('perps.transactions.activity.status_completed')
+        : status === 'failed'
+          ? strings('perps.transactions.activity.status_failed')
+          : strings('perps.transactions.activity.status_pending');
 
-      return {
-        id: `withdrawal-${id}`,
-        type: 'withdrawal' as const,
-        category: 'withdrawal' as const,
-        title: strings('perps.transactions.activity.withdrew_amount', {
+    const title = amountBN.isZero()
+      ? strings('perps.transactions.activity.withdrawal_title')
+      : strings('perps.transactions.activity.withdrew_amount', {
           amount,
           symbol: asset,
-        }),
-        subtitle: statusText,
-        timestamp,
+        });
+
+    return {
+      id: `withdrawal-${id}`,
+      type: 'withdrawal' as const,
+      category: 'withdrawal' as const,
+      title,
+      subtitle: statusText,
+      timestamp,
+      asset,
+      depositWithdrawal: {
+        amount: displayAmount,
+        amountNumber: -amountBN.toNumber(),
+        isPositive: false,
         asset,
-        depositWithdrawal: {
-          amount: displayAmount,
-          amountNumber: -amountBN.toNumber(), // Negative for withdrawals
-          isPositive,
-          asset,
-          txHash: txHash || '',
-          status,
-          type: 'withdrawal' as const,
-        },
-      };
-    });
+        txHash: txHash || '',
+        status,
+        type: 'withdrawal' as const,
+      },
+    };
+  });
+}
+
+/**
+ * Convert wallet TransactionMeta (perpsWithdraw) to WithdrawalRequest format
+ * so it can be passed to transformWithdrawalRequestsToTransactions.
+ * @param transactions - Array of TransactionMeta with type perpsWithdraw
+ * @returns Array of WithdrawalRequest objects
+ */
+export function walletPerpsWithdrawalsToRequests(
+  transactions: TransactionMeta[],
+): WithdrawalRequest[] {
+  return transactions.map((tx) => {
+    const tokenData = getTokenTransferData(tx);
+    const decoded = tokenData?.data
+      ? parseStandardTokenTransactionData(tokenData.data)
+      : undefined;
+    const amountWei = decoded?.args?._value?.toString?.();
+    const amountBN =
+      amountWei !== undefined
+        ? new BigNumber(
+            calcTokenAmount(amountWei, ARBITRUM_USDC.decimals).toString(),
+          )
+        : new BigNumber(0);
+
+    return {
+      id: `wallet-${tx.id}`,
+      timestamp: tx.time ?? 0,
+      amount: amountBN.toFixed(2),
+      asset: ARBITRUM_USDC.symbol,
+      txHash: tx.hash,
+      status: WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] ?? 'pending',
+    };
+  });
 }
 
 /**

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -750,7 +750,7 @@ export function transformWithdrawalRequestsToTransactions(
         });
 
     return {
-      id: `withdrawal-${id}`,
+      id,
       type: 'withdrawal' as const,
       category: 'withdrawal' as const,
       title,
@@ -793,7 +793,7 @@ export function walletPerpsWithdrawalsToRequests(
         : new BigNumber(0);
 
     return {
-      id: `wallet-${tx.id}`,
+      id: `wallet-withdrawal-${tx.id}`,
       timestamp: tx.time ?? 0,
       amount: amountBN.toFixed(2),
       asset: ARBITRUM_USDC.symbol,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2023,6 +2023,7 @@
       "trade_again": "Trade again",
       "activity": {
         "deposit_title": "Deposit",
+        "withdrawal_title": "Withdrawal",
         "deposited_amount": "Deposited {{amount}} {{symbol}}",
         "withdrew_amount": "Withdrew {{amount}} {{symbol}}",
         "status_completed": "Completed",


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps deposit and withdraw transactions already show in the main Activity → Transactions list, but wallet-originated withdrawals were missing from Activity → Perps → Deposits.

Two issues caused this: the hook only merged wallet deposits (not withdrawals), and the `perpsWithdraw` type lives on a nested transaction so direct `tx.type` checks missed it.

Fix: converts wallet `TransactionMeta` to `WithdrawalRequest` via `walletPerpsWithdrawalsToRequests()`, then reuses `transformWithdrawalRequestsToTransactions()`. Uses `hasTransactionType()` for both deposits and withdrawals. Deduplicates against backend history by txHash.

## **Changelog**

CHANGELOG entry: Fixed perps withdraw transactions not appearing in the Perps activity Deposits tab

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1167

## **Manual testing steps**

```gherkin
Feature: Perps withdraw in Perps activity tab

  Scenario: user views perps withdraw in Deposits sub-tab
    Given the user has completed at least one perps withdrawal

    When user navigates to Activity → Perps → Deposits
    Then the perps withdraw transaction appears in the list
    And it shows the correct amount, status, and timestamp
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how wallet perps transactions are classified, transformed, and de-duplicated in `usePerpsTransactionHistory`, which can affect what users see in activity history (especially status/amount) if tx type or txHash handling is wrong.
> 
> **Overview**
> **Adds wallet-originated perps withdrawals to the Perps Activity → Deposits tab.** The transaction history hook now detects `perpsWithdraw` via `hasTransactionType`, converts matching wallet `TransactionMeta` into withdrawal requests, and merges the resulting withdrawal transactions alongside existing wallet deposits.
> 
> **Improves consistency and de-duplication across sources.** Wallet deposits/withdrawals are now de-duplicated against REST user history by normalized `txHash`, and withdrawal transforms now support `pending`/`failed` statuses and a zero-amount fallback title (`Withdrawal`). Tests were expanded to cover inclusion and txHash de-dupe for withdrawals, and localization adds `perps.transactions.activity.withdrawal_title`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a72cd55640d49c44a65f0378bbe8e28d6685b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->