### PR TITLE
test: fixed component view test

### DIFF
--- a/tests/component-view/renderers/perpsViewRenderer.tsx
+++ b/tests/component-view/renderers/perpsViewRenderer.tsx
@@ -197,6 +197,21 @@ export function renderPerpsView(
     </AccessRestrictedProvider>
   );
 
+  const wrapRouteWithPerpsProviders = (
+    RouteComponent: React.ComponentType<unknown>,
+  ) => {
+    const WrappedRoute = (props: Record<string, unknown>) => (
+      <AccessRestrictedProvider>
+        <PerpsConnectionContext.Provider value={testConnectionValue}>
+          <PerpsStreamProvider testStreamManager={testStreamManager}>
+            <RouteComponent {...props} />
+          </PerpsStreamProvider>
+        </PerpsConnectionContext.Provider>
+      </AccessRestrictedProvider>
+    );
+    return WrappedRoute as unknown as React.ComponentType;
+  };
+
   if (extraRoutes?.length) {
     const Stack = createStackNavigator();
     const InnerStack = createStackNavigator();
@@ -212,10 +227,13 @@ export function renderPerpsView(
     const nestedScreens = (
       <>
         {nestedPerpsRoutes.map(({ name, Component: Extra }) => (
+          // Extra routes can render real views (not only probes), so keep provider parity.
           <InnerStack.Screen
             key={name}
             name={name}
-            component={Extra ?? DefaultRouteProbe(name)}
+            component={wrapRouteWithPerpsProviders(
+              Extra ?? DefaultRouteProbe(name),
+            )}
           />
         ))}
       </>
@@ -234,7 +252,9 @@ export function renderPerpsView(
           <Stack.Screen
             key={`root-${name}`}
             name={name}
-            component={Extra ?? DefaultRouteProbe(name)}
+            component={wrapRouteWithPerpsProviders(
+              Extra ?? DefaultRouteProbe(name),
+            )}
           />
         ))}
         {nestedPerpsRoutes.length ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adjusts component-view rendering behavior; main risk is breaking navigation assertions if provider wrapping alters route props or stack behavior.
> 
> **Overview**
> Updates `renderPerpsView` test renderer so **all `extraRoutes` screens** (both root stack and `Routes.PERPS.ROOT` nested stack) are wrapped with the same Perps providers (`AccessRestrictedProvider`, `PerpsConnectionContext`, `PerpsStreamProvider`) as the primary view. This ensures extra routes can render real Perps views (not just probes) without missing-context errors during component-view tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3dae39b543cc4dffcf73b8be400e19b0707fad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->