### PR TITLE
chore: restore Android APK download link in Slack RC build notifications 

### DIFF
--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -150,12 +150,45 @@ jobs:
           ANDROID_BUILD_NUMBER: ${{ needs.trigger-android-rc-build.outputs.android_version_code }}
           BUILD_PIPELINE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  resolve-artifact-urls:
+    name: Resolve artifact download URLs
+    runs-on: ubuntu-latest
+    needs:
+      - trigger-ios-rc-build
+      - trigger-android-rc-build
+    if: always() && needs.trigger-android-rc-build.result == 'success'
+    permissions:
+      actions: read
+    outputs:
+      android_url: ${{ steps.resolve.outputs.android_url }}
+      ios_url: ${{ steps.resolve.outputs.ios_url }}
+    steps:
+      - name: Query artifacts API
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          RUN_ID="${{ github.run_id }}"
+          ARTIFACTS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" --paginate --jq '.artifacts')
+
+          ANDROID_ID=$(echo "$ARTIFACTS" | jq -r '.[] | select(.name | startswith("android-apk-")) | .id' | head -1)
+          if [[ -n "$ANDROID_ID" && "$ANDROID_ID" != "null" ]]; then
+            echo "android_url=https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${ANDROID_ID}" >> "$GITHUB_OUTPUT"
+          fi
+
+          IOS_ID=$(echo "$ARTIFACTS" | jq -r '.[] | select(.name | startswith("ios-ipa-")) | .id' | head -1)
+          if [[ -n "$IOS_ID" && "$IOS_ID" != "null" ]]; then
+            echo "ios_url=https://github.com/${REPO}/actions/runs/${RUN_ID}/artifacts/${IOS_ID}" >> "$GITHUB_OUTPUT"
+          fi
+
   slack-notification:
     name: Slack RC Notification
     needs:
       - validate-and-check-label
       - trigger-ios-rc-build
       - trigger-android-rc-build
+      - resolve-artifact-urls
     if: always() && needs.trigger-android-rc-build.result == 'success'
     uses: ./.github/workflows/slack-rc-notification.yml
     with:
@@ -163,4 +196,6 @@ jobs:
       semver: ${{ needs.trigger-ios-rc-build.outputs.semantic_version }}
       ios_build_number: ${{ needs.trigger-ios-rc-build.outputs.ios_version_code }}
       android_build_number: ${{ needs.trigger-android-rc-build.outputs.android_version_code }}
+      android_build_url: ${{ needs.resolve-artifact-urls.outputs.android_url }}
+      ios_build_url: ${{ needs.resolve-artifact-urls.outputs.ios_url }}
     secrets: inherit

--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           REPO="${{ github.repository }}"
           RUN_ID="${{ github.run_id }}"
-          ARTIFACTS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" --paginate --jq '.artifacts')
+          ARTIFACTS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" --jq '.artifacts')
 
           ANDROID_ID=$(echo "$ARTIFACTS" | jq -r '.[] | select(.name | startswith("android-apk-")) | .id' | head -1)
           if [[ -n "$ANDROID_ID" && "$ANDROID_ID" != "null" ]]; then

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -31,6 +31,16 @@ on:
         required: false
         type: string
         default: ''
+      android_build_url:
+        description: 'Android APK download URL (optional; shown in Slack if valid)'
+        required: false
+        type: string
+        default: ''
+      ios_build_url:
+        description: 'iOS build URL (optional; shown in Slack if valid)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   slack-notification:
@@ -63,4 +73,6 @@ jobs:
           IOS_BUILD_NUMBER: ${{ inputs.ios_build_number || steps.build-meta.outputs.ios_version_code }}
           ANDROID_BUILD_NUMBER: ${{ inputs.android_build_number || steps.build-meta.outputs.android_version_code }}
           BUILD_PIPELINE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ANDROID_PUBLIC_URL: ${{ inputs.android_build_url }}
+          IOS_PUBLIC_URL: ${{ inputs.ios_build_url }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After the migration from Bitrise to GitHub Actions, the Slack RC build notification stopped including a download link for the Android APK. In the old Bitrise flow (`rc-builds.sh`), `ANDROID_PUBLIC_URL` was fetched from Bitrise's public artifact API and passed directly to `slack-rc-notification.mjs`. With GitHub Actions, no equivalent URL was ever threaded through to the notification script, leaving the download section empty.

This PR restores the link by:

1. Adding a lightweight `resolve-artifact-urls` job to `build-rc-auto.yml` that queries the GitHub Actions Artifacts API after both iOS and Android builds complete. It finds the uploaded `android-apk-*` and `ios-ipa-*` artifacts by name prefix and constructs their GitHub artifact URLs.
2. Passing those URLs to `slack-rc-notification.yml` as new optional inputs (`android_build_url`, `ios_build_url`), which are forwarded to the script as `ANDROID_PUBLIC_URL` and `IOS_PUBLIC_URL`.

No changes to `build.yml`, `runway-ota-build-core.yml`, or `slack-rc-notification.mjs` — the script already consumes these env vars and handles missing/invalid values gracefully. The approach is also forward-compatible: when `runway-ota-build-core.yml` is replaced with a direct `build.yml` call, only the `needs:` on `resolve-artifact-urls` needs updating.

> Note: GitHub artifact URLs require a GitHub login (unlike Bitrise's public install pages), but all team members in the release Slack channel have GitHub access.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)