### PR TITLE
feat: `ButtonIcon` pilot migration

### DIFF
--- a/app/components/UI/Rewards/components/ReferralDetails/CopyableField.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/CopyableField.test.tsx
@@ -71,14 +71,14 @@ describe('CopyableField', () => {
       );
 
       const copyButton = getByLabelText('Copy');
-      expect(copyButton.props.disabled).toBe(true);
+      expect(copyButton).toBeDisabled();
     });
 
     it('should enable copy button when value is provided', () => {
       const { getByLabelText } = render(<CopyableField {...defaultProps} />);
 
       const copyButton = getByLabelText('Copy');
-      expect(copyButton.props.disabled).toBe(false);
+      expect(copyButton).toBeEnabled();
     });
   });
 
@@ -101,7 +101,7 @@ describe('CopyableField', () => {
       expect(getByText('-')).toBeTruthy();
 
       const copyButton = getByLabelText('Copy');
-      expect(copyButton.props.disabled).toBe(true);
+      expect(copyButton).toBeDisabled();
     });
 
     it('should handle long values', () => {

--- a/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
@@ -2,16 +2,14 @@ import React, { useState } from 'react';
 import {
   Box,
   BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  IconColor,
+  IconName,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import ButtonIcon from '../../../../../component-library/components/Buttons/ButtonIcon';
-import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon.types';
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon/Icon.types';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 
 interface CopyableFieldProps {
@@ -56,13 +54,13 @@ const CopyableField: React.FC<CopyableFieldProps> = ({
       </Box>
       <ButtonIcon
         iconName={isCopied ? IconName.CopySuccess : IconName.Copy}
-        size={ButtonIconSizes.Md}
+        size={ButtonIconSize.Md}
         onPress={handleCopy}
         isDisabled={!value}
         accessibilityLabel={isCopied ? 'Copied' : 'Copy'}
         accessibilityRole="button"
         testID="copy-button"
-        iconColor={isCopied ? IconColor.Success : undefined}
+        iconProps={isCopied ? { color: IconColor.SuccessDefault } : undefined}
       />
     </Box>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `ButtonIcon` from DSRN package (pilot migration).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-637

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/52caaa86-3c3f-41c6-be95-6fc1556ca844

### **After**

https://github.com/user-attachments/assets/7e3620dc-49f8-4d11-918e-6f0b27783f09

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps a single button component and updates tests; main risk is minor visual/behavioral mismatch in disabled/icon rendering across platforms.
> 
> **Overview**
> Migrates `ReferralDetails/CopyableField` to use `ButtonIcon` from `@metamask/design-system-react-native`, updating the API usage (`ButtonIconSize` and `iconProps` for success color) and removing legacy component-library imports.
> 
> Updates `CopyableField` tests to assert enabled/disabled state via `toBeDisabled()`/`toBeEnabled()` instead of reading `props.disabled`, aligning expectations with the new button implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5b3f9d14f259e16e0a711805eeac34d876a4ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->