### PR TITLE
test: improves flake for BTC send toke and SolanDapp specs

### DIFF
--- a/tests/page-objects/Browser/SolanaTestDApp.ts
+++ b/tests/page-objects/Browser/SolanaTestDApp.ts
@@ -1,11 +1,11 @@
 import { dataTestIds } from '@metamask/test-dapp-solana';
-import { getTestDappLocalUrl } from '../../framework/fixtures/FixtureUtils';
 import Matchers from '../../framework/Matchers';
 import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
 import Browser from './BrowserView';
 import Gestures from '../../framework/Gestures';
 import { waitFor } from 'detox';
 import { SolanaTestDappSelectorsWebIDs } from '../../selectors/Browser/SolanaTestDapp.selectors';
+import { getDappUrl } from '../../framework/fixtures/FixtureUtils';
 
 /**
  * Get a test element by data-testid
@@ -75,7 +75,7 @@ class SolanaTestDApp {
   async navigateToSolanaTestDApp(): Promise<void> {
     await Browser.tapUrlInputBox();
 
-    await Browser.navigateToURL(getTestDappLocalUrl());
+    await Browser.navigateToURL(getDappUrl(0));
 
     await waitFor(element(by.id(BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID)))
       .toBeVisible()
@@ -91,7 +91,7 @@ class SolanaTestDApp {
    */
   async tapButton(webElement: WebElement): Promise<void> {
     await Gestures.scrollToWebViewPort(webElement);
-    await Gestures.tap(webElement);
+    await Gestures.waitAndTap(webElement);
   }
 
   getHeader() {

--- a/tests/smoke/confirmations/send/send-btc-token.spec.ts
+++ b/tests/smoke/confirmations/send/send-btc-token.spec.ts
@@ -23,9 +23,11 @@ describe(SmokeConfirmations('Send Bitcoin'), () => {
             {
               homepageRedesignV1: { enabled: false, minimumVersion: '0.0.0' },
               homepageSectionsV1: { enabled: false, minimumVersion: '0.0.0' },
-              tokenDetailsV2: false,
+              tokenDetailsV2AbTest: {
+                value: { variant: 'control', minimumVersion: '0.0.0' },
+              },
             },
-            3000,
+            1000,
           );
         },
       },

--- a/tests/smoke/confirmations/send/send-btc-token.spec.ts
+++ b/tests/smoke/confirmations/send/send-btc-token.spec.ts
@@ -6,7 +6,6 @@ import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
 import { loginToApp } from '../../../flows/wallet.flow';
 import Assertions from '../../../framework/Assertions';
-import NetworkListModal from '../../../page-objects/Network/NetworkListModal';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
 
@@ -26,13 +25,14 @@ describe(SmokeConfirmations('Send Bitcoin'), () => {
               homepageSectionsV1: { enabled: false, minimumVersion: '0.0.0' },
               tokenDetailsV2: false,
             },
-            1000,
+            3000,
           );
         },
       },
       async () => {
         await loginToApp();
-        await device.disableSynchronization();
+        // Making the assertion before disabling synchronization so that flags
+        // are properly fetched and this mocked flag is set
         await Assertions.expectElementToNotBeVisible(
           WalletView.balanceEmptyStateContainer,
           {
@@ -40,6 +40,7 @@ describe(SmokeConfirmations('Send Bitcoin'), () => {
             timeout: 30000,
           },
         );
+        await device.disableSynchronization();
         await WalletView.tapOnToken(TOKEN, 0);
         await TokenOverview.tapSendButton();
         await SendView.enterZeroAmount();


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
`tests/smoke/multichain/solana-wallet-standard/transferSol.spec.ts`:
- uses `waitAndTap` instead of `tap` in order to avoid race conditions when tapping Solana test dapp elements
-  updates deprecated `getTestDappLocalUrl()` for `getDappUrl(0)`

`tests/smoke/confirmations/send/send-btc-token.spec.ts`:
- Disables synchronization at a later stage of the test to make sure flags are properly mocked as there is a race condition between fetching flags and navigating to the BTC token to tap send

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1776155346024039

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test utilities and a smoke test’s synchronization/feature-flag setup, with no production logic impact.
> 
> **Overview**
> Improves E2E test stability by updating the Solana test dapp page object to use `getDappUrl(0)` (replacing deprecated `getTestDappLocalUrl`) and switching WebView interactions from `tap` to `waitAndTap` to reduce race conditions.
> 
> Adjusts the BTC send smoke test’s remote feature flag mocking (uses `tokenDetailsV2AbTest`) and moves `device.disableSynchronization()` until after an initial wallet assertion so mocked flags are fetched before the test proceeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96eef696f35de27b40d6ba0911b41a559b6386b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->