### PR TITLE
fix: update info icon color to IconAlternative for better visibility

### DIFF
--- a/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
+++ b/app/components/UI/Earn/components/AssetOverviewClaimBonus/AssetOverviewClaimBonus.tsx
@@ -235,7 +235,7 @@ const AssetOverviewClaimBonus: React.FC<AssetOverviewClaimBonusProps> = ({
             <ButtonIcon
               iconName={IconName.Info}
               size={ButtonIconSize.Sm}
-              iconProps={{ color: IconColor.IconDefault }}
+              iconProps={{ color: IconColor.IconAlternative }}
               onPress={handleInfoPress}
               testID={ASSET_OVERVIEW_CLAIM_BONUS_TEST_IDS.INFO_BUTTON}
             />

--- a/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
+++ b/app/components/UI/Earn/hooks/useMusdConversionNavbar.tsx
@@ -111,7 +111,7 @@ export function useMusdConversionNavbar() {
         <ButtonIcon
           iconName={IconName.Info}
           size={ButtonIconSize.Md}
-          iconProps={{ color: IconColor.IconDefault }}
+          iconProps={{ color: IconColor.IconAlternative }}
           onPress={onInfoPress}
         />
       </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The info icon (ⓘ) next to the "Your bonus" heading and in the mUSD conversion navbar was rendering in the default icon color (near-black/white), which didn't match the design spec. The design calls for a muted gray that de-emphasizes the info affordance relative to the heading text.

This PR updates both info icon instances to use the `IconColor.IconAlternative` design token so the icon renders in a medium gray that matches the Figma design in both light and dark modes.

## **Changelog**

CHANGELOG entry: Fixed the info icon color next to the "Your bonus" heading and in the mUSD conversion navbar to match the design spec.

## **Related issues**

Fixes: MUSD-650

## **Manual testing steps**

```gherkin
Feature: mUSD "Your bonus" info icon color

  Scenario: user views the Your bonus section on the asset overview
    Given the user has an mUSD balance eligible for bonus display
    And the user is on the mUSD asset overview screen

    When the user scrolls to the "Your bonus" section
    Then the info icon next to "Your bonus" renders in a muted gray (IconAlternative)
    And the icon is clearly visible against both light and dark backgrounds

  Scenario: user views the mUSD conversion navbar
    Given the user is on the mUSD conversion flow

    When the conversion screen header renders
    Then the info icon in the navbar header renders in a muted gray (IconAlternative)
    And tapping the icon still opens the existing info tooltip/modal
```

## **Screenshots/Recordings**

### **Before**

Info icon rendered in the default dark color, indistinguishable from the heading text.

### **After**

![](https://files.slack.com/files-pri/T02P98BKE-F0ASCDHERNW/image.png)
![](https://files.slack.com/files-pri/T02P98BKE-F0ASABKA4Q6/image.png)

Info icon renders in muted gray (`IconColor.IconAlternative`), matching the Figma design.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that updates a design token for two info icons; no behavior, data flow, or navigation logic is modified.
> 
> **Overview**
> Updates the mUSD Earn UI to render the ⓘ info icons in a muted gray by switching their `ButtonIcon` `iconProps.color` from `IconColor.IconDefault` to `IconColor.IconAlternative` in both the asset overview “Your bonus” section and the mUSD conversion navbar header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb46553bae7e7e12c0e02e3aca6fd645e609b33e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->