### PR TITLE
fix(predict): enable gas station for predictDepositAndOrder pay token selection cp-7.73.0

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -204,6 +204,58 @@ describe('useTransactionPayToken', () => {
       );
     });
 
+    it('updates transaction with selectedGasFeeToken for predictDepositAndOrder when pay token matches required token', async () => {
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDepositAndOrder,
+        requiredTokens: [REQUIRED_TOKEN_MOCK],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedGasFeeToken: PAY_TOKEN_MOCK.address,
+          isGasFeeTokenIgnoredIfBalance: true,
+        }),
+        TRANSACTION_ID_MOCK,
+      );
+    });
+
+    it('resets selectedGasFeeToken for predictDepositAndOrder when pay token does not match required token', async () => {
+      const differentToken = {
+        address: '0xDifferentTokenAddress1234567890123456789012',
+        chainId: ChainId.mainnet,
+        skipIfBalance: false,
+      } as unknown as TransactionPayRequiredToken;
+
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDepositAndOrder,
+        requiredTokens: [differentToken],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      await flushPromises();
+
+      expect(updateTransactionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedGasFeeToken: undefined,
+          isGasFeeTokenIgnoredIfBalance: undefined,
+        }),
+        TRANSACTION_ID_MOCK,
+      );
+    });
+
     it('does not update transaction for non-predictDeposit transaction types', async () => {
       const { result } = runHook({
         payToken: PAY_TOKEN_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -64,6 +64,7 @@ export function useTransactionPayToken(): {
       // perps deposits only use relay, so doesn't need gasFeeToken update
       const isPredictDepositTransaction = hasTransactionType(transactionMeta, [
         TransactionType.predictDeposit,
+        TransactionType.predictDepositAndOrder,
       ]);
 
       if (isPredictDepositTransaction && transactionMeta) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `setPayToken` hook only set `selectedGasFeeToken` on the transaction metadata for `predictDeposit` transactions, skipping `predictDepositAndOrder`. This caused the "pay with any token" flow to fail when selecting tokens that require gas station support (e.g. USDC.e on Polygon).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction metadata updates used for gas fee token selection, which can affect Predict deposit+order transaction execution. Scope is small and covered by new unit tests.
> 
> **Overview**
> Fixes Predict *deposit+order* pay-token selection by treating `TransactionType.predictDepositAndOrder` like `predictDeposit` when deciding whether to set or clear `selectedGasFeeToken`/`isGasFeeTokenIgnoredIfBalance`.
> 
> Adds unit tests to verify `selectedGasFeeToken` is set when the chosen pay token matches the primary required token, and reset otherwise, for `predictDepositAndOrder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48bdfbace15437bb096e1d2a4c421e169f0ebf96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->