### PR TITLE
fix: hide network filter on mUSD tokens view

### DIFF
--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -394,24 +394,21 @@ describe('Tokens', () => {
   });
 
   describe('showOnlyMusd (Cash view)', () => {
-    it('passes showAddToken false and hideSort true to TokenListControlBar', async () => {
+    it('does not render TokenListControlBar when showOnlyMusd', async () => {
       const { mockSelectSortedAssetsBySelectedAccountGroup } =
         arrangeMockSelectors();
       mockSelectSortedAssetsBySelectedAccountGroup.mockReturnValue([]);
 
-      renderComponent(initialState, true, true);
+      const { queryByTestId } = renderComponent(initialState, true, true);
 
       await waitFor(() => {
-        expect(
-          TokenListControlBarModule.TokenListControlBar,
-        ).toHaveBeenCalledWith(
-          expect.objectContaining({
-            showAddToken: false,
-            hideSort: true,
-          }),
-          expect.anything(),
-        );
+        expect(queryByTestId('tokens-empty-state')).toBeOnTheScreen();
       });
+
+      expect(queryByTestId('token-list-control-bar')).toBeNull();
+      expect(
+        TokenListControlBarModule.TokenListControlBar,
+      ).not.toHaveBeenCalled();
     });
 
     it('does not render add token button when showOnlyMusd', async () => {

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -318,12 +318,14 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
         }
         testID={WalletViewSelectorsIDs.TOKENS_CONTAINER}
       >
-        <TokenListControlBar
-          goToAddToken={goToAddToken}
-          showAddToken={!showOnlyMusd}
-          hideSort={showOnlyMusd}
-          style={isFullView ? tw`px-4 pb-4` : undefined}
-        />
+        {!showOnlyMusd && (
+          <TokenListControlBar
+            goToAddToken={goToAddToken}
+            showAddToken={!showOnlyMusd}
+            hideSort={showOnlyMusd}
+            style={isFullView ? tw`px-4 pb-4` : undefined}
+          />
+        )}
         {tokenContent}
         <ScamWarningModal
           showScamWarningModal={showScamWarningModal}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Hides the "Popular networks" network-filter dropdown on the mUSD-only tokens view (rendered by `CashTokensFullView`, the "Money" screen).

The `Tokens` component is shared between the legacy wallet tab, the homepage redesign, and the Cash/mUSD view. In the Cash case it's mounted with `showOnlyMusd={true}`, which already hides the add-token button and the sort button. The only remaining control in `TokenListControlBar` was the network filter, which doesn't make sense on a single-token view: mUSD is deployed on a fixed set of chains and the user isn't browsing a multi-token list here.

The change guards the `TokenListControlBar` render in `app/components/UI/Tokens/index.tsx` on `!showOnlyMusd`. No new props, no changes to `BaseControlBar` (which is shared with DeFi, Activity, and Settings and must stay untouched), and every other caller of `Tokens` is unaffected.

## **Changelog**

CHANGELOG entry: Removed the network filter from the Money (mUSD) tokens view.

## **Related issues**

Fixes: MUSD-643

## **Manual testing steps**

```gherkin
Feature: Money (mUSD) tokens view control bar

  Scenario: user opens the Money screen
    Given the user has the mUSD conversion flow enabled and is geo-eligible
    And the user is on the wallet homepage

    When the user taps the "Money" section to open the full mUSD tokens view
    Then the "Popular networks" dropdown is not shown above the token list
    And the mUSD token balances, "Your bonus" section, "Convert your stablecoins" section, and "Convert to mUSD" CTA are all still shown

  Scenario: user opens the main tokens tab
    Given the user is on the wallet homepage

    When the user views the main tokens list
    Then the "Popular networks" dropdown is still shown above the token list
    And the sort and add-token controls are still shown
```

## **Screenshots/Recordings**

### **Before**

<!-- Money screen with the "Popular networks" dropdown visible above the mUSD rows -->

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/05b8e5f4-2124-4c70-9216-21764e13b207" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/94cbcf5a-483e-48ad-a882-4afe792149f8" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-conditional rendering change limited to the `showOnlyMusd` (Cash/mUSD) variant, with updated unit tests to prevent regressions. Main tokens views should be unaffected, but reviewers should sanity-check the Cash screen header/spacing when the control bar is removed.
> 
> **Overview**
> Hides the `TokenListControlBar` entirely when `Tokens` is rendered with `showOnlyMusd`, removing the remaining network filter UI from the mUSD-only Cash view.
> 
> Updates the Cash-view unit test to assert the control bar is not rendered/called (instead of verifying specific props), while keeping the empty-state assertions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb57af48eecb42dc6c11535815d78a1a59c08b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->