### PR TITLE
chore(rewards): stats page

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -139,6 +139,7 @@ import RewardsClaimBottomSheetModal from '../../UI/Rewards/components/Tabs/Level
 import RewardOptInAccountGroupModal from '../../UI/Rewards/components/Settings/RewardOptInAccountGroupModal';
 import EndOfSeasonClaimBottomSheet from '../../UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet';
 import RewardsSelectSheet from '../../UI/Rewards/components/RewardsSelectSheet';
+import OndoPendingSheet from '../../UI/Rewards/components/Campaigns/OndoPendingSheet';
 import CampaignTourStepView from '../../UI/Rewards/Views/CampaignTourStepView';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import SitesFullView from '../../Views/SitesFullView/SitesFullView';
@@ -342,10 +343,12 @@ const RewardsHome = () => {
       <Stack.Screen
         name={Routes.MODAL.REWARDS_SELECT_SHEET}
         component={RewardsSelectSheet}
-        options={{
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={{ presentation: 'transparentModal' }}
+      />
+      <Stack.Screen
+        name={Routes.MODAL.REWARDS_ONDO_PENDING_SHEET}
+        component={OndoPendingSheet}
+        options={{ presentation: 'transparentModal' }}
       />
     </Stack.Navigator>
   );

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/MarketHoursContent.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/MarketHoursContent.test.tsx
@@ -45,7 +45,7 @@ describe('MarketHoursContent', () => {
       await waitFor(() => {
         expect(
           getByText(
-            /You're trading within regular market hours.*9:30 am to 4 pm ET/i,
+            /You're trading within regular market hours.*9:30 am to 4 pm EST/i,
           ),
         ).toBeOnTheScreen();
       });
@@ -79,7 +79,7 @@ describe('MarketHoursContent', () => {
       await waitFor(() => {
         expect(
           getByText(
-            /You're trading outside of regular market hours.*9:30 am to 4 pm ET/i,
+            /You're trading outside of regular market hours.*9:30 am to 4 pm EST/i,
           ),
         ).toBeOnTheScreen();
       });

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -13,6 +13,7 @@ import MusdCalculatorView from './Views/MusdCalculatorView';
 import OndoLeaderboardView from './Views/OndoLeaderboardView';
 import OndoCampaignRwaSelectorView from './Views/OndoCampaignRwaSelectorView';
 import OndoCampaignPortfolioView from './Views/OndoCampaignPortfolioView';
+import OndoCampaignStatsView from './Views/OndoCampaignStatsView';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { selectIsRewardsVersionBlocked } from '../../../reducers/rewards/selectors';
@@ -133,6 +134,11 @@ const RewardsNavigator: React.FC = () => {
           <Stack.Screen
             name={Routes.REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW}
             component={OndoCampaignPortfolioView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.REWARDS_ONDO_CAMPAIGN_STATS}
+            component={OndoCampaignStatsView}
             options={{ headerShown: false }}
           />
         </>

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -306,30 +306,67 @@ jest.mock('../components/Campaigns/OndoPortfolio', () => {
     __esModule: true,
     default: ({
       onOpenAccountPicker,
+      onNotEligible,
     }: {
       marketOpen?: boolean;
       onOpenAccountPicker?: (config: unknown) => void;
+      onNotEligible?: (action: () => void) => void;
     }) =>
-      ReactActual.createElement(Pressable, {
-        testID: 'ondo-campaign-portfolio',
-        onPress: () =>
-          onOpenAccountPicker?.({
-            row: {
-              tokenAsset: 'eip155:1/erc20:0xabc',
-              tokenSymbol: 'USDC',
-              tokenName: 'USD Coin',
-            },
-            entries: [
-              {
-                group: { id: 'group-1', metadata: { name: 'Account 1' } },
-                balance: '100',
+      ReactActual.createElement(
+        View,
+        null,
+        ReactActual.createElement(Pressable, {
+          testID: 'ondo-campaign-portfolio',
+          onPress: () =>
+            onOpenAccountPicker?.({
+              row: {
+                tokenAsset: 'eip155:1/erc20:0xabc',
+                tokenSymbol: 'USDC',
+                tokenName: 'USD Coin',
               },
-            ],
-            tokenDecimals: 6,
-          }),
-      }),
+              entries: [
+                {
+                  group: { id: 'group-1', metadata: { name: 'Account 1' } },
+                  balance: '100',
+                },
+              ],
+              tokenDecimals: 6,
+            }),
+        }),
+        ReactActual.createElement(Pressable, {
+          testID: 'ondo-campaign-portfolio-not-eligible',
+          onPress: () => onNotEligible?.(jest.fn()),
+        }),
+      ),
     AccountGroupSelectRow: () => ReactActual.createElement(View, null),
     getChainHex: jest.fn(() => '0x1'),
+  };
+});
+
+jest.mock('../components/Campaigns/OndoNotEligibleSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onClose,
+      onConfirm,
+    }: {
+      onClose: () => void;
+      onConfirm: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'ondo-not-eligible-sheet' },
+        ReactActual.createElement(Pressable, {
+          testID: 'ondo-not-eligible-sheet-close',
+          onPress: onClose,
+        }),
+        ReactActual.createElement(Pressable, {
+          testID: 'ondo-not-eligible-sheet-confirm',
+          onPress: onConfirm,
+        }),
+      ),
   };
 });
 
@@ -949,7 +986,7 @@ describe('OndoCampaignDetailsView', () => {
   });
 
   describe('prize pool', () => {
-    it('renders OndoPrizePool when campaign exists', () => {
+    it('renders OndoPrizePool when campaign is active', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -965,6 +1002,90 @@ describe('OndoCampaignDetailsView', () => {
       });
       const { queryByTestId } = render(<OndoCampaignDetailsView />);
       expect(queryByTestId(ONDO_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeNull();
+    });
+
+    it('does not render OndoPrizePool when campaign is complete', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
+          }),
+        ],
+      });
+      const { queryByTestId } = render(<OndoCampaignDetailsView />);
+      expect(queryByTestId(ONDO_PRIZE_POOL_TEST_IDS.CONTAINER)).toBeNull();
+    });
+  });
+
+  describe('stats title navigation', () => {
+    it('navigates to the stats view when the stats title is pressed', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [createTestCampaign()],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
+        refetch: jest.fn(),
+      });
+      const { getByText } = render(<OndoCampaignDetailsView />);
+      fireEvent.press(getByText('rewards.ondo_campaign_stats.title'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.REWARDS_ONDO_CAMPAIGN_STATS,
+        { campaignId: 'campaign-1' },
+      );
+    });
+  });
+
+  describe('not-eligible sheet', () => {
+    it('shows OndoNotEligibleSheet when portfolio triggers onNotEligible', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [createTestCampaign()],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
+      fireEvent.press(getByTestId('ondo-campaign-portfolio-not-eligible'));
+      expect(getByTestId('ondo-not-eligible-sheet')).toBeDefined();
+    });
+
+    it('dismisses OndoNotEligibleSheet when close is pressed', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [createTestCampaign()],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignDetailsView />,
+      );
+      fireEvent.press(getByTestId('ondo-campaign-portfolio-not-eligible'));
+      fireEvent.press(getByTestId('ondo-not-eligible-sheet-close'));
+      expect(queryByTestId('ondo-not-eligible-sheet')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -1,20 +1,21 @@
-import React, { useEffect, useMemo } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Pressable, ScrollView } from 'react-native';
 import { useSelector } from 'react-redux';
 import { selectReferralCode } from '../../../../reducers/rewards/selectors';
-import {
-  useNavigation,
-  useRoute,
-  RouteProp,
-  type NavigationProp,
-  type ParamListBase,
-} from '@react-navigation/native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
   Icon,
+  IconColor,
   IconName,
   IconSize,
   Skeleton,
@@ -32,6 +33,7 @@ import OndoLeaderboard from '../components/Campaigns/OndoLeaderboard';
 import OndoPortfolio from '../components/Campaigns/OndoPortfolio';
 import OndoAccountPickerSheet from '../components/Campaigns/OndoAccountPickerSheet';
 import OndoCampaignCTA from '../components/Campaigns/OndoCampaignCTA';
+import OndoNotEligibleSheet from '../components/Campaigns/OndoNotEligibleSheet';
 import CampaignStatsSummary from '../components/Campaigns/CampaignStatsSummary';
 import OndoPrizePool from '../components/Campaigns/OndoPrizePool';
 import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
@@ -46,6 +48,7 @@ import { useGetOndoCampaignDeposits } from '../hooks/useGetOndoCampaignDeposits'
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { OndoCampaignHowItWorks } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../utils/ondoCampaignConstants';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -67,6 +70,19 @@ const OndoCampaignDetailsView: React.FC = () => {
   const referralCode = useSelector(selectReferralCode);
   const { pendingPicker, setPendingPicker, sheetRef, handleGroupSelect } =
     useOndoAccountPicker(campaignId);
+
+  const [portfolioNotEligibleAction, setPortfolioNotEligibleAction] = useState<
+    (() => void) | null
+  >(null);
+  const portfolioNotEligibleActionRef = useRef<(() => void) | null>(null);
+
+  const handlePortfolioNotEligible = useCallback(
+    (confirmAction: () => void) => {
+      portfolioNotEligibleActionRef.current = confirmAction;
+      setPortfolioNotEligibleAction(() => confirmAction);
+    },
+    [],
+  );
 
   const {
     deposits,
@@ -120,6 +136,7 @@ const OndoCampaignDetailsView: React.FC = () => {
   );
 
   const {
+    leaderboard: leaderboardData,
     tierNames,
     selectedTier,
     selectedTierData,
@@ -131,6 +148,63 @@ const OndoCampaignDetailsView: React.FC = () => {
   } = useGetOndoLeaderboard(campaignId, {
     defaultTier: leaderboardPosition?.projectedTier,
   });
+
+  const leaderboardUserPosition = useMemo(
+    () =>
+      leaderboardPosition
+        ? {
+            projectedTier: leaderboardPosition.projectedTier,
+            rank: leaderboardPosition.rank,
+            neighbors: leaderboardPosition.neighbors ?? [],
+          }
+        : null,
+    [leaderboardPosition],
+  );
+
+  const tierMinDeposit = useMemo(
+    () =>
+      leaderboardPosition &&
+      campaign &&
+      getCampaignStatus(campaign) === 'active'
+        ? (leaderboardData?.tiers[leaderboardPosition.projectedTier]
+            ?.minDeposit ?? null)
+        : null,
+    [leaderboardData, leaderboardPosition, campaign],
+  );
+
+  const leaderboardPendingSheetPosition = useMemo(
+    () =>
+      leaderboardPosition &&
+      !leaderboardPosition.qualified &&
+      tierMinDeposit != null
+        ? {
+            tier: leaderboardPosition.projectedTier,
+            netDeposit: leaderboardPosition.netDeposit,
+            qualifiedDays: leaderboardPosition.qualifiedDays,
+            tierMinDeposit,
+          }
+        : null,
+    [leaderboardPosition, tierMinDeposit],
+  );
+
+  const notEligibleForCampaign = useMemo((): boolean => {
+    if (!campaign) return false;
+    if (isOptedIn && leaderboardPosition?.qualified) return false;
+    if (getCampaignStatus(campaign) !== 'active') return false;
+    // Backend counts calendar days (UTC): the day a position is opened counts as day 1,
+    // and every subsequent calendar day until endDate inclusive counts too.
+    // daysAvailable = floor((endDate - startOfTodayUTC) / 24h) + 1
+    const now = new Date();
+    const startOfTodayUTC = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+    );
+    const endDate = new Date(campaign.endDate).getTime();
+    const daysAvailable =
+      Math.floor((endDate - startOfTodayUTC) / (1000 * 60 * 60 * 24)) + 1;
+    return daysAvailable < ONDO_GM_REQUIRED_QUALIFIED_DAYS;
+  }, [campaign, isOptedIn, leaderboardPosition]);
 
   const {
     showHowItWorksSection,
@@ -147,16 +221,12 @@ const OndoCampaignDetailsView: React.FC = () => {
       };
     }
 
-    const showHowItWorksSection =
-      Boolean(campaign.details?.howItWorks) &&
-      !hasPositions &&
-      getCampaignStatus(campaign) === 'active';
-
-    const showStatsSummarySection = hasPositions;
-
     return {
-      showHowItWorksSection,
-      showStatsSummarySection,
+      showHowItWorksSection:
+        Boolean(campaign.details?.howItWorks) &&
+        !hasPositions &&
+        getCampaignStatus(campaign) === 'active',
+      showStatsSummarySection: hasPositions,
       showPortfolioSection: isOptedIn,
       showLeaderboardSection: true,
     };
@@ -220,18 +290,6 @@ const OndoCampaignDetailsView: React.FC = () => {
             <>
               <CampaignStatus campaign={campaign} optedIn={isOptedIn} />
 
-              <Box twClassName="p-4">
-                <Text variant={TextVariant.HeadingMd} twClassName="mb-1">
-                  {strings('rewards.ondo_campaign_prize_pool.title')}
-                </Text>
-                <OndoPrizePool
-                  totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
-                  isLoading={isDepositsLoading}
-                  hasError={hasDepositsError}
-                  refetch={refetchDeposits}
-                />
-              </Box>
-
               {/* Phase 1: Not opted in, show how it works section */}
               {showHowItWorksSection && (
                 <>
@@ -248,6 +306,29 @@ const OndoCampaignDetailsView: React.FC = () => {
               {showStatsSummarySection && (
                 <>
                   <Box twClassName="p-4">
+                    <Pressable
+                      onPress={() =>
+                        navigation.navigate(
+                          Routes.REWARDS_ONDO_CAMPAIGN_STATS,
+                          { campaignId },
+                        )
+                      }
+                    >
+                      <Box
+                        flexDirection={BoxFlexDirection.Row}
+                        alignItems={BoxAlignItems.Center}
+                        twClassName="gap-2 mb-4"
+                      >
+                        <Text variant={TextVariant.HeadingMd}>
+                          {strings('rewards.ondo_campaign_stats.title')}
+                        </Text>
+                        <Icon
+                          name={IconName.ArrowRight}
+                          size={IconSize.Md}
+                          color={IconColor.IconAlternative}
+                        />
+                      </Box>
+                    </Pressable>
                     <CampaignStatsSummary
                       leaderboardPosition={leaderboardPosition}
                       portfolioSummary={portfolioData?.summary ?? null}
@@ -261,6 +342,20 @@ const OndoCampaignDetailsView: React.FC = () => {
                         hasError: hasPortfolioError,
                         refetch: refetchPortfolio,
                       }}
+                      showHeader={false}
+                      tierMinDeposit={tierMinDeposit}
+                      onQualifyPress={
+                        leaderboardPendingSheetPosition
+                          ? () =>
+                              navigation.navigate(
+                                Routes.MODAL.REWARDS_ONDO_PENDING_SHEET,
+                                {
+                                  variant: 'own',
+                                  ...leaderboardPendingSheetPosition,
+                                },
+                              )
+                          : undefined
+                      }
                     />
                   </Box>
                 </>
@@ -281,7 +376,7 @@ const OndoCampaignDetailsView: React.FC = () => {
                         )}
                       </Text>
                       <TextButton
-                        variant={TextVariant.BodyMd}
+                        variant={TextVariant.ButtonLabelMd}
                         onPress={() =>
                           navigation.navigate(
                             Routes.REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW,
@@ -304,9 +399,30 @@ const OndoCampaignDetailsView: React.FC = () => {
                       isCampaignComplete={
                         getCampaignStatus(campaign) === 'complete'
                       }
+                      notEligibleForCampaign={notEligibleForCampaign}
+                      onNotEligible={handlePortfolioNotEligible}
                     />
                   </Box>
                 </>
+              )}
+
+              {(getCampaignStatus(campaign) === 'active' ||
+                showLeaderboardSection) && (
+                <Box twClassName="my-5 border-b border-border-muted" />
+              )}
+
+              {getCampaignStatus(campaign) === 'active' && (
+                <Box twClassName="p-4">
+                  <Text variant={TextVariant.HeadingMd} twClassName="mb-1">
+                    {strings('rewards.ondo_campaign_prize_pool.title')}
+                  </Text>
+                  <OndoPrizePool
+                    totalUsdDeposited={deposits?.totalUsdDeposited ?? null}
+                    isLoading={isDepositsLoading}
+                    hasError={hasDepositsError}
+                    refetch={refetchDeposits}
+                  />
+                </Box>
               )}
 
               {showLeaderboardSection && (
@@ -328,7 +444,11 @@ const OndoCampaignDetailsView: React.FC = () => {
                         <Text variant={TextVariant.HeadingMd}>
                           {strings('rewards.ondo_campaign_leaderboard.title')}
                         </Text>
-                        <Icon name={IconName.ArrowRight} size={IconSize.Md} />
+                        <Icon
+                          name={IconName.ArrowRight}
+                          size={IconSize.Md}
+                          color={IconColor.IconAlternative}
+                        />
                       </Box>
                     </Pressable>
                     <OndoLeaderboard
@@ -345,15 +465,8 @@ const OndoCampaignDetailsView: React.FC = () => {
                       onRetry={refetchLeaderboard}
                       maxEntries={5}
                       currentUserReferralCode={referralCode}
-                      userPosition={
-                        leaderboardPosition
-                          ? {
-                              projectedTier: leaderboardPosition.projectedTier,
-                              rank: leaderboardPosition.rank,
-                              neighbors: leaderboardPosition.neighbors,
-                            }
-                          : null
-                      }
+                      userPosition={leaderboardUserPosition}
+                      pendingSheetPosition={leaderboardPendingSheetPosition}
                     />
                   </Box>
                 </>
@@ -371,6 +484,7 @@ const OndoCampaignDetailsView: React.FC = () => {
             }}
             hasPositions={hasPositions}
             campaignId={campaignId}
+            notEligibleForCampaign={notEligibleForCampaign}
           />
         )}
 
@@ -380,6 +494,21 @@ const OndoCampaignDetailsView: React.FC = () => {
             sheetRef={sheetRef}
             onClose={() => setPendingPicker(null)}
             onGroupSelect={handleGroupSelect}
+          />
+        )}
+
+        {portfolioNotEligibleAction && (
+          <OndoNotEligibleSheet
+            onClose={() => {
+              setPortfolioNotEligibleAction(null);
+              portfolioNotEligibleActionRef.current = null;
+            }}
+            onConfirm={() => {
+              const action = portfolioNotEligibleActionRef.current;
+              portfolioNotEligibleActionRef.current = null;
+              setPortfolioNotEligibleAction(null);
+              action?.();
+            }}
           />
         )}
       </SafeAreaView>

--- a/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignPortfolioView.tsx
@@ -175,6 +175,7 @@ const OndoCampaignPortfolioView: React.FC = () => {
       >
         <HeaderCompactStandard
           title={strings('rewards.ondo_campaign_portfolio.activity_title')}
+          titleProps={{ variant: TextVariant.HeadingSm }}
           onBack={() => navigation.goBack()}
           backButtonProps={{ testID: 'campaign-portfolio-back-button' }}
           includesTopInset

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -80,6 +80,13 @@ jest.mock('../../Bridge/hooks/useSwapBridgeNavigation', () => ({
   SwapBridgeNavigationLocation: { Rewards: 'Rewards' },
 }));
 
+jest.mock('../../Bridge/hooks/useRWAToken', () => ({
+  useRWAToken: () => ({
+    isStockToken: jest.fn(() => false),
+    isTokenTradingOpen: jest.fn(() => true),
+  }),
+}));
+
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -20,7 +20,6 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
-  FontWeight,
   Icon,
   IconColor,
   IconName,
@@ -50,9 +49,11 @@ import {
   SwapBridgeNavigationLocation,
 } from '../../Bridge/hooks/useSwapBridgeNavigation';
 import type { BridgeToken } from '../../Bridge/types';
+import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
 import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet';
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
+import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -93,6 +94,12 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   } = route.params;
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [isAfterHoursSheetOpen, setIsAfterHoursSheetOpen] = useState(false);
+  const [afterHoursNextOpen, setAfterHoursNextOpen] = useState<Date | null>(
+    null,
+  );
+  const [afterHoursPendingToken, setAfterHoursPendingToken] =
+    useState<BridgeToken | null>(null);
 
   // Build the source BridgeToken from route params (swap mode only)
   const srcBridgeToken = useMemo((): BridgeToken | undefined => {
@@ -152,6 +159,8 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
 
   const showSkeleton = isLoading || isFiltering;
 
+  const { isTokenTradingOpen } = useRWAToken();
+
   const { goToSwaps } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.Rewards,
     sourcePage: 'OndoCampaignRwaSelector',
@@ -183,9 +192,20 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
         rwaData: asset.rwaData as BridgeToken['rwaData'],
       };
 
+      if (!isTokenTradingOpen(destToken)) {
+        const rawNextOpen = destToken.rwaData?.market?.nextOpen;
+        const nextOpenDate = rawNextOpen ? new Date(String(rawNextOpen)) : null;
+        setAfterHoursNextOpen(
+          nextOpenDate && !isNaN(nextOpenDate.getTime()) ? nextOpenDate : null,
+        );
+        setAfterHoursPendingToken(destToken);
+        setIsAfterHoursSheetOpen(true);
+        return;
+      }
+
       goToSwaps(undefined, destToken);
     },
-    [goToSwaps],
+    [goToSwaps, isTokenTradingOpen],
   );
 
   const title =
@@ -195,7 +215,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
         alignItems={BoxAlignItems.Center}
         twClassName="gap-2"
       >
-        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('rewards.ondo_rwa_asset_selector.title_swap_prefix')}
         </Text>
         <BadgeWrapper
@@ -217,9 +237,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
             size={28}
           />
         </BadgeWrapper>
-        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
-          {srcTokenSymbol}
-        </Text>
+        <Text variant={TextVariant.HeadingSm}>{srcTokenSymbol}</Text>
       </Box>
     ) : (
       strings('rewards.ondo_rwa_asset_selector.title_open_position')
@@ -316,6 +334,24 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
             showsVerticalScrollIndicator={false}
             contentContainerStyle={tw.style('pt-2 pb-4')}
             ListEmptyComponent={renderEmpty}
+          />
+        )}
+        {isAfterHoursSheetOpen && (
+          <OndoAfterHoursSheet
+            onClose={() => {
+              setIsAfterHoursSheetOpen(false);
+              setAfterHoursNextOpen(null);
+              setAfterHoursPendingToken(null);
+            }}
+            onConfirm={() => {
+              setIsAfterHoursSheetOpen(false);
+              setAfterHoursNextOpen(null);
+              if (afterHoursPendingToken) {
+                goToSwaps(undefined, afterHoursPendingToken);
+              }
+              setAfterHoursPendingToken(null);
+            }}
+            nextOpenAt={afterHoursNextOpen}
           />
         )}
       </SafeAreaView>

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -1,0 +1,525 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OndoCampaignStatsView, {
+  ONDO_CAMPAIGN_STATS_VIEW_TEST_IDS,
+} from './OndoCampaignStatsView';
+import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
+import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
+import type {
+  CampaignDto,
+  CampaignLeaderboardPositionDto,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+  useRoute: () => ({ params: { campaignId: 'campaign-ondo-123' } }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('react-native-safe-area-context');
+  return {
+    ...actual,
+    useSafeAreaInsets: jest.fn(() => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    })),
+    SafeAreaView: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children: React.ReactNode;
+      testID?: string;
+    }) => ReactActual.createElement(View, { ...props, testID }, children),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return { ...actual };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock(
+  '../../../../component-library/components-temp/HeaderCompactStandard',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { View, Text, Pressable } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        title,
+        onBack,
+        backButtonProps,
+      }: {
+        title: string;
+        onBack: () => void;
+        backButtonProps?: { testID?: string };
+      }) =>
+        ReactActual.createElement(
+          View,
+          { testID: 'header' },
+          ReactActual.createElement(Text, null, title),
+          ReactActual.createElement(Pressable, {
+            onPress: onBack,
+            testID: backButtonProps?.testID ?? 'header-back-button',
+          }),
+        ),
+    };
+  },
+);
+
+jest.mock('../../../Views/ErrorBoundary', () => {
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  };
+});
+
+jest.mock('../components/RewardsErrorBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      title,
+      onConfirm,
+      confirmButtonLabel,
+    }: {
+      title: string;
+      description?: string;
+      onConfirm?: () => void;
+      confirmButtonLabel?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'error-banner' },
+        ReactActual.createElement(Text, null, title),
+        confirmButtonLabel &&
+          ReactActual.createElement(Pressable, {
+            onPress: onConfirm,
+            testID: 'error-retry-button',
+          }),
+      ),
+  };
+});
+
+jest.mock('../components/Campaigns/OndoLeaderboard.utils', () => ({
+  formatTierDisplayName: (tier: string) => tier,
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: Record<string, unknown>) => {
+    if (params) return `${key}:${JSON.stringify(params)}`;
+    return key;
+  },
+}));
+
+jest.mock('../utils/formatUtils', () => ({
+  formatPercentChange: (value: number) => `${(value * 100).toFixed(2)}%`,
+  formatUsd: (value: number | string) =>
+    `$${Number(value).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`,
+}));
+
+jest.mock('../components/Campaigns/CampaignTile.utils');
+jest.mock('../hooks/useRewardCampaigns');
+jest.mock('../hooks/useGetCampaignParticipantStatus');
+jest.mock('../hooks/useGetOndoPortfolioPosition');
+jest.mock('../hooks/useGetOndoLeaderboardPosition');
+jest.mock('../hooks/useGetOndoLeaderboard');
+
+const mockGetCampaignStatus = getCampaignStatus as jest.MockedFunction<
+  typeof getCampaignStatus
+>;
+const mockUseRewardCampaigns = useRewardCampaigns as jest.MockedFunction<
+  typeof useRewardCampaigns
+>;
+const mockUseGetCampaignParticipantStatus =
+  useGetCampaignParticipantStatus as jest.MockedFunction<
+    typeof useGetCampaignParticipantStatus
+  >;
+const mockUseGetOndoPortfolioPosition =
+  useGetOndoPortfolioPosition as jest.MockedFunction<
+    typeof useGetOndoPortfolioPosition
+  >;
+const mockUseGetOndoLeaderboardPosition =
+  useGetOndoLeaderboardPosition as jest.MockedFunction<
+    typeof useGetOndoLeaderboardPosition
+  >;
+const mockUseGetOndoLeaderboard = useGetOndoLeaderboard as jest.MockedFunction<
+  typeof useGetOndoLeaderboard
+>;
+
+const mockRefetch = jest.fn();
+
+const leaderboardDefaults = {
+  leaderboard: null,
+  isLoading: false,
+  hasError: false,
+  isLeaderboardNotYetComputed: false,
+  tierNames: [],
+  selectedTier: null,
+  selectedTierData: null,
+  computedAt: null,
+  setSelectedTier: jest.fn(),
+  refetch: mockRefetch,
+};
+
+const positionDefaults = {
+  position: null as CampaignLeaderboardPositionDto | null,
+  isLoading: false,
+  hasError: false,
+  hasFetched: false,
+  refetch: mockRefetch,
+};
+
+const portfolioDefaults = {
+  portfolio: null,
+  isLoading: false,
+  hasError: false,
+  hasFetched: false,
+  refetch: mockRefetch,
+};
+
+const createTestCampaign = (
+  overrides: Partial<CampaignDto> = {},
+): CampaignDto => {
+  const now = new Date();
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const nextMonth = new Date(now);
+  nextMonth.setMonth(nextMonth.getMonth() + 1);
+  return {
+    id: 'campaign-ondo-123',
+    name: 'Test Campaign',
+    startDate: yesterday.toISOString(),
+    endDate: nextMonth.toISOString(),
+    termsAndConditions: null,
+    excludedRegions: [],
+    details: null,
+    featured: true,
+    type: 'ONDO_HOLDING' as never,
+    ...overrides,
+  };
+};
+
+const makePendingPosition = (
+  overrides: Partial<CampaignLeaderboardPositionDto> = {},
+): CampaignLeaderboardPositionDto => ({
+  rank: 8,
+  projectedTier: 'STARTER',
+  qualified: false,
+  qualifiedDays: 3,
+  totalInTier: 100,
+  rateOfReturn: 0.05,
+  currentUsdValue: 5000,
+  totalUsdDeposited: 4000,
+  netDeposit: 3500,
+  neighbors: [],
+  computedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const makeQualifiedPosition = (
+  overrides: Partial<CampaignLeaderboardPositionDto> = {},
+): CampaignLeaderboardPositionDto => ({
+  rank: 3,
+  projectedTier: 'MID',
+  qualified: true,
+  qualifiedDays: 10,
+  totalInTier: 100,
+  rateOfReturn: 0.12,
+  currentUsdValue: 15000,
+  totalUsdDeposited: 12000,
+  netDeposit: 11000,
+  neighbors: [],
+  computedAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('OndoCampaignStatsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCampaignStatus.mockReturnValue('active');
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasLoaded: false,
+      hasError: false,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: null,
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoPortfolioPosition.mockReturnValue(portfolioDefaults);
+    mockUseGetOndoLeaderboardPosition.mockReturnValue(positionDefaults);
+    mockUseGetOndoLeaderboard.mockReturnValue(leaderboardDefaults);
+  });
+
+  it('renders with the correct container testID', () => {
+    const { getByTestId } = render(<OndoCampaignStatsView />);
+    expect(
+      getByTestId(ONDO_CAMPAIGN_STATS_VIEW_TEST_IDS.CONTAINER),
+    ).toBeDefined();
+  });
+
+  it('navigates back when the back button is pressed', () => {
+    const { getByTestId } = render(<OndoCampaignStatsView />);
+    fireEvent.press(getByTestId('ondo-campaign-stats-back-button'));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows dash placeholders when no position data is available', () => {
+    const { getAllByText } = render(<OndoCampaignStatsView />);
+    expect(getAllByText('-').length).toBeGreaterThan(0);
+  });
+
+  it('shows formatted return value when position is available', () => {
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makeQualifiedPosition({ rateOfReturn: 0.15 }),
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(getByText('15.00%')).toBeDefined();
+  });
+
+  it('shows negative return with error color class when rate of return is negative', () => {
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makePendingPosition({ rateOfReturn: -0.03 }),
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(getByText('-3.00%')).toBeDefined();
+  });
+
+  it('shows market value from portfolio summary', () => {
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: {
+        positions: [],
+        summary: {
+          totalCurrentValue: '12000',
+          totalBookValue: '11000',
+          totalUsdDeposited: '11000',
+          netDeposit: '10500',
+          totalCashedOut: '0',
+          portfolioPnl: '1000',
+          portfolioPnlPercent: '0.09',
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(getByText('$12,000.00')).toBeDefined();
+  });
+
+  it('shows pending tag when position is not qualified', () => {
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makePendingPosition(),
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(
+      getByText('rewards.ondo_campaign_leaderboard.pending'),
+    ).toBeDefined();
+  });
+
+  it('shows qualified tag when position is qualified', () => {
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makeQualifiedPosition(),
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(
+      getByText('rewards.ondo_campaign_leaderboard.qualified'),
+    ).toBeDefined();
+  });
+
+  it('shows error banner when leaderboard fails with no cached data', () => {
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: null,
+      hasError: true,
+    });
+    const { getByTestId } = render(<OndoCampaignStatsView />);
+    expect(getByTestId('error-banner')).toBeDefined();
+  });
+
+  it('shows error banner when portfolio fails with no cached data', () => {
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: null,
+      hasError: true,
+    });
+    const { getByTestId } = render(<OndoCampaignStatsView />);
+    expect(getByTestId('error-banner')).toBeDefined();
+  });
+
+  it('calls both refetch functions when retry is pressed on error banner', () => {
+    const refetchPosition = jest.fn();
+    const refetchPortfolio = jest.fn();
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: null,
+      hasError: true,
+      refetch: refetchPosition,
+    });
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: null,
+      hasError: true,
+      refetch: refetchPortfolio,
+    });
+    const { getByTestId } = render(<OndoCampaignStatsView />);
+    fireEvent.press(getByTestId('error-retry-button'));
+    expect(refetchPosition).toHaveBeenCalledTimes(1);
+    expect(refetchPortfolio).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows qualify card when campaign is active, position is pending, and tierMinDeposit is set', () => {
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [createTestCampaign()],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasLoaded: true,
+      hasError: false,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: { optedIn: true, participantCount: 1 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makePendingPosition({
+        projectedTier: 'STARTER',
+        qualifiedDays: 3,
+      }),
+    });
+    mockUseGetOndoLeaderboard.mockReturnValue({
+      ...leaderboardDefaults,
+      leaderboard: {
+        tiers: {
+          STARTER: {
+            minDeposit: 500,
+            entries: [],
+            totalParticipants: 100,
+          },
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(
+      getByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    ).toBeDefined();
+  });
+
+  it('navigates to pending sheet when qualify card is pressed', () => {
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [createTestCampaign()],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasLoaded: true,
+      hasError: false,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: { optedIn: true, participantCount: 1 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makePendingPosition({
+        projectedTier: 'STARTER',
+        qualifiedDays: 3,
+      }),
+    });
+    mockUseGetOndoLeaderboard.mockReturnValue({
+      ...leaderboardDefaults,
+      leaderboard: {
+        tiers: {
+          STARTER: {
+            minDeposit: 500,
+            entries: [],
+            totalParticipants: 100,
+          },
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    fireEvent.press(
+      getByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'RewardsOndoPendingSheet',
+      expect.objectContaining({ variant: 'own', tier: 'STARTER' }),
+    );
+  });
+
+  it('shows qualified card when position is qualified and tierMinDeposit is set', () => {
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [createTestCampaign()],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasLoaded: true,
+      hasError: false,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: { optedIn: true, participantCount: 1 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makeQualifiedPosition({ projectedTier: 'MID' }),
+    });
+    mockUseGetOndoLeaderboard.mockReturnValue({
+      ...leaderboardDefaults,
+      leaderboard: {
+        tiers: {
+          MID: {
+            minDeposit: 1000,
+            entries: [],
+            totalParticipants: 50,
+          },
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(
+      getByText('rewards.ondo_campaign_stats.qualified_title'),
+    ).toBeDefined();
+  });
+});

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -140,6 +140,20 @@ jest.mock('../utils/formatUtils', () => ({
     })}`,
 }));
 
+// Mock Engine to prevent @metamask/social-controllers resolution chain
+jest.mock('../../../../core/Engine/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: { setSelectedAccountGroup: jest.fn() },
+    },
+    controllerMessenger: {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    },
+  },
+}));
+
 jest.mock('../components/Campaigns/CampaignTile.utils');
 jest.mock('../hooks/useRewardCampaigns');
 jest.mock('../hooks/useGetCampaignParticipantStatus');
@@ -524,5 +538,45 @@ describe('OndoCampaignStatsView', () => {
     expect(
       getByText('rewards.ondo_campaign_stats.qualified_title'),
     ).toBeDefined();
+  });
+
+  it('hides qualified card when campaign is complete even if position is qualified', () => {
+    mockGetCampaignStatus.mockReturnValue('complete');
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [createTestCampaign()],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasLoaded: true,
+      hasError: false,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: { optedIn: true, participantCount: 1 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetOndoLeaderboardPosition.mockReturnValue({
+      ...positionDefaults,
+      position: makeQualifiedPosition({ projectedTier: 'MID' }),
+    });
+    mockUseGetOndoLeaderboard.mockReturnValue({
+      ...leaderboardDefaults,
+      leaderboard: {
+        campaignId: 'campaign-ondo-123',
+        tiers: {
+          MID: {
+            minDeposit: 1000,
+            entries: [],
+            totalParticipants: 50,
+          },
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { queryByText } = render(<OndoCampaignStatsView />);
+    expect(
+      queryByText('rewards.ondo_campaign_stats.qualified_title'),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -424,6 +424,7 @@ describe('OndoCampaignStatsView', () => {
     mockUseGetOndoLeaderboard.mockReturnValue({
       ...leaderboardDefaults,
       leaderboard: {
+        campaignId: 'campaign-ondo-123',
         tiers: {
           STARTER: {
             minDeposit: 500,
@@ -465,6 +466,7 @@ describe('OndoCampaignStatsView', () => {
     mockUseGetOndoLeaderboard.mockReturnValue({
       ...leaderboardDefaults,
       leaderboard: {
+        campaignId: 'campaign-ondo-123',
         tiers: {
           STARTER: {
             minDeposit: 500,
@@ -507,6 +509,7 @@ describe('OndoCampaignStatsView', () => {
     mockUseGetOndoLeaderboard.mockReturnValue({
       ...leaderboardDefaults,
       leaderboard: {
+        campaignId: 'campaign-ondo-123',
         tiers: {
           MID: {
             minDeposit: 1000,

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -1,0 +1,395 @@
+import React, { useMemo } from 'react';
+import { Pressable, ScrollView } from 'react-native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Skeleton,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
+import ErrorBoundary from '../../../Views/ErrorBoundary';
+import {
+  StatCell,
+  PendingTag,
+  QualifiedTag,
+} from '../components/Campaigns/CampaignStatsSummary';
+import RewardsErrorBanner from '../components/RewardsErrorBanner';
+import { formatTierDisplayName } from '../components/Campaigns/OndoLeaderboard.utils';
+import { strings } from '../../../../../locales/i18n';
+import { formatPercentChange, formatUsd } from '../utils/formatUtils';
+import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../utils/ondoCampaignConstants';
+import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
+import { useGetOndoPortfolioPosition } from '../hooks/useGetOndoPortfolioPosition';
+import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
+import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
+import Routes from '../../../../constants/navigation/Routes';
+
+// ParamListBase requires an index signature, which interfaces don't support
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type OndoCampaignStatsRouteParams = {
+  OndoCampaignStats: { campaignId: string };
+};
+
+export const ONDO_CAMPAIGN_STATS_VIEW_TEST_IDS = {
+  CONTAINER: 'ondo-campaign-stats-view-container',
+} as const;
+
+const CheckIcon: React.FC = () => (
+  <Icon
+    name={IconName.Check}
+    size={IconSize.Sm}
+    color={IconColor.SuccessDefault}
+  />
+);
+
+const OndoCampaignStatsView: React.FC = () => {
+  const tw = useTailwind();
+  const navigation = useNavigation();
+  const route =
+    useRoute<RouteProp<OndoCampaignStatsRouteParams, 'OndoCampaignStats'>>();
+  const { campaignId } = route.params;
+
+  const { campaigns } = useRewardCampaigns();
+  const campaign = useMemo(
+    () => campaigns.find((c) => c.id === campaignId) ?? null,
+    [campaigns, campaignId],
+  );
+  const isCampaignActive =
+    campaign != null && getCampaignStatus(campaign) === 'active';
+
+  const { status: participantStatusData } =
+    useGetCampaignParticipantStatus(campaignId);
+  const isOptedIn = participantStatusData?.optedIn === true;
+
+  const {
+    portfolio: portfolioData,
+    isLoading: isPortfolioLoading,
+    hasError: hasPortfolioError,
+    refetch: refetchPortfolio,
+  } = useGetOndoPortfolioPosition(isOptedIn ? campaignId : undefined);
+
+  const {
+    position: leaderboardPosition,
+    isLoading: isLeaderboardPositionLoading,
+    hasError: hasLeaderboardPositionError,
+    refetch: refetchLeaderboardPosition,
+  } = useGetOndoLeaderboardPosition(isOptedIn ? campaignId : undefined);
+
+  const { leaderboard: leaderboardData } = useGetOndoLeaderboard(campaignId, {
+    defaultTier: leaderboardPosition?.projectedTier,
+  });
+
+  const leaderboardLoading =
+    isLeaderboardPositionLoading && !leaderboardPosition;
+  const portfolioLoading = isPortfolioLoading && !portfolioData;
+
+  const leaderboardError = hasLeaderboardPositionError && !leaderboardPosition;
+  const portfolioError = hasPortfolioError && !portfolioData;
+
+  const isPending =
+    leaderboardPosition != null && !leaderboardPosition.qualified;
+  const isQualified =
+    leaderboardPosition != null && leaderboardPosition.qualified;
+
+  const isNegativeReturn = (leaderboardPosition?.rateOfReturn ?? 0) < 0;
+
+  const returnValue = leaderboardPosition
+    ? formatPercentChange(leaderboardPosition.rateOfReturn)
+    : '-';
+
+  const returnColor = isNegativeReturn
+    ? TextColor.ErrorDefault
+    : TextColor.SuccessDefault;
+
+  const marketValue = portfolioData?.summary
+    ? formatUsd(portfolioData.summary.totalCurrentValue)
+    : '-';
+
+  const netDepositedValue = portfolioData?.summary
+    ? formatUsd(portfolioData.summary.netDeposit)
+    : '-';
+
+  const cashedOutValue = portfolioData?.summary
+    ? formatUsd(portfolioData.summary.totalCashedOut)
+    : '-';
+
+  const rankValue = leaderboardPosition ? `${leaderboardPosition.rank}` : '-';
+
+  const tierValue = leaderboardPosition
+    ? formatTierDisplayName(leaderboardPosition.projectedTier)
+    : '-';
+
+  const netDepositValue = leaderboardPosition
+    ? formatUsd(leaderboardPosition.netDeposit)
+    : '-';
+
+  const daysHeldValue = leaderboardPosition
+    ? `${leaderboardPosition.qualifiedDays}/${ONDO_GM_REQUIRED_QUALIFIED_DAYS}`
+    : '-';
+
+  const daysRemaining = leaderboardPosition
+    ? Math.max(
+        ONDO_GM_REQUIRED_QUALIFIED_DAYS - leaderboardPosition.qualifiedDays,
+        0,
+      )
+    : 0;
+
+  const tierMinDeposit = useMemo(
+    () =>
+      leaderboardPosition && leaderboardData
+        ? (leaderboardData.tiers[leaderboardPosition.projectedTier]
+            ?.minDeposit ?? null)
+        : null,
+    [leaderboardData, leaderboardPosition],
+  );
+
+  const showQualifyCard =
+    isCampaignActive &&
+    isPending &&
+    daysRemaining > 0 &&
+    tierMinDeposit != null;
+
+  return (
+    <ErrorBoundary navigation={navigation} view="OndoCampaignStatsView">
+      <SafeAreaView
+        edges={{ bottom: 'additive' }}
+        style={tw.style('flex-1 bg-default')}
+        testID={ONDO_CAMPAIGN_STATS_VIEW_TEST_IDS.CONTAINER}
+      >
+        <HeaderCompactStandard
+          title={strings('rewards.ondo_campaign_stats.title')}
+          titleProps={{ variant: TextVariant.HeadingSm }}
+          onBack={() => navigation.goBack()}
+          backButtonProps={{ testID: 'ondo-campaign-stats-back-button' }}
+          includesTopInset
+        />
+
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={tw.style('pb-4')}
+        >
+          <Box twClassName="p-4 gap-3">
+            {/* ── Top section: return + market values ── */}
+            <Box>
+              <Text variant={TextVariant.HeadingMd}>
+                {strings('rewards.ondo_campaign_stats.label_your_return')}
+              </Text>
+
+              {leaderboardLoading ? (
+                <Skeleton style={tw.style('h-9 w-28 rounded')} />
+              ) : (
+                <Text
+                  variant={TextVariant.DisplayLg}
+                  fontWeight={FontWeight.Bold}
+                  color={returnColor}
+                >
+                  {returnValue}
+                </Text>
+              )}
+            </Box>
+
+            {isNegativeReturn ? (
+              <>
+                <Box flexDirection={BoxFlexDirection.Row}>
+                  <StatCell
+                    label={strings(
+                      'rewards.ondo_campaign_stats.label_market_value',
+                    )}
+                    value={marketValue}
+                    isLoading={portfolioLoading}
+                    valueColor={TextColor.ErrorDefault}
+                  />
+                  <StatCell
+                    label={strings(
+                      'rewards.ondo_campaign_stats.label_net_deposited',
+                    )}
+                    value={netDepositedValue}
+                    isLoading={portfolioLoading}
+                  />
+                </Box>
+                <Box flexDirection={BoxFlexDirection.Row}>
+                  <StatCell
+                    label={strings(
+                      'rewards.ondo_campaign_stats.label_cashed_out',
+                    )}
+                    value={cashedOutValue}
+                    isLoading={portfolioLoading}
+                  />
+                  <Box twClassName="flex-1" />
+                </Box>
+              </>
+            ) : (
+              <Box flexDirection={BoxFlexDirection.Row}>
+                <StatCell
+                  label={strings(
+                    'rewards.ondo_campaign_stats.label_market_value',
+                  )}
+                  value={marketValue}
+                  isLoading={portfolioLoading}
+                  valueColor={TextColor.SuccessDefault}
+                />
+                <Box twClassName="flex-1" />
+              </Box>
+            )}
+
+            {/* ── Divider ── */}
+            <Box twClassName="my-5 border-b border-border-muted" />
+
+            {/* ── Rank section heading ── */}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName="gap-2"
+            >
+              <Text variant={TextVariant.HeadingMd}>
+                {strings('rewards.ondo_campaign_stats.label_your_rank')}
+              </Text>
+              {isPending && <PendingTag />}
+              {isQualified && <QualifiedTag />}
+            </Box>
+
+            {/* Rank | Tier */}
+            <Box flexDirection={BoxFlexDirection.Row}>
+              <StatCell
+                label={strings('rewards.ondo_campaign_stats.label_rank')}
+                value={rankValue}
+                isLoading={leaderboardLoading}
+              />
+              <StatCell
+                label={strings('rewards.ondo_campaign_stats.label_tier')}
+                value={tierValue}
+                isLoading={leaderboardLoading}
+              />
+            </Box>
+
+            {/* Net deposit | Days held */}
+            <Box flexDirection={BoxFlexDirection.Row}>
+              <StatCell
+                label={strings('rewards.ondo_campaign_stats.label_net_deposit')}
+                value={netDepositValue}
+                isLoading={leaderboardLoading}
+                suffix={isQualified ? <CheckIcon /> : undefined}
+              />
+              <StatCell
+                label={strings('rewards.ondo_campaign_stats.label_days_held')}
+                value={daysHeldValue}
+                isLoading={leaderboardLoading}
+                valueColor={
+                  leaderboardPosition &&
+                  leaderboardPosition.qualifiedDays <
+                    ONDO_GM_REQUIRED_QUALIFIED_DAYS
+                    ? TextColor.WarningDefault
+                    : TextColor.TextDefault
+                }
+                suffix={isQualified ? <CheckIcon /> : undefined}
+              />
+            </Box>
+
+            {/* ── Qualify for this rank card ── */}
+            {showQualifyCard && (
+              <Pressable
+                onPress={() => {
+                  if (!leaderboardPosition || tierMinDeposit == null) return;
+                  navigation.navigate(Routes.MODAL.REWARDS_ONDO_PENDING_SHEET, {
+                    variant: 'own',
+                    tier: leaderboardPosition.projectedTier,
+                    netDeposit: leaderboardPosition.netDeposit,
+                    qualifiedDays: leaderboardPosition.qualifiedDays,
+                    tierMinDeposit,
+                  });
+                }}
+              >
+                <Box twClassName="bg-muted rounded-xl p-4 mt-2 gap-2">
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={2}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {strings(
+                        'rewards.ondo_campaign_leaderboard.qualify_for_rank_title',
+                      )}
+                    </Text>
+                    <Icon
+                      name={IconName.ArrowRight}
+                      size={IconSize.Sm}
+                      color={IconColor.IconAlternative}
+                    />
+                  </Box>
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings(
+                      'rewards.ondo_campaign_leaderboard.qualify_for_rank_description',
+                      {
+                        minDeposit: formatUsd(tierMinDeposit ?? 0),
+                        daysRemaining,
+                      },
+                    )}
+                  </Text>
+                </Box>
+              </Pressable>
+            )}
+
+            {/* ── You're qualified card ── */}
+            {isQualified && tierMinDeposit != null && (
+              <Box twClassName="bg-muted rounded-xl p-4 mt-2 gap-2">
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {strings('rewards.ondo_campaign_stats.qualified_title')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {strings(
+                    'rewards.ondo_campaign_stats.qualified_description',
+                    { minDeposit: formatUsd(tierMinDeposit) },
+                  )}
+                </Text>
+              </Box>
+            )}
+
+            {/* ── Error banner ── */}
+            {(leaderboardError || portfolioError) && (
+              <RewardsErrorBanner
+                title={strings('rewards.ondo_campaign_stats.stats_error_title')}
+                description={strings(
+                  'rewards.ondo_campaign_stats.stats_error_description',
+                )}
+                onConfirm={() => {
+                  refetchLeaderboardPosition();
+                  refetchPortfolio();
+                }}
+                confirmButtonLabel={strings(
+                  'rewards.ondo_campaign_stats.retry',
+                )}
+              />
+            )}
+          </Box>
+        </ScrollView>
+      </SafeAreaView>
+    </ErrorBoundary>
+  );
+};
+
+export default OndoCampaignStatsView;

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -149,11 +149,11 @@ const OndoCampaignStatsView: React.FC = () => {
 
   const tierMinDeposit = useMemo(
     () =>
-      leaderboardPosition && leaderboardData
+      leaderboardPosition && leaderboardData && isCampaignActive
         ? (leaderboardData.tiers[leaderboardPosition.projectedTier]
             ?.minDeposit ?? null)
         : null,
-    [leaderboardData, leaderboardPosition],
+    [leaderboardData, leaderboardPosition, isCampaignActive],
   );
 
   const showQualifyCard =

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
@@ -5,6 +5,7 @@ import OndoLeaderboardView, {
 } from './OndoLeaderboardView';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 
 const mockGoBack = jest.fn();
 
@@ -53,6 +54,7 @@ jest.mock(
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => null),
+  useDispatch: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('../../../Views/ErrorBoundary', () => {
@@ -86,6 +88,7 @@ jest.mock('../components/Campaigns/OndoLeaderboard.utils', () => ({
 
 jest.mock('../hooks/useGetOndoLeaderboard');
 jest.mock('../hooks/useGetOndoLeaderboardPosition');
+jest.mock('../hooks/useGetCampaignParticipantStatus');
 
 const mockUseGetOndoLeaderboard = useGetOndoLeaderboard as jest.MockedFunction<
   typeof useGetOndoLeaderboard
@@ -93,6 +96,10 @@ const mockUseGetOndoLeaderboard = useGetOndoLeaderboard as jest.MockedFunction<
 const mockUseGetOndoLeaderboardPosition =
   useGetOndoLeaderboardPosition as jest.MockedFunction<
     typeof useGetOndoLeaderboardPosition
+  >;
+const mockUseGetCampaignParticipantStatus =
+  useGetCampaignParticipantStatus as jest.MockedFunction<
+    typeof useGetCampaignParticipantStatus
   >;
 
 const hookDefaults = {
@@ -123,6 +130,12 @@ describe('OndoLeaderboardView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: null,
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
     mockUseGetOndoLeaderboard.mockReturnValue(hookDefaults);
     mockUseGetOndoLeaderboardPosition.mockReturnValue(positionDefaults);
   });
@@ -167,11 +180,22 @@ describe('OndoLeaderboardView', () => {
     );
   });
 
-  it('calls useGetOndoLeaderboardPosition with the campaign ID from route params', () => {
+  it('calls useGetOndoLeaderboardPosition with the campaign ID when opted in', () => {
+    mockUseGetCampaignParticipantStatus.mockReturnValue({
+      status: { optedIn: true, participantCount: 1 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
     render(<OndoLeaderboardView />);
     expect(mockUseGetOndoLeaderboardPosition).toHaveBeenCalledWith(
       'campaign-ondo-123',
     );
+  });
+
+  it('calls useGetOndoLeaderboardPosition with undefined when not opted in', () => {
+    render(<OndoLeaderboardView />);
+    expect(mockUseGetOndoLeaderboardPosition).toHaveBeenCalledWith(undefined);
   });
 
   it('navigates back when the back button is pressed', () => {
@@ -288,5 +312,134 @@ describe('OndoLeaderboardView', () => {
       'campaign-ondo-123',
       expect.objectContaining({ defaultTier: 'MID' }),
     );
+  });
+
+  describe('pendingSheetPosition', () => {
+    it('passes pendingSheetPosition to OndoLeaderboard when position is pending and tier has minDeposit', () => {
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: {
+          rank: 8,
+          projectedTier: 'STARTER',
+          qualified: false,
+          qualifiedDays: 3,
+          totalInTier: 100,
+          rateOfReturn: 0.05,
+          currentUsdValue: 5000,
+          totalUsdDeposited: 4000,
+          netDeposit: 3500,
+          neighbors: [],
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+      mockUseGetOndoLeaderboard.mockReturnValue({
+        ...hookDefaults,
+        leaderboard: {
+          tiers: {
+            STARTER: {
+              minDeposit: 500,
+              entries: [],
+              totalParticipants: 100,
+            },
+          },
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      render(<OndoLeaderboardView />);
+
+      expect(mockOndoLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pendingSheetPosition: {
+            tier: 'STARTER',
+            netDeposit: 3500,
+            qualifiedDays: 3,
+            tierMinDeposit: 500,
+          },
+        }),
+      );
+    });
+
+    it('passes pendingSheetPosition as null when position is qualified', () => {
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: {
+          rank: 3,
+          projectedTier: 'MID',
+          qualified: true,
+          qualifiedDays: 10,
+          totalInTier: 100,
+          rateOfReturn: 0.1,
+          currentUsdValue: 12500,
+          totalUsdDeposited: 10000,
+          netDeposit: 8500,
+          neighbors: [],
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+      mockUseGetOndoLeaderboard.mockReturnValue({
+        ...hookDefaults,
+        leaderboard: {
+          tiers: {
+            MID: { minDeposit: 1000, entries: [], totalParticipants: 50 },
+          },
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      render(<OndoLeaderboardView />);
+
+      expect(mockOndoLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({ pendingSheetPosition: null }),
+      );
+    });
+
+    it('passes pendingSheetPosition as null when leaderboard has no tier minDeposit', () => {
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: {
+          rank: 8,
+          projectedTier: 'STARTER',
+          qualified: false,
+          qualifiedDays: 3,
+          totalInTier: 100,
+          rateOfReturn: 0.05,
+          currentUsdValue: 5000,
+          totalUsdDeposited: 4000,
+          netDeposit: 3500,
+          neighbors: [],
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+      // leaderboard has no tiers data → minDeposit is null
+      mockUseGetOndoLeaderboard.mockReturnValue({
+        ...hookDefaults,
+        leaderboard: null,
+      });
+
+      render(<OndoLeaderboardView />);
+
+      expect(mockOndoLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({ pendingSheetPosition: null }),
+      );
+    });
   });
 });

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
@@ -109,7 +109,7 @@ const hookDefaults = {
   isLeaderboardNotYetComputed: false,
   tierNames: ['STARTER', 'MID'],
   selectedTier: 'STARTER',
-  selectedTierData: { entries: [], totalParticipants: 10 },
+  selectedTierData: { entries: [], totalParticipants: 10, minDeposit: 500 },
   computedAt: '2024-03-20T12:00:00.000Z',
   setSelectedTier: jest.fn(),
   refetch: jest.fn(),
@@ -341,6 +341,7 @@ describe('OndoLeaderboardView', () => {
       mockUseGetOndoLeaderboard.mockReturnValue({
         ...hookDefaults,
         leaderboard: {
+          campaignId: 'campaign-ondo-123',
           tiers: {
             STARTER: {
               minDeposit: 500,
@@ -392,6 +393,7 @@ describe('OndoLeaderboardView', () => {
       mockUseGetOndoLeaderboard.mockReturnValue({
         ...hookDefaults,
         leaderboard: {
+          campaignId: 'campaign-ondo-123',
           tiers: {
             MID: { minDeposit: 1000, entries: [], totalParticipants: 50 },
           },

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ScrollView } from 'react-native';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import {
@@ -21,6 +21,7 @@ import {
 import { formatTierDisplayName } from '../components/Campaigns/OndoLeaderboard.utils';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
+import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { strings } from '../../../../../locales/i18n';
 import { selectReferralCode } from '../../../../reducers/rewards/selectors';
 
@@ -42,13 +43,17 @@ const OndoLeaderboardView: React.FC = () => {
   const { campaignId } = route.params;
   const referralCode = useSelector(selectReferralCode);
 
+  const { status: participantStatus } =
+    useGetCampaignParticipantStatus(campaignId);
+  const isOptedIn = participantStatus?.optedIn === true;
+
   const { position, isLoading: isPositionLoading } =
-    useGetOndoLeaderboardPosition(campaignId);
+    useGetOndoLeaderboardPosition(isOptedIn ? campaignId : undefined);
 
   const isPending = position != null && !position.qualified;
   const isQualified = position != null && position.qualified;
-
   const {
+    leaderboard: leaderboardData,
     tierNames,
     selectedTier,
     selectedTierData,
@@ -61,6 +66,19 @@ const OndoLeaderboardView: React.FC = () => {
     defaultTier: position?.projectedTier,
   });
 
+  const pendingSheetPosition = useMemo(() => {
+    if (!position || position.qualified) return null;
+    const tierMinDeposit =
+      leaderboardData?.tiers[position.projectedTier]?.minDeposit ?? null;
+    if (tierMinDeposit == null) return null;
+    return {
+      tier: position.projectedTier,
+      netDeposit: position.netDeposit,
+      qualifiedDays: position.qualifiedDays,
+      tierMinDeposit,
+    };
+  }, [position, leaderboardData]);
+
   return (
     <ErrorBoundary navigation={navigation} view="OndoLeaderboardView">
       <SafeAreaView
@@ -70,6 +88,7 @@ const OndoLeaderboardView: React.FC = () => {
       >
         <HeaderCompactStandard
           title={strings('rewards.ondo_campaign_leaderboard.title')}
+          titleProps={{ variant: TextVariant.HeadingSm }}
           onBack={() => navigation.goBack()}
           backButtonProps={{ testID: 'ondo-leaderboard-back-button' }}
           includesTopInset
@@ -118,6 +137,7 @@ const OndoLeaderboardView: React.FC = () => {
               isLeaderboardNotYetComputed={isLeaderboardNotYetComputed}
               onRetry={refetchLeaderboard}
               currentUserReferralCode={referralCode}
+              pendingSheetPosition={pendingSheetPosition}
             />
           </Box>
         </ScrollView>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
@@ -11,7 +11,13 @@ import type {
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
-  return { ...actual };
+  const ReactActual = jest.requireActual('react');
+  const RN = jest.requireActual('react-native');
+  return {
+    ...actual,
+    Text: (props: Record<string, unknown>) =>
+      ReactActual.createElement(RN.Text, props, props.children),
+  };
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
@@ -56,6 +56,16 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.ondo_campaign_leaderboard.tier_upper': 'Platinum',
       'rewards.ondo_campaign_leaderboard.pending': 'Pending',
       'rewards.ondo_campaign_leaderboard.qualified': 'Qualified',
+      'rewards.ondo_campaign_stats.title': 'Stats',
+      'rewards.ondo_campaign_stats.stats_error_title':
+        'Unable to load all stats',
+      'rewards.ondo_campaign_stats.stats_error_description':
+        'We had a problem loading your stats. Please try again later.',
+      'rewards.ondo_campaign_stats.retry': 'Retry',
+      'rewards.ondo_campaign_stats.label_return': 'Return',
+      'rewards.ondo_campaign_stats.label_market_value': 'Market Value',
+      'rewards.ondo_campaign_stats.label_rank': 'Rank',
+      'rewards.ondo_campaign_stats.label_tier': 'Tier',
     };
     return t[key] ?? key;
   },
@@ -185,9 +195,16 @@ describe('CampaignStatsSummary', () => {
     ).toBe('-5.00%');
   });
 
-  it('renders Stats title', () => {
+  it('renders Stats title by default', () => {
     const { getByText } = render(<CampaignStatsSummary {...baseProps} />);
     expect(getByText('Stats')).toBeDefined();
+  });
+
+  it('hides Stats title when showHeader is false', () => {
+    const { queryByText } = render(
+      <CampaignStatsSummary {...baseProps} showHeader={false} />,
+    );
+    expect(queryByText('Stats')).toBeNull();
   });
 
   // ── Pending / Qualified tags ────────────────────────────────────────
@@ -325,8 +342,8 @@ describe('CampaignStatsSummary', () => {
 
   // ── Leaderboard error ─────────────────────────────────────────────
 
-  it('shows leaderboard error banner when leaderboard fails with no data', () => {
-    const { getByTestId, queryByTestId } = render(
+  it('shows stats error banner when leaderboard fails with no data', () => {
+    const { getByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
         leaderboardPosition={null}
@@ -335,14 +352,11 @@ describe('CampaignStatsSummary', () => {
     );
 
     expect(
-      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR),
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR),
     ).toBeDefined();
-    expect(
-      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.PORTFOLIO_ERROR),
-    ).toBeNull();
   });
 
-  it('calls leaderboard refetch on leaderboard error retry', () => {
+  it('calls both refetches on stats error retry when leaderboard fails', () => {
     const { getByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
@@ -352,13 +366,13 @@ describe('CampaignStatsSummary', () => {
     );
 
     fireEvent.press(
-      getByTestId(`${CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR}-retry`),
+      getByTestId(`${CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR}-retry`),
     );
     expect(mockLeaderboardRefetch).toHaveBeenCalledTimes(1);
-    expect(mockPortfolioRefetch).not.toHaveBeenCalled();
+    expect(mockPortfolioRefetch).toHaveBeenCalledTimes(1);
   });
 
-  it('hides leaderboard error when stale leaderboard data exists', () => {
+  it('hides stats error when stale leaderboard data exists', () => {
     const { queryByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
@@ -367,14 +381,14 @@ describe('CampaignStatsSummary', () => {
     );
 
     expect(
-      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR),
+      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR),
     ).toBeNull();
   });
 
   // ── Portfolio error ───────────────────────────────────────────────
 
-  it('shows portfolio error banner when portfolio fails with no data', () => {
-    const { getByTestId, queryByTestId } = render(
+  it('shows stats error banner when portfolio fails with no data', () => {
+    const { getByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
         portfolioSummary={null}
@@ -383,14 +397,11 @@ describe('CampaignStatsSummary', () => {
     );
 
     expect(
-      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.PORTFOLIO_ERROR),
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR),
     ).toBeDefined();
-    expect(
-      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR),
-    ).toBeNull();
   });
 
-  it('calls portfolio refetch on portfolio error retry', () => {
+  it('calls both refetches on stats error retry when portfolio fails', () => {
     const { getByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
@@ -400,16 +411,16 @@ describe('CampaignStatsSummary', () => {
     );
 
     fireEvent.press(
-      getByTestId(`${CAMPAIGN_STATS_SUMMARY_TEST_IDS.PORTFOLIO_ERROR}-retry`),
+      getByTestId(`${CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR}-retry`),
     );
     expect(mockPortfolioRefetch).toHaveBeenCalledTimes(1);
-    expect(mockLeaderboardRefetch).not.toHaveBeenCalled();
+    expect(mockLeaderboardRefetch).toHaveBeenCalledTimes(1);
   });
 
   // ── Both errors ───────────────────────────────────────────────────
 
-  it('shows both error banners when both sources fail with no data', () => {
-    const { getByTestId } = render(
+  it('shows a single stats error banner when both sources fail with no data', () => {
+    const { getAllByTestId } = render(
       <CampaignStatsSummary
         {...baseProps}
         leaderboardPosition={null}
@@ -420,10 +431,106 @@ describe('CampaignStatsSummary', () => {
     );
 
     expect(
-      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR),
-    ).toBeDefined();
+      getAllByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR),
+    ).toHaveLength(1);
+  });
+
+  // ── Qualify for rank card ─────────────────────────────────────────
+
+  it('shows the qualify card when position is pending and tierMinDeposit is provided', () => {
+    const pendingPosition: CampaignLeaderboardPositionDto = {
+      ...MOCK_POSITION,
+      qualified: false,
+      qualifiedDays: 3,
+    };
+
+    const { getByText } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={pendingPosition}
+        tierMinDeposit={500}
+      />,
+    );
+
     expect(
-      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.PORTFOLIO_ERROR),
+      getByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
     ).toBeDefined();
+  });
+
+  it('does not show the qualify card when position is qualified', () => {
+    const { queryByText } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={MOCK_POSITION}
+        tierMinDeposit={500}
+      />,
+    );
+
+    expect(
+      queryByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    ).toBeNull();
+  });
+
+  it('does not show the qualify card when tierMinDeposit is null', () => {
+    const pendingPosition: CampaignLeaderboardPositionDto = {
+      ...MOCK_POSITION,
+      qualified: false,
+      qualifiedDays: 3,
+    };
+
+    const { queryByText } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={pendingPosition}
+        tierMinDeposit={null}
+      />,
+    );
+
+    expect(
+      queryByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    ).toBeNull();
+  });
+
+  it('does not show the qualify card when qualifiedDays meets the requirement', () => {
+    const pendingPosition: CampaignLeaderboardPositionDto = {
+      ...MOCK_POSITION,
+      qualified: false,
+      qualifiedDays: 10, // equals ONDO_GM_REQUIRED_QUALIFIED_DAYS
+    };
+
+    const { queryByText } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={pendingPosition}
+        tierMinDeposit={500}
+      />,
+    );
+
+    expect(
+      queryByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    ).toBeNull();
+  });
+
+  it('calls onQualifyPress when the qualify card is pressed', () => {
+    const mockOnQualifyPress = jest.fn();
+    const pendingPosition: CampaignLeaderboardPositionDto = {
+      ...MOCK_POSITION,
+      qualified: false,
+      qualifiedDays: 3,
+    };
+
+    const { getByText } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={pendingPosition}
+        tierMinDeposit={500}
+        onQualifyPress={mockOnQualifyPress}
+      />,
+    );
+
+    fireEvent.press(
+      getByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
+    );
+    expect(mockOnQualifyPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { TextColor } from '@metamask/design-system-react-native';
 import CampaignStatsSummary, {
   CAMPAIGN_STATS_SUMMARY_TEST_IDS,
 } from './CampaignStatsSummary';
@@ -175,6 +176,44 @@ describe('CampaignStatsSummary', () => {
     expect(
       getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.RANK).props.children,
     ).toBe('5');
+  });
+
+  it('uses error color for market value when portfolioPnl is negative, regardless of leaderboard position', () => {
+    const negativePortfolio: OndoGmPortfolioSummaryDto = {
+      ...MOCK_SUMMARY,
+      portfolioPnl: '-500.000000',
+    };
+
+    const { getByTestId } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={null}
+        portfolioSummary={negativePortfolio}
+      />,
+    );
+
+    expect(
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE).props.color,
+    ).toBe(TextColor.ErrorDefault);
+  });
+
+  it('uses success color for market value when portfolioPnl is positive', () => {
+    const { getByTestId } = render(<CampaignStatsSummary {...baseProps} />);
+
+    expect(
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE).props.color,
+    ).toBe(TextColor.SuccessDefault);
+  });
+
+  it('omits valueColor for market value when portfolioSummary is null', () => {
+    const { getByTestId } = render(
+      <CampaignStatsSummary {...baseProps} portfolioSummary={null} />,
+    );
+
+    // Returns '-' and uses the StatCell default color (TextDefault)
+    expect(
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE).props.children,
+    ).toBe('-');
   });
 
   it('handles negative rate of return', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { Pressable } from 'react-native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  BoxJustifyContent,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -16,6 +22,7 @@ import type {
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../locales/i18n';
 import { formatPercentChange, formatUsd } from '../../utils/formatUtils';
+import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../../utils/ondoCampaignConstants';
 import { formatTierDisplayName } from './OndoLeaderboard.utils';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 
@@ -40,7 +47,7 @@ export const StatCell: React.FC<StatCellProps> = ({
 }) => {
   const tw = useTailwind();
   return (
-    <Box style={CELL_STYLE}>
+    <Box style={CELL_STYLE} twClassName="gap-0.5">
       <Text
         variant={TextVariant.BodySm}
         fontWeight={FontWeight.Medium}
@@ -58,10 +65,9 @@ export const StatCell: React.FC<StatCellProps> = ({
         >
           <Text
             variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Bold}
+            fontWeight={FontWeight.Medium}
             color={valueColor}
             testID={testID}
-            twClassName="font-semibold"
           >
             {value}
           </Text>
@@ -79,12 +85,11 @@ export const CAMPAIGN_STATS_SUMMARY_TEST_IDS = {
   RANK: 'campaign-stats-summary-rank',
   TIER: 'campaign-stats-summary-tier',
   PENDING_TAG: 'campaign-stats-summary-pending-tag',
-  LEADERBOARD_ERROR: 'campaign-stats-summary-leaderboard-error',
-  PORTFOLIO_ERROR: 'campaign-stats-summary-portfolio-error',
+  STATS_ERROR: 'campaign-stats-summary-stats-error',
 } as const;
 
 export const PendingTag: React.FC<{ testID?: string }> = ({ testID }) => (
-  <Box twClassName="bg-muted rounded-[6px] px-1" testID={testID}>
+  <Box twClassName="bg-muted rounded-[6px] px-1.5" testID={testID}>
     <Text
       variant={TextVariant.BodyXs}
       fontWeight={FontWeight.Medium}
@@ -96,7 +101,7 @@ export const PendingTag: React.FC<{ testID?: string }> = ({ testID }) => (
 );
 
 export const QualifiedTag: React.FC<{ testID?: string }> = ({ testID }) => (
-  <Box twClassName="bg-success-muted rounded-[6px] px-1" testID={testID}>
+  <Box twClassName="bg-success-muted rounded-[6px] px-1.5" testID={testID}>
     <Text
       variant={TextVariant.BodyXs}
       fontWeight={FontWeight.Medium}
@@ -118,6 +123,11 @@ interface CampaignStatsSummaryProps {
   portfolioSummary: OndoGmPortfolioSummaryDto | null;
   leaderboard: DataSourceState;
   portfolio: DataSourceState;
+  showHeader?: boolean;
+  /** Minimum deposit (USD) for the user's projected tier — enables the "Qualify for this rank" card */
+  tierMinDeposit?: number | null;
+  /** Called when the user taps the "Qualify for this rank" card arrow */
+  onQualifyPress?: () => void;
 }
 
 const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
@@ -125,6 +135,9 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
   portfolioSummary,
   leaderboard,
   portfolio,
+  showHeader = true,
+  tierMinDeposit,
+  onQualifyPress,
 }) => {
   const leaderboardLoading = leaderboard.isLoading && !leaderboardPosition;
   const portfolioLoading = portfolio.isLoading && !portfolioSummary;
@@ -137,9 +150,15 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
   const isQualified =
     leaderboardPosition != null && leaderboardPosition.qualified;
 
+  const isNegativeReturn = (leaderboardPosition?.rateOfReturn ?? 0) < 0;
+
   const returnValue = leaderboardPosition
     ? formatPercentChange(leaderboardPosition.rateOfReturn)
     : '-';
+
+  const returnColor = isNegativeReturn
+    ? TextColor.ErrorDefault
+    : TextColor.SuccessDefault;
 
   const marketValue = portfolioSummary
     ? formatUsd(portfolioSummary.totalCurrentValue)
@@ -153,28 +172,32 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
 
   return (
     <Box twClassName="gap-3" testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.CONTAINER}>
-      <Text variant={TextVariant.HeadingMd}>Stats</Text>
+      {showHeader && (
+        <Text variant={TextVariant.HeadingMd}>
+          {strings('rewards.ondo_campaign_stats.title')}
+        </Text>
+      )}
 
       <Box flexDirection={BoxFlexDirection.Row}>
         <StatCell
-          label="Return"
+          label={strings('rewards.ondo_campaign_stats.label_return')}
           value={returnValue}
           isLoading={leaderboardLoading}
-          valueColor={TextColor.SuccessDefault}
+          valueColor={returnColor}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.RETURN}
         />
         <StatCell
-          label="Market Value"
+          label={strings('rewards.ondo_campaign_stats.label_market_value')}
           value={marketValue}
           isLoading={portfolioLoading}
-          valueColor={TextColor.SuccessDefault}
+          valueColor={returnColor}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE}
         />
       </Box>
 
       <Box flexDirection={BoxFlexDirection.Row}>
         <StatCell
-          label="Rank"
+          label={strings('rewards.ondo_campaign_stats.label_rank')}
           value={rankValue}
           isLoading={leaderboardLoading}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.RANK}
@@ -187,7 +210,7 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
           }
         />
         <StatCell
-          label="Tier"
+          label={strings('rewards.ondo_campaign_stats.label_tier')}
           value={tierValue}
           isLoading={leaderboardLoading}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.TIER}
@@ -205,23 +228,66 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
         />
       </Box>
 
-      {leaderboardError && (
-        <RewardsErrorBanner
-          title="Unable to load leaderboard stats"
-          description="Something went wrong. Please try again."
-          onConfirm={leaderboard.refetch}
-          confirmButtonLabel="Retry"
-          testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.LEADERBOARD_ERROR}
-        />
-      )}
+      {isPending &&
+        tierMinDeposit != null &&
+        leaderboardPosition &&
+        Math.max(
+          ONDO_GM_REQUIRED_QUALIFIED_DAYS - leaderboardPosition.qualifiedDays,
+          0,
+        ) > 0 && (
+          <Pressable onPress={onQualifyPress}>
+            <Box twClassName="bg-muted rounded-xl p-4 mt-2 gap-2">
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={2}
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {strings(
+                    'rewards.ondo_campaign_leaderboard.qualify_for_rank_title',
+                  )}
+                </Text>
+                <Icon
+                  name={IconName.ArrowRight}
+                  size={IconSize.Sm}
+                  color={IconColor.IconAlternative}
+                />
+              </Box>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings(
+                  'rewards.ondo_campaign_leaderboard.qualify_for_rank_description',
+                  {
+                    minDeposit: formatUsd(tierMinDeposit),
+                    daysRemaining: Math.max(
+                      ONDO_GM_REQUIRED_QUALIFIED_DAYS -
+                        leaderboardPosition.qualifiedDays,
+                      1,
+                    ),
+                  },
+                )}
+              </Text>
+            </Box>
+          </Pressable>
+        )}
 
-      {portfolioError && (
+      {(leaderboardError || portfolioError) && (
         <RewardsErrorBanner
-          title="Unable to load portfolio stats"
-          description="Something went wrong. Please try again."
-          onConfirm={portfolio.refetch}
-          confirmButtonLabel="Retry"
-          testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.PORTFOLIO_ERROR}
+          title={strings('rewards.ondo_campaign_stats.stats_error_title')}
+          description={strings(
+            'rewards.ondo_campaign_stats.stats_error_description',
+          )}
+          onConfirm={() => {
+            leaderboard.refetch();
+            portfolio.refetch();
+          }}
+          confirmButtonLabel={strings('rewards.ondo_campaign_stats.retry')}
+          testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.STATS_ERROR}
         />
       )}
     </Box>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
-  BoxJustifyContent,
   Icon,
   IconColor,
   IconName,
@@ -160,6 +159,12 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
     ? TextColor.ErrorDefault
     : TextColor.SuccessDefault;
 
+  const marketValueColor: TextColor | undefined = portfolioSummary
+    ? parseFloat(portfolioSummary.portfolioPnl) < 0
+      ? TextColor.ErrorDefault
+      : TextColor.SuccessDefault
+    : undefined;
+
   const marketValue = portfolioSummary
     ? formatUsd(portfolioSummary.totalCurrentValue)
     : '-';
@@ -190,7 +195,7 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
           label={strings('rewards.ondo_campaign_stats.label_market_value')}
           value={marketValue}
           isLoading={portfolioLoading}
-          valueColor={returnColor}
+          valueColor={marketValueColor}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE}
         />
       </Box>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignsPreview.tsx
@@ -7,6 +7,7 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   Icon,
+  IconColor,
   IconName,
   IconSize,
   Text,
@@ -61,7 +62,11 @@ const CampaignsPreview: React.FC = () => {
           <Text variant={TextVariant.HeadingMd}>
             {strings('rewards.campaigns_preview.title')}
           </Text>
-          <Icon name={IconName.ArrowRight} size={IconSize.Md} />
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Md}
+            color={IconColor.IconAlternative}
+          />
         </Box>
       </Pressable>
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OndoAfterHoursSheet from './OndoAfterHoursSheet';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    BottomSheet: ({
+      children,
+      onClose,
+    }: {
+      children?: React.ReactNode;
+      onClose?: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'bottom-sheet' },
+        children,
+        ReactActual.createElement(Pressable, {
+          testID: 'sheet-backdrop-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../utils/formatUtils', () => ({
+  formatTimeRemaining: jest.fn(() => '2h 30m'),
+}));
+
+describe('OndoAfterHoursSheet', () => {
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title and description', () => {
+    const { getByTestId } = render(
+      <OndoAfterHoursSheet onClose={mockOnClose} nextOpenAt={null} />,
+    );
+    expect(getByTestId('ondo-after-hours-sheet-title')).toBeDefined();
+    expect(getByTestId('ondo-after-hours-sheet-description')).toBeDefined();
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    const { getByTestId } = render(
+      <OndoAfterHoursSheet onClose={mockOnClose} nextOpenAt={null} />,
+    );
+    fireEvent.press(getByTestId('ondo-after-hours-sheet-close'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when the got-it button is pressed and onConfirm is provided', () => {
+    const { getByTestId } = render(
+      <OndoAfterHoursSheet
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        nextOpenAt={null}
+      />,
+    );
+    fireEvent.press(getByTestId('ondo-after-hours-sheet-got-it'));
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('falls back to onClose when onConfirm is not provided and got-it is pressed', () => {
+    const { getByTestId } = render(
+      <OndoAfterHoursSheet onClose={mockOnClose} nextOpenAt={null} />,
+    );
+    fireEvent.press(getByTestId('ondo-after-hours-sheet-got-it'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows countdown pill when nextOpenAt is provided', () => {
+    const nextOpenAt = new Date(Date.now() + 2 * 60 * 60 * 1000);
+    const { getByText } = render(
+      <OndoAfterHoursSheet onClose={mockOnClose} nextOpenAt={nextOpenAt} />,
+    );
+    expect(getByText('2h 30m')).toBeDefined();
+  });
+
+  it('does not show countdown pill when nextOpenAt is null', () => {
+    const { queryByText } = render(
+      <OndoAfterHoursSheet onClose={mockOnClose} nextOpenAt={null} />,
+    );
+    expect(queryByText('2h 30m')).toBeNull();
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxBackgroundColor,
+  BottomSheet,
+  Button,
+  ButtonIcon,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { formatTimeRemaining } from '../../utils/formatUtils';
+
+interface OndoAfterHoursSheetProps {
+  onClose: () => void;
+  onConfirm?: () => void;
+  nextOpenAt: Date | null;
+}
+
+const OndoAfterHoursSheet: React.FC<OndoAfterHoursSheetProps> = ({
+  onClose,
+  onConfirm,
+  nextOpenAt,
+}) => {
+  const countdownText = nextOpenAt ? formatTimeRemaining(nextOpenAt) : null;
+
+  return (
+    <BottomSheet onClose={onClose}>
+      <Box twClassName="px-4 pb-4">
+        {/* Header row: spacer + close button */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.End}
+          twClassName="mb-4"
+        >
+          <ButtonIcon
+            iconName={IconName.Close}
+            iconProps={{ color: IconColor.IconDefault }}
+            onPress={onClose}
+            testID="ondo-after-hours-sheet-close"
+          />
+        </Box>
+
+        {/* Clock icon */}
+        <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+          <Icon name={IconName.AfterHours} size={IconSize.Xl} />
+        </Box>
+
+        {/* Title */}
+        <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontWeight={FontWeight.Bold}
+            testID="ondo-after-hours-sheet-title"
+          >
+            {strings('rewards.ondo_campaign_after_hours_trading.title')}
+          </Text>
+        </Box>
+
+        {/* Countdown pill */}
+        {countdownText && (
+          <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+            <Box
+              backgroundColor={BoxBackgroundColor.BackgroundMuted}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName="rounded-full px-4 py-2 gap-1"
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings(
+                  'rewards.ondo_campaign_after_hours_trading.reopens_in_label',
+                )}
+              </Text>
+              <Text variant={TextVariant.BodyMd}>{countdownText}</Text>
+            </Box>
+          </Box>
+        )}
+
+        {/* Description */}
+        <Box twClassName="mb-6">
+          <Text
+            variant={TextVariant.BodyMd}
+            testID="ondo-after-hours-sheet-description"
+            twClassName="text-center"
+          >
+            {strings('rewards.ondo_campaign_after_hours_trading.content')}
+          </Text>
+        </Box>
+
+        {/* Got it CTA */}
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={onConfirm ?? onClose}
+          twClassName="w-full"
+          testID="ondo-after-hours-sheet-got-it"
+        >
+          {strings('rewards.ondo_campaign_after_hours_trading.got_it_button')}
+        </Button>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default OndoAfterHoursSheet;

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -37,6 +37,33 @@ jest.mock('./CampaignOptInSheet', () => {
   };
 });
 
+jest.mock('./OndoNotEligibleSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onClose,
+      onConfirm,
+    }: {
+      onClose: () => void;
+      onConfirm: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'ondo-not-eligible-sheet' },
+        ReactActual.createElement(Pressable, {
+          testID: 'not-eligible-close',
+          onPress: onClose,
+        }),
+        ReactActual.createElement(Pressable, {
+          testID: 'not-eligible-confirm',
+          onPress: onConfirm,
+        }),
+      ),
+  };
+});
+
 const mockShowToast = jest.fn();
 const mockEntriesClosed = jest.fn(() => ({ variant: 'icon' }));
 
@@ -56,7 +83,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.ondo.open_position': 'Open Position',
+      'rewards.campaign_details.ondo.open_position': 'Swap Ondo assets',
       'rewards.campaign_details.ondo.entries_closed_title': 'Entries closed',
       'rewards.campaign_details.ondo.entries_closed_description':
         'You missed the opt-in window. Check back for more campaigns in the future.',
@@ -188,7 +215,7 @@ describe('OndoCampaignCTA', () => {
   });
 
   describe('opted in, no portfolio positions', () => {
-    it('renders the "Open Position" button', () => {
+    it('renders the "Swap Ondo assets" button', () => {
       const { getByTestId, getByText } = render(
         <OndoCampaignCTA
           campaign={buildCampaign()}
@@ -199,7 +226,7 @@ describe('OndoCampaignCTA', () => {
       );
 
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-      expect(getByText('Open Position')).toBeOnTheScreen();
+      expect(getByText('Swap Ondo assets')).toBeOnTheScreen();
     });
 
     it('navigates to RWA asset selector in open_position mode when pressed', () => {
@@ -221,7 +248,7 @@ describe('OndoCampaignCTA', () => {
   });
 
   describe('opted in, with portfolio positions', () => {
-    it('renders the "Open Position" button', () => {
+    it('renders the "Swap Ondo assets" button', () => {
       const { getByTestId, getByText } = render(
         <OndoCampaignCTA
           campaign={buildCampaign()}
@@ -232,7 +259,7 @@ describe('OndoCampaignCTA', () => {
       );
 
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-      expect(getByText('Open Position')).toBeOnTheScreen();
+      expect(getByText('Swap Ondo assets')).toBeOnTheScreen();
     });
 
     it('navigates to RWA asset selector in swap mode when pressed', () => {
@@ -250,6 +277,135 @@ describe('OndoCampaignCTA', () => {
         Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
         { mode: 'swap', campaignId: 'campaign-1' },
       );
+    });
+  });
+
+  describe('notEligibleForCampaign', () => {
+    describe('not opted in + notEligibleForCampaign=true', () => {
+      it('shows the Join Campaign button', () => {
+        const { getByTestId, getByText } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={notOptedIn}
+            {...defaultProps}
+            notEligibleForCampaign
+          />,
+        );
+        expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
+        expect(getByText('Join Campaign')).toBeOnTheScreen();
+      });
+
+      it('fires entries-closed toast (not the opt-in sheet) when pressed', () => {
+        const { getByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={notOptedIn}
+            {...defaultProps}
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        expect(mockEntriesClosed).toHaveBeenCalledTimes(1);
+        expect(mockShowToast).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not open the opt-in sheet when pressed', () => {
+        const { getByTestId, queryByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={notOptedIn}
+            {...defaultProps}
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        expect(queryByTestId('campaign-opt-in-sheet')).toBeNull();
+      });
+    });
+
+    describe('opted in + notEligibleForCampaign=true', () => {
+      it('shows the OndoNotEligibleSheet when the CTA is pressed', () => {
+        const { getByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={optedIn}
+            {...defaultProps}
+            hasPositions={false}
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        expect(getByTestId('ondo-not-eligible-sheet')).toBeDefined();
+      });
+
+      it('dismisses the OndoNotEligibleSheet when close is pressed', () => {
+        const { getByTestId, queryByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={optedIn}
+            {...defaultProps}
+            hasPositions={false}
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        expect(getByTestId('ondo-not-eligible-sheet')).toBeDefined();
+        fireEvent.press(getByTestId('not-eligible-close'));
+        expect(queryByTestId('ondo-not-eligible-sheet')).toBeNull();
+      });
+
+      it('navigates to open_position and dismisses the sheet on confirm (no positions)', () => {
+        const { getByTestId, queryByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={optedIn}
+            {...defaultProps}
+            hasPositions={false}
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        fireEvent.press(getByTestId('not-eligible-confirm'));
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+          { mode: 'open_position', campaignId: 'campaign-1' },
+        );
+        expect(queryByTestId('ondo-not-eligible-sheet')).toBeNull();
+      });
+
+      it('navigates to swap and dismisses the sheet on confirm (with positions)', () => {
+        const { getByTestId, queryByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={optedIn}
+            {...defaultProps}
+            hasPositions
+            notEligibleForCampaign
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        fireEvent.press(getByTestId('not-eligible-confirm'));
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR,
+          { mode: 'swap', campaignId: 'campaign-1' },
+        );
+        expect(queryByTestId('ondo-not-eligible-sheet')).toBeNull();
+      });
+
+      it('does not navigate when notEligibleForCampaign=false (normal flow)', () => {
+        const { getByTestId, queryByTestId } = render(
+          <OndoCampaignCTA
+            campaign={buildCampaign()}
+            participantStatus={optedIn}
+            {...defaultProps}
+            hasPositions={false}
+            notEligibleForCampaign={false}
+          />,
+        );
+        fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+        expect(queryByTestId('ondo-not-eligible-sheet')).toBeNull();
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -14,6 +14,7 @@ import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
 import useRewardsToast from '../../hooks/useRewardsToast';
 import CampaignOptInCta, { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
+import OndoNotEligibleSheet from './OndoNotEligibleSheet';
 
 interface OndoCampaignCTAProps {
   campaign: CampaignDto;
@@ -23,6 +24,7 @@ interface OndoCampaignCTAProps {
   >;
   hasPositions: boolean;
   campaignId: string;
+  notEligibleForCampaign?: boolean;
 }
 
 /**
@@ -38,23 +40,48 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   participantStatus,
   hasPositions,
   campaignId,
+  notEligibleForCampaign = false,
 }) => {
   const navigation = useNavigation();
   const { showToast, RewardsToastOptions } = useRewardsToast();
+  const [isNotEligibleSheetOpen, setIsNotEligibleSheetOpen] = useState(false);
+  const pendingActionRef = useRef<(() => void) | null>(null);
 
-  const onOpenPosition = useCallback(() => {
+  const navigateToOpenPosition = useCallback(() => {
     navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
       mode: 'open_position',
       campaignId,
     });
   }, [navigation, campaignId]);
 
-  const onSwapAssets = useCallback(() => {
+  const navigateToSwapAssets = useCallback(() => {
     navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR, {
       mode: 'swap',
       campaignId,
     });
   }, [navigation, campaignId]);
+
+  const guardedNavigate = useCallback(
+    (navigate: () => void) => {
+      if (notEligibleForCampaign) {
+        pendingActionRef.current = navigate;
+        setIsNotEligibleSheetOpen(true);
+        return;
+      }
+      navigate();
+    },
+    [notEligibleForCampaign],
+  );
+
+  const onOpenPosition = useCallback(
+    () => guardedNavigate(navigateToOpenPosition),
+    [guardedNavigate, navigateToOpenPosition],
+  );
+
+  const onSwapAssets = useCallback(
+    () => guardedNavigate(navigateToSwapAssets),
+    [guardedNavigate, navigateToSwapAssets],
+  );
 
   const campaignStatus = getCampaignStatus(campaign);
   const isLoading = participantStatus.isLoading;
@@ -96,6 +123,21 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   }
 
   if (!isOptedIn) {
+    if (notEligibleForCampaign) {
+      return (
+        <Box twClassName="px-4 pt-2">
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            onPress={handleEntriesClosedPress}
+            testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
+          >
+            {strings('rewards.campaign_details.join_campaign')}
+          </Button>
+        </Box>
+      );
+    }
     return (
       <CampaignOptInCta
         campaign={campaign}
@@ -104,34 +146,30 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
     );
   }
 
-  if (hasPositions) {
-    return (
+  return (
+    <>
       <Box twClassName="px-4 pt-2">
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           isFullWidth
-          onPress={onSwapAssets}
+          onPress={hasPositions ? onSwapAssets : onOpenPosition}
           testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
         >
           {strings('rewards.campaign_details.ondo.open_position')}
         </Button>
       </Box>
-    );
-  }
-
-  return (
-    <Box twClassName="px-4 pt-2">
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Lg}
-        isFullWidth
-        onPress={onOpenPosition}
-        testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-      >
-        {strings('rewards.campaign_details.ondo.open_position')}
-      </Button>
-    </Box>
+      {isNotEligibleSheetOpen && (
+        <OndoNotEligibleSheet
+          onClose={() => setIsNotEligibleSheetOpen(false)}
+          onConfirm={() => {
+            setIsNotEligibleSheetOpen(false);
+            pendingActionRef.current?.();
+            pendingActionRef.current = null;
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
@@ -50,6 +50,13 @@ interface UserPosition {
   neighbors: CampaignLeaderboardEntry[];
 }
 
+interface PendingSheetPosition {
+  tier: string;
+  netDeposit: number;
+  qualifiedDays: number;
+  tierMinDeposit: number;
+}
+
 interface CampaignLeaderboardProps {
   tierNames: string[];
   selectedTier: string | null;
@@ -65,6 +72,8 @@ interface CampaignLeaderboardProps {
   maxEntries?: number;
   /** User's leaderboard position; enables neighbor display in preview mode. */
   userPosition?: UserPosition | null;
+  /** Current user's position data; enables pending sheet on Pending tag tap. */
+  pendingSheetPosition?: PendingSheetPosition | null;
 }
 
 /**
@@ -73,7 +82,8 @@ interface CampaignLeaderboardProps {
 const LeaderboardEntryRow: React.FC<{
   entry: CampaignLeaderboardEntry;
   isCurrentUser?: boolean;
-}> = ({ entry, isCurrentUser = false }) => (
+  onPendingPress?: () => void;
+}> = ({ entry, isCurrentUser = false, onPendingPress }) => (
   <Box
     flexDirection={BoxFlexDirection.Row}
     alignItems={BoxAlignItems.Center}
@@ -86,17 +96,20 @@ const LeaderboardEntryRow: React.FC<{
       alignItems={BoxAlignItems.Center}
       twClassName="gap-3"
     >
-      <Text
-        variant={TextVariant.BodyMd}
-        twClassName="w-8 text-text-alternative"
-      >
+      <Text variant={TextVariant.BodyMd} twClassName="w-8">
         #{String(entry.rank).padStart(2, '0')}
       </Text>
       <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
         {entry.referralCode}
       </Text>
       {!entry.qualified ? (
-        <PendingTag testID={CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG} />
+        onPendingPress ? (
+          <Pressable onPress={onPendingPress}>
+            <PendingTag testID={CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG} />
+          </Pressable>
+        ) : (
+          <PendingTag testID={CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG} />
+        )
       ) : isCurrentUser ? (
         <Icon
           name={IconName.Check}
@@ -188,6 +201,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
   currentUserReferralCode,
   maxEntries,
   userPosition,
+  pendingSheetPosition,
 }) => {
   const navigation = useNavigation();
 
@@ -240,6 +254,31 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
       !!currentUserReferralCode &&
       entry.referralCode === currentUserReferralCode,
     [currentUserReferralCode],
+  );
+
+  const buildOnPendingPress = useCallback(
+    (entry: CampaignLeaderboardEntry) => {
+      if (!entry.qualified) {
+        if (isCurrentUser(entry) && pendingSheetPosition) {
+          return () => {
+            navigation.navigate(Routes.MODAL.REWARDS_ONDO_PENDING_SHEET, {
+              variant: 'own',
+              tier: pendingSheetPosition.tier,
+              netDeposit: pendingSheetPosition.netDeposit,
+              qualifiedDays: pendingSheetPosition.qualifiedDays,
+              tierMinDeposit: pendingSheetPosition.tierMinDeposit,
+            });
+          };
+        }
+        return () => {
+          navigation.navigate(Routes.MODAL.REWARDS_ONDO_PENDING_SHEET, {
+            variant: 'other',
+          });
+        };
+      }
+      return undefined;
+    },
+    [isCurrentUser, navigation, pendingSheetPosition],
   );
 
   if (isLoading && entries.length === 0) {
@@ -359,6 +398,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
               key={`${entry.rank}-${entry.referralCode}`}
               entry={entry}
               isCurrentUser={isCurrentUser(entry)}
+              onPendingPress={buildOnPendingPress(entry)}
             />
           ))}
           {showSplitView && userPosition && (
@@ -369,6 +409,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
                   key={`neighbor-${entry.rank}-${entry.referralCode}`}
                   entry={entry}
                   isCurrentUser={isCurrentUser(entry)}
+                  onPendingPress={buildOnPendingPress(entry)}
                 />
               ))}
             </>

--- a/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OndoNotEligibleSheet, {
+  ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS,
+} from './OndoNotEligibleSheet';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    BottomSheet: ({
+      children,
+      onClose,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onClose?: () => void;
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        children,
+        ReactActual.createElement(Pressable, {
+          testID: 'sheet-backdrop-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: Record<string, unknown>) => {
+    if (params) return `${key}(${JSON.stringify(params)})`;
+    return key;
+  },
+}));
+
+describe('OndoNotEligibleSheet', () => {
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with the container testID', () => {
+    const { getByTestId } = render(
+      <OndoNotEligibleSheet onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+    expect(
+      getByTestId(ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER),
+    ).toBeDefined();
+  });
+
+  it('renders title and body text', () => {
+    const { getByTestId } = render(
+      <OndoNotEligibleSheet onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+    expect(getByTestId(ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.TITLE)).toBeDefined();
+    expect(getByTestId(ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.BODY)).toBeDefined();
+  });
+
+  it('calls onClose when cancel button is pressed', () => {
+    const { getByTestId } = render(
+      <OndoNotEligibleSheet onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+    fireEvent.press(getByTestId(ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CANCEL));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when confirm button is pressed', () => {
+    const { getByTestId } = render(
+      <OndoNotEligibleSheet onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+    fireEvent.press(getByTestId(ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONFIRM));
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when the close icon button is pressed', () => {
+    const { getByTestId } = render(
+      <OndoNotEligibleSheet onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+    fireEvent.press(getByTestId('ondo-not-eligible-sheet-close'));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BottomSheet,
+  Button,
+  ButtonIcon,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../../utils/ondoCampaignConstants';
+
+export const ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS = {
+  CONTAINER: 'ondo-not-eligible-sheet-container',
+  TITLE: 'ondo-not-eligible-sheet-title',
+  BODY: 'ondo-not-eligible-sheet-body',
+  CANCEL: 'ondo-not-eligible-sheet-cancel',
+  CONFIRM: 'ondo-not-eligible-sheet-confirm',
+} as const;
+
+interface OndoNotEligibleSheetProps {
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const OndoNotEligibleSheet: React.FC<OndoNotEligibleSheetProps> = ({
+  onClose,
+  onConfirm,
+}) => (
+  <BottomSheet
+    onClose={onClose}
+    testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER}
+  >
+    <Box twClassName="px-4 pb-4">
+      {/* Close button */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="justify-end mb-4"
+      >
+        <ButtonIcon
+          iconName={IconName.Close}
+          iconProps={{ color: IconColor.IconDefault }}
+          onPress={onClose}
+          testID="ondo-not-eligible-sheet-close"
+        />
+      </Box>
+
+      {/* Warning icon */}
+      <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+        <Icon
+          name={IconName.Danger}
+          size={IconSize.Xl}
+          color={IconColor.WarningDefault}
+        />
+      </Box>
+
+      {/* Title */}
+      <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.TITLE}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.title')}
+        </Text>
+      </Box>
+
+      {/* Body */}
+      <Box twClassName="mb-6">
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.BODY}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.body', {
+            days: ONDO_GM_REQUIRED_QUALIFIED_DAYS,
+          })}
+        </Text>
+      </Box>
+
+      {/* Buttons */}
+      <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onPress={onClose}
+          twClassName="flex-1"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CANCEL}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.cancel')}
+        </Button>
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={onConfirm}
+          twClassName="flex-1"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONFIRM}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.confirm')}
+        </Button>
+      </Box>
+    </Box>
+  </BottomSheet>
+);
+
+export default OndoNotEligibleSheet;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OndoPendingSheet, {
+  ONDO_PENDING_SHEET_TEST_IDS,
+} from './OndoPendingSheet';
+
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    BottomSheet: ({
+      children,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      goBack?: () => void;
+      testID?: string;
+    }) => ReactActual.createElement(View, { testID }, children),
+    BottomSheetHeader: ({
+      children,
+      onClose,
+    }: {
+      children?: React.ReactNode;
+      onClose?: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'bottom-sheet-header' },
+        children,
+        ReactActual.createElement(Pressable, {
+          testID: 'sheet-header-close',
+          onPress: onClose,
+        }),
+      ),
+  };
+});
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: Record<string, unknown>) => {
+    if (params) return `${key}(${JSON.stringify(params)})`;
+    return key;
+  },
+}));
+
+jest.mock('./CampaignStatsSummary', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    StatCell: ({
+      label,
+      testID,
+    }: {
+      label: string;
+      value: string;
+      testID?: string;
+      suffix?: React.ReactNode;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(Text, null, label),
+      ),
+    PendingTag: () => ReactActual.createElement(View, null),
+  };
+});
+
+jest.mock('./OndoLeaderboard.utils', () => ({
+  formatTierDisplayName: (tier: string) => tier.toLowerCase(),
+}));
+
+jest.mock('../../utils/formatUtils', () => ({
+  formatUsd: (value: number) => `$${value.toFixed(2)}`,
+}));
+
+describe('OndoPendingSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('own variant', () => {
+    const ownProps = {
+      route: {
+        params: {
+          variant: 'own' as const,
+          tier: 'STARTER',
+          netDeposit: 1000,
+          qualifiedDays: 3,
+          tierMinDeposit: 500,
+        },
+      },
+    };
+
+    it('renders with container testID', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...ownProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CONTAINER)).toBeDefined();
+    });
+
+    it('renders tier and net deposit stat cells', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...ownProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.TIER_CELL)).toBeDefined();
+      expect(
+        getByTestId(ONDO_PENDING_SHEET_TEST_IDS.NET_DEPOSIT_CELL),
+      ).toBeDefined();
+    });
+
+    it('renders body text with pending explanation', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...ownProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.BODY)).toBeDefined();
+    });
+
+    it('renders CTA button', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...ownProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CTA)).toBeDefined();
+    });
+
+    it('pressing CTA does not crash', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...ownProps} />);
+      fireEvent.press(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CTA));
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CONTAINER)).toBeDefined();
+    });
+  });
+
+  describe('other variant', () => {
+    const otherProps = {
+      route: { params: { variant: 'other' as const } },
+    };
+
+    it('renders with container testID', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...otherProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CONTAINER)).toBeDefined();
+    });
+
+    it('renders body text for other variant', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...otherProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.BODY)).toBeDefined();
+    });
+
+    it('does not render tier/deposit cells', () => {
+      const { queryByTestId } = render(<OndoPendingSheet {...otherProps} />);
+      expect(queryByTestId(ONDO_PENDING_SHEET_TEST_IDS.TIER_CELL)).toBeNull();
+      expect(
+        queryByTestId(ONDO_PENDING_SHEET_TEST_IDS.NET_DEPOSIT_CELL),
+      ).toBeNull();
+    });
+
+    it('renders CTA button', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...otherProps} />);
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CTA)).toBeDefined();
+    });
+
+    it('pressing sheet header close does not crash', () => {
+      const { getByTestId } = render(<OndoPendingSheet {...otherProps} />);
+      fireEvent.press(getByTestId('sheet-header-close'));
+      expect(getByTestId(ONDO_PENDING_SHEET_TEST_IDS.CONTAINER)).toBeDefined();
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  Box,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { StatCell, PendingTag } from './CampaignStatsSummary';
+import { formatTierDisplayName } from './OndoLeaderboard.utils';
+import { formatUsd } from '../../utils/formatUtils';
+import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../../utils/ondoCampaignConstants';
+import { strings } from '../../../../../../locales/i18n';
+
+export const ONDO_PENDING_SHEET_TEST_IDS = {
+  CONTAINER: 'ondo-pending-sheet-container',
+  TIER_CELL: 'ondo-pending-sheet-tier-cell',
+  NET_DEPOSIT_CELL: 'ondo-pending-sheet-net-deposit-cell',
+  BODY: 'ondo-pending-sheet-body',
+  CTA: 'ondo-pending-sheet-cta',
+} as const;
+
+type OndoPendingSheetParams =
+  | {
+      variant: 'own';
+      tier: string;
+      netDeposit: number;
+      qualifiedDays: number;
+      tierMinDeposit: number;
+    }
+  | { variant: 'other' };
+
+interface OndoPendingSheetProps {
+  route: {
+    params: OndoPendingSheetParams;
+  };
+}
+
+const OndoPendingSheet: React.FC<OndoPendingSheetProps> = ({ route }) => {
+  const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const { params } = route;
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleGotIt = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      goBack={navigation.goBack}
+      testID={ONDO_PENDING_SHEET_TEST_IDS.CONTAINER}
+    >
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingMd} twClassName="text-center">
+          {strings('rewards.ondo_campaign_leaderboard.pending_sheet_title')}
+        </Text>
+      </BottomSheetHeader>
+
+      <Box twClassName="px-4 pb-4 pt-6 gap-6">
+        {params.variant === 'own' ? (
+          <>
+            <Box flexDirection={BoxFlexDirection.Row}>
+              <StatCell
+                label={strings(
+                  'rewards.ondo_campaign_leaderboard.pending_sheet_tier_label',
+                )}
+                value={formatTierDisplayName(params.tier)}
+                suffix={<PendingTag />}
+                testID={ONDO_PENDING_SHEET_TEST_IDS.TIER_CELL}
+              />
+              <StatCell
+                label={strings(
+                  'rewards.ondo_campaign_leaderboard.pending_sheet_net_deposit_label',
+                )}
+                value={formatUsd(params.netDeposit)}
+                testID={ONDO_PENDING_SHEET_TEST_IDS.NET_DEPOSIT_CELL}
+              />
+            </Box>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              testID={ONDO_PENDING_SHEET_TEST_IDS.BODY}
+            >
+              {strings(
+                'rewards.ondo_campaign_leaderboard.pending_sheet_own_body',
+                {
+                  minDeposit: formatUsd(params.tierMinDeposit),
+                  daysRemaining: Math.max(
+                    ONDO_GM_REQUIRED_QUALIFIED_DAYS - params.qualifiedDays,
+                    1,
+                  ),
+                },
+              )}
+            </Text>
+          </>
+        ) : (
+          <Text
+            variant={TextVariant.BodyMd}
+            testID={ONDO_PENDING_SHEET_TEST_IDS.BODY}
+          >
+            {strings(
+              'rewards.ondo_campaign_leaderboard.pending_sheet_other_body',
+            )}
+          </Text>
+        )}
+
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={handleGotIt}
+          twClassName="w-full"
+          testID={ONDO_PENDING_SHEET_TEST_IDS.CTA}
+        >
+          {strings('rewards.ondo_campaign_leaderboard.pending_sheet_cta')}
+        </Button>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default OndoPendingSheet;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -148,6 +148,8 @@ interface OndoPortfolioProps {
   campaignId: string;
   onOpenAccountPicker: (config: AccountPickerConfig) => void;
   isCampaignComplete?: boolean;
+  notEligibleForCampaign?: boolean;
+  onNotEligible?: (confirmAction: () => void) => void;
 }
 
 const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
@@ -158,6 +160,8 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   campaignId,
   onOpenAccountPicker,
   isCampaignComplete = false,
+  notEligibleForCampaign = false,
+  onNotEligible,
 }) => {
   const navigation = useNavigation();
 
@@ -283,6 +287,11 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
 
   const handleRowPress = useCallback(
     (row: OndoGmPortfolioPositionDto) => {
+      if (notEligibleForCampaign) {
+        onNotEligible?.(() => navigateToSwap(row));
+        return;
+      }
+
       const accountsForRow = getAccountsWithBalance(row);
       const groupsForRow = getGroupsFromAccounts(accountsForRow);
 
@@ -314,11 +323,13 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
       });
     },
     [
+      notEligibleForCampaign,
+      onNotEligible,
+      navigateToSwap,
       getAccountsWithBalance,
       getGroupsFromAccounts,
       getGroupBalance,
       selectedGroup,
-      navigateToSwap,
       onOpenAccountPicker,
       resolveTokenDecimals,
     ],

--- a/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.test.tsx
@@ -54,6 +54,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.ondo_campaign_prize_pool.next_label': 'Next',
       'rewards.ondo_campaign_prize_pool.volume_subtext':
         '{{current}} of {{target}} volume',
+      'rewards.ondo_campaign_prize_pool.max_tier_subtext':
+        '{{maxThreshold}}+ TVL — all milestones reached',
     };
     let result = t[key] ?? key;
     if (params) {
@@ -130,7 +132,9 @@ describe('OndoPrizePool', () => {
 
     expect(getByText('$100,000.00')).toBeDefined();
     expect(queryByText('Next')).toBeNull();
-    expect(getByTestId(ONDO_PRIZE_POOL_TEST_IDS.SUBTEXT)).toBeDefined();
+
+    const subtext = getByTestId(ONDO_PRIZE_POOL_TEST_IDS.SUBTEXT);
+    expect(subtext.props.children).toBe('$6M+ TVL — all milestones reached');
 
     const progressBar = getByTestId(ONDO_PRIZE_POOL_TEST_IDS.PROGRESS_BAR);
     const innerBar = progressBar.props.children;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPrizePool.tsx
@@ -133,7 +133,11 @@ const OndoPrizePool: React.FC<OndoPrizePoolProps> = ({
         justifyContent={BoxJustifyContent.Between}
       >
         <Box>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+          >
             {strings('rewards.ondo_campaign_prize_pool.current_label')}
           </Text>
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
@@ -144,6 +148,7 @@ const OndoPrizePool: React.FC<OndoPrizePoolProps> = ({
           <Box alignItems={BoxAlignItems.End}>
             <Text
               variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
               color={TextColor.TextAlternative}
             >
               {strings('rewards.ondo_campaign_prize_pool.next_label')}
@@ -170,10 +175,14 @@ const OndoPrizePool: React.FC<OndoPrizePoolProps> = ({
         color={TextColor.TextAlternative}
         testID={ONDO_PRIZE_POOL_TEST_IDS.SUBTEXT}
       >
-        {strings('rewards.ondo_campaign_prize_pool.volume_subtext', {
-          current: formatCompactUsd(deposited),
-          target: formatCompactUsd(nextThreshold),
-        })}
+        {isMaxTier
+          ? strings('rewards.ondo_campaign_prize_pool.max_tier_subtext', {
+              maxThreshold: formatCompactUsd(nextThreshold),
+            })
+          : strings('rewards.ondo_campaign_prize_pool.volume_subtext', {
+              current: formatCompactUsd(deposited),
+              target: formatCompactUsd(nextThreshold),
+            })}
       </Text>
     </Box>
   );

--- a/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
@@ -82,6 +82,7 @@ const MOCK_LEADERBOARD: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 50,
+      minDeposit: 500,
     },
     MID: {
       entries: [
@@ -94,6 +95,7 @@ const MOCK_LEADERBOARD: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 30,
+      minDeposit: 1000,
     },
   },
 };

--- a/app/components/UI/Rewards/utils/ondoCampaignConstants.ts
+++ b/app/components/UI/Rewards/utils/ondoCampaignConstants.ts
@@ -1,0 +1,6 @@
+/**
+ * Number of qualifying days required to be eligible for a prize in an Ondo GM campaign.
+ * A "qualifying day" is any day the participant holds their net deposit above the tier
+ * minimum — days do not need to be consecutive.
+ */
+export const ONDO_GM_REQUIRED_QUALIFIED_DAYS = 10;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -107,6 +107,7 @@ const Routes = {
   REWARDS_ONDO_CAMPAIGN_LEADERBOARD: 'RewardsOndoCampaignLeaderboard',
   REWARDS_ONDO_CAMPAIGN_RWA_ASSET_SELECTOR: 'RewardsOndoRwaAssetSelector',
   REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW: 'RewardsOndoCampaignPortfolioView',
+  REWARDS_ONDO_CAMPAIGN_STATS: 'RewardsOndoCampaignStats',
   REWARDS_CAMPAIGN_TOUR_STEP: 'RewardsCampaignTourStep',
   TRENDING_VIEW: 'TrendingView',
   TRENDING_FEED: 'TrendingFeed',
@@ -150,6 +151,7 @@ const Routes = {
     OTA_UPDATES_MODAL: 'OTAUpdatesModal',
     REWARDS_END_OF_SEASON_CLAIM_BOTTOM_SHEET: 'EndOfSeasonClaimBottomSheet',
     REWARDS_SELECT_SHEET: 'RewardsSelectSheet',
+    REWARDS_ONDO_PENDING_SHEET: 'RewardsOndoPendingSheet',
   },
   ONBOARDING: {
     ROOT_NAV: 'OnboardingRootNav',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -19221,7 +19221,7 @@ describe('RewardsController', () => {
       campaignId: mockCampaignId,
       computedAt: '2024-03-20T12:00:00.000Z',
       tiers: {
-        STARTER: { entries: [], totalParticipants: 100 },
+        STARTER: { entries: [], totalParticipants: 100, minDeposit: 500 },
       },
     };
 

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -303,6 +303,12 @@ export interface CampaignLeaderboardTier {
    * @example 150
    */
   totalParticipants: number;
+
+  /**
+   * Minimum USD net deposit required to qualify for this tier
+   * @example 5000
+   */
+  minDeposit: number;
 }
 
 /**

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -696,6 +696,7 @@ export type CampaignLeaderboardState = {
         qualified: boolean;
       }[];
       totalParticipants: number;
+      minDeposit: number;
     };
   };
   lastFetched: number;

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -5152,6 +5152,7 @@ const mockLeaderboard: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 150,
+      minDeposit: 500,
     },
     MID: {
       entries: [
@@ -5178,6 +5179,7 @@ const mockLeaderboard: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 75,
+      minDeposit: 1000,
     },
   },
 };

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3422,6 +3422,7 @@ describe('Rewards selectors', () => {
           },
         ],
         totalParticipants: 50,
+        minDeposit: 500,
       },
       MID: {
         entries: [
@@ -3434,6 +3435,7 @@ describe('Rewards selectors', () => {
           },
         ],
         totalParticipants: 30,
+        minDeposit: 1000,
       },
     },
   };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1814,12 +1814,13 @@
       "market_hours": {
         "title": "Market hours",
         "closes_in": "Closes in {{time}}",
-        "content": "You're trading within regular market hours (9:30 am to 4 pm ET). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
+        "content": "You're trading within regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
       },
       "after_hours_trading": {
         "title": "After-hours trading",
         "reopens_in": "Reopens in {{time}}",
-        "content": "You're trading outside of regular market hours (9:30 am to 4 pm ET). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
+        "reopens_in_label": "Reopens in",
+        "content": "You're trading outside of regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates."
       },
       "spread": {
         "title": "Spread",
@@ -8084,7 +8085,7 @@
       "ondo": {
         "entries_closed_title": "Entries closed",
         "entries_closed_description": "You missed the opt-in window. Check back for more campaigns in the future.",
-        "open_position": "Open Position"
+        "open_position": "Swap Ondo assets"
       }
     },
     "ondo_campaign_prize_pool": {
@@ -8092,6 +8093,7 @@
       "current_label": "Current",
       "next_label": "Next",
       "volume_subtext": "{{current}} of {{target}} volume",
+      "max_tier_subtext": "{{maxThreshold}}+ TVL — all milestones reached",
       "error_title": "Failed to load prize pool",
       "error_description": "There was an error loading the prize pool. Please try again.",
       "retry_button": "Retry"
@@ -8115,6 +8117,7 @@
       "portfolio_pnl_percent": "P&L (%)",
       "summary_cost_basis": "Cost basis",
       "summary_net_deposit": "Net deposit",
+      "summary_cashed_out": "Cashed out",
       "position_current_value": "Value",
       "position_unrealized_pnl": "P&L",
       "updated_at": "Last updated: {{time}}",
@@ -8157,7 +8160,33 @@
       "tier_upper": "Platinum",
       "select_tier": "Select Tier",
       "pending": "Pending",
-      "qualified": "Qualified"
+      "qualified": "Qualified",
+      "pending_sheet_title": "Pending",
+      "pending_sheet_tier_label": "Tier",
+      "pending_sheet_net_deposit_label": "Net Deposit",
+      "pending_sheet_own_body": "Hold a minimum balance of {{minDeposit}} for {{daysRemaining}} more day(s) to qualify for this tier.",
+      "pending_sheet_other_body": "This participant hasn't yet met the holding requirement for their projected tier.",
+      "pending_sheet_cta": "Got it",
+      "qualify_for_rank_title": "Qualify for this rank",
+      "qualify_for_rank_description": "Keep your deposit above {{minDeposit}} for {{daysRemaining}} more days, including the final day."
+    },
+    "ondo_campaign_stats": {
+      "title": "Stats",
+      "stats_error_title": "Unable to load all stats",
+      "stats_error_description": "We had a problem loading your stats. Please try again later.",
+      "retry": "Retry",
+      "label_return": "Return",
+      "label_market_value": "Market Value",
+      "label_net_deposited": "Net deposited",
+      "label_cashed_out": "Cashed out",
+      "label_rank": "Rank",
+      "label_tier": "Tier",
+      "label_your_return": "Your return",
+      "label_your_rank": "Your rank",
+      "label_net_deposit": "Net deposit",
+      "label_days_held": "Days held",
+      "qualified_title": "You're qualified",
+      "qualified_description": "Keep your net deposit above {{minDeposit}} through the final day to stay eligible."
     },
     "ondo_campaign_activity": {
       "title": "All activity",
@@ -8170,6 +8199,18 @@
       "retry_button": "Retry",
       "empty_title": "No activity yet",
       "empty_description": "Your campaign activity will appear here once you have transactions."
+    },
+    "ondo_campaign_after_hours_trading": {
+      "title": "After-hours trading",
+      "reopens_in_label": "Reopens in",
+      "content": "You're trading outside of regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates.",
+      "got_it_button": "Got it"
+    },
+    "ondo_campaign_not_eligible": {
+      "title": "Not eligible",
+      "body": "This position won't be entered in the campaign. It won't meet the {{days}}-day hold requirement.",
+      "cancel": "Cancel",
+      "confirm": "I understand"
     },
     "campaigns_preview": {
       "title": "Campaigns",


### PR DESCRIPTION
## **Description**

New: Campaign Stats Screen

A dedicated screen showing the user's personal performance in the campaign — their current return (positive in green, negative in red), total portfolio value, rank, tier (Bronze, Silver, Platinum), net deposit amount, days held, and whether they're Qualified or Pending.

New: Tier-based Leaderboard

The leaderboard now lets users filter by tier (Bronze, Silver, Platinum). Each entry shows rank, referral code, and return percentage. Users see their own position highlighted, plus a count of total participants in that tier.

New: "Qualify for this rank" & "You're qualified" cards

- If a user is pending, they see a card telling them exactly how much more they need to deposit and how many more days to hold to qualify.
- Once they meet the requirements, the card flips to "You're qualified."

New: After-Hours Trading popup

When a user tries to swap an asset outside market hours, a popup appears explaining that trading is closed, shows a countdown to when markets reopen, and warns about wider price spreads.

New: Eligibility warning popup

If there aren't enough days left in the campaign to meet the holding requirement, a warning popup tells the user their new position won't count toward the campaign, with options to cancel or proceed anyway.

New: "Entries closed" state

If the campaign has ended and the user never opted in, the join button is locked and shows "Entries closed." Tapping it shows a message explaining they missed the opt-in window.

Updated: Portfolio section

Now shows each deposited asset with its current value, shares owned, and profit/loss percentage. Users can tap a position to swap it for a different asset, or tap a link to view their full activity history.

Updated: Prize pool display

Shows the current prize pool size and how much additional volume is needed to unlock the next reward tier.

## **Changelog**


CHANGELOG entry: ondo campaign rewards - stats page

## **Screenshots/Recordings**

- Active Campaign

- Opted in

Negative return but qualified

<img width="952" height="1763" alt="negative-qualified" src="https://github.com/user-attachments/assets/0e27784a-f5ce-4033-b338-e2916a259427" />

<img width="952" height="1763" alt="negative-qualified-2" src="https://github.com/user-attachments/assets/d07d0535-b2a1-4603-b4b4-4be694dc33c7" />

Positive return but pending

<img width="1025" height="1799" alt="positive-pending-1" src="https://github.com/user-attachments/assets/b4e231a0-a0af-45db-90a8-572551c8322d" />

<img width="1025" height="1799" alt="positive-pendin-2-leaderboard-bottom-20" src="https://github.com/user-attachments/assets/14e37219-9605-466b-b788-507527fce233" />

Leaderboard top 5 (in others its 18th position)

<img width="943" height="539" alt="leaderboard-top-5" src="https://github.com/user-attachments/assets/55c98e89-0c94-494d-882b-b02516ef6731" />

Prize pool variants

<img width="962" height="324" alt="prize-pool-fully-reached" src="https://github.com/user-attachments/assets/c154f79a-723b-4fa8-ba9b-5885b3fd541b" />

<img width="962" height="324" alt="prize-pool-unlock" src="https://github.com/user-attachments/assets/da6f91f0-d12c-4654-a87d-680412769d4d" />

Leaderboard page (positive return pending)

<img width="1025" height="1799" alt="positive-pending" src="https://github.com/user-attachments/assets/636d6806-c6ee-4635-bd07-6e2761919db0" />

Stats page positive but pending

<img width="952" height="1763" alt="positive-pending" src="https://github.com/user-attachments/assets/6d5c8d1f-e519-47b6-9b43-e26a4df7c8dc" />

Stats page positive & qualified 

<img width="951" height="1830" alt="positive-qualified-complete" src="https://github.com/user-attachments/assets/570f8f11-1d4e-415f-ab48-a0e70a747b47" />

Stats page but negative return and cashed out

<img width="952" height="1763" alt="negative-qualified-cashed-out" src="https://github.com/user-attachments/assets/9298e079-30ff-4625-8ac1-eec3890df4fb" />

Open position or swap position but outside of market hours

<img width="957" height="845" alt="open-position-market-hours" src="https://github.com/user-attachments/assets/52accff5-3d36-4e0b-af50-a2062fb58b78" />

Open position but can't qualify for tier treshold  anymore

<img width="1156" height="701" alt="not eligible" src="https://github.com/user-attachments/assets/b67d484a-0977-4d63-bec5-f4f414273ca4" />

- Not Opted in

<img width="916" height="1813" alt="Screenshot from 2026-04-13 15-32-09" src="https://github.com/user-attachments/assets/afc04260-729d-4867-bdd8-7caad4db9527" />

<img width="916" height="1813" alt="Screenshot from 2026-04-13 15-32-12" src="https://github.com/user-attachments/assets/12cb1a91-c999-4f38-b535-e8aa8a6b6c4a" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new rewards navigation routes, screens, and bottom sheets with updated Ondo campaign eligibility/pending logic and new `minDeposit` data plumbing; mistakes could impact campaign UX and leaderboard/stats rendering but do not touch security-critical flows.
> 
> **Overview**
> Introduces a dedicated **Ondo campaign Stats** screen (`RewardsOndoCampaignStats`) and wires it into the rewards navigator, including navigation from the campaign details stats header.
> 
> Adds new bottom sheets for **Pending** (`RewardsOndoPendingSheet`), **After-hours trading** (`OndoAfterHoursSheet`), and **Not eligible** (`OndoNotEligibleSheet`), and updates campaign details/portfolio/CTA flows to gate swaps/position actions when the user can no longer meet the `ONDO_GM_REQUIRED_QUALIFIED_DAYS` requirement.
> 
> Extends Ondo leaderboard tier data with `minDeposit` and updates `OndoLeaderboard`/`CampaignStatsSummary` to show qualify messaging, open the pending sheet from pending tags/cards, unify stats error handling, and tweak prize pool/max-tier copy and various UI text/icon styles (including ET→EST strings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7be45eb5f9dcb5db4efcbc5ed479ee21984a9ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->