### PR TITLE
refactor: update DeFiSection to improve viewport tracking and event firing logic

### DIFF
--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -96,20 +96,21 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
-    // Always pass sectionViewRef once loading is done so the viewport check
-    // decides when to fire. When the section returns null (empty, no error),
-    // sectionViewRef.current is null and the viewport check returns early —
-    // no premature immediate fire via the null path.
-    const willRender = !isLoading;
+    // Only attach a ref when this section mounts a root View (loading skeleton,
+    // error UI, or positions). When empty after load we return null — pass null
+    // here and disable the hook's immediate-fire path so HOME_VIEWED is not sent.
+    const sectionMountsVisibleRoot =
+      isDeFiEnabled && !(isEmpty && !hasError && !isLoading);
 
     const { onLayout } = useHomeViewedEvent({
-      sectionRef: willRender ? sectionViewRef : null,
+      sectionRef: sectionMountsVisibleRoot ? sectionViewRef : null,
       isLoading,
       sectionName: HomeSectionNames.DEFI,
       sectionIndex,
       totalSectionsLoaded,
       isEmpty: isEmpty || hasError || !isDeFiEnabled,
       itemCount: isEmpty ? 0 : positions.length,
+      fireImmediateWhenNoView: false,
     });
 
     useSectionPerformance({

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.test.ts
@@ -151,6 +151,19 @@ describe('useHomeViewedEvent', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     });
 
+    it('does not fire the immediate path when fireImmediateWhenNoView is false', () => {
+      renderHook(() =>
+        useHomeViewedEvent({
+          ...defaultParams,
+          sectionRef: null,
+          isLoading: false,
+          fireImmediateWhenNoView: false,
+        }),
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
     it('only fires once even after multiple re-renders with null ref', () => {
       const { rerender } = renderHook(() =>
         useHomeViewedEvent({
@@ -301,6 +314,41 @@ describe('useHomeViewedEvent', () => {
         triggerScroll();
       });
 
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not subscribe or fire while isLoading is true even with a ref', () => {
+      const mockRef = createMockRef(0, 200);
+      renderHook(() =>
+        useHomeViewedEvent({
+          ...defaultParams,
+          sectionRef: mockRef,
+          isLoading: true,
+        }),
+      );
+
+      expect(mockSubscribeToScroll).not.toHaveBeenCalled();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('subscribes and fires after loading when ref is in viewport', () => {
+      const mockRef = createMockRef(0, 200);
+      const { rerender } = renderHook(
+        ({ loading }: { loading: boolean }) =>
+          useHomeViewedEvent({
+            ...defaultParams,
+            sectionRef: mockRef,
+            isLoading: loading,
+          }),
+        { initialProps: { loading: true } },
+      );
+
+      expect(mockSubscribeToScroll).not.toHaveBeenCalled();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+
+      rerender({ loading: false });
+
+      expect(mockSubscribeToScroll).toHaveBeenCalledTimes(1);
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     });
 

--- a/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useHomeViewedEvent.ts
@@ -24,8 +24,8 @@ export type HomeSectionName =
 interface UseHomeViewedEventParams {
   /**
    * Ref to the section's root View. Pass `null` when the section does not
-   * render (e.g. DeFi with no positions) — the event will fire immediately
-   * once `isLoading` is false.
+   * render — once `isLoading` is false, the hook may fire immediately (see
+   * `fireImmediateWhenNoView`) or not, depending on product rules.
    */
   sectionRef: RefObject<View> | null;
   /** Whether the section data is still being fetched. */
@@ -42,6 +42,14 @@ interface UseHomeViewedEventParams {
    * E.g. for Tokens: number of token rows. For NFTs in empty state: 0.
    */
   itemCount: number;
+  /**
+   * When `sectionRef` is `null` and loading has finished, fire `HOME_VIEWED`
+   * once (e.g. What's Happening with no items still wants an empty impression).
+   * Set to `false` when the section is omitted from the UI entirely (e.g. DeFi
+   * with no positions).
+   * @default true
+   */
+  fireImmediateWhenNoView?: boolean;
 }
 
 /**
@@ -49,8 +57,11 @@ interface UseHomeViewedEventParams {
  * user's viewport (≥ 30 % of the section is visible).
  *
  * - Re-fires on every homepage visit (when `visitId` increments).
- * - For sections that do not render (e.g. DeFi with no positions), fires
- * immediately once loading has finished (when `sectionRef` is `null`).
+ * - For sections that do not render but still want an impression (e.g. What's
+ * Happening empty), may fire immediately once loading has finished when
+ * `sectionRef` is `null` and `fireImmediateWhenNoView` is true (default).
+ * - Viewport tracking is deferred until `isLoading` is false so skeletons do not
+ * emit section_viewed for content that will be hidden when load completes.
  * - Uses a subscription pattern instead of React state so scroll events do
  * not trigger re-renders of section components.
  */
@@ -62,6 +73,7 @@ const useHomeViewedEvent = ({
   totalSectionsLoaded,
   isEmpty,
   itemCount,
+  fireImmediateWhenNoView = true,
 }: UseHomeViewedEventParams) => {
   const {
     subscribeToScroll,
@@ -128,8 +140,9 @@ const useHomeViewedEvent = ({
   // the event to re-fire after hasFiredRef is reset by the effect above.
   useEffect(() => {
     if (sectionRef !== null || isLoading) return;
+    if (!fireImmediateWhenNoView) return;
     fireEvent();
-  }, [sectionRef, isLoading, fireEvent, visitId]);
+  }, [sectionRef, isLoading, fireEvent, visitId, fireImmediateWhenNoView]);
 
   // Holds the latest checkVisibility so the onLayout callback can re-trigger
   // a check after the native layout pass completes.
@@ -139,7 +152,7 @@ const useHomeViewedEvent = ({
   // every scroll event. Uses subscribeToScroll so no React re-renders occur
   // during scrolling.
   useEffect(() => {
-    if (!sectionRef?.current || viewportHeight === 0) return;
+    if (isLoading || !sectionRef?.current || viewportHeight === 0) return;
 
     const checkVisibility = () => {
       if (hasFiredRef.current) return;
@@ -178,6 +191,7 @@ const useHomeViewedEvent = ({
     sectionRef,
     subscribeToScroll,
     fireEvent,
+    isLoading,
   ]);
 
   // Sections attach this to their root View's onLayout prop. onLayout fires


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`Home Viewed` with `interaction_type: section_viewed` was firing for the DeFi homepage section even when the user had no positions and the section was not rendered (`return null`). That happened because the viewport hook subscribed while the loading skeleton was on screen (with `is_empty: false`), so the event could fire before the empty final state; once `hasFiredRef` was set, the incorrect impression was already recorded.

This change:

- Passes `sectionRef` to `useHomeViewedEvent` only when DeFi actually mounts a root view (loading skeleton, error UI, or positions), and sets `fireImmediateWhenNoView: false` so the “null ref after load” path does not emit an event when the section is omitted entirely.
- Extends `useHomeViewedEvent` with optional `fireImmediateWhenNoView` (default `true`) so sections like What’s Happening can keep firing an empty impression when they intentionally use `sectionRef: null` after load.
- Defers viewport/scroll subscription until `isLoading` is false so skeleton states do not count as viewed before final content is known.

Unit tests were added/updated in `useHomeViewedEvent.test.ts` for the new flag and loading behavior.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28165
Refs: https://consensyssoftware.atlassian.net/browse/TMCU-605

## **Manual testing steps**

```gherkin
Feature: Home Viewed analytics for DeFi section

  Scenario: No Home Viewed section_viewed for DeFi when user has no positions
    Given the DeFi homepage feature is enabled
    And the selected account has no DeFi positions (empty successful response, not an error)
    When the user opens the Wallet home tab and scrolls through the feed
    Then no "Home Viewed" event with section_name "defi" and interaction_type "section_viewed" is recorded in the analytics debugger or Segment

  Scenario: Home Viewed still fires when DeFi section is visible
    Given the DeFi homepage feature is enabled
    And the selected account has at least one DeFi position
    When the user opens the Wallet home tab and scrolls until the DeFi section is substantially visible
    Then a "Home Viewed" event with section_name "defi" and interaction_type "section_viewed" is recorded as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes homepage analytics firing rules and scroll-subscription timing; could affect when/if `HOME_VIEWED` events are emitted across sections if the new flag is misused or loading state is incorrect.
> 
> **Overview**
> Prevents the DeFi homepage section from emitting `HOME_VIEWED`/`section_viewed` analytics when it ultimately renders nothing (no positions): `DeFiSection` now only passes a `sectionRef` when it actually mounts a root view, and explicitly disables the hook’s null-ref immediate-fire behavior.
> 
> Extends `useHomeViewedEvent` with an optional `fireImmediateWhenNoView` flag (default `true`) and defers viewport measurement/scroll subscription until `isLoading` is false to avoid firing impressions while skeletons are shown; unit tests were updated to cover the new flag and loading-to-loaded transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877743697f77a002487e15e12cefcdce63eb4d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->