### PR TITLE
fix(bridge): support disabled networks in swap deeplinks

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -327,7 +327,7 @@ const Main = (props) => {
           labelOptions: [
             {
               label: `${
-                (newNetwork?.name || deletedNetwork?.name) ??
+                (deletedNetwork?.name || newNetwork?.name) ??
                 strings('asset_details.network')
               } `,
               isBold: true,

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -94,7 +94,7 @@ import {
 } from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
 import { useIsOnBridgeRoute } from '../../UI/Bridge/hooks/useIsOnBridgeRoute';
-import { consumeSuppressedNetworkAddedToast } from '../../../util/networks/networkToastSuppression';
+import { shouldShowNetworkListToast } from './utils';
 
 const Stack = createStackNavigator();
 
@@ -317,9 +317,10 @@ const Main = (props) => {
           ),
       );
 
-      const shouldShowNetworkAddedToast =
-        newNetwork && !consumeSuppressedNetworkAddedToast(newNetwork?.chainId);
-      const shouldShowToast = shouldShowNetworkAddedToast || deletedNetwork;
+      const shouldShowToast = shouldShowNetworkListToast({
+        newNetworkChainId: newNetwork?.chainId,
+        hasDeletedNetwork: Boolean(deletedNetwork),
+      });
       if (shouldShowToast) {
         toastRef?.current?.showToast({
           variant: ToastVariants.Plain,

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -342,7 +342,7 @@ const Main = (props) => {
       }
     }
     previousNetworkConfigurations.current = networkConfigurations;
-  }, [isOnBridgeRoute, networkConfigurations, networkImage, toastRef]);
+  }, [networkConfigurations, networkImage, toastRef]);
 
   useEffect(() => {
     if (locale.current !== I18n.locale) {

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -94,6 +94,7 @@ import {
 } from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
 import { useIsOnBridgeRoute } from '../../UI/Bridge/hooks/useIsOnBridgeRoute';
+import { consumeSuppressedNetworkAddedToast } from '../../../util/networks/networkToastSuppression';
 
 const Stack = createStackNavigator();
 
@@ -298,11 +299,9 @@ const Main = (props) => {
     );
 
     // Emit network addition/deletion toast if network list changes
-    // Bridge routes are skipped as they interfere with bridge UI
     if (
       previousNetworkValues.length &&
-      currentNetworkValues.length !== previousNetworkValues.length &&
-      !isOnBridgeRoute
+      currentNetworkValues.length !== previousNetworkValues.length
     ) {
       // Find the newly added network by comparing chainIds
       const newNetwork = currentNetworkValues.find(
@@ -318,24 +317,29 @@ const Main = (props) => {
           ),
       );
 
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Plain,
-        labelOptions: [
-          {
-            label: `${
-              (newNetwork?.name || deletedNetwork?.name) ??
-              strings('asset_details.network')
-            } `,
-            isBold: true,
-          },
-          {
-            label: deletedNetwork
-              ? strings('toast.network_removed')
-              : strings('toast.network_added'),
-          },
-        ],
-        networkImageSource: networkImage,
-      });
+      const shouldShowNetworkAddedToast =
+        newNetwork && !consumeSuppressedNetworkAddedToast(newNetwork?.chainId);
+      const shouldShowToast = shouldShowNetworkAddedToast || deletedNetwork;
+      if (shouldShowToast) {
+        toastRef?.current?.showToast({
+          variant: ToastVariants.Plain,
+          labelOptions: [
+            {
+              label: `${
+                (newNetwork?.name || deletedNetwork?.name) ??
+                strings('asset_details.network')
+              } `,
+              isBold: true,
+            },
+            {
+              label: deletedNetwork
+                ? strings('toast.network_removed')
+                : strings('toast.network_added'),
+            },
+          ],
+          networkImageSource: networkImage,
+        });
+      }
     }
     previousNetworkConfigurations.current = networkConfigurations;
   }, [isOnBridgeRoute, networkConfigurations, networkImage, toastRef]);

--- a/app/components/Nav/Main/utils.test.ts
+++ b/app/components/Nav/Main/utils.test.ts
@@ -1,7 +1,16 @@
 import { ImageSourcePropType } from 'react-native';
-import { handleShowNetworkActiveToast } from './utils';
+import {
+  handleShowNetworkActiveToast,
+  shouldShowNetworkListToast,
+} from './utils';
 import { ToastVariants } from '../../../component-library/components/Toast';
 import { strings } from '../../../../locales/i18n';
+import {
+  clearSuppressedNetworkAddedToast,
+  consumeSuppressedNetworkAddedToast,
+  resetSuppressedNetworkAddedToasts,
+  suppressNextNetworkAddedToast,
+} from '../../../util/networks/networkToastSuppression';
 
 describe('handleShowNetworkActiveToast', () => {
   const mockToastRef = {
@@ -16,6 +25,7 @@ describe('handleShowNetworkActiveToast', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSuppressedNetworkAddedToasts();
   });
 
   it('shows toast when not on bridge route', () => {
@@ -132,5 +142,41 @@ describe('handleShowNetworkActiveToast', () => {
     // Assert
     const calledWith = mockToastRef.current.showToast.mock.calls[0][0];
     expect(calledWith.networkImageSource).toBe(customNetworkImage);
+  });
+});
+
+describe('shouldShowNetworkListToast', () => {
+  beforeEach(() => {
+    resetSuppressedNetworkAddedToasts();
+  });
+
+  it('suppresses an added-network toast only once', () => {
+    suppressNextNetworkAddedToast('0xa');
+
+    expect(
+      shouldShowNetworkListToast({
+        newNetworkChainId: '0xa',
+        hasDeletedNetwork: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowNetworkListToast({
+        newNetworkChainId: '0xa',
+        hasDeletedNetwork: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('clears suppressed added-network toasts explicitly', () => {
+    suppressNextNetworkAddedToast('0xa');
+
+    clearSuppressedNetworkAddedToast('0xa');
+
+    expect(consumeSuppressedNetworkAddedToast('0xa')).toBe(false);
+  });
+
+  it('returns false when consuming without a chain id', () => {
+    expect(consumeSuppressedNetworkAddedToast()).toBe(false);
   });
 });

--- a/app/components/Nav/Main/utils.ts
+++ b/app/components/Nav/Main/utils.ts
@@ -1,6 +1,7 @@
 import { ImageSourcePropType } from 'react-native';
 import { ToastVariants } from '../../../component-library/components/Toast';
 import { strings } from '../../../../locales/i18n';
+import { consumeSuppressedNetworkAddedToast } from '../../../util/networks/networkToastSuppression';
 
 export const handleShowNetworkActiveToast = (
   isOnBridgeRoute: boolean,
@@ -22,4 +23,18 @@ export const handleShowNetworkActiveToast = (
       networkImageSource: networkImage,
     });
   }
+};
+
+export const shouldShowNetworkListToast = ({
+  newNetworkChainId,
+  hasDeletedNetwork,
+}: {
+  newNetworkChainId?: string;
+  hasDeletedNetwork: boolean;
+}) => {
+  const shouldShowNetworkAddedToast =
+    Boolean(newNetworkChainId) &&
+    !consumeSuppressedNetworkAddedToast(newNetworkChainId);
+
+  return shouldShowNetworkAddedToast || hasDeletedNetwork;
 };

--- a/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.test.ts
@@ -13,6 +13,10 @@ import { createMockToken } from '../testUtils/fixtures';
 import Routes from '../../../../constants/navigation/Routes';
 import { BridgeToken, TokenSelectorType } from '../types';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
+import {
+  consumeSuppressedNetworkAddedToast,
+  resetSuppressedNetworkAddedToasts,
+} from '../../../../util/networks/networkToastSuppression';
 
 const mockDispatch = jest.fn();
 const mockHandleSwitchTokensInner = jest.fn().mockResolvedValue(undefined);
@@ -176,6 +180,7 @@ const renderTokenSelectionHook = (
 describe('useTokenSelection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSuppressedNetworkAddedToasts();
     // Non-stock token behavior
     mockIsStockToken.mockReturnValue(false);
     mockIsTokenTradingOpen.mockReturnValue(true);
@@ -312,6 +317,7 @@ describe('useTokenSelection', () => {
       expect(mockDispatch).not.toHaveBeenCalled();
       expect(mockAutoUpdateDestToken).not.toHaveBeenCalled();
       expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(consumeSuppressedNetworkAddedToast('0xa')).toBe(false);
     });
 
     it('continues dest selection when addNetwork rejects', async () => {

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -22,6 +22,7 @@ import { Hex } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
 import { PopularList } from '../../../../util/networks/customNetworks';
+import { suppressNextNetworkAddedToast } from '../../../../util/networks/networkToastSuppression';
 
 /**
  * Hook to manage token selection logic for Bridge token selector
@@ -69,6 +70,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
           try {
             const hexChainId = toHex(popularNetwork.chainId) as Hex;
             const { blockExplorerUrl } = popularNetwork.rpcPrefs;
+            suppressNextNetworkAddedToast(popularNetwork.chainId);
             await Engine.context.NetworkController.addNetwork({
               chainId: hexChainId,
               blockExplorerUrls: blockExplorerUrl ? [blockExplorerUrl] : [],

--- a/app/components/UI/Bridge/hooks/useTokenSelection.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSelection.ts
@@ -22,7 +22,10 @@ import { Hex } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
 import { PopularList } from '../../../../util/networks/customNetworks';
-import { suppressNextNetworkAddedToast } from '../../../../util/networks/networkToastSuppression';
+import {
+  clearSuppressedNetworkAddedToast,
+  suppressNextNetworkAddedToast,
+} from '../../../../util/networks/networkToastSuppression';
 
 /**
  * Hook to manage token selection logic for Bridge token selector
@@ -88,6 +91,7 @@ export const useTokenSelection = (type: TokenSelectorType) => {
               ],
             });
           } catch {
+            clearSuppressedNetworkAddedToast(popularNetwork.chainId);
             if (isSourcePicker) {
               // Source requires a configured network to sign transactions.
               // Abort selection if the network couldn't be added.

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSwapUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSwapUrl.test.ts
@@ -2,6 +2,8 @@ import { handleSwapUrl } from '../handleSwapUrl';
 import NavigationService from '../../../../NavigationService';
 import { BridgeViewMode } from '../../../../../components/UI/Bridge/types';
 import { fetchAssetMetadata } from '../../../../../components/UI/Bridge/hooks/useAssetMetadata/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { resetSuppressedNetworkAddedToasts } from '../../../../../util/networks/networkToastSuppression';
 
 jest.mock('../../../../NavigationService', () => ({
   navigation: {
@@ -24,14 +26,11 @@ jest.mock(
 jest.mock('../../../../Engine', () => ({
   context: {
     NetworkController: {
-      getNetworkConfigurationByChainId: jest.fn().mockReturnValue({
-        rpcEndpoints: [
-          {
-            networkClientId: 'mainnetNetworkClientId',
-          },
-        ],
-        defaultRpcEndpointIndex: 0,
-      }),
+      getNetworkConfigurationByChainId: jest.fn(),
+      addNetwork: jest.fn(),
+    },
+    NetworkEnablementController: {
+      enableNetwork: jest.fn(),
     },
     MultichainNetworkController: {
       state: {
@@ -41,8 +40,32 @@ jest.mock('../../../../Engine', () => ({
   },
 }));
 
+const mockEngine = jest.requireMock('../../../../Engine') as {
+  context: {
+    NetworkController: {
+      getNetworkConfigurationByChainId: jest.Mock;
+      addNetwork: jest.Mock;
+    };
+    NetworkEnablementController: {
+      enableNetwork: jest.Mock;
+    };
+  };
+};
 const mockNavigate = NavigationService.navigation.navigate as jest.Mock;
 const mockFetchAssetMetadata = fetchAssetMetadata as jest.Mock;
+const mockGetNetworkConfigurationByChainId =
+  mockEngine.context.NetworkController.getNetworkConfigurationByChainId;
+const mockAddNetwork = mockEngine.context.NetworkController.addNetwork;
+const mockEnableNetwork =
+  mockEngine.context.NetworkEnablementController.enableNetwork;
+const availableNetworkConfig = {
+  rpcEndpoints: [
+    {
+      networkClientId: 'mainnetNetworkClientId',
+    },
+  ],
+  defaultRpcEndpointIndex: 0,
+};
 
 describe('handleSwapUrl', () => {
   const expectedSourceToken = {
@@ -64,12 +87,17 @@ describe('handleSwapUrl', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSuppressedNetworkAddedToasts();
+    mockGetNetworkConfigurationByChainId.mockReturnValue(
+      availableNetworkConfig,
+    );
     // Mock fetchAssetMetadata to return token data based on the address
     mockFetchAssetMetadata.mockImplementation(async (address) => {
+      const assetId = String(address);
       // Parse the address from CAIP format if needed
-      const tokenAddress = address.includes('/')
-        ? address.split(':')[2]
-        : address;
+      const tokenAddress = assetId.includes('/')
+        ? (assetId.split(':').at(-1) ?? assetId)
+        : assetId;
 
       if (
         tokenAddress.toLowerCase() ===
@@ -119,6 +147,7 @@ describe('handleSwapUrl', () => {
         location: 'Main View',
       },
     });
+    expect(mockEnableNetwork).toHaveBeenCalledWith(CHAIN_IDS.MAINNET);
   });
 
   it('navigates to Bridge view with partial parameters (only source token)', async () => {
@@ -133,6 +162,83 @@ describe('handleSwapUrl', () => {
         sourceToken: expectedSourceToken,
         destToken: undefined,
         sourceAmount: undefined,
+        sourcePage: 'deeplink',
+        bridgeViewMode: BridgeViewMode.Unified,
+        location: 'Main View',
+      },
+    });
+  });
+
+  it('adds and enables supported missing EVM source networks before navigating', async () => {
+    const expectedOptimismSourceToken = {
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: CHAIN_IDS.OPTIMISM,
+      decimals: 6,
+      name: 'Optimism USDC',
+      symbol: 'USDC',
+      image: 'https://example.com/op-usdc.png',
+    };
+    const expectedOptimismDestToken = {
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: CHAIN_IDS.OPTIMISM,
+      decimals: 6,
+      name: 'Optimism USDT',
+      symbol: 'USDT',
+      image: 'https://example.com/op-usdt.png',
+    };
+
+    mockFetchAssetMetadata.mockImplementation(async (address) => {
+      const assetId = String(address);
+      const tokenAddress = assetId.includes('/')
+        ? (assetId.split(':').at(-1) ?? assetId)
+        : assetId;
+
+      if (
+        tokenAddress.toLowerCase() ===
+        '0x1111111111111111111111111111111111111111'
+      ) {
+        return {
+          ...expectedOptimismSourceToken,
+          assetId: 'eip155:10/erc20:0x1111111111111111111111111111111111111111',
+        };
+      }
+
+      if (
+        tokenAddress.toLowerCase() ===
+        '0x2222222222222222222222222222222222222222'
+      ) {
+        return {
+          ...expectedOptimismDestToken,
+          assetId: 'eip155:10/erc20:0x2222222222222222222222222222222222222222',
+        };
+      }
+
+      return undefined;
+    });
+
+    mockGetNetworkConfigurationByChainId
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue(availableNetworkConfig);
+
+    const swapPath =
+      'from=eip155:10/erc20:0x1111111111111111111111111111111111111111&to=eip155:10/erc20:0x2222222222222222222222222222222222222222&amount=1000000';
+
+    await handleSwapUrl({ swapPath });
+
+    expect(mockAddNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: CHAIN_IDS.OPTIMISM,
+        name: 'OP',
+        nativeCurrency: 'ETH',
+      }),
+    );
+    expect(mockEnableNetwork).toHaveBeenCalledWith(CHAIN_IDS.OPTIMISM);
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: {
+        sourceToken: expectedOptimismSourceToken,
+        destToken: expectedOptimismDestToken,
+        sourceAmount: '1.0',
         sourcePage: 'deeplink',
         bridgeViewMode: BridgeViewMode.Unified,
         location: 'Main View',
@@ -187,6 +293,37 @@ describe('handleSwapUrl', () => {
 
     await handleSwapUrl({ swapPath });
 
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: {
+        sourceToken: undefined,
+        destToken: undefined,
+        sourceAmount: undefined,
+        sourcePage: 'deeplink',
+        bridgeViewMode: BridgeViewMode.Unified,
+        location: 'Main View',
+      },
+    });
+  });
+
+  it('falls back when the source chain is configured but not swap supported', async () => {
+    mockFetchAssetMetadata.mockResolvedValueOnce({
+      address: '0x3333333333333333333333333333333333333333',
+      chainId: '0x1234',
+      symbol: 'TEST',
+      name: 'Unsupported Token',
+      decimals: 18,
+      image: 'https://example.com/test.png',
+      assetId: 'eip155:4660/erc20:0x3333333333333333333333333333333333333333',
+    });
+
+    const swapPath =
+      'from=eip155:4660/erc20:0x3333333333333333333333333333333333333333';
+
+    await handleSwapUrl({ swapPath });
+
+    expect(mockEnableNetwork).not.toHaveBeenCalledWith('0x1234');
+    expect(mockAddNetwork).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
       screen: 'BridgeView',
       params: {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSwapUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSwapUrl.test.ts
@@ -3,7 +3,11 @@ import NavigationService from '../../../../NavigationService';
 import { BridgeViewMode } from '../../../../../components/UI/Bridge/types';
 import { fetchAssetMetadata } from '../../../../../components/UI/Bridge/hooks/useAssetMetadata/utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { resetSuppressedNetworkAddedToasts } from '../../../../../util/networks/networkToastSuppression';
+import {
+  consumeSuppressedNetworkAddedToast,
+  resetSuppressedNetworkAddedToasts,
+} from '../../../../../util/networks/networkToastSuppression';
+import { PopularList } from '../../../../../util/networks/customNetworks';
 
 jest.mock('../../../../NavigationService', () => ({
   navigation: {
@@ -49,6 +53,11 @@ const mockEngine = jest.requireMock('../../../../Engine') as {
     NetworkEnablementController: {
       enableNetwork: jest.Mock;
     };
+    MultichainNetworkController: {
+      state: {
+        multichainNetworkConfigurationsByChainId: Record<string, unknown>;
+      };
+    };
   };
 };
 const mockNavigate = NavigationService.navigation.navigate as jest.Mock;
@@ -88,6 +97,8 @@ describe('handleSwapUrl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetSuppressedNetworkAddedToasts();
+    mockEngine.context.MultichainNetworkController.state.multichainNetworkConfigurationsByChainId =
+      {};
     mockGetNetworkConfigurationByChainId.mockReturnValue(
       availableNetworkConfig,
     );
@@ -239,6 +250,123 @@ describe('handleSwapUrl', () => {
         sourceToken: expectedOptimismSourceToken,
         destToken: expectedOptimismDestToken,
         sourceAmount: '1.0',
+        sourcePage: 'deeplink',
+        bridgeViewMode: BridgeViewMode.Unified,
+        location: 'Main View',
+      },
+    });
+  });
+
+  it('falls back when a supported missing EVM source network is not in PopularList', async () => {
+    const optimismIndex = PopularList.findIndex(
+      (network) => network.chainId === CHAIN_IDS.OPTIMISM,
+    );
+    const [optimismNetwork] = PopularList.splice(optimismIndex, 1);
+
+    mockFetchAssetMetadata.mockResolvedValueOnce({
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: CHAIN_IDS.OPTIMISM,
+      symbol: 'USDC',
+      name: 'Optimism USDC',
+      decimals: 6,
+      image: 'https://example.com/op-usdc.png',
+      assetId: 'eip155:10/erc20:0x1111111111111111111111111111111111111111',
+    });
+    mockGetNetworkConfigurationByChainId.mockReturnValue(undefined);
+
+    try {
+      await handleSwapUrl({
+        swapPath:
+          'from=eip155:10/erc20:0x1111111111111111111111111111111111111111',
+      });
+    } finally {
+      PopularList.splice(optimismIndex, 0, optimismNetwork);
+    }
+
+    expect(mockAddNetwork).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: {
+        sourceToken: undefined,
+        destToken: undefined,
+        sourceAmount: undefined,
+        sourcePage: 'deeplink',
+        bridgeViewMode: BridgeViewMode.Unified,
+        location: 'Main View',
+      },
+    });
+  });
+
+  it('clears toast suppression and falls back when adding a supported source network fails', async () => {
+    mockFetchAssetMetadata.mockResolvedValueOnce({
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: CHAIN_IDS.OPTIMISM,
+      symbol: 'USDC',
+      name: 'Optimism USDC',
+      decimals: 6,
+      image: 'https://example.com/op-usdc.png',
+      assetId: 'eip155:10/erc20:0x1111111111111111111111111111111111111111',
+    });
+    mockGetNetworkConfigurationByChainId.mockReturnValue(undefined);
+    mockAddNetwork.mockRejectedValueOnce(new Error('addNetwork failed'));
+
+    await handleSwapUrl({
+      swapPath:
+        'from=eip155:10/erc20:0x1111111111111111111111111111111111111111',
+    });
+
+    expect(consumeSuppressedNetworkAddedToast(CHAIN_IDS.OPTIMISM)).toBe(false);
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: {
+        sourceToken: undefined,
+        destToken: undefined,
+        sourceAmount: undefined,
+        sourcePage: 'deeplink',
+        bridgeViewMode: BridgeViewMode.Unified,
+        location: 'Main View',
+      },
+    });
+  });
+
+  it('enables available supported CAIP source chains before navigating', async () => {
+    const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    const solanaAssetId = `${solanaChainId}/slip44:501`;
+    const expectedSolanaToken = {
+      address: solanaAssetId,
+      chainId: solanaChainId,
+      decimals: 9,
+      name: 'Solana',
+      symbol: 'SOL',
+      image: 'https://example.com/sol.png',
+    };
+
+    mockFetchAssetMetadata.mockResolvedValueOnce({
+      address: 'ignored-for-nonevm',
+      chainId: solanaChainId,
+      symbol: 'SOL',
+      name: 'Solana',
+      decimals: 9,
+      image: 'https://example.com/sol.png',
+      assetId: solanaAssetId,
+    });
+    mockEnableNetwork.mockImplementation(async (chainId: string) => {
+      mockEngine.context.MultichainNetworkController.state.multichainNetworkConfigurationsByChainId[
+        chainId
+      ] = { chainId };
+    });
+
+    await handleSwapUrl({
+      swapPath: `from=${solanaAssetId}`,
+    });
+
+    expect(mockEnableNetwork).toHaveBeenCalledWith(solanaChainId);
+    expect(mockNavigate).toHaveBeenCalledWith('Bridge', {
+      screen: 'BridgeView',
+      params: {
+        sourceToken: expectedSolanaToken,
+        destToken: undefined,
+        sourceAmount: undefined,
         sourcePage: 'deeplink',
         bridgeViewMode: BridgeViewMode.Unified,
         location: 'Main View',

--- a/app/core/DeeplinkManager/handlers/legacy/handleSwapUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleSwapUrl.ts
@@ -7,6 +7,7 @@ import {
   isCaipChainId,
   parseCaipAssetType,
 } from '@metamask/utils';
+import { RpcEndpointType } from '@metamask/network-controller';
 import {
   BridgeToken,
   BridgeViewMode,
@@ -15,12 +16,18 @@ import Routes from '../../../../constants/navigation/Routes';
 import { BridgeRouteParams } from '../../../../components/UI/Bridge/hooks/useSwapBridgeNavigation';
 import { fetchAssetMetadata } from '../../../../components/UI/Bridge/hooks/useAssetMetadata/utils';
 import {
+  ALLOWED_BRIDGE_CHAIN_IDS,
   isNonEvmChainId,
   MetaMetricsSwapsEventSource,
 } from '@metamask/bridge-controller';
 import { ethers } from 'ethers';
 import Engine from '../../../Engine';
 import { isHex } from 'viem';
+import { PopularList } from '../../../../util/networks/customNetworks';
+import {
+  clearSuppressedNetworkAddedToast,
+  suppressNextNetworkAddedToast,
+} from '../../../../util/networks/networkToastSuppression';
 
 import { HandleSwapUrlParams } from '../../types/deepLink.types';
 
@@ -76,6 +83,80 @@ const isChainAvailable = (chainId: Hex | CaipChainId) => {
   return false;
 };
 
+const isSwapSupportedChain = (chainId: Hex | CaipChainId) =>
+  (
+    ALLOWED_BRIDGE_CHAIN_IDS as readonly (Hex | CaipChainId | string)[]
+  ).includes(chainId);
+
+const enableChainInBackground = (chainId: Hex | CaipChainId) => {
+  Engine.context.NetworkEnablementController?.enableNetwork?.(chainId);
+};
+
+const addEvmNetworkFromPopularList = async (chainId: Hex) => {
+  const popularNetwork = PopularList.find(
+    (network) => network.chainId === chainId,
+  );
+
+  if (!popularNetwork) {
+    return;
+  }
+
+  const { blockExplorerUrl } = popularNetwork.rpcPrefs ?? {};
+
+  suppressNextNetworkAddedToast(chainId);
+
+  try {
+    await Engine.context.NetworkController.addNetwork({
+      chainId,
+      blockExplorerUrls: blockExplorerUrl ? [blockExplorerUrl] : [],
+      defaultRpcEndpointIndex: 0,
+      defaultBlockExplorerUrlIndex: blockExplorerUrl ? 0 : undefined,
+      name: popularNetwork.nickname,
+      nativeCurrency: popularNetwork.ticker,
+      rpcEndpoints: [
+        {
+          url: popularNetwork.rpcUrl,
+          failoverUrls: popularNetwork.failoverRpcUrls,
+          name: popularNetwork.nickname,
+          type: RpcEndpointType.Custom,
+        },
+      ],
+    });
+  } catch (error) {
+    clearSuppressedNetworkAddedToast(chainId);
+    throw error;
+  }
+};
+
+const ensureChainAvailable = async (chainId: Hex | CaipChainId) => {
+  if (!isSwapSupportedChain(chainId)) {
+    return false;
+  }
+
+  if (isChainAvailable(chainId)) {
+    enableChainInBackground(chainId);
+    return true;
+  }
+
+  if (isCaipChainId(chainId)) {
+    enableChainInBackground(chainId);
+    return isChainAvailable(chainId);
+  }
+
+  try {
+    await addEvmNetworkFromPopularList(chainId);
+  } catch {
+    // Continue and re-check availability in case another flow added it first.
+  }
+
+  if (!isChainAvailable(chainId)) {
+    return false;
+  }
+
+  enableChainInBackground(chainId);
+  return true;
+};
+
 /**
  * Handles deeplinks for the unified swap/bridge experience
  *
@@ -108,15 +189,25 @@ export const handleSwapUrl = async ({ swapPath }: HandleSwapUrlParams) => {
         ? await validateAndLookupToken(fromCaip)
         : undefined;
 
-    // Check if user has added the source chain to their wallet
-    if (sourceToken?.chainId && !isChainAvailable(sourceToken?.chainId)) {
+    // Ensure supported source chains exist and are enabled before the Bridge
+    // view tries to switch into them on mount.
+    if (
+      sourceToken?.chainId &&
+      !(await ensureChainAvailable(sourceToken.chainId))
+    ) {
       throw new Error('Chain not available');
     }
 
-    const destToken =
+    const destTokenCandidate =
       toCaip && isCaipAssetType(toCaip)
         ? await validateAndLookupToken(toCaip)
         : undefined;
+
+    const destToken =
+      destTokenCandidate?.chainId &&
+      !(await ensureChainAvailable(destTokenCandidate.chainId))
+        ? undefined
+        : destTokenCandidate;
 
     // Process amount
     const sourceAmount =

--- a/app/core/DeeplinkManager/handlers/legacy/handleSwapUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleSwapUrl.ts
@@ -88,8 +88,12 @@ const isSwapSupportedChain = (chainId: Hex | CaipChainId) =>
     ALLOWED_BRIDGE_CHAIN_IDS as readonly (Hex | CaipChainId | string)[]
   ).includes(chainId);
 
-const enableChainInBackground = (chainId: Hex | CaipChainId) => {
-  Engine.context.NetworkEnablementController?.enableNetwork?.(chainId);
+const enableChainInBackground = async (chainId: Hex | CaipChainId) => {
+  try {
+    await Engine.context.NetworkEnablementController?.enableNetwork?.(chainId);
+  } catch {
+    // Best-effort only. Chain availability is re-checked independently.
+  }
 };
 
 const addEvmNetworkFromPopularList = async (chainId: Hex) => {
@@ -134,12 +138,12 @@ const ensureChainAvailable = async (chainId: Hex | CaipChainId) => {
   }
 
   if (isChainAvailable(chainId)) {
-    enableChainInBackground(chainId);
+    await enableChainInBackground(chainId);
     return true;
   }
 
   if (isCaipChainId(chainId)) {
-    enableChainInBackground(chainId);
+    await enableChainInBackground(chainId);
     return isChainAvailable(chainId);
   }
 
@@ -153,7 +157,7 @@ const ensureChainAvailable = async (chainId: Hex | CaipChainId) => {
     return false;
   }
 
-  enableChainInBackground(chainId);
+  await enableChainInBackground(chainId);
   return true;
 };
 

--- a/app/util/networks/networkToastSuppression.ts
+++ b/app/util/networks/networkToastSuppression.ts
@@ -1,0 +1,30 @@
+const suppressedNetworkAddedToasts = new Set<string>();
+
+const normalizeChainId = (chainId: string) => chainId.toLowerCase();
+
+export const suppressNextNetworkAddedToast = (chainId: string) => {
+  suppressedNetworkAddedToasts.add(normalizeChainId(chainId));
+};
+
+export const clearSuppressedNetworkAddedToast = (chainId: string) => {
+  suppressedNetworkAddedToasts.delete(normalizeChainId(chainId));
+};
+
+/**
+ * Atomically checks whether the next "network added" toast is suppressed for
+ * this chain and clears that one-shot suppression entry.
+ *
+ * Returns `true` only when a matching suppression entry existed and was
+ * removed. Returns `false` when `chainId` is missing or no entry was present.
+ */
+export const consumeSuppressedNetworkAddedToast = (chainId?: string) => {
+  if (!chainId) {
+    return false;
+  }
+
+  return suppressedNetworkAddedToasts.delete(normalizeChainId(chainId));
+};
+
+export const resetSuppressedNetworkAddedToasts = () => {
+  suppressedNetworkAddedToasts.clear();
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes SWAPS-4336, where swap deeplinks targeting supported but disabled networks could fall back to the default Bridge pair and show an unexpected network-added toast. The deeplink flow now checks swap support first, enables already-known networks in the background, auto-adds supported missing EVM networks from `PopularList`, and consumes one-shot toast suppression correctly so deeplink and Bridge token-selector adds stay silent while normal manual add/remove toasts still behave as expected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed swap deeplinks on supported disabled networks so the requested chain opens without an extra network-added toast.

## **Related issues**

Refs: [SWAPS-4336](https://consensyssoftware.atlassian.net/browse/SWAPS-4336)

## **Manual testing steps**

```gherkin
Feature: open swap deeplinks on supported disabled networks

  Scenario: deeplink adds a supported disabled network without showing an add toast
    Given Sei is disabled in the wallet
    When the user opens a swap deeplink for "SEI -> USDC" on Sei
    Then Bridge opens with "SEI -> USDC" selected on Sei
    And no "network added" toast is shown

  Scenario: manual re-add still shows the add toast after deeplink suppression is consumed
    Given Sei was added by deeplink and then disabled again
    When the user adds Sei back manually
    Then a "network added" toast is shown
    When the user removes Sei again
    Then a "network removed" toast is shown

  Scenario: bridge token selection adds a missing supported network silently
    Given a supported EVM network from the Bridge token selector is disabled
    When the user selects a token on that network in Bridge
    Then the network is added in the background
    And no "network added" toast is shown
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[SWAPS-4336]: https://consensyssoftware.atlassian.net/browse/SWAPS-4336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deeplink-driven network enablement and auto-add behavior for Bridge/Swaps, which can affect navigation, network configuration state, and user-facing toasts. Risk is moderated by added unit tests, but failures could still cause incorrect chain selection or missing/extra notifications.
> 
> **Overview**
> Fixes swap deeplinks so supported-but-disabled (or missing) source/dest chains are made available before `BridgeView` mounts, instead of falling back to default params.
> 
> Adds one-shot suppression for *network-added* toasts via `networkToastSuppression`, wires `Main`'s add/remove network toast logic through `shouldShowNetworkListToast`, and uses the suppression when Bridge token selection or swap deeplinks auto-add EVM networks from `PopularList` (clearing suppression on failures).
> 
> Extends `handleSwapUrl` to verify swap support (`ALLOWED_BRIDGE_CHAIN_IDS`), best-effort enable known chains, auto-add supported missing EVM networks, and drop unsupported/unavailable dest tokens; expands tests to cover these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3efc141772cef22829125ec3cf5c21d18dedcbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->