### PR TITLE
feat(rewards): add deeplinks for campaigns, musd, and benefits pages

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -339,16 +339,18 @@ describe('RewardsNavigator', () => {
     mockIsFocused.mockReturnValue(true);
   });
 
+  const buildNavWrapper = (component: React.ReactElement) => (
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Test">{() => component}</Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
+  );
+
   const renderWithNavigation = (component: React.ReactElement) =>
-    render(
-      <Provider store={store}>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen name="Test">{() => component}</Stack.Screen>
-          </Stack.Navigator>
-        </NavigationContainer>
-      </Provider>,
-    );
+    render(buildNavWrapper(component));
 
   describe('Initial route determination', () => {
     beforeEach(() => {
@@ -711,6 +713,33 @@ describe('RewardsNavigator', () => {
         expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
       });
       expect(mockSetParams).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate to dashboard after setParams clears deeplink params', async () => {
+      // Regression: the useEffect re-fires when setParams clears the params to
+      // undefined. Without the skipNextEffectRef guard it would fall through to
+      // navigate(REWARDS_DASHBOARD), overriding the deeplink destination.
+      mockRouteParams = { page: 'campaigns' };
+
+      const { rerender } = renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_CAMPAIGNS_VIEW,
+        );
+      });
+
+      // Simulate what setParams does in the real app: clear params and
+      // re-render the component with the updated route.
+      mockRouteParams = {};
+      mockNavigate.mockClear();
+
+      await act(async () => {
+        rerender(buildNavWrapper(<RewardsNavigator />));
+      });
+
+      // The guard must prevent a navigate(REWARDS_DASHBOARD) call here.
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
     });
   });
 

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -187,7 +187,9 @@ jest.mock('../../../reducers/rewards/selectors', () => ({
 // Mock react-navigation/native hooks
 const mockNavigate = jest.fn();
 const mockSetOptions = jest.fn();
+const mockSetParams = jest.fn();
 const mockIsFocused = jest.fn();
+let mockRouteParams: { page?: string; campaign?: string } = {};
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -196,7 +198,9 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
       setOptions: mockSetOptions,
+      setParams: mockSetParams,
     }),
+    useRoute: () => ({ params: mockRouteParams }),
     useIsFocused: () => mockIsFocused(),
   };
 });
@@ -226,6 +230,21 @@ jest.mock('./hooks/useRewardsVersionGuard', () => ({
   __esModule: true,
   default: jest.fn().mockReturnValue({ fetchVersionRequirements: jest.fn() }),
 }));
+
+jest.mock('./Views/BenefitsView', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: function MockBenefitsView() {
+      return ReactActual.createElement(
+        View,
+        { testID: 'benefits-view' },
+        ReactActual.createElement(Text, null, 'Benefits View'),
+      );
+    },
+  };
+});
 
 // Mock RewardsUpdateRequired component
 jest.mock('./components/RewardsUpdateRequired/RewardsUpdateRequired', () => {
@@ -272,6 +291,7 @@ describe('RewardsNavigator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = {};
 
     // Set default mock return values
     mockSelectRewardsSubscriptionId.mockReturnValue(null);
@@ -578,6 +598,119 @@ describe('RewardsNavigator', () => {
       expect(mockUseSeasonStatus).toHaveBeenCalledWith({
         onlyForExplicitFetch: false,
       });
+    });
+  });
+
+  describe('Deeplink navigation params', () => {
+    beforeEach(() => {
+      mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
+      mockNavigate.mockClear();
+      mockSetParams.mockClear();
+    });
+
+    it('navigates to campaigns view when page=campaigns param is set', async () => {
+      mockRouteParams = { page: 'campaigns' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_CAMPAIGNS_VIEW,
+        );
+      });
+    });
+
+    it('navigates to ondo campaign when campaign=ondo param is set', async () => {
+      mockRouteParams = { campaign: 'ondo' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
+        );
+      });
+    });
+
+    it('navigates to season1 campaign when campaign=season1 param is set', async () => {
+      mockRouteParams = { campaign: 'season1' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_SEASON_ONE_CAMPAIGN_DETAILS_VIEW,
+        );
+      });
+    });
+
+    it('navigates to musd calculator when page=musd param is set', async () => {
+      mockRouteParams = { page: 'musd' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.REWARDS_MUSD_CALCULATOR_VIEW,
+        );
+      });
+    });
+
+    it('navigates to benefits view when page=benefits param is set', async () => {
+      mockRouteParams = { page: 'benefits' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_BENEFITS_VIEW);
+      });
+    });
+
+    it('navigates to dashboard when no deeplink params are set', async () => {
+      mockRouteParams = {};
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+      });
+    });
+
+    it('clears deeplink params via setParams after handling page param', async () => {
+      mockRouteParams = { page: 'campaigns' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockSetParams).toHaveBeenCalledWith({
+          page: undefined,
+          campaign: undefined,
+        });
+      });
+    });
+
+    it('clears deeplink params via setParams after handling campaign param', async () => {
+      mockRouteParams = { campaign: 'ondo' };
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockSetParams).toHaveBeenCalledWith({
+          page: undefined,
+          campaign: undefined,
+        });
+      });
+    });
+
+    it('does not call setParams when no deeplink params are present', async () => {
+      mockRouteParams = {};
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+      });
+      expect(mockSetParams).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -32,9 +32,9 @@ const RewardsNavigator: React.FC = () => {
   const isVersionBlocked = useSelector(selectIsRewardsVersionBlocked);
   const navigation = useNavigation();
   const route = useRoute();
-  const deepLinkParams = route.params as
-    | { page?: string; campaign?: string }
-    | undefined;
+  const deepLinkPage = (route.params as { page?: string } | undefined)?.page;
+  const deepLinkCampaign = (route.params as { campaign?: string } | undefined)
+    ?.campaign;
   const { colors } = useTheme();
 
   useRewardsVersionGuard();
@@ -64,23 +64,34 @@ const RewardsNavigator: React.FC = () => {
       return;
     }
     if (subscriptionId) {
-      if (deepLinkParams?.page === 'campaigns') {
+      if (deepLinkPage === 'campaigns') {
         navigation.navigate(Routes.REWARDS_CAMPAIGNS_VIEW);
-      } else if (deepLinkParams?.campaign === 'ondo') {
+      } else if (deepLinkCampaign === 'ondo') {
         navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW);
-      } else if (deepLinkParams?.campaign === 'season1') {
+      } else if (deepLinkCampaign === 'season1') {
         navigation.navigate(Routes.REWARDS_SEASON_ONE_CAMPAIGN_DETAILS_VIEW);
-      } else if (deepLinkParams?.page === 'musd') {
+      } else if (deepLinkPage === 'musd') {
         navigation.navigate(Routes.REWARDS_MUSD_CALCULATOR_VIEW);
-      } else if (deepLinkParams?.page === 'benefits') {
+      } else if (deepLinkPage === 'benefits') {
         navigation.navigate(Routes.REWARDS_BENEFITS_VIEW);
       } else {
         navigation.navigate(Routes.REWARDS_DASHBOARD);
       }
+      // Clear deeplink params after first use so re-fires (e.g. on account
+      // switch) don't re-navigate the user away from where they are.
+      if (deepLinkPage || deepLinkCampaign) {
+        navigation.setParams({ page: undefined, campaign: undefined });
+      }
     } else {
       navigation.navigate(Routes.REWARDS_ONBOARDING_FLOW);
     }
-  }, [navigation, subscriptionId, isVersionBlocked, deepLinkParams]);
+  }, [
+    navigation,
+    subscriptionId,
+    isVersionBlocked,
+    deepLinkPage,
+    deepLinkCampaign,
+  ]);
 
   if (isVersionBlocked) {
     return <RewardsUpdateRequired />;

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import Routes from '../../../constants/navigation/Routes';
 import OnboardingNavigator from './OnboardingNavigator';
@@ -36,6 +36,11 @@ const RewardsNavigator: React.FC = () => {
   const deepLinkCampaign = (route.params as { campaign?: string } | undefined)
     ?.campaign;
   const { colors } = useTheme();
+  // Tracks that the effect fired because setParams just cleared the deeplink
+  // params. The next fire (params → undefined) must be skipped to prevent the
+  // else-branch from navigating to REWARDS_DASHBOARD and overriding the
+  // intended deeplink destination.
+  const skipNextEffectRef = useRef(false);
 
   useRewardsVersionGuard();
 
@@ -64,6 +69,13 @@ const RewardsNavigator: React.FC = () => {
       return;
     }
     if (subscriptionId) {
+      // Skip this fire: it was triggered by setParams clearing the deeplink
+      // params. Without the guard the else-branch below would immediately
+      // navigate to REWARDS_DASHBOARD, overriding the deeplink destination.
+      if (skipNextEffectRef.current) {
+        skipNextEffectRef.current = false;
+        return;
+      }
       if (deepLinkPage === 'campaigns') {
         navigation.navigate(Routes.REWARDS_CAMPAIGNS_VIEW);
       } else if (deepLinkCampaign === 'ondo') {
@@ -77,9 +89,11 @@ const RewardsNavigator: React.FC = () => {
       } else {
         navigation.navigate(Routes.REWARDS_DASHBOARD);
       }
-      // Clear deeplink params after first use so re-fires (e.g. on account
-      // switch) don't re-navigate the user away from where they are.
+      // Consume deeplink params after first use. setParams will re-fire this
+      // effect with both values as undefined; skipNextEffectRef prevents that
+      // from landing on REWARDS_DASHBOARD.
       if (deepLinkPage || deepLinkCampaign) {
+        skipNextEffectRef.current = true;
         navigation.setParams({ page: undefined, campaign: undefined });
       }
     } else {

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -14,11 +14,12 @@ import OndoLeaderboardView from './Views/OndoLeaderboardView';
 import OndoCampaignRwaSelectorView from './Views/OndoCampaignRwaSelectorView';
 import OndoCampaignPortfolioView from './Views/OndoCampaignPortfolioView';
 import OndoCampaignStatsView from './Views/OndoCampaignStatsView';
+import BenefitsView from './Views/BenefitsView';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { selectIsRewardsVersionBlocked } from '../../../reducers/rewards/selectors';
 import { useCandidateSubscriptionId } from './hooks/useCandidateSubscriptionId';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { useSeasonStatus } from './hooks/useSeasonStatus';
 import { useTheme } from '../../../util/theme';
 import { useGeoRewardsMetadata } from './hooks/useGeoRewardsMetadata';
@@ -30,6 +31,10 @@ const RewardsNavigator: React.FC = () => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const isVersionBlocked = useSelector(selectIsRewardsVersionBlocked);
   const navigation = useNavigation();
+  const route = useRoute();
+  const deepLinkParams = route.params as
+    | { page?: string; campaign?: string }
+    | undefined;
   const { colors } = useTheme();
 
   useRewardsVersionGuard();
@@ -59,11 +64,23 @@ const RewardsNavigator: React.FC = () => {
       return;
     }
     if (subscriptionId) {
-      navigation.navigate(Routes.REWARDS_DASHBOARD);
+      if (deepLinkParams?.page === 'campaigns') {
+        navigation.navigate(Routes.REWARDS_CAMPAIGNS_VIEW);
+      } else if (deepLinkParams?.campaign === 'ondo') {
+        navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW);
+      } else if (deepLinkParams?.campaign === 'season1') {
+        navigation.navigate(Routes.REWARDS_SEASON_ONE_CAMPAIGN_DETAILS_VIEW);
+      } else if (deepLinkParams?.page === 'musd') {
+        navigation.navigate(Routes.REWARDS_MUSD_CALCULATOR_VIEW);
+      } else if (deepLinkParams?.page === 'benefits') {
+        navigation.navigate(Routes.REWARDS_BENEFITS_VIEW);
+      } else {
+        navigation.navigate(Routes.REWARDS_DASHBOARD);
+      }
     } else {
       navigation.navigate(Routes.REWARDS_ONBOARDING_FLOW);
     }
-  }, [navigation, subscriptionId, isVersionBlocked]);
+  }, [navigation, subscriptionId, isVersionBlocked, deepLinkParams]);
 
   if (isVersionBlocked) {
     return <RewardsUpdateRequired />;
@@ -139,6 +156,11 @@ const RewardsNavigator: React.FC = () => {
           <Stack.Screen
             name={Routes.REWARDS_ONDO_CAMPAIGN_STATS}
             component={OndoCampaignStatsView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.REWARDS_BENEFITS_VIEW}
+            component={BenefitsView}
             options={{ headerShown: false }}
           />
         </>

--- a/app/components/UI/Rewards/Views/BenefitsView/BenefitsView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitsView/BenefitsView.test.tsx
@@ -10,6 +10,6 @@ describe('BenefitsView', () => {
 
   it('renders the Benefits text', () => {
     const { getByText } = render(<BenefitsView />);
-    expect(getByText('Benefits')).toBeTruthy();
+    expect(getByText('Benefits')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Rewards/Views/BenefitsView/BenefitsView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitsView/BenefitsView.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import BenefitsView from './index';
+
+describe('BenefitsView', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = render(<BenefitsView />);
+    expect(toJSON()).not.toBeNull();
+  });
+
+  it('renders the Benefits text', () => {
+    const { getByText } = render(<BenefitsView />);
+    expect(getByText('Benefits')).toBeTruthy();
+  });
+});

--- a/app/components/UI/Rewards/Views/BenefitsView/index.tsx
+++ b/app/components/UI/Rewards/Views/BenefitsView/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+const BenefitsView: React.FC = () => (
+  <View>
+    <Text>Benefits</Text>
+  </View>
+);
+
+export default BenefitsView;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -109,6 +109,7 @@ const Routes = {
   REWARDS_ONDO_CAMPAIGN_PORTFOLIO_VIEW: 'RewardsOndoCampaignPortfolioView',
   REWARDS_ONDO_CAMPAIGN_STATS: 'RewardsOndoCampaignStats',
   REWARDS_CAMPAIGN_TOUR_STEP: 'RewardsCampaignTourStep',
+  REWARDS_BENEFITS_VIEW: 'RewardsBenefitsView',
   TRENDING_VIEW: 'TrendingView',
   TRENDING_FEED: 'TrendingFeed',
   WHATS_HAPPENING_DETAIL: 'WhatsHappeningDetailView',

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
@@ -119,6 +119,77 @@ describe('handleRewardsUrl', () => {
     });
   });
 
+  describe('with page/campaign navigation params', () => {
+    it('navigates to rewards view with page=campaigns param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?page=campaigns' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: 'campaigns',
+        campaign: undefined,
+      });
+    });
+
+    it('navigates to rewards view with campaign=ondo param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=ondo' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: undefined,
+        campaign: 'ondo',
+      });
+    });
+
+    it('navigates to rewards view with campaign=season1 param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=season1' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: undefined,
+        campaign: 'season1',
+      });
+    });
+
+    it('navigates to rewards view with page=musd param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?page=musd' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: 'musd',
+        campaign: undefined,
+      });
+    });
+
+    it('navigates to rewards view with page=benefits param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?page=benefits' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: 'benefits',
+        campaign: undefined,
+      });
+    });
+
+    it('ignores unknown page value and navigates without params', async () => {
+      await handleRewardsUrl({ rewardsPath: '?page=unknown' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
+    it('ignores unknown campaign value and navigates without params', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=unknown' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
+    it('dispatches referral code and passes page param when both are present', async () => {
+      await handleRewardsUrl({
+        rewardsPath: '?referral=abc123&page=campaigns',
+      });
+
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith('abc123');
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
+        page: 'campaigns',
+        campaign: undefined,
+      });
+    });
+  });
+
   describe('error handling', () => {
     it('falls back to wallet view when navigation fails', async () => {
       mockNavigate.mockImplementationOnce(() => {

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -14,6 +14,8 @@ interface HandleRewardsUrlParams {
  */
 interface RewardsNavigationParams {
   referral?: string;
+  page?: 'campaigns' | 'musd' | 'benefits';
+  campaign?: 'ondo' | 'season1';
 }
 
 /**
@@ -28,10 +30,19 @@ const parseRewardsNavigationParams = (
     rewardsPath.includes('?') ? rewardsPath.split('?')[1] : '',
   );
 
+  const pageParam = urlParams.get('page');
+  const campaignParam = urlParams.get('campaign');
+
   return {
     referral:
       (urlParams.get('referral') as RewardsNavigationParams['referral']) ||
       undefined,
+    page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
+      ? pageParam
+      : undefined) as RewardsNavigationParams['page'],
+    campaign: (['ondo', 'season1'].includes(campaignParam ?? '')
+      ? campaignParam
+      : undefined) as RewardsNavigationParams['campaign'],
   };
 };
 
@@ -43,6 +54,11 @@ const parseRewardsNavigationParams = (
  * Supported URL formats:
  * - https://link.metamask.io/rewards
  * - https://link.metamask.io/rewards?referral=code
+ * - https://link.metamask.io/rewards?page=campaigns
+ * - https://link.metamask.io/rewards?page=musd
+ * - https://link.metamask.io/rewards?page=benefits
+ * - https://link.metamask.io/rewards?campaign=ondo
+ * - https://link.metamask.io/rewards?campaign=season1
  */
 export const handleRewardsUrl = async ({
   rewardsPath,
@@ -66,7 +82,14 @@ export const handleRewardsUrl = async ({
       // Clear any existing referral code
       ReduxService.store.dispatch(setOnboardingReferralCode(null));
     }
-    NavigationService.navigation.navigate(Routes.REWARDS_VIEW);
+    if (urlParams.page || urlParams.campaign) {
+      NavigationService.navigation.navigate(Routes.REWARDS_VIEW, {
+        page: urlParams.page,
+        campaign: urlParams.campaign,
+      });
+    } else {
+      NavigationService.navigation.navigate(Routes.REWARDS_VIEW);
+    }
   } catch (error) {
     DevLogger.log('Failed to handle rewards deeplink:', error);
     // Fallback to wallet home on error


### PR DESCRIPTION
## Description

Extends the `/rewards` deeplink handler to support `?page=` and `?campaign=` query params, enabling deep navigation to specific pages within the Rewards flow.

Jira: https://consensyssoftware.atlassian.net/browse/RWDS-1152

### New deeplinks

| URL | Destination |
|-----|-------------|
| `/rewards?page=campaigns` | Campaigns page |
| `/rewards?campaign=ondo` | Ondo campaign details |
| `/rewards?campaign=season1` | Season 1 campaign details |
| `/rewards?page=musd` | mUSD bonus calculator |
| `/rewards?page=benefits` | Benefits page (placeholder — page not yet in main) |

### Behaviour

- **Subscribed users**: deeplink routes directly to the requested page
- **Non-subscribed users**: deeplink still routes through onboarding first (unchanged behaviour)
- **No page/campaign param**: existing behaviour preserved (navigates to REWARDS_VIEW, then dashboard or onboarding)
- **Unknown param value**: falls through to default navigation (no crash)

## Changelog

CHANGELOG entry: add campaign related deeplinks + musd/benefits

## Checklist

- [x] Tests written for all new deeplink params
- [x] ESLint passes (no warnings)
- [x] Prettier passes (no formatting changes)
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Rewards navigation behavior based on route params and mutates navigation params via `setParams`, which could affect initial routing and back/forward behavior if edge cases slip through.
> 
> **Overview**
> Adds support for `/rewards` deeplinks that include `?page=` or `?campaign=` query params, passing those params into `Routes.REWARDS_VIEW` and routing subscribed users directly to the requested Rewards sub-screen.
> 
> Updates `RewardsNavigator` to read `route.params` (`page`/`campaign`), navigate to the appropriate destination (campaigns, mUSD calculator, benefits, or specific campaign details), and then clear the params with a guard (`skipNextEffectRef`) to avoid a follow-up redirect to `REWARDS_DASHBOARD`.
> 
> Registers a new `REWARDS_BENEFITS_VIEW` route and adds a placeholder `BenefitsView`, with expanded unit tests covering param parsing, navigation behavior, and regression around `setParams` re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403df65d05e9db75d4d7919443a1416dfaf592bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->