### PR TITLE
chore(rewards): Ondo campaign various fixes

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -343,12 +343,18 @@ const RewardsHome = () => {
       <Stack.Screen
         name={Routes.MODAL.REWARDS_SELECT_SHEET}
         component={RewardsSelectSheet}
-        options={{ presentation: 'transparentModal' }}
+        options={{
+          presentation: 'transparentModal',
+          cardStyle: { backgroundColor: 'transparent' },
+        }}
       />
       <Stack.Screen
         name={Routes.MODAL.REWARDS_ONDO_PENDING_SHEET}
         component={OndoPendingSheet}
-        options={{ presentation: 'transparentModal' }}
+        options={{
+          presentation: 'transparentModal',
+          cardStyle: { backgroundColor: 'transparent' },
+        }}
       />
     </Stack.Navigator>
   );

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -221,6 +221,13 @@ jest.mock('./hooks/useGeoRewardsMetadata', () => ({
   useGeoRewardsMetadata: jest.fn(),
 }));
 
+// Mock useReferralDetails hook
+jest.mock('./hooks/useReferralDetails', () => ({
+  useReferralDetails: jest.fn().mockReturnValue({
+    fetchReferralDetails: jest.fn(),
+  }),
+}));
+
 // Mock useRewardsVersionGuard hook
 jest.mock('./hooks/useRewardsVersionGuard', () => ({
   __esModule: true,

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -23,6 +23,7 @@ import { useSeasonStatus } from './hooks/useSeasonStatus';
 import { useTheme } from '../../../util/theme';
 import { useGeoRewardsMetadata } from './hooks/useGeoRewardsMetadata';
 import useRewardsVersionGuard from './hooks/useRewardsVersionGuard';
+import { useReferralDetails } from './hooks/useReferralDetails';
 import RewardsUpdateRequired from './components/RewardsUpdateRequired/RewardsUpdateRequired';
 const Stack = createStackNavigator();
 
@@ -42,6 +43,9 @@ const RewardsNavigator: React.FC = () => {
 
   // Fetch geo rewards metadata so optinAllowedForGeo is available across all rewards screens
   useGeoRewardsMetadata({});
+
+  // Fetch referral details so referral code is available across all rewards screens
+  useReferralDetails();
 
   // Determine initial route - always start with onboarding intro step initially
   const getInitialRoute = () => {

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
@@ -162,7 +162,8 @@ const campaignWithoutTour: CampaignDto = {
 let mockCampaigns: CampaignDto[] = [campaignWithTour];
 
 jest.mock('../../../../reducers/rewards/selectors', () => ({
-  selectCampaigns: () => mockCampaigns,
+  selectCampaignById: (id: string) => () =>
+    mockCampaigns.find((c) => c.id === id) ?? null,
 }));
 
 jest.mock('react-redux', () => ({

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
@@ -22,7 +22,7 @@ import {
   Text,
 } from '@metamask/design-system-react-native';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
-import { selectCampaigns } from '../../../../reducers/rewards/selectors';
+import { selectCampaignById } from '../../../../reducers/rewards/selectors';
 import Routes from '../../../../constants/navigation/Routes';
 import ProgressIndicator from '../components/Onboarding/ProgressIndicator';
 import CampaignTourStep, {
@@ -47,11 +47,11 @@ const CampaignTourStepView: React.FC = () => {
   const { campaignId } = route.params;
   const safeAreaInsets = useSafeAreaInsets();
 
-  const campaigns = useSelector(selectCampaigns);
-  const campaign = useMemo(
-    () => campaigns.find((c) => c.id === campaignId),
-    [campaigns, campaignId],
+  const selectCampaign = useMemo(
+    () => selectCampaignById(campaignId),
+    [campaignId],
   );
+  const campaign = useSelector(selectCampaign);
 
   const tour = campaign?.details?.howItWorks?.tour;
   const [currentTab, setCurrentTab] = useState(0);

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -465,7 +465,6 @@ describe('OndoCampaignDetailsView', () => {
       isLoading: false,
       hasError: false,
       isLeaderboardNotYetComputed: false,
-      tierNames: [],
       selectedTier: null,
       selectedTierData: null,
       computedAt: null,

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -48,6 +48,7 @@ import { useGetOndoCampaignDeposits } from '../hooks/useGetOndoCampaignDeposits'
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { OndoCampaignHowItWorks } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { getTierMinNetDeposit } from '../components/Campaigns/OndoLeaderboard.utils';
 import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../utils/ondoCampaignConstants';
 
 // ParamListBase requires an index signature, which interfaces don't support
@@ -136,7 +137,7 @@ const OndoCampaignDetailsView: React.FC = () => {
   );
 
   const {
-    leaderboard: leaderboardData,
+    leaderboard,
     tierNames,
     selectedTier,
     selectedTierData,
@@ -166,10 +167,12 @@ const OndoCampaignDetailsView: React.FC = () => {
       leaderboardPosition &&
       campaign &&
       getCampaignStatus(campaign) === 'active'
-        ? (leaderboardData?.tiers[leaderboardPosition.projectedTier]
-            ?.minDeposit ?? null)
+        ? getTierMinNetDeposit(
+            campaign.details?.tiers,
+            leaderboardPosition.projectedTier,
+          )
         : null,
-    [leaderboardData, leaderboardPosition, campaign],
+    [campaign, leaderboardPosition],
   );
 
   const leaderboardPendingSheetPosition = useMemo(

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -293,7 +293,7 @@ const OndoCampaignDetailsView: React.FC = () => {
               {/* Phase 1: Not opted in, show how it works section */}
               {showHowItWorksSection && (
                 <>
-                  <Box twClassName="px-4 py-4">
+                  <Box twClassName="p-4">
                     <CampaignHowItWorks
                       howItWorks={
                         campaign.details?.howItWorks as OndoCampaignHowItWorks
@@ -317,7 +317,7 @@ const OndoCampaignDetailsView: React.FC = () => {
                       <Box
                         flexDirection={BoxFlexDirection.Row}
                         alignItems={BoxAlignItems.Center}
-                        twClassName="gap-2 mb-4"
+                        twClassName="gap-2 mb-3"
                       >
                         <Text variant={TextVariant.HeadingMd}>
                           {strings('rewards.ondo_campaign_stats.title')}
@@ -408,7 +408,7 @@ const OndoCampaignDetailsView: React.FC = () => {
 
               {(getCampaignStatus(campaign) === 'active' ||
                 showLeaderboardSection) && (
-                <Box twClassName="my-5 border-b border-border-muted" />
+                <Box twClassName="my-1 border-b border-border-muted" />
               )}
 
               {getCampaignStatus(campaign) === 'active' && (

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -138,7 +138,6 @@ const OndoCampaignDetailsView: React.FC = () => {
 
   const {
     leaderboard,
-    tierNames,
     selectedTier,
     selectedTierData,
     setSelectedTier,
@@ -149,6 +148,11 @@ const OndoCampaignDetailsView: React.FC = () => {
   } = useGetOndoLeaderboard(campaignId, {
     defaultTier: leaderboardPosition?.projectedTier,
   });
+
+  const tierNames = useMemo(
+    () => campaign?.details?.tiers?.map((t) => t.name) ?? [],
+    [campaign],
+  );
 
   const leaderboardUserPosition = useMemo(
     () =>

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -122,6 +122,14 @@ jest.mock('../components/RewardsErrorBanner', () => {
 
 jest.mock('../components/Campaigns/OndoLeaderboard.utils', () => ({
   formatTierDisplayName: (tier: string) => tier,
+  getTierMinNetDeposit: jest.fn(
+    (
+      tiers: { name: string; minNetDeposit: number }[] | undefined,
+      name: string,
+    ) =>
+      tiers?.find((t: { name: string }) => t.name === name)?.minNetDeposit ??
+      null,
+  ),
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -229,7 +237,13 @@ const createTestCampaign = (
     endDate: nextMonth.toISOString(),
     termsAndConditions: null,
     excludedRegions: [],
-    details: null,
+    details: {
+      howItWorks: { title: '', description: '', steps: [] },
+      tiers: [
+        { name: 'STARTER', minNetDeposit: 500 },
+        { name: 'MID', minNetDeposit: 1000 },
+      ],
+    },
     featured: true,
     type: 'ONDO_HOLDING' as never,
     ...overrides,
@@ -435,20 +449,6 @@ describe('OndoCampaignStatsView', () => {
         qualifiedDays: 3,
       }),
     });
-    mockUseGetOndoLeaderboard.mockReturnValue({
-      ...leaderboardDefaults,
-      leaderboard: {
-        campaignId: 'campaign-ondo-123',
-        tiers: {
-          STARTER: {
-            minDeposit: 500,
-            entries: [],
-            totalParticipants: 100,
-          },
-        },
-        computedAt: '2024-01-01T00:00:00Z',
-      },
-    });
     const { getByText } = render(<OndoCampaignStatsView />);
     expect(
       getByText('rewards.ondo_campaign_leaderboard.qualify_for_rank_title'),
@@ -476,20 +476,6 @@ describe('OndoCampaignStatsView', () => {
         projectedTier: 'STARTER',
         qualifiedDays: 3,
       }),
-    });
-    mockUseGetOndoLeaderboard.mockReturnValue({
-      ...leaderboardDefaults,
-      leaderboard: {
-        campaignId: 'campaign-ondo-123',
-        tiers: {
-          STARTER: {
-            minDeposit: 500,
-            entries: [],
-            totalParticipants: 100,
-          },
-        },
-        computedAt: '2024-01-01T00:00:00Z',
-      },
     });
     const { getByText } = render(<OndoCampaignStatsView />);
     fireEvent.press(
@@ -520,20 +506,6 @@ describe('OndoCampaignStatsView', () => {
       ...positionDefaults,
       position: makeQualifiedPosition({ projectedTier: 'MID' }),
     });
-    mockUseGetOndoLeaderboard.mockReturnValue({
-      ...leaderboardDefaults,
-      leaderboard: {
-        campaignId: 'campaign-ondo-123',
-        tiers: {
-          MID: {
-            minDeposit: 1000,
-            entries: [],
-            totalParticipants: 50,
-          },
-        },
-        computedAt: '2024-01-01T00:00:00Z',
-      },
-    });
     const { getByText } = render(<OndoCampaignStatsView />);
     expect(
       getByText('rewards.ondo_campaign_stats.qualified_title'),
@@ -559,20 +531,6 @@ describe('OndoCampaignStatsView', () => {
     mockUseGetOndoLeaderboardPosition.mockReturnValue({
       ...positionDefaults,
       position: makeQualifiedPosition({ projectedTier: 'MID' }),
-    });
-    mockUseGetOndoLeaderboard.mockReturnValue({
-      ...leaderboardDefaults,
-      leaderboard: {
-        campaignId: 'campaign-ondo-123',
-        tiers: {
-          MID: {
-            minDeposit: 1000,
-            entries: [],
-            totalParticipants: 50,
-          },
-        },
-        computedAt: '2024-01-01T00:00:00Z',
-      },
     });
     const { queryByText } = render(<OndoCampaignStatsView />);
     expect(

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -25,7 +25,10 @@ import {
   QualifiedTag,
 } from '../components/Campaigns/CampaignStatsSummary';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
-import { formatTierDisplayName } from '../components/Campaigns/OndoLeaderboard.utils';
+import {
+  formatTierDisplayName,
+  getTierMinNetDeposit,
+} from '../components/Campaigns/OndoLeaderboard.utils';
 import { strings } from '../../../../../locales/i18n';
 import { formatPercentChange, formatUsd } from '../utils/formatUtils';
 import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../utils/ondoCampaignConstants';
@@ -149,11 +152,13 @@ const OndoCampaignStatsView: React.FC = () => {
 
   const tierMinDeposit = useMemo(
     () =>
-      leaderboardPosition && leaderboardData && isCampaignActive
-        ? (leaderboardData.tiers[leaderboardPosition.projectedTier]
-            ?.minDeposit ?? null)
+      leaderboardPosition && campaign && isCampaignActive
+        ? getTierMinNetDeposit(
+            campaign.details?.tiers,
+            leaderboardPosition.projectedTier,
+          )
         : null,
-    [leaderboardData, leaderboardPosition, isCampaignActive],
+    [campaign, leaderboardPosition, isCampaignActive],
   );
 
   const showQualifyCard =
@@ -339,7 +344,7 @@ const OndoCampaignStatsView: React.FC = () => {
                     {strings(
                       'rewards.ondo_campaign_leaderboard.qualify_for_rank_description',
                       {
-                        minDeposit: formatUsd(tierMinDeposit ?? 0),
+                        minNetDeposit: formatUsd(tierMinDeposit ?? 0),
                         daysRemaining,
                       },
                     )}
@@ -363,7 +368,7 @@ const OndoCampaignStatsView: React.FC = () => {
                 >
                   {strings(
                     'rewards.ondo_campaign_stats.qualified_description',
-                    { minDeposit: formatUsd(tierMinDeposit) },
+                    { minNetDeposit: formatUsd(tierMinDeposit) },
                   )}
                 </Text>
               </Box>

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import OndoLeaderboardView, {
   ONDO_LEADERBOARD_VIEW_TEST_IDS,
 } from './OndoLeaderboardView';
+import { useSelector } from 'react-redux';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
@@ -53,9 +54,11 @@ jest.mock(
 );
 
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => null),
+  useSelector: jest.fn(),
   useDispatch: jest.fn(() => jest.fn()),
 }));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 jest.mock('../../../Views/ErrorBoundary', () => {
   const ReactActual = jest.requireActual('react');
@@ -84,6 +87,14 @@ jest.mock('../components/Campaigns/OndoLeaderboard', () => {
 
 jest.mock('../components/Campaigns/OndoLeaderboard.utils', () => ({
   formatTierDisplayName: (tier: string) => tier,
+  getTierMinNetDeposit: jest.fn(
+    (
+      tiers: { name: string; minNetDeposit: number }[] | undefined,
+      name: string,
+    ) =>
+      tiers?.find((t: { name: string }) => t.name === name)?.minNetDeposit ??
+      null,
+  ),
 }));
 
 jest.mock('../hooks/useGetOndoLeaderboard');
@@ -109,7 +120,7 @@ const hookDefaults = {
   isLeaderboardNotYetComputed: false,
   tierNames: ['STARTER', 'MID'],
   selectedTier: 'STARTER',
-  selectedTierData: { entries: [], totalParticipants: 10, minDeposit: 500 },
+  selectedTierData: { entries: [], totalParticipants: 10 },
   computedAt: '2024-03-20T12:00:00.000Z',
   setSelectedTier: jest.fn(),
   refetch: jest.fn(),
@@ -128,8 +139,38 @@ describe('OndoLeaderboardView', () => {
     refetch: jest.fn(),
   };
 
+  const mockCampaign = {
+    id: 'campaign-ondo-123',
+    type: 'ONDO_HOLDING' as const,
+    name: 'Test Campaign',
+    startDate: '2024-01-01T00:00:00Z',
+    endDate: '2099-12-31T23:59:59Z',
+    termsAndConditions: null,
+    excludedRegions: [],
+    statusLabel: '',
+    image: null,
+    featured: false,
+    details: {
+      howItWorks: { title: '', description: '', steps: [] },
+      tiers: [
+        { name: 'STARTER', minNetDeposit: 500 },
+        { name: 'MID', minNetDeposit: 1000 },
+      ],
+    },
+  };
+
+  const mockState = {
+    rewards: {
+      referralCode: null,
+      campaigns: [mockCampaign],
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(mockState),
+    );
     mockUseGetCampaignParticipantStatus.mockReturnValue({
       status: null,
       isLoading: false,
@@ -315,7 +356,7 @@ describe('OndoLeaderboardView', () => {
   });
 
   describe('pendingSheetPosition', () => {
-    it('passes pendingSheetPosition to OndoLeaderboard when position is pending and tier has minDeposit', () => {
+    it('passes pendingSheetPosition to OndoLeaderboard when position is pending and tier has minNetDeposit', () => {
       mockUseGetCampaignParticipantStatus.mockReturnValue({
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
@@ -335,20 +376,6 @@ describe('OndoLeaderboardView', () => {
           totalUsdDeposited: 4000,
           netDeposit: 3500,
           neighbors: [],
-          computedAt: '2024-01-01T00:00:00Z',
-        },
-      });
-      mockUseGetOndoLeaderboard.mockReturnValue({
-        ...hookDefaults,
-        leaderboard: {
-          campaignId: 'campaign-ondo-123',
-          tiers: {
-            STARTER: {
-              minDeposit: 500,
-              entries: [],
-              totalParticipants: 100,
-            },
-          },
           computedAt: '2024-01-01T00:00:00Z',
         },
       });
@@ -390,16 +417,6 @@ describe('OndoLeaderboardView', () => {
           computedAt: '2024-01-01T00:00:00Z',
         },
       });
-      mockUseGetOndoLeaderboard.mockReturnValue({
-        ...hookDefaults,
-        leaderboard: {
-          campaignId: 'campaign-ondo-123',
-          tiers: {
-            MID: { minDeposit: 1000, entries: [], totalParticipants: 50 },
-          },
-          computedAt: '2024-01-01T00:00:00Z',
-        },
-      });
 
       render(<OndoLeaderboardView />);
 
@@ -408,7 +425,23 @@ describe('OndoLeaderboardView', () => {
       );
     });
 
-    it('passes pendingSheetPosition as null when leaderboard has no tier minDeposit', () => {
+    it('passes pendingSheetPosition as null when campaign has no config tiers', () => {
+      const noTiersState = {
+        rewards: {
+          referralCode: null,
+          campaigns: [
+            {
+              ...mockCampaign,
+              details: {
+                howItWorks: { title: '', description: '', steps: [] },
+              },
+            },
+          ],
+        },
+      };
+      mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+        selector(noTiersState),
+      );
       mockUseGetCampaignParticipantStatus.mockReturnValue({
         status: { optedIn: true, participantCount: 1 },
         isLoading: false,
@@ -430,11 +463,6 @@ describe('OndoLeaderboardView', () => {
           neighbors: [],
           computedAt: '2024-01-01T00:00:00Z',
         },
-      });
-      // leaderboard has no tiers data → minDeposit is null
-      mockUseGetOndoLeaderboard.mockReturnValue({
-        ...hookDefaults,
-        leaderboard: null,
       });
 
       render(<OndoLeaderboardView />);

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -65,7 +65,6 @@ const OndoLeaderboardView: React.FC = () => {
   const isQualified = position != null && position.qualified;
   const {
     leaderboard: leaderboardData,
-    tierNames,
     selectedTier,
     selectedTierData,
     setSelectedTier,
@@ -76,6 +75,11 @@ const OndoLeaderboardView: React.FC = () => {
   } = useGetOndoLeaderboard(campaignId, {
     defaultTier: position?.projectedTier,
   });
+
+  const tierNames = useMemo(
+    () => campaign?.details?.tiers?.map((t) => t.name) ?? [],
+    [campaign],
+  );
 
   const pendingSheetPosition = useMemo(() => {
     if (!position || position.qualified) return null;

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -18,12 +18,18 @@ import {
   PendingTag,
   QualifiedTag,
 } from '../components/Campaigns/CampaignStatsSummary';
-import { formatTierDisplayName } from '../components/Campaigns/OndoLeaderboard.utils';
+import {
+  formatTierDisplayName,
+  getTierMinNetDeposit,
+} from '../components/Campaigns/OndoLeaderboard.utils';
 import { useGetOndoLeaderboard } from '../hooks/useGetOndoLeaderboard';
 import { useGetOndoLeaderboardPosition } from '../hooks/useGetOndoLeaderboardPosition';
 import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticipantStatus';
 import { strings } from '../../../../../locales/i18n';
-import { selectReferralCode } from '../../../../reducers/rewards/selectors';
+import {
+  selectReferralCode,
+  selectCampaignById,
+} from '../../../../reducers/rewards/selectors';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -42,6 +48,11 @@ const OndoLeaderboardView: React.FC = () => {
     useRoute<RouteProp<OndoLeaderboardRouteParams, 'OndoLeaderboard'>>();
   const { campaignId } = route.params;
   const referralCode = useSelector(selectReferralCode);
+  const selectCampaign = useMemo(
+    () => selectCampaignById(campaignId),
+    [campaignId],
+  );
+  const campaign = useSelector(selectCampaign);
 
   const { status: participantStatus } =
     useGetCampaignParticipantStatus(campaignId);
@@ -68,8 +79,10 @@ const OndoLeaderboardView: React.FC = () => {
 
   const pendingSheetPosition = useMemo(() => {
     if (!position || position.qualified) return null;
-    const tierMinDeposit =
-      leaderboardData?.tiers[position.projectedTier]?.minDeposit ?? null;
+    const tierMinDeposit = getTierMinNetDeposit(
+      campaign?.details?.tiers,
+      position.projectedTier,
+    );
     if (tierMinDeposit == null) return null;
     return {
       tier: position.projectedTier,
@@ -77,7 +90,7 @@ const OndoLeaderboardView: React.FC = () => {
       qualifiedDays: position.qualifiedDays,
       tierMinDeposit,
     };
-  }, [position, leaderboardData]);
+  }, [position, campaign]);
 
   return (
     <ErrorBoundary navigation={navigation} view="OndoLeaderboardView">

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -385,6 +385,46 @@ describe('RewardsDashboard', () => {
       // Assert
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_SETTINGS_VIEW);
     });
+
+    it('navigates to referral view when referral button is pressed', () => {
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      fireEvent.press(getByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON));
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REFERRAL_REWARDS_VIEW);
+    });
+  });
+
+  describe('referral button state', () => {
+    it('always renders the referral button as enabled regardless of subscription state', () => {
+      // Arrange - no subscriptionId
+      mockSelectRewardsSubscriptionId.mockReturnValue(null);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId) return null;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedAccountGroup)
+          return defaultSelectorValues.selectedAccountGroup;
+        return undefined;
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const referralButton = getByTestId(
+        REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
+      );
+
+      // Assert - referral button is never disabled
+      const isDisabled =
+        referralButton.props.disabled === true ||
+        referralButton.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(false);
+    });
   });
 
   describe('settings button state', () => {

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -195,7 +195,7 @@ const RewardsDashboard: React.FC = () => {
             {
               iconName: IconName.UserCircleAdd,
               onPress: () => navigation.navigate(Routes.REFERRAL_REWARDS_VIEW),
-              disabled: !subscriptionId,
+              testID: REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
             },
           ]}
         />

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -192,6 +192,11 @@ const RewardsDashboard: React.FC = () => {
               disabled: !subscriptionId,
               testID: REWARDS_VIEW_SELECTORS.SETTINGS_BUTTON,
             },
+            {
+              iconName: IconName.UserCircleAdd,
+              onPress: () => navigation.navigate(Routes.REFERRAL_REWARDS_VIEW),
+              disabled: !subscriptionId,
+            },
           ]}
         />
         <Box twClassName="flex-1 gap-4">

--- a/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import RewardsReferralView from './RewardsReferralView';
 
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: mockGoBack }),
 }));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('react-native-share', () => ({
+  open: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
@@ -17,13 +28,14 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock';
+import {
+  createMockUseAnalyticsHook,
+  createMockEventBuilder,
+} from '../../../../util/test/analyticsMock';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const mockTrackEvent = jest.fn();
-const mockCreateEventBuilder = jest.fn().mockReturnValue({
-  build: jest.fn().mockReturnValue({ event: 'REWARDS_REFERRALS_VIEWED' }),
-});
+const mockCreateEventBuilder = jest.fn(() => createMockEventBuilder());
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
 
@@ -31,6 +43,9 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
       'rewards.referral_title': 'Referrals',
+      'rewards.referral.actions.share_referral_link': 'Refer a friend',
+      'rewards.referral.actions.share_referral_subject':
+        'Join MetaMask Rewards',
     };
     return translations[key] || key;
   },
@@ -91,6 +106,8 @@ jest.mock('../components/ReferralDetails/ReferralDetails', () => {
   };
 });
 
+import Share from 'react-native-share';
+
 describe('RewardsReferralView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -100,6 +117,13 @@ describe('RewardsReferralView', () => {
         createEventBuilder: mockCreateEventBuilder,
       }),
     );
+    mockUseSelector.mockImplementation((selector) => {
+      // selectReferralCode
+      if (selector.name === 'selectReferralCode') return 'TESTCODE';
+      // selectReferralDetailsLoading
+      if (selector.name === 'selectReferralDetailsLoading') return false;
+      return undefined;
+    });
   });
 
   describe('rendering', () => {
@@ -159,6 +183,66 @@ describe('RewardsReferralView', () => {
 
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('sticky share button', () => {
+    it('renders the share button', () => {
+      const { getByTestId } = render(<RewardsReferralView />);
+
+      expect(getByTestId('referral-share-button')).toBeOnTheScreen();
+    });
+
+    it('renders the share button with correct label', () => {
+      const { getByText } = render(<RewardsReferralView />);
+
+      expect(getByText('Refer a friend')).toBeOnTheScreen();
+    });
+
+    it('disables the share button when referral code is loading', () => {
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector.name === 'selectReferralCode') return null;
+        if (selector.name === 'selectReferralDetailsLoading') return true;
+        return undefined;
+      });
+
+      const { getByTestId } = render(<RewardsReferralView />);
+      const button = getByTestId('referral-share-button');
+
+      const isDisabled =
+        button.props.disabled === true ||
+        button.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(true);
+    });
+
+    it('disables the share button when referral code is absent', () => {
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector.name === 'selectReferralCode') return null;
+        if (selector.name === 'selectReferralDetailsLoading') return false;
+        return undefined;
+      });
+
+      const { getByTestId } = render(<RewardsReferralView />);
+      const button = getByTestId('referral-share-button');
+
+      const isDisabled =
+        button.props.disabled === true ||
+        button.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(true);
+    });
+
+    it('calls Share.open when the share button is pressed', async () => {
+      const { getByTestId } = render(<RewardsReferralView />);
+
+      fireEvent.press(getByTestId('referral-share-button'));
+
+      await waitFor(() => {
+        expect(Share.open).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://link.metamask.io/rewards?referral=TESTCODE',
+          }),
+        );
       });
     });
   });

--- a/app/components/UI/Rewards/Views/RewardsReferralView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsReferralView.tsx
@@ -3,18 +3,34 @@ import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScrollView } from 'react-native';
+import { useSelector } from 'react-redux';
+import Share from 'react-native-share';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import ReferralDetails from '../components/ReferralDetails/ReferralDetails';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import {
+  selectReferralCode,
+  selectReferralDetailsLoading,
+} from '../../../../reducers/rewards/selectors';
+import { buildReferralUrl, RewardsMetricsButtons } from '../utils';
 
 const ReferralRewardsView: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const hasTrackedReferralsViewed = useRef(false);
   const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const referralCode = useSelector(selectReferralCode);
+  const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
 
   useEffect(() => {
     if (!hasTrackedReferralsViewed.current) {
@@ -24,6 +40,22 @@ const ReferralRewardsView: React.FC = () => {
       hasTrackedReferralsViewed.current = true;
     }
   }, [trackEvent, createEventBuilder]);
+
+  const handleShareLink = async () => {
+    if (!referralCode) return;
+    const link = buildReferralUrl(referralCode);
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
+        .addProperties({
+          button_type: RewardsMetricsButtons.SHARE_REFERRAL_LINK,
+        })
+        .build(),
+    );
+    await Share.open({
+      message: strings('rewards.referral.actions.share_referral_subject'),
+      url: link,
+    });
+  };
 
   return (
     <ErrorBoundary navigation={navigation} view="ReferralRewardsView">
@@ -43,6 +75,19 @@ const ReferralRewardsView: React.FC = () => {
         >
           <ReferralDetails />
         </ScrollView>
+
+        <Box twClassName="px-4 pt-2">
+          <Button
+            variant={ButtonVariant.Primary}
+            isFullWidth
+            size={ButtonSize.Lg}
+            onPress={handleShareLink}
+            disabled={!referralCode || referralDetailsLoading}
+            testID="referral-share-button"
+          >
+            {strings('rewards.referral.actions.share_referral_link')}
+          </Button>
+        </Box>
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
@@ -268,7 +268,7 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
                 {strings(
                   'rewards.ondo_campaign_leaderboard.qualify_for_rank_description',
                   {
-                    minDeposit: formatUsd(tierMinDeposit),
+                    minNetDeposit: formatUsd(tierMinDeposit),
                     daysRemaining: Math.max(
                       ONDO_GM_REQUIRED_QUALIFIED_DAYS -
                         leaderboardPosition.qualifiedDays,

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatus.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatus.tsx
@@ -50,7 +50,16 @@ const CampaignStatus: React.FC<CampaignStatusProps> = ({
 
   return (
     <Box twClassName="gap-4 p-4" testID={CAMPAIGN_STATUS_TEST_IDS.CONTAINER}>
-      <Box twClassName="gap-2">
+      <Box>
+        {howItWorksTitle ? (
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Bold}
+            testID={CAMPAIGN_STATUS_TEST_IDS.HOW_IT_WORKS_TITLE}
+          >
+            {howItWorksTitle}
+          </Text>
+        ) : null}
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
@@ -59,7 +68,7 @@ const CampaignStatus: React.FC<CampaignStatusProps> = ({
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            twClassName="gap-1 bg-success-muted rounded px-1.5"
+            twClassName="gap-1"
             testID={CAMPAIGN_STATUS_TEST_IDS.STATUS_LABEL}
           >
             <Text
@@ -82,16 +91,6 @@ const CampaignStatus: React.FC<CampaignStatusProps> = ({
             </Text>
           </Box>
         </Box>
-
-        {howItWorksTitle ? (
-          <Text
-            variant={TextVariant.HeadingLg}
-            fontWeight={FontWeight.Bold}
-            testID={CAMPAIGN_STATUS_TEST_IDS.HOW_IT_WORKS_TITLE}
-          >
-            {howItWorksTitle}
-          </Text>
-        ) : null}
       </Box>
       <Box twClassName="rounded-xl overflow-hidden h-50 bg-muted">
         <ImageBackground

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.test.ts
@@ -2,6 +2,7 @@ import {
   formatRateOfReturn,
   formatComputedAt,
   formatTierDisplayName,
+  getTierMinNetDeposit,
 } from './OndoLeaderboard.utils';
 
 jest.mock('../../../../../../locales/i18n', () => ({
@@ -95,6 +96,29 @@ describe('OndoLeaderboard.utils', () => {
 
     it('returns the raw key for an unknown tier', () => {
       expect(formatTierDisplayName('UNKNOWN')).toBe('UNKNOWN');
+    });
+  });
+
+  describe('getTierMinNetDeposit', () => {
+    const tiers = [
+      { name: 'STARTER', minNetDeposit: 500 },
+      { name: 'MID', minNetDeposit: 1000 },
+    ];
+
+    it('returns minNetDeposit for a matching tier', () => {
+      expect(getTierMinNetDeposit(tiers, 'STARTER')).toBe(500);
+    });
+
+    it('is case-insensitive', () => {
+      expect(getTierMinNetDeposit(tiers, 'mid')).toBe(1000);
+    });
+
+    it('returns null for an unknown tier', () => {
+      expect(getTierMinNetDeposit(tiers, 'UPPER')).toBeNull();
+    });
+
+    it('returns null when tiers is undefined', () => {
+      expect(getTierMinNetDeposit(undefined, 'STARTER')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.test.ts
@@ -85,6 +85,14 @@ describe('OndoLeaderboard.utils', () => {
       expect(formatTierDisplayName('UPPER')).toBe('Platinum');
     });
 
+    it('handles lowercase input', () => {
+      expect(formatTierDisplayName('starter')).toBe('Bronze');
+    });
+
+    it('handles mixed-case input', () => {
+      expect(formatTierDisplayName('Mid')).toBe('Silver');
+    });
+
     it('returns the raw key for an unknown tier', () => {
       expect(formatTierDisplayName('UNKNOWN')).toBe('UNKNOWN');
     });

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.ts
@@ -19,6 +19,6 @@ const TIER_I18N_KEYS: Record<string, string> = {
  * Returns the raw key when no mapping is found.
  */
 export const formatTierDisplayName = (tier: string): string => {
-  const key = TIER_I18N_KEYS[tier];
+  const key = TIER_I18N_KEYS[tier.toUpperCase()];
   return key ? strings(key) : tier;
 };

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.utils.ts
@@ -1,4 +1,5 @@
 import { strings } from '../../../../../../locales/i18n';
+import type { OndoCampaignTier } from '../../../../../core/Engine/controllers/rewards-controller/types';
 
 // Re-export shared helpers so existing consumers keep working
 export {
@@ -22,3 +23,14 @@ export const formatTierDisplayName = (tier: string): string => {
   const key = TIER_I18N_KEYS[tier.toUpperCase()];
   return key ? strings(key) : tier;
 };
+
+/**
+ * Looks up the minNetDeposit for a tier from campaign config tiers.
+ * Returns null when the tier or config is missing.
+ */
+export const getTierMinNetDeposit = (
+  tiers: OndoCampaignTier[] | undefined,
+  tierName: string,
+): number | null =>
+  tiers?.find((t) => t.name.toUpperCase() === tierName.toUpperCase())
+    ?.minNetDeposit ?? null;

--- a/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPendingSheet.tsx
@@ -96,7 +96,7 @@ const OndoPendingSheet: React.FC<OndoPendingSheetProps> = ({ route }) => {
               {strings(
                 'rewards.ondo_campaign_leaderboard.pending_sheet_own_body',
                 {
-                  minDeposit: formatUsd(params.tierMinDeposit),
+                  minNetDeposit: formatUsd(params.tierMinDeposit),
                   daysRemaining: Math.max(
                     ONDO_GM_REQUIRED_QUALIFIED_DAYS - params.qualifiedDays,
                     1,

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -48,6 +48,7 @@ import {
   groupPortfolioPositionsByAsset,
   formatPnlPercent,
   isPnlNonNegative,
+  sanitizeTokenName,
 } from './OndoPortfolio.utils';
 import { formatComputedAt } from './OndoLeaderboard.utils';
 import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
@@ -462,7 +463,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {row.tokenName}
+                      {sanitizeTokenName(row.tokenName)}
                     </Text>
                     <Text
                       variant={TextVariant.BodyMd}

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
@@ -2,6 +2,7 @@ import {
   groupPortfolioPositionsByAsset,
   formatPnlPercent,
   isPnlNonNegative,
+  sanitizeTokenName,
 } from './OndoPortfolio.utils';
 
 describe('groupPortfolioPositionsByAsset', () => {
@@ -109,5 +110,41 @@ describe('isPnlNonNegative', () => {
 
   it('returns false for non-parseable value (BigNumber NaN is not >= 0)', () => {
     expect(isPnlNonNegative('—')).toBe(false);
+  });
+});
+
+describe('sanitizeTokenName', () => {
+  it('strips "(Ondo Tokenized)" and trims', () => {
+    expect(sanitizeTokenName('US Dollar (Ondo Tokenized)')).toBe('US Dollar');
+  });
+
+  it('is case-insensitive', () => {
+    expect(sanitizeTokenName('Token (ondo tokenized)')).toBe('Token');
+  });
+
+  it('truncates to 20 characters with ellipsis', () => {
+    expect(sanitizeTokenName('A Very Long Token Name That Exceeds')).toBe(
+      'A Very Long Token Na...',
+    );
+  });
+
+  it('strips then truncates with ellipsis', () => {
+    const long = 'Extremely Long Name Here (Ondo Tokenized)';
+    const result = sanitizeTokenName(long);
+    expect(result).toBe('Extremely Long Name...');
+  });
+
+  it('does not add ellipsis when exactly 20 characters', () => {
+    expect(sanitizeTokenName('12345678901234567890')).toBe(
+      '12345678901234567890',
+    );
+  });
+
+  it('returns the name unchanged when no stripping or truncation is needed', () => {
+    expect(sanitizeTokenName('OUSG')).toBe('OUSG');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeTokenName('')).toBe('');
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.ts
@@ -61,3 +61,11 @@ export function groupPortfolioPositionsByAsset(
 
   return Array.from(map.values());
 }
+
+const MAX_TOKEN_NAME_LENGTH = 20;
+
+export function sanitizeTokenName(raw: string): string {
+  const cleaned = raw.replace(/\(Ondo Tokenized\)/gi, '').trim();
+  if (cleaned.length <= MAX_TOKEN_NAME_LENGTH) return cleaned;
+  return `${cleaned.slice(0, MAX_TOKEN_NAME_LENGTH).trim()}...`;
+}

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonReferralDetails.tsx
@@ -21,7 +21,7 @@ import RewardsErrorBanner from '../RewardsErrorBanner';
 import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 
 const PreviousSeasonReferralDetails = () => {
-  const { fetchReferralDetails } = useReferralDetails();
+  const { fetchReferralDetails } = useReferralDetails({ fetchOnMount: false });
   const seasonId = useSelector(selectSeasonId);
   const totalReferees = useSelector(selectReferralCount);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonUnlockedRewards.test.tsx
@@ -36,7 +36,6 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../../../reducers/rewards/selectors', () => ({
   selectUnlockedRewards: jest.fn(),
   selectSeasonTiers: jest.fn(),
-  selectSeasonShouldInstallNewVersion: jest.fn(),
   selectUnlockedRewardLoading: jest.fn(),
   selectUnlockedRewardError: jest.fn(),
   selectCurrentTier: jest.fn(),

--- a/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Box,
+  BoxAlignItems,
   BoxFlexDirection,
   Text,
   TextColor,
@@ -43,6 +44,7 @@ const CopyableField: React.FC<CopyableFieldProps> = ({
     <Box
       twClassName="bg-muted border-muted rounded-md px-4 py-3"
       flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
     >
       <Box twClassName="flex-1">
         <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
@@ -51,7 +53,7 @@ const CopyableField: React.FC<CopyableFieldProps> = ({
         {valueLoading ? (
           <Skeleton height={24} width={75} />
         ) : (
-          <Text variant={TextVariant.BodySm}>{value || '-'}</Text>
+          <Text variant={TextVariant.BodyMd}>{value || '-'}</Text>
         )}
       </Box>
       <ButtonIcon

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
@@ -4,12 +4,7 @@ import ReferralActionsSection from './ReferralActionsSection';
 
 // Mock the strings function
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: jest.fn((key: string) => {
-    const translations: Record<string, string> = {
-      'rewards.referral.actions.share_referral_link': 'Share Referral Link',
-    };
-    return translations[key] || key;
-  }),
+  strings: jest.fn((key: string) => key),
 }));
 
 // Mock CopyableField component
@@ -55,7 +50,6 @@ describe('ReferralActionsSection', () => {
     referralCodeError: false,
     onCopyCode: jest.fn(),
     onCopyLink: jest.fn(),
-    onShareLink: jest.fn(),
   };
 
   beforeEach(() => {
@@ -64,7 +58,7 @@ describe('ReferralActionsSection', () => {
 
   describe('rendering', () => {
     it('should render correctly with all props', () => {
-      const { getByTestId, getByText } = render(
+      const { getByTestId } = render(
         <ReferralActionsSection {...defaultProps} />,
       );
 
@@ -74,7 +68,6 @@ describe('ReferralActionsSection', () => {
       expect(
         getByTestId('copyable-field-rewards.referral.referral_link'),
       ).toBeTruthy();
-      expect(getByText('Share Referral Link')).toBeTruthy();
     });
 
     it('should render with null referral code', () => {
@@ -156,25 +149,6 @@ describe('ReferralActionsSection', () => {
       expect(
         getByText('link.metamask.io/rewards?referral=CUSTOM456'),
       ).toBeTruthy();
-    });
-  });
-
-  describe('share functionality', () => {
-    it('should call onShareLink with correct URL when share button is pressed', () => {
-      const mockOnShareLink = jest.fn();
-      const { getByText } = render(
-        <ReferralActionsSection
-          {...defaultProps}
-          onShareLink={mockOnShareLink}
-        />,
-      );
-
-      const shareButton = getByText('Share Referral Link');
-      fireEvent.press(shareButton);
-
-      expect(mockOnShareLink).toHaveBeenCalledWith(
-        'https://link.metamask.io/rewards?referral=TEST123',
-      );
     });
   });
 
@@ -329,7 +303,6 @@ describe('ReferralActionsSection', () => {
           referralCodeError
           onCopyCode={jest.fn()}
           onCopyLink={jest.fn()}
-          onShareLink={jest.fn()}
         />,
       );
 
@@ -351,7 +324,6 @@ describe('ReferralActionsSection', () => {
           referralCodeError
           onCopyCode={jest.fn()}
           onCopyLink={jest.fn()}
-          onShareLink={jest.fn()}
         />,
       );
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import CopyableField from './CopyableField';
 import { strings } from '../../../../../../locales/i18n';
 import { REFERRAL_LINK_PATH, buildReferralUrl } from '../../utils';
@@ -15,7 +10,6 @@ interface ReferralActionsSectionProps {
   referralCodeError: boolean;
   onCopyCode?: () => void;
   onCopyLink?: (link: string) => void;
-  onShareLink?: (link: string) => void;
 }
 
 const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
@@ -24,7 +18,6 @@ const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
   referralCodeError,
   onCopyCode,
   onCopyLink,
-  onShareLink,
 }) => {
   // Show error banner when there's an error and not loading
   if (referralCodeError && !referralCodeLoading && !referralCode) {
@@ -50,18 +43,6 @@ const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
         }
         valueLoading={referralCodeLoading}
       />
-
-      <Button
-        variant={ButtonVariant.Primary}
-        isFullWidth
-        size={ButtonSize.Lg}
-        onPress={() =>
-          referralCode ? onShareLink?.(buildReferralUrl(referralCode)) : null
-        }
-        disabled={!onShareLink || !referralCode || referralCodeLoading}
-      >
-        {strings('rewards.referral.actions.share_referral_link')}
-      </Button>
     </Box>
   );
 };

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
@@ -213,9 +213,6 @@ describe('ReferralDetails', () => {
 
       // Assert
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -250,16 +247,6 @@ describe('ReferralDetails', () => {
   });
 
   describe('props passing to child components', () => {
-    it('renders ReferralStatsSection', () => {
-      // Arrange & Act
-      renderComponent();
-
-      // Assert
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
-    });
-
     it('passes loading state to ReferralActionsSection when referral details are loading', () => {
       // Arrange
       const referralCode = 'TEST456';
@@ -446,9 +433,7 @@ describe('ReferralDetails', () => {
       renderComponent();
 
       // Assert - Component should render despite loading state
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
+      expect(screen.getByTestId('referral-actions-section')).toBeTruthy();
     });
 
     it('should handle referral details loading state', () => {
@@ -487,9 +472,6 @@ describe('ReferralDetails', () => {
 
       // Assert
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
   });
@@ -533,9 +515,6 @@ describe('ReferralDetails', () => {
 
       // Assert - All child components should be present in column layout
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
   });
@@ -564,9 +543,6 @@ describe('ReferralDetails', () => {
       expect(getByTestId('error-description')).toBeTruthy();
       // Other components should not be rendered
       expect(queryByTestId('referral-info-section')).toBeNull();
-      expect(
-        screen.queryByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeNull();
       expect(queryByTestId('referral-actions-section')).toBeNull();
     });
 
@@ -615,10 +591,7 @@ describe('ReferralDetails', () => {
       expect(getByTestId('error-title')).toBeTruthy();
       expect(getByTestId('error-description')).toBeTruthy();
       expect(getByTestId('error-retry-button')).toBeTruthy();
-      // Stats and actions sections should not be rendered
-      expect(
-        screen.queryByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeNull();
+      // Actions section should not be rendered
       expect(queryByTestId('referral-actions-section')).toBeNull();
       // Info section should still be rendered
       expect(queryByTestId('referral-info-section')).toBeTruthy();
@@ -644,9 +617,6 @@ describe('ReferralDetails', () => {
       // Assert
       expect(queryByText("Referral details couldn't be loaded")).toBeNull();
       // Normal components should render
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -670,9 +640,6 @@ describe('ReferralDetails', () => {
       // Assert
       expect(queryByText("Referral details couldn't be loaded")).toBeNull();
       // Normal components should render
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -713,13 +680,9 @@ describe('ReferralDetails', () => {
 
       // Assert - All components should be findable, indicating proper accessibility
       const infoSection = getByTestId('referral-info-section');
-      const statsSection = screen.getByText(
-        'rewards.referral_stats_earned_from_referrals',
-      );
       const actionsSection = getByTestId('referral-actions-section');
 
       expect(infoSection).toBeTruthy();
-      expect(statsSection).toBeTruthy();
       expect(actionsSection).toBeTruthy();
     });
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import ReferralInfoSection from './ReferralInfoSection';
-import ReferralStatsSection from './ReferralStatsSection';
 import ReferralActionsSection from './ReferralActionsSection';
-import Share from 'react-native-share';
 import { strings } from '../../../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import {
-  selectBalanceRefereePortion,
   selectReferralCode,
-  selectReferralCount,
   selectReferralDetailsError,
   selectReferralDetailsLoading,
   selectSeasonStatusError,
@@ -30,8 +26,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   showInfoSection = true,
 }) => {
   const referralCode = useSelector(selectReferralCode);
-  const refereeCount = useSelector(selectReferralCount);
-  const balanceRefereePortion = useSelector(selectBalanceRefereePortion);
   const seasonStatusError = useSelector(selectSeasonStatusError);
   const seasonStartDate = useSelector(selectSeasonStartDate);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
@@ -67,20 +61,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
     }
   };
 
-  const handleShareLink = async (link: string) => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
-        .addProperties({
-          button_type: RewardsMetricsButtons.SHARE_REFERRAL_LINK,
-        })
-        .build(),
-    );
-    await Share.open({
-      message: `${strings('rewards.referral.actions.share_referral_subject')}`,
-      url: link,
-    });
-  };
-
   if (seasonStatusError && !seasonStartDate) {
     return (
       <RewardsErrorBanner
@@ -93,7 +73,7 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   }
 
   return (
-    <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-4">
+    <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-6">
       {showInfoSection && <ReferralInfoSection />}
 
       {!referralDetailsLoading && referralDetailsError && !referralCode ? (
@@ -108,24 +88,13 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
           )}
         />
       ) : (
-        <>
-          <ReferralStatsSection
-            earnedPointsFromReferees={balanceRefereePortion}
-            refereeCount={refereeCount}
-            earnedPointsFromRefereesLoading={referralDetailsLoading}
-            refereeCountLoading={referralDetailsLoading}
-            refereeCountError={referralDetailsError}
-          />
-
-          <ReferralActionsSection
-            referralCode={referralCode}
-            referralCodeLoading={referralDetailsLoading}
-            referralCodeError={referralDetailsError}
-            onCopyCode={handleCopyCode}
-            onCopyLink={handleCopyLink}
-            onShareLink={handleShareLink}
-          />
-        </>
+        <ReferralActionsSection
+          referralCode={referralCode}
+          referralCodeLoading={referralDetailsLoading}
+          referralCodeError={referralDetailsError}
+          onCopyCode={handleCopyCode}
+          onCopyLink={handleCopyLink}
+        />
       )}
     </Box>
   );

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
@@ -37,7 +37,7 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
   const referralDetailsError = useSelector(selectReferralDetailsError);
 
-  const { fetchReferralDetails } = useReferralDetails();
+  const { fetchReferralDetails } = useReferralDetails({ fetchOnMount: false });
 
   const { trackEvent, createEventBuilder } = useAnalytics();
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
@@ -6,9 +6,9 @@ import ReferralInfoSection from './ReferralInfoSection';
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
-      'rewards.referral.info.title': 'Invite Friends & Earn',
+      'rewards.referral.info.title': 'Share your code with friends',
       'rewards.referral.info.description':
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
     };
     return translations[key] || key;
   }),
@@ -19,10 +19,10 @@ describe('ReferralInfoSection', () => {
     it('should render correctly', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      expect(getByText('Invite Friends & Earn')).toBeTruthy();
+      expect(getByText('Share your code with friends')).toBeTruthy();
       expect(
         getByText(
-          'Share your referral code with friends and earn rewards when they join MetaMask.',
+          'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
         ),
       ).toBeTruthy();
     });
@@ -30,7 +30,7 @@ describe('ReferralInfoSection', () => {
     it('should display the correct title', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      const titleElement = getByText('Invite Friends & Earn');
+      const titleElement = getByText('Share your code with friends');
       expect(titleElement).toBeTruthy();
     });
 
@@ -38,7 +38,7 @@ describe('ReferralInfoSection', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
       const descriptionElement = getByText(
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
       );
       expect(descriptionElement).toBeTruthy();
     });
@@ -48,9 +48,9 @@ describe('ReferralInfoSection', () => {
     it('should render text elements that are accessible', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      const titleElement = getByText('Invite Friends & Earn');
+      const titleElement = getByText('Share your code with friends');
       const descriptionElement = getByText(
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
       );
 
       expect(titleElement).toBeTruthy();

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
@@ -49,7 +49,7 @@ const ReferredByCodeSection: React.FC = () => {
     applyReferralCodeSuccess,
   } = useApplyReferralCode();
 
-  const { fetchReferralDetails } = useReferralDetails();
+  const { fetchReferralDetails } = useReferralDetails({ fetchOnMount: false });
 
   const hasReferredByCode = Boolean(referredByCode);
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/ReferralStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/ReferralStatsSummary.tsx
@@ -28,7 +28,7 @@ const ReferralStatsSummary = ({
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
   const referralDetailsError = useSelector(selectReferralDetailsError);
 
-  const { fetchReferralDetails } = useReferralDetails();
+  const { fetchReferralDetails } = useReferralDetails({ fetchOnMount: false });
 
   return (
     <Box twClassName="w-full">

--- a/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
@@ -82,7 +82,6 @@ const MOCK_LEADERBOARD: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 50,
-      minDeposit: 500,
     },
     MID: {
       entries: [
@@ -95,7 +94,6 @@ const MOCK_LEADERBOARD: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 30,
-      minDeposit: 1000,
     },
   },
 };

--- a/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.test.ts
@@ -204,7 +204,6 @@ describe('useGetOndoLeaderboard', () => {
     const { result } = renderHook(() => useGetOndoLeaderboard(CAMPAIGN_ID));
 
     expect(result.current.leaderboard).toEqual(MOCK_LEADERBOARD);
-    expect(result.current.tierNames).toEqual(['STARTER', 'MID']);
     expect(result.current.selectedTier).toBe('STARTER');
     expect(result.current.computedAt).toBe('2024-03-20T12:00:00.000Z');
   });
@@ -257,7 +256,7 @@ describe('useGetOndoLeaderboard', () => {
     );
   });
 
-  it('setSelectedTier does not dispatch action when tier is invalid', () => {
+  it('setSelectedTier dispatches action for any tier name', () => {
     setupSelectors({
       leaderboard: MOCK_LEADERBOARD,
       isLoading: false,
@@ -270,11 +269,11 @@ describe('useGetOndoLeaderboard', () => {
     mockDispatch.mockClear();
 
     act(() => {
-      result.current.setSelectedTier('INVALID');
+      result.current.setSelectedTier('UPPER');
     });
 
-    expect(mockDispatch).not.toHaveBeenCalledWith(
-      setOndoCampaignLeaderboardSelectedTier('INVALID'),
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setOndoCampaignLeaderboardSelectedTier('UPPER'),
     );
   });
 
@@ -300,7 +299,7 @@ describe('useGetOndoLeaderboard', () => {
     );
   });
 
-  it('does not apply defaultTier when it is not in tierNames', async () => {
+  it('applies defaultTier even when not in leaderboard tiers', async () => {
     setupSelectors({
       leaderboard: MOCK_LEADERBOARD,
       isLoading: false,
@@ -308,7 +307,6 @@ describe('useGetOndoLeaderboard', () => {
       tierNames: ['STARTER', 'MID'],
       selectedTier: null,
     });
-    mockDispatch.mockClear();
 
     renderHook(() =>
       useGetOndoLeaderboard(CAMPAIGN_ID, { defaultTier: 'UPPER' }),
@@ -318,7 +316,7 @@ describe('useGetOndoLeaderboard', () => {
       await Promise.resolve();
     });
 
-    expect(mockDispatch).not.toHaveBeenCalledWith(
+    expect(mockDispatch).toHaveBeenCalledWith(
       setOndoCampaignLeaderboardSelectedTier('UPPER'),
     );
   });

--- a/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoLeaderboard.ts
@@ -5,7 +5,6 @@ import {
   selectOndoCampaignLeaderboard,
   selectOndoCampaignLeaderboardLoading,
   selectOndoCampaignLeaderboardError,
-  selectOndoCampaignLeaderboardTierNames,
   selectOndoCampaignLeaderboardSelectedTier,
 } from '../../../../reducers/rewards/selectors';
 import {
@@ -33,8 +32,6 @@ export interface UseGetOndoLeaderboardResult {
   hasError: boolean;
   /** Whether the leaderboard hasn't been computed yet by the backend (404) */
   isLeaderboardNotYetComputed: boolean;
-  /** List of available tier names (e.g., ['STARTER', 'MID', 'UPPER']) */
-  tierNames: string[];
   /** Currently selected tier name */
   selectedTier: string | null;
   /** Leaderboard data for the currently selected tier */
@@ -67,7 +64,6 @@ export const useGetOndoLeaderboard = (
   const hasError = useSelector(selectOndoCampaignLeaderboardError);
   const [isLeaderboardNotYetComputed, setIsLeaderboardNotYetComputed] =
     useState(false);
-  const tierNames = useSelector(selectOndoCampaignLeaderboardTierNames);
   const selectedTier = useSelector(selectOndoCampaignLeaderboardSelectedTier);
 
   // Track if we've already applied the defaultTier to avoid overriding user selection
@@ -111,23 +107,17 @@ export const useGetOndoLeaderboard = (
   // Update selected tier when defaultTier becomes available (e.g., after position loads)
   // Only apply once - don't override subsequent user selections
   useEffect(() => {
-    if (
-      !hasAppliedDefaultTier.current &&
-      defaultTier &&
-      tierNames.includes(defaultTier)
-    ) {
+    if (!hasAppliedDefaultTier.current && defaultTier) {
       hasAppliedDefaultTier.current = true;
       dispatch(setOndoCampaignLeaderboardSelectedTier(defaultTier));
     }
-  }, [defaultTier, tierNames, dispatch]);
+  }, [defaultTier, dispatch]);
 
   const setSelectedTier = useCallback(
     (tier: string) => {
-      if (tierNames.includes(tier)) {
-        dispatch(setOndoCampaignLeaderboardSelectedTier(tier));
-      }
+      dispatch(setOndoCampaignLeaderboardSelectedTier(tier));
     },
-    [tierNames, dispatch],
+    [dispatch],
   );
 
   const selectedTierData = useMemo(
@@ -140,7 +130,6 @@ export const useGetOndoLeaderboard = (
     isLoading,
     hasError,
     isLeaderboardNotYetComputed,
-    tierNames,
     selectedTier,
     selectedTierData,
     computedAt: leaderboard?.computedAt ?? null,

--- a/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
@@ -181,6 +181,31 @@ describe('useReferralDetails', () => {
     expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
   });
 
+  it('does not fetch on mount when fetchOnMount is false', () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
+
+    renderHook(() => useReferralDetails({ fetchOnMount: false }));
+
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('still returns fetchReferralDetails when fetchOnMount is false', () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
+
+    const { result } = renderHook(() =>
+      useReferralDetails({ fetchOnMount: false }),
+    );
+
+    expect(typeof result.current.fetchReferralDetails).toBe('function');
+  });
+
   it('prevents duplicate fetch calls when already loading', async () => {
     mockUseSelector
       .mockReturnValueOnce('test-subscription-id')

--- a/app/components/UI/Rewards/hooks/useReferralDetails.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.ts
@@ -12,7 +12,11 @@ import type { SubscriptionSeasonReferralDetailState } from '../../../../core/Eng
 import { useFocusEffect } from '@react-navigation/native';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 
-export const useReferralDetails = (): {
+export const useReferralDetails = ({
+  fetchOnMount = true,
+}: {
+  fetchOnMount?: boolean;
+} = {}): {
   fetchReferralDetails: () => Promise<void>;
 } => {
   const dispatch = useDispatch();
@@ -60,21 +64,25 @@ export const useReferralDetails = (): {
 
   useFocusEffect(
     useCallback(() => {
+      if (!fetchOnMount) {
+        return;
+      }
       fetchReferralDetails();
-    }, [fetchReferralDetails]),
+    }, [fetchReferralDetails, fetchOnMount]),
   );
 
   const invalidateEvents = useMemo(
     () =>
-      [
-        'RewardsController:accountLinked',
-        'RewardsController:rewardClaimed',
-        'RewardsController:balanceUpdated',
-      ] as const,
-    [],
+      fetchOnMount
+        ? [
+            'RewardsController:accountLinked' as const,
+            'RewardsController:rewardClaimed' as const,
+            'RewardsController:balanceUpdated' as const,
+          ]
+        : [],
+    [fetchOnMount],
   );
 
-  // Listen for events that should trigger a refetch of referral details
   useInvalidateByRewardEvents(invalidateEvents, fetchReferralDetails);
 
   return { fetchReferralDetails };

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -8812,64 +8812,6 @@ describe('RewardsController', () => {
       // Assert
       expect(result.balance.total).toBe(largeBalance);
     });
-
-    it('preserves shouldInstallNewVersion when present', () => {
-      // Arrange
-      const seasonMetadata: SeasonDtoState = {
-        id: 'season-update',
-        name: 'Update Required Season',
-        startDate: Date.now(),
-        endDate: Date.now() + 86400000,
-        tiers: createTestTiers(),
-        activityTypes: [],
-        waysToEarn: [],
-        shouldInstallNewVersion: '1.2.3',
-      };
-
-      const seasonState: SeasonStateDto = {
-        balance: 5000,
-        currentTierId: 'gold',
-        updatedAt: new Date(),
-      };
-
-      // Act
-      const result = controller.convertToSeasonStatusDto(
-        seasonMetadata,
-        seasonState,
-      );
-
-      // Assert
-      expect(result.season.shouldInstallNewVersion).toBe('1.2.3');
-    });
-
-    it('handles shouldInstallNewVersion when undefined', () => {
-      // Arrange
-      const seasonMetadata: SeasonDtoState = {
-        id: 'season-no-update',
-        name: 'No Update Required Season',
-        startDate: Date.now(),
-        endDate: Date.now() + 86400000,
-        tiers: createTestTiers(),
-        activityTypes: [],
-        waysToEarn: [],
-        // shouldInstallNewVersion is intentionally omitted
-      };
-
-      const seasonState: SeasonStateDto = {
-        balance: 3000,
-        currentTierId: 'silver',
-        updatedAt: new Date(),
-      };
-
-      // Act
-      const result = controller.convertToSeasonStatusDto(
-        seasonMetadata,
-        seasonState,
-      );
-
-      // Assert
-      expect(result.season.shouldInstallNewVersion).toBeUndefined();
-    });
   });
 
   describe('convertInternalAccountToCaipAccountId', () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -19163,7 +19163,7 @@ describe('RewardsController', () => {
       campaignId: mockCampaignId,
       computedAt: '2024-03-20T12:00:00.000Z',
       tiers: {
-        STARTER: { entries: [], totalParticipants: 100, minDeposit: 500 },
+        STARTER: { entries: [], totalParticipants: 100 },
       },
     };
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -503,7 +503,6 @@ export class RewardsController extends BaseController<
       tiers: season.tiers,
       activityTypes: season.activityTypes,
       waysToEarn: season.waysToEarn,
-      shouldInstallNewVersion: season.shouldInstallNewVersion,
     };
   }
 
@@ -523,7 +522,6 @@ export class RewardsController extends BaseController<
         tiers: seasonMetadata.tiers,
         activityTypes: seasonMetadata.activityTypes,
         waysToEarn: seasonMetadata.waysToEarn,
-        shouldInstallNewVersion: seasonMetadata.shouldInstallNewVersion,
       },
       balance: {
         total: seasonState.balance,
@@ -2098,8 +2096,6 @@ export class RewardsController extends BaseController<
             tiers: seasonMetadata.tiers,
             activityTypes: seasonMetadata.activityTypes,
             waysToEarn: seasonMetadata.waysToEarn,
-            shouldInstallNewVersion:
-              seasonMetadata.shouldInstallNewVersion?.mobile,
           });
 
           // Add lastFetched timestamp

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1234,7 +1234,6 @@ export interface SeasonDto {
   tiers: SeasonTierDto[];
   activityTypes: SeasonActivityTypeDto[];
   waysToEarn: SeasonWayToEarnDto[];
-  shouldInstallNewVersion?: string | undefined;
 }
 
 export interface SeasonStatusBalanceDto {
@@ -1373,7 +1372,6 @@ export type SeasonDtoState = {
   activityTypes: SeasonActivityTypeDto[];
   waysToEarn: SeasonWayToEarnDto[];
   lastFetched?: number;
-  shouldInstallNewVersion?: string | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -2118,14 +2116,6 @@ export interface SeasonMetadataDto {
    * Ways to earn for the season
    */
   waysToEarn: SeasonWayToEarnDto[];
-
-  /**
-   * Optional version requirements for mobile and extension
-   */
-  shouldInstallNewVersion?: {
-    mobile: string | undefined;
-    extension: string | undefined;
-  };
 }
 
 /**

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -213,6 +213,13 @@ export type ThemeImageState = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CampaignDetailsState = {
   howItWorks: OndoCampaignHowItWorksState;
+  tiers?: OndoCampaignTierState[];
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type OndoCampaignTierState = {
+  name: string;
+  minNetDeposit: number;
 };
 
 /**
@@ -303,12 +310,6 @@ export interface CampaignLeaderboardTier {
    * @example 150
    */
   totalParticipants: number;
-
-  /**
-   * Minimum USD net deposit required to qualify for this tier
-   * @example 5000
-   */
-  minDeposit: number;
 }
 
 /**
@@ -696,7 +697,6 @@ export type CampaignLeaderboardState = {
         qualified: boolean;
       }[];
       totalParticipants: number;
-      minDeposit: number;
     };
   };
   lastFetched: number;
@@ -771,8 +771,14 @@ export interface OndoCampaignHowItWorks {
   tour?: OndoCampaignTourStepDto[];
 }
 
+export interface OndoCampaignTier {
+  name: string;
+  minNetDeposit: number;
+}
+
 export interface OndoHoldingDetails {
   howItWorks: OndoCampaignHowItWorks;
+  tiers?: OndoCampaignTier[];
 }
 
 export type CampaignDetails = OndoHoldingDetails;

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -5056,7 +5056,6 @@ const mockLeaderboard: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 150,
-      minDeposit: 500,
     },
     MID: {
       entries: [
@@ -5083,7 +5082,6 @@ const mockLeaderboard: CampaignLeaderboardDto = {
         },
       ],
       totalParticipants: 75,
-      minDeposit: 1000,
     },
   },
 };

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -187,7 +187,6 @@ describe('rewardsReducer', () => {
       expect(state.currentTier?.id).toBe('tier-bronze');
       expect(state.nextTier?.id).toBe('tier-silver');
       expect(state.nextTierPointsNeeded).toBe(1000);
-      expect(state.seasonShouldInstallNewVersion).toBe(null);
     });
 
     it('should set fields to null when season status is null', () => {
@@ -212,7 +211,6 @@ describe('rewardsReducer', () => {
         ],
         balanceTotal: 1000,
         balanceRefereePortion: 200,
-        seasonShouldInstallNewVersion: '1.0.0',
         currentTier: {
           id: 'tier-gold',
           name: 'Gold',
@@ -242,7 +240,6 @@ describe('rewardsReducer', () => {
       expect(state.currentTier).toBe(null);
       expect(state.nextTier).toBe(null);
       expect(state.nextTierPointsNeeded).toBe(null);
-      expect(state.seasonShouldInstallNewVersion).toBe(null);
     });
 
     it('should handle season status with invalid balance types', () => {
@@ -478,96 +475,6 @@ describe('rewardsReducer', () => {
       const state = rewardsReducer(stateWithWaysToEarn, action);
 
       expect(state.seasonWaysToEarn).toEqual([]);
-    });
-
-    it('should set seasonShouldInstallNewVersion when provided', () => {
-      // Arrange
-      const mockSeasonStatus = {
-        season: {
-          id: 'season-with-version',
-          name: 'Season With Version',
-          startDate: new Date('2024-01-01').getTime(),
-          endDate: new Date('2024-12-31').getTime(),
-          tiers: [],
-          shouldInstallNewVersion: '2.0.0',
-        },
-        balance: {
-          total: 100,
-        },
-        tier: {
-          currentTier: null,
-          nextTier: null,
-          nextTierPointsNeeded: null,
-        },
-      } as unknown as SeasonStatusState;
-      const action = setSeasonStatus(mockSeasonStatus);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.seasonShouldInstallNewVersion).toBe('2.0.0');
-    });
-
-    it('should set seasonShouldInstallNewVersion to null when not provided', () => {
-      // Arrange
-      const mockSeasonStatus = {
-        season: {
-          id: 'season-without-version',
-          name: 'Season Without Version',
-          startDate: new Date('2024-01-01').getTime(),
-          endDate: new Date('2024-12-31').getTime(),
-          tiers: [],
-        },
-        balance: {
-          total: 100,
-        },
-        tier: {
-          currentTier: null,
-          nextTier: null,
-          nextTierPointsNeeded: null,
-        },
-      } as unknown as SeasonStatusState;
-      const action = setSeasonStatus(mockSeasonStatus);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.seasonShouldInstallNewVersion).toBe(null);
-    });
-
-    it('should set seasonShouldInstallNewVersion to null when undefined', () => {
-      // Arrange
-      const stateWithVersion = {
-        ...initialState,
-        seasonShouldInstallNewVersion: '1.0.0',
-      };
-      const mockSeasonStatus = {
-        season: {
-          id: 'season-undefined-version',
-          name: 'Season Undefined Version',
-          startDate: new Date('2024-01-01').getTime(),
-          endDate: new Date('2024-12-31').getTime(),
-          tiers: [],
-          shouldInstallNewVersion: undefined,
-        },
-        balance: {
-          total: 100,
-        },
-        tier: {
-          currentTier: null,
-          nextTier: null,
-          nextTierPointsNeeded: null,
-        },
-      } as unknown as SeasonStatusState;
-      const action = setSeasonStatus(mockSeasonStatus);
-
-      // Act
-      const state = rewardsReducer(stateWithVersion, action);
-
-      // Assert
-      expect(state.seasonShouldInstallNewVersion).toBe(null);
     });
   });
 
@@ -1507,7 +1414,6 @@ describe('rewardsReducer', () => {
               icon: 'Speedometer',
             },
           ],
-          seasonShouldInstallNewVersion: null,
         };
         const action = setCandidateSubscriptionId('new-subscription-id');
 
@@ -2105,7 +2011,6 @@ describe('rewardsReducer', () => {
         ],
         seasonActivityTypes: [],
         seasonWaysToEarn: [],
-        seasonShouldInstallNewVersion: null,
         onboardingActiveStep: OnboardingStep.STEP_1,
         onboardingReferralCode: 'REF123',
         candidateSubscriptionId: 'some-id',
@@ -2222,7 +2127,6 @@ describe('rewardsReducer', () => {
         ],
         seasonActivityTypes: [],
         seasonWaysToEarn: [],
-        seasonShouldInstallNewVersion: null,
         onboardingActiveStep: OnboardingStep.STEP_2,
         onboardingReferralCode: 'PERSISTED_REF',
         candidateSubscriptionId: 'some-id',

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -69,7 +69,6 @@ export interface RewardsState {
   seasonTiers: SeasonTierDto[];
   seasonActivityTypes: SeasonActivityTypeDto[];
   seasonWaysToEarn: SeasonWayToEarnDto[];
-  seasonShouldInstallNewVersion: string | null;
 
   // Subscription Referral state
   referralDetailsLoading: boolean;
@@ -187,9 +186,6 @@ export const initialState: RewardsState = {
   balanceRefereePortion: 0,
   balanceUpdatedAt: null,
 
-  // Should install new version state
-  seasonShouldInstallNewVersion: null,
-
   onboardingActiveStep: OnboardingStep.INTRO,
   onboardingReferralCode: null,
   candidateSubscriptionId: 'pending',
@@ -291,8 +287,6 @@ const rewardsSlice = createSlice({
       state.seasonTiers = action.payload?.season.tiers || [];
       state.seasonActivityTypes = action.payload?.season.activityTypes || [];
       state.seasonWaysToEarn = action.payload?.season.waysToEarn || [];
-      state.seasonShouldInstallNewVersion =
-        action.payload?.season?.shouldInstallNewVersion || null;
 
       // Season Balance state
       state.balanceTotal =
@@ -748,8 +742,6 @@ const rewardsSlice = createSlice({
               seasonTiers: action.payload.rewards.seasonTiers,
               seasonActivityTypes: action.payload.rewards.seasonActivityTypes,
               seasonWaysToEarn: action.payload.rewards.seasonWaysToEarn,
-              seasonShouldInstallNewVersion:
-                action.payload.rewards.seasonShouldInstallNewVersion,
               referralCode: action.payload.rewards.referralCode,
               refereeCount: action.payload.rewards.refereeCount,
               currentTier: action.payload.rewards.currentTier,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -39,7 +39,6 @@ import {
   selectUnlockedRewardError,
   selectSeasonRewardById,
   selectPointsEvents,
-  selectSeasonShouldInstallNewVersion,
   selectBulkLinkState,
   selectBulkLinkIsRunning,
   selectBulkLinkTotalAccounts,
@@ -2509,46 +2508,6 @@ describe('Rewards selectors', () => {
 
       expect(result1).toBe(result2); // Same reference
       expect(result1).toEqual(result2); // Same value
-    });
-  });
-
-  describe('selectSeasonShouldInstallNewVersion', () => {
-    it('returns null when season should install new version is not set', () => {
-      const mockState = { rewards: { seasonShouldInstallNewVersion: null } };
-      mockedUseSelector.mockImplementation((selector) => selector(mockState));
-
-      const { result } = renderHook(() =>
-        useSelector(selectSeasonShouldInstallNewVersion),
-      );
-      expect(result.current).toBeNull();
-    });
-
-    it('returns version string when set', () => {
-      const mockState = {
-        rewards: { seasonShouldInstallNewVersion: '1.2.3' },
-      };
-      mockedUseSelector.mockImplementation((selector) => selector(mockState));
-
-      const { result } = renderHook(() =>
-        useSelector(selectSeasonShouldInstallNewVersion),
-      );
-      expect(result.current).toBe('1.2.3');
-    });
-
-    describe('Direct selector calls', () => {
-      it('returns null when season should install new version is null', () => {
-        const state = createMockRootState({
-          seasonShouldInstallNewVersion: null,
-        });
-        expect(selectSeasonShouldInstallNewVersion(state)).toBeNull();
-      });
-
-      it('returns version string when set', () => {
-        const state = createMockRootState({
-          seasonShouldInstallNewVersion: '2.0.0',
-        });
-        expect(selectSeasonShouldInstallNewVersion(state)).toBe('2.0.0');
-      });
     });
   });
 

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3381,7 +3381,6 @@ describe('Rewards selectors', () => {
           },
         ],
         totalParticipants: 50,
-        minDeposit: 500,
       },
       MID: {
         entries: [
@@ -3394,7 +3393,6 @@ describe('Rewards selectors', () => {
           },
         ],
         totalParticipants: 30,
-        minDeposit: 1000,
       },
     },
   };

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -118,9 +118,6 @@ export const selectSeasonRewardById =
 export const selectPointsEvents = (state: RootState) =>
   state.rewards.pointsEvents;
 
-export const selectSeasonShouldInstallNewVersion = (state: RootState) =>
-  state.rewards.seasonShouldInstallNewVersion;
-
 // Bulk link selectors
 export const selectBulkLinkState = (state: RootState) => state.rewards.bulkLink;
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -153,6 +153,9 @@ export const selectBulkLinkAccountProgress = (state: RootState) => {
 // Campaigns selectors
 export const selectCampaigns = (state: RootState) => state.rewards.campaigns;
 
+export const selectCampaignById = (campaignId: string) => (state: RootState) =>
+  state.rewards.campaigns?.find((c) => c.id === campaignId) ?? null;
+
 export const selectCampaignsLoading = (state: RootState) =>
   state.rewards.campaignsLoading;
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7986,8 +7986,8 @@
         "share_referral_subject": "Join MetaMask Rewards"
       },
       "info": {
-        "title": "Share your code to earn more",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "title": "Share your code with friends",
+        "description": "Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm."
       },
       "referral_code_copied": "Referral code copied to clipboard"
     },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8164,11 +8164,11 @@
       "pending_sheet_title": "Pending",
       "pending_sheet_tier_label": "Tier",
       "pending_sheet_net_deposit_label": "Net Deposit",
-      "pending_sheet_own_body": "Hold a minimum balance of {{minDeposit}} for {{daysRemaining}} more day(s) to qualify for this tier.",
+      "pending_sheet_own_body": "Hold a minimum balance of {{minNetDeposit}} for {{daysRemaining}} more day(s) to qualify for this tier.",
       "pending_sheet_other_body": "This participant hasn't yet met the holding requirement for their projected tier.",
       "pending_sheet_cta": "Got it",
       "qualify_for_rank_title": "Qualify for this rank",
-      "qualify_for_rank_description": "Keep your deposit above {{minDeposit}} for {{daysRemaining}} more days, including the final day."
+      "qualify_for_rank_description": "Keep your deposit above {{minNetDeposit}} for {{daysRemaining}} more days, including the final day."
     },
     "ondo_campaign_stats": {
       "title": "Stats",
@@ -8186,7 +8186,7 @@
       "label_net_deposit": "Net deposit",
       "label_days_held": "Days held",
       "qualified_title": "You're qualified",
-      "qualified_description": "Keep your net deposit above {{minDeposit}} through the final day to stay eligible."
+      "qualified_description": "Keep your net deposit above {{minNetDeposit}} through the final day to stay eligible."
     },
     "ondo_campaign_activity": {
       "title": "All activity",

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -782,7 +782,6 @@
       "seasonEndDate": null,
       "seasonId": null,
       "seasonName": null,
-      "seasonShouldInstallNewVersion": null,
       "seasonStartDate": null,
       "seasonStatusError": null,
       "seasonStatusLoading": false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
1. Fix tier config in campaign details
- Adds a new tiers?: OndoCampaignTier[] field to OndoHoldingDetails, where each tier has name and minNetDeposit
- A new getTierMinNetDeposit() helper in OndoLeaderboard.utils.ts provides case-insensitive tier lookup.

2. Tier names now driven by campaign config, not leaderboard data
- tierNames is derived from campaign.details.tiers in the views
- useGetOndoLeaderboard no longer owns or exposes tierNames
- setSelectedTier no longer gates against leaderboard-derived tier names
- All campaign-defined tiers are selectable; tiers without leaderboard data show a "no entries" message

3. New selectCampaignById selector

4. Token name sanitization
- Added sanitizeTokenName() in OndoPortfolio.utils.ts — strips "(Ondo Tokenized)", trims, truncates to 20 chars with ellipsis. 

5. Misc fixes
- formatTierDisplayName now uppercases the key before lookup (case-insensitive)
- CampaignStatus switches position of campaign name and date label
- Call useReferralDetails at RewardsNavigator so user's referralCode is available for display

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-04-13 at 15 53 07" src="https://github.com/user-attachments/assets/70aa663f-4163-4491-8474-fe6ddf922a7f" />


<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-04-13 at 17 29 43" src="https://github.com/user-attachments/assets/d8750054-287c-4dc2-81d3-1178eaaca222" />

<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-04-13 at 17 29 02" src="https://github.com/user-attachments/assets/f2886ad4-0f29-4c9c-8175-71f31a358b31" />

<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-04-13 at 17 29 31" src="https://github.com/user-attachments/assets/2d251b5d-0e1f-4035-bde8-0f1aa96f8279" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Rewards controller/types and Redux state/selector behavior (removing `shouldInstallNewVersion`, changing tier handling) which can affect rewards flows and persistence; UI changes are straightforward but touch multiple rewards screens.
> 
> **Overview**
> **Rewards/Ondo campaign tiers are now driven by campaign config instead of leaderboard payloads.** This adds `tiers` (with `minNetDeposit`) to campaign details/types and introduces `getTierMinNetDeposit()`; leaderboard tier selection (`useGetOndoLeaderboard`) no longer validates against server-provided tier lists and will apply any `defaultTier`.
> 
> **UI now reads campaign data directly and updates copy accordingly.** `OndoCampaignDetailsView`, `OndoCampaignStatsView`, and `OndoLeaderboardView` derive `tierNames` and min-deposit messaging from `campaign.details.tiers`, switch strings to `minNetDeposit`, and add a new `selectCampaignById` selector used by views like `CampaignTourStepView`.
> 
> **Referral UX is expanded and refactored.** Rewards now fetch referral details at `RewardsNavigator`, `useReferralDetails` gains `fetchOnMount` to avoid auto-fetch in some components, the dashboard adds a referral icon button, and the referral view adds a sticky “Refer a friend” share button (with analytics + `react-native-share`), while the old share button inside `ReferralActionsSection` is removed.
> 
> **Misc fixes/polish.** Token names in Ondo portfolio are sanitized/truncated, `formatTierDisplayName` is case-insensitive, some layout spacing is adjusted, rewards modals get transparent `cardStyle`, and the deprecated season `shouldInstallNewVersion` state/selector/tests/fixtures are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f44956e95d5ea9f6a91d0084aaf27696675440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->