### PR TITLE
fix(test): skip flaky Name Lookup Snap E2E test suite

### DIFF
--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -18,7 +18,7 @@ jest.setTimeout(150_000);
 
 const TOKEN = 'Ethereum';
 
-describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
+describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {
@@ -49,7 +49,7 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await TabBarComponent.tapHome();
         await device.disableSynchronization();
         await WalletView.waitForTokenToBeReady(TOKEN);
-        // await WalletView.tapOnToken(TOKEN);
+        await WalletView.tapOnToken(TOKEN);
         await TokenOverview.tapSendButton();
 
         const domain = 'metamask.domain';

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -18,7 +18,7 @@ jest.setTimeout(150_000);
 
 const TOKEN = 'Ethereum';
 
-describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
+describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {
@@ -50,9 +50,6 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await device.disableSynchronization();
         await WalletView.waitForTokenToBeReady(TOKEN);
         await WalletView.tapOnToken(TOKEN);
-        await Assertions.expectElementToBeVisible(TokenOverview.container, {
-          description: 'Token Overview screen is visible after tapping token',
-        });
         await TokenOverview.tapSendButton();
 
         const domain = 'metamask.domain';

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -49,7 +49,7 @@ describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await TabBarComponent.tapHome();
         await device.disableSynchronization();
         await WalletView.waitForTokenToBeReady(TOKEN);
-        await WalletView.tapOnToken(TOKEN);
+        // await WalletView.tapOnToken(TOKEN);
         await TokenOverview.tapSendButton();
 
         const domain = 'metamask.domain';

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -18,7 +18,7 @@ jest.setTimeout(150_000);
 
 const TOKEN = 'Ethereum';
 
-describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
+describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {
@@ -50,6 +50,9 @@ describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await device.disableSynchronization();
         await WalletView.waitForTokenToBeReady(TOKEN);
         await WalletView.tapOnToken(TOKEN);
+        await Assertions.expectElementToBeVisible(TokenOverview.container, {
+          description: 'Token Overview screen is visible after tapping token',
+        });
         await TokenOverview.tapSendButton();
 
         const domain = 'metamask.domain';


### PR DESCRIPTION
## **Description**

The `test-snap-name-lookup.spec.ts` E2E test is consistently failing on main in the `flask-android-smoke (3)` CI job. The `waitAndTap()` call on the Send Button times out after navigating to the Token Overview screen with synchronization disabled.

This PR skips the entire Name Lookup Snap test suite via `describe.skip` until the underlying flakiness is resolved.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1718](https://consensyssoftware.atlassian.net/browse/MMQA-1718)

## **Manual testing steps**

```gherkin
Feature: Name Lookup Snap E2E Test

  Scenario: Name Lookup Snap test suite is skipped in CI
    Given the flask-android-smoke (3) CI job runs

    When the Name Lookup Snap test suite is encountered
    Then the suite is skipped via describe.skip
    And no Send Button visibility timeout occurs
```

## **Screenshots/Recordings**

### **Before**

[CI failure on main: flask-android-smoke (3)](https://github.com/MetaMask/metamask-mobile/actions/runs/24365248196/job/71160542851?pr=28174)

### **After**

PR passing CI with the entire suite skipped

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-1718]: https://consensyssoftware.atlassian.net/browse/MMQA-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ