### PR TITLE
chore(musd): clarify variable-rate disclaimer in bonus tooltip

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6039,7 +6039,7 @@
     "your_bonus_tooltip_your_bonus": "Your bonus",
     "your_bonus_tooltip_your_bonus_desc": ":  {{percentage}}% annualized bonus you earn just for holding mUSD. You can claim it daily on Linea. ",
     "your_bonus_tooltip_annual_bonus": "Estimated annual bonus: ",
-    "your_bonus_tooltip_annual_bonus_desc": "A projection of what you'd earn over a year based on your current balance and rate.",
+    "your_bonus_tooltip_annual_bonus_desc": "A projection of what you'd earn over a year based on your current balance and rate. Rate is variable and may change.",
     "your_bonus_tooltip_lifetime_bonus": "Lifetime bonus claimed: ",
     "your_bonus_tooltip_lifetime_bonus_desc": "The total bonus you've claimed since you started.",
     "learn_more": "Learn more",


### PR DESCRIPTION
## **Description**

Updates the copy in the **Your bonus** info tooltip on the mUSD asset overview card to clarify that the displayed rate is variable and may change. The projection text previously stopped at "…based on your current balance and rate." which left users without context on whether that rate is guaranteed. This one-sentence addition matches the latest product copy.

Only the English source string is touched; other locales will be picked up by the translation pipeline.

## **Changelog**

CHANGELOG entry: Updated the mUSD bonus tooltip to clarify that the estimated annual bonus rate is variable and may change.

## **Related issues**

Fixes: [MUSD-627](https://consensyssoftware.atlassian.net/browse/MUSD-627)

## **Manual testing steps**

```gherkin
Feature: mUSD bonus tooltip copy

  Scenario: user opens the Your bonus tooltip on the mUSD asset overview
    Given the user holds mUSD and is on the mUSD asset overview screen
    And the bonus card is visible

    When the user taps the info icon next to "Your bonus"
    Then the tooltip opens
    And the "Estimated annual bonus" section reads:
      "A projection of what you'd earn over a year based on your current balance and rate. Rate is variable and may change."
```

## **Screenshots/Recordings**

### **Before**

_Tooltip ended at "…based on your current balance and rate."_

### **After**

_Tooltip now appends "Rate is variable and may change."_

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-627]: https://consensyssoftware.atlassian.net/browse/MUSD-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to an English i18n string; no logic, data handling, or behavior changes.
> 
> **Overview**
> Updates the English locale string for the mUSD **"Estimated annual bonus"** tooltip to append a disclaimer that the rate is variable and may change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd1f3cedbfed19e781e96e41ce9d956a5620e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->