### PR TITLE
feat(perps): agentic lifecycle actions and multi-device support

### DIFF
--- a/scripts/perps/agentic/README.md
+++ b/scripts/perps/agentic/README.md
@@ -238,6 +238,9 @@ Executable gate checks that must pass before a flow runs. Defined in `teams/<tea
 | `select_account` | `address` | Switch Ethereum account |
 | `toggle_testnet` | | Enable/disable testnet mode |
 | `switch_provider` | `provider` | Switch perps provider |
+| `app_background` | `duration_ms` | Send app to home screen (iOS: Cmd+Shift+H). Waits `duration_ms` (default 5000) |
+| `app_foreground` | | Bring app back to foreground via `xcrun simctl launch` |
+| `app_restart` | `boot_wait_ms` | Terminate + relaunch app. Waits `boot_wait_ms` (default 15000) for Metro reconnect |
 | `switch` | `cases` | Branch based on assertions (workflow only) |
 | `end` | | Terminal node with pass/fail (workflow only) |
 

--- a/scripts/perps/agentic/cdp-bridge.js
+++ b/scripts/perps/agentic/cdp-bridge.js
@@ -705,6 +705,28 @@ Environment:
   const port = loadPort();
   const timeout = Number.parseInt(process.env.CDP_TIMEOUT || '5000', 10);
 
+  // `status` probes ALL connected targets so both platforms are visible.
+  if (command === 'status') {
+    const { discoverAllTargets } = require('./lib/target-discovery');
+    const allTargets = await discoverAllTargets(port);
+    const results = [];
+    for (const target of allTargets) {
+      let client;
+      try {
+        client = await createWSClient(target.wsUrl, timeout);
+        const platform = await cdpEval(client, 'globalThis.__AGENTIC__?.platform') || '';
+        const result = await handler(client, args.slice(1), { deviceName: target.deviceName, platform });
+        results.push(result);
+      } catch {
+        // Target not responsive — skip
+      } finally {
+        if (client) client.close();
+      }
+    }
+    console.log(JSON.stringify(results.length === 1 ? results[0] : results, null, 2));
+    return;
+  }
+
   const { wsUrl, deviceName } = await discoverTarget(port);
   const client = await createWSClient(wsUrl, timeout);
 

--- a/scripts/perps/agentic/lib/app-lifecycle.js
+++ b/scripts/perps/agentic/lib/app-lifecycle.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+function detectPlatform() {
+  if (process.env.ADB_SERIAL || process.env.ANDROID_SERIAL) {
+    return 'android';
+  }
+  if (process.platform === 'darwin') {
+    return 'ios';
+  }
+  throw new Error(
+    'Cannot detect simulator platform. Set ADB_SERIAL for Android or run on macOS for iOS.',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// iOS helpers
+// ---------------------------------------------------------------------------
+
+function resolveBootedSimulatorUdid() {
+  const result = spawnSync(
+    'xcrun',
+    ['simctl', 'list', 'devices', 'booted', '-j'],
+    { encoding: 'utf8' },
+  );
+  const parsed = JSON.parse(result.stdout || '{}');
+  for (const devices of Object.values(parsed.devices || {})) {
+    for (const d of devices) {
+      if (d.state === 'Booted') {
+        return d.udid;
+      }
+    }
+  }
+  throw new Error('No booted iOS simulator found');
+}
+
+function resolveIosBundleId(udid) {
+  const result = spawnSync('xcrun', ['simctl', 'listapps', udid], {
+    encoding: 'utf8',
+  });
+  const match = (result.stdout || '').match(
+    /CFBundleIdentifier\s*=\s*"(io\.metamask\.[^"]+)"/,
+  );
+  return match ? match[1] : 'io.metamask.MetaMask';
+}
+
+function iosBackground() {
+  spawnSync(
+    'osascript',
+    [
+      '-e', 'tell application "Simulator" to activate',
+      '-e', 'delay 0.3',
+      '-e', 'tell application "System Events" to keystroke "h" using {command down, shift down}',
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+function iosForeground(udid, bundleId) {
+  spawnSync('xcrun', ['simctl', 'launch', udid, bundleId], {
+    encoding: 'utf8',
+  });
+}
+
+function iosTerminate(udid, bundleId) {
+  spawnSync('xcrun', ['simctl', 'terminate', udid, bundleId], {
+    encoding: 'utf8',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Android helpers
+// ---------------------------------------------------------------------------
+
+function resolveAdbSerial() {
+  return process.env.ADB_SERIAL || process.env.ANDROID_SERIAL || '';
+}
+
+function resolveAndroidPackage() {
+  // Check for running MetaMask activity
+  const serial = resolveAdbSerial();
+  const args = serial ? ['-s', serial] : [];
+  const result = spawnSync(
+    'adb',
+    [...args, 'shell', 'dumpsys', 'activity', 'activities'],
+    { encoding: 'utf8' },
+  );
+  const match = (result.stdout || '').match(
+    /(io\.metamask[.\w]*)\/.+Activity/,
+  );
+  return match ? match[1] : 'io.metamask';
+}
+
+function adbShell(...shellArgs) {
+  const serial = resolveAdbSerial();
+  const args = serial ? ['-s', serial] : [];
+  return spawnSync('adb', [...args, 'shell', ...shellArgs], {
+    encoding: 'utf8',
+  });
+}
+
+function androidBackground() {
+  adbShell('input', 'keyevent', 'KEYCODE_HOME');
+}
+
+function androidForeground(packageName) {
+  adbShell(
+    'monkey',
+    '-p', packageName,
+    '-c', 'android.intent.category.LAUNCHER',
+    '1',
+  );
+}
+
+function androidTerminate(packageName) {
+  adbShell('am', 'force-stop', packageName);
+}
+
+// ---------------------------------------------------------------------------
+// Public API — platform-agnostic
+// ---------------------------------------------------------------------------
+
+/**
+ * Send the app to the OS home screen.
+ * @returns {{ bundleId: string }} Resolved app identifier
+ */
+function backgroundApp() {
+  const platform = detectPlatform();
+  if (platform === 'ios') {
+    const udid = resolveBootedSimulatorUdid();
+    const bundleId = resolveIosBundleId(udid);
+    iosBackground();
+    return { bundleId };
+  }
+  const packageName = resolveAndroidPackage();
+  androidBackground();
+  return { bundleId: packageName };
+}
+
+/**
+ * Bring the app back to the foreground.
+ * @returns {{ bundleId: string }}
+ */
+function foregroundApp() {
+  const platform = detectPlatform();
+  if (platform === 'ios') {
+    const udid = resolveBootedSimulatorUdid();
+    const bundleId = resolveIosBundleId(udid);
+    iosForeground(udid, bundleId);
+    return { bundleId };
+  }
+  const packageName = resolveAndroidPackage();
+  androidForeground(packageName);
+  return { bundleId: packageName };
+}
+
+/**
+ * Terminate and relaunch the app.
+ * @returns {{ bundleId: string }}
+ */
+function restartApp() {
+  const platform = detectPlatform();
+  if (platform === 'ios') {
+    const udid = resolveBootedSimulatorUdid();
+    const bundleId = resolveIosBundleId(udid);
+    iosTerminate(udid, bundleId);
+    iosForeground(udid, bundleId);
+    return { bundleId };
+  }
+  const packageName = resolveAndroidPackage();
+  androidTerminate(packageName);
+  androidForeground(packageName);
+  return { bundleId: packageName };
+}
+
+module.exports = {
+  backgroundApp,
+  detectPlatform,
+  foregroundApp,
+  restartApp,
+};

--- a/scripts/perps/agentic/lib/config.js
+++ b/scripts/perps/agentic/lib/config.js
@@ -25,12 +25,15 @@ function loadPort() {
 
 /** Read IOS_SIMULATOR name from .js.env or env (default: none — accept any device) */
 function loadSimulatorName() {
-  return process.env.IOS_SIMULATOR || loadEnvValue('IOS_SIMULATOR') || '';
+  // Explicit empty string in env means "no simulator" — don't fall through to .js.env
+  if ('IOS_SIMULATOR' in process.env) return process.env.IOS_SIMULATOR;
+  return loadEnvValue('IOS_SIMULATOR') || '';
 }
 
 /** Read ANDROID_DEVICE serial from .js.env or env (default: none — accept any device) */
 function loadAndroidDevice() {
-  return process.env.ANDROID_DEVICE || loadEnvValue('ANDROID_DEVICE') || '';
+  if ('ANDROID_DEVICE' in process.env) return process.env.ANDROID_DEVICE;
+  return loadEnvValue('ANDROID_DEVICE') || '';
 }
 
 module.exports = { loadEnvValue, loadPort, loadSimulatorName, loadAndroidDevice };

--- a/scripts/perps/agentic/lib/target-discovery.js
+++ b/scripts/perps/agentic/lib/target-discovery.js
@@ -165,7 +165,7 @@ async function discoverAllTargets(port) {
   const seen = new Set();
   const results = [];
   for (const candidate of candidates) {
-    const device = candidate.deviceName || 'unknown';
+    const device = candidate.deviceName || candidate.id || candidate.webSocketDebuggerUrl;
     if (seen.has(device)) continue;
     const hasAgentic = await probeTarget(candidate.webSocketDebuggerUrl);
     if (hasAgentic) {

--- a/scripts/perps/agentic/lib/target-discovery.js
+++ b/scripts/perps/agentic/lib/target-discovery.js
@@ -132,4 +132,48 @@ async function discoverTarget(port) {
   return { wsUrl: candidates[0].webSocketDebuggerUrl, deviceName: candidates[0].deviceName || '' };
 }
 
-module.exports = { discoverTarget };
+/**
+ * Discover ALL Hermes targets with __AGENTIC__ installed (one per platform/device).
+ * Groups by deviceName so each device returns at most one target.
+ */
+async function discoverAllTargets(port) {
+  const listUrl = `http://localhost:${port}/json/list`;
+  let targets;
+  try {
+    targets = await fetchJSON(listUrl);
+  } catch (e) {
+    throw new Error(
+      `Cannot reach Metro at ${listUrl}. Is Metro running?\n  ${e.message}`,
+    );
+  }
+
+  const candidates = (targets || []).filter(
+    (t) =>
+      t.webSocketDebuggerUrl &&
+      t.title &&
+      (/react/i.test(t.title) || /hermes/i.test(t.title)),
+  );
+
+  // Sort by page number descending (JS runtime has higher page number)
+  candidates.sort((a, b) => {
+    const aPage = Number.parseInt((a.id || '').split('-').pop() || '0', 10);
+    const bPage = Number.parseInt((b.id || '').split('-').pop() || '0', 10);
+    return bPage - aPage;
+  });
+
+  // Group by deviceName, probe each to find the JS runtime target
+  const seen = new Set();
+  const results = [];
+  for (const candidate of candidates) {
+    const device = candidate.deviceName || 'unknown';
+    if (seen.has(device)) continue;
+    const hasAgentic = await probeTarget(candidate.webSocketDebuggerUrl);
+    if (hasAgentic) {
+      seen.add(device);
+      results.push({ wsUrl: candidate.webSocketDebuggerUrl, deviceName: device });
+    }
+  }
+  return results;
+}
+
+module.exports = { discoverTarget, discoverAllTargets };

--- a/scripts/perps/agentic/lib/workflow.js
+++ b/scripts/perps/agentic/lib/workflow.js
@@ -22,6 +22,10 @@ const EXECUTABLE_ACTIONS = new Set([
   'select_account',
   'toggle_testnet',
   'switch_provider',
+  // App lifecycle actions
+  'app_background',
+  'app_foreground',
+  'app_restart',
 ]);
 
 const CONTROL_ACTIONS = new Set(['switch', 'end']);

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -228,6 +228,13 @@ sweep_port() {
   holder_pid=$(lsof -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1 || true)
   [ -z "$holder_pid" ] && return 0
 
+  # Probe /status first — if Metro responds, it's alive and reusable regardless of process name
+  if curl -sf "http://localhost:$port/status" >/dev/null 2>&1; then
+    ok "Port $port ($label) — Metro already running (PID $holder_pid), reusing"
+    # start-metro.sh will detect running Metro and only launch the app
+    return 0
+  fi
+
   local holder_cmd
   holder_cmd=$(ps -p "$holder_pid" -o command= 2>/dev/null || echo unknown)
 
@@ -531,6 +538,8 @@ fi
 
 # ── Step: Metro ─────────────────────────────────────────────────────
 step "Starting Metro" "Bundler on port $PORT → logs at $LOGFILE"
+# start-metro.sh detects running Metro and skips start. With --launch it
+# opens the app via expo deeplink for the target platform regardless.
 bash "$SCRIPTS/start-metro.sh" --platform "$PLAT" $($DO_LAUNCH && echo "--launch" || echo "")
 ok "Metro running on port $PORT"
 
@@ -589,10 +598,11 @@ for p in json.loads(sys.stdin.read() or "[]"):
   fail "CDP did not become available after ${CDP_TIMEOUT}s"
 fi
 
-# Verify CDP is connected to the right platform
-CDP_PLATFORM=$(node "$SCRIPTS/cdp-bridge.js" status 2>/dev/null | jq -r '.platform // empty' || true)
-if [ -n "$CDP_PLATFORM" ] && [ "$CDP_PLATFORM" != "$PLAT" ]; then
-  fail "CDP connected to $CDP_PLATFORM app but expected $PLAT — launch the $PLAT app first"
+# Verify CDP is connected to the right platform (status may return object or array)
+CDP_STATUS=$(node "$SCRIPTS/cdp-bridge.js" status 2>/dev/null || true)
+CDP_HAS_PLAT=$(echo "$CDP_STATUS" | jq -r 'if type == "array" then [.[].platform] else [.platform] end | map(select(. == "'"$PLAT"'")) | length' 2>/dev/null || echo 0)
+if [ "$CDP_HAS_PLAT" = "0" ]; then
+  warn "CDP did not find $PLAT app — it may still be loading"
 fi
 
 # Brief stabilization

--- a/scripts/perps/agentic/teams/perps/evals/core.json
+++ b/scripts/perps/agentic/teams/perps/evals/core.json
@@ -23,5 +23,10 @@
     "description": "Watchlist markets from controller state",
     "expression": "JSON.stringify(Engine.context.PerpsController.state.watchlistMarkets)",
     "async": false
+  },
+  "available-dexs": {
+    "description": "HIP-3 DEX list (validates DEX discovery cache)",
+    "expression": "Engine.context.PerpsController.getAvailableDexs().then(function(dexs){return JSON.stringify({count:dexs.length,dexs:dexs,hasMainDex:dexs.indexOf('')>=0})})",
+    "async": true
   }
 }

--- a/scripts/perps/agentic/teams/perps/recipes/app-lifecycle.json
+++ b/scripts/perps/agentic/teams/perps/recipes/app-lifecycle.json
@@ -1,0 +1,181 @@
+{
+  "title": "App Lifecycle — validate data survives background, long background, and restart",
+  "description": "Reference recipe demonstrating three lifecycle stress levels: short background (within WS grace period), long background (exceeds grace period, forces full WS reconnection), and full app restart. Use as a template for PR recipes that need lifecycle validation.",
+  "inputs": {
+    "symbol": {
+      "type": "string",
+      "default": "BTC",
+      "description": "Market symbol to verify price recovery"
+    },
+    "short_background_ms": {
+      "type": "number",
+      "default": 5000,
+      "description": "Short background duration — within WS grace period (cache preserved)"
+    },
+    "long_background_ms": {
+      "type": "number",
+      "default": 30000,
+      "description": "Long background duration — exceeds WS grace period (forces full reconnection)"
+    },
+    "test_short_background": {
+      "type": "boolean",
+      "default": true,
+      "description": "Test short background/foreground cycle"
+    },
+    "test_long_background": {
+      "type": "boolean",
+      "default": true,
+      "description": "Test long background that triggers WS reconnection"
+    },
+    "test_restart": {
+      "type": "boolean",
+      "default": false,
+      "description": "Test full app restart (slower, needs ~20s boot + possible unlock)"
+    }
+  },
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
+      "entry": "nav-market-list",
+      "nodes": {
+        "nav-market-list": {
+          "action": "navigate",
+          "target": "PerpsTrendingView",
+          "next": "wait-markets"
+        },
+        "wait-markets": {
+          "action": "wait_for",
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
+          "assert": { "operator": "gt", "field": "count", "value": 0 },
+          "next": "baseline-price"
+        },
+        "baseline-price": {
+          "action": "eval_async",
+          "description": "Baseline — confirm markets and price data loaded",
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
+          "assert": { "operator": "neq", "field": "price", "value": "0" },
+          "next": "short-background"
+        },
+
+        "short-background": {
+          "action": "app_background",
+          "description": "Short background — within WS grace period, cache should be preserved",
+          "when": { "operator": "eq", "field": "inputs.test_short_background", "value": true },
+          "duration_ms": "{{short_background_ms}}",
+          "next": "short-foreground"
+        },
+        "short-foreground": {
+          "action": "app_foreground",
+          "when": { "operator": "eq", "field": "inputs.test_short_background", "value": true },
+          "next": "wait-post-short"
+        },
+        "wait-post-short": {
+          "action": "wait_for",
+          "when": { "operator": "eq", "field": "inputs.test_short_background", "value": true },
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
+          "assert": { "operator": "gt", "field": "count", "value": 0 },
+          "timeout_ms": 15000,
+          "next": "verify-post-short"
+        },
+        "verify-post-short": {
+          "action": "eval_async",
+          "description": "Confirm markets + price survive short background",
+          "when": { "operator": "eq", "field": "inputs.test_short_background", "value": true },
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
+          "assert": { "operator": "neq", "field": "price", "value": "0" },
+          "next": "long-background"
+        },
+
+        "long-background": {
+          "action": "app_background",
+          "description": "Long background — exceeds WS grace period, forces full reconnection",
+          "when": { "operator": "eq", "field": "inputs.test_long_background", "value": true },
+          "duration_ms": "{{long_background_ms}}",
+          "next": "long-foreground"
+        },
+        "long-foreground": {
+          "action": "app_foreground",
+          "when": { "operator": "eq", "field": "inputs.test_long_background", "value": true },
+          "next": "wait-post-long"
+        },
+        "wait-post-long": {
+          "action": "wait_for",
+          "when": { "operator": "eq", "field": "inputs.test_long_background", "value": true },
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
+          "assert": { "operator": "gt", "field": "count", "value": 0 },
+          "timeout_ms": 30000,
+          "next": "verify-post-long"
+        },
+        "verify-post-long": {
+          "action": "eval_async",
+          "description": "Confirm markets + DEXs recover after full WS reconnection",
+          "when": { "operator": "eq", "field": "inputs.test_long_background", "value": true },
+          "expression": "(function(){return Promise.all([Engine.context.PerpsController.getMarketDataWithPrices(),Engine.context.PerpsController.getAvailableDexs()]).then(function(r){var m=r[0].find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({markets:r[0].length,dexs:r[1].length,price:m?m.price:'0'})})})()",
+          "assert": { "operator": "neq", "field": "price", "value": "0" },
+          "next": "restart-app"
+        },
+
+        "restart-app": {
+          "action": "app_restart",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "boot_wait_ms": 20000,
+          "next": "detect-post-restart"
+        },
+        "detect-post-restart": {
+          "action": "eval_sync",
+          "description": "Detect login vs wallet after restart",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "expression": "(function(){try{var r=globalThis.__AGENTIC__.getRoute();return JSON.stringify({route:r.name})}catch(e){return JSON.stringify({route:'unknown'})}})()",
+          "next": "check-needs-unlock"
+        },
+        "check-needs-unlock": {
+          "action": "switch",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "cases": [
+            {
+              "label": "needs-login",
+              "when": { "operator": "eq", "field": "nodes.detect-post-restart.result.route", "value": "Login" },
+              "next": "enter-password"
+            }
+          ],
+          "default": "nav-after-restart"
+        },
+        "enter-password": {
+          "action": "set_input",
+          "test_id": "login-password-input",
+          "value": "qwerasdf",
+          "next": "press-login"
+        },
+        "press-login": {
+          "action": "press",
+          "test_id": "log-in-button",
+          "next": "nav-after-restart"
+        },
+        "nav-after-restart": {
+          "action": "navigate",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "target": "PerpsTrendingView",
+          "next": "wait-post-restart"
+        },
+        "wait-post-restart": {
+          "action": "wait_for",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){return JSON.stringify({count:ms.length})})",
+          "assert": { "operator": "gt", "field": "count", "value": 0 },
+          "timeout_ms": 30000,
+          "next": "verify-post-restart"
+        },
+        "verify-post-restart": {
+          "action": "eval_async",
+          "description": "Confirm markets reload cleanly after full restart",
+          "when": { "operator": "eq", "field": "inputs.test_restart", "value": true },
+          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='{{symbol}}'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
+          "assert": { "operator": "neq", "field": "price", "value": "0" },
+          "next": "done"
+        },
+
+        "done": { "action": "end", "status": "pass" }
+      }
+    }
+  }
+}

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -1694,12 +1694,14 @@ async function main() {
         const origLog = console.log.bind(console);
         const origError = console.error.bind(console);
         console.log = (...args) => {
-          origLog(...args);
-          logStream.write(formatArgs(args) + '\n');
+          const formatted = formatArgs(args);
+          origLog(formatted);
+          logStream.write(formatted + '\n');
         };
         console.error = (...args) => {
-          origError(...args);
-          logStream.write(formatArgs(args) + '\n');
+          const formatted = formatArgs(args);
+          origError(formatted);
+          logStream.write(formatted + '\n');
         };
         teardownLog = () => {
           console.log = origLog;

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -14,6 +14,7 @@ const {
   normalizeWorkflowDocument,
   renderWorkflowMermaid,
 } = require('./lib/workflow');
+const { backgroundApp, foregroundApp, restartApp } = require('./lib/app-lifecycle');
 const {
   getAppRoot,
   getTeamsDir,
@@ -42,6 +43,7 @@ function parseArgs(argv) {
     artifactsDir: '',
     dryRun: false,
     hud: true,
+    inputOverrides: {},
     recipe: '',
     singleStep: '',
     skipManual: false,
@@ -76,6 +78,17 @@ function parseArgs(argv) {
       case '--testnet':
         options.testnet = true;
         break;
+      case '--input': {
+        const kv = argv[i + 1] || '';
+        const eq = kv.indexOf('=');
+        if (eq < 1) throw new Error('--input expects key=value (e.g. --input test_restart=true)');
+        const k = kv.slice(0, eq);
+        const raw = kv.slice(eq + 1);
+        // Parse booleans and numbers
+        options.inputOverrides[k] = raw === 'true' ? true : raw === 'false' ? false : Number.isFinite(Number(raw)) ? Number(raw) : raw;
+        i += 1;
+        break;
+      }
       case '--help':
       case '-h':
         printHelp();
@@ -327,6 +340,12 @@ function describeStep(step) {
       return `toggle testnet=${step.enabled !== undefined ? step.enabled : 'true'}`;
     case 'switch_provider':
       return `switch provider ${step.provider}`;
+    case 'app_background':
+      return `background app ${step.duration_ms || 5000}ms`;
+    case 'app_foreground':
+      return 'foreground app';
+    case 'app_restart':
+      return 'restart app';
     case 'switch':
       return step.description || 'evaluate branch';
     case 'end':
@@ -1077,6 +1096,52 @@ async function runExecutableNode(node, context, options = {}) {
     return { next: node.next || '' };
   }
 
+  // --- App lifecycle (delegated to lib/app-lifecycle.js) ---
+  if (node.action === 'app_background') {
+    const { bundleId } = backgroundApp();
+    const durationMs = Number(node.duration_ms || 5000);
+    await new Promise((resolve) => setTimeout(resolve, durationMs));
+    stats.passed += 1;
+    console.log(`  backgrounded for ${durationMs}ms`);
+    console.log('  PASS');
+    console.log('');
+    finalizeNodeRecord(context, node, {
+      next: node.next || '', result: { backgrounded: true, durationMs, bundleId }, startedAt,
+    });
+    context.currentStepRef.current = null;
+    return { next: node.next || '' };
+  }
+
+  if (node.action === 'app_foreground') {
+    const { bundleId } = foregroundApp();
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    stats.passed += 1;
+    console.log(`  foregrounded (${bundleId})`);
+    console.log('  PASS');
+    console.log('');
+    finalizeNodeRecord(context, node, {
+      next: node.next || '', result: { foregrounded: true, bundleId }, startedAt,
+    });
+    context.currentStepRef.current = null;
+    return { next: node.next || '' };
+  }
+
+  if (node.action === 'app_restart') {
+    const { bundleId } = restartApp();
+    const bootWaitMs = Number(node.boot_wait_ms || 15000);
+    console.log(`  waiting ${bootWaitMs}ms for app boot + Metro reconnect...`);
+    await new Promise((resolve) => setTimeout(resolve, bootWaitMs));
+    stats.passed += 1;
+    console.log(`  restarted (${bundleId})`);
+    console.log('  PASS');
+    console.log('');
+    finalizeNodeRecord(context, node, {
+      next: node.next || '', result: { restarted: true, bundleId }, startedAt,
+    });
+    context.currentStepRef.current = null;
+    return { next: node.next || '' };
+  }
+
   // --- Log watch ---
   if (node.action === 'log_watch') {
     const metroLogPath = process.env.METRO_LOG || path.join(appRoot, '.agent', 'metro.log');
@@ -1555,6 +1620,7 @@ async function main() {
       artifactsDir: options.artifactsDir,
       dryRun: options.dryRun,
       hud: options.hud,
+      inputOverrides: options.inputOverrides,
       singleStep: options.singleStep,
       skipManual: options.skipManual,
     };
@@ -1579,7 +1645,7 @@ async function main() {
       }
     }
 
-    await runRecipe(recipeInput.recipePath, runOptions);
+    await runRecipe(recipeInput.recipePath, runOptions, runOptions.inputOverrides);
   } catch (error) {
     console.error(String(error.message || error));
     process.exit(1);

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -1372,8 +1372,10 @@ async function executeWorkflowNode(node, context, options = {}) {
   if ((node.action === 'switch' || node.action === 'end') && node.when && !evaluateWorkflowCondition(node.when, context)) {
     const startedAt = new Date().toISOString();
     context.currentStepRef.current = node;
-    context.stats.total += 1;
-    context.stats.skipped += 1;
+    if (shouldCountNode(node)) {
+      context.stats.total += 1;
+      context.stats.skipped += 1;
+    }
     console.log(`[${node.id || '?'}] ${describeStep(node)}`);
     console.log('  [SKIPPED - when condition did not match]');
     console.log('');
@@ -1653,20 +1655,51 @@ async function main() {
       skipManual: options.skipManual,
     };
 
-    // Set up log capture — tee stdout/stderr to a log file
+    // Set up log capture — tee stdout/stderr to a sanitized log file.
+    // Redacts tokens, secrets, passwords, and bearer strings before writing
+    // to avoid CodeQL clear-text-logging alerts.
     if (options.log && !options.dryRun) {
       const artifacts = ensureRunArtifacts(runOptions, recipeInput.recipePath);
       if (artifacts) {
+        const REDACT_KEYS =
+          /token|secret|password|passwd|authorization|api[_-]?key|client[_-]?key|id[_-]?token|refresh[_-]?token|access[_-]?token/i;
+        const redactValue = (key, value) => {
+          if (REDACT_KEYS.test(String(key))) {
+            return '[REDACTED]';
+          }
+          return value;
+        };
+        const sanitizeArg = (arg) => {
+          if (arg instanceof Error) {
+            return `[${arg.name}] ${arg.message}`;
+          }
+          if (typeof arg === 'string') {
+            return arg.replace(
+              /(bearer\s+)[a-z0-9\-._~+/]+=*/gi,
+              '$1[REDACTED]',
+            );
+          }
+          if (arg && typeof arg === 'object') {
+            try {
+              return JSON.stringify(arg, redactValue);
+            } catch (_) {
+              return '[Unserializable Object]';
+            }
+          }
+          return String(arg);
+        };
+        const formatArgs = (args) => args.map(sanitizeArg).join(' ');
+
         const logStream = fs.createWriteStream(artifacts.runLogPath, { flags: 'w' });
         const origLog = console.log.bind(console);
         const origError = console.error.bind(console);
         console.log = (...args) => {
           origLog(...args);
-          logStream.write(args.map(String).join(' ') + '\n');
+          logStream.write(formatArgs(args) + '\n');
         };
         console.error = (...args) => {
           origError(...args);
-          logStream.write(args.map(String).join(' ') + '\n');
+          logStream.write(formatArgs(args) + '\n');
         };
         teardownLog = () => {
           console.log = origLog;

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -44,6 +44,7 @@ function parseArgs(argv) {
     dryRun: false,
     hud: true,
     inputOverrides: {},
+    log: true,
     recipe: '',
     singleStep: '',
     skipManual: false,
@@ -63,6 +64,9 @@ function parseArgs(argv) {
         break;
       case '--no-hud':
         options.hud = false;
+        break;
+      case '--no-log':
+        options.log = false;
         break;
       case '--skip-manual':
         options.skipManual = true;
@@ -124,6 +128,7 @@ function printHelp() {
     [--testnet]
     [--artifacts-dir <path>]
     [--dry-run]
+    [--no-log]
 
 The runner executes workflow files stored under:
   scripts/perps/agentic/teams/<team>/{flows,recipes}
@@ -133,7 +138,8 @@ Runtime features:
   - Scenarios use validate.workflow with explicit nodes, transitions, switch branches, and end nodes.
   - setup / teardown hooks live under validate.workflow.setup / validate.workflow.teardown.
   - Failures capture screenshots, route/state snapshots, eval refs, and recent logs.
-  - Successful runs emit workflow.json, workflow.mmd, trace.json, and summary.json artifacts.`);
+  - Successful runs emit workflow.json, workflow.mmd, trace.json, summary.json, and run.log artifacts.
+  - Console output is teed to run.log by default. Use --no-log to disable.`);
 }
 
 function resolveRecipeInput(appRoot, inputPath) {
@@ -546,6 +552,7 @@ function ensureRunArtifacts(runOptions, recipePath) {
     workflowPath: path.join(rootDir, 'workflow.json'),
     workflowMermaidPath: path.join(rootDir, 'workflow.mmd'),
     summaryPath: path.join(rootDir, 'summary.json'),
+    runLogPath: path.join(rootDir, 'run.log'),
   };
 
   [artifacts.rootDir, artifacts.screenshotsDir, artifacts.failuresDir, artifacts.logsDir]
@@ -1361,6 +1368,25 @@ async function executeEndNode(node, context) {
 }
 
 async function executeWorkflowNode(node, context, options = {}) {
+  // Handle when-guard for switch/end nodes (runExecutableNode handles its own)
+  if ((node.action === 'switch' || node.action === 'end') && node.when && !evaluateWorkflowCondition(node.when, context)) {
+    const startedAt = new Date().toISOString();
+    context.currentStepRef.current = node;
+    context.stats.total += 1;
+    context.stats.skipped += 1;
+    console.log(`[${node.id || '?'}] ${describeStep(node)}`);
+    console.log('  [SKIPPED - when condition did not match]');
+    console.log('');
+    finalizeNodeRecord(context, node, {
+      next: node.default || node.next || '',
+      note: 'when condition did not match',
+      startedAt,
+      status: 'skipped',
+    });
+    context.currentStepRef.current = null;
+    return { next: node.default || node.next || '' };
+  }
+
   if (node.action === 'end') {
     return executeEndNode(node, context);
   }
@@ -1605,6 +1631,7 @@ async function runRecipe(recipePath, runOptions, flowParams = {}, depth = 0) {
 // ---------------------------------------------------------------------------
 
 async function main() {
+  let teardownLog = null;
   try {
     const options = parseArgs(process.argv.slice(2));
     const appRoot = getAppRoot();
@@ -1621,9 +1648,33 @@ async function main() {
       dryRun: options.dryRun,
       hud: options.hud,
       inputOverrides: options.inputOverrides,
+      log: options.log,
       singleStep: options.singleStep,
       skipManual: options.skipManual,
     };
+
+    // Set up log capture — tee stdout/stderr to a log file
+    if (options.log && !options.dryRun) {
+      const artifacts = ensureRunArtifacts(runOptions, recipeInput.recipePath);
+      if (artifacts) {
+        const logStream = fs.createWriteStream(artifacts.runLogPath, { flags: 'w' });
+        const origLog = console.log.bind(console);
+        const origError = console.error.bind(console);
+        console.log = (...args) => {
+          origLog(...args);
+          logStream.write(args.map(String).join(' ') + '\n');
+        };
+        console.error = (...args) => {
+          origError(...args);
+          logStream.write(args.map(String).join(' ') + '\n');
+        };
+        teardownLog = () => {
+          console.log = origLog;
+          console.error = origError;
+          logStream.end();
+        };
+      }
+    }
 
     // Apply CLI initial conditions before running the recipe
     if (!options.dryRun) {
@@ -1646,7 +1697,13 @@ async function main() {
     }
 
     await runRecipe(recipeInput.recipePath, runOptions, runOptions.inputOverrides);
+    if (teardownLog) {
+      teardownLog();
+    }
   } catch (error) {
+    if (teardownLog) {
+      teardownLog();
+    }
     console.error(String(error.message || error));
     process.exit(1);
   }

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -1701,10 +1701,10 @@ async function main() {
       teardownLog();
     }
   } catch (error) {
+    console.error(String(error.message || error));
     if (teardownLog) {
       teardownLog();
     }
-    console.error(String(error.message || error));
     process.exit(1);
   }
 }

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -85,7 +85,7 @@ function parseArgs(argv) {
         const k = kv.slice(0, eq);
         const raw = kv.slice(eq + 1);
         // Parse booleans and numbers
-        options.inputOverrides[k] = raw === 'true' ? true : raw === 'false' ? false : Number.isFinite(Number(raw)) ? Number(raw) : raw;
+        options.inputOverrides[k] = raw === 'true' ? true : raw === 'false' ? false : raw !== '' && Number.isFinite(Number(raw)) ? Number(raw) : raw;
         i += 1;
         break;
       }


### PR DESCRIPTION
## **Description**

Add app lifecycle actions (`app_background`, `app_foreground`, `app_restart`) to the agentic tooling with platform-aware implementations (iOS `simctl` + Android `adb`). Enable multi-device CDP target discovery so `status` probes all targets across both platforms. Fix preflight to reuse a healthy Metro instance (curl /status check) and warn on platform mismatch instead of failing. Add `--input key=value` flag to `validate-recipe.js`.

Also fixes switch/end nodes bypassing `when` guards (caused TypeError on default config), and adds automatic `run.log` capture for every recipe execution.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Agentic lifecycle actions and multi-device support

  Scenario: run app-lifecycle recipe in dry-run mode
    Given the agentic tooling is available

    When user runs validate-recipe with app-lifecycle.json --dry-run
    Then recipe parses and validates without errors

  Scenario: CDP bridge status shows multiple targets
    Given both iOS simulator and Android emulator are running

    When user runs cdp-bridge.js status
    Then both platform targets are listed

  Scenario: lifecycle actions execute per platform
    Given the app is running on iOS simulator

    When user triggers app_background action
    Then the app moves to background via simctl
```

## **Screenshots/Recordings**

### **Before**

N/A — new tooling feature

### **After**

- `node validate-recipe.js recipes/app-lifecycle.json --dry-run` — parses OK
- Lifecycle actions validated on both iOS simulator and Android emulator
- Multi-device target discovery working across platforms

## **Validation Recipe**

<details><summary>app-lifecycle.json (20 nodes — short background, long background, restart)</summary>

```json
{
  "title": "App Lifecycle — validate data survives background, long background, and restart",
  "description": "Reference recipe demonstrating three lifecycle stress levels: short background (within WS grace period), long background (exceeds grace period, forces full WS reconnection), and full app restart. Use as a template for PR recipes that need lifecycle validation.",
  "inputs": {
    "symbol": { "type": "string", "default": "BTC" },
    "short_background_ms": { "type": "number", "default": 5000 },
    "long_background_ms": { "type": "number", "default": 30000 },
    "test_short_background": { "type": "boolean", "default": true },
    "test_long_background": { "type": "boolean", "default": true },
    "test_restart": { "type": "boolean", "default": false }
  },
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "nav-market-list",
      "nodes": {
        "nav-market-list": { "action": "navigate", "target": "PerpsTrendingView", "next": "wait-markets" },
        "wait-markets": { "action": "wait_for", "assert": { "operator": "gt", "field": "count", "value": 0 }, "next": "baseline-price" },
        "baseline-price": { "action": "eval_async", "description": "Baseline — confirm markets and price data loaded", "next": "short-background" },
        "short-background": { "action": "app_background", "when": "test_short_background", "duration_ms": "{{short_background_ms}}", "next": "short-foreground" },
        "short-foreground": { "action": "app_foreground", "next": "wait-post-short" },
        "wait-post-short": { "action": "wait_for", "next": "verify-post-short" },
        "verify-post-short": { "action": "eval_async", "description": "Confirm markets + price survive short background", "next": "long-background" },
        "long-background": { "action": "app_background", "description": "Exceeds WS grace period", "duration_ms": 30000, "next": "long-foreground" },
        "long-foreground": { "action": "app_foreground", "next": "wait-post-long" },
        "wait-post-long": { "action": "wait_for", "next": "verify-post-long" },
        "verify-post-long": { "action": "eval_async", "description": "Confirm markets + DEXs recover after WS reconnection", "next": "restart-app" },
        "restart-app": { "action": "app_restart", "when": "test_restart", "next": "detect-post-restart" },
        "...": "remaining restart/unlock/verify nodes",
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Validation Logs**

Command:
```bash
node scripts/perps/agentic/validate-recipe.js \
  scripts/perps/agentic/teams/perps/recipes/app-lifecycle.json
```

<details><summary>Full output (11/17 passed, 6 skipped — iOS)</summary>

```
Running recipe: App Lifecycle — validate data survives background, long background, and restart
Team: perps
Pre-conditions: wallet.unlocked, perps.feature_enabled
Workflow nodes: 20

Pre-conditions: PASS

[nav-market-list] navigate to PerpsTrendingView
  result: {"navigated":"PerpsTrendingView",...}
  PASS

[wait-markets] wait for condition
  result: {"count":291}
  PASS

[baseline-price] Baseline — confirm markets and price data loaded
  result: {"found":true,"price":"$71,046"}
  PASS

[short-background] Short background — within WS grace period, cache should be preserved
  backgrounded for 5000ms
  PASS

[short-foreground] foreground app
  foregrounded (io.metamask.MetaMask)
  PASS

[wait-post-short] wait for condition
  result: {"count":291}
  PASS

[verify-post-short] Confirm markets + price survive short background
  result: {"found":true,"price":"$71,058"}
  PASS

[long-background] Long background — exceeds WS grace period, forces full reconnection
  backgrounded for 30000ms
  PASS

[long-foreground] foreground app
  foregrounded (io.metamask.MetaMask)
  PASS

[wait-post-long] wait for condition
  result: {"count":291}
  PASS

[verify-post-long] Confirm markets + DEXs recover after full WS reconnection
  result: {"markets":291,"dexs":9,"price":"$71,039"}
  PASS

[restart-app] restart app
  [SKIPPED - when condition did not match]

[detect-post-restart] Detect login vs wallet after restart
  [SKIPPED - when condition did not match]

[check-needs-unlock] evaluate branch
  [SKIPPED - when condition did not match]

[nav-after-restart] navigate to PerpsTrendingView
  [SKIPPED - when condition did not match]

[wait-post-restart] wait for condition
  [SKIPPED - when condition did not match]

[verify-post-restart] Confirm markets reload cleanly after full restart
  [SKIPPED - when condition did not match]

----------------------------------------
Results: 11/17 passed, 6 skipped
Recipe: PASS
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow actions that spawn `xcrun`/`adb` processes and changes CDP target selection/reporting, which can affect automation reliability across devices. Also introduces automatic log capture/redaction and new CLI flags that alter runner behavior.
> 
> **Overview**
> **Agentic workflows can now exercise app lifecycle events.** The recipe runner adds new actions (`app_background`, `app_foreground`, `app_restart`) implemented via a new `lib/app-lifecycle.js` that uses `simctl`/AppleScript on iOS and `adb` on Android, and documents these actions plus a new `teams/perps/recipes/app-lifecycle.json` reference recipe.
> 
> **CDP and preflight scripts now better support multi-device setups.** `cdp-bridge.js status` probes *all* discovered Hermes targets (via new `discoverAllTargets`) and returns either a single object or an array; `preflight.sh` reuses an already-healthy Metro instance by probing `/status` and loosens the platform check to a warning when the expected platform target isn’t found.
> 
> **Recipe execution UX improved.** `validate-recipe.js` adds `--input key=value` for overriding recipe inputs, `--no-log` to disable logging, captures console output to `run.log` with basic redaction, and fixes `when` guards to apply to `switch`/`end` nodes (skipping them safely instead of executing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3948ed03158d769fadec1476c3fff6fd17b9417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->