### PR TITLE
fix: tempo disable confirm button until gas autoselect

### DIFF
--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -5,13 +5,6 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictBalance from './PredictBalance';
 import { strings } from '../../../../../../locales/i18n';
 
-// Mock React Query
-jest.mock('@tanstack/react-query', () => ({
-  useQueryClient: () => ({
-    invalidateQueries: jest.fn(),
-  }),
-}));
-
 // Mock React Navigation
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -71,6 +71,7 @@ jest.mock('../../hooks/usePredictBalance', () => ({
 
 const mockInvalidateQueries = jest.fn();
 jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
   useQueryClient: () => ({
     invalidateQueries: mockInvalidateQueries,
   }),

--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -26,6 +26,7 @@ import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { emptySignatureControllerMock } from '../../__mocks__/controllers/signature-controller-mock';
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
+import { useIsGaslessLoading } from '../../hooks/gas/useIsGaslessLoading';
 
 const mockConfirmSpy = jest.fn();
 const mockRejectSpy = jest.fn();
@@ -78,6 +79,12 @@ jest.mock('../../hooks/ui/useFullScreenConfirmation', () => ({
   })),
 }));
 
+jest.mock('../../hooks/gas/useIsGaslessLoading', () => ({
+  useIsGaslessLoading: jest.fn(() => ({
+    isGaslessLoading: false,
+  })),
+}));
+
 const mockTrackAlertMetrics = jest.fn();
 
 (useConfirmationAlertMetrics as jest.Mock).mockReturnValue({
@@ -101,6 +108,7 @@ describe('Footer', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useIsGaslessLoadingMock = jest.mocked(useIsGaslessLoading);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -124,6 +132,7 @@ describe('Footer', () => {
     });
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: false });
   });
 
   it('should render correctly', () => {
@@ -228,9 +237,29 @@ describe('Footer', () => {
     ).toBe(true);
   });
 
-  it('disables confirm button if quotes are loading', () => {
+  it('disables confirm button if transaction pay is loading', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: false });
+    const state = merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      emptySignatureControllerMock,
+      { securityAlerts: { alerts: {} } },
+    );
 
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state,
+    });
+
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
+    ).toBe(true);
+  });
+
+  it('disables confirm button if gasless support is loading', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: true });
     const state = merge(
       {},
       simpleSendTransactionControllerMock,

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -39,6 +39,7 @@ import { PredictClaimFooter } from '../predict-confirmations/predict-claim-foote
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useQRHardwareContext } from '../../context/qr-hardware-context';
+import { useIsGaslessLoading } from '../../hooks/gas/useIsGaslessLoading';
 
 const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.moneyAccountDeposit,
@@ -71,6 +72,7 @@ export const Footer = () => {
     TRANSFER_TRANSACTION_TYPES.includes(transactionType) &&
     transactionMetadata?.origin === MMM_ORIGIN;
   const isPayLoading = useIsTransactionPayLoading();
+  const { isGaslessLoading } = useIsGaslessLoading();
 
   const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
     useConfirmationContext();
@@ -158,7 +160,8 @@ export const Footer = () => {
     needsCameraPermission ||
     hasBlockingAlerts ||
     isTransactionValueUpdating ||
-    isPayLoading;
+    isPayLoading ||
+    isGaslessLoading;
 
   const buttons = [
     {

--- a/app/components/Views/confirmations/context/qr-hardware-context/qr-hardware-context.test.tsx
+++ b/app/components/Views/confirmations/context/qr-hardware-context/qr-hardware-context.test.tsx
@@ -74,6 +74,12 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('../../hooks/gas/useIsGaslessLoading', () => ({
+  useIsGaslessLoading: jest.fn(() => ({
+    isGaslessLoading: false,
+  })),
+}));
+
 const mockPendingScanRequest: QrScanRequest = {
   request: {
     requestId: 'c95ecc76-d6e9-4a0a-afa3-31429bc80566',

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -1,0 +1,209 @@
+import { GasFeeToken } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+import { useIsGaslessSupported } from './useIsGaslessSupported';
+import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { useIsGaslessLoading } from './useIsGaslessLoading';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+
+jest.mock('./useIsGaslessSupported');
+jest.mock('../useHasInsufficientBalance');
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../../../../selectors/preferencesController');
+
+const mockedUseIsGaslessSupported = jest.mocked(useIsGaslessSupported);
+const mockedUseHasInsufficientBalance = jest.mocked(useHasInsufficientBalance);
+const mockedUseTransactionMetadataRequest = jest.mocked(
+  useTransactionMetadataRequest,
+);
+const mockSelectUseTransactionSimulations = jest.mocked(
+  selectUseTransactionSimulations,
+);
+
+async function runHook({
+  simulationEnabled,
+  gaslessSupported,
+  insufficientBalance,
+  pending = false,
+  isSmartTransaction = true,
+  gasFeeTokens,
+  excludeNativeTokenForFee,
+  selectedGasFeeToken,
+}: {
+  simulationEnabled: boolean;
+  gaslessSupported: boolean;
+  insufficientBalance: boolean;
+  pending?: boolean;
+  isSmartTransaction?: boolean;
+  gasFeeTokens?: GasFeeToken[];
+  excludeNativeTokenForFee?: boolean;
+  selectedGasFeeToken?: Hex;
+}) {
+  mockedUseIsGaslessSupported.mockReturnValue({
+    isSupported: gaslessSupported,
+    isSmartTransaction,
+    pending,
+  });
+  mockedUseHasInsufficientBalance.mockReturnValue({
+    hasInsufficientBalance: insufficientBalance,
+    nativeCurrency: 'USD',
+  });
+  mockedUseTransactionMetadataRequest.mockReturnValue({
+    gasFeeTokens,
+    excludeNativeTokenForFee,
+    selectedGasFeeToken,
+  } as unknown as ReturnType<typeof useTransactionMetadataRequest>);
+  mockSelectUseTransactionSimulations.mockReturnValue(simulationEnabled);
+  const { result } = renderHookWithProvider(useIsGaslessLoading);
+  return result.current;
+}
+
+describe('useIsGaslessLoading', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true if pending', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      pending: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if simulation is disabled', async () => {
+    const result = await runHook({
+      simulationEnabled: false,
+      gaslessSupported: true,
+      insufficientBalance: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gasless is not supported', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: false,
+      insufficientBalance: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if there is no insufficient balance', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: false,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gas fee tokens are undefined (still loading)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: undefined, // this triggers loading
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if gas fee tokens are present', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens is an empty array', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [],
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present and dont match selectedGasFeeToken (non-reg)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gas fee tokens are present and dont match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if gas fee tokens are present AND match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [
+        { tokenAddress: '0x123' },
+        { tokenAddress: '0x789' },
+      ] as unknown as GasFeeToken[],
+      // Matches the first one
+      selectedGasFeeToken: '0x123',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present AND selectedGasFeeToken is undefined with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: undefined,
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens is empty array with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,0 +1,62 @@
+import { useSelector } from 'react-redux';
+
+import { GasFeeToken } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { useIsGaslessSupported } from './useIsGaslessSupported';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+
+// Chains with no native may have selectedGasFeeToken inconsistent with gasFeeTokens
+function hasWrongSelectedGasFeeToken({
+  gasFeeTokens,
+  selectedGasFeeToken,
+}: {
+  gasFeeTokens: GasFeeToken[];
+  selectedGasFeeToken?: Hex;
+}) {
+  return (
+    gasFeeTokens.length &&
+    selectedGasFeeToken &&
+    selectedGasFeeToken !== NATIVE_TOKEN_ADDRESS &&
+    !gasFeeTokens.some(
+      ({ tokenAddress }) =>
+        tokenAddress?.toLocaleLowerCase() ===
+        selectedGasFeeToken?.toLocaleLowerCase(),
+    )
+  );
+}
+
+export function useIsGaslessLoading() {
+  const transactionMeta = useTransactionMetadataRequest();
+
+  const { gasFeeTokens, excludeNativeTokenForFee, selectedGasFeeToken } =
+    transactionMeta ?? {};
+
+  const {
+    isSupported: isGaslessSupported,
+    pending: isGaslessSupportedPending,
+  } = useIsGaslessSupported();
+  const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
+
+  const { hasInsufficientBalance } = useHasInsufficientBalance();
+
+  const isGaslessSupportedFinished =
+    !isGaslessSupportedPending && isGaslessSupported;
+
+  const hasNoNativeTokenAvailable =
+    excludeNativeTokenForFee || hasInsufficientBalance;
+
+  const isGaslessLoading = Boolean(
+    isSimulationEnabled &&
+      hasNoNativeTokenAvailable &&
+      (isGaslessSupportedPending || isGaslessSupportedFinished) &&
+      (!gasFeeTokens ||
+        (excludeNativeTokenForFee &&
+          hasWrongSelectedGasFeeToken({ gasFeeTokens, selectedGasFeeToken }))),
+  );
+
+  return { isGaslessLoading };
+}

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessSupported.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessSupported.test.ts
@@ -2,18 +2,26 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { waitFor } from '@testing-library/react-native';
 import { merge } from 'lodash';
 import { transferConfirmationState } from '../../../../../util/test/confirm-data-helpers';
-import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { isRelaySupported } from '../../../../../util/transactions/transaction-relay';
 import { transferTransactionStateMock } from '../../__mocks__/transfer-transaction-mock';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useIsGaslessSupported } from './useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmartTransactions';
 
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+
 jest.mock('../../../../../util/transactions/sentinel-api');
 jest.mock('../../../../../util/transaction-controller');
 jest.mock('../../../../../util/transactions/transaction-relay');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('./useGaslessSupportedSmartTransactions');
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({
+    invalidateQueries: jest.fn(),
+  }),
+}));
 
 const SMART_TRANSACTIONS_ENABLED_STATE = {
   swaps: {

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessSupported.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessSupported.ts
@@ -1,7 +1,8 @@
-import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useAsyncResult } from '../../../../hooks/useAsyncResult';
-import { isRelaySupported } from '../../../../../util/transactions/transaction-relay';
+import { useQuery } from '@tanstack/react-query';
 import { Hex } from '@metamask/utils';
+
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { isRelaySupported } from '../../../../../util/transactions/transaction-relay';
 import { isHardwareAccount } from '../../../../../util/address';
 import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmartTransactions';
 
@@ -20,7 +21,7 @@ import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmart
 export function useIsGaslessSupported() {
   const transactionMeta = useTransactionMetadataRequest();
 
-  const { chainId, txParams } = transactionMeta ?? {};
+  const { txParams, chainId } = transactionMeta ?? {};
 
   const {
     isSmartTransaction,
@@ -31,15 +32,11 @@ export function useIsGaslessSupported() {
   const shouldCheck7702Eligibility =
     !smartTransactionPending && !isSmartTransactionAndBundleSupported;
 
-  const { value: relaySupportsChain, pending: relayPending } =
-    useAsyncResult(async () => {
-      if (!shouldCheck7702Eligibility) {
-        return undefined;
-      }
-
-      return isRelaySupported(chainId as Hex);
-    }, [chainId, shouldCheck7702Eligibility]);
-
+  const { data: relaySupportsChain, isFetching: relayPending } = useQuery({
+    queryKey: ['relaySupportsChain', chainId],
+    queryFn: () => isRelaySupported(chainId as Hex),
+    enabled: shouldCheck7702Eligibility && Boolean(chainId),
+  });
   const is7702Supported = Boolean(
     relaySupportsChain &&
       // contract deployments can't be delegated
@@ -55,12 +52,12 @@ export function useIsGaslessSupported() {
     !isHardwareWallet &&
     Boolean(isSmartTransactionAndBundleSupported || is7702Supported);
 
-  const isPending =
-    smartTransactionPending || (shouldCheck7702Eligibility && relayPending);
+  const is7702SupportedPending = shouldCheck7702Eligibility && relayPending;
+  const pending = smartTransactionPending || is7702SupportedPending;
 
   return {
     isSupported,
     isSmartTransaction,
-    pending: isPending,
+    pending,
   };
 }

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -17,6 +17,7 @@ import { Theme } from '../theme/models';
 import configureStore from './configureStore';
 import { RootState } from '../../reducers';
 import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -45,7 +46,9 @@ export default function renderWithProvider(
   const store = configureStore(state);
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   require('../../store')._updateMockState(state);
-
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   const InnerProvider = ({ children }: { children: React.ReactElement }) => {
     let wrappedChildren = children;
     if (includeFeatureFlagOverrideProvider) {
@@ -57,9 +60,11 @@ export default function renderWithProvider(
     }
     return (
       <Provider store={store}>
-        <ThemeContext.Provider value={theme}>
-          {wrappedChildren}
-        </ThemeContext.Provider>
+        <QueryClientProvider client={queryClient}>
+          <ThemeContext.Provider value={theme}>
+            {wrappedChildren}
+          </ThemeContext.Provider>
+        </QueryClientProvider>
       </Provider>
     );
   };
@@ -110,8 +115,13 @@ export function renderHookWithProvider<Result, Props>(
   const store = configureStore(state);
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   require('../../store')._updateMockState(state);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   const Providers = ({ children }: { children: React.ReactElement }) => (
-    <Provider store={store}>{children}</Provider>
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
   );
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The goal of the change is to prevent a premature "enablement" for the Confirm button when a transaction is loading. There are pre-existing race conditions that allowed users to confirm a transaction before everything is fully loaded. Those conditions could make the tx skip gasless flows, falling back to native token for gas payment.

The impact is bigger on Tempo because using a native token is not an option (there is no native token on Tempo), which means that such race condition will always result in a failed tx (the tx won't be sent to the RPC or relayer). 

The changes solve the race conditions cases, as well as adds some extra conditions for the loading when on a chain that has no native token.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add new `isGaslessLoading` guard to Confirmation button - consistently with Extension.
CHANGELOG entry: `useIsGaslessSupported` to use `useQuery` instead of `useAsync` to avoid race conditions.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-944?atlOrigin=eyJpIjoiYWFiY2U0NjU1ZjEzNGNmODlmOTZkNTQwNzM4N2MxMTUiLCJwIjoiaiJ9

## **Manual testing steps**

**Repeating instructions shared for Extension since Mobile flow will be very similar (just "tap" instead of click ;))**

- On Tempo mainnet, find `pathUSD` and click on "Send".
- Set amount to 0.01 and select the account to send to (any account).
- As soon as you clicked on the recipient account, start "spam clicking" on "Confirm" or the location where you know "Confirm" will appear.
- 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19a8535d-d73b-452b-98c2-d8471000fd48" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2846ad13-ba71-4101-b96b-74a86abdc7b7" />

What should be observed is that despite spam-clicking, it should not be possible to "Confirm" the transaction "too soon" and it should always succeed no matter how "early" you click on "Confirm".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation disablement logic around gasless support and switches gasless eligibility checks to React Query; could affect when users can confirm transactions and may introduce edge-case loading states on chains without native gas.
> 
> **Overview**
> Prevents premature transaction confirmation by **disabling the Confirm button while gasless support/fee-token auto-selection is still loading** (`Footer` now gates on new `useIsGaslessLoading` in addition to transaction pay loading).
> 
> Adds `useIsGaslessLoading` to detect gasless-related loading (including Tempo-style *no native token* cases and mismatched `selectedGasFeeToken`), and refactors `useIsGaslessSupported` to use React Query (`useQuery`) for relay support checks to reduce race conditions.
> 
> Test infrastructure is updated to wrap `renderWithProvider`/`renderHookWithProvider` with a `QueryClientProvider`, and relevant tests are adjusted/mocked accordingly (including new unit tests for `useIsGaslessLoading`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164017bd9d68db64fcc375b2d9e4f0f4608ecc4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->