### PR TITLE
fix: resolve formatting and lint errors in SafeAreaViewWithHookTopInset test

### DIFF
--- a/app/shims/SafeAreaViewWithHookTopInset.test.tsx
+++ b/app/shims/SafeAreaViewWithHookTopInset.test.tsx
@@ -19,9 +19,11 @@ jest.mock('react-native-safe-area-context/src/SafeAreaView', () => {
   const { View: RNView } =
     jest.requireActual<typeof import('react-native')>('react-native');
   return {
-    SafeAreaView: forwardRef((props: Record<string, unknown>, ref: unknown) => (
-      <RNView ref={ref} {...props} testID="native-safe-area-view" />
-    )),
+    SafeAreaView: forwardRef(
+      (props: Record<string, unknown>, ref: React.Ref<View>) => (
+        <RNView ref={ref} {...props} testID="native-safe-area-view" />
+      ),
+    ),
   };
 });
 

--- a/app/shims/SafeAreaViewWithHookTopInset.test.tsx
+++ b/app/shims/SafeAreaViewWithHookTopInset.test.tsx
@@ -15,13 +15,22 @@ jest.mock('react-native-safe-area-context/src/SafeAreaContext', () => ({
 }));
 
 jest.mock('react-native-safe-area-context/src/SafeAreaView', () => {
-  const { forwardRef } = require('react');
-  const { View: RNView } = require('react-native');
+  const { forwardRef } = jest.requireActual<typeof import('react')>('react');
+  const { View: RNView } =
+    jest.requireActual<typeof import('react-native')>('react-native');
   return {
     SafeAreaView: forwardRef((props: Record<string, unknown>, ref: unknown) => (
       <RNView ref={ref} {...props} testID="native-safe-area-view" />
     )),
   };
+});
+
+const testStyles = StyleSheet.create({
+  paddingTop10: { paddingTop: 10 },
+  paddingTop100: { paddingTop: 100 },
+  marginTop6: { marginTop: 6 },
+  paddingTopNaN: { paddingTop: NaN },
+  paddingTopPercent: { paddingTop: '20%' as unknown as number },
 });
 
 function getNativeViewProps(root: ReturnType<typeof render>) {
@@ -63,9 +72,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('passes through a record of edges, turning top off for hook handling', () => {
       const props = getNativeViewProps(
-        render(
-          <SafeAreaView edges={{ top: 'maximum', bottom: 'additive' }} />,
-        ),
+        render(<SafeAreaView edges={{ top: 'maximum', bottom: 'additive' }} />),
       );
       expect(props.edges).toEqual({
         top: 'off',
@@ -77,9 +84,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('leaves edges unchanged when top is explicitly off', () => {
       const props = getNativeViewProps(
-        render(
-          <SafeAreaView edges={{ top: 'off', bottom: 'additive' }} />,
-        ),
+        render(<SafeAreaView edges={{ top: 'off', bottom: 'additive' }} />),
       );
       expect(props.edges).toEqual({
         top: 'off',
@@ -111,7 +116,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('sums existing paddingTop with insets.top in additive mode', () => {
       const props = getNativeViewProps(
-        render(<SafeAreaView style={{ paddingTop: 10 }} />),
+        render(<SafeAreaView style={testStyles.paddingTop10} />),
       );
       const flat = StyleSheet.flatten(props.style);
       expect(flat).toMatchObject({ paddingTop: 54 });
@@ -122,7 +127,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
         render(
           <SafeAreaView
             edges={{ top: 'maximum', bottom: 'additive' }}
-            style={{ paddingTop: 100 }}
+            style={testStyles.paddingTop100}
           />,
         ),
       );
@@ -135,7 +140,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
         render(
           <SafeAreaView
             edges={{ top: 'maximum' }}
-            style={{ paddingTop: 10 }}
+            style={testStyles.paddingTop10}
           />,
         ),
       );
@@ -153,9 +158,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('sums existing marginTop with insets.top in additive mode', () => {
       const props = getNativeViewProps(
-        render(
-          <SafeAreaView mode="margin" style={{ marginTop: 6 }} />,
-        ),
+        render(<SafeAreaView mode="margin" style={testStyles.marginTop6} />),
       );
       const flat = StyleSheet.flatten(props.style);
       expect(flat).toMatchObject({ marginTop: 50 });
@@ -191,7 +194,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('treats NaN paddingTop as 0', () => {
       const props = getNativeViewProps(
-        render(<SafeAreaView style={{ paddingTop: NaN }} />),
+        render(<SafeAreaView style={testStyles.paddingTopNaN} />),
       );
       const flat = StyleSheet.flatten(props.style);
       expect(flat).toMatchObject({ paddingTop: 44 });
@@ -199,11 +202,7 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
     it('treats string paddingTop as 0', () => {
       const props = getNativeViewProps(
-        render(
-          <SafeAreaView
-            style={{ paddingTop: '20%' as unknown as number }}
-          />,
-        ),
+        render(<SafeAreaView style={testStyles.paddingTopPercent} />),
       );
       const flat = StyleSheet.flatten(props.style);
       expect(flat).toMatchObject({ paddingTop: 44 });
@@ -221,17 +220,13 @@ describe('SafeAreaViewWithHookTopInset', () => {
   describe('prop passthrough', () => {
     it('passes arbitrary props to the native SafeAreaView', () => {
       const props = getNativeViewProps(
-        render(
-          <SafeAreaView testID="custom" accessibilityLabel="test" />,
-        ),
+        render(<SafeAreaView testID="custom" accessibilityLabel="test" />),
       );
       expect(props.accessibilityLabel).toBe('test');
     });
 
     it('passes mode through to the native SafeAreaView', () => {
-      const props = getNativeViewProps(
-        render(<SafeAreaView mode="margin" />),
-      );
+      const props = getNativeViewProps(render(<SafeAreaView mode="margin" />));
       expect(props.mode).toBe('margin');
     });
   });
@@ -249,7 +244,9 @@ describe('SafeAreaViewWithHookTopInset', () => {
 
       rerender(<SafeAreaView />);
 
-      const flat = StyleSheet.flatten(getByTestId('native-safe-area-view').props.style);
+      const flat = StyleSheet.flatten(
+        getByTestId('native-safe-area-view').props.style,
+      );
       expect(flat).toMatchObject({ paddingTop: 20 });
     });
   });


### PR DESCRIPTION
## **Description**

Fix Prettier formatting violations and eslint errors in `SafeAreaViewWithHookTopInset.test.tsx` introduced by #28622. These break lint checks on any unrelated PR that touches this file.

**Changes:**
- Reformat JSX to match Prettier config
- Extract inline styles to `StyleSheet.create` to fix `react-native/no-inline-styles`
- Replace `require()` with `jest.requireActual()` in `jest.mock` factory to fix `@typescript-eslint/no-require-imports`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes lint/formatting regressions from #28622

## **Manual testing steps**

```gherkin
Feature: SafeAreaViewWithHookTopInset test lint compliance

  Scenario: lint and tests pass on the test file
    Given the file app/shims/SafeAreaViewWithHookTopInset.test.tsx

    When running eslint on the file
    Then zero errors are reported

    When running jest on the file
    Then all 20 tests pass
```

## **Screenshots/Recordings**

N/A — no visual changes, formatting and lint fixes only.

### **Before**

6 eslint errors on `main`:
- 2x `@typescript-eslint/no-require-imports` — `require()` inside `jest.mock` factory
- 4x `react-native/no-inline-styles` — inline style objects in test assertions

### **After**

0 eslint errors, 0 eslint-disable comments, all 20 tests passing.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a Jest test file and only adjust mocks/style declarations to satisfy linting/formatting, without touching runtime code paths.
> 
> **Overview**
> Cleans up `SafeAreaViewWithHookTopInset.test.tsx` to pass lint/format checks by switching `jest.mock` factories from `require()` to typed `jest.requireActual()` and tightening ref typings in the mock `SafeAreaView`.
> 
> Replaces inline style objects used in tests with a shared `StyleSheet.create` (`testStyles`) and applies minor Prettier-driven JSX/line-wrap formatting changes, leaving test coverage/behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a20c769d8e7422ffe9b03076cdae5b24e4da85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->