### PR TITLE
fix: add background color to MusdQuickConvertView to prevent glitchy navigation transition cp-7-73.0

### DIFF
--- a/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.styles.ts
+++ b/app/components/UI/Earn/Views/MusdQuickConvertView/MusdQuickConvertView.styles.ts
@@ -1,10 +1,12 @@
 import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = () =>
+const styleSheet = ({ theme }: { theme: Theme }) =>
   StyleSheet.create({
     container: {
       flex: 1,
       padding: 16,
+      backgroundColor: theme.colors.background.default,
     },
     listContainer: {
       flex: 1,


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

During the navigation transition from the mUSD Conversion Education screen to the Quick Convert screen (`MusdQuickConvertView`), the animation appeared glitchy. The incoming screen had no `backgroundColor` set on its container, making it transparent during the slide-in animation. This caused the native background (often black or the OS default) to bleed through.

The fix adds `backgroundColor: theme.colors.background.default` to the `MusdQuickConvertView` container style, using the existing theme system. The `styleSheet` function signature is updated to accept `{ theme }` (matching the pattern already used by the adjacent education view), which the `useStyles` hook injects automatically.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a visual glitch during the navigation transition to the mUSD Quick Convert screen

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mUSD Quick Convert navigation transition

  Background:
    Given I am logged into MetaMask Mobile
    And the mUSD Quick Convert feature flag is enabled
    And I have a stablecoin balance eligible for mUSD conversion

  Scenario: user navigates from the education screen to the Quick Convert screen
    Given I am on the mUSD Conversion Education screen

    When user taps the primary CTA button to continue
    Then the app navigates to the mUSD Quick Convert screen
    And the transition animation is smooth with no black or transparent flash

  Scenario: transition renders correctly in dark mode
    Given I have dark mode enabled on my device
    And I am on the mUSD Conversion Education screen

    When user taps the primary CTA button to continue
    Then the Quick Convert screen slides in with the correct dark background color
    And no visual glitch or background bleed is visible during the transition
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0f7f4421-575d-4ca1-a65b-d5ba20983f6a



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts styling to use the theme background color; minimal chance of regressions beyond visual appearance.
> 
> **Overview**
> Fixes a glitchy navigation transition into `MusdQuickConvertView` by giving the screen container an explicit themed `backgroundColor`.
> 
> Updates the `MusdQuickConvertView.styles` `styleSheet` to accept `{ theme }` and use `theme.colors.background.default`, preventing transparency/black bleed during the slide-in animation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c6ef5ae3031923ff3434b6cc5793918d563563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->