### PR TITLE
chore(rewards): reenable referrals view

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -385,6 +385,46 @@ describe('RewardsDashboard', () => {
       // Assert
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_SETTINGS_VIEW);
     });
+
+    it('navigates to referral view when referral button is pressed', () => {
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      fireEvent.press(getByTestId(REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON));
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REFERRAL_REWARDS_VIEW);
+    });
+  });
+
+  describe('referral button state', () => {
+    it('always renders the referral button as enabled regardless of subscription state', () => {
+      // Arrange - no subscriptionId
+      mockSelectRewardsSubscriptionId.mockReturnValue(null);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId) return null;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedAccountGroup)
+          return defaultSelectorValues.selectedAccountGroup;
+        return undefined;
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const referralButton = getByTestId(
+        REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
+      );
+
+      // Assert - referral button is never disabled
+      const isDisabled =
+        referralButton.props.disabled === true ||
+        referralButton.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(false);
+    });
   });
 
   describe('settings button state', () => {

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -195,7 +195,7 @@ const RewardsDashboard: React.FC = () => {
             {
               iconName: IconName.UserCircleAdd,
               onPress: () => navigation.navigate(Routes.REFERRAL_REWARDS_VIEW),
-              disabled: !subscriptionId,
+              testID: REWARDS_VIEW_SELECTORS.REFERRAL_BUTTON,
             },
           ]}
         />

--- a/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsReferralView.test.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import RewardsReferralView from './RewardsReferralView';
 
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: mockGoBack }),
 }));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('react-native-share', () => ({
+  open: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
@@ -17,13 +28,14 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock';
+import {
+  createMockUseAnalyticsHook,
+  createMockEventBuilder,
+} from '../../../../util/test/analyticsMock';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const mockTrackEvent = jest.fn();
-const mockCreateEventBuilder = jest.fn().mockReturnValue({
-  build: jest.fn().mockReturnValue({ event: 'REWARDS_REFERRALS_VIEWED' }),
-});
+const mockCreateEventBuilder = jest.fn(() => createMockEventBuilder());
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
 
@@ -31,6 +43,9 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const translations: Record<string, string> = {
       'rewards.referral_title': 'Referrals',
+      'rewards.referral.actions.share_referral_link': 'Refer a friend',
+      'rewards.referral.actions.share_referral_subject':
+        'Join MetaMask Rewards',
     };
     return translations[key] || key;
   },
@@ -91,6 +106,8 @@ jest.mock('../components/ReferralDetails/ReferralDetails', () => {
   };
 });
 
+import Share from 'react-native-share';
+
 describe('RewardsReferralView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -100,6 +117,13 @@ describe('RewardsReferralView', () => {
         createEventBuilder: mockCreateEventBuilder,
       }),
     );
+    mockUseSelector.mockImplementation((selector) => {
+      // selectReferralCode
+      if (selector.name === 'selectReferralCode') return 'TESTCODE';
+      // selectReferralDetailsLoading
+      if (selector.name === 'selectReferralDetailsLoading') return false;
+      return undefined;
+    });
   });
 
   describe('rendering', () => {
@@ -159,6 +183,66 @@ describe('RewardsReferralView', () => {
 
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('sticky share button', () => {
+    it('renders the share button', () => {
+      const { getByTestId } = render(<RewardsReferralView />);
+
+      expect(getByTestId('referral-share-button')).toBeOnTheScreen();
+    });
+
+    it('renders the share button with correct label', () => {
+      const { getByText } = render(<RewardsReferralView />);
+
+      expect(getByText('Refer a friend')).toBeOnTheScreen();
+    });
+
+    it('disables the share button when referral code is loading', () => {
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector.name === 'selectReferralCode') return null;
+        if (selector.name === 'selectReferralDetailsLoading') return true;
+        return undefined;
+      });
+
+      const { getByTestId } = render(<RewardsReferralView />);
+      const button = getByTestId('referral-share-button');
+
+      const isDisabled =
+        button.props.disabled === true ||
+        button.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(true);
+    });
+
+    it('disables the share button when referral code is absent', () => {
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector.name === 'selectReferralCode') return null;
+        if (selector.name === 'selectReferralDetailsLoading') return false;
+        return undefined;
+      });
+
+      const { getByTestId } = render(<RewardsReferralView />);
+      const button = getByTestId('referral-share-button');
+
+      const isDisabled =
+        button.props.disabled === true ||
+        button.props.accessibilityState?.disabled === true;
+      expect(isDisabled).toBe(true);
+    });
+
+    it('calls Share.open when the share button is pressed', async () => {
+      const { getByTestId } = render(<RewardsReferralView />);
+
+      fireEvent.press(getByTestId('referral-share-button'));
+
+      await waitFor(() => {
+        expect(Share.open).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://link.metamask.io/rewards?referral=TESTCODE',
+          }),
+        );
       });
     });
   });

--- a/app/components/UI/Rewards/Views/RewardsReferralView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsReferralView.tsx
@@ -3,18 +3,34 @@ import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScrollView } from 'react-native';
+import { useSelector } from 'react-redux';
+import Share from 'react-native-share';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import ReferralDetails from '../components/ReferralDetails/ReferralDetails';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import {
+  selectReferralCode,
+  selectReferralDetailsLoading,
+} from '../../../../reducers/rewards/selectors';
+import { buildReferralUrl, RewardsMetricsButtons } from '../utils';
 
 const ReferralRewardsView: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const hasTrackedReferralsViewed = useRef(false);
   const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const referralCode = useSelector(selectReferralCode);
+  const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
 
   useEffect(() => {
     if (!hasTrackedReferralsViewed.current) {
@@ -24,6 +40,22 @@ const ReferralRewardsView: React.FC = () => {
       hasTrackedReferralsViewed.current = true;
     }
   }, [trackEvent, createEventBuilder]);
+
+  const handleShareLink = async () => {
+    if (!referralCode) return;
+    const link = buildReferralUrl(referralCode);
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
+        .addProperties({
+          button_type: RewardsMetricsButtons.SHARE_REFERRAL_LINK,
+        })
+        .build(),
+    );
+    await Share.open({
+      message: strings('rewards.referral.actions.share_referral_subject'),
+      url: link,
+    });
+  };
 
   return (
     <ErrorBoundary navigation={navigation} view="ReferralRewardsView">
@@ -43,6 +75,19 @@ const ReferralRewardsView: React.FC = () => {
         >
           <ReferralDetails />
         </ScrollView>
+
+        <Box twClassName="px-4 pt-2">
+          <Button
+            variant={ButtonVariant.Primary}
+            isFullWidth
+            size={ButtonSize.Lg}
+            onPress={handleShareLink}
+            disabled={!referralCode || referralDetailsLoading}
+            testID="referral-share-button"
+          >
+            {strings('rewards.referral.actions.share_referral_link')}
+          </Button>
+        </Box>
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/CopyableField.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Box,
+  BoxAlignItems,
   BoxFlexDirection,
   Text,
   TextColor,
@@ -43,6 +44,7 @@ const CopyableField: React.FC<CopyableFieldProps> = ({
     <Box
       twClassName="bg-muted border-muted rounded-md px-4 py-3"
       flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
     >
       <Box twClassName="flex-1">
         <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
@@ -51,7 +53,7 @@ const CopyableField: React.FC<CopyableFieldProps> = ({
         {valueLoading ? (
           <Skeleton height={24} width={75} />
         ) : (
-          <Text variant={TextVariant.BodySm}>{value || '-'}</Text>
+          <Text variant={TextVariant.BodyMd}>{value || '-'}</Text>
         )}
       </Box>
       <ButtonIcon

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
@@ -4,12 +4,7 @@ import ReferralActionsSection from './ReferralActionsSection';
 
 // Mock the strings function
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: jest.fn((key: string) => {
-    const translations: Record<string, string> = {
-      'rewards.referral.actions.share_referral_link': 'Share Referral Link',
-    };
-    return translations[key] || key;
-  }),
+  strings: jest.fn((key: string) => key),
 }));
 
 // Mock CopyableField component
@@ -55,7 +50,6 @@ describe('ReferralActionsSection', () => {
     referralCodeError: false,
     onCopyCode: jest.fn(),
     onCopyLink: jest.fn(),
-    onShareLink: jest.fn(),
   };
 
   beforeEach(() => {
@@ -64,7 +58,7 @@ describe('ReferralActionsSection', () => {
 
   describe('rendering', () => {
     it('should render correctly with all props', () => {
-      const { getByTestId, getByText } = render(
+      const { getByTestId } = render(
         <ReferralActionsSection {...defaultProps} />,
       );
 
@@ -74,7 +68,6 @@ describe('ReferralActionsSection', () => {
       expect(
         getByTestId('copyable-field-rewards.referral.referral_link'),
       ).toBeTruthy();
-      expect(getByText('Share Referral Link')).toBeTruthy();
     });
 
     it('should render with null referral code', () => {
@@ -156,25 +149,6 @@ describe('ReferralActionsSection', () => {
       expect(
         getByText('link.metamask.io/rewards?referral=CUSTOM456'),
       ).toBeTruthy();
-    });
-  });
-
-  describe('share functionality', () => {
-    it('should call onShareLink with correct URL when share button is pressed', () => {
-      const mockOnShareLink = jest.fn();
-      const { getByText } = render(
-        <ReferralActionsSection
-          {...defaultProps}
-          onShareLink={mockOnShareLink}
-        />,
-      );
-
-      const shareButton = getByText('Share Referral Link');
-      fireEvent.press(shareButton);
-
-      expect(mockOnShareLink).toHaveBeenCalledWith(
-        'https://link.metamask.io/rewards?referral=TEST123',
-      );
     });
   });
 
@@ -329,7 +303,6 @@ describe('ReferralActionsSection', () => {
           referralCodeError
           onCopyCode={jest.fn()}
           onCopyLink={jest.fn()}
-          onShareLink={jest.fn()}
         />,
       );
 
@@ -351,7 +324,6 @@ describe('ReferralActionsSection', () => {
           referralCodeError
           onCopyCode={jest.fn()}
           onCopyLink={jest.fn()}
-          onShareLink={jest.fn()}
         />,
       );
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import CopyableField from './CopyableField';
 import { strings } from '../../../../../../locales/i18n';
 import { REFERRAL_LINK_PATH, buildReferralUrl } from '../../utils';
@@ -15,7 +10,6 @@ interface ReferralActionsSectionProps {
   referralCodeError: boolean;
   onCopyCode?: () => void;
   onCopyLink?: (link: string) => void;
-  onShareLink?: (link: string) => void;
 }
 
 const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
@@ -24,7 +18,6 @@ const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
   referralCodeError,
   onCopyCode,
   onCopyLink,
-  onShareLink,
 }) => {
   // Show error banner when there's an error and not loading
   if (referralCodeError && !referralCodeLoading && !referralCode) {
@@ -50,18 +43,6 @@ const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
         }
         valueLoading={referralCodeLoading}
       />
-
-      <Button
-        variant={ButtonVariant.Primary}
-        isFullWidth
-        size={ButtonSize.Lg}
-        onPress={() =>
-          referralCode ? onShareLink?.(buildReferralUrl(referralCode)) : null
-        }
-        disabled={!onShareLink || !referralCode || referralCodeLoading}
-      >
-        {strings('rewards.referral.actions.share_referral_link')}
-      </Button>
     </Box>
   );
 };

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
@@ -213,9 +213,6 @@ describe('ReferralDetails', () => {
 
       // Assert
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -250,16 +247,6 @@ describe('ReferralDetails', () => {
   });
 
   describe('props passing to child components', () => {
-    it('renders ReferralStatsSection', () => {
-      // Arrange & Act
-      renderComponent();
-
-      // Assert
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
-    });
-
     it('passes loading state to ReferralActionsSection when referral details are loading', () => {
       // Arrange
       const referralCode = 'TEST456';
@@ -446,9 +433,7 @@ describe('ReferralDetails', () => {
       renderComponent();
 
       // Assert - Component should render despite loading state
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
+      expect(screen.getByTestId('referral-actions-section')).toBeTruthy();
     });
 
     it('should handle referral details loading state', () => {
@@ -487,9 +472,6 @@ describe('ReferralDetails', () => {
 
       // Assert
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
   });
@@ -533,9 +515,6 @@ describe('ReferralDetails', () => {
 
       // Assert - All child components should be present in column layout
       expect(getByTestId('referral-info-section')).toBeTruthy();
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
   });
@@ -564,9 +543,6 @@ describe('ReferralDetails', () => {
       expect(getByTestId('error-description')).toBeTruthy();
       // Other components should not be rendered
       expect(queryByTestId('referral-info-section')).toBeNull();
-      expect(
-        screen.queryByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeNull();
       expect(queryByTestId('referral-actions-section')).toBeNull();
     });
 
@@ -615,10 +591,7 @@ describe('ReferralDetails', () => {
       expect(getByTestId('error-title')).toBeTruthy();
       expect(getByTestId('error-description')).toBeTruthy();
       expect(getByTestId('error-retry-button')).toBeTruthy();
-      // Stats and actions sections should not be rendered
-      expect(
-        screen.queryByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeNull();
+      // Actions section should not be rendered
       expect(queryByTestId('referral-actions-section')).toBeNull();
       // Info section should still be rendered
       expect(queryByTestId('referral-info-section')).toBeTruthy();
@@ -644,9 +617,6 @@ describe('ReferralDetails', () => {
       // Assert
       expect(queryByText("Referral details couldn't be loaded")).toBeNull();
       // Normal components should render
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -670,9 +640,6 @@ describe('ReferralDetails', () => {
       // Assert
       expect(queryByText("Referral details couldn't be loaded")).toBeNull();
       // Normal components should render
-      expect(
-        screen.getByText('rewards.referral_stats_earned_from_referrals'),
-      ).toBeTruthy();
       expect(getByTestId('referral-actions-section')).toBeTruthy();
     });
 
@@ -713,13 +680,9 @@ describe('ReferralDetails', () => {
 
       // Assert - All components should be findable, indicating proper accessibility
       const infoSection = getByTestId('referral-info-section');
-      const statsSection = screen.getByText(
-        'rewards.referral_stats_earned_from_referrals',
-      );
       const actionsSection = getByTestId('referral-actions-section');
 
       expect(infoSection).toBeTruthy();
-      expect(statsSection).toBeTruthy();
       expect(actionsSection).toBeTruthy();
     });
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import ReferralInfoSection from './ReferralInfoSection';
-import ReferralStatsSection from './ReferralStatsSection';
 import ReferralActionsSection from './ReferralActionsSection';
-import Share from 'react-native-share';
 import { strings } from '../../../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import {
-  selectBalanceRefereePortion,
   selectReferralCode,
-  selectReferralCount,
   selectReferralDetailsError,
   selectReferralDetailsLoading,
   selectSeasonStatusError,
@@ -30,8 +26,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   showInfoSection = true,
 }) => {
   const referralCode = useSelector(selectReferralCode);
-  const refereeCount = useSelector(selectReferralCount);
-  const balanceRefereePortion = useSelector(selectBalanceRefereePortion);
   const seasonStatusError = useSelector(selectSeasonStatusError);
   const seasonStartDate = useSelector(selectSeasonStartDate);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
@@ -67,20 +61,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
     }
   };
 
-  const handleShareLink = async (link: string) => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
-        .addProperties({
-          button_type: RewardsMetricsButtons.SHARE_REFERRAL_LINK,
-        })
-        .build(),
-    );
-    await Share.open({
-      message: `${strings('rewards.referral.actions.share_referral_subject')}`,
-      url: link,
-    });
-  };
-
   if (seasonStatusError && !seasonStartDate) {
     return (
       <RewardsErrorBanner
@@ -93,7 +73,7 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   }
 
   return (
-    <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-4">
+    <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-6">
       {showInfoSection && <ReferralInfoSection />}
 
       {!referralDetailsLoading && referralDetailsError && !referralCode ? (
@@ -108,24 +88,13 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
           )}
         />
       ) : (
-        <>
-          <ReferralStatsSection
-            earnedPointsFromReferees={balanceRefereePortion}
-            refereeCount={refereeCount}
-            earnedPointsFromRefereesLoading={referralDetailsLoading}
-            refereeCountLoading={referralDetailsLoading}
-            refereeCountError={referralDetailsError}
-          />
-
-          <ReferralActionsSection
-            referralCode={referralCode}
-            referralCodeLoading={referralDetailsLoading}
-            referralCodeError={referralDetailsError}
-            onCopyCode={handleCopyCode}
-            onCopyLink={handleCopyLink}
-            onShareLink={handleShareLink}
-          />
-        </>
+        <ReferralActionsSection
+          referralCode={referralCode}
+          referralCodeLoading={referralDetailsLoading}
+          referralCodeError={referralDetailsError}
+          onCopyCode={handleCopyCode}
+          onCopyLink={handleCopyLink}
+        />
       )}
     </Box>
   );

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
@@ -6,9 +6,9 @@ import ReferralInfoSection from './ReferralInfoSection';
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
-      'rewards.referral.info.title': 'Invite Friends & Earn',
+      'rewards.referral.info.title': 'Share your code with friends',
       'rewards.referral.info.description':
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
     };
     return translations[key] || key;
   }),
@@ -19,10 +19,10 @@ describe('ReferralInfoSection', () => {
     it('should render correctly', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      expect(getByText('Invite Friends & Earn')).toBeTruthy();
+      expect(getByText('Share your code with friends')).toBeTruthy();
       expect(
         getByText(
-          'Share your referral code with friends and earn rewards when they join MetaMask.',
+          'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
         ),
       ).toBeTruthy();
     });
@@ -30,7 +30,7 @@ describe('ReferralInfoSection', () => {
     it('should display the correct title', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      const titleElement = getByText('Invite Friends & Earn');
+      const titleElement = getByText('Share your code with friends');
       expect(titleElement).toBeTruthy();
     });
 
@@ -38,7 +38,7 @@ describe('ReferralInfoSection', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
       const descriptionElement = getByText(
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
       );
       expect(descriptionElement).toBeTruthy();
     });
@@ -48,9 +48,9 @@ describe('ReferralInfoSection', () => {
     it('should render text elements that are accessible', () => {
       const { getByText } = render(<ReferralInfoSection />);
 
-      const titleElement = getByText('Invite Friends & Earn');
+      const titleElement = getByText('Share your code with friends');
       const descriptionElement = getByText(
-        'Share your referral code with friends and earn rewards when they join MetaMask.',
+        'Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm.',
       );
 
       expect(titleElement).toBeTruthy();

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7986,8 +7986,8 @@
         "share_referral_subject": "Join MetaMask Rewards"
       },
       "info": {
-        "title": "Share your code to earn more",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "title": "Share your code with friends",
+        "description": "Some campaigns may have extra benefits for referrals. Check the description for each campaign to confirm."
       },
       "referral_code_copied": "Referral code copied to clipboard"
     },


### PR DESCRIPTION
## Description

Re-enables the referrals page in the Rewards feature with copy and UX updates:

- Update referral info copy: new title "Share your code with friends" and updated description
- Remove the stats section (earned points / referral count) from the referral page
- Move the "Refer a friend" CTA button outside the `ScrollView` as a sticky bottom button, matching the campaign details page pattern
- Fix vertical alignment of copy icons in `CopyableField` (`alignItems: center`)
- Update value text in `CopyableField` from `BodySm` to `BodyMd`
- Increase spacing between the info section and fields from `gap-4` to `gap-6`

## Changelog

CHANGELOG entry: null

## Screenshots/Recordings

<img width="955" height="1986" alt="image" src="https://github.com/user-attachments/assets/1df4c9f9-f34c-4ca9-b7e1-4d6a530c7aa9" />
