### PR TITLE
fix: perps funding transition shows blank screen in between confirmations screen

### DIFF
--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -59,6 +59,7 @@ function getRedesignedConfirmationsHeaderOptions({
         headerLeft: () => null,
         headerShown: true,
         title: '',
+        presentation: 'transparentModal',
       }
     : { header: () => null };
 }

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -59,7 +59,7 @@ function getRedesignedConfirmationsHeaderOptions({
         headerLeft: () => null,
         headerShown: true,
         title: '',
-        presentation: 'transparentModal',
+        presentation: 'transparentModal' as const,
       }
     : { header: () => null };
 }


### PR DESCRIPTION
## **Description**

Perps funding transition shows blank screen in between confirmations screen

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-520

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**


https://github.com/user-attachments/assets/8ca2caeb-7058-4c33-9d43-e5afae171fe8


### **After**


https://github.com/user-attachments/assets/b429e5fb-2583-46f8-9ebc-addc90372725


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation tweak limited to the perps redesigned confirmations screen, but it could affect transition/stack behavior on iOS/Android if modal presentation differs from existing routes.
> 
> **Overview**
> Fixes a blank screen during the perps funding flow by changing the `RedesignedConfirmations` screen options to present as a `transparentModal` when the perps header is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18815fd89e76100337f7f5698843722fb154903d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->