### PR TITLE
chore: migrating money account deposit fund alert to alert system

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.styles.ts
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.styles.ts
@@ -23,10 +23,6 @@ const styleSheet = (_params: { theme: Theme }) =>
     footerText: {
       alignSelf: 'center',
     },
-
-    noFundsText: {
-      alignSelf: 'center',
-    },
   });
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -443,7 +443,7 @@ describe('CustomAmountInfo', () => {
     });
   });
 
-  it('renders no funds message for moneyAccountDeposit when no tokens available', () => {
+  it('renders no funds alert message for moneyAccountDeposit when alert is present', () => {
     useTransactionMetadataRequestMock.mockReturnValue({
       type: TransactionType.moneyAccountDeposit,
       txParams: { from: '0x123' },
@@ -454,16 +454,21 @@ describe('CustomAmountInfo', () => {
       hasTokens: false,
     });
 
+    useTransactionCustomAmountAlertsMock.mockReturnValue({
+      alertTitle: strings('alert_system.account_no_funds.message'),
+      alertMessage: strings('alert_system.account_no_funds.message'),
+    });
+
     const { getByText } = render({
       transactionType: TransactionType.moneyAccountDeposit,
     });
 
     expect(
-      getByText(strings('confirm.no_funds_use_different_account')),
+      getByText(strings('alert_system.account_no_funds.message')),
     ).toBeOnTheScreen();
   });
 
-  it('does not render no funds message for moneyAccountDeposit when tokens available', () => {
+  it('does not render no funds alert for moneyAccountDeposit when tokens available', () => {
     useTransactionMetadataRequestMock.mockReturnValue({
       type: TransactionType.moneyAccountDeposit,
       txParams: { from: '0x123' },
@@ -474,8 +479,8 @@ describe('CustomAmountInfo', () => {
     });
 
     expect(
-      queryByText(strings('confirm.no_funds_use_different_account')),
-    ).not.toBeOnTheScreen();
+      queryByText(strings('alert_system.account_no_funds.message')),
+    ).toBeNull();
   });
 
   it('renders AccountSelector for moneyAccountDeposit transactions', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -52,10 +52,6 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-  FontWeight as FontWeightComponent,
-  Text as TextComponent,
-  TextColor as TextColorComponent,
-  TextVariant as TextVariantComponent,
 } from '@metamask/design-system-react-native';
 import { useAlerts } from '../../../context/alert-system-context';
 import { AlertKeys } from '../../../constants/alerts';
@@ -242,16 +238,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           <AlertMessage alertMessage={alertMessage} />
           {!hidePayTokenAmount && (
             <>
-              {isMoneyAccountDeposit && !hasTokens && (
-                <TextComponent
-                  variant={TextVariantComponent.BodyMd}
-                  fontWeight={FontWeightComponent.Medium}
-                  color={TextColorComponent.ErrorDefault}
-                  style={styles.noFundsText}
-                >
-                  {strings('confirm.no_funds_use_different_account')}
-                </TextComponent>
-              )}
               {isMoneyAccountDeposit && (
                 <AccountSelector
                   label={strings('confirm.label.from')}

--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -14,6 +14,7 @@ export enum AlertKeys {
   InsufficientPayTokenFees = 'insufficient_pay_token_fees',
   InsufficientPerpsBalance = 'insufficient_perps_balance',
   InsufficientPredictBalance = 'insufficient_predict_balance',
+  AccountNoFunds = 'account_no_funds',
   NoPayTokenQuotes = 'no_pay_token_quotes',
   OriginTrustSignalMalicious = 'origin_trust_signal_malicious',
   OriginTrustSignalWarning = 'origin_trust_signal_warning',

--- a/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { AlertKeys } from '../../constants/alerts';
+import { Severity } from '../../types/alerts';
+import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayAvailableTokens } from '../pay/useTransactionPayAvailableTokens';
+import { useAccountNoFundsAlert } from './useAccountNoFundsAlert';
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../pay/useTransactionPayAvailableTokens');
+
+function runHook() {
+  return renderHook(() => useAccountNoFundsAlert());
+}
+
+describe('useAccountNoFundsAlert', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.moneyAccountDeposit,
+      txParams: { from: '0xabc' },
+    } as TransactionMeta);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: true,
+    });
+  });
+
+  it('returns alert for moneyAccountDeposit with no available tokens', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: false,
+    });
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([
+      {
+        key: AlertKeys.AccountNoFunds,
+        title: strings('alert_system.account_no_funds.message'),
+        message: strings('alert_system.account_no_funds.message'),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ]);
+  });
+
+  it('returns no alert for moneyAccountDeposit with available tokens', () => {
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert for non-moneyAccountDeposit transaction', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.contractInteraction,
+      txParams: { from: '0xabc' },
+    } as TransactionMeta);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: false,
+    });
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert when transaction metadata is undefined', () => {
+    useTransactionMetadataRequestMock.mockReturnValue(undefined as never);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: false,
+    });
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+});

--- a/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
+import { AlertKeys } from '../../constants/alerts';
+import { Alert, Severity } from '../../types/alerts';
+import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayAvailableTokens } from '../pay/useTransactionPayAvailableTokens';
+import { hasTransactionType } from '../../utils/transaction';
+
+export function useAccountNoFundsAlert(): Alert[] {
+  const transactionMeta = useTransactionMetadataRequest();
+  const { hasTokens } = useTransactionPayAvailableTokens();
+
+  const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountDeposit,
+  ]);
+
+  return useMemo(() => {
+    if (!isMoneyAccountDeposit || hasTokens) {
+      return [];
+    }
+
+    return [
+      {
+        key: AlertKeys.AccountNoFunds,
+        title: strings('alert_system.account_no_funds.message'),
+        message: strings('alert_system.account_no_funds.message'),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ];
+  }, [isMoneyAccountDeposit, hasTokens]);
+}

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
@@ -33,6 +33,14 @@ jest.mock('./useInsufficientPerpsBalanceAlert', () => ({
   ],
 }));
 
+jest.mock('./useAccountNoFundsAlert', () => ({
+  useAccountNoFundsAlert: () => [
+    {
+      id: 'alert-6',
+    },
+  ],
+}));
+
 describe('usePendingAmountAlerts', () => {
   it('returns alerts', () => {
     const { result } = renderHook(() =>
@@ -41,11 +49,10 @@ describe('usePendingAmountAlerts', () => {
 
     expect(result.current).toStrictEqual([
       { id: 'alert-1' },
-      {
-        id: 'alert-3',
-      },
+      { id: 'alert-3' },
       { id: 'alert-4' },
       { id: 'alert-5' },
+      { id: 'alert-6' },
     ]);
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
@@ -4,6 +4,7 @@ import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBa
 import { usePerpsHardwareAccountAlert } from './usePerpsHardwareAccountAlert';
 import { useInsufficientPredictBalanceAlert } from './useInsufficientPredictBalanceAlert';
 import { useInsufficientPerpsBalanceAlert } from './useInsufficientPerpsBalanceAlert';
+import { useAccountNoFundsAlert } from './useAccountNoFundsAlert';
 
 export function usePendingAmountAlerts({
   pendingTokenAmount,
@@ -24,18 +25,22 @@ export function usePendingAmountAlerts({
     pendingAmount: pendingTokenAmount ?? '0',
   });
 
+  const accountNoFundsAlert = useAccountNoFundsAlert();
+
   return useMemo(
     () => [
       ...perpsHardwareAccountAlert,
       ...insufficientTokenFundsAlert,
       ...insufficientPredictBalanceAlert,
       ...insufficientPerpsBalanceAlert,
+      ...accountNoFundsAlert,
     ],
     [
       insufficientTokenFundsAlert,
       perpsHardwareAccountAlert,
       insufficientPredictBalanceAlert,
       insufficientPerpsBalanceAlert,
+      accountNoFundsAlert,
     ],
   );
 }

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -121,6 +121,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.InsufficientPayTokenNative]: 'insufficient_funds_for_gas',
   [AlertKeys.InsufficientPerpsBalance]: 'insufficient_funds',
   [AlertKeys.InsufficientPredictBalance]: 'insufficient_funds',
+  [AlertKeys.AccountNoFunds]: 'account_no_funds',
   [AlertKeys.NoPayTokenQuotes]: 'no_payment_route_available',
   [AlertKeys.OriginTrustSignalMalicious]: 'origin_trust_signal_malicious',
   [AlertKeys.OriginTrustSignalWarning]: 'origin_trust_signal_warning',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -117,6 +117,9 @@
       "message": "This payment route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
       "title": "No quotes"
     },
+    "account_no_funds": {
+      "message": "No funds available. Use a different account."
+    },
     "perps_hardware_account": {
       "title": "Wallet not supported",
       "message": "Hardware wallets aren't supported.\nSwitch wallets to continue."
@@ -6715,8 +6718,7 @@
     "edit_amount_done": "Continue",
     "deposit_edit_amount_done": "Add funds",
     "deposit_edit_amount_predict_withdraw": "Withdraw",
-    "deposit_edit_amount_musd_conversion": "Convert to mUSD",
-    "no_funds_use_different_account": "No funds available. Use a different account."
+    "deposit_edit_amount_musd_conversion": "Convert to mUSD"
   },
   "change_in_simulation_modal": {
     "title": "Results have changed",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Using alert system for money account related errors.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1182

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `moneyAccountDeposit` “no funds” is surfaced by introducing a new blocking alert and wiring it into the shared pending-amount alert pipeline, which can affect confirm-button enablement and user flow. Risk is limited to confirmations/UX and is covered by added unit tests.
> 
> **Overview**
> Moves the `moneyAccountDeposit` “no funds” state into the confirmations *alert system* by introducing a new blocking `AccountNoFunds` alert (with metrics mapping) and feeding it through `usePendingAmountAlerts`.
> 
> Removes the old inline “no funds” red text from `CustomAmountInfo`, updates tests to assert alert-driven rendering, and adds new i18n under `alert_system.account_no_funds` while deleting the legacy `confirm.no_funds_use_different_account` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92ce45c1a4b59ece5740574927d1edcabd072a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->