### PR TITLE
chore(ci): enable RC rolling builds

### DIFF
--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -4,6 +4,10 @@
 # It runs on every commit pushed to a release branch, but only when the release PR
 # has the 'auto-rc-builds' label.
 #
+# Rolling builds: when a new run starts for the same release branch, any queued or
+# in-progress run of this workflow for that branch is cancelled (same behavior as
+# Bitrise “Rolling builds” / “Abort running builds” for one branch + one workflow).
+#
 # Builds are triggered via the Runway OTA/build pipeline (runway-ota-build-core.yml):
 # - iOS runs first and performs the version bump.
 # - Android runs after, skipping the version bump (already done by iOS).
@@ -15,6 +19,10 @@ on:
   push:
     branches:
       - 'release/*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Adds **rolling builds** for the **Auto RC builds** workflow (`.github/workflows/build-rc-auto.yml`) by setting a **concurrency group** on `github.workflow` + `github.ref` with **`cancel-in-progress: true`**.

When a new run starts for a given `release/*` branch, any **queued or in-progress** run of the same workflow for that branch is **cancelled**, so only the latest push is built. This mirrors Bitrise-style rolling builds and avoids piling up redundant RC builds when the release branch gets several commits in a short time.

## Changelog

CHANGELOG entry: null

internal CI behavior only.

## Related issues

Fix: https://consensyssoftware.atlassian.net/browse/MCWP-518

## Manual testing steps

N/A — CI-only change. Verify by pushing multiple commits quickly to a labeled release PR and confirming older Auto RC workflow runs are cancelled while the newest run proceeds.