### PR TITLE
feat(predict): add outcome grouping logic for sport events

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -8074,4 +8074,122 @@ describe('PolymarketProvider', () => {
       expect(requestUrl.searchParams.get('limit')).toBe('50');
     });
   });
+
+  describe('extendedSportsMarketsLeagues pass-through', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('getMarkets passes extendedSportsMarketsLeagues to parsePolymarketEvents', async () => {
+      const leagues = ['nfl', 'nba'];
+      const provider = createProvider({
+        liveSportsLeagues: ['nfl'],
+        extendedSportsMarketsLeagues: leagues,
+      });
+      mockFetchEventsFromPolymarketApi.mockResolvedValue({
+        events: [{ id: 'event-1' }],
+        category: 'trending',
+        isSearch: false,
+      });
+      mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+      mockParsePolymarketEvents.mockReturnValue([]);
+
+      await provider.getMarkets();
+
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ extendedSportsMarketsLeagues: leagues }),
+      );
+    });
+
+    it('getMarkets passes empty extendedSportsMarketsLeagues when flag has no leagues', async () => {
+      const provider = createProvider();
+      mockFetchEventsFromPolymarketApi.mockResolvedValue({
+        events: [{ id: 'event-1' }],
+        category: 'trending',
+        isSearch: false,
+      });
+      mockParsePolymarketEvents.mockReturnValue([]);
+
+      await provider.getMarkets();
+
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ extendedSportsMarketsLeagues: [] }),
+      );
+    });
+
+    it('getMarketDetails passes extendedSportsMarketsLeagues to parsePolymarketEvents', async () => {
+      const leagues = ['nfl'];
+      const provider = createProvider({
+        liveSportsLeagues: ['nfl'],
+        extendedSportsMarketsLeagues: leagues,
+      });
+      const mockEvent = { id: 'market-1', question: 'Test?' };
+      mockIsLiveSportsEvent.mockReturnValue(true);
+      mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
+      mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+      mockParsePolymarketEvents.mockReturnValue([
+        { id: 'market-1', title: 'Test' },
+      ]);
+
+      await provider.getMarketDetails({ marketId: 'market-1' });
+
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        [mockEvent],
+        expect.objectContaining({ extendedSportsMarketsLeagues: leagues }),
+      );
+    });
+
+    it('getMarketSeries passes extendedSportsMarketsLeagues to parsePolymarketEvents', async () => {
+      const leagues = ['nfl', 'nba'];
+      const provider = createProvider({
+        liveSportsLeagues: ['nfl'],
+        extendedSportsMarketsLeagues: leagues,
+      });
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue([{ id: 'event-1' }]),
+      };
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse);
+      mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+      mockParsePolymarketEvents.mockReturnValue([]);
+
+      await provider.getMarketSeries({
+        seriesId: '10684',
+        endDateMin: '2026-04-06T00:00:00.000Z',
+        endDateMax: '2026-04-07T00:00:00.000Z',
+      });
+
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ extendedSportsMarketsLeagues: leagues }),
+      );
+    });
+
+    it('getCarouselMarkets passes extendedSportsMarketsLeagues to parsePolymarketEvents', async () => {
+      const leagues = ['nfl'];
+      const provider = createProvider({
+        liveSportsLeagues: ['nfl'],
+        extendedSportsMarketsLeagues: leagues,
+      });
+      mockFetchCarouselFromPolymarketApi.mockResolvedValue([
+        { event: { id: 'event-1' } },
+      ]);
+      mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+      mockParsePolymarketEvents.mockReturnValue([]);
+
+      await provider.getCarouselMarkets();
+
+      expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ extendedSportsMarketsLeagues: leagues }),
+      );
+    });
+  });
 });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -293,9 +293,12 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(isSportsEvent);
 
+      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
+
       const [parsedMarket] = parsePolymarketEvents([event], {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
+        extendedSportsMarketsLeagues,
       });
 
       if (!parsedMarket) {
@@ -399,10 +402,13 @@ export class PolymarketProvider implements PredictProvider {
       // Step 3: Create team lookup and parse events
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
+      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
+
       const parsedMarkets = parsePolymarketEvents(events, {
         category,
         sortMarketsBy: 'price',
         teamLookup,
+        extendedSportsMarketsLeagues,
       });
 
       const markets = isSearch
@@ -466,9 +472,12 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
+      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
+
       return parsePolymarketEvents(events, {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
+        extendedSportsMarketsLeagues,
       });
     } catch (error) {
       DevLogger.log('Error fetching series events via Polymarket API:', error);
@@ -496,10 +505,13 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
+      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
+
       const parsedMarkets = parsePolymarketEvents(events, {
         category: 'trending',
         sortMarketsBy: 'price',
         teamLookup,
+        extendedSportsMarketsLeagues,
       }).filter((m) => m.status === 'open' && m.outcomes.length > 0);
 
       return liveSportsEnabled

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -175,9 +175,12 @@ export class PolymarketProvider implements PredictProvider {
     return filterSupportedLeagues(liveSportsLeagues);
   }
 
+  #getExtendedSportsMarketsLeagues(): string[] {
+    return this.#getFeatureFlags().extendedSportsMarketsLeagues;
+  }
+
   #hasExtendedMarketsForLeague(league: string): boolean {
-    const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
-    return extendedSportsMarketsLeagues.includes(league);
+    return this.#getExtendedSportsMarketsLeagues().includes(league);
   }
 
   #createTeamLookup(
@@ -293,12 +296,10 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(isSportsEvent);
 
-      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
-
       const [parsedMarket] = parsePolymarketEvents([event], {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
-        extendedSportsMarketsLeagues,
+        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
       });
 
       if (!parsedMarket) {
@@ -402,13 +403,11 @@ export class PolymarketProvider implements PredictProvider {
       // Step 3: Create team lookup and parse events
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
-      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
-
       const parsedMarkets = parsePolymarketEvents(events, {
         category,
         sortMarketsBy: 'price',
         teamLookup,
-        extendedSportsMarketsLeagues,
+        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
       });
 
       const markets = isSearch
@@ -472,12 +471,10 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
-      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
-
       return parsePolymarketEvents(events, {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
-        extendedSportsMarketsLeagues,
+        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
       });
     } catch (error) {
       DevLogger.log('Error fetching series events via Polymarket API:', error);
@@ -505,13 +502,11 @@ export class PolymarketProvider implements PredictProvider {
 
       const teamLookup = this.#createTeamLookup(liveSportsEnabled);
 
-      const { extendedSportsMarketsLeagues } = this.#getFeatureFlags();
-
       const parsedMarkets = parsePolymarketEvents(events, {
         category: 'trending',
         sortMarketsBy: 'price',
         teamLookup,
-        extendedSportsMarketsLeagues,
+        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
       }).filter((m) => m.status === 'open' && m.outcomes.length > 0);
 
       return liveSportsEnabled

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -83,3 +83,39 @@ export const MATIC_CONTRACTS: ContractConfig = {
 
 export const POLYGON_USDC_CAIP_ASSET_ID =
   `${POLYGON_MAINNET_CAIP_CHAIN_ID}/erc20:${MATIC_CONTRACTS.collateral}` as const;
+
+export const SPORTS_MARKET_TYPE_TO_GROUP: Record<string, string> = {
+  first_half_moneyline: 'first-half',
+  first_half_spreads: 'first-half',
+  first_half_totals: 'first-half',
+  team_totals: 'team-totals',
+  anytime_touchdowns: 'touchdowns',
+  first_touchdowns: 'touchdowns',
+  rushing_yards: 'rushing',
+  receiving_yards: 'receiving',
+  points: 'points',
+  assists: 'assists',
+  rebounds: 'rebounds',
+  soccer_anytime_goalscorer: 'goalscorers',
+  soccer_exact_score: 'exact-score',
+  soccer_halftime_result: 'halftime',
+  total_corners: 'corners',
+};
+
+export const GROUP_ORDER: string[] = [
+  'game-lines',
+  'first-half',
+  'team-totals',
+  'touchdowns',
+  'rushing',
+  'receiving',
+  'points',
+  'assists',
+  'rebounds',
+  'goalscorers',
+  'exact-score',
+  'halftime',
+  'corners',
+];
+
+export const DEFAULT_GROUP_KEY = 'game-lines';

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -119,3 +119,9 @@ export const GROUP_ORDER: string[] = [
 ];
 
 export const DEFAULT_GROUP_KEY = 'game-lines';
+
+export const SPORTS_MARKET_TYPE_PRIORITIES: Record<string, number> = {
+  moneyline: 0,
+  spreads: 1,
+  totals: 2,
+};

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -4,6 +4,7 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import Engine from '../../../../../core/Engine';
 import {
   PredictCategory,
+  PredictOutcome,
   PredictPositionStatus,
   Side,
   PredictActivityBuy,
@@ -11,6 +12,7 @@ import {
   PredictActivityEntry,
 } from '../../types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
+import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
 import {
   ClobAuthDomain,
   EIP712Domain,
@@ -37,6 +39,7 @@ import {
 } from './types';
 import { GetMarketsParams } from '../types';
 import {
+  buildOutcomeGroups,
   buildPolyHmacSignature,
   calculateFees,
   createApiKey,
@@ -56,10 +59,12 @@ import {
   getOrderTypedData,
   getPolymarketEndpoints,
   getPredictPositionStatus,
+  GROUP_ORDER,
   parsePolymarketEvents,
   parsePolymarketPositions,
   parsePolymarketActivity,
   priceValid,
+  SPORTS_MARKET_TYPE_TO_GROUP,
   submitClobOrder,
   decimalPlaces,
   roundNormal,
@@ -1471,6 +1476,86 @@ describe('polymarket utils', () => {
         'market-second',
         'market-third',
       ]);
+    });
+
+    it('populates outcomeGroups for sport event when extendedSportsMarketsLeagues includes league', () => {
+      const sportEvent: PolymarketApiEvent = {
+        id: 'nfl-game-1',
+        slug: 'nfl-sea-den-2025-01-15',
+        title: 'Seahawks vs. Broncos',
+        description: 'NFL game',
+        icon: 'https://example.com/icon.png',
+        closed: false,
+        tags: [
+          { id: '1', label: 'Sports', slug: 'sports' },
+          { id: '2', label: 'Games', slug: 'games' },
+          { id: '3', label: 'NFL', slug: 'nfl' },
+        ],
+        series: [],
+        markets: [
+          {
+            ...mockEvent.markets[0],
+            conditionId: 'moneyline-1',
+            sportsMarketType: 'moneyline',
+          },
+        ],
+        liquidity: 50000,
+        volume: 100000,
+        gameId: 'game-123',
+      };
+      const mockTeamLookup = jest.fn((league: string, abbreviation: string) => {
+        const teams: Record<
+          string,
+          Record<
+            string,
+            {
+              id: string;
+              name: string;
+              logo: string;
+              abbreviation: string;
+              color: string;
+              alias: string;
+            }
+          >
+        > = {
+          nfl: {
+            sea: {
+              id: 'sea',
+              name: 'Seahawks',
+              logo: '',
+              abbreviation: 'sea',
+              color: TEST_HEX_COLORS.TEAM_SEA,
+              alias: 'Seahawks',
+            },
+            den: {
+              id: 'den',
+              name: 'Broncos',
+              logo: '',
+              abbreviation: 'den',
+              color: TEST_HEX_COLORS.TEAM_DEN,
+              alias: 'Broncos',
+            },
+          },
+        };
+        return teams[league]?.[abbreviation];
+      });
+
+      const resultWithLeague = parsePolymarketEvents([sportEvent], {
+        category: 'sports',
+        teamLookup: mockTeamLookup,
+        extendedSportsMarketsLeagues: ['nfl'],
+      });
+
+      expect(resultWithLeague[0].outcomeGroups).toBeDefined();
+      expect(Array.isArray(resultWithLeague[0].outcomeGroups)).toBe(true);
+
+      const resultWithoutLeague = parsePolymarketEvents([sportEvent], {
+        category: 'sports',
+        teamLookup: mockTeamLookup,
+        extendedSportsMarketsLeagues: [],
+      });
+
+      expect(resultWithoutLeague[0].outcomeGroups).toBeUndefined();
     });
   });
 
@@ -3944,6 +4029,255 @@ describe('polymarket utils', () => {
     it('includes all necessary approval calls', () => {
       const calls = getAllowanceCalls({ address: mockAddress });
       expect(calls.length).toBe(6);
+    });
+  });
+
+  describe('buildOutcomeGroups', () => {
+    const createMockPolymarketApiMarket = (
+      overrides: Partial<PolymarketApiMarket> = {},
+    ): PolymarketApiMarket => ({
+      conditionId: 'condition-default',
+      question: 'Market?',
+      description: 'Description',
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: 'Group',
+      status: 'open',
+      volumeNum: 100,
+      liquidity: 100,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: '["0.5", "0.5"]',
+      closed: false,
+      active: true,
+      resolvedBy: '',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+      ...overrides,
+    });
+
+    const createMockOutcome = (id: string): PredictOutcome => ({
+      id,
+      providerId: POLYMARKET_PROVIDER_ID,
+      marketId: 'event-1',
+      title: `Market ${id}`,
+      description: `Description ${id}`,
+      image: 'https://example.com/icon.png',
+      groupItemTitle: `Group ${id}`,
+      status: 'open',
+      volume: 100,
+      tokens: [
+        { id: 'token-1', title: 'Yes', price: 0.5 },
+        { id: 'token-2', title: 'No', price: 0.5 },
+      ],
+      negRisk: false,
+      tickSize: '0.01',
+    });
+
+    it('groups mixed sport event into game-lines, first-half, and touchdowns', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'to-1',
+          sportsMarketType: 'totals',
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'fhs-1',
+          sportsMarketType: 'first_half_spreads',
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'at-1',
+          sportsMarketType: 'anytime_touchdowns',
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((g) => g.key)).toEqual([
+        'game-lines',
+        'first-half',
+        'touchdowns',
+      ]);
+      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+        'ml-1',
+        'sp-1',
+        'to-1',
+      ]);
+      expect(result[1].outcomes.map((o) => o.id)).toEqual(['fhs-1']);
+      expect(result[2].outcomes.map((o) => o.id)).toEqual(['at-1']);
+    });
+
+    it('groups all standard market types into single game-lines group', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'to-1',
+          sportsMarketType: 'totals',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+        'ml-1',
+        'sp-1',
+        'to-1',
+      ]);
+    });
+
+    it('falls back unknown sportsMarketType to game-lines', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'unknown-1',
+          sportsMarketType: 'some_new_type',
+        }),
+      ];
+      const outcomes = [createMockOutcome('unknown-1')];
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+    });
+
+    it('falls back undefined sportsMarketType to game-lines', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'undef-1',
+          sportsMarketType: undefined,
+        }),
+      ];
+      const outcomes = [createMockOutcome('undef-1')];
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+    });
+
+    it('groups single mapped type into standalone group', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'fhs-1',
+          sportsMarketType: 'first_half_spreads',
+        }),
+      ];
+      const outcomes = [createMockOutcome('fhs-1')];
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('first-half');
+    });
+
+    it('returns empty array for empty inputs', () => {
+      const result = buildOutcomeGroups([], []);
+
+      expect(result).toEqual([]);
+    });
+
+    it('sorts game-lines outcomes by sportsMarketType priority then liquidity+volume', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'to-1',
+          sportsMarketType: 'totals',
+          liquidity: 10,
+          volumeNum: 10,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 500,
+          volumeNum: 500,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+          liquidity: 200,
+          volumeNum: 200,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+        'ml-1',
+        'sp-1',
+        'to-1',
+      ]);
+    });
+
+    it('orders groups by GROUP_ORDER priority with unknown keys at end', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'at-1',
+          sportsMarketType: 'anytime_touchdowns',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'fhs-1',
+          sportsMarketType: 'first_half_spreads',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result.map((g) => g.key)).toEqual([
+        'game-lines',
+        'first-half',
+        'touchdowns',
+      ]);
+      expect(GROUP_ORDER.indexOf('game-lines')).toBeLessThan(
+        GROUP_ORDER.indexOf('first-half'),
+      );
+      expect(GROUP_ORDER.indexOf('first-half')).toBeLessThan(
+        GROUP_ORDER.indexOf('touchdowns'),
+      );
+      expect(SPORTS_MARKET_TYPE_TO_GROUP.first_half_spreads).toBe(
+        'first-half',
+      );
+      expect(SPORTS_MARKET_TYPE_TO_GROUP.anytime_touchdowns).toBe(
+        'touchdowns',
+      );
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -4108,13 +4108,16 @@ describe('polymarket utils', () => {
         'first-half',
         'touchdowns',
       ]);
-      expect(result[0].outcomes.map((o) => o.id)).toEqual([
-        'ml-1',
-        'sp-1',
-        'to-1',
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual([
+        'moneyline',
+        'spreads',
+        'totals',
       ]);
       expect(result[1].outcomes.map((o) => o.id)).toEqual(['fhs-1']);
+      expect(result[1].subgroups).toBeUndefined();
       expect(result[2].outcomes.map((o) => o.id)).toEqual(['at-1']);
+      expect(result[2].subgroups).toBeUndefined();
     });
 
     it('groups all standard market types into single game-lines group', () => {
@@ -4144,9 +4147,19 @@ describe('polymarket utils', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
-      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual([
+        'moneyline',
+        'spreads',
+        'totals',
+      ]);
+      expect(result[0].subgroups?.[0].outcomes.map((o) => o.id)).toEqual([
         'ml-1',
+      ]);
+      expect(result[0].subgroups?.[1].outcomes.map((o) => o.id)).toEqual([
         'sp-1',
+      ]);
+      expect(result[0].subgroups?.[2].outcomes.map((o) => o.id)).toEqual([
         'to-1',
       ]);
     });
@@ -4202,7 +4215,7 @@ describe('polymarket utils', () => {
       expect(result).toEqual([]);
     });
 
-    it('sorts game-lines outcomes by sportsMarketType priority then liquidity+volume', () => {
+    it('sorts game-lines subgroups by sportsMarketType priority', () => {
       const markets = [
         createMockPolymarketApiMarket({
           conditionId: 'to-1',
@@ -4229,10 +4242,11 @@ describe('polymarket utils', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
-      expect(result[0].outcomes.map((o) => o.id)).toEqual([
-        'ml-1',
-        'sp-1',
-        'to-1',
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual([
+        'moneyline',
+        'spreads',
+        'totals',
       ]);
     });
 
@@ -4302,23 +4316,52 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('sorts non-game-lines group outcomes by liquidity+volume descending', () => {
+    it('sorts first-half subgroups by normalized sportsMarketType priority (moneyline, spreads, totals)', () => {
       const markets = [
         createMockPolymarketApiMarket({
-          conditionId: 'fhm-low',
-          sportsMarketType: 'first_half_moneyline',
-          liquidity: 30,
-          volumeNum: 20,
+          conditionId: 'fht-1',
+          sportsMarketType: 'first_half_totals',
+          liquidity: 500,
+          volumeNum: 500,
         }),
         createMockPolymarketApiMarket({
-          conditionId: 'fhs-high',
+          conditionId: 'fhm-1',
+          sportsMarketType: 'first_half_moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'fhs-1',
           sportsMarketType: 'first_half_spreads',
-          liquidity: 400,
+          liquidity: 300,
           volumeNum: 300,
         }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('first-half');
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual([
+        'first_half_moneyline',
+        'first_half_spreads',
+        'first_half_totals',
+      ]);
+    });
+
+    it('creates subgroups for touchdowns group with anytime and first types', () => {
+      const markets = [
         createMockPolymarketApiMarket({
-          conditionId: 'fht-mid',
-          sportsMarketType: 'first_half_totals',
+          conditionId: 'at-1',
+          sportsMarketType: 'anytime_touchdowns',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'ft-1',
+          sportsMarketType: 'first_touchdowns',
           liquidity: 100,
           volumeNum: 100,
         }),
@@ -4328,12 +4371,265 @@ describe('polymarket utils', () => {
       const result = buildOutcomeGroups(outcomes, markets);
 
       expect(result).toHaveLength(1);
-      expect(result[0].key).toBe('first-half');
-      expect(result[0].outcomes.map((o) => o.id)).toEqual([
-        'fhs-high',
-        'fht-mid',
-        'fhm-low',
+      expect(result[0].key).toBe('touchdowns');
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups).toHaveLength(2);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual(
+        expect.arrayContaining(['anytime_touchdowns', 'first_touchdowns']),
+      );
+    });
+
+    it('keeps single-type group flat without subgroups (points)', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'pts-1',
+          sportsMarketType: 'points',
+          liquidity: 200,
+          volumeNum: 200,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'pts-2',
+          sportsMarketType: 'points',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('points');
+      expect(result[0].outcomes).toHaveLength(2);
+      expect(result[0].outcomes.map((o) => o.id)).toEqual(['pts-1', 'pts-2']);
+      expect(result[0].subgroups).toBeUndefined();
+    });
+
+    it('creates subgroups for game-lines with moneyline and spreads only', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+      expect(result[0].outcomes).toEqual([]);
+      expect(result[0].subgroups).toHaveLength(2);
+      expect(result[0].subgroups?.map((s) => s.key)).toEqual([
+        'moneyline',
+        'spreads',
       ]);
+    });
+
+    it('keeps game-lines flat when only moneyline exists', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('game-lines');
+      expect(result[0].outcomes).toHaveLength(1);
+      expect(result[0].outcomes[0].id).toBe('ml-1');
+      expect(result[0].subgroups).toBeUndefined();
+    });
+
+    it('sorts outcomes by liquidity+volume within each subgroup', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-low',
+          sportsMarketType: 'spreads',
+          liquidity: 50,
+          volumeNum: 50,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-high',
+          sportsMarketType: 'spreads',
+          liquidity: 500,
+          volumeNum: 500,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      const spreadsSubgroup = result[0].subgroups?.find(
+        (s) => s.key === 'spreads',
+      );
+      expect(spreadsSubgroup?.outcomes.map((o) => o.id)).toEqual([
+        'sp-high',
+        'sp-low',
+      ]);
+    });
+
+    it('mixed event produces subgrouped and flat groups', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'to-1',
+          sportsMarketType: 'totals',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'pts-1',
+          sportsMarketType: 'points',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      const gameLines = result.find((g) => g.key === 'game-lines');
+      const points = result.find((g) => g.key === 'points');
+      expect(gameLines?.subgroups).toHaveLength(3);
+      expect(gameLines?.outcomes).toEqual([]);
+      expect(points?.outcomes).toHaveLength(1);
+      expect(points?.subgroups).toBeUndefined();
+    });
+
+    it('multiple spread thresholds within spreads subgroup', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'ml-1',
+          sportsMarketType: 'moneyline',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-1',
+          sportsMarketType: 'spreads',
+          liquidity: 300,
+          volumeNum: 300,
+          groupItemThreshold: 3.5,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-2',
+          sportsMarketType: 'spreads',
+          liquidity: 200,
+          volumeNum: 200,
+          groupItemThreshold: 7.5,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-3',
+          sportsMarketType: 'spreads',
+          liquidity: 100,
+          volumeNum: 100,
+          groupItemThreshold: 10.5,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      const spreadsSubgroup = result[0].subgroups?.find(
+        (s) => s.key === 'spreads',
+      );
+      expect(spreadsSubgroup?.outcomes).toHaveLength(3);
+      expect(spreadsSubgroup?.outcomes.map((o) => o.id)).toEqual([
+        'sp-1',
+        'sp-2',
+        'sp-3',
+      ]);
+    });
+  });
+
+  describe('parsePolymarketMarket - sportsMarketType mapping', () => {
+    const createMarketForSportsType = (
+      overrides: Partial<PolymarketApiMarket> = {},
+    ): PolymarketApiMarket => ({
+      conditionId: 'market-1',
+      question: 'Will it rain?',
+      description: 'Weather prediction',
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: 'Weather',
+      status: 'open',
+      volumeNum: 1000,
+      liquidity: 500,
+      negRisk: false,
+      clobTokenIds: '["token-1", "token-2"]',
+      outcomes: '["Yes", "No"]',
+      outcomePrices: '["0.6", "0.4"]',
+      closed: false,
+      active: true,
+      resolvedBy: '0x123',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+      ...overrides,
+    });
+
+    const createEventForSportsType = (): PolymarketApiEvent => ({
+      id: 'event-1',
+      slug: 'test-event',
+      title: 'Test Event',
+      description: 'A test event',
+      icon: 'https://example.com/icon.png',
+      closed: false,
+      tags: [],
+      series: [],
+      markets: [],
+      liquidity: 1000,
+      volume: 5000,
+    });
+
+    it('parsePolymarketMarket maps sportsMarketType from raw market', () => {
+      const market = createMarketForSportsType({
+        sportsMarketType: 'spreads',
+      });
+      const event = createEventForSportsType();
+
+      const result = parsePolymarketMarket(market, event);
+
+      expect(result.sportsMarketType).toBe('spreads');
+    });
+
+    it('parsePolymarketMarket maps undefined when raw market has no sportsMarketType', () => {
+      const market = createMarketForSportsType();
+      const event = createEventForSportsType();
+
+      const result = parsePolymarketMarket(market, event);
+
+      expect(result.sportsMarketType).toBeUndefined();
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1134,6 +1134,7 @@ describe('polymarket utils', () => {
             groupItemThreshold: undefined,
             status: 'open',
             volume: 1000,
+            liquidity: 500,
             resolutionStatus: 'unresolved',
             tokens: [
               {
@@ -1147,6 +1148,7 @@ describe('polymarket utils', () => {
                 price: 0.4,
               },
             ],
+            sportsMarketType: undefined,
             negRisk: true,
             tickSize: '0.01',
             resolvedBy: '0x0000000000000000000000000000000000000000',
@@ -2153,12 +2155,15 @@ describe('polymarket utils', () => {
         description: 'Weather prediction',
         image: 'https://example.com/icon.png',
         groupItemTitle: 'Weather',
+        groupItemThreshold: undefined,
         status: 'open',
         volume: 1000,
+        liquidity: 500,
         tokens: [
           { id: 'token-1', title: 'Yes', price: 0.6 },
           { id: 'token-2', title: 'No', price: 0.4 },
         ],
+        sportsMarketType: undefined,
         negRisk: false,
         tickSize: '0.01',
         resolvedBy: '0x123',
@@ -4057,7 +4062,10 @@ describe('polymarket utils', () => {
       ...overrides,
     });
 
-    const createMockOutcome = (id: string): PredictOutcome => ({
+    const createMockOutcome = (
+      id: string,
+      overrides?: Partial<PredictOutcome>,
+    ): PredictOutcome => ({
       id,
       providerId: POLYMARKET_PROVIDER_ID,
       marketId: 'event-1',
@@ -4067,12 +4075,14 @@ describe('polymarket utils', () => {
       groupItemTitle: `Group ${id}`,
       status: 'open',
       volume: 100,
+      liquidity: 100,
       tokens: [
         { id: 'token-1', title: 'Yes', price: 0.5 },
         { id: 'token-2', title: 'No', price: 0.5 },
       ],
       negRisk: false,
       tickSize: '0.01',
+      ...overrides,
     });
 
     it('groups mixed sport event into game-lines, first-half, and touchdowns', () => {
@@ -4098,9 +4108,13 @@ describe('polymarket utils', () => {
           sportsMarketType: 'anytime_touchdowns',
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(3);
       expect(result.map((g) => g.key)).toEqual([
@@ -4141,9 +4155,15 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4171,9 +4191,13 @@ describe('polymarket utils', () => {
           sportsMarketType: 'some_new_type',
         }),
       ];
-      const outcomes = [createMockOutcome('unknown-1')];
+      const outcomes = [
+        createMockOutcome('unknown-1', {
+          sportsMarketType: 'some_new_type',
+        }),
+      ];
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4188,7 +4212,7 @@ describe('polymarket utils', () => {
       ];
       const outcomes = [createMockOutcome('undef-1')];
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4201,16 +4225,20 @@ describe('polymarket utils', () => {
           sportsMarketType: 'first_half_spreads',
         }),
       ];
-      const outcomes = [createMockOutcome('fhs-1')];
+      const outcomes = [
+        createMockOutcome('fhs-1', {
+          sportsMarketType: 'first_half_spreads',
+        }),
+      ];
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('first-half');
     });
 
     it('returns empty array for empty inputs', () => {
-      const result = buildOutcomeGroups([], []);
+      const result = buildOutcomeGroups([]);
 
       expect(result).toEqual([]);
     });
@@ -4236,9 +4264,15 @@ describe('polymarket utils', () => {
           volumeNum: 200,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4271,9 +4305,13 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result.map((g) => g.key)).toEqual([
         'game-lines',
@@ -4305,9 +4343,15 @@ describe('polymarket utils', () => {
           volumeNum: 500,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].outcomes.map((o) => o.id)).toEqual([
@@ -4337,9 +4381,15 @@ describe('polymarket utils', () => {
           volumeNum: 300,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('first-half');
@@ -4366,9 +4416,13 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('touchdowns');
@@ -4394,9 +4448,15 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('points');
@@ -4420,9 +4480,13 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4443,9 +4507,13 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       expect(result).toHaveLength(1);
       expect(result[0].key).toBe('game-lines');
@@ -4475,9 +4543,15 @@ describe('polymarket utils', () => {
           volumeNum: 500,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       const spreadsSubgroup = result[0].subgroups?.find(
         (s) => s.key === 'spreads',
@@ -4515,9 +4589,13 @@ describe('polymarket utils', () => {
           volumeNum: 100,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       const gameLines = result.find((g) => g.key === 'game-lines');
       const points = result.find((g) => g.key === 'points');
@@ -4557,9 +4635,15 @@ describe('polymarket utils', () => {
           groupItemThreshold: 10.5,
         }),
       ];
-      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+      const outcomes = markets.map((m) =>
+        createMockOutcome(m.conditionId, {
+          sportsMarketType: m.sportsMarketType,
+          volume: m.volumeNum ?? 100,
+          liquidity: m.liquidity ?? 100,
+        }),
+      );
 
-      const result = buildOutcomeGroups(outcomes, markets);
+      const result = buildOutcomeGroups(outcomes);
 
       const spreadsSubgroup = result[0].subgroups?.find(
         (s) => s.key === 'spreads',

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -4272,12 +4272,8 @@ describe('polymarket utils', () => {
       expect(GROUP_ORDER.indexOf('first-half')).toBeLessThan(
         GROUP_ORDER.indexOf('touchdowns'),
       );
-      expect(SPORTS_MARKET_TYPE_TO_GROUP.first_half_spreads).toBe(
-        'first-half',
-      );
-      expect(SPORTS_MARKET_TYPE_TO_GROUP.anytime_touchdowns).toBe(
-        'touchdowns',
-      );
+      expect(SPORTS_MARKET_TYPE_TO_GROUP.first_half_spreads).toBe('first-half');
+      expect(SPORTS_MARKET_TYPE_TO_GROUP.anytime_touchdowns).toBe('touchdowns');
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -4275,6 +4275,66 @@ describe('polymarket utils', () => {
       expect(SPORTS_MARKET_TYPE_TO_GROUP.first_half_spreads).toBe('first-half');
       expect(SPORTS_MARKET_TYPE_TO_GROUP.anytime_touchdowns).toBe('touchdowns');
     });
+
+    it('tiebreaks game-lines outcomes by liquidity+volume when sportsMarketType priority is equal', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-low',
+          sportsMarketType: 'spreads',
+          liquidity: 50,
+          volumeNum: 50,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'sp-high',
+          sportsMarketType: 'spreads',
+          liquidity: 500,
+          volumeNum: 500,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+        'sp-high',
+        'sp-low',
+      ]);
+    });
+
+    it('sorts non-game-lines group outcomes by liquidity+volume descending', () => {
+      const markets = [
+        createMockPolymarketApiMarket({
+          conditionId: 'fhm-low',
+          sportsMarketType: 'first_half_moneyline',
+          liquidity: 30,
+          volumeNum: 20,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'fhs-high',
+          sportsMarketType: 'first_half_spreads',
+          liquidity: 400,
+          volumeNum: 300,
+        }),
+        createMockPolymarketApiMarket({
+          conditionId: 'fht-mid',
+          sportsMarketType: 'first_half_totals',
+          liquidity: 100,
+          volumeNum: 100,
+        }),
+      ];
+      const outcomes = markets.map((m) => createMockOutcome(m.conditionId));
+
+      const result = buildOutcomeGroups(outcomes, markets);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].key).toBe('first-half');
+      expect(result[0].outcomes.map((o) => o.id)).toEqual([
+        'fhs-high',
+        'fht-mid',
+        'fhm-low',
+      ]);
+    });
   });
 
   describe('parsePolymarketEvents - series metadata', () => {

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -487,7 +487,7 @@ const normalizeSportsMarketType = (type: string): string => {
 };
 
 const getSportsMarketTypePriority = (type: string): number =>
-  SPORTS_MARKET_TYPE_PRIORITIES[normalizeSportsMarketType(type)] ?? 3;
+  SPORTS_MARKET_TYPE_PRIORITIES[type.toLowerCase()] ?? 3;
 
 export function buildOutcomeGroups(
   outcomes: PredictOutcome[],
@@ -515,8 +515,12 @@ export function buildOutcomeGroups(
   for (const [, groupOutcomes] of groupMap) {
     groupOutcomes.sort((a, b) => {
       const priorityDiff =
-        getSportsMarketTypePriority(a.sportsMarketType ?? '') -
-        getSportsMarketTypePriority(b.sportsMarketType ?? '');
+        getSportsMarketTypePriority(
+          normalizeSportsMarketType(a.sportsMarketType ?? ''),
+        ) -
+        getSportsMarketTypePriority(
+          normalizeSportsMarketType(b.sportsMarketType ?? ''),
+        );
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
@@ -557,7 +561,8 @@ export function buildOutcomeGroups(
     const subgroupEntries = [...typeMap.entries()];
     subgroupEntries.sort(
       (a, b) =>
-        getSportsMarketTypePriority(a[0]) - getSportsMarketTypePriority(b[0]),
+        getSportsMarketTypePriority(normalizeSportsMarketType(a[0])) -
+        getSportsMarketTypePriority(normalizeSportsMarketType(b[0])),
     );
 
     return {

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -525,8 +525,8 @@ export function buildOutcomeGroups(
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
-      const aScore = a.liquidity + a.volume;
-      const bScore = b.liquidity + b.volume;
+      const aScore = (a.liquidity ?? 0) + a.volume;
+      const bScore = (b.liquidity ?? 0) + b.volume;
       return bScore - aScore;
     });
   }

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -486,14 +486,25 @@ export const isSportEvent = (event: PolymarketApiEvent): boolean =>
  * Get the sort priority for a sports market type
  * moneyline: 0, spreads: 1, totals: 2, others: 3 (then alphabetically)
  */
-const getSportsMarketTypePriority = (type: string): number => {
-  const priorities: Record<string, number> = {
-    moneyline: 0,
-    spreads: 1,
-    totals: 2,
-  };
-  return priorities[type.toLowerCase()] ?? 3;
+const SPORTS_MARKET_TYPE_PRIORITIES: Record<string, number> = {
+  moneyline: 0,
+  spreads: 1,
+  totals: 2,
 };
+
+const normalizeSportsMarketType = (type: string): string => {
+  const lower = type.toLowerCase();
+  const prefixes = ['first_half_'];
+  for (const prefix of prefixes) {
+    if (lower.startsWith(prefix)) {
+      return lower.slice(prefix.length);
+    }
+  }
+  return lower;
+};
+
+const getSportsMarketTypePriority = (type: string): number =>
+  SPORTS_MARKET_TYPE_PRIORITIES[normalizeSportsMarketType(type)] ?? 3;
 
 export function buildOutcomeGroups(
   outcomes: PredictOutcome[],
@@ -532,36 +543,23 @@ export function buildOutcomeGroups(
     }
   }
 
-  for (const [groupKey, groupOutcomes] of groupMap) {
-    if (groupKey === DEFAULT_GROUP_KEY) {
-      groupOutcomes.sort((a, b) => {
-        const aType = marketLookup.get(a.id)?.sportsMarketType ?? '';
-        const bType = marketLookup.get(b.id)?.sportsMarketType ?? '';
-        const priorityDiff =
-          getSportsMarketTypePriority(aType) -
-          getSportsMarketTypePriority(bType);
-        if (priorityDiff !== 0) {
-          return priorityDiff;
-        }
-        const aScore =
-          (marketLookup.get(a.id)?.liquidity ?? 0) +
-          (marketLookup.get(a.id)?.volumeNum ?? 0);
-        const bScore =
-          (marketLookup.get(b.id)?.liquidity ?? 0) +
-          (marketLookup.get(b.id)?.volumeNum ?? 0);
-        return bScore - aScore;
-      });
-    } else {
-      groupOutcomes.sort((a, b) => {
-        const aScore =
-          (marketLookup.get(a.id)?.liquidity ?? 0) +
-          (marketLookup.get(a.id)?.volumeNum ?? 0);
-        const bScore =
-          (marketLookup.get(b.id)?.liquidity ?? 0) +
-          (marketLookup.get(b.id)?.volumeNum ?? 0);
-        return bScore - aScore;
-      });
-    }
+  for (const [, groupOutcomes] of groupMap) {
+    groupOutcomes.sort((a, b) => {
+      const aType = marketLookup.get(a.id)?.sportsMarketType ?? '';
+      const bType = marketLookup.get(b.id)?.sportsMarketType ?? '';
+      const priorityDiff =
+        getSportsMarketTypePriority(aType) - getSportsMarketTypePriority(bType);
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+      const aScore =
+        (marketLookup.get(a.id)?.liquidity ?? 0) +
+        (marketLookup.get(a.id)?.volumeNum ?? 0);
+      const bScore =
+        (marketLookup.get(b.id)?.liquidity ?? 0) +
+        (marketLookup.get(b.id)?.volumeNum ?? 0);
+      return bScore - aScore;
+    });
   }
 
   const groupEntries = [...groupMap.entries()];
@@ -576,10 +574,37 @@ export function buildOutcomeGroups(
     return a[0].localeCompare(b[0]);
   });
 
-  return groupEntries.map(([key, groupOutcomes]) => ({
-    key,
-    outcomes: groupOutcomes,
-  }));
+  return groupEntries.map(([key, groupOutcomes]) => {
+    const typeMap = new Map<string, PredictOutcome[]>();
+    for (const outcome of groupOutcomes) {
+      const type = marketLookup.get(outcome.id)?.sportsMarketType ?? key;
+      const bucket = typeMap.get(type);
+      if (bucket) {
+        bucket.push(outcome);
+      } else {
+        typeMap.set(type, [outcome]);
+      }
+    }
+
+    if (typeMap.size < 2) {
+      return { key, outcomes: groupOutcomes };
+    }
+
+    const subgroupEntries = [...typeMap.entries()];
+    subgroupEntries.sort(
+      (a, b) =>
+        getSportsMarketTypePriority(a[0]) - getSportsMarketTypePriority(b[0]),
+    );
+
+    return {
+      key,
+      outcomes: [],
+      subgroups: subgroupEntries.map(([subKey, subOutcomes]) => ({
+        key: subKey,
+        outcomes: subOutcomes,
+      })),
+    };
+  });
 }
 
 export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
@@ -801,6 +826,7 @@ export const parsePolymarketMarket = (
   status: market.closed ? PredictMarketStatus.CLOSED : PredictMarketStatus.OPEN,
   volume: market.volumeNum ?? 0,
   tokens: parsePolymarketMarketOutcomes(market, event),
+  sportsMarketType: market.sportsMarketType,
   negRisk: market.negRisk,
   tickSize: market.orderPriceMinTickSize.toString(),
   resolvedBy: market.resolvedBy,

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -482,10 +482,6 @@ export const isSportEvent = (event: PolymarketApiEvent): boolean =>
     (tag) => tag.slug === 'sports',
   );
 
-/**
- * Get the sort priority for a sports market type
- * moneyline: 0, spreads: 1, totals: 2, others: 3 (then alphabetically)
- */
 const SPORTS_MARKET_TYPE_PRIORITIES: Record<string, number> = {
   moneyline: 0,
   spreads: 1,
@@ -494,11 +490,8 @@ const SPORTS_MARKET_TYPE_PRIORITIES: Record<string, number> = {
 
 const normalizeSportsMarketType = (type: string): string => {
   const lower = type.toLowerCase();
-  const prefixes = ['first_half_'];
-  for (const prefix of prefixes) {
-    if (lower.startsWith(prefix)) {
-      return lower.slice(prefix.length);
-    }
+  if (lower.startsWith('first_half_')) {
+    return lower.slice('first_half_'.length);
   }
   return lower;
 };
@@ -545,19 +538,16 @@ export function buildOutcomeGroups(
 
   for (const [, groupOutcomes] of groupMap) {
     groupOutcomes.sort((a, b) => {
-      const aType = marketLookup.get(a.id)?.sportsMarketType ?? '';
-      const bType = marketLookup.get(b.id)?.sportsMarketType ?? '';
+      const aMarket = marketLookup.get(a.id);
+      const bMarket = marketLookup.get(b.id);
       const priorityDiff =
-        getSportsMarketTypePriority(aType) - getSportsMarketTypePriority(bType);
+        getSportsMarketTypePriority(aMarket?.sportsMarketType ?? '') -
+        getSportsMarketTypePriority(bMarket?.sportsMarketType ?? '');
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
-      const aScore =
-        (marketLookup.get(a.id)?.liquidity ?? 0) +
-        (marketLookup.get(a.id)?.volumeNum ?? 0);
-      const bScore =
-        (marketLookup.get(b.id)?.liquidity ?? 0) +
-        (marketLookup.get(b.id)?.volumeNum ?? 0);
+      const aScore = (aMarket?.liquidity ?? 0) + (aMarket?.volumeNum ?? 0);
+      const bScore = (bMarket?.liquidity ?? 0) + (bMarket?.volumeNum ?? 0);
       return bScore - aScore;
     });
   }
@@ -905,9 +895,9 @@ export const parsePolymarketEvents = (
       );
 
       const outcomeGroupingEnabled =
-        !!game &&
-        !!eventLeague &&
-        !!extendedSportsMarketsLeagues?.includes(eventLeague);
+        game &&
+        eventLeague &&
+        extendedSportsMarketsLeagues?.includes(eventLeague);
 
       const outcomeGroups = outcomeGroupingEnabled
         ? buildOutcomeGroups(outcomes, markets)

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -478,11 +478,6 @@ export const submitClobOrder = async ({
   }
 };
 
-export const isSportEvent = (event: PolymarketApiEvent): boolean =>
-  (Array.isArray(event.tags) ? event.tags : []).some(
-    (tag) => tag.slug === 'sports',
-  );
-
 const normalizeSportsMarketType = (type: string): string => {
   const lower = type.toLowerCase();
   if (lower.startsWith('first_half_')) {

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -18,6 +18,7 @@ import {
   PredictActivity,
   Result,
   PredictOutcome,
+  PredictOutcomeGroup,
   PredictOutcomeToken,
 } from '../../types';
 import { getRecurrence } from '../../utils/format';
@@ -39,15 +40,18 @@ import type {
 } from '../types';
 import {
   ClobAuthDomain,
+  DEFAULT_GROUP_KEY,
   EIP712Domain,
+  GROUP_ORDER,
   HASH_ZERO_BYTES32,
   MATIC_CONTRACTS,
   MSG_TO_SIGN,
   POLYGON_MAINNET_CHAIN_ID,
+  POLYMARKET_PROVIDER_ID,
   ROUNDING_CONFIG,
   SLIPPAGE_BUY,
   SLIPPAGE_SELL,
-  POLYMARKET_PROVIDER_ID,
+  SPORTS_MARKET_TYPE_TO_GROUP,
 } from './constants';
 import { Permit2FeeAuthorization, SafeFeeAuthorization } from './safe/types';
 import {
@@ -70,6 +74,8 @@ import {
 } from './types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
 import { PredictFeeCollection } from '../../types/flags';
+
+export { SPORTS_MARKET_TYPE_TO_GROUP, GROUP_ORDER } from './constants';
 
 export const getPolymarketEndpoints = () => ({
   GAMMA_API_ENDPOINT: 'https://gamma-api.polymarket.com',
@@ -471,6 +477,111 @@ export const submitClobOrder = async ({
   }
 };
 
+export const isSportEvent = (event: PolymarketApiEvent): boolean =>
+  (Array.isArray(event.tags) ? event.tags : []).some(
+    (tag) => tag.slug === 'sports',
+  );
+
+/**
+ * Get the sort priority for a sports market type
+ * moneyline: 0, spreads: 1, totals: 2, others: 3 (then alphabetically)
+ */
+const getSportsMarketTypePriority = (type: string): number => {
+  const priorities: Record<string, number> = {
+    moneyline: 0,
+    spreads: 1,
+    totals: 2,
+  };
+  return priorities[type.toLowerCase()] ?? 3;
+};
+
+export function buildOutcomeGroups(
+  outcomes: PredictOutcome[],
+  rawMarkets: PolymarketApiMarket[],
+): PredictOutcomeGroup[] {
+  if (outcomes.length === 0 || rawMarkets.length === 0) {
+    return [];
+  }
+
+  const marketLookup = new Map<
+    string,
+    { sportsMarketType?: string; liquidity: number; volumeNum: number }
+  >();
+  for (const market of rawMarkets) {
+    marketLookup.set(market.conditionId, {
+      sportsMarketType: market.sportsMarketType,
+      liquidity: market.liquidity ?? 0,
+      volumeNum: market.volumeNum ?? 0,
+    });
+  }
+
+  const groupMap = new Map<string, PredictOutcome[]>();
+
+  for (const outcome of outcomes) {
+    const marketInfo = marketLookup.get(outcome.id);
+    const sportsMarketType = marketInfo?.sportsMarketType;
+    const groupKey =
+      (sportsMarketType && SPORTS_MARKET_TYPE_TO_GROUP[sportsMarketType]) ||
+      DEFAULT_GROUP_KEY;
+
+    const bucket = groupMap.get(groupKey);
+    if (bucket) {
+      bucket.push(outcome);
+    } else {
+      groupMap.set(groupKey, [outcome]);
+    }
+  }
+
+  for (const [groupKey, groupOutcomes] of groupMap) {
+    if (groupKey === DEFAULT_GROUP_KEY) {
+      groupOutcomes.sort((a, b) => {
+        const aType = marketLookup.get(a.id)?.sportsMarketType ?? '';
+        const bType = marketLookup.get(b.id)?.sportsMarketType ?? '';
+        const priorityDiff =
+          getSportsMarketTypePriority(aType) -
+          getSportsMarketTypePriority(bType);
+        if (priorityDiff !== 0) {
+          return priorityDiff;
+        }
+        const aScore =
+          (marketLookup.get(a.id)?.liquidity ?? 0) +
+          (marketLookup.get(a.id)?.volumeNum ?? 0);
+        const bScore =
+          (marketLookup.get(b.id)?.liquidity ?? 0) +
+          (marketLookup.get(b.id)?.volumeNum ?? 0);
+        return bScore - aScore;
+      });
+    } else {
+      groupOutcomes.sort((a, b) => {
+        const aScore =
+          (marketLookup.get(a.id)?.liquidity ?? 0) +
+          (marketLookup.get(a.id)?.volumeNum ?? 0);
+        const bScore =
+          (marketLookup.get(b.id)?.liquidity ?? 0) +
+          (marketLookup.get(b.id)?.volumeNum ?? 0);
+        return bScore - aScore;
+      });
+    }
+  }
+
+  const groupEntries = [...groupMap.entries()];
+  groupEntries.sort((a, b) => {
+    const aIndex = GROUP_ORDER.indexOf(a[0]);
+    const bIndex = GROUP_ORDER.indexOf(b[0]);
+    const aPriority = aIndex === -1 ? GROUP_ORDER.length : aIndex;
+    const bPriority = bIndex === -1 ? GROUP_ORDER.length : bIndex;
+    if (aPriority !== bPriority) {
+      return aPriority - bPriority;
+    }
+    return a[0].localeCompare(b[0]);
+  });
+
+  return groupEntries.map(([key, groupOutcomes]) => ({
+    key,
+    outcomes: groupOutcomes,
+  }));
+}
+
 export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
   market.sportsMarketType?.toLowerCase().includes('spread') ?? false;
 
@@ -487,19 +598,6 @@ const sortByLiquidityAndVolume = (
     const bScore = (b.liquidity ?? 0) + (b.volumeNum ?? 0);
     return bScore - aScore;
   });
-
-/**
- * Get the sort priority for a sports market type
- * moneyline: 0, spreads: 1, totals: 2, others: 3 (then alphabetically)
- */
-const getSportsMarketTypePriority = (type: string): number => {
-  const priorities: Record<string, number> = {
-    moneyline: 0,
-    spreads: 1,
-    totals: 2,
-  };
-  return priorities[type.toLowerCase()] ?? 3;
-};
 
 const formatMarketGroupItemTitle = (market: PolymarketApiMarket): string => {
   if (isSpreadMarket(market)) {
@@ -718,6 +816,7 @@ export interface ParsePolymarketEventsOptions {
   category: PredictCategory;
   sortMarketsBy?: 'price' | 'ascending' | 'descending';
   teamLookup?: PolymarketTeamLookupFn;
+  extendedSportsMarketsLeagues?: string[];
 }
 
 export const parsePolymarketEvents = (
@@ -730,7 +829,7 @@ export const parsePolymarketEvents = (
       ? { category: categoryOrOptions, sortMarketsBy }
       : categoryOrOptions;
 
-  const { category, teamLookup } = options;
+  const { category, teamLookup, extendedSportsMarketsLeagues } = options;
   const sortBy = options.sortMarketsBy ?? sortMarketsBy;
 
   const parsedMarkets: PredictMarket[] = events.map(
@@ -775,6 +874,19 @@ export const parsePolymarketEvents = (
             }
           : undefined;
 
+      const outcomes = markets.map((market: PolymarketApiMarket) =>
+        parsePolymarketMarket(market, event),
+      );
+
+      const outcomeGroupingEnabled =
+        !!game &&
+        !!eventLeague &&
+        !!extendedSportsMarketsLeagues?.includes(eventLeague);
+
+      const outcomeGroups = outcomeGroupingEnabled
+        ? buildOutcomeGroups(outcomes, markets)
+        : undefined;
+
       return {
         id: event.id,
         slug: event.slug,
@@ -789,9 +901,8 @@ export const parsePolymarketEvents = (
         endDate: event.endDate,
         category,
         tags: tags.map((t) => t.slug),
-        outcomes: markets.map((market: PolymarketApiMarket) =>
-          parsePolymarketMarket(market, event),
-        ),
+        outcomes,
+        ...(outcomeGroups && { outcomeGroups }),
         liquidity: event.liquidity,
         volume: event.volume,
         game,

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -43,6 +43,7 @@ import {
   DEFAULT_GROUP_KEY,
   EIP712Domain,
   GROUP_ORDER,
+  SPORTS_MARKET_TYPE_PRIORITIES,
   HASH_ZERO_BYTES32,
   MATIC_CONTRACTS,
   MSG_TO_SIGN,
@@ -482,12 +483,6 @@ export const isSportEvent = (event: PolymarketApiEvent): boolean =>
     (tag) => tag.slug === 'sports',
   );
 
-const SPORTS_MARKET_TYPE_PRIORITIES: Record<string, number> = {
-  moneyline: 0,
-  spreads: 1,
-  totals: 2,
-};
-
 const normalizeSportsMarketType = (type: string): string => {
   const lower = type.toLowerCase();
   if (lower.startsWith('first_half_')) {
@@ -501,31 +496,17 @@ const getSportsMarketTypePriority = (type: string): number =>
 
 export function buildOutcomeGroups(
   outcomes: PredictOutcome[],
-  rawMarkets: PolymarketApiMarket[],
 ): PredictOutcomeGroup[] {
-  if (outcomes.length === 0 || rawMarkets.length === 0) {
+  if (outcomes.length === 0) {
     return [];
-  }
-
-  const marketLookup = new Map<
-    string,
-    { sportsMarketType?: string; liquidity: number; volumeNum: number }
-  >();
-  for (const market of rawMarkets) {
-    marketLookup.set(market.conditionId, {
-      sportsMarketType: market.sportsMarketType,
-      liquidity: market.liquidity ?? 0,
-      volumeNum: market.volumeNum ?? 0,
-    });
   }
 
   const groupMap = new Map<string, PredictOutcome[]>();
 
   for (const outcome of outcomes) {
-    const marketInfo = marketLookup.get(outcome.id);
-    const sportsMarketType = marketInfo?.sportsMarketType;
     const groupKey =
-      (sportsMarketType && SPORTS_MARKET_TYPE_TO_GROUP[sportsMarketType]) ||
+      (outcome.sportsMarketType &&
+        SPORTS_MARKET_TYPE_TO_GROUP[outcome.sportsMarketType]) ||
       DEFAULT_GROUP_KEY;
 
     const bucket = groupMap.get(groupKey);
@@ -538,16 +519,14 @@ export function buildOutcomeGroups(
 
   for (const [, groupOutcomes] of groupMap) {
     groupOutcomes.sort((a, b) => {
-      const aMarket = marketLookup.get(a.id);
-      const bMarket = marketLookup.get(b.id);
       const priorityDiff =
-        getSportsMarketTypePriority(aMarket?.sportsMarketType ?? '') -
-        getSportsMarketTypePriority(bMarket?.sportsMarketType ?? '');
+        getSportsMarketTypePriority(a.sportsMarketType ?? '') -
+        getSportsMarketTypePriority(b.sportsMarketType ?? '');
       if (priorityDiff !== 0) {
         return priorityDiff;
       }
-      const aScore = (aMarket?.liquidity ?? 0) + (aMarket?.volumeNum ?? 0);
-      const bScore = (bMarket?.liquidity ?? 0) + (bMarket?.volumeNum ?? 0);
+      const aScore = a.liquidity + a.volume;
+      const bScore = b.liquidity + b.volume;
       return bScore - aScore;
     });
   }
@@ -567,7 +546,7 @@ export function buildOutcomeGroups(
   return groupEntries.map(([key, groupOutcomes]) => {
     const typeMap = new Map<string, PredictOutcome[]>();
     for (const outcome of groupOutcomes) {
-      const type = marketLookup.get(outcome.id)?.sportsMarketType ?? key;
+      const type = outcome.sportsMarketType ?? key;
       const bucket = typeMap.get(type);
       if (bucket) {
         bucket.push(outcome);
@@ -815,6 +794,7 @@ export const parsePolymarketMarket = (
       : undefined,
   status: market.closed ? PredictMarketStatus.CLOSED : PredictMarketStatus.OPEN,
   volume: market.volumeNum ?? 0,
+  liquidity: market.liquidity ?? 0,
   tokens: parsePolymarketMarketOutcomes(market, event),
   sportsMarketType: market.sportsMarketType,
   negRisk: market.negRisk,
@@ -900,7 +880,7 @@ export const parsePolymarketEvents = (
         extendedSportsMarketsLeagues?.includes(eventLeague);
 
       const outcomeGroups = outcomeGroupingEnabled
-        ? buildOutcomeGroups(outcomes, markets)
+        ? buildOutcomeGroups(outcomes)
         : undefined;
 
       return {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -110,6 +110,7 @@ export type PredictMarket = {
   category: PredictCategory;
   tags: string[];
   outcomes: PredictOutcome[];
+  outcomeGroups?: PredictOutcomeGroup[];
   liquidity: number;
   volume: number;
   game?: PredictMarketGame;
@@ -258,6 +259,11 @@ export interface CryptoPriceUpdate {
   price: number;
   timestamp: number;
 }
+
+export type PredictOutcomeGroup = {
+  key: string;
+  outcomes: PredictOutcome[];
+};
 
 export type PredictOutcome = {
   id: string;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -276,7 +276,7 @@ export type PredictOutcome = {
   status: 'open' | 'closed' | 'resolved';
   tokens: PredictOutcomeToken[];
   volume: number;
-  liquidity: number;
+  liquidity?: number;
   groupItemTitle: string;
   groupItemThreshold?: number;
   negRisk?: boolean;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -263,6 +263,7 @@ export interface CryptoPriceUpdate {
 export type PredictOutcomeGroup = {
   key: string;
   outcomes: PredictOutcome[];
+  subgroups?: PredictOutcomeGroup[];
 };
 
 export type PredictOutcome = {
@@ -279,6 +280,7 @@ export type PredictOutcome = {
   groupItemThreshold?: number;
   negRisk?: boolean;
   tickSize?: string;
+  sportsMarketType?: string;
   resolvedBy?: string;
   resolutionStatus?: string;
 };

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -276,6 +276,7 @@ export type PredictOutcome = {
   status: 'open' | 'closed' | 'resolved';
   tokens: PredictOutcomeToken[];
   volume: number;
+  liquidity: number;
   groupItemTitle: string;
   groupItemThreshold?: number;
   negRisk?: boolean;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -286,11 +286,6 @@ export type PredictOutcome = {
   resolutionStatus?: string;
 };
 
-export type PredictOutcomeGroup = {
-  key: string;
-  outcomes: PredictOutcome[];
-};
-
 export type PredictOutcomeToken = {
   id: string;
   title: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sport events with extended market types (spreads, totals, player props, etc.) return a flat list of outcomes that the UI cannot meaningfully section without reimplementing grouping logic. This PR adds a provider-level `buildOutcomeGroups()` utility that groups `PredictOutcome` objects by their `sportsMarketType` into structured `PredictOutcomeGroup` objects, enabling the UI to render tabbed/sectioned outcome views directly.

### What changed

- **New type `PredictOutcomeGroup`** (`{ key, outcomes }`) added to core types; `PredictMarket` gains an optional `outcomeGroups` field.
- **Grouping constants** (`SPORTS_MARKET_TYPE_TO_GROUP`, `GROUP_ORDER`, `DEFAULT_GROUP_KEY`) added to `providers/polymarket/constants.ts`. Known `sportsMarketType` values map to named group keys (e.g. `first_half_*` → `first-half`, `anytime_touchdowns` → `touchdowns`); everything unmapped defaults to `game-lines`.
- **`buildOutcomeGroups()`** in `utils.ts` buckets outcomes into groups, sorts within each group (game-lines preserves moneyline → spreads → totals sub-ordering; others sort by volume), and orders groups by `GROUP_ORDER` priority.
- **Integration in `parsePolymarketEvents()`** — grouping runs conditionally when the event is a sport event and its league is in `extendedSportsMarketsLeagues`. The flat `outcomes` array is unchanged for backward compatibility.
- **`PolymarketProvider`** passes `extendedSportsMarketsLeagues` to all four `parsePolymarketEvents()` call sites (getMarkets, getMarketDetails, getMarketSeries, getCarouselMarkets).
- **14 new tests** — 8 unit tests for `buildOutcomeGroups()`, 1 integration test for `parsePolymarketEvents()`, and 5 pass-through tests for `PolymarketProvider`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-804

## **Manual testing steps**

```gherkin
Feature: Outcome grouping for sport events

  Scenario: sport event outcomes are grouped when extended markets enabled
    Given a sport event with multiple sportsMarketType values (moneyline, spreads, totals, first_half_spreads)
    And the event's league is included in extendedSportsMarketsLeagues

    When the event is parsed via parsePolymarketEvents
    Then the resulting PredictMarket contains an outcomeGroups array
    And groups are ordered: game-lines, first-half
    And game-lines contains moneyline, spreads, totals outcomes in sub-order
    And the flat outcomes array remains unchanged

  Scenario: non-sport event has no outcome groups
    Given a crypto or politics event

    When the event is parsed via parsePolymarketEvents
    Then the resulting PredictMarket has outcomeGroups as undefined
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new outcome grouping data to `PredictMarket` and changes Polymarket parsing to conditionally compute and sort grouped outcomes based on feature flags, which could affect sports market rendering and ordering. Scope is limited to Polymarket provider and is gated by `extendedSportsMarketsLeagues`.
> 
> **Overview**
> Adds an optional `outcomeGroups` structure to `PredictMarket` and extends `PredictOutcome` with `liquidity` and `sportsMarketType` to support richer sports-market presentation.
> 
> Implements `buildOutcomeGroups()` and related grouping/order constants to bucket and sort outcomes by `sportsMarketType` (with subgrouping for multi-type groups) and wires this into `parsePolymarketEvents()` only when the event’s league is in the `extendedSportsMarketsLeagues` feature flag; `PolymarketProvider` now passes that flag through for `getMarkets`, `getMarketDetails`, `getMarketSeries`, and `getCarouselMarkets`, with added unit/integration tests covering grouping and pass-through behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06c1685cb36cfe6c6c74721432f87b1366f401b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->