### PR TITLE
feat(predict): use PredictPositionDetail in picks for extended sports markets

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -64,7 +64,6 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
   const { data: activePositions = [] } = usePredictPositions({
     marketId: market.id,
     claimable: false,
-    refetchInterval: 10000,
   });
   const { data: claimablePositions = [] } = usePredictPositions({
     marketId: market.id,

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import PredictPicks from './PredictPicks';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import {
+  PredictMarketStatus,
   PredictPositionStatus,
   Recurrence,
   type PredictPosition,
   type PredictMarket,
+  type PredictMarketGame,
 } from '../../types';
 import { formatPrice } from '../../utils/format';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -19,6 +22,28 @@ jest.mock('@react-navigation/native', () => ({
     navigate: mockNavigate,
   }),
 }));
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+jest.mock('../PredictPositionDetail', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      position,
+      marketStatus,
+    }: {
+      position: { id: string };
+      marketStatus: string;
+    }) => (
+      <View
+        testID={`predict-position-detail-${position.id}`}
+        accessibilityLabel={marketStatus}
+      />
+    ),
+  };
+});
 jest.mock('../../hooks/usePredictActionGuard');
 jest.mock('../../hooks/usePredictLivePositions', () => ({
   usePredictLivePositions: jest.fn((positions: unknown[]) => ({
@@ -28,6 +53,8 @@ jest.mock('../../hooks/usePredictLivePositions', () => ({
   })),
 }));
 jest.mock('../../utils/format');
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 const mockUsePredictActionGuard = usePredictActionGuard as jest.MockedFunction<
   typeof usePredictActionGuard
@@ -79,6 +106,35 @@ const createMockMarket = (
   ...overrides,
 });
 
+const createMockGame = (
+  overrides: Partial<PredictMarketGame> = {},
+): PredictMarketGame => ({
+  id: 'game-1',
+  startTime: '2025-12-31T00:00:00Z',
+  status: 'scheduled',
+  league: 'nba',
+  elapsed: null,
+  period: null,
+  score: null,
+  homeTeam: {
+    id: 'team-1',
+    name: 'Lakers',
+    logo: 'https://example.com/lakers.png',
+    abbreviation: 'LAL',
+    color: 'purple',
+    alias: 'Lakers',
+  },
+  awayTeam: {
+    id: 'team-2',
+    name: 'Celtics',
+    logo: 'https://example.com/celtics.png',
+    abbreviation: 'BOS',
+    color: 'green',
+    alias: 'Celtics',
+  },
+  ...overrides,
+});
+
 const createMockPosition = (
   overrides: Partial<PredictPosition> = {},
 ): PredictPosition => ({
@@ -111,6 +167,7 @@ describe('PredictPicks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockNavigate.mockClear();
+    mockUseSelector.mockReturnValue([]);
     mockUsePredictActionGuard.mockReturnValue({
       executeGuardedAction: mockExecuteGuardedAction,
       isEligible: true,
@@ -548,6 +605,120 @@ describe('PredictPicks', () => {
           navigation: expect.any(Object),
         }),
       );
+    });
+  });
+
+  describe('PredictPositionDetail rendering (extendedSportsMarkets flag)', () => {
+    it('renders PredictPositionDetail for live positions when league is in extendedLeagues', () => {
+      mockUseSelector.mockReturnValue(['nba']);
+      const market = createMockMarket({ game: createMockGame() });
+      const position = createMockPosition({ id: 'pos-live' });
+
+      render(
+        <PredictPicks
+          market={market}
+          positions={[position]}
+          claimablePositions={[]}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('predict-position-detail-pos-live'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders PredictPositionDetail for claimable positions with CLOSED status', () => {
+      mockUseSelector.mockReturnValue(['nba']);
+      const market = createMockMarket({ game: createMockGame() });
+      const position = createMockPosition({
+        id: 'pos-claimable',
+        claimable: true,
+      });
+
+      render(
+        <PredictPicks
+          market={market}
+          positions={[]}
+          claimablePositions={[position]}
+        />,
+      );
+
+      const detail = screen.getByTestId(
+        'predict-position-detail-pos-claimable',
+      );
+      expect(detail).toBeOnTheScreen();
+      expect(detail.props.accessibilityLabel).toBe(PredictMarketStatus.CLOSED);
+    });
+
+    it('renders PredictPositionDetail with market status for live positions', () => {
+      mockUseSelector.mockReturnValue(['nba']);
+      const market = createMockMarket({
+        status: 'open',
+        game: createMockGame(),
+      });
+
+      render(
+        <PredictPicks
+          market={market}
+          positions={[createMockPosition({ id: 'pos-1' })]}
+          claimablePositions={[]}
+        />,
+      );
+
+      const detail = screen.getByTestId('predict-position-detail-pos-1');
+      expect(detail.props.accessibilityLabel).toBe(PredictMarketStatus.OPEN);
+    });
+
+    it('renders PredictPickItem when league is not in extendedLeagues', () => {
+      mockUseSelector.mockReturnValue(['ucl']);
+      const market = createMockMarket({ game: createMockGame() });
+
+      render(
+        <PredictPicks
+          market={market}
+          positions={[createMockPosition({ id: 'pos-1' })]}
+          claimablePositions={[]}
+        />,
+      );
+
+      expect(screen.queryByTestId('predict-position-detail-pos-1')).toBeNull();
+      expect(screen.getByText(/Yes/)).toBeOnTheScreen();
+    });
+
+    it('renders PredictPickItem when market has no game', () => {
+      mockUseSelector.mockReturnValue(['nba']);
+
+      render(
+        <PredictPicks
+          market={createMockMarket()}
+          positions={[createMockPosition({ id: 'pos-1' })]}
+          claimablePositions={[]}
+        />,
+      );
+
+      expect(screen.queryByTestId('predict-position-detail-pos-1')).toBeNull();
+    });
+
+    it('renders both live and claimable as PredictPositionDetail when flag enabled', () => {
+      mockUseSelector.mockReturnValue(['nba']);
+      const market = createMockMarket({ game: createMockGame() });
+
+      render(
+        <PredictPicks
+          market={market}
+          positions={[createMockPosition({ id: 'pos-live' })]}
+          claimablePositions={[
+            createMockPosition({ id: 'pos-claim', claimable: true }),
+          ]}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('predict-position-detail-pos-live'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-position-detail-pos-claim'),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
+++ b/app/components/UI/Predict/components/PredictPicks/PredictPicks.tsx
@@ -1,13 +1,20 @@
 import { Box } from '@metamask/design-system-react-native';
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { usePredictLivePositions } from '../../hooks/usePredictLivePositions';
 import { PredictEventValues } from '../../constants/eventNames';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
-import { PredictMarket, PredictPosition } from '../../types';
+import {
+  PredictMarket,
+  PredictMarketStatus,
+  PredictPosition,
+} from '../../types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictNavigationParamList } from '../../types/navigation';
+import { selectExtendedSportsMarketsLeagues } from '../../selectors/featureFlags';
 import PredictPickItem from './PredictPickItem';
+import PredictPositionDetail from '../PredictPositionDetail';
 import {
   PREDICT_PICKS_TEST_ID,
   PREDICT_PICKS_TEST_IDS,
@@ -34,6 +41,11 @@ const PredictPicks: React.FC<PredictPicksProps> = ({
     navigation,
   });
 
+  const extendedLeagues = useSelector(selectExtendedSportsMarketsLeagues);
+  const usePositionDetail = market.game?.league
+    ? extendedLeagues.includes(market.game.league)
+    : false;
+
   const onCashOut = (position: PredictPosition) => {
     executeGuardedAction(
       () => {
@@ -50,6 +62,29 @@ const PredictPicks: React.FC<PredictPicksProps> = ({
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CASHOUT },
     );
   };
+
+  if (usePositionDetail) {
+    return (
+      <Box testID={testID} twClassName="flex-col pt-3">
+        {livePositions.map((position) => (
+          <PredictPositionDetail
+            key={position.id}
+            position={position}
+            market={market}
+            marketStatus={market.status as PredictMarketStatus}
+          />
+        ))}
+        {claimablePositions.map((position) => (
+          <PredictPositionDetail
+            key={position.id}
+            position={position}
+            market={market}
+            marketStatus={PredictMarketStatus.CLOSED}
+          />
+        ))}
+      </Box>
+    );
+  }
 
   return (
     <Box testID={testID} twClassName="flex-col">

--- a/app/components/UI/Predict/hooks/useGameDetailsTabs.test.ts
+++ b/app/components/UI/Predict/hooks/useGameDetailsTabs.test.ts
@@ -139,7 +139,7 @@ describe('useGameDetailsTabs', () => {
       expect(result.current.activeTab).toBe(0);
     });
 
-    it('resets activeTab to 0 when it exceeds tabs length', () => {
+    it('preserves activeTab when tabs change', () => {
       const { result, rerender } = renderHook(
         (props) => useGameDetailsTabs(props),
         {
@@ -156,7 +156,7 @@ describe('useGameDetailsTabs', () => {
       expect(result.current.activeTab).toBe(1);
 
       rerender({ ...defaultParams, activePositions: [] });
-      expect(result.current.activeTab).toBe(0);
+      expect(result.current.activeTab).toBe(1);
     });
   });
 

--- a/app/components/UI/Predict/hooks/useGameDetailsTabs.ts
+++ b/app/components/UI/Predict/hooks/useGameDetailsTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import { selectExtendedSportsMarketsLeagues } from '../selectors/featureFlags';
@@ -38,13 +38,6 @@ export function useGameDetailsTabs({
     });
     return result;
   }, [hasPositions]);
-
-  useEffect(() => {
-    if (!enabled) return;
-    if (activeTab >= tabs.length) {
-      setActiveTab(0);
-    }
-  }, [tabs, activeTab, enabled]);
 
   const handleTabPress = useCallback((tabIndex: number) => {
     setActiveTab(tabIndex);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Predict Picks section (used in game details) currently renders `PredictPickItem` — a simple row showing "Picked [outcome] at $X" with PnL. For sports markets with extended market types (spreads, totals, player props), we need the richer `PredictPositionDetail` component that already exists on the regular market details screen, which includes icons, real-time preview values, percentage PnL, privacy mode support, and a full-width cash-out button.

This PR conditionally renders `PredictPositionDetail` instead of `PredictPickItem` inside `PredictPicks` when the market's league is in the `extendedSportsMarketsLeagues` feature flag — following the same flag pattern used by `useGameDetailsTabs`. When the flag is disabled (or the market has no game/league), the existing `PredictPickItem` rendering is preserved.

Also includes a minor cleanup: removes an unnecessary `useEffect` in `useGameDetailsTabs` that was resetting `activeTab` when tabs changed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-803

## **Manual testing steps**

```gherkin
Feature: PredictPositionDetail in sports prediction picks

  Scenario: user views positions for an extended sports market
    Given the user has open positions on a sports market with a league in extendedSportsMarketsLeagues (e.g. NBA)

    When user navigates to the game details screen
    Then positions are displayed using the rich PredictPositionDetail component
    And each position shows an icon, title, shares info, real-time current value, and percentage PnL
    And each open position has a full-width "Cash out" button

  Scenario: user views positions for a non-extended sports market
    Given the user has open positions on a sports market whose league is NOT in extendedSportsMarketsLeagues

    When user navigates to the game details screen
    Then positions are displayed using the original PredictPickItem component
    And each position shows "Picked [outcome] at $X" format with PnL value

  Scenario: user views positions for a non-sports market
    Given the user has open positions on a non-sports prediction market (no game property)

    When user navigates to the market details screen
    Then positions are displayed using the original PredictPickItem component
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/6f09c287-4371-4f4f-859c-7dbb69a673d8

### **After**

https://github.com/user-attachments/assets/a5790c3f-f276-4428-b604-a8aaed2a1ddd

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conditional rendering for the Picks list and adjusts tab state behavior; also removes polling on active positions, which could affect UI freshness and user interaction flows in game details.
> 
> **Overview**
> **Game details picks rendering is upgraded for extended sports markets.** `PredictPicks` now checks `selectExtendedSportsMarketsLeagues` and, when the market’s `game.league` is enabled, renders `PredictPositionDetail` (including forcing `CLOSED` status for claimable positions) instead of `PredictPickItem`.
> 
> **Behavioral tweaks and coverage.** `useGameDetailsTabs` no longer resets `activeTab` when the tab set changes, tests were updated/added for the new picks rendering and tab behavior, and `PredictGameDetailsContent` stops polling active positions by removing the `refetchInterval` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c9faa9e18adaab8b2373378f4acc261ed8e994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->