### PR TITLE
feat(predict): hide crypto up/down markets from featured carousel when flag is disabled

### DIFF
--- a/app/components/UI/Predict/hooks/useFeaturedCarouselData.test.ts
+++ b/app/components/UI/Predict/hooks/useFeaturedCarouselData.test.ts
@@ -5,6 +5,13 @@ import Engine from '../../../../core/Engine';
 import { useFeaturedCarouselData } from './useFeaturedCarouselData';
 import { type PredictMarket, Recurrence } from '../types';
 
+let mockUpDownEnabled = true;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: () => mockUpDownEnabled,
+}));
+
 jest.mock('../../../../util/Logger');
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -61,6 +68,7 @@ const createMockMarket = (
 describe('useFeaturedCarouselData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUpDownEnabled = true;
   });
 
   it('returns loading state initially', () => {
@@ -146,5 +154,64 @@ describe('useFeaturedCarouselData', () => {
     });
 
     expect(mockGetCarouselMarkets).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters out crypto up/down markets when flag is disabled', async () => {
+    mockUpDownEnabled = false;
+    const { Wrapper } = createWrapper();
+    const mockMarkets = [
+      createMockMarket({ id: 'regular', tags: ['politics'] }),
+      createMockMarket({
+        id: 'updown',
+        tags: ['up-or-down', 'crypto'],
+        series: {
+          id: 's1',
+          slug: 'btc-weekly',
+          title: 'BTC Weekly',
+          recurrence: 'weekly',
+        },
+      }),
+    ];
+    mockGetCarouselMarkets.mockResolvedValue(mockMarkets);
+
+    const { result } = renderHook(() => useFeaturedCarouselData(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.markets).toHaveLength(1);
+    expect(result.current.markets[0].id).toBe('regular');
+  });
+
+  it('includes crypto up/down markets when flag is enabled', async () => {
+    mockUpDownEnabled = true;
+    const { Wrapper } = createWrapper();
+    const mockMarkets = [
+      createMockMarket({ id: 'regular', tags: ['politics'] }),
+      createMockMarket({
+        id: 'updown',
+        tags: ['up-or-down', 'crypto'],
+        series: {
+          id: 's1',
+          slug: 'btc-weekly',
+          title: 'BTC Weekly',
+          recurrence: 'weekly',
+        },
+      }),
+    ];
+    mockGetCarouselMarkets.mockResolvedValue(mockMarkets);
+
+    const { result } = renderHook(() => useFeaturedCarouselData(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.markets).toHaveLength(2);
   });
 });

--- a/app/components/UI/Predict/hooks/useFeaturedCarouselData.ts
+++ b/app/components/UI/Predict/hooks/useFeaturedCarouselData.ts
@@ -1,9 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import Logger from '../../../../util/Logger';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { predictQueries } from '../queries';
+import { selectPredictUpDownEnabledFlag } from '../selectors/featureFlags';
 import type { PredictMarket } from '../types';
+import { isCryptoUpDown } from '../utils/cryptoUpDown';
 import { ensureError } from '../utils/predictErrorHandler';
 
 export interface UseFeaturedCarouselDataResult {
@@ -15,6 +18,7 @@ export interface UseFeaturedCarouselDataResult {
 
 export const useFeaturedCarouselData = (): UseFeaturedCarouselDataResult => {
   const query = useQuery(predictQueries.featuredCarousel.options());
+  const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
 
   useEffect(() => {
     if (!query.error) return;
@@ -35,8 +39,16 @@ export const useFeaturedCarouselData = (): UseFeaturedCarouselDataResult => {
     });
   }, [query.error]);
 
+  const markets = useMemo(() => {
+    const data = query.data ?? [];
+    if (upDownEnabled) {
+      return data;
+    }
+    return data.filter((market) => !isCryptoUpDown(market));
+  }, [query.data, upDownEnabled]);
+
   return {
-    markets: query.data ?? [],
+    markets,
     isLoading: query.isLoading,
     error: query.error?.message ?? null,
     refetch: query.refetch,


### PR DESCRIPTION
## **Description**

Hides incomplete crypto Up/Down markets from the featured carousel when the `predictUpDown` feature flag is disabled.

The `useFeaturedCarouselData` hook now reads `selectPredictUpDownEnabledFlag` and filters out markets matching `isCryptoUpDown()` (tagged `up-or-down` + `crypto` with series metadata) when the flag is off. When enabled, all markets pass through unchanged. This reuses the same flag already consumed by `PredictFeed` and `PredictMarketDetails`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Hide crypto Up/Down markets from featured carousel

  Scenario: Up/Down markets hidden when flag is disabled
    Given the predictUpDown feature flag is disabled
    And the featured carousel API returns crypto Up/Down markets

    When the Predict feed loads
    Then the featured carousel does not display any crypto Up/Down markets
    And non-Up/Down markets are displayed normally

  Scenario: Up/Down markets shown when flag is enabled
    Given the predictUpDown feature flag is enabled
    And the featured carousel API returns crypto Up/Down markets

    When the Predict feed loads
    Then the featured carousel displays all markets including crypto Up/Down
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, UI-facing filtering change gated by an existing feature flag, with added unit tests. Main risk is accidentally hiding/showing markets if tagging/series metadata is inconsistent.
> 
> **Overview**
> The featured carousel data hook now reads the `predictUpDown` feature flag (`selectPredictUpDownEnabledFlag`) and **filters out crypto Up/Down markets** (via `isCryptoUpDown`) when the flag is disabled.
> 
> Updates tests to mock `useSelector` and adds coverage to ensure Up/Down markets are excluded when the flag is off and included when on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b18056a56c8bc20bfadc865fe89b194f5ec44cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->