### PR TITLE
perf: enable React Compiler for onboarding web3auth screens

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,13 @@ module.exports = {
           const pathsToInclude = [
             'app/components/Nav',
             'app/components/UI/DeepLinkModal',
+            'app/components/Views/Onboarding',
+            'app/components/Views/ChoosePassword',
+            'app/components/Views/SocialLoginIosUser',
+            'app/components/Views/OAuthRehydration',
+            'app/components/Views/Login',
+            'app/components/Views/WalletRecovery',
+            'app/components/Views/WalletCreationError',
           ];
           return pathsToInclude.some((path) => filename.includes(path));
         },


### PR DESCRIPTION
## Description
Enable React Compiler for onboarding/web3auth-related screen directories by expanding the `pathsToInclude` allowlist in `babel.config.js`.

This follows the existing incremental rollout approach (path-based inclusion) and does not remove `useMemo`/`useCallback` from component code.

## Changes
- Added the following directories to React Compiler `sources` allowlist:
  - `app/components/Views/Onboarding`
  - `app/components/Views/ChoosePassword`
  - `app/components/Views/SocialLoginIosUser`
  - `app/components/Views/OAuthRehydration`
  - `app/components/Views/Login`
  - `app/components/Views/WalletRecovery`
  - `app/components/Views/WalletCreationError`

## Why
Onboarding/web3auth screens were not being compiled because only `app/components/Nav` and `app/components/UI/DeepLinkModal` were previously allowlisted.

## Testing
- `yarn eslint babel.config.js`
