### PR TITLE
feat: split request_source to distinguish SDKv1 from MWP

### DIFF
--- a/app/components/hooks/useAnalytics/useAnalytics.types.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.types.ts
@@ -18,7 +18,7 @@ type AnalyticsEventBuilderType = ReturnType<
 >;
 
 /**
- * Source type constants for analytics tracking
+ * Source type constants for analytics tracking (used on Connect Request events).
  */
 export const SourceType = {
   SDK: 'sdk',
@@ -27,6 +27,16 @@ export const SourceType = {
   IN_APP_BROWSER: 'in-app browser',
   PERMISSION_SYSTEM: 'permission system',
   DAPP_DEEPLINK_URL: 'dapp-deeplink-url',
+} as const;
+
+/**
+ * Transport type constants — identifies the underlying connection transport.
+ * Values align with the segment-schema transport_type enum.
+ */
+export const TransportType = {
+  SOCKET_RELAY: 'socket_relay',
+  MWP: 'mwp',
+  WALLETCONNECT: 'walletconnect',
 } as const;
 
 export interface UseAnalyticsHook {

--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -268,6 +268,7 @@ export default {
   ADD_CUSTOM_NETWORK_CUSTOM_TAB_ID: 'custom-tab',
   REQUEST_SOURCES: {
     SDK_REMOTE_CONN: 'MetaMask-SDK-Remote-Conn',
+    MM_CONNECT: 'MetaMask-Connect',
     WC: 'WalletConnect',
     WC2: 'WalletConnectV2',
     IN_APP_BROWSER: 'In-App-Browser',

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -27,6 +27,7 @@ import { store } from '../../store';
 import { v1 as random } from 'uuid';
 import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants';
+import { TransportType } from '../../components/hooks/useAnalytics/useAnalytics.types';
 import PPOMUtil from '../../lib/ppom/ppom-util';
 import { setEventStageError, setEventStage } from '../../actions/rpcEvents';
 import { isWhitelistedRPC, RPCStageTypes } from '../../reducers/rpcEvents';
@@ -415,7 +416,7 @@ export const getRpcMethodMiddleware = ({
 
   const getSource = () => {
     if (analytics?.isRemoteConn) {
-      return analytics?.transport === 'mwp'
+      return analytics?.transport === TransportType.MWP
         ? AppConstants.REQUEST_SOURCES.MM_CONNECT
         : AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
     }

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -414,8 +414,11 @@ export const getRpcMethodMiddleware = ({
   const origin = channelId ?? hostname;
 
   const getSource = () => {
-    if (analytics?.isRemoteConn)
-      return AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
+    if (analytics?.isRemoteConn) {
+      return analytics?.transport === 'mwp'
+        ? AppConstants.REQUEST_SOURCES.MM_CONNECT
+        : AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
+    }
     if (isWalletConnect) return AppConstants.REQUEST_SOURCES.WC;
     return AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
   };

--- a/app/core/SDKConnect/getDefaultBridgeParams.ts
+++ b/app/core/SDKConnect/getDefaultBridgeParams.ts
@@ -38,6 +38,7 @@ const getDefaultBridgeParams = (clientInfo: DappClient) => ({
       isWalletConnect: false,
       analytics: {
         isRemoteConn: true,
+        transport: 'socket_relay',
         platform:
           clientInfo.originatorInfo.platform ??
           AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnect/getDefaultBridgeParams.ts
+++ b/app/core/SDKConnect/getDefaultBridgeParams.ts
@@ -1,6 +1,7 @@
 import { ImageSourcePropType } from 'react-native';
 import AppConstants from '../AppConstants';
 import getRpcMethodMiddleware from '../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../components/hooks/useAnalytics/useAnalytics.types';
 import { DappClient } from './dapp-sdk-types';
 
 const getDefaultBridgeParams = (clientInfo: DappClient) => ({
@@ -38,7 +39,7 @@ const getDefaultBridgeParams = (clientInfo: DappClient) => ({
       isWalletConnect: false,
       analytics: {
         isRemoteConn: true,
-        transport: 'socket_relay',
+        transport: TransportType.SOCKET_RELAY,
         platform:
           clientInfo.originatorInfo.platform ??
           AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -96,6 +96,7 @@ export const setupBridge = ({
         isWalletConnect: false,
         analytics: {
           isRemoteConn: true,
+          transport: 'socket_relay',
           platform:
             originatorInfo?.platform ?? AppConstants.MM_SDK.UNKNOWN_PARAM,
         },

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -3,6 +3,7 @@ import BackgroundBridge from '../../BackgroundBridge/BackgroundBridge';
 import getRpcMethodMiddleware, {
   RPCMethodsMiddleParameters,
 } from '../../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
 
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -96,7 +97,7 @@ export const setupBridge = ({
         isWalletConnect: false,
         analytics: {
           isRemoteConn: true,
-          transport: 'socket_relay',
+          transport: TransportType.SOCKET_RELAY,
           platform:
             originatorInfo?.platform ?? AppConstants.MM_SDK.UNKNOWN_PARAM,
         },

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -4,6 +4,7 @@ import { IRPCBridgeAdapter } from '../types/rpc-bridge-adapter';
 import Engine, { RootExtendedMessenger } from '../../Engine';
 import AppConstants from '../../AppConstants';
 import getRpcMethodMiddleware from '../../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
 import { ImageSourcePropType } from 'react-native';
 import { ConnectionInfo } from '../types/connection-info';
 import { whenEngineReady } from '../utils/when-engine-ready';
@@ -153,7 +154,7 @@ export class RPCBridgeAdapter
           isWalletConnect: false,
           analytics: {
             isRemoteConn: true,
-            transport: 'mwp',
+            transport: TransportType.MWP,
             platform:
               this.connInfo.metadata.sdk.platform ??
               AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -153,6 +153,7 @@ export class RPCBridgeAdapter
           isWalletConnect: false,
           analytics: {
             isRemoteConn: true,
+            transport: 'mwp',
             platform:
               this.connInfo.metadata.sdk.platform ??
               AppConstants.MM_SDK.UNKNOWN_PARAM,


### PR DESCRIPTION
## Summary

Both SDKv1 (socket relay) and MWP/SDKv2 connections produced the same `request_source` value (`MetaMask-SDK-Remote-Conn`) on RPC pipeline events (`Transaction Added`, `Signature Requested`, etc.), making them indistinguishable in analytics.

Adds a `transport` field (`socket_relay` | `mwp`) to the analytics param passed to `getRpcMethodMiddleware` and branches `getSource()` on it:
- SDKv1: `MetaMask-SDK-Remote-Conn` (unchanged — preserves data continuity)
- MWP/V2: `MetaMask-Connect` (new)

## Related

- Discussion and decision: https://consensyssoftware.atlassian.net/browse/WAPI-1398

## Test plan

- [ ] Connect via SDKv1 → trigger a signature or transaction → verify `request_source` is `MetaMask-SDK-Remote-Conn`
- [ ] Connect via MWP/V2 → trigger a signature or transaction → verify `request_source` is `MetaMask-Connect`
- [ ] WalletConnect and in-app browser `request_source` values unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive analytics metadata change that only affects how `request_source` is computed for remote SDK connections; main risk is misclassification if `transport` is omitted or set incorrectly.
> 
> **Overview**
> Remote SDK connections now pass an explicit analytics `transport` (e.g., `socket_relay` vs `mwp`) into `getRpcMethodMiddleware`, and `getSource()` uses it to split `request_source` between **SDKv1 socket-relay** (`MetaMask-SDK-Remote-Conn`, unchanged) and **MWP/SDKv2** (`MetaMask-Connect`, new).
> 
> Adds the shared `TransportType` enum and wires it into SDKv1 bridge setup and SDKv2 RPC bridge adapter so RPC pipeline events can be attributed correctly in analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27ae07cbd99fb6f0f4633f22ae6c0303565c0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->