### PR TITLE
fix: navigation default settings transitions cp-7.73.0

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -181,7 +181,14 @@ const OnboardingSuccessFlow = () => {
   const { colors } = useTheme();
 
   return (
-    <Stack.Navigator initialRouteName={Routes.ONBOARDING.SUCCESS}>
+    <Stack.Navigator
+      initialRouteName={Routes.ONBOARDING.SUCCESS}
+      screenOptions={{
+        cardStyle: { backgroundColor: colors.background.default },
+        headerStyle: { backgroundColor: colors.background.default },
+        headerShadowVisible: false,
+      }}
+    >
       <Stack.Screen
         name={Routes.ONBOARDING.SUCCESS}
         component={OnboardingSuccess}
@@ -192,10 +199,6 @@ const OnboardingSuccessFlow = () => {
       <Stack.Screen
         name={Routes.ONBOARDING.DEFAULT_SETTINGS}
         component={DefaultSettings}
-        options={{
-          headerStyle: { backgroundColor: colors.background.default },
-          cardStyle: { backgroundColor: colors.background.default },
-        }}
       />
       <Stack.Screen
         name={Routes.ONBOARDING.GENERAL_SETTINGS}
@@ -221,7 +224,12 @@ const OnboardingNav = () => {
   const { colors } = useTheme();
 
   return (
-    <Stack.Navigator initialRouteName={'Onboarding'}>
+    <Stack.Navigator
+      initialRouteName={'Onboarding'}
+      screenOptions={{
+        cardStyle: { backgroundColor: colors.background.default },
+      }}
+    >
       <Stack.Screen name="Onboarding" component={Onboarding} />
       <Stack.Screen
         name={Routes.ONBOARDING.SOCIAL_LOGIN_SUCCESS_NEW_USER}
@@ -253,7 +261,6 @@ const OnboardingNav = () => {
         component={DefaultSettings}
         options={{
           headerStyle: { backgroundColor: colors.background.default },
-          cardStyle: { backgroundColor: colors.background.default },
         }}
       />
       <Stack.Screen name="ManualBackupStep1" component={ManualBackupStep1} />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Transitioning from default settings to each individual tab is not working correctly

https://github.com/user-attachments/assets/21b9940a-68b9-4c40-a10b-aba54b7996d7

![transition](https://github.com/user-attachments/assets/73683672-fd43-4724-92ee-95377f55ee29)



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix default settings navigation

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation configuration change; could subtly affect onboarding stack visuals (background/header) and transition behavior but does not touch business logic or data handling.
> 
> **Overview**
> Fixes the broken transition from `DefaultSettings` into the individual onboarding settings screens by moving background/header styling into `Stack.Navigator`-level `screenOptions` for `OnboardingSuccessFlow`, and removing per-screen overrides.
> 
> Also standardizes `OnboardingNav` card background via navigator `screenOptions` (dropping redundant per-screen `cardStyle`) to keep transitions visually consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a8f517be43c65eb802f9514e0005939c905bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->