### PR TITLE
test: removes step for iOS setup environment

### DIFF
--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -50,7 +50,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: yarn setup:github-ci --node
+          command: yarn setup:github-ci --no-build-ios --no-build-android
 
       - name: Configure Keystore
         uses: MetaMask/github-tools/.github/actions/configure-keystore@v1

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -44,23 +44,13 @@ jobs:
           retry_wait_seconds: 30
           command: yarn install --immutable
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache@v4
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
-
-      - name: Install Foundry if cache missed
-        if: steps.restore-metamask.outputs.cache-hit != 'true'
-        run: yarn install:foundryup
       - name: Setup project
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: yarn setup:github-ci --no-build-ios
+          command: yarn setup:github-ci --node
 
       - name: Configure Keystore
         uses: MetaMask/github-tools/.github/actions/configure-keystore@v1

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -30,12 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup iOS Environment
-        timeout-minutes: 15
-        uses: ./.github/actions/setup-e2e-env
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          platform: ios
-          setup-simulator: false
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       - name: Install dependencies
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -50,7 +50,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: yarn setup:github-ci --node
+          command: yarn setup:github-ci --no-build-ios --no-build-android
 
       - name: Download Main iOS App artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios-flask.yml
@@ -44,23 +44,13 @@ jobs:
           retry_wait_seconds: 30
           command: yarn install --immutable
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache@v4
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
-
-      - name: Install Foundry if cache missed
-        if: steps.restore-metamask.outputs.cache-hit != 'true'
-        run: yarn install:foundryup
       - name: Setup project
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: yarn setup:github-ci --no-build-android
+          command: yarn setup:github-ci --node
 
       - name: Download Main iOS App artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## **Description**
Removes non needed complex setup process for iOS in favor or node setup only for Flask E2E Builds.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1700

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI workflow-only changes, but they affect the environment/bootstrap steps for Flask E2E repack/build jobs and could break smoke runs if any removed setup (e.g., Foundry or iOS env prep) was still implicitly required.
> 
> **Overview**
> Simplifies the Flask E2E smoke test GitHub Actions workflows by removing the `.metamask` cache/Foundry installation steps and, for iOS, replacing the custom `setup-e2e-env` action with a plain `actions/setup-node` + Yarn cache.
> 
> Updates both iOS and Android repack jobs to run `yarn setup:github-ci` with both `--no-build-ios` and `--no-build-android`, ensuring the workflows only prepare dependencies/config without triggering platform builds during the repack phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a706cd2b5dfa130ae59581182bddef508aa6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->