### PR TITLE
chore(ci): derive RC slack notification changelog from git ancestry

### DIFF
--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source_branch }}
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -45,7 +45,7 @@ const REPO_URL = process.env.GITHUB_REPOSITORY
   ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
   : 'https://github.com/MetaMask/metamask-mobile';
 
-const MAX_RC_COMMIT_LINES = 20;
+const MAX_RC_COMMIT_LINES = 10;
 
 /** Commits whose subject starts with this (version bump automation) are omitted from the RC list. */
 const SKIP_CI_BUMP_VERSION_SUBJECT = /^\[skip ci\] Bump version number to/;

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -1,128 +1,187 @@
 /**
  * Slack RC Build Notification Script
  *
- * This script posts a notification to Slack after an RC build completes.
- * It reads the CHANGELOG.md using @metamask/auto-changelog to extract entries
- * for the current version and formats them into a Slack message with PR links.
+ * Posts a Slack message after an RC build. The *What's in this RC* block lists
+ * commits from **git history** (merge-base + ancestry path).
  *
- * Required Environment Variables:
- *   - SEMVER: The semantic version (e.g., "7.40.0")
+ * Algorithm:
+ *   - Run `git merge-base <headRef> <baseRef>` (default **headRef**: `HEAD`, override with
+ *     `HEAD_REF`; default **baseRef**: `origin/main`, override with `MERGE_BASE_REF`) to get
+ *     the fork point as a **merge-base commit hash**.
+ *   - List commits on the fork-to-tip path only:
+ *     `git log --ancestry-path <merge-base-hash>..<headRef>` (same full hash from `git merge-base`; output uses short hash + subject), with optional
+ *     PR links from `#123` / `(#123)` in subjects.
+ *   - Omit commits whose subject starts with `[skip ci] Bump version number to` (automation noise).
+ *   - Cap the list (see `MAX_RC_COMMIT_LINES`) and append *…and N more* when needed.
+ *
+ * **Fail-open:** If merge-base fails, `git log` errors, or the ancestry path is empty,
+ * the notification is still sent: *What's in this RC* is omitted in favor of a short
+ * fallback with a link to release notes on GitHub when needed. The process exits 0;
+ * git problems are logged to stderr. This matches CI/local use where shallow clones or
+ * missing refs can make history unavailable.
+ *
+ * Required environment variables:
+ *   - SEMVER: Semantic version (e.g. "7.40.0")
  *   - IOS_BUILD_NUMBER: iOS build number
  *   - ANDROID_BUILD_NUMBER: Android build number
  *   - SLACK_BOT_TOKEN: Slack Bot OAuth token for API calls
  *
- * Optional Environment Variables:
+ * Optional environment variables:
  *   - ANDROID_PUBLIC_URL: Public URL for Android APK download
  *   - IOS_PUBLIC_URL: Public URL for iOS build
- *   - BUILD_PIPELINE_URL: URL to the GitHub Actions pipeline
- *   - GITHUB_REPOSITORY: Repository in format "owner/repo"
- *   - TEST_CHANNEL: Override channel for testing (e.g., "#mm-test-channel")
+ *   - BUILD_PIPELINE_URL: GitHub Actions pipeline URL (footer: pipeline + release notes link)
+ *   - GITHUB_REPOSITORY: "owner/repo" (defaults to metamask-mobile)
+ *   - MERGE_BASE_REF: Ref for merge-base (default: origin/main)
+ *   - HEAD_REF: Tip ref for `git merge-base` and `git log` range (default: `HEAD`; e.g. a
+ *     branch name or SHA to preview another tip without checking it out)
+ *   - SLACK_RC_NOTIFICATION_DRY_RUN: Set to `1` or `true` to print the message JSON and
+ *     exit without calling Slack (`SLACK_BOT_TOKEN` not required in this mode)
  */
 
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-// eslint-disable-next-line import-x/no-extraneous-dependencies
-import { parseChangelog } from '@metamask/auto-changelog';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { execFileSync } from 'child_process';
 
 // Configuration
 const REPO_URL = process.env.GITHUB_REPOSITORY
   ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
   : 'https://github.com/MetaMask/metamask-mobile';
 
+const MAX_RC_COMMIT_LINES = 20;
+
+/** Commits whose subject starts with this (version bump automation) are omitted from the RC list. */
+const SKIP_CI_BUMP_VERSION_SUBJECT = /^\[skip ci\] Bump version number to/;
+
 /**
- * Extract changelog entries for a specific version using auto-changelog
- * @param {string} version - The version to extract entries for
- * @returns {Object|null} The release changes or null if not found
+ * Run `git merge-base` and return the merge-base **commit hash**, or `null` if git errors
+ * or output is empty (fail-open: caller skips the RC commit list).
+ * @param {string} headRef
+ * @param {string} baseRef
+ * @returns {string|null} Merge-base commit hash (hex string from `git merge-base`), or `null` on failure
  */
-function extractChangelogEntries(version) {
-  const changelogPath = join(__dirname, '..', 'CHANGELOG.md');
-
-  let changelogContent;
+function getMergeBase(headRef, baseRef) {
   try {
-    changelogContent = readFileSync(changelogPath, 'utf8');
-  } catch (error) {
-    console.error(`Failed to read CHANGELOG.md: ${error.message}`);
-    return null;
-  }
-
-  try {
-    const changelog = parseChangelog({
-      changelogContent,
-      repoUrl: REPO_URL,
-      shouldExtractPrLinks: true,
+    const out = execFileSync('git', ['merge-base', headRef, baseRef], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
-
-    // Get changes for this specific version
-    const releaseChanges = changelog.getReleaseChanges(version);
-
-    if (!releaseChanges) {
-      console.warn(`No release found for version ${version}`);
-      return null;
-    }
-
-    return releaseChanges;
+    const sha = out.trim();
+    return sha || null;
   } catch (error) {
-    console.error(`Failed to parse CHANGELOG.md: ${error.message}`);
+    console.error(
+      `[slack-rc-notification] git merge-base ${headRef} ${baseRef} failed (RC commit list skipped): ${error.message}`,
+    );
     return null;
   }
 }
 
 /**
- * Format changelog entries for Slack
- * @param {Object} changes - The changelog changes object
- * @param {number} maxEntries - Maximum entries to display
- * @returns {string} Formatted changelog text for Slack
+ * @param {string} mergeBaseCommitHash - Commit hash returned by `git merge-base` (common ancestor of `headRef` and the base ref)
+ * @param {string} headRef - Tip ref (default in callers: `HEAD`, overridable via `HEAD_REF`)
+ * @returns {string[]} Raw `hash\\tsubject` lines from `git log --ancestry-path` from merge-base to `headRef`,
+ *   excluding `[skip ci] Bump version number to …` subjects; empty array if no commits or if git fails (fail-open).
  */
-function formatChangesForSlack(changes, maxEntries = 15) {
-  const formattedEntries = [];
-
-  // Priority order for categories
-  const categoryOrder = [
-    'Added',
-    'Fixed',
-    'Changed',
-    'Deprecated',
-    'Removed',
-    'Uncategorized',
-  ];
-
-  for (const category of categoryOrder) {
-    const entries = changes[category] || [];
-    for (const entry of entries) {
-      if (formattedEntries.length >= maxEntries) {
-        break;
-      }
-
-      // Build description with PR links
-      let description = entry.description;
-
-      // If we have PR numbers from auto-changelog, format them for Slack
-      if (entry.prNumbers && entry.prNumbers.length > 0) {
-        const prLinks = entry.prNumbers
-          .map((prNum) => `<${REPO_URL}/pull/${prNum}|#${prNum}>`)
-          .join(', ');
-        description = `${description} (${prLinks})`;
-      }
-
-      formattedEntries.push(`• ${description}`);
+function getAncestryPathLogLines(mergeBaseCommitHash, headRef) {
+  try {
+    const out = execFileSync(
+      'git',
+      ['log', '--ancestry-path', `${mergeBaseCommitHash}..${headRef}`, '--pretty=format:%h\t%s'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    if (!out.trim()) {
+      return [];
     }
+    return out
+      .trim()
+      .split('\n')
+      .filter((line) => {
+        const tab = line.indexOf('\t');
+        const subject = tab >= 0 ? line.slice(tab + 1) : line;
+        return !SKIP_CI_BUMP_VERSION_SUBJECT.test(subject.trim());
+      });
+  } catch (error) {
+    console.error(
+      `[slack-rc-notification] git log --ancestry-path failed (RC commit list skipped): ${error.message}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Link (#123) and standalone #123 in a commit subject to the repo PR URL (Slack mrkdwn).
+ * @param {string} subject
+ * @returns {string}
+ */
+function formatSubjectWithPrLinks(subject) {
+  let result = subject;
+  result = result.replace(/\(#(\d+)\)/g, (_, n) => `(<${REPO_URL}/pull/${n}|#${n}>)`);
+  result = result.replace(/(^|\s)#(\d+)\b/g, (_, lead, n) => `${lead}<${REPO_URL}/pull/${n}|#${n}>`);
+  return result;
+}
+
+/**
+ * Format one `hash\\tsubject` log line for Slack (bullet, short hash, subject with PR links).
+ * @param {string} line
+ * @returns {string}
+ */
+function formatCommitLineForSlack(line) {
+  const tab = line.indexOf('\t');
+  const hash = tab >= 0 ? line.slice(0, tab) : '';
+  const subject = tab >= 0 ? line.slice(tab + 1) : line;
+  const linked = formatSubjectWithPrLinks(subject);
+  return `• \`${hash}\` ${linked}`;
+}
+
+/**
+ * Build Slack mrkdwn for RC commits (capped) and optional "...and N more" line.
+ * @param {string[]} logLines - Full list of hash\\tsubject lines
+ * @param {number} maxEntries
+ * @returns {{ text: string, hasEntries: boolean }}
+ */
+function formatCommitsForSlack(logLines, maxEntries = MAX_RC_COMMIT_LINES) {
+  if (!logLines.length) {
+    return { text: '', hasEntries: false };
   }
 
-  // Count remaining entries
-  const allEntriesCount = Object.values(changes)
-    .flat()
-    .filter(Boolean).length;
-  const remaining = allEntriesCount - formattedEntries.length;
-
+  const slice = logLines.slice(0, maxEntries);
+  const remaining = logLines.length - slice.length;
+  const bullets = slice.map(formatCommitLineForSlack);
   if (remaining > 0) {
-    formattedEntries.push(`\n_...and ${remaining} more changes_`);
+    bullets.push(`\n_...and ${remaining} more_`);
+  }
+  return { text: bullets.join('\n'), hasEntries: true };
+}
+
+/**
+ * Resolve merge-base with `MERGE_BASE_REF` (default `origin/main`) and collect commits
+ * via `git log --ancestry-path`.
+ * @returns {{ text: string, hasEntries: boolean }} Slack mrkdwn and whether to show the RC list
+ */
+function extractRcCommitsFromGit() {
+  const baseRef = process.env.MERGE_BASE_REF ?? 'origin/main';
+  const headRef = (process.env.HEAD_REF ?? '').trim() || 'HEAD';
+  console.log(`\n📖 Git history (merge-base ${headRef} with ${baseRef}, ancestry-path to ${headRef})...`);
+
+  const mergeBase = getMergeBase(headRef, baseRef);
+  if (!mergeBase) {
+    console.warn(
+      '   Could not resolve merge-base; skipping “What’s in this RC” (Slack will show fallback + release notes link when available)',
+    );
+    return { text: '', hasEntries: false };
+  }
+  console.log(`   merge-base: ${mergeBase}`);
+
+  const logLines = getAncestryPathLogLines(mergeBase, headRef);
+  if (!logLines.length) {
+    console.warn(
+      '   No commits on ancestry path; skipping “What’s in this RC” (Slack will show fallback + release notes link when available)',
+    );
+    return { text: '', hasEntries: false };
   }
 
-  return formattedEntries.join('\n');
+  console.log(`   Found ${logLines.length} commit(s) on ancestry path`);
+  return formatCommitsForSlack(logLines);
 }
 
 /**
@@ -158,8 +217,8 @@ function buildSlackMessage(options) {
     androidUrl,
     iosUrl,
     pipelineUrl,
-    changelogText,
-    hasChangelog,
+    rcCommitsText,
+    hasRcCommits,
   } = options;
 
   const blocks = [
@@ -210,8 +269,8 @@ function buildSlackMessage(options) {
     },
   ];
 
-  // Add changelog section if we have entries
-  if (hasChangelog && changelogText) {
+  // Add RC commit list if we have entries
+  if (hasRcCommits && rcCommitsText) {
     blocks.push(
       {
         type: 'divider',
@@ -220,16 +279,20 @@ function buildSlackMessage(options) {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*📋 What's in this RC:*\n${changelogText}`,
+          text: `*📋 What's in this RC:*\n${rcCommitsText}`,
         },
       },
     );
   } else {
+    const releaseNotesMrkdwn = `<${REPO_URL}/tree/release/${version}|View release notes>`;
+    const fallbackMrkdwn = pipelineUrl
+      ? `_Could not list RC commits (empty ancestry path, merge-base failed, incomplete git history, or \`git log\` failed). For full notes see ${releaseNotesMrkdwn} — also linked in the footer below._`
+      : `_Could not list RC commits (empty ancestry path, merge-base failed, incomplete git history, or \`git log\` failed). For full notes see ${releaseNotesMrkdwn}._`;
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '_No changelog entries found for this version. Check CHANGELOG.md_',
+        text: fallbackMrkdwn,
       },
     });
   }
@@ -245,7 +308,7 @@ function buildSlackMessage(options) {
         elements: [
           {
             type: 'mrkdwn',
-            text: `<${pipelineUrl}|View Build Pipeline> | <${REPO_URL}/blob/release/${version}/CHANGELOG.md|View Full Changelog>`,
+            text: `<${pipelineUrl}|View Build Pipeline> | <${REPO_URL}/tree/release/${version}|View full release notes>`,
           },
         ],
       },
@@ -312,8 +375,13 @@ function getSlackChannel(version) {
  * Main function
  */
 async function main() {
-  // Validate required environment variables (fail open - just log and return)
-  const requiredEnvVars = ['SEMVER', 'SLACK_BOT_TOKEN'];
+  const dryRunEnv = process.env.SLACK_RC_NOTIFICATION_DRY_RUN;
+  const isDryRun =
+    dryRunEnv === '1' || String(dryRunEnv).toLowerCase() === 'true';
+
+  // Validate required environment variables (fail open - just log and return).
+  // Dry-run only needs SEMVER so you can inspect blocks without Slack or a token.
+  const requiredEnvVars = isDryRun ? ['SEMVER'] : ['SEMVER', 'SLACK_BOT_TOKEN'];
   const missingVars = requiredEnvVars.filter((v) => !process.env[v]);
 
   if (missingVars.length > 0) {
@@ -331,38 +399,16 @@ async function main() {
   const pipelineUrl = process.env.BUILD_PIPELINE_URL;
   const botToken = process.env.SLACK_BOT_TOKEN;
 
-  // TEST_CHANNEL allows overriding the channel for local testing
-  const testChannel = process.env.TEST_CHANNEL;
-  const expectedChannelName = testChannel || getSlackChannel(version);
-  const isTestMode = Boolean(testChannel);
+  const expectedChannelName = getSlackChannel(version);
 
   console.log(`\n📣 Preparing Slack notification for RC v${version} (${buildNumber})`);
-  if (isTestMode) {
-    console.log(`🧪 TEST MODE: Posting to override channel: ${expectedChannelName}`);
+  if (isDryRun) {
+    console.log('🧪 DRY RUN: will print payload JSON and not call Slack');
   } else {
     console.log(`📍 Target channel: ${expectedChannelName}`);
   }
 
-  // Extract changelog entries using auto-changelog
-  console.log('\n📖 Reading CHANGELOG.md...');
-  const changes = extractChangelogEntries(version);
-
-  let changelogText = '';
-  let hasChangelog = false;
-
-  if (changes) {
-    const totalChanges = Object.values(changes)
-      .flat()
-      .filter(Boolean).length;
-    console.log(`   Found ${totalChanges} changelog entries for v${version}`);
-
-    if (totalChanges > 0) {
-      hasChangelog = true;
-      changelogText = formatChangesForSlack(changes);
-    }
-  } else {
-    console.log('   ⚠️ Could not read changelog');
-  }
+  const { text: rcCommitsText, hasEntries: hasRcCommits } = extractRcCommitsFromGit();
 
   // Build and send the message
   console.log('\n📤 Posting to Slack...');
@@ -373,9 +419,21 @@ async function main() {
     androidUrl,
     iosUrl,
     pipelineUrl,
-    changelogText,
-    hasChangelog,
+    rcCommitsText,
+    hasRcCommits,
   });
+
+  if (isDryRun) {
+    const preview = {
+      channel: expectedChannelName,
+      text: payload.text,
+      blocks: payload.blocks,
+    };
+    console.log('\n--- Slack payload (dry run) ---\n');
+    console.log(JSON.stringify(preview, null, 2));
+    console.log('\n--- end dry run ---\n');
+    return;
+  }
 
   const result = await postToSlack(botToken, expectedChannelName, payload);
 
@@ -399,4 +457,3 @@ main().catch((error) => {
   console.error('⚠️ Unexpected error (non-critical):', error);
   // Don't exit with error code - this is a non-critical notification
 });
-


### PR DESCRIPTION
## **Description**

RC Slack notifications previously parsed **CHANGELOG.md** with `@metamask/auto-changelog`. It wasn't working because the release changelog is on a different branch and do not follow the format we want for the slack notification. This change builds the “What’s in this RC” section from **git** instead:

- **`A`** = `git merge-base HEAD <base>` (default **`origin/main`**, overridable via **`CHANGELOG_MERGE_BASE_REF`**)
- **`B`** = **`HEAD`**
- List commits with **`git log --ancestry-path A..B`** so only commits on the path between the fork point and the RC tip are included.

The reusable Slack workflow checkout is updated from **`fetch-depth: 1`** to **`fetch-depth: 0`** so **`merge-base`** has enough history on the runner.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 
https://consensyssoftware.atlassian.net/browse/INFRA-3482
https://consensyssoftware.atlassian.net/browse/MCWP-442

## **Manual testing steps**

```gherkin
Feature: RC Slack notification changelog

  Scenario: Verify git-based commit list on a release branch
    Given a clone with full history and a remote tracking branch (e.g. origin/main)
    When CHANGELOG_MERGE_BASE_REF is unset or set to origin/main and the script runs with SLACK_BOT_TOKEN and TEST_CHANNEL
    Then the Slack message lists commits from git log --ancestry-path $(git merge-base HEAD origin/main)..HEAD and respects the entry cap

  Scenario: GitHub Actions reusable workflow
    Given the slack-rc-notification workflow runs after an RC build
    When the checkout uses fetch-depth 0
    Then merge-base and ancestry-path succeed and the notification posts without shallow-clone errors
```

## **Screenshots/Recordings**

### **Before**

<img width="571" height="221" alt="image" src="https://github.com/user-attachments/assets/abf62ebf-3fa9-4ecd-a35f-3ec98aa1586d" />


### **After**

Message preview [link](https://app.slack.com/block-kit-builder/T02P98BKE#{%22blocks%22:[{%22type%22:%22header%22,%22text%22:{%22type%22:%22plain_text%22,%22text%22:%22%F0%9F%9A%80%20Mobile%20RC%20Build%20v7.73.0%20(iOS%204400%20/%20Android%204400)%22,%22emoji%22:true}},{%22type%22:%22section%22,%22fields%22:[{%22type%22:%22mrkdwn%22,%22text%22:%22*Version:*\n7.73.0%22},{%22type%22:%22mrkdwn%22,%22text%22:%22*Build%20Number:*\niOS%204400%20/%20Android%204400%22}]},{%22type%22:%22section%22,%22text%22:{%22type%22:%22mrkdwn%22,%22text%22:%22*%F0%9F%93%A6%20Download%20Links:*%22}},{%22type%22:%22section%22,%22fields%22:[{%22type%22:%22mrkdwn%22,%22text%22:%22*Android%20APK:*\n_Not%20available_%22},{%22type%22:%22mrkdwn%22,%22text%22:%22*iOS%20Build:*\n_Check%20TestFlight_%22}]},{%22type%22:%22divider%22},{%22type%22:%22section%22,%22text%22:{%22type%22:%22mrkdwn%22,%22text%22:%22*%F0%9F%93%8B%20What's%20in%20this%20RC:*\n%E2%80%A2%20%605e54464545%60%20chore(runway):%20cherry-pick%20feat(predict):%20track%20mmpay%20submitted%20event%20with%20payment%20token%20address%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28598|#28598%3E)\n%E2%80%A2%20%601dc0621c4b%60%20chore(runway):%20cherry-pick%20fix(bridge):%20harden%20token%20hooks%20against%20malformed%20API%20responses%20cp-7.73.0%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28537|#28537%3E)\n%E2%80%A2%20%60d6c3b9a527%60%20chore(runway):%20cherry-pick%20fix(perps):%20extract%20payment%20token%20init%20into%20useInitPerpsPaymentToken%20hook%20and%20move%20it%20to%20the%20parent%20cp-7.73.0%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28579|#28579%3E)\n%E2%80%A2%20%603993d6c45b%60%20chore(runway):%20cherry-pick%20fix:%20update%20account%20status%20screen%20with%20new%20ui%20design%20system%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28541|#28541%3E)\n%E2%80%A2%20%60849de28bc5%60%20fix:%20unit%20test%20to%20align%20ramps%20selector%20test%20mock%20%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28585|#28585%3E)\n%E2%80%A2%20%60a9bb8ee57e%60%20Auto%20rc%20trigger%20commit%20--%20This%20is%20an%20empty%20commit\n%E2%80%A2%20%60aef5f19d78%60%20ci:%20cherry%20pick%2028202%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28559|#28559%3E)\n%E2%80%A2%20%60dac8f5a525%60%20chore:cherry%20pick%2028490%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28556|#28556%3E)\n%E2%80%A2%20%60e7967a1867%60%20chore:%20cherry%20pick%2028423%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28540|#28540%3E)\n%E2%80%A2%20%60f69bf23caf%60%20chore(runway):%20cherry-pick%206334093%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28523|#28523%3E)\n%E2%80%A2%20%60f1772829aa%60%20cherry%20pick%2028368%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28535|#28535%3E)\n%E2%80%A2%20%60422d3986cb%60%20chore:%20use%20push%20EAS%20directly%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28362|#28362%3E)%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28550|#28550%3E)\n%E2%80%A2%20%60435fa92b80%60%20chore(runway):%20cherry-pick%20fix:%20backfill-consent-event%20cp-7.73.0%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28530|#28530%3E)\n%E2%80%A2%20%60317287eed0%60%20chore(runway):%20cherry-pick%20fix(predict):%20reset%20active%20order%20state%20on%20payment%20token%20clear%20and%20suppress%20stale%20balance%20alert%20cp-7.73.0%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28529|#28529%3E)\n%E2%80%A2%20%6083e68c0f30%60%20chore(runway):%20cherry-pick%20refactor(onboarding):%20migrate%20OAuthRehydration%20to%20design%20system%20cp-7.73.0%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28528|#28528%3E)\n%E2%80%A2%20%60a49e807209%60%20chore(release):%20merge%20stable%20into%20release/7.73.0%20%20(%3Chttps://github.com/MetaMask/metamask-mobile/pull/28510|#28510%3E)\n%E2%80%A2%20%60eb8a937d63%60%20chore:%20merge%20stable%20into%20release/7.73.0%20(stable%20sync)%22}}]})

---
