### PR TITLE
refactor(perps): unify dual DEX discovery caches to prevent desync bugs

### DIFF
--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -7315,9 +7315,9 @@ describe('HyperLiquidProvider', () => {
       // Create a provider instance with equity enabled for this specific test
       const testProvider = createTestProvider({ hip3Enabled: true });
 
-      // Override the private cachedValidatedDexs to simulate already validated state
+      // Override the private dexDiscoveryState to force re-evaluation
       // This avoids the complex initialization flow
-      Object.defineProperty(testProvider, 'cachedValidatedDexs', {
+      Object.defineProperty(testProvider, 'dexDiscoveryState', {
         value: null, // Force re-evaluation
         writable: true,
         configurable: true,
@@ -7634,7 +7634,11 @@ describe('HyperLiquidProvider', () => {
     describe('getAllAvailableDexs', () => {
       interface ProviderWithDexMethods {
         getAllAvailableDexs(): Promise<(string | null)[]>;
-        cachedAllPerpDexs: ({ name: string; url: string } | null)[] | null;
+        dexDiscoveryState: {
+          raw: ({ name: string; url: string } | null)[];
+          validated: (string | null)[];
+          timestamp: number;
+        } | null;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -7642,17 +7646,21 @@ describe('HyperLiquidProvider', () => {
 
       beforeEach(() => {
         testableProvider = provider as unknown as ProviderWithDexMethods;
-        // Reset cache
-        testableProvider.cachedAllPerpDexs = null;
+        // Reset unified state
+        testableProvider.dexDiscoveryState = null;
       });
 
       it('returns cached DEX list when cache is populated', async () => {
         // Arrange
-        testableProvider.cachedAllPerpDexs = [
-          null,
-          { name: 'dex1', url: 'https://dex1.example' },
-          { name: 'dex2', url: 'https://dex2.example' },
-        ];
+        testableProvider.dexDiscoveryState = {
+          raw: [
+            null,
+            { name: 'dex1', url: 'https://dex1.example' },
+            { name: 'dex2', url: 'https://dex2.example' },
+          ],
+          validated: [null, 'dex1', 'dex2'],
+          timestamp: Date.now(),
+        };
 
         // Act
         const result = await testableProvider.getAllAvailableDexs();
@@ -7680,7 +7688,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null, 'dex1', 'dex2']);
-        expect(testableProvider.cachedAllPerpDexs).toEqual(mockDexs);
+        expect(testableProvider.dexDiscoveryState?.raw).toEqual(mockDexs);
         expect(mockClientService.getInfoClient).toHaveBeenCalledTimes(1);
       });
 
@@ -7697,7 +7705,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.cachedAllPerpDexs).toBeNull();
+        expect(testableProvider.dexDiscoveryState).toBeNull();
       });
 
       it('returns fallback when API returns non-array', async () => {
@@ -7713,7 +7721,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.cachedAllPerpDexs).toBeNull();
+        expect(testableProvider.dexDiscoveryState).toBeNull();
       });
 
       it('returns fallback and logs error when API throws', async () => {
@@ -7731,7 +7739,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.cachedAllPerpDexs).toBeNull();
+        expect(testableProvider.dexDiscoveryState).toBeNull();
         expect(mockPlatformDependencies.logger.error).toHaveBeenCalledWith(
           mockError,
           expect.objectContaining({
@@ -7747,12 +7755,16 @@ describe('HyperLiquidProvider', () => {
 
       it('filters out null entries from cached DEX list', async () => {
         // Arrange
-        testableProvider.cachedAllPerpDexs = [
-          null,
-          { name: 'dex1', url: 'https://dex1.example' },
-          null,
-          { name: 'dex2', url: 'https://dex2.example' },
-        ];
+        testableProvider.dexDiscoveryState = {
+          raw: [
+            null,
+            { name: 'dex1', url: 'https://dex1.example' },
+            null,
+            { name: 'dex2', url: 'https://dex2.example' },
+          ],
+          validated: [null, 'dex1', 'dex2'],
+          timestamp: Date.now(),
+        };
 
         // Act
         const result = await testableProvider.getAllAvailableDexs();
@@ -7763,7 +7775,11 @@ describe('HyperLiquidProvider', () => {
 
       it('returns only main DEX when cached list contains only null', async () => {
         // Arrange
-        testableProvider.cachedAllPerpDexs = [null];
+        testableProvider.dexDiscoveryState = {
+          raw: [null],
+          validated: [null],
+          timestamp: Date.now(),
+        };
 
         // Act
         const result = await testableProvider.getAllAvailableDexs();

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -9409,6 +9409,61 @@ describe('HyperLiquidProvider', () => {
         // clearinghouseState should be called for both main + xyz DEX (from cache)
         expect(infoClient.clearinghouseState).toHaveBeenCalledTimes(2);
       });
+
+      it('filters DEXs via testnet config when in testnet mode', async () => {
+        // Arrange: testnet mode with TESTNET_HIP3_CONFIG.EnabledDexs = ['xyz']
+        (mockClientService.isTestnetMode as jest.Mock).mockReturnValue(true);
+        const testnetProvider = createTestProvider({
+          hip3Enabled: true,
+          isTestnet: true,
+        });
+
+        // perpDexs returns main + xyz + other DEX
+        mockStandaloneInfoClient.perpDexs.mockResolvedValue([
+          null,
+          { name: 'xyz' },
+          { name: 'otherdex' },
+        ]);
+        mockStandaloneInfoClient.clearinghouseState.mockResolvedValue({
+          assetPositions: [],
+          marginSummary: { totalMarginUsed: '0', accountValue: '0' },
+        });
+
+        // Act
+        await testnetProvider.getPositions({
+          standalone: true,
+          userAddress: mockUserAddress,
+        });
+
+        // Assert: clearinghouseState called for main + xyz only (otherdex filtered out)
+        expect(
+          mockStandaloneInfoClient.clearinghouseState,
+        ).toHaveBeenCalledTimes(2);
+        // Restore
+        (mockClientService.isTestnetMode as jest.Mock).mockReturnValue(false);
+      });
+
+      it('updates unified state atomically when standalone perpDexs succeeds', async () => {
+        // Arrange
+        mockStandaloneInfoClient.clearinghouseState.mockResolvedValue({
+          assetPositions: [],
+          marginSummary: { totalMarginUsed: '0', accountValue: '0' },
+        });
+
+        // Act: first standalone call populates dexDiscoveryState
+        await hip3Provider.getPositions({
+          standalone: true,
+          userAddress: mockUserAddress,
+        });
+
+        // Assert: second call reuses cached state — perpDexs NOT called again
+        mockStandaloneInfoClient.perpDexs.mockClear();
+        await hip3Provider.getPositions({
+          standalone: true,
+          userAddress: mockUserAddress,
+        });
+        expect(mockStandaloneInfoClient.perpDexs).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -7315,13 +7315,7 @@ describe('HyperLiquidProvider', () => {
       // Create a provider instance with equity enabled for this specific test
       const testProvider = createTestProvider({ hip3Enabled: true });
 
-      // Override the private dexDiscoveryState to force re-evaluation
-      // This avoids the complex initialization flow
-      Object.defineProperty(testProvider, 'dexDiscoveryState', {
-        value: null, // Force re-evaluation
-        writable: true,
-        configurable: true,
-      });
+      // DEX discovery cache starts with null state on a fresh provider — no reset needed
 
       // Act
       const result = await testProvider.getAvailableHip3Dexs();
@@ -7634,11 +7628,14 @@ describe('HyperLiquidProvider', () => {
     describe('getAllAvailableDexs', () => {
       interface ProviderWithDexMethods {
         getAllAvailableDexs(): Promise<(string | null)[]>;
-        dexDiscoveryState: {
-          raw: ({ name: string; url: string } | null)[];
-          validated: (string | null)[];
-          timestamp: number;
-        } | null;
+        dexDiscoveryCache: {
+          state: {
+            raw: ({ name: string; url: string } | null)[];
+            validated: (string | null)[];
+            timestamp: number;
+          } | null;
+          reset(): void;
+        };
       }
 
       // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -7647,12 +7644,12 @@ describe('HyperLiquidProvider', () => {
       beforeEach(() => {
         testableProvider = provider as unknown as ProviderWithDexMethods;
         // Reset unified state
-        testableProvider.dexDiscoveryState = null;
+        testableProvider.dexDiscoveryCache.reset();
       });
 
       it('returns cached DEX list when cache is populated', async () => {
         // Arrange
-        testableProvider.dexDiscoveryState = {
+        testableProvider.dexDiscoveryCache.state = {
           raw: [
             null,
             { name: 'dex1', url: 'https://dex1.example' },
@@ -7688,7 +7685,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null, 'dex1', 'dex2']);
-        expect(testableProvider.dexDiscoveryState?.raw).toEqual(mockDexs);
+        expect(testableProvider.dexDiscoveryCache.state?.raw).toEqual(mockDexs);
         expect(mockClientService.getInfoClient).toHaveBeenCalledTimes(1);
       });
 
@@ -7705,7 +7702,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.dexDiscoveryState).toBeNull();
+        expect(testableProvider.dexDiscoveryCache.state).toBeNull();
       });
 
       it('returns fallback when API returns non-array', async () => {
@@ -7721,7 +7718,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.dexDiscoveryState).toBeNull();
+        expect(testableProvider.dexDiscoveryCache.state).toBeNull();
       });
 
       it('returns fallback and logs error when API throws', async () => {
@@ -7739,7 +7736,7 @@ describe('HyperLiquidProvider', () => {
 
         // Assert
         expect(result).toEqual([null]);
-        expect(testableProvider.dexDiscoveryState).toBeNull();
+        expect(testableProvider.dexDiscoveryCache.state).toBeNull();
         expect(mockPlatformDependencies.logger.error).toHaveBeenCalledWith(
           mockError,
           expect.objectContaining({
@@ -7755,7 +7752,7 @@ describe('HyperLiquidProvider', () => {
 
       it('filters out null entries from cached DEX list', async () => {
         // Arrange
-        testableProvider.dexDiscoveryState = {
+        testableProvider.dexDiscoveryCache.state = {
           raw: [
             null,
             { name: 'dex1', url: 'https://dex1.example' },
@@ -7775,7 +7772,7 @@ describe('HyperLiquidProvider', () => {
 
       it('returns only main DEX when cached list contains only null', async () => {
         // Arrange
-        testableProvider.dexDiscoveryState = {
+        testableProvider.dexDiscoveryCache.state = {
           raw: [null],
           validated: [null],
           timestamp: Date.now(),
@@ -9450,7 +9447,7 @@ describe('HyperLiquidProvider', () => {
           marginSummary: { totalMarginUsed: '0', accountValue: '0' },
         });
 
-        // Act: first standalone call populates dexDiscoveryState
+        // Act: first standalone call populates dexDiscoveryCache
         await hip3Provider.getPositions({
           standalone: true,
           userAddress: mockUserAddress,

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -1034,6 +1034,13 @@ export class HyperLiquidProvider implements PerpsProvider {
    * @returns Array of DEX names to use (null = main DEX, strings = HIP-3 DEXs)
    */
   async #getValidatedDexs(): Promise<(string | null)[]> {
+    // Kill switch: HIP-3 disabled, return main DEX only
+    // Must check before cache — #getAllAvailableDexs() can populate
+    // state.validated without the hip3Enabled gate
+    if (!this.#hip3Enabled) {
+      return [null];
+    }
+
     // Return cached result if available
     if (this.#dexDiscoveryCache.state?.validated) {
       return this.#dexDiscoveryCache.state.validated;

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -13,10 +13,8 @@ import {
   HIP3_FEE_CONFIG,
   HIP3_MARGIN_CONFIG,
   HYPERLIQUID_WITHDRAWAL_MINUTES,
-  MAINNET_HIP3_CONFIG,
   REFERRAL_CONFIG,
   SPOT_ASSET_ID_OFFSET,
-  TESTNET_HIP3_CONFIG,
   TRADING_DEFAULTS,
   USDC_DECIMALS,
   USDH_CONFIG,
@@ -30,6 +28,7 @@ import {
 } from '../constants/perpsConfig';
 import { PERPS_TRANSACTIONS_HISTORY_CONSTANTS } from '../constants/transactionsHistoryConfig';
 import { PERPS_ERROR_CODES } from '../perpsErrorCodes';
+import { DexDiscoveryCacheManager } from '../services/DexDiscoveryCacheManager';
 import {
   HyperLiquidClientService,
   WebSocketConnectionState,
@@ -109,11 +108,7 @@ import type {
   SpotMetaResponse,
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
-import type {
-  DexDiscoveryState,
-  ExtendedAssetMeta,
-  ExtendedPerpDex,
-} from '../types/perps-types';
+import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
 import { aggregateAccountStates } from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
@@ -310,10 +305,10 @@ export class HyperLiquidProvider implements PerpsProvider {
   // Pre-fetched in ensureReadyForTrading() to avoid API failures during order placement
   #cachedSpotMeta: SpotMetaResponse | null = null;
 
-  // Unified DEX discovery state — single source of truth for all perpDexs() derivatives.
+  // Unified DEX discovery cache — single source of truth for all perpDexs() derivatives.
   // Replaces three separate caches to eliminate desync bugs by construction.
-  // All writes go through #updateDexDiscovery(); readers use .raw, .validated, .timestamp.
-  #dexDiscoveryState: DexDiscoveryState | null = null;
+  // All writes go through #dexDiscoveryCache.update(); readers use .state.
+  readonly #dexDiscoveryCache: DexDiscoveryCacheManager;
 
   // Session cache for referral state (cleared on disconnect/reconnect)
   // Key: `network:userAddress`, Value: true if referral is set
@@ -405,6 +400,11 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Initialize services with injected platform dependencies
     this.#clientService = new HyperLiquidClientService(this.#deps, {
       isTestnet,
+    });
+    this.#dexDiscoveryCache = new DexDiscoveryCacheManager({
+      isTestnetMode: (): boolean => this.#clientService.isTestnetMode(),
+      debugLogger: this.#deps.debugLogger,
+      getAllowlistMarkets: (): string[] => this.#allowlistMarkets,
     });
     this.#walletService = new HyperLiquidWalletService(
       this.#deps,
@@ -977,127 +977,6 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
-   * Single atomic writer for DEX discovery state.
-   * All code paths that fetch perpDexs() MUST call this — no direct field writes.
-   *
-   * @param allDexs - Raw perpDexs() API response array.
-   * @returns The newly created unified discovery state.
-   */
-  #updateDexDiscovery(allDexs: (ExtendedPerpDex | null)[]): DexDiscoveryState {
-    const validated = this.#computeValidatedDexs(allDexs);
-    const state: DexDiscoveryState = {
-      raw: allDexs,
-      validated,
-      timestamp: Date.now(),
-    };
-    this.#dexDiscoveryState = state;
-    return state;
-  }
-
-  /**
-   * Pure filtering of perpDexs() response into validated DEX names.
-   * Encapsulates testnet/mainnet feature-flag logic previously duplicated
-   * in #fetchValidatedDexsInternal and #getStandaloneValidatedDexs.
-   *
-   * @param allDexs - Raw perpDexs() API response array.
-   * @returns Filtered DEX name list (null = main DEX, strings = HIP-3 DEXs).
-   */
-  #computeValidatedDexs(
-    allDexs: (ExtendedPerpDex | null)[],
-  ): (string | null)[] {
-    // Extract HIP-3 DEX names (filter out null which represents main DEX)
-    const availableHip3Dexs: string[] = [];
-    allDexs.forEach((dex) => {
-      if (dex !== null) {
-        availableHip3Dexs.push(dex.name);
-      }
-    });
-
-    // Testnet-specific filtering
-    if (this.#clientService.isTestnetMode()) {
-      const { EnabledDexs, AutoDiscoverAll } = TESTNET_HIP3_CONFIG;
-
-      if (!AutoDiscoverAll) {
-        if (EnabledDexs.length === 0) {
-          this.#deps.debugLogger.log(
-            'HyperLiquidProvider: Testnet - using main DEX only (HIP-3 DEXs filtered)',
-            {
-              availableHip3Dexs: availableHip3Dexs.length,
-              reason: 'TESTNET_HIP3_CONFIG.EnabledDexs is empty',
-            },
-          );
-          return [null];
-        }
-
-        const filteredDexs = availableHip3Dexs.filter((dex) =>
-          EnabledDexs.includes(dex),
-        );
-        this.#deps.debugLogger.log(
-          'HyperLiquidProvider: Testnet - filtered to allowed DEXs',
-          {
-            allowedDexs: EnabledDexs,
-            filteredDexs,
-            availableHip3Dexs: availableHip3Dexs.length,
-          },
-        );
-        return [null, ...filteredDexs];
-      }
-
-      this.#deps.debugLogger.log(
-        'HyperLiquidProvider: Testnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
-        { totalDexCount: availableHip3Dexs.length + 1 },
-      );
-    } else {
-      // Mainnet-specific filtering
-      const { AutoDiscoverAll } = MAINNET_HIP3_CONFIG;
-
-      if (!AutoDiscoverAll) {
-        const allowedDexsFromAllowlist = this.#extractDexsFromAllowlist();
-
-        if (allowedDexsFromAllowlist.length === 0) {
-          this.#deps.debugLogger.log(
-            'HyperLiquidProvider: Mainnet - using main DEX only (no HIP-3 DEXs in allowlist)',
-            {
-              availableHip3Dexs: availableHip3Dexs.length,
-              allowlistMarkets: this.#allowlistMarkets,
-            },
-          );
-          return [null];
-        }
-
-        const filteredDexs = availableHip3Dexs.filter((dex) =>
-          allowedDexsFromAllowlist.includes(dex),
-        );
-        this.#deps.debugLogger.log(
-          'HyperLiquidProvider: Mainnet - filtered to allowlist DEXs',
-          {
-            allowedDexsFromAllowlist,
-            filteredDexs,
-            availableHip3Dexs: availableHip3Dexs.length,
-          },
-        );
-        return [null, ...filteredDexs];
-      }
-
-      this.#deps.debugLogger.log(
-        'HyperLiquidProvider: Mainnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
-        { totalDexCount: availableHip3Dexs.length + 1 },
-      );
-    }
-
-    // Fallback: all DEXs (when AUTO_DISCOVER_ALL is true)
-    this.#deps.debugLogger.log(
-      'HyperLiquidProvider: All DEXs enabled (market filtering at data layer)',
-      {
-        mainDex: true,
-        hip3Dexs: availableHip3Dexs,
-        totalDexCount: availableHip3Dexs.length + 1,
-      },
-    );
-    return [null, ...availableHip3Dexs];
-  }
-
-  /**
    * Get all available DEXs without allowlist filtering
    * Used when skipFilters=true in getMarkets()
    *
@@ -1105,9 +984,9 @@ export class HyperLiquidProvider implements PerpsProvider {
    */
   async #getAllAvailableDexs(): Promise<(string | null)[]> {
     // Use unified state if available
-    if (this.#dexDiscoveryState) {
+    if (this.#dexDiscoveryCache.state) {
       const availableHip3Dexs: string[] = [];
-      this.#dexDiscoveryState.raw.forEach((dex) => {
+      this.#dexDiscoveryCache.state.raw.forEach((dex) => {
         if (dex !== null) {
           availableHip3Dexs.push(dex.name);
         }
@@ -1123,7 +1002,7 @@ export class HyperLiquidProvider implements PerpsProvider {
         return [null]; // Fallback to main DEX only
       }
 
-      const state = this.#updateDexDiscovery(allDexs);
+      const state = this.#dexDiscoveryCache.update(allDexs);
       const availableHip3Dexs: string[] = [];
       state.raw.forEach((dex) => {
         if (dex !== null) {
@@ -1156,8 +1035,8 @@ export class HyperLiquidProvider implements PerpsProvider {
    */
   async #getValidatedDexs(): Promise<(string | null)[]> {
     // Return cached result if available
-    if (this.#dexDiscoveryState?.validated) {
-      return this.#dexDiscoveryState.validated;
+    if (this.#dexDiscoveryCache.state?.validated) {
+      return this.#dexDiscoveryCache.state.validated;
     }
 
     // If a fetch is already in progress, reuse the pending promise
@@ -1193,7 +1072,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       this.#deps.debugLogger.log(
         'HyperLiquidProvider: HIP-3 disabled via hip3Enabled flag',
       );
-      const state = this.#updateDexDiscovery([null]);
+      const state = this.#dexDiscoveryCache.update([null]);
       return state.validated;
     }
 
@@ -1227,7 +1106,7 @@ export class HyperLiquidProvider implements PerpsProvider {
     }
 
     // Atomically update unified state (raw + validated + timestamp)
-    const state = this.#updateDexDiscovery(allDexs);
+    const state = this.#dexDiscoveryCache.update(allDexs);
 
     this.#deps.debugLogger.log(
       'HyperLiquidProvider: Available DEXs (market filtering applied at data layer)',
@@ -1238,41 +1117,6 @@ export class HyperLiquidProvider implements PerpsProvider {
     );
 
     return state.validated;
-  }
-
-  /**
-   * Extract unique DEX names from allowlist market patterns
-   * Patterns can be: "xyz:*" (wildcard), "xyz:TSLA" (exact), or "xyz" (DEX shorthand)
-   *
-   * @returns Array of unique DEX names from the allowlist
-   */
-  #extractDexsFromAllowlist(): string[] {
-    if (this.#allowlistMarkets.length === 0) {
-      return [];
-    }
-
-    const dexNames = new Set<string>();
-
-    for (const pattern of this.#allowlistMarkets) {
-      // Pattern formats:
-      // - "xyz:*" -> DEX "xyz" (wildcard)
-      // - "xyz:TSLA" -> DEX "xyz" (exact match)
-      // - "xyz" -> DEX "xyz" (shorthand)
-      const colonIndex = pattern.indexOf(':');
-      if (colonIndex > 0) {
-        // Has colon - extract DEX prefix
-        const dex = pattern.substring(0, colonIndex);
-        dexNames.add(dex);
-      } else if (pattern.length > 0 && !pattern.includes('*')) {
-        // No colon and not a wildcard - could be DEX shorthand
-        // Only add if it looks like a valid DEX name (lowercase alphanumeric)
-        if (/^[a-z][a-z0-9]*$/iu.test(pattern)) {
-          dexNames.add(pattern.toLowerCase());
-        }
-      }
-    }
-
-    return Array.from(dexNames);
   }
 
   /**
@@ -1354,7 +1198,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       return false;
     }
 
-    if (!this.#dexDiscoveryState) {
+    if (!this.#dexDiscoveryCache.state) {
       try {
         await this.#getValidatedDexs();
       } catch (error) {
@@ -1371,7 +1215,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
     }
 
-    const allPerpDexs = this.#dexDiscoveryState?.raw ?? [null];
+    const allPerpDexs = this.#dexDiscoveryCache.state?.raw ?? [null];
     const perpDexIndex = allPerpDexs.findIndex((entry) => {
       if (dex === null) {
         return entry === null;
@@ -1498,15 +1342,15 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Return cached data if still valid (uses unified state timestamp for TTL)
     if (
-      this.#dexDiscoveryState &&
-      now - this.#dexDiscoveryState.timestamp <
+      this.#dexDiscoveryCache.state &&
+      now - this.#dexDiscoveryCache.state.timestamp <
         HIP3_FEE_CONFIG.PerpDexsCacheTtlMs
     ) {
-      const raw = this.#dexDiscoveryState.raw as ExtendedPerpDex[];
+      const raw = this.#dexDiscoveryCache.state.raw as ExtendedPerpDex[];
       this.#deps.debugLogger.log(
         '[getCachedPerpDexs] Using cached perpDexs data',
         {
-          age: `${Math.round((now - this.#dexDiscoveryState.timestamp) / 1000)}s`,
+          age: `${Math.round((now - this.#dexDiscoveryCache.state.timestamp) / 1000)}s`,
           count: raw.length,
         },
       );
@@ -1521,7 +1365,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       (await infoClient.perpDexs()) as unknown as ExtendedPerpDex[];
 
     // Atomically update unified state (raw + validated + timestamp)
-    this.#updateDexDiscovery(perpDexs);
+    this.#dexDiscoveryCache.update(perpDexs);
 
     this.#deps.debugLogger.log(
       '[getCachedPerpDexs] Fetched and cached perpDexs data',
@@ -2137,7 +1981,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // If getValidatedDexs fails, fall back to main DEX only to keep the provider
       // functional. Without this, a transient perpDexs() failure would permanently
       // brick #ensureReady via the cached rejected promise.
-      // Do not set #dexDiscoveryState here — leave it null
+      // Do not update #dexDiscoveryCache here — leave state null
       // so #getValidatedDexs retries on the next call (same as #fetchValidatedDexsInternal).
       this.#deps.debugLogger.log(
         '[buildAssetMapping] getValidatedDexs failed, falling back to main DEX',
@@ -2146,10 +1990,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       dexsToMap = [null];
     }
 
-    // Local fallback only — never write [null] into #dexDiscoveryState here.
-    // That state is owned exclusively by #updateDexDiscovery; writing a
+    // Local fallback only — never write [null] into #dexDiscoveryCache here.
+    // That state is owned exclusively by #dexDiscoveryCache.update(); writing a
     // fallback here would prevent subsequent callers from retrying perpDexs().
-    const allPerpDexs = this.#dexDiscoveryState?.raw ?? [null];
+    const allPerpDexs = this.#dexDiscoveryCache.state?.raw ?? [null];
 
     this.#deps.debugLogger.log(
       'HyperLiquidProvider: Starting asset mapping rebuild',
@@ -2227,7 +2071,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Build mapping with DEX prefixes for HIP-3 DEXs using the utility function
     this.#symbolToAssetId.clear();
-    let dexDiscoveryComplete = this.#dexDiscoveryState !== null;
+    let dexDiscoveryComplete = this.#dexDiscoveryCache.state !== null;
 
     allMetas.forEach((result) => {
       if (
@@ -2716,7 +2560,7 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Try other HIP-3 DEXs
     // Get all available DEXs from cache (includes all HIP-3 DEXs since we no longer filter)
     const availableDexs =
-      this.#dexDiscoveryState?.validated?.filter(
+      this.#dexDiscoveryCache.state?.validated?.filter(
         (dex): dex is string => dex !== null,
       ) ?? [];
     for (const dex of availableDexs) {
@@ -4774,13 +4618,13 @@ export class HyperLiquidProvider implements PerpsProvider {
    */
   async #getStandaloneValidatedDexs(): Promise<(string | null)[]> {
     // Return cached result if available (unified state)
-    if (this.#dexDiscoveryState?.validated) {
-      return this.#dexDiscoveryState.validated;
+    if (this.#dexDiscoveryCache.state?.validated) {
+      return this.#dexDiscoveryCache.state.validated;
     }
 
     // Kill switch: HIP-3 disabled, return main DEX only
     if (!this.#hip3Enabled) {
-      const state = this.#updateDexDiscovery([null]);
+      const state = this.#dexDiscoveryCache.update([null]);
       return state.validated;
     }
 
@@ -4807,7 +4651,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Atomically update unified state (raw + validated + timestamp).
     // buildAssetMapping uses state.raw for perpDexIndex computation.
-    const state = this.#updateDexDiscovery(allDexs);
+    const state = this.#dexDiscoveryCache.update(allDexs);
     return state.validated;
   }
 
@@ -7870,7 +7714,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // to prevent repeated signing requests across reconnections
       this.#cachedMetaByDex.clear();
       this.#cachedSpotMeta = null;
-      this.#dexDiscoveryState = null;
+      this.#dexDiscoveryCache.reset();
       this.#dexDiscoveryComplete = false;
 
       // Await pending initialization before clearing to prevent the IIFE from

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -109,7 +109,11 @@ import type {
   SpotMetaResponse,
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
-import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
+import type {
+  DexDiscoveryState,
+  ExtendedAssetMeta,
+  ExtendedPerpDex,
+} from '../types/perps-types';
 import { aggregateAccountStates } from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
@@ -306,12 +310,10 @@ export class HyperLiquidProvider implements PerpsProvider {
   // Pre-fetched in ensureReadyForTrading() to avoid API failures during order placement
   #cachedSpotMeta: SpotMetaResponse | null = null;
 
-  // Cache for perpDexs data (deployerFeeScale for dynamic fee calculation)
-  // TTL-based cache - fee scales rarely change
-  #perpDexsCache: {
-    data: ExtendedPerpDex[] | null;
-    timestamp: number;
-  } = { data: null, timestamp: 0 };
+  // Unified DEX discovery state — single source of truth for all perpDexs() derivatives.
+  // Replaces three separate caches to eliminate desync bugs by construction.
+  // All writes go through #updateDexDiscovery(); readers use .raw, .validated, .timestamp.
+  #dexDiscoveryState: DexDiscoveryState | null = null;
 
   // Session cache for referral state (cleared on disconnect/reconnect)
   // Key: `network:userAddress`, Value: true if referral is set
@@ -343,11 +345,6 @@ export class HyperLiquidProvider implements PerpsProvider {
   readonly #blocklistMarkets: string[];
 
   #useDexAbstraction: boolean;
-
-  // Cache for validated DEXs to avoid redundant perpDexs() API calls
-  #cachedValidatedDexs: (string | null)[] | null = null;
-
-  #cachedAllPerpDexs: ({ name: string } | null)[] | null = null;
 
   // True once DEX discovery has succeeded with real data (not a fallback).
   // When false, #ensureReadyPromise is reset after each init so the next
@@ -980,19 +977,137 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Single atomic writer for DEX discovery state.
+   * All code paths that fetch perpDexs() MUST call this — no direct field writes.
+   *
+   * @param allDexs - Raw perpDexs() API response array.
+   * @returns The newly created unified discovery state.
+   */
+  #updateDexDiscovery(allDexs: (ExtendedPerpDex | null)[]): DexDiscoveryState {
+    const validated = this.#computeValidatedDexs(allDexs);
+    const state: DexDiscoveryState = {
+      raw: allDexs,
+      validated,
+      timestamp: Date.now(),
+    };
+    this.#dexDiscoveryState = state;
+    return state;
+  }
+
+  /**
+   * Pure filtering of perpDexs() response into validated DEX names.
+   * Encapsulates testnet/mainnet feature-flag logic previously duplicated
+   * in #fetchValidatedDexsInternal and #getStandaloneValidatedDexs.
+   *
+   * @param allDexs - Raw perpDexs() API response array.
+   * @returns Filtered DEX name list (null = main DEX, strings = HIP-3 DEXs).
+   */
+  #computeValidatedDexs(
+    allDexs: (ExtendedPerpDex | null)[],
+  ): (string | null)[] {
+    // Extract HIP-3 DEX names (filter out null which represents main DEX)
+    const availableHip3Dexs: string[] = [];
+    allDexs.forEach((dex) => {
+      if (dex !== null) {
+        availableHip3Dexs.push(dex.name);
+      }
+    });
+
+    // Testnet-specific filtering
+    if (this.#clientService.isTestnetMode()) {
+      const { EnabledDexs, AutoDiscoverAll } = TESTNET_HIP3_CONFIG;
+
+      if (!AutoDiscoverAll) {
+        if (EnabledDexs.length === 0) {
+          this.#deps.debugLogger.log(
+            'HyperLiquidProvider: Testnet - using main DEX only (HIP-3 DEXs filtered)',
+            {
+              availableHip3Dexs: availableHip3Dexs.length,
+              reason: 'TESTNET_HIP3_CONFIG.EnabledDexs is empty',
+            },
+          );
+          return [null];
+        }
+
+        const filteredDexs = availableHip3Dexs.filter((dex) =>
+          EnabledDexs.includes(dex),
+        );
+        this.#deps.debugLogger.log(
+          'HyperLiquidProvider: Testnet - filtered to allowed DEXs',
+          {
+            allowedDexs: EnabledDexs,
+            filteredDexs,
+            availableHip3Dexs: availableHip3Dexs.length,
+          },
+        );
+        return [null, ...filteredDexs];
+      }
+
+      this.#deps.debugLogger.log(
+        'HyperLiquidProvider: Testnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
+        { totalDexCount: availableHip3Dexs.length + 1 },
+      );
+    } else {
+      // Mainnet-specific filtering
+      const { AutoDiscoverAll } = MAINNET_HIP3_CONFIG;
+
+      if (!AutoDiscoverAll) {
+        const allowedDexsFromAllowlist = this.#extractDexsFromAllowlist();
+
+        if (allowedDexsFromAllowlist.length === 0) {
+          this.#deps.debugLogger.log(
+            'HyperLiquidProvider: Mainnet - using main DEX only (no HIP-3 DEXs in allowlist)',
+            {
+              availableHip3Dexs: availableHip3Dexs.length,
+              allowlistMarkets: this.#allowlistMarkets,
+            },
+          );
+          return [null];
+        }
+
+        const filteredDexs = availableHip3Dexs.filter((dex) =>
+          allowedDexsFromAllowlist.includes(dex),
+        );
+        this.#deps.debugLogger.log(
+          'HyperLiquidProvider: Mainnet - filtered to allowlist DEXs',
+          {
+            allowedDexsFromAllowlist,
+            filteredDexs,
+            availableHip3Dexs: availableHip3Dexs.length,
+          },
+        );
+        return [null, ...filteredDexs];
+      }
+
+      this.#deps.debugLogger.log(
+        'HyperLiquidProvider: Mainnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
+        { totalDexCount: availableHip3Dexs.length + 1 },
+      );
+    }
+
+    // Fallback: all DEXs (when AUTO_DISCOVER_ALL is true)
+    this.#deps.debugLogger.log(
+      'HyperLiquidProvider: All DEXs enabled (market filtering at data layer)',
+      {
+        mainDex: true,
+        hip3Dexs: availableHip3Dexs,
+        totalDexCount: availableHip3Dexs.length + 1,
+      },
+    );
+    return [null, ...availableHip3Dexs];
+  }
+
+  /**
    * Get all available DEXs without allowlist filtering
    * Used when skipFilters=true in getMarkets()
    *
    * @returns Array of all DEX names (null for main DEX, strings for HIP-3 DEXs)
    */
   async #getAllAvailableDexs(): Promise<(string | null)[]> {
-    // If already cached by getValidatedDexs, use that
-    if (
-      this.#cachedAllPerpDexs !== null &&
-      Array.isArray(this.#cachedAllPerpDexs)
-    ) {
+    // Use unified state if available
+    if (this.#dexDiscoveryState) {
       const availableHip3Dexs: string[] = [];
-      this.#cachedAllPerpDexs.forEach((dex) => {
+      this.#dexDiscoveryState.raw.forEach((dex) => {
         if (dex !== null) {
           availableHip3Dexs.push(dex.name);
         }
@@ -1000,7 +1115,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       return [null, ...availableHip3Dexs];
     }
 
-    // Fetch fresh from API
+    // Fetch fresh from API and update unified state
     const infoClient = this.#clientService.getInfoClient();
     try {
       const allDexs = await infoClient.perpDexs();
@@ -1008,9 +1123,9 @@ export class HyperLiquidProvider implements PerpsProvider {
         return [null]; // Fallback to main DEX only
       }
 
-      this.#cachedAllPerpDexs = allDexs;
+      const state = this.#updateDexDiscovery(allDexs);
       const availableHip3Dexs: string[] = [];
-      allDexs.forEach((dex) => {
+      state.raw.forEach((dex) => {
         if (dex !== null) {
           availableHip3Dexs.push(dex.name);
         }
@@ -1041,8 +1156,8 @@ export class HyperLiquidProvider implements PerpsProvider {
    */
   async #getValidatedDexs(): Promise<(string | null)[]> {
     // Return cached result if available
-    if (this.#cachedValidatedDexs !== null) {
-      return this.#cachedValidatedDexs;
+    if (this.#dexDiscoveryState?.validated) {
+      return this.#dexDiscoveryState.validated;
     }
 
     // If a fetch is already in progress, reuse the pending promise
@@ -1078,9 +1193,8 @@ export class HyperLiquidProvider implements PerpsProvider {
       this.#deps.debugLogger.log(
         'HyperLiquidProvider: HIP-3 disabled via hip3Enabled flag',
       );
-      this.#cachedAllPerpDexs = [null];
-      this.#cachedValidatedDexs = [null];
-      return this.#cachedValidatedDexs;
+      const state = this.#updateDexDiscovery([null]);
+      return state.validated;
     }
 
     // Fetch all available DEXs from HyperLiquid
@@ -1112,123 +1226,18 @@ export class HyperLiquidProvider implements PerpsProvider {
       return [null];
     }
 
-    // Cache for buildAssetMapping() to avoid duplicate call
-    this.#cachedAllPerpDexs = allDexs;
-
-    // Extract HIP-3 DEX names (filter out null which represents main DEX)
-    const availableHip3Dexs: string[] = [];
-    allDexs.forEach((dex) => {
-      if (dex !== null) {
-        availableHip3Dexs.push(dex.name);
-      }
-    });
+    // Atomically update unified state (raw + validated + timestamp)
+    const state = this.#updateDexDiscovery(allDexs);
 
     this.#deps.debugLogger.log(
       'HyperLiquidProvider: Available DEXs (market filtering applied at data layer)',
       {
-        count: availableHip3Dexs.length,
-        dexNames: availableHip3Dexs,
+        count: state.validated.filter((dex) => dex !== null).length,
+        dexNames: state.validated.filter((dex) => dex !== null),
       },
     );
 
-    // Testnet-specific filtering: Limit DEXs to avoid subscription overload
-    // On testnet, there are many HIP-3 DEXs (test deployments) that cause instability
-    if (this.#clientService.isTestnetMode()) {
-      const { EnabledDexs, AutoDiscoverAll } = TESTNET_HIP3_CONFIG;
-
-      if (!AutoDiscoverAll) {
-        if (EnabledDexs.length === 0) {
-          // Main DEX only - no HIP-3 DEXs on testnet
-          this.#deps.debugLogger.log(
-            'HyperLiquidProvider: Testnet - using main DEX only (HIP-3 DEXs filtered)',
-            {
-              availableHip3Dexs: availableHip3Dexs.length,
-              reason: 'TESTNET_HIP3_CONFIG.EnabledDexs is empty',
-            },
-          );
-          this.#cachedValidatedDexs = [null];
-          return this.#cachedValidatedDexs;
-        }
-
-        // Filter to specific allowed DEXs on testnet
-        const filteredDexs = availableHip3Dexs.filter((dex) =>
-          EnabledDexs.includes(dex),
-        );
-        this.#deps.debugLogger.log(
-          'HyperLiquidProvider: Testnet - filtered to allowed DEXs',
-          {
-            allowedDexs: EnabledDexs,
-            filteredDexs,
-            availableHip3Dexs: availableHip3Dexs.length,
-          },
-        );
-        this.#cachedValidatedDexs = [null, ...filteredDexs];
-        return this.#cachedValidatedDexs;
-      }
-
-      // AUTO_DISCOVER_ALL is true - proceed with all DEXs (not recommended for testnet)
-      this.#deps.debugLogger.log(
-        'HyperLiquidProvider: Testnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
-        { totalDexCount: availableHip3Dexs.length + 1 },
-      );
-    } else {
-      // Mainnet-specific filtering: Extract allowed DEXs from the allowlist patterns
-      // This reduces WebSocket subscription overhead dynamically based on feature flags
-      const { AutoDiscoverAll } = MAINNET_HIP3_CONFIG;
-
-      if (!AutoDiscoverAll) {
-        // Extract unique DEX names from allowlist patterns
-        // Patterns like "xyz:*", "xyz:TSLA", or "xyz" all indicate DEX "xyz"
-        const allowedDexsFromAllowlist = this.#extractDexsFromAllowlist();
-
-        if (allowedDexsFromAllowlist.length === 0) {
-          // No HIP-3 DEXs in allowlist - main DEX only
-          this.#deps.debugLogger.log(
-            'HyperLiquidProvider: Mainnet - using main DEX only (no HIP-3 DEXs in allowlist)',
-            {
-              availableHip3Dexs: availableHip3Dexs.length,
-              allowlistMarkets: this.#allowlistMarkets,
-            },
-          );
-          this.#cachedValidatedDexs = [null];
-          return this.#cachedValidatedDexs;
-        }
-
-        // Filter to DEXs that are both available AND in the allowlist
-        const filteredDexs = availableHip3Dexs.filter((dex) =>
-          allowedDexsFromAllowlist.includes(dex),
-        );
-        this.#deps.debugLogger.log(
-          'HyperLiquidProvider: Mainnet - filtered to allowlist DEXs',
-          {
-            allowedDexsFromAllowlist,
-            filteredDexs,
-            availableHip3Dexs: availableHip3Dexs.length,
-          },
-        );
-        this.#cachedValidatedDexs = [null, ...filteredDexs];
-        return this.#cachedValidatedDexs;
-      }
-
-      // AUTO_DISCOVER_ALL is true - proceed with all DEXs
-      this.#deps.debugLogger.log(
-        'HyperLiquidProvider: Mainnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
-        { totalDexCount: availableHip3Dexs.length + 1 },
-      );
-    }
-
-    // Fallback: Return all DEXs (when AUTO_DISCOVER_ALL is true)
-    // Market filtering is applied at subscription data layer
-    this.#deps.debugLogger.log(
-      'HyperLiquidProvider: All DEXs enabled (market filtering at data layer)',
-      {
-        mainDex: true,
-        hip3Dexs: availableHip3Dexs,
-        totalDexCount: availableHip3Dexs.length + 1,
-      },
-    );
-    this.#cachedValidatedDexs = [null, ...availableHip3Dexs];
-    return this.#cachedValidatedDexs;
+    return state.validated;
   }
 
   /**
@@ -1345,7 +1354,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       return false;
     }
 
-    if (!this.#cachedAllPerpDexs) {
+    if (!this.#dexDiscoveryState) {
       try {
         await this.#getValidatedDexs();
       } catch (error) {
@@ -1362,7 +1371,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
     }
 
-    const allPerpDexs = this.#cachedAllPerpDexs ?? [null];
+    const allPerpDexs = this.#dexDiscoveryState?.raw ?? [null];
     const perpDexIndex = allPerpDexs.findIndex((entry) => {
       if (dex === null) {
         return entry === null;
@@ -1487,19 +1496,21 @@ export class HyperLiquidProvider implements PerpsProvider {
   async #getCachedPerpDexs(): Promise<ExtendedPerpDex[]> {
     const now = Date.now();
 
-    // Return cached data if still valid
+    // Return cached data if still valid (uses unified state timestamp for TTL)
     if (
-      this.#perpDexsCache.data &&
-      now - this.#perpDexsCache.timestamp < HIP3_FEE_CONFIG.PerpDexsCacheTtlMs
+      this.#dexDiscoveryState &&
+      now - this.#dexDiscoveryState.timestamp <
+        HIP3_FEE_CONFIG.PerpDexsCacheTtlMs
     ) {
+      const raw = this.#dexDiscoveryState.raw as ExtendedPerpDex[];
       this.#deps.debugLogger.log(
         '[getCachedPerpDexs] Using cached perpDexs data',
         {
-          age: `${Math.round((now - this.#perpDexsCache.timestamp) / 1000)}s`,
-          count: this.#perpDexsCache.data.length,
+          age: `${Math.round((now - this.#dexDiscoveryState.timestamp) / 1000)}s`,
+          count: raw.length,
         },
       );
-      return this.#perpDexsCache.data;
+      return raw;
     }
 
     // Fetch fresh data from API
@@ -1509,8 +1520,8 @@ export class HyperLiquidProvider implements PerpsProvider {
     const perpDexs =
       (await infoClient.perpDexs()) as unknown as ExtendedPerpDex[];
 
-    // Cache the result
-    this.#perpDexsCache = { data: perpDexs, timestamp: now };
+    // Atomically update unified state (raw + validated + timestamp)
+    this.#updateDexDiscovery(perpDexs);
 
     this.#deps.debugLogger.log(
       '[getCachedPerpDexs] Fetched and cached perpDexs data',
@@ -2126,7 +2137,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // If getValidatedDexs fails, fall back to main DEX only to keep the provider
       // functional. Without this, a transient perpDexs() failure would permanently
       // brick #ensureReady via the cached rejected promise.
-      // Do not set #cachedAllPerpDexs or #cachedValidatedDexs here — leave them null
+      // Do not set #dexDiscoveryState here — leave it null
       // so #getValidatedDexs retries on the next call (same as #fetchValidatedDexsInternal).
       this.#deps.debugLogger.log(
         '[buildAssetMapping] getValidatedDexs failed, falling back to main DEX',
@@ -2135,10 +2146,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       dexsToMap = [null];
     }
 
-    // Local fallback only — never write [null] into #cachedAllPerpDexs here.
-    // That cache is owned exclusively by #fetchValidatedDexsInternal; writing a
+    // Local fallback only — never write [null] into #dexDiscoveryState here.
+    // That state is owned exclusively by #updateDexDiscovery; writing a
     // fallback here would prevent subsequent callers from retrying perpDexs().
-    const allPerpDexs = this.#cachedAllPerpDexs ?? [null];
+    const allPerpDexs = this.#dexDiscoveryState?.raw ?? [null];
 
     this.#deps.debugLogger.log(
       'HyperLiquidProvider: Starting asset mapping rebuild',
@@ -2216,7 +2227,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     // Build mapping with DEX prefixes for HIP-3 DEXs using the utility function
     this.#symbolToAssetId.clear();
-    let dexDiscoveryComplete = this.#cachedValidatedDexs !== null;
+    let dexDiscoveryComplete = this.#dexDiscoveryState !== null;
 
     allMetas.forEach((result) => {
       if (
@@ -2705,8 +2716,9 @@ export class HyperLiquidProvider implements PerpsProvider {
     // Try other HIP-3 DEXs
     // Get all available DEXs from cache (includes all HIP-3 DEXs since we no longer filter)
     const availableDexs =
-      this.#cachedValidatedDexs?.filter((dex): dex is string => dex !== null) ??
-      [];
+      this.#dexDiscoveryState?.validated?.filter(
+        (dex): dex is string => dex !== null,
+      ) ?? [];
     for (const dex of availableDexs) {
       if (dex === targetDex) {
         continue;
@@ -4761,15 +4773,15 @@ export class HyperLiquidProvider implements PerpsProvider {
    * @returns A promise that resolves to the result.
    */
   async #getStandaloneValidatedDexs(): Promise<(string | null)[]> {
-    // Return cached result if available
-    if (this.#cachedValidatedDexs !== null) {
-      return this.#cachedValidatedDexs;
+    // Return cached result if available (unified state)
+    if (this.#dexDiscoveryState?.validated) {
+      return this.#dexDiscoveryState.validated;
     }
 
     // Kill switch: HIP-3 disabled, return main DEX only
     if (!this.#hip3Enabled) {
-      this.#cachedValidatedDexs = [null];
-      return this.#cachedValidatedDexs;
+      const state = this.#updateDexDiscovery([null]);
+      return state.validated;
     }
 
     // Fetch available DEXs via standalone client
@@ -4783,41 +4795,20 @@ export class HyperLiquidProvider implements PerpsProvider {
       this.#deps.debugLogger.log(
         'HyperLiquidProvider: standalone perpDexs() failed, falling back to main DEX only',
       );
+      // Do not cache — transient error, allow retry on next call
       return [null];
     }
 
     // Validate response
     if (!allDexs || !Array.isArray(allDexs)) {
+      // Do not cache — may be transient, allow retry on next call
       return [null];
     }
 
-    // Populate #cachedAllPerpDexs so buildAssetMapping can compute perpDexIndex.
-    // Without this, getValidatedDexs returns from #cachedValidatedDexs (string names)
-    // but #cachedAllPerpDexs (raw objects for index computation) stays null,
-    // causing "Could not find perpDexIndex for DEX xyz" failures.
-    this.#cachedAllPerpDexs = allDexs;
-
-    // Extract HIP-3 DEX names (filter out null which represents main DEX)
-    const availableHip3Dexs: string[] = [];
-    allDexs.forEach((dex) => {
-      if (dex !== null) {
-        availableHip3Dexs.push(dex.name);
-      }
-    });
-
-    // Filter by allowlist patterns (same logic as fetchValidatedDexsInternal)
-    const allowedDexsFromAllowlist = this.#extractDexsFromAllowlist();
-    if (allowedDexsFromAllowlist.length === 0) {
-      this.#cachedValidatedDexs = [null];
-      return this.#cachedValidatedDexs;
-    }
-
-    const filteredDexs = availableHip3Dexs.filter((dex) =>
-      allowedDexsFromAllowlist.includes(dex),
-    );
-
-    this.#cachedValidatedDexs = [null, ...filteredDexs];
-    return this.#cachedValidatedDexs;
+    // Atomically update unified state (raw + validated + timestamp).
+    // buildAssetMapping uses state.raw for perpDexIndex computation.
+    const state = this.#updateDexDiscovery(allDexs);
+    return state.validated;
   }
 
   /**
@@ -7879,7 +7870,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // to prevent repeated signing requests across reconnections
       this.#cachedMetaByDex.clear();
       this.#cachedSpotMeta = null;
-      this.#perpDexsCache = { data: null, timestamp: 0 };
+      this.#dexDiscoveryState = null;
       this.#dexDiscoveryComplete = false;
 
       // Await pending initialization before clearing to prevent the IIFE from

--- a/app/controllers/perps/services/DexDiscoveryCacheManager.ts
+++ b/app/controllers/perps/services/DexDiscoveryCacheManager.ts
@@ -1,0 +1,181 @@
+import {
+  MAINNET_HIP3_CONFIG,
+  TESTNET_HIP3_CONFIG,
+} from '../constants/hyperLiquidConfig';
+import type { DexDiscoveryState, ExtendedPerpDex } from '../types/perps-types';
+
+type DexDiscoveryDeps = {
+  isTestnetMode: () => boolean;
+  debugLogger: { log: (...args: unknown[]) => void };
+  getAllowlistMarkets: () => string[];
+};
+
+/**
+ * Manages the unified DEX discovery cache — single source of truth for all perpDexs() derivatives.
+ *
+ * Extracted from HyperLiquidProvider to isolate cache logic.
+ * All writes go through update(); readers use .state.
+ */
+export class DexDiscoveryCacheManager {
+  /**
+   * Unified DEX discovery state.
+   * null = not yet fetched; object = raw + validated + timestamp.
+   */
+  state: DexDiscoveryState | null = null;
+
+  readonly #deps: DexDiscoveryDeps;
+
+  constructor(deps: DexDiscoveryDeps) {
+    this.#deps = deps;
+  }
+
+  /**
+   * Single atomic writer for DEX discovery state.
+   * All code paths that fetch perpDexs() MUST call this — no direct field writes.
+   *
+   * @param allDexs - Raw perpDexs() API response array.
+   * @returns The newly created unified discovery state.
+   */
+  update(allDexs: (ExtendedPerpDex | null)[]): DexDiscoveryState {
+    const validated = this.computeValidatedDexs(allDexs);
+    const newState: DexDiscoveryState = {
+      raw: allDexs,
+      validated,
+      timestamp: Date.now(),
+    };
+    this.state = newState;
+    return newState;
+  }
+
+  /**
+   * Reset state to null (used on disconnect/reconnect).
+   */
+  reset(): void {
+    this.state = null;
+  }
+
+  /**
+   * Pure filtering of perpDexs() response into validated DEX names.
+   * Encapsulates testnet/mainnet feature-flag logic.
+   *
+   * @param allDexs - Raw perpDexs() API response array.
+   * @returns Filtered DEX name list (null = main DEX, strings = HIP-3 DEXs).
+   */
+  computeValidatedDexs(allDexs: (ExtendedPerpDex | null)[]): (string | null)[] {
+    const availableHip3Dexs: string[] = [];
+    allDexs.forEach((dex) => {
+      if (dex !== null) {
+        availableHip3Dexs.push(dex.name);
+      }
+    });
+
+    if (this.#deps.isTestnetMode()) {
+      const { EnabledDexs, AutoDiscoverAll } = TESTNET_HIP3_CONFIG;
+
+      if (!AutoDiscoverAll) {
+        if (EnabledDexs.length === 0) {
+          this.#deps.debugLogger.log(
+            'HyperLiquidProvider: Testnet - using main DEX only (HIP-3 DEXs filtered)',
+            {
+              availableHip3Dexs: availableHip3Dexs.length,
+              reason: 'TESTNET_HIP3_CONFIG.EnabledDexs is empty',
+            },
+          );
+          return [null];
+        }
+
+        const filteredDexs = availableHip3Dexs.filter((dex) =>
+          EnabledDexs.includes(dex),
+        );
+        this.#deps.debugLogger.log(
+          'HyperLiquidProvider: Testnet - filtered to allowed DEXs',
+          {
+            allowedDexs: EnabledDexs,
+            filteredDexs,
+            availableHip3Dexs: availableHip3Dexs.length,
+          },
+        );
+        return [null, ...filteredDexs];
+      }
+
+      this.#deps.debugLogger.log(
+        'HyperLiquidProvider: Testnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
+        { totalDexCount: availableHip3Dexs.length + 1 },
+      );
+    } else {
+      const { AutoDiscoverAll } = MAINNET_HIP3_CONFIG;
+
+      if (!AutoDiscoverAll) {
+        const allowedDexsFromAllowlist = this.extractDexsFromAllowlist();
+
+        if (allowedDexsFromAllowlist.length === 0) {
+          this.#deps.debugLogger.log(
+            'HyperLiquidProvider: Mainnet - using main DEX only (no HIP-3 DEXs in allowlist)',
+            {
+              availableHip3Dexs: availableHip3Dexs.length,
+              allowlistMarkets: this.#deps.getAllowlistMarkets(),
+            },
+          );
+          return [null];
+        }
+
+        const filteredDexs = availableHip3Dexs.filter((dex) =>
+          allowedDexsFromAllowlist.includes(dex),
+        );
+        this.#deps.debugLogger.log(
+          'HyperLiquidProvider: Mainnet - filtered to allowlist DEXs',
+          {
+            allowedDexsFromAllowlist,
+            filteredDexs,
+            availableHip3Dexs: availableHip3Dexs.length,
+          },
+        );
+        return [null, ...filteredDexs];
+      }
+
+      this.#deps.debugLogger.log(
+        'HyperLiquidProvider: Mainnet - AUTO_DISCOVER_ALL enabled, using all DEXs',
+        { totalDexCount: availableHip3Dexs.length + 1 },
+      );
+    }
+
+    this.#deps.debugLogger.log(
+      'HyperLiquidProvider: All DEXs enabled (market filtering at data layer)',
+      {
+        mainDex: true,
+        hip3Dexs: availableHip3Dexs,
+        totalDexCount: availableHip3Dexs.length + 1,
+      },
+    );
+    return [null, ...availableHip3Dexs];
+  }
+
+  /**
+   * Extract unique DEX names from allowlist market patterns.
+   * Patterns can be: "xyz:*" (wildcard), "xyz:TSLA" (exact), or "xyz" (DEX shorthand).
+   *
+   * @returns Array of unique DEX names from the allowlist.
+   */
+  extractDexsFromAllowlist(): string[] {
+    const allowlistMarkets = this.#deps.getAllowlistMarkets();
+    if (allowlistMarkets.length === 0) {
+      return [];
+    }
+
+    const dexNames = new Set<string>();
+
+    for (const pattern of allowlistMarkets) {
+      const colonIndex = pattern.indexOf(':');
+      if (colonIndex > 0) {
+        const dex = pattern.substring(0, colonIndex);
+        dexNames.add(dex);
+      } else if (pattern.length > 0 && !pattern.includes('*')) {
+        if (/^[a-z][a-z0-9]*$/iu.test(pattern)) {
+          dexNames.add(pattern.toLowerCase());
+        }
+      }
+    }
+
+    return Array.from(dexNames);
+  }
+}

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -3686,21 +3686,74 @@ export class HyperLiquidSubscriptionService {
     this.#dexAccountCache.clear();
     this.#dexAssetCtxsCache.clear();
 
-    // Clear subscription references (actual cleanup handled by client service)
+    // Unsubscribe all active subscriptions before clearing references.
+    // Without this, orphaned subscriptions try to send unsubscribe frames
+    // on the closing WebSocket, causing SOCKET_NOT_CONNECTED errors.
+    if (this.#globalAllMidsSubscription) {
+      this.#globalAllMidsSubscription.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.globalAllMids'),
+        );
+      });
+    }
     this.#globalAllMidsSubscription = undefined;
     this.#globalAllMidsPromise = undefined;
+
+    this.#globalActiveAssetSubscriptions.forEach((sub, symbol) => {
+      sub.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.activeAsset', { symbol }),
+        );
+      });
+    });
     this.#globalActiveAssetSubscriptions.clear();
     this.#pendingActiveAssetPromises.clear();
+
+    this.#globalBboSubscriptions.forEach((sub, symbol) => {
+      sub.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.bbo', { symbol }),
+        );
+      });
+    });
     this.#globalBboSubscriptions.clear();
     this.#pendingBboPromises.clear();
+
+    this.#webData3Subscriptions.forEach((sub, dexName) => {
+      sub.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.webData3', { dex: dexName }),
+        );
+      });
+    });
     this.#webData3Subscriptions.clear();
     this.#webData3SubscriptionPromise = undefined;
 
-    // HIP-3: Clear assetCtxs subscriptions (clearinghouseState no longer needed with webData3)
+    // HIP-3: Clear assetCtxs subscriptions
+    this.#assetCtxsSubscriptions.forEach((sub, dexName) => {
+      sub.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.assetCtxs', { dex: dexName }),
+        );
+      });
+    });
     this.#assetCtxsSubscriptions.clear();
     this.#assetCtxsSubscriptionPromises.clear();
 
     // HIP-3: Clear per-DEX allMids subscriptions
+    this.#dexAllMidsSubscriptions.forEach((sub, dexName) => {
+      sub.unsubscribe().catch((error: Error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(error, 'HyperLiquidSubscriptionService.clearAll'),
+          this.#getErrorContext('clearAll.dexAllMids', { dex: dexName }),
+        );
+      });
+    });
     this.#dexAllMidsSubscriptions.clear();
     this.#dexAllMidsSubscriptionPromises.clear();
 

--- a/app/controllers/perps/types/perps-types.ts
+++ b/app/controllers/perps/types/perps-types.ts
@@ -137,3 +137,17 @@ export type ExtendedPerpDex = {
   /** ISO timestamp of last fee scale change */
   lastDeployerFeeScaleChangeTime?: string;
 };
+
+/**
+ * Unified DEX discovery state — single source of truth for all perpDexs() derivatives.
+ * Replaces three separate caches (#cachedAllPerpDexs, #cachedValidatedDexs, #perpDexsCache)
+ * to eliminate desync bugs by construction.
+ */
+export type DexDiscoveryState = {
+  /** perpDexs() API response (raw objects with deployerFeeScale etc.) */
+  raw: (ExtendedPerpDex | null)[];
+  /** Feature-flag-filtered DEX names (null = main DEX, strings = HIP-3 DEXs) */
+  validated: (string | null)[];
+  /** When raw was fetched — used for fee-scale TTL checks */
+  timestamp: number;
+};


### PR DESCRIPTION
## **Description**

Consolidate three separate DEX discovery caches (`mainnetDexCache`, `testnetDexCache`, `dexDiscoveryTimestamp`) into a single `DexDiscoveryState` managed by a new `DexDiscoveryCacheManager` service. This eliminates desync bugs where mainnet and testnet caches could get out of step, and reduces HyperLiquidProvider by ~170 lines.

Also fixes a WebSocket leak in `HyperLiquidSubscriptionService.clearAll()` — it now unsubscribes all active subscriptions before clearing refs, eliminating `SOCKET_NOT_CONNECTED` errors on reconnect.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2760](https://consensyssoftware.atlassian.net/browse/TAT-2760)

## **Manual testing steps**

```gherkin
Feature: Perps DEX discovery cache consolidation

  Scenario: user opens perps and switches networks
    Given the app is on mainnet with perps tab visible

    When user navigates to perps and views available DEXs
    Then DEX list loads correctly from unified cache

  Scenario: user triggers reconnection after background
    Given the app has active WebSocket subscriptions

    When user backgrounds and foregrounds the app
    Then subscriptions reconnect without SOCKET_NOT_CONNECTED errors
```

## **Screenshots/Recordings**

### **Before**

N/A — internal refactor

### **After**

Validated live:
- 22/22 iOS evals passing
- 22/22 Android evals passing
- 0 SOCKET_NOT_CONNECTED errors across both platforms
- `yarn jest HyperLiquidProvider --no-coverage` — 282 tests passing

https://github.com/user-attachments/assets/4d90fff9-ac58-4c4e-9967-6cbd28bc9cde

https://github.com/user-attachments/assets/ac9d19c4-2193-4d4f-a679-1882dc9123c6

## **Validation Recipe**

<details><summary>recipe.json (22 steps — disconnect, background, long-background, restart)</summary>

```json
{
  "title": "DEX Discovery — validate cache across disconnect, background, and restart",
  "inputs": {
    "symbol": {
      "type": "string",
      "default": "BTC",
      "description": "Market symbol to verify"
    },
    "test_disconnect": {
      "type": "boolean",
      "default": true,
      "description": "Test disconnect/init cycle clears and restores cache"
    },
    "test_background": {
      "type": "boolean",
      "default": true,
      "description": "Test background/foreground preserves cache"
    },
    "test_restart": {
      "type": "boolean",
      "default": false,
      "description": "Test full app restart reloads cache (slower, needs ~20s boot)"
    },
    "background_duration_ms": {
      "type": "number",
      "default": 5000,
      "description": "How long to keep the app in background (ms)"
    }
  },
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "nav-market-list",
      "nodes": {
        "nav-market-list": {
          "action": "navigate",
          "target": "PerpsTrendingView",
          "next": "wait-markets"
        },
        "wait-markets": {
          "action": "wait_for",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "next": "check-price"
        },
        "check-price": {
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
          "assert": { "operator": "neq", "field": "price", "value": "0" },
          "next": "check-dexs"
        },
        "check-dexs": {
          "action": "eval_async",
          "description": "Verify DEX discovery cache is populated",
          "expression": "Engine.context.PerpsController.getAvailableDexs().then(function(dexs){return JSON.stringify({count:dexs.length,hasMainDex:dexs.indexOf('')>=0})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "next": "disconnect"
        },
        "disconnect": {
          "action": "eval_async",
          "description": "Tear down provider — clears DEX discovery cache",
          "when": { "operator": "eq", "field": "inputs.test_disconnect", "value": true },
          "expression": "Engine.context.PerpsController.disconnect().then(function(){return JSON.stringify({disconnected:true})})",
          "assert": { "operator": "eq", "field": "disconnected", "value": true },
          "next": "reconnect"
        },
        "reconnect": {
          "action": "eval_async",
          "description": "Re-init provider — must rebuild cache from scratch",
          "when": { "operator": "eq", "field": "inputs.test_disconnect", "value": true },
          "expression": "Engine.context.PerpsController.init().then(function(){return JSON.stringify({reinited:true})})",
          "assert": { "operator": "eq", "field": "reinited", "value": true },
          "next": "wait-reconnect"
        },
        "wait-reconnect": {
          "action": "wait_for",
          "when": { "operator": "eq", "field": "inputs.test_disconnect", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "timeout_ms": 20000,
          "next": "verify-dexs-reconnect"
        },
        "verify-dexs-reconnect": {
          "action": "eval_async",
          "description": "Confirm DEX cache restored after reconnect",
          "when": { "operator": "eq", "field": "inputs.test_disconnect", "value": true },
          "expression": "Engine.context.PerpsController.getAvailableDexs().then(function(dexs){return JSON.stringify({count:dexs.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "next": "background-app"
        },
        "background-app": {
          "action": "app_background",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "duration_ms": "{{background_duration_ms}}",
          "next": "foreground-app"
        },
        "foreground-app": {
          "action": "app_foreground",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "next": "wait-post-foreground"
        },
        "wait-post-foreground": {
          "action": "wait_for",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "timeout_ms": 15000,
          "next": "verify-post-foreground"
        },
        "verify-post-foreground": {
          "action": "eval_async",
          "description": "Confirm markets + price survive short background",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
          "assert": { "operator": "neq", "field": "price", "value": "0" },
          "next": "long-background-app"
        },
        "long-background-app": {
          "action": "app_background",
          "description": "Background 30s — exceeds WS grace period, forces full reconnection",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "duration_ms": 30000,
          "next": "long-foreground-app"
        },
        "long-foreground-app": {
          "action": "app_foreground",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "next": "wait-post-long-foreground"
        },
        "wait-post-long-foreground": {
          "action": "wait_for",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "timeout_ms": 30000,
          "next": "verify-post-long-foreground"
        },
        "verify-post-long-foreground": {
          "action": "eval_async",
          "description": "Confirm markets + DEXs recover after full WS reconnection",
          "when": { "operator": "eq", "field": "inputs.test_background", "value": true },
          "expression": "Engine.context.PerpsController.getAvailableDexs().then(function(dexs){return JSON.stringify({count:dexs.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "next": "restart-app"
        },
        "restart-app": {
          "action": "app_restart",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "boot_wait_ms": 20000,
          "next": "detect-post-restart"
        },
        "detect-post-restart": {
          "action": "eval_sync",
          "description": "Detect login vs wallet after restart",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "expression": "(function(){try{var r=globalThis.__AGENTIC__.getRoute();return JSON.stringify({route:r.name})}catch(e){return JSON.stringify({route:'unknown'})}})()",
          "next": "check-needs-unlock"
        },
        "check-needs-unlock": {
          "action": "switch",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "cases": [
            {
              "label": "needs-login",
              "when": { "operator": "eq", "field": "nodes.detect-post-restart.result.route", "value": "Login" },
              "next": "enter-password"
            }
          ],
          "default": "nav-after-restart"
        },
        "enter-password": {
          "action": "set_input",
          "test_id": "login-password-input",
          "value": "qwerasdf",
          "next": "press-login"
        },
        "press-login": {
          "action": "press",
          "test_id": "log-in-button",
          "next": "nav-after-restart"
        },
        "nav-after-restart": {
          "action": "navigate",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "target": "PerpsTrendingView",
          "next": "wait-post-restart"
        },
        "wait-post-restart": {
          "action": "wait_for",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "timeout_ms": 30000,
          "next": "verify-post-restart"
        },
        "verify-post-restart": {
          "action": "eval_async",
          "description": "Confirm markets reload cleanly after full restart",
          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
          "assert": { "operator": "neq", "field": "price", "value": "0" },
          "next": "done"
        },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2760]: https://consensyssoftware.atlassian.net/browse/TAT-2760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
