### PR TITLE
fix(predict): use game data instead of tags to determine sport market sorting

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -69,9 +69,8 @@ import {
   previewOrder,
   getAllowanceCalls,
   fetchCarouselFromPolymarketApi,
-  isSportEvent,
   isSpreadMarket,
-  sortSportMarkets,
+  sortGameMarkets,
   sortMarketsByField,
   sortMarkets,
   parsePolymarketMarket,
@@ -1475,68 +1474,6 @@ describe('polymarket utils', () => {
     });
   });
 
-  describe('isSportEvent', () => {
-    it('returns true when event has sports tag', () => {
-      const sportEvent: PolymarketApiEvent = {
-        id: 'sport-event-1',
-        slug: 'sport-event',
-        title: 'Sport Event',
-        description: 'A sport event',
-        icon: 'https://example.com/icon.png',
-        closed: false,
-        tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
-        series: [],
-        markets: [],
-        liquidity: 1000,
-        volume: 5000,
-      };
-
-      const result = isSportEvent(sportEvent);
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when event has no sports tag', () => {
-      const nonSportEvent: PolymarketApiEvent = {
-        id: 'non-sport-event-1',
-        slug: 'non-sport-event',
-        title: 'Non Sport Event',
-        description: 'A non-sport event',
-        icon: 'https://example.com/icon.png',
-        closed: false,
-        tags: [{ id: '2', label: 'Politics', slug: 'politics' }],
-        series: [],
-        markets: [],
-        liquidity: 1000,
-        volume: 5000,
-      };
-
-      const result = isSportEvent(nonSportEvent);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when event has empty tags', () => {
-      const eventWithNoTags: PolymarketApiEvent = {
-        id: 'event-no-tags',
-        slug: 'event-no-tags',
-        title: 'Event No Tags',
-        description: 'An event with no tags',
-        icon: 'https://example.com/icon.png',
-        closed: false,
-        tags: [],
-        series: [],
-        markets: [],
-        liquidity: 1000,
-        volume: 5000,
-      };
-
-      const result = isSportEvent(eventWithNoTags);
-
-      expect(result).toBe(false);
-    });
-  });
-
   describe('isSpreadMarket', () => {
     it('returns true when sportsMarketType contains spread', () => {
       const spreadMarket: PolymarketApiMarket = {
@@ -1650,7 +1587,7 @@ describe('polymarket utils', () => {
     });
   });
 
-  describe('sortSportMarkets', () => {
+  describe('sortGameMarkets', () => {
     const createSportMarket = (
       id: string,
       sportsMarketType: string,
@@ -1685,7 +1622,7 @@ describe('polymarket utils', () => {
         createSportMarket('spreads-1', 'spreads', 100, 100),
       ];
 
-      const result = sortSportMarkets(markets);
+      const result = sortGameMarkets(markets);
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-1',
@@ -1701,7 +1638,7 @@ describe('polymarket utils', () => {
         createSportMarket('moneyline-1', 'moneyline', 100, 100),
       ];
 
-      const result = sortSportMarkets(markets);
+      const result = sortGameMarkets(markets);
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-1',
@@ -1717,7 +1654,7 @@ describe('polymarket utils', () => {
         createSportMarket('moneyline-medium', 'moneyline', 300, 200), // score: 500
       ];
 
-      const result = sortSportMarkets(markets);
+      const result = sortGameMarkets(markets);
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-high',
@@ -1732,7 +1669,7 @@ describe('polymarket utils', () => {
         createSportMarket('moneyline-1', 'moneyline', 100, 100),
       ];
 
-      const result = sortSportMarkets(markets);
+      const result = sortGameMarkets(markets);
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-1',
@@ -1750,7 +1687,7 @@ describe('polymarket utils', () => {
         createSportMarket('moneyline-high', 'moneyline', 400, 400),
       ];
 
-      const result = sortSportMarkets(markets);
+      const result = sortGameMarkets(markets);
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-high',
@@ -1925,20 +1862,19 @@ describe('polymarket utils', () => {
       ];
       const event = createEvent([], markets);
 
-      const result = sortMarkets(event, 'price');
+      const result = sortMarkets({ event, sortBy: 'price' });
 
       expect(result.map((m) => m.conditionId)).toEqual(['high', 'low']);
     });
 
-    it('uses sortSportMarkets for sport events when no sortBy parameter', () => {
+    it('uses sortGameMarkets for game events when no sortBy parameter', () => {
       const markets = [
         createMarket('totals-1', '["0.5", "0.5"]', 100, 100, 'totals'),
         createMarket('moneyline-1', '["0.5", "0.5"]', 100, 100, 'moneyline'),
       ];
-      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
-      const event = createEvent(sportTags, markets);
+      const event = createEvent([], markets);
 
-      const result = sortMarkets(event);
+      const result = sortMarkets({ event, isGameEvent: true });
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-1',
@@ -1946,31 +1882,47 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('uses event.sortBy for non-sport events when no sortBy parameter', () => {
+    it('uses event.sortBy for non-game events when no sortBy parameter', () => {
       const markets = [
         createMarket('low', '["0.3", "0.7"]', 100, 100),
         createMarket('high', '["0.9", "0.1"]', 100, 100),
       ];
       const event = createEvent([], markets, 'price');
 
-      const result = sortMarkets(event);
+      const result = sortMarkets({ event });
 
       expect(result.map((m) => m.conditionId)).toEqual(['high', 'low']);
     });
 
-    it('returns markets unchanged when no sorting specified for non-sport events', () => {
+    it('returns markets unchanged when no sorting specified for non-game events', () => {
       const markets = [
         createMarket('first', '["0.3", "0.7"]', 100, 100),
         createMarket('second', '["0.9", "0.1"]', 100, 100),
       ];
       const event = createEvent([], markets);
 
-      const result = sortMarkets(event);
+      const result = sortMarkets({ event });
 
       expect(result.map((m) => m.conditionId)).toEqual(['first', 'second']);
     });
 
-    it('prioritizes sport event sorting over sortBy parameter', () => {
+    it('does not apply game sorting when isGameEvent is not set even with sport tags', () => {
+      const markets = [
+        createMarket('totals-1', '["0.5", "0.5"]', 100, 100, 'totals'),
+        createMarket('moneyline-1', '["0.5", "0.5"]', 100, 100, 'moneyline'),
+      ];
+      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
+      const event = createEvent(sportTags, markets);
+
+      const result = sortMarkets({ event });
+
+      expect(result.map((m) => m.conditionId)).toEqual([
+        'totals-1',
+        'moneyline-1',
+      ]);
+    });
+
+    it('prioritizes game event sorting over sortBy parameter', () => {
       const markets = [
         createMarket('totals-high-price', '["0.9", "0.1"]', 100, 100, 'totals'),
         createMarket(
@@ -1981,10 +1933,9 @@ describe('polymarket utils', () => {
           'moneyline',
         ),
       ];
-      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
-      const event = createEvent(sportTags, markets);
+      const event = createEvent([], markets);
 
-      const result = sortMarkets(event, 'price');
+      const result = sortMarkets({ event, sortBy: 'price', isGameEvent: true });
 
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-low-price',
@@ -1992,7 +1943,7 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('places moneyline first for sport events even when moneyline has lower price', () => {
+    it('places moneyline first for game events even when moneyline has lower price', () => {
       const markets = [
         createMarket(
           'spreads-high-price',
@@ -2010,10 +1961,9 @@ describe('polymarket utils', () => {
           'moneyline',
         ),
       ];
-      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
-      const event = createEvent(sportTags, markets);
+      const event = createEvent([], markets);
 
-      const result = sortMarkets(event, 'price');
+      const result = sortMarkets({ event, sortBy: 'price', isGameEvent: true });
 
       // Moneyline first despite having the lowest price
       expect(result.map((m) => m.conditionId)).toEqual([
@@ -2023,23 +1973,23 @@ describe('polymarket utils', () => {
       ]);
     });
 
-    it('uses sortBy parameter for non-sport events when sortBy is provided', () => {
+    it('uses sortBy parameter for non-game events when sortBy is provided', () => {
       const markets = [
         createMarket('low-price', '["0.2", "0.8"]', 100, 100),
         createMarket('high-price', '["0.8", "0.2"]', 100, 100),
       ];
       const event = createEvent([], markets);
 
-      const result = sortMarkets(event, 'price');
+      const result = sortMarkets({ event, sortBy: 'price' });
 
-      // Non-sport events still respect sortBy
+      // Non-game events still respect sortBy
       expect(result.map((m) => m.conditionId)).toEqual([
         'high-price',
         'low-price',
       ]);
     });
 
-    it('ignores event.sortBy for sport events', () => {
+    it('ignores event.sortBy for game events', () => {
       const markets = [
         createMarket('totals-high-price', '["0.9", "0.1"]', 100, 100, 'totals'),
         createMarket(
@@ -2050,12 +2000,11 @@ describe('polymarket utils', () => {
           'moneyline',
         ),
       ];
-      const sportTags = [{ id: '1', label: 'Sports', slug: 'sports' }];
-      const event = createEvent(sportTags, markets, 'price');
+      const event = createEvent([], markets, 'price');
 
-      const result = sortMarkets(event);
+      const result = sortMarkets({ event, isGameEvent: true });
 
-      // Sport sorting wins over event.sortBy
+      // Game sorting wins over event.sortBy
       expect(result.map((m) => m.conditionId)).toEqual([
         'moneyline-low-price',
         'totals-high-price',

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -471,11 +471,6 @@ export const submitClobOrder = async ({
   }
 };
 
-export const isSportEvent = (event: PolymarketApiEvent): boolean =>
-  (Array.isArray(event.tags) ? event.tags : []).some(
-    (tag) => tag.slug === 'sports',
-  );
-
 export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
   market.sportsMarketType?.toLowerCase().includes('spread') ?? false;
 
@@ -597,7 +592,7 @@ const parsePolymarketMarketOutcomes = (
  * 3. Within each group, sort by liquidity + volume (descending)
  * 4. Return flattened array of all groups in order
  */
-export const sortSportMarkets = (
+export const sortGameMarkets = (
   markets: PolymarketApiMarket[],
 ): PolymarketApiMarket[] => {
   // Group markets by sportsMarketType
@@ -663,15 +658,20 @@ export const sortMarketsByField = (
   });
 };
 
-export const sortMarkets = (
-  event: PolymarketApiEvent,
-  sortBy?: 'price' | 'ascending' | 'descending',
-): PolymarketApiMarket[] => {
+export const sortMarkets = ({
+  event,
+  sortBy,
+  isGameEvent,
+}: {
+  event: PolymarketApiEvent;
+  sortBy?: 'price' | 'ascending' | 'descending';
+  isGameEvent?: boolean;
+}): PolymarketApiMarket[] => {
   const markets = Array.isArray(event.markets) ? event.markets : [];
   const eventSortBy = event.sortBy;
 
-  if (isSportEvent(event)) {
-    return sortSportMarkets(markets);
+  if (isGameEvent) {
+    return sortGameMarkets(markets);
   }
 
   if (sortBy) {
@@ -738,10 +738,6 @@ export const parsePolymarketEvents = (
       const tags = Array.isArray(event.tags) ? event.tags : [];
       const eventLeague = getEventLeague(event);
 
-      const markets = sortMarkets(event, sortBy).filter(
-        (market: PolymarketApiMarket) => market?.active !== false,
-      );
-
       const predictTeamLookup: TeamLookup | undefined = teamLookup
         ? (league, abbr) => {
             const apiTeam = teamLookup(league, abbr);
@@ -753,6 +749,12 @@ export const parsePolymarketEvents = (
         eventLeague && predictTeamLookup
           ? (buildGameData(event, eventLeague, predictTeamLookup) ?? undefined)
           : undefined;
+
+      const markets = sortMarkets({
+        event,
+        sortBy,
+        isGameEvent: !!game,
+      }).filter((market: PolymarketApiMarket) => market?.active !== false);
 
       // As per Polymarket's team, we should use the first market's description
       // rather than the event's description. The event's description is not


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

A previous fix introduced sport-specific market sorting (moneyline → spreads → totals) but applied it to **all** sport-related markets based on the presence of a `sports` tag. This was incorrect — that sorting order only applies to **game markets** (events where we can build valid game data with teams, scores, etc.), not to all sport-related events (e.g. "Who will win the MVP?" or "Will X break the record?").

The two sorting strategies are:
- **Game markets** (actual matchups with teams): sort by `sportsMarketType` priority — moneyline first, spreads second, totals third, then by liquidity+volume within each group.
- **Regular sport-related markets** (non-game sport events): use the standard sorting — `sortBy` param, `event.sortBy`, or original order.

**Changes:**
- Removed `isSportEvent()` which checked tags — tags alone are not sufficient to determine game vs non-game.
- Renamed `sortSportMarkets` → `sortGameMarkets` to clarify intent.
- Changed `sortMarkets` from positional args to a named params object with an explicit `isGameEvent` boolean.
- Moved `sortMarkets` call in `parsePolymarketEvents` to **after** `buildGameData`, using `isGameEvent: !!game` — only events where game data was successfully built get game-specific sorting.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where sport-related prediction markets were incorrectly sorted using game-specific ordering instead of standard sorting

## **Related issues**

Fixes: [PRED-814](https://consensyssoftware.atlassian.net/browse/PRED-814)

## **Manual testing steps**

```gherkin
Feature: Prediction market sorting for sport events

  Scenario: game markets sort by sportsMarketType priority
    Given the user opens a sport event that is an actual game (e.g. Lakers vs Celtics)

    When the markets load
    Then moneyline markets appear first
    And spreads markets appear second
    And totals markets appear third

  Scenario: non-game sport markets use standard sorting
    Given the user opens a sport event that is NOT a game (e.g. "Who will win MVP?")

    When the markets load
    Then markets appear in their default order (by sortBy or original order)
    And moneyline/spreads/totals priority sorting is NOT applied
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/dfd729c8-1c17-4b3b-8ef9-20f31c16f644

### **After**

https://github.com/user-attachments/assets/904c3eba-ae35-407b-9797-b9f8272d16c7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[PRED-814]: https://consensyssoftware.atlassian.net/browse/PRED-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes market sorting behavior for Polymarket events by gating the moneyline/spreads/totals ordering behind a new `isGameEvent` flag; incorrect classification could change the order users see. Risk is limited to UI presentation/sorting logic with updated unit tests covering the new cases.
> 
> **Overview**
> Fixes Polymarket market ordering so the game-specific grouping (moneyline → spreads → totals, then liquidity/volume) is applied **only** when an event successfully parses into game data, rather than based on a `sports` tag.
> 
> This removes `isSportEvent`, renames `sortSportMarkets` to `sortGameMarkets`, and refactors `sortMarkets` to accept a named-params object with an explicit `isGameEvent` override; `parsePolymarketEvents` now computes `game` first and passes `isGameEvent: !!game`. Tests are updated to reflect the new API and to assert that sport-tagged but non-game events keep standard sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360fe4fc4905747c76958f0fe556cf9932adfbf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->