### PR TITLE
fix(earn): aggregate mUSD balance across mainnet and Linea for estimated annual bonus

### DIFF
--- a/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.test.tsx
+++ b/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.test.tsx
@@ -19,11 +19,18 @@ import AppConstants from '../../../../../core/AppConstants';
 import { ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS } from './AssetOverviewClaimBonus.testIds';
 import { TokenI } from '../../../Tokens/types';
 import useTokenBalance from '../../../TokenDetails/hooks/useTokenBalance';
+import { selectAsset } from '../../../../../selectors/assets/assets-list';
+import { MUSD_TOKEN_ADDRESS } from '../../constants/musd';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 
 jest.mock('../MerklRewards/hooks/useMerklBonusClaim');
 jest.mock('../../../../hooks/useAnalytics/useAnalytics');
 jest.mock('../../../../hooks/useTooltipModal');
 jest.mock('../../../TokenDetails/hooks/useTokenBalance');
+jest.mock('../../../../../selectors/assets/assets-list', () => ({
+  selectAsset: jest.fn(),
+}));
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
   addEventListener: jest.fn(),
   removeEventListener: jest.fn(),
@@ -35,6 +42,7 @@ jest.mock('react-native/Libraries/Linking/Linking', () => ({
 const mockUseMerklBonusClaim = useMerklBonusClaim as jest.MockedFunction<
   typeof useMerklBonusClaim
 >;
+const mockSelectAsset = selectAsset as jest.MockedFunction<typeof selectAsset>;
 
 const createMockAsset = (overrides: Partial<TokenI> = {}): TokenI => ({
   address: '0x8d652c6d4A8F3Db96Cd866C1a9220B1447F29898',
@@ -115,6 +123,8 @@ describe('AssetOverviewClaimBonus', () => {
         claimRewards: mockClaimRewards,
       }),
     );
+
+    mockSelectAsset.mockReturnValue(undefined);
   });
 
   describe('always renders for eligible tokens', () => {
@@ -471,6 +481,211 @@ describe('AssetOverviewClaimBonus', () => {
         }),
       );
       expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'mock-built-event' });
+    });
+  });
+
+  describe('mUSD balance aggregation across mainnet and Linea', () => {
+    const createMockMusdAsset = (balance: string) =>
+      ({
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: CHAIN_IDS.MAINNET,
+        symbol: 'mUSD',
+        balance,
+      }) as unknown as ReturnType<typeof selectAsset>;
+
+    const mockPerChainMusdBalance = ({
+      mainnet,
+      linea,
+    }: {
+      mainnet?: string;
+      linea?: string;
+    }) => {
+      mockSelectAsset.mockImplementation((_state, params) => {
+        if (params?.chainId === CHAIN_IDS.MAINNET) {
+          return mainnet !== undefined
+            ? createMockMusdAsset(mainnet)
+            : undefined;
+        }
+        if (params?.chainId === CHAIN_IDS.LINEA_MAINNET) {
+          return linea !== undefined ? createMockMusdAsset(linea) : undefined;
+        }
+        return undefined;
+      });
+    };
+
+    it('uses the sum of mainnet and Linea mUSD balances for the estimated annual bonus', () => {
+      mockPerChainMusdBalance({ mainnet: '700', linea: '300' });
+      mockUseMerklBonusClaim.mockReturnValue(
+        createMockMerklClaimData({
+          claimableReward: '5.00',
+          lifetimeBonusClaimed: '50.00',
+          claimRewards: mockClaimRewards,
+        }),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '0',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      // (700 + 300) * 3% = 30.00
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.ANNUAL_BONUS_VALUE),
+      ).toHaveTextContent('+$30.00');
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.CLAIM_BUTTON),
+      ).toHaveTextContent('Claim $5.00 bonus');
+    });
+
+    it('uses the mainnet balance alone when Linea returns no asset', () => {
+      mockPerChainMusdBalance({ mainnet: '500' });
+      mockUseMerklBonusClaim.mockReturnValue(
+        createMockMerklClaimData({ claimableReward: null }),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '0',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      // 500 * 3% = 15.00, "Accruing next bonus" because balance > 0 & no claim
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.ANNUAL_BONUS_VALUE),
+      ).toHaveTextContent('+$15.00');
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.CLAIM_BUTTON),
+      ).toHaveTextContent('Accruing next bonus');
+    });
+
+    it('uses the Linea balance alone when mainnet returns no asset', () => {
+      mockPerChainMusdBalance({ linea: '200' });
+      mockUseMerklBonusClaim.mockReturnValue(
+        createMockMerklClaimData({ claimableReward: null }),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '0',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      // 200 * 3% = 6.00 — regression guard for the checksum fix (8ee95eb):
+      // before the fix, selectAsset was called with a non-checksummed address
+      // on Linea and always returned undefined, dropping Linea balances.
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.ANNUAL_BONUS_VALUE),
+      ).toHaveTextContent('+$6.00');
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.CLAIM_BUTTON),
+      ).toHaveTextContent('Accruing next bonus');
+    });
+
+    it('treats balance as zero when neither chain returns an mUSD asset', () => {
+      mockPerChainMusdBalance({});
+      mockUseMerklBonusClaim.mockReturnValue(
+        createMockMerklClaimData({
+          claimableReward: null,
+          lifetimeBonusClaimed: '0.00',
+        }),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '999',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.ANNUAL_BONUS_VALUE),
+      ).toHaveTextContent('+$0.00');
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.CLAIM_BUTTON),
+      ).toHaveTextContent('No accruing bonus');
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.CLAIM_BUTTON),
+      ).toBeDisabled();
+    });
+
+    it('ignores useTokenBalance liveBalance for mUSD assets', () => {
+      // liveBalance of 9_999 would imply +$299.97 annual if the non-mUSD
+      // fallback ran; the aggregated path must use 100 + 50 = 150 instead.
+      (
+        useTokenBalance as jest.MockedFunction<typeof useTokenBalance>
+      ).mockReturnValue({
+        balance: '9999',
+        fiatBalance: '$9999',
+        tokenFormattedBalance: '9999 mUSD',
+        isTronNative: false,
+        stakedTrxAsset: undefined,
+        inLockPeriodBalance: undefined,
+        readyForWithdrawalBalance: undefined,
+      });
+      mockPerChainMusdBalance({ mainnet: '100', linea: '50' });
+      mockUseMerklBonusClaim.mockReturnValue(
+        createMockMerklClaimData({ claimableReward: null }),
+      );
+
+      const { getByTestId } = renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '9999',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      expect(
+        getByTestId(ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.ANNUAL_BONUS_VALUE),
+      ).toHaveTextContent('+$4.50');
+    });
+
+    it('looks up mUSD on each chain using checksummed addresses', () => {
+      mockPerChainMusdBalance({ mainnet: '10', linea: '10' });
+
+      renderWithProvider(
+        <AssetOverviewClaimBonus
+          asset={createMockAsset({
+            address: MUSD_TOKEN_ADDRESS,
+            symbol: 'mUSD',
+            balance: '0',
+          })}
+        />,
+        { state: mockInitialState },
+      );
+
+      const checksummed = toChecksumHexAddress(MUSD_TOKEN_ADDRESS);
+      expect(mockSelectAsset).toHaveBeenCalledWith(expect.any(Object), {
+        address: checksummed,
+        chainId: CHAIN_IDS.MAINNET,
+      });
+      expect(mockSelectAsset).toHaveBeenCalledWith(expect.any(Object), {
+        address: checksummed,
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      });
     });
   });
 

--- a/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.test.tsx
+++ b/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { Linking } from 'react-native';
-import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import renderWithProvider, {
+  DeepPartial,
+} from '../../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
+import { RootState } from '../../../../../reducers';
 import AssetOverviewClaimBonus from '.';
 import {
   useMerklBonusClaim,
@@ -60,6 +64,10 @@ const createMockMerklClaimData = (
   ...overrides,
 });
 
+const mockInitialState: DeepPartial<RootState> = {
+  engine: { backgroundState },
+};
+
 describe('AssetOverviewClaimBonus', () => {
   const mockTrackEvent = jest.fn();
   const mockCreateEventBuilder = jest.fn();
@@ -113,6 +121,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('renders the section header, tag, rows, and CTA', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -142,6 +151,7 @@ describe('AssetOverviewClaimBonus', () => {
 
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -164,6 +174,7 @@ describe('AssetOverviewClaimBonus', () => {
         <AssetOverviewClaimBonus
           asset={createMockAsset({ balance: '1000', balanceFiat: '$1000' })}
         />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -205,6 +216,7 @@ describe('AssetOverviewClaimBonus', () => {
         <AssetOverviewClaimBonus
           asset={createMockAsset({ balance: '500', balanceFiat: '$500' })}
         />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -244,6 +256,7 @@ describe('AssetOverviewClaimBonus', () => {
         <AssetOverviewClaimBonus
           asset={createMockAsset({ balance: '0', balanceFiat: '$0' })}
         />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -282,6 +295,7 @@ describe('AssetOverviewClaimBonus', () => {
         <AssetOverviewClaimBonus
           asset={createMockAsset({ balance: '0', balanceFiat: '$0' })}
         />,
+        { state: mockInitialState },
       );
 
       expect(
@@ -310,6 +324,7 @@ describe('AssetOverviewClaimBonus', () => {
 
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       const button = getByTestId(
@@ -328,6 +343,7 @@ describe('AssetOverviewClaimBonus', () => {
 
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       const button = getByTestId(
@@ -341,6 +357,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('calls claimRewards on claim button press', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -355,6 +372,7 @@ describe('AssetOverviewClaimBonus', () => {
 
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={asset} />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -378,6 +396,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('prevents duplicate claim presses via isClaimPressedRef guard', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       const button = getByTestId(
@@ -401,6 +420,7 @@ describe('AssetOverviewClaimBonus', () => {
         <AssetOverviewClaimBonus
           asset={createMockAsset({ balance: '1000' })}
         />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -415,6 +435,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('opens tooltip modal with correct content on info button press', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -433,6 +454,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('fires TOOLTIP_OPENED analytics on info button press', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -456,6 +478,7 @@ describe('AssetOverviewClaimBonus', () => {
     it('opens terms URL and fires analytics when terms link is pressed', () => {
       const { getByTestId } = renderWithProvider(
         <AssetOverviewClaimBonus asset={createMockAsset()} />,
+        { state: mockInitialState },
       );
 
       fireEvent.press(
@@ -464,7 +487,9 @@ describe('AssetOverviewClaimBonus', () => {
 
       const tooltipDescription = mockOpenTooltipModal.mock.calls[0][1];
 
-      const { getByText } = renderWithProvider(tooltipDescription);
+      const { getByText } = renderWithProvider(tooltipDescription, {
+        state: mockInitialState,
+      });
       fireEvent.press(getByText('Terms apply.'));
 
       expect(Linking.openURL).toHaveBeenCalledWith(

--- a/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
+++ b/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
@@ -29,9 +29,15 @@ import { MUSD_EVENTS_CONSTANTS } from '../../constants/events/musdEvents';
 import AppConstants from '../../../../../core/AppConstants';
 import { selectNetworkConfigurationByChainId } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS } from './AssetOverviewClaimBonus.testIds';
-import { MUSD_CONVERSION_APY } from '../../constants/musd';
+import {
+  MUSD_CONVERSION_APY,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+  isMusdToken,
+} from '../../constants/musd';
 import useTokenBalance from '../../../TokenDetails/hooks/useTokenBalance';
+import { selectAsset } from '../../../../../selectors/assets/assets-list';
 import TagBase, {
   TagSeverity,
 } from '../../../../../component-library/base-components/TagBase';
@@ -72,8 +78,28 @@ const AssetOverviewClaimBonus: React.FC<AssetOverviewClaimBonusProps> = ({
   // Use live balance from Redux store — route params may be stale.
   const { balance: liveBalance } = useTokenBalance(asset);
 
+  // mUSD bonuses are distributed across both mainnet and Linea regardless of
+  // which chain's asset details screen we're rendering, so the estimate must
+  // sum the user's holdings on both chains. For non-mUSD eligible tokens we
+  // keep the per-chain balance from useTokenBalance.
+  const mainnetMusdAsset = useSelector((state: RootState) =>
+    selectAsset(state, {
+      address: MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET],
+      chainId: CHAIN_IDS.MAINNET,
+    }),
+  );
+  const lineaMusdAsset = useSelector((state: RootState) =>
+    selectAsset(state, {
+      address: MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET],
+      chainId: CHAIN_IDS.LINEA_MAINNET,
+    }),
+  );
+
   // State derivation
-  const balance = parseFloat(liveBalance || asset.balance) || 0;
+  const balance = isMusdToken(asset.address)
+    ? (parseFloat(mainnetMusdAsset?.balance ?? '0') || 0) +
+      (parseFloat(lineaMusdAsset?.balance ?? '0') || 0)
+    : parseFloat(liveBalance || asset.balance) || 0;
   const hasBalance = balance > 0;
   const hasClaimable = claimableReward !== null;
 

--- a/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
+++ b/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../constants/musd';
 import useTokenBalance from '../../../TokenDetails/hooks/useTokenBalance';
 import { selectAsset } from '../../../../../selectors/assets/assets-list';
+import { toFormattedAddress } from '../../../../../util/address';
 import TagBase, {
   TagSeverity,
 } from '../../../../../component-library/base-components/TagBase';
@@ -84,13 +85,17 @@ const AssetOverviewClaimBonus: React.FC<AssetOverviewClaimBonusProps> = ({
   // keep the per-chain balance from useTokenBalance.
   const mainnetMusdAsset = useSelector((state: RootState) =>
     selectAsset(state, {
-      address: MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET],
+      address: toFormattedAddress(
+        MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET],
+      ),
       chainId: CHAIN_IDS.MAINNET,
     }),
   );
   const lineaMusdAsset = useSelector((state: RootState) =>
     selectAsset(state, {
-      address: MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET],
+      address: toFormattedAddress(
+        MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET],
+      ),
       chainId: CHAIN_IDS.LINEA_MAINNET,
     }),
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Estimated annual bonus" row in the bonus card on the mUSD asset details screen (and the Cash/Money tokens full view) was being computed against a single chain's mUSD balance. mUSD bonuses are actually distributed by Merkl across both Ethereum mainnet and Linea, so users with mUSD on both chains were seeing an estimate that only reflected one of those balances depending on which screen they opened:

- Opening the Linea mUSD details page → estimate = Linea balance × 3%
- Opening the mainnet mUSD details page → estimate = mainnet balance × 3%
- Opening the Cash full view → estimate = mainnet balance × 3% (the view passes a hardcoded mainnet asset reference)

Worse, none of those views agreed with each other, and none of them agreed with the "Lifetime bonus claimed" line shown right below the estimate — which is sourced from the Linea Merkl Distributor contract and is already global across both chains. Same component, two different scopes.

This PR makes the estimate global so it lines up with the lifetime line and with what users actually accrue:

- For mUSD assets, the balance feeding the estimate is now the sum of the user's mainnet mUSD balance and Linea mUSD balance, regardless of which chain's asset details page is being rendered. Two `useSelector(selectAsset, ...)` calls (one per eligible chain) are added; both run unconditionally so hook order is stable.
- For non-mUSD eligible tokens (the AGLAMERKL test token path that the same component supports), the existing per-chain `useTokenBalance(asset)` behaviour is preserved untouched.
- The aggregation is gated on `isMusdToken(asset.address)` so the test-token path is fully bypassed.
- Everything downstream of the `balance` variable — `hasBalance`, `formattedAnnualBonus`, and the CTA `ctaLabel`/`ctaDisabled` derivation — automatically picks up the aggregate semantics. The CTA on the Linea details page will now correctly say "accruing next bonus" for a user whose only balance is on mainnet, matching the lifetime line above it.

The 3% APY is still a hardcoded display constant. Switching it to a live Merkl APR is intentionally out of scope here (the rate fluctuates weekly and the wording around "estimated" is acceptable per product), and is tracked separately.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the mUSD estimated annual bonus so it reflects the user's combined mUSD balance across Ethereum mainnet and Linea instead of only the chain currently being viewed.

## **Related issues**

Fixes: MUSD-628

## **Manual testing steps**

```gherkin
Feature: Estimated annual mUSD bonus aggregates across mainnet and Linea

  Background:
    Given the user holds mUSD on both Ethereum mainnet and Linea
    And the user's mainnet mUSD balance is $15.25
    And the user's Linea mUSD balance is $4.96

  Scenario: User opens the mUSD asset details page on Linea
    When the user navigates to the mUSD asset details on Linea
    Then the "Your bonus" card is visible
    And the "Estimated annual bonus" row shows +$0.61
    And the CTA reads "Accruing next bonus"

  Scenario: User opens the mUSD asset details page on Mainnet
    When the user navigates to the mUSD asset details on Ethereum mainnet
    Then the "Estimated annual bonus" row shows +$0.61
    And the CTA reads "Accruing next bonus"

  Scenario: User opens the Cash/Money tokens full view
    When the user navigates to the Cash tokens full view
    Then the "Estimated annual bonus" row shows +$0.61

  Scenario: User has mUSD only on mainnet, opens Linea details page
    Given the user holds mUSD only on Ethereum mainnet
    And the user's mainnet mUSD balance is $100.00
    And the user's Linea mUSD balance is $0
    When the user navigates to the mUSD asset details on Linea
    Then the "Estimated annual bonus" row shows +$3.00
    And the CTA reads "Accruing next bonus"

  Scenario: User has no mUSD on either chain
    Given the user holds no mUSD on Ethereum mainnet or Linea
    When the user navigates to the mUSD asset details on either chain
    Then the "Estimated annual bonus" row shows +$0.00
    And the CTA reads "No accruing bonus"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the balance source for mUSD bonus estimation to sum holdings across two chains via Redux selectors, which could affect displayed bonus/CTA behavior if asset lookup or address formatting is wrong. Scope is limited to the Earn mUSD bonus card and adds thorough unit coverage.
> 
> **Overview**
> Fixes the mUSD *Estimated annual bonus* calculation to use the **combined mUSD balance across Ethereum mainnet and Linea**, regardless of which chain’s asset details screen is open.
> 
> `AssetOverviewClaimBonus` now detects mUSD via `isMusdToken`, looks up mUSD assets on both chains using `selectAsset` with `toFormattedAddress` (checksummed), and sums their balances; non-mUSD tokens continue to use `useTokenBalance`.
> 
> Tests were updated to provide Redux background state and expanded with new cases covering mainnet-only/Linea-only/both/none balances, ignoring `useTokenBalance` for mUSD, and verifying checksummed address lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8048663a8563460c6f122fb6d00978ed60be459c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->