### PR TITLE
chore(rewards): preset Ondo USD as source for new positions if owned

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import OndoCampaignRwaSelectorView from './OndoCampaignRwaSelectorView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
-import { selectCurrentSubscriptionAccounts } from '../../../../selectors/rewards';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
 
 const mockGoBack = jest.fn();
@@ -20,9 +20,12 @@ let mockRouteParams: {
 
 jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
 
-jest.mock('../../../../selectors/rewards', () => ({
-  selectCurrentSubscriptionAccounts: jest.fn(),
-}));
+jest.mock(
+  '../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupInternalAccounts: jest.fn(),
+  }),
+);
 
 jest.mock('../../../../selectors/tokenBalancesController', () => ({
   selectAllTokenBalances: jest.fn(),
@@ -178,9 +181,6 @@ jest.mock('../../Trending/components/TrendingTokenLogo', () => {
 
 jest.mock('@metamask/utils', () => ({
   ...jest.requireActual('@metamask/utils'),
-  parseCaipAccountId: jest.fn((caipAccount: string) => ({
-    address: caipAccount.split(':').pop() ?? '0xaccount',
-  })),
 }));
 
 const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
@@ -192,8 +192,8 @@ const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
     rwaData: null,
   }) as unknown as TrendingAsset;
 
-// Default mock values: no subscription accounts, no balances
-let mockSubscriptionAccounts: { account: string }[] = [];
+// Default mock values: no active group accounts, no balances
+let mockActiveGroupAccounts: { address: string }[] = [];
 let mockAllTokenBalances: Record<
   string,
   Record<string, Record<string, string>>
@@ -204,11 +204,11 @@ describe('OndoCampaignRwaSelectorView', () => {
     jest.clearAllMocks();
     mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
     mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
-    mockSubscriptionAccounts = [];
+    mockActiveGroupAccounts = [];
     mockAllTokenBalances = {};
     (useSelector as jest.Mock).mockImplementation((selector) => {
-      if (selector === selectCurrentSubscriptionAccounts)
-        return mockSubscriptionAccounts;
+      if (selector === selectSelectedAccountGroupInternalAccounts)
+        return mockActiveGroupAccounts;
       if (selector === selectAllTokenBalances) return mockAllTokenBalances;
       return undefined;
     });
@@ -332,10 +332,10 @@ describe('OndoCampaignRwaSelectorView', () => {
   });
 
   describe('open_position mode — USDY source preselection', () => {
-    const ACCOUNT_CAIP = 'eip155:1:0xaccount1';
     // parseCaip19 mock always returns assetReference '0xabc', so the balance
     // lookup key matches that address regardless of the USDY_CAIP19 constant.
     const USDY_HEX_ADDRESS = '0xabc';
+    const ACCOUNT_ADDRESS = '0xaccount1';
 
     beforeEach(() => {
       mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
@@ -348,9 +348,9 @@ describe('OndoCampaignRwaSelectorView', () => {
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
       mockAllTokenBalances = {
-        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
@@ -369,9 +369,9 @@ describe('OndoCampaignRwaSelectorView', () => {
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
       mockAllTokenBalances = {
-        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
@@ -381,12 +381,12 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(srcArg?.symbol).toBe('USDY');
     });
 
-    it('passes undefined as source token when subscription accounts are empty', () => {
+    it('passes undefined as source token when active group accounts are empty', () => {
       mockUseRwaTokens.mockReturnValue({
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockSubscriptionAccounts = [];
+      mockActiveGroupAccounts = [];
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
@@ -401,9 +401,9 @@ describe('OndoCampaignRwaSelectorView', () => {
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
       mockAllTokenBalances = {
-        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x0' } },
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x0' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
@@ -426,9 +426,9 @@ describe('OndoCampaignRwaSelectorView', () => {
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
       mockAllTokenBalances = {
-        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import OndoCampaignRwaSelectorView from './OndoCampaignRwaSelectorView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
+import { selectCurrentSubscriptionAccounts } from '../../../../selectors/rewards';
+import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
 
 const mockGoBack = jest.fn();
 const mockGoToSwaps = jest.fn();
@@ -14,6 +17,16 @@ let mockRouteParams: {
   srcTokenName?: string;
   srcTokenDecimals?: number;
 } = { mode: 'open_position', campaignId: 'campaign-1' };
+
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+
+jest.mock('../../../../selectors/rewards', () => ({
+  selectCurrentSubscriptionAccounts: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/tokenBalancesController', () => ({
+  selectAllTokenBalances: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: mockGoBack }),
@@ -136,7 +149,9 @@ jest.mock(
 
 // Silence utility mocks
 jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
-  getTrendingTokenImageUrl: jest.fn(() => 'https://mock.image'),
+  getTrendingTokenImageUrl: jest.fn(
+    (assetId: string) => `https://mock.image/${assetId}`,
+  ),
 }));
 
 jest.mock('../../../../util/theme', () => ({
@@ -161,6 +176,13 @@ jest.mock('../../Trending/components/TrendingTokenLogo', () => {
   };
 });
 
+jest.mock('@metamask/utils', () => ({
+  ...jest.requireActual('@metamask/utils'),
+  parseCaipAccountId: jest.fn((caipAccount: string) => ({
+    address: caipAccount.split(':').pop() ?? '0xaccount',
+  })),
+}));
+
 const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
   ({
     symbol,
@@ -170,11 +192,36 @@ const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
     rwaData: null,
   }) as unknown as TrendingAsset;
 
+const USDY_ASSET_ID = 'eip155:1/erc20:0xusdy';
+const buildUsdyToken = (): TrendingAsset =>
+  ({
+    symbol: 'USDY',
+    name: 'Ondo USD Yield',
+    decimals: 18,
+    assetId: USDY_ASSET_ID,
+    rwaData: null,
+  }) as unknown as TrendingAsset;
+
+// Default mock values: no subscription accounts, no balances
+let mockSubscriptionAccounts: { account: string }[] = [];
+let mockAllTokenBalances: Record<
+  string,
+  Record<string, Record<string, string>>
+> = {};
+
 describe('OndoCampaignRwaSelectorView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
     mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
+    mockSubscriptionAccounts = [];
+    mockAllTokenBalances = {};
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      if (selector === selectCurrentSubscriptionAccounts)
+        return mockSubscriptionAccounts;
+      if (selector === selectAllTokenBalances) return mockAllTokenBalances;
+      return undefined;
+    });
   });
 
   it('renders without crashing', () => {
@@ -291,6 +338,122 @@ describe('OndoCampaignRwaSelectorView', () => {
       fireEvent.changeText(input, 'AAPL');
       // Skeleton replaces the token list
       expect(queryByTestId('token-row-MSFT')).toBeNull();
+    });
+  });
+
+  describe('open_position mode — USDY source preselection', () => {
+    const ACCOUNT_CAIP = 'eip155:1:0xaccount1';
+    const USDY_HEX_ADDRESS = '0xabc'; // matches parseCaip19 mock → assetReference: '0xabc'
+
+    beforeEach(() => {
+      mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
+    });
+
+    it('passes USDY as source token when user holds a non-zero USDY balance', () => {
+      const usdy = buildUsdyToken();
+      const aapl = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({
+        data: [usdy, aapl],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      // allTokenBalances[address][chainHex][tokenHex] = non-zero hex
+      mockAllTokenBalances = {
+        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      const [srcArg, destArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg).toBeDefined();
+      expect(srcArg?.symbol).toBe('USDY');
+      expect(destArg?.symbol).toBe('AAPL');
+    });
+
+    it('passes undefined as source token when subscription accounts are empty', () => {
+      const usdy = buildUsdyToken();
+      const aapl = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({
+        data: [usdy, aapl],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [];
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg).toBeUndefined();
+    });
+
+    it('passes undefined as source token when USDY balance is zero', () => {
+      const usdy = buildUsdyToken();
+      const aapl = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({
+        data: [usdy, aapl],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockAllTokenBalances = {
+        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x0' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg).toBeUndefined();
+    });
+
+    it('passes undefined as source token when USDY is not in the token list', () => {
+      const aapl = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({
+        data: [aapl],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockAllTokenBalances = {
+        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg).toBeUndefined();
+    });
+
+    it('does not preset USDY as source in swap mode even when user holds balance', () => {
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: 'eip155:1/erc20:0xabc',
+        srcTokenSymbol: 'USDC',
+        srcTokenDecimals: 6,
+      };
+      const usdy = buildUsdyToken();
+      const aapl = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({
+        data: [usdy, aapl],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockAllTokenBalances = {
+        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      // In swap mode ondoUsdSrcToken is always undefined
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -192,16 +192,6 @@ const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
     rwaData: null,
   }) as unknown as TrendingAsset;
 
-const USDY_ASSET_ID = 'eip155:1/erc20:0xusdy';
-const buildUsdyToken = (): TrendingAsset =>
-  ({
-    symbol: 'USDY',
-    name: 'Ondo USD Yield',
-    decimals: 18,
-    assetId: USDY_ASSET_ID,
-    rwaData: null,
-  }) as unknown as TrendingAsset;
-
 // Default mock values: no subscription accounts, no balances
 let mockSubscriptionAccounts: { account: string }[] = [];
 let mockAllTokenBalances: Record<
@@ -343,21 +333,22 @@ describe('OndoCampaignRwaSelectorView', () => {
 
   describe('open_position mode — USDY source preselection', () => {
     const ACCOUNT_CAIP = 'eip155:1:0xaccount1';
-    const USDY_HEX_ADDRESS = '0xabc'; // matches parseCaip19 mock → assetReference: '0xabc'
+    // parseCaip19 mock always returns assetReference '0xabc', so the balance
+    // lookup key matches that address regardless of the USDY_CAIP19 constant.
+    const USDY_HEX_ADDRESS = '0xabc';
 
     beforeEach(() => {
       mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
     });
 
     it('passes USDY as source token when user holds a non-zero USDY balance', () => {
-      const usdy = buildUsdyToken();
-      const aapl = buildToken('AAPL');
+      // rwaTokens intentionally does NOT contain USDY — preset comes from the
+      // hardcoded constant, not from the token list.
       mockUseRwaTokens.mockReturnValue({
-        data: [usdy, aapl],
+        data: [buildToken('AAPL')],
         isLoading: false,
       });
       mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
-      // allTokenBalances[address][chainHex][tokenHex] = non-zero hex
       mockAllTokenBalances = {
         '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
       };
@@ -372,11 +363,27 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(destArg?.symbol).toBe('AAPL');
     });
 
-    it('passes undefined as source token when subscription accounts are empty', () => {
-      const usdy = buildUsdyToken();
-      const aapl = buildToken('AAPL');
+    it('preset survives search — applies even when rwaTokens is filtered to non-USDY results', () => {
+      // Simulate the user having searched for "AAPL": rwaTokens contains only AAPL.
       mockUseRwaTokens.mockReturnValue({
-        data: [usdy, aapl],
+        data: [buildToken('AAPL')],
+        isLoading: false,
+      });
+      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
+      mockAllTokenBalances = {
+        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg?.symbol).toBe('USDY');
+    });
+
+    it('passes undefined as source token when subscription accounts are empty', () => {
+      mockUseRwaTokens.mockReturnValue({
+        data: [buildToken('AAPL')],
         isLoading: false,
       });
       mockSubscriptionAccounts = [];
@@ -390,34 +397,13 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
 
     it('passes undefined as source token when USDY balance is zero', () => {
-      const usdy = buildUsdyToken();
-      const aapl = buildToken('AAPL');
       mockUseRwaTokens.mockReturnValue({
-        data: [usdy, aapl],
+        data: [buildToken('AAPL')],
         isLoading: false,
       });
       mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
       mockAllTokenBalances = {
         '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x0' } },
-      };
-
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      fireEvent.press(getByTestId('token-row-AAPL'));
-
-      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-      const [srcArg] = mockGoToSwaps.mock.calls[0];
-      expect(srcArg).toBeUndefined();
-    });
-
-    it('passes undefined as source token when USDY is not in the token list', () => {
-      const aapl = buildToken('AAPL');
-      mockUseRwaTokens.mockReturnValue({
-        data: [aapl],
-        isLoading: false,
-      });
-      mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
-      mockAllTokenBalances = {
-        '0xaccount1': { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
@@ -436,10 +422,8 @@ describe('OndoCampaignRwaSelectorView', () => {
         srcTokenSymbol: 'USDC',
         srcTokenDecimals: 6,
       };
-      const usdy = buildUsdyToken();
-      const aapl = buildToken('AAPL');
       mockUseRwaTokens.mockReturnValue({
-        data: [usdy, aapl],
+        data: [buildToken('AAPL')],
         isLoading: false,
       });
       mockSubscriptionAccounts = [{ account: ACCOUNT_CAIP }];
@@ -451,7 +435,6 @@ describe('OndoCampaignRwaSelectorView', () => {
       fireEvent.press(getByTestId('token-row-AAPL'));
 
       expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-      // In swap mode ondoUsdSrcToken is always undefined
       const [srcArg] = mockGoToSwaps.mock.calls[0];
       expect(srcArg).toBeUndefined();
     });

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -58,6 +58,13 @@ import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
 import { selectCurrentSubscriptionAccounts } from '../../../../selectors/rewards';
 import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
 
+// USDY (Ondo USD Yield) on Ethereum mainnet — used to preset the source token
+// for open_position mode. This is the only network where USDY is supported in
+// the RWA campaign feature.
+const USDY_CAIP19 =
+  'eip155:1/erc20:0x96f6ef951840721adbf46ac996b59e0235cb985c' as const;
+const USDY_DECIMALS = 18;
+
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type OndoCampaignRwaSelectorRouteParams = {
@@ -144,21 +151,14 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
   const allTokenBalances = useSelector(selectAllTokenBalances);
 
-  // Find the USDY token from the fetched RWA token list.
-  const ondoUsdToken = useMemo(
-    () => rwaTokens.find((t) => t.symbol === 'USDY'),
-    [rwaTokens],
-  );
-
   // In open_position mode, preset USDY as the source if the user holds a balance.
+  // Uses a hardcoded CAIP-19 so the preset is independent of the search state —
+  // rwaTokens is filtered by searchQuery and may not contain USDY when a user
+  // searches for another token (e.g. "AAPL").
   const ondoUsdSrcToken = useMemo((): BridgeToken | undefined => {
-    if (
-      mode !== 'open_position' ||
-      !ondoUsdToken ||
-      !subscriptionAccounts?.length
-    )
+    if (mode !== 'open_position' || !subscriptionAccounts?.length)
       return undefined;
-    const parsed = parseCaip19(ondoUsdToken.assetId);
+    const parsed = parseCaip19(USDY_CAIP19);
     if (!parsed || parsed.namespace !== 'eip155') return undefined;
     const chainHex = caipChainIdToHex(
       `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
@@ -175,14 +175,13 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     if (!hasBalance) return undefined;
     return {
       address: parsed.assetReference,
-      symbol: ondoUsdToken.symbol,
-      name: ondoUsdToken.name,
-      decimals: ondoUsdToken.decimals,
+      symbol: 'USDY',
+      name: 'Ondo USD Yield',
+      decimals: USDY_DECIMALS,
       chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
-      image: getTrendingTokenImageUrl(ondoUsdToken.assetId),
-      rwaData: ondoUsdToken.rwaData as BridgeToken['rwaData'],
+      image: getTrendingTokenImageUrl(USDY_CAIP19),
     };
-  }, [mode, ondoUsdToken, subscriptionAccounts, allTokenBalances]);
+  }, [mode, subscriptionAccounts, allTokenBalances]);
 
   // Show skeleton while client-side filters are being applied.
   // useRwaTokens applies search/sort synchronously but via useStableReference,

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -12,6 +12,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -30,7 +31,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Hex, type CaipChainId } from '@metamask/utils';
+import { parseCaipAccountId, Hex, type CaipChainId } from '@metamask/utils';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import TrendingTokenLogo from '../../Trending/components/TrendingTokenLogo';
@@ -54,6 +55,8 @@ import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
+import { selectCurrentSubscriptionAccounts } from '../../../../selectors/rewards';
+import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -138,6 +141,49 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     chainIds,
   });
 
+  const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
+  const allTokenBalances = useSelector(selectAllTokenBalances);
+
+  // Find the USDY token from the fetched RWA token list.
+  const ondoUsdToken = useMemo(
+    () => rwaTokens.find((t) => t.symbol === 'USDY'),
+    [rwaTokens],
+  );
+
+  // In open_position mode, preset USDY as the source if the user holds a balance.
+  const ondoUsdSrcToken = useMemo((): BridgeToken | undefined => {
+    if (
+      mode !== 'open_position' ||
+      !ondoUsdToken ||
+      !subscriptionAccounts?.length
+    )
+      return undefined;
+    const parsed = parseCaip19(ondoUsdToken.assetId);
+    if (!parsed || parsed.namespace !== 'eip155') return undefined;
+    const chainHex = caipChainIdToHex(
+      `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+    );
+    const tokenHex = parsed.assetReference.toLowerCase() as Hex;
+    const hasBalance = subscriptionAccounts.some((a) => {
+      const address = parseCaipAccountId(a.account).address;
+      const bal =
+        allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex]?.[
+          tokenHex
+        ];
+      return bal !== undefined && !!parseInt(bal, 16);
+    });
+    if (!hasBalance) return undefined;
+    return {
+      address: parsed.assetReference,
+      symbol: ondoUsdToken.symbol,
+      name: ondoUsdToken.name,
+      decimals: ondoUsdToken.decimals,
+      chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      image: getTrendingTokenImageUrl(ondoUsdToken.assetId),
+      rwaData: ondoUsdToken.rwaData as BridgeToken['rwaData'],
+    };
+  }, [mode, ondoUsdToken, subscriptionAccounts, allTokenBalances]);
+
   // Show skeleton while client-side filters are being applied.
   // useRwaTokens applies search/sort synchronously but via useStableReference,
   // which delays opts by one render cycle — so rwaTokens lags behind the inputs
@@ -203,9 +249,9 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
         return;
       }
 
-      goToSwaps(undefined, destToken);
+      goToSwaps(ondoUsdSrcToken, destToken);
     },
-    [goToSwaps, isTokenTradingOpen],
+    [goToSwaps, isTokenTradingOpen, ondoUsdSrcToken],
   );
 
   const title =
@@ -347,7 +393,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
               setIsAfterHoursSheetOpen(false);
               setAfterHoursNextOpen(null);
               if (afterHoursPendingToken) {
-                goToSwaps(undefined, afterHoursPendingToken);
+                goToSwaps(ondoUsdSrcToken, afterHoursPendingToken);
               }
               setAfterHoursPendingToken(null);
             }}

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -31,7 +31,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { parseCaipAccountId, Hex, type CaipChainId } from '@metamask/utils';
+import { Hex, type CaipChainId } from '@metamask/utils';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import TrendingTokenLogo from '../../Trending/components/TrendingTokenLogo';
@@ -55,7 +55,7 @@ import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
-import { selectCurrentSubscriptionAccounts } from '../../../../selectors/rewards';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
 
 // USDY (Ondo USD Yield) on Ethereum mainnet — used to preset the source token
@@ -148,7 +148,9 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     chainIds,
   });
 
-  const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
+  const activeGroupAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
+  );
   const allTokenBalances = useSelector(selectAllTokenBalances);
 
   // In open_position mode, preset USDY as the source if the user holds a balance.
@@ -156,7 +158,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   // rwaTokens is filtered by searchQuery and may not contain USDY when a user
   // searches for another token (e.g. "AAPL").
   const ondoUsdSrcToken = useMemo((): BridgeToken | undefined => {
-    if (mode !== 'open_position' || !subscriptionAccounts?.length)
+    if (mode !== 'open_position' || !activeGroupAccounts.length)
       return undefined;
     const parsed = parseCaip19(USDY_CAIP19);
     if (!parsed || parsed.namespace !== 'eip155') return undefined;
@@ -164,10 +166,9 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
       `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
     );
     const tokenHex = parsed.assetReference.toLowerCase() as Hex;
-    const hasBalance = subscriptionAccounts.some((a) => {
-      const address = parseCaipAccountId(a.account).address;
+    const hasBalance = activeGroupAccounts.some((a) => {
       const bal =
-        allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex]?.[
+        allTokenBalances?.[a.address.toLowerCase() as Hex]?.[chainHex]?.[
           tokenHex
         ];
       return bal !== undefined && !!parseInt(bal, 16);
@@ -181,7 +182,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
       chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
       image: getTrendingTokenImageUrl(USDY_CAIP19),
     };
-  }, [mode, subscriptionAccounts, allTokenBalances]);
+  }, [mode, activeGroupAccounts, allTokenBalances]);
 
   // Show skeleton while client-side filters are being applied.
   // useRwaTokens applies search/sort synchronously but via useStableReference,


### PR DESCRIPTION
## Summary

- In `open_position` mode on the RWA selector page, check if the active account group's accounts hold any USDY (Ondo USD) balance
- If a balance is found, USDY is pre-selected as the source token when navigating to the swap flow
- Falls back to the default (mainnet ETH) when the user holds no USDY
- Covers the after-hours confirmation path as well

Jira: https://consensyssoftware.atlassian.net/browse/RWDS-1161

## Screenshots

<!-- N/A -->

## Changelog

CHANGELOG entry: null

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts swap-navigation inputs based on on-device token balance lookups, which can alter default funding behavior for opening positions. Risk is moderate due to reliance on selectors/balance parsing and potential edge cases across accounts/chains.
> 
> **Overview**
> In `OndoCampaignRwaSelectorView`, *open-position* selections now attempt to **preselect USDY (Ondo USD Yield) as the swap source token** when any active group account holds a non-zero USDY balance (using a hardcoded Ethereum mainnet CAIP-19), rather than always passing an undefined source.
> 
> This preset is applied both for the normal token-select path and the after-hours confirmation path, and is intentionally independent of the RWA token search/filter state.
> 
> Tests were expanded to mock `react-redux` selectors and to cover the USDY preselection behavior (non-zero balance, zero/absent balance, no accounts, and ensuring *swap mode* does not apply the preset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a296039e561742c28ff9c2fb7aa320fb1b28e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->