### PR TITLE
test(snaps): Fix name lookup E2E

### DIFF
--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -26,7 +26,7 @@ import ToastModal from '../wallet/ToastModal';
 import SolanaTestDApp from './SolanaTestDApp';
 
 export const TEST_SNAPS_URL =
-  'https://metamask.github.io/snaps/test-snaps/3.4.1/';
+  'https://metamask.github.io/snaps/test-snaps/3.4.2/';
 
 class TestSnaps {
   get getConnectSnapButton(): DetoxElement {

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -17,7 +17,7 @@ jest.setTimeout(150_000);
 
 const TOKEN = 'Ethereum';
 
-describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
+describe(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -11,7 +11,6 @@ import { Assertions, Gestures, Matchers } from '../../framework';
 import BrowserView from '../../page-objects/Browser/BrowserView';
 import TransactionConfirmView from '../../page-objects/Send/TransactionConfirmView';
 import TokenOverview from '../../page-objects/wallet/TokenOverview';
-import { LOCAL_NODE_RPC_URL } from '../../framework/Constants';
 import NetworkListModal from '../../page-objects/Network/NetworkListModal';
 
 jest.setTimeout(150_000);

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -7,12 +7,12 @@ import TestSnaps from '../../page-objects/Browser/TestSnaps';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import WalletView from '../../page-objects/wallet/WalletView';
 import RedesignedSendView from '../../page-objects/Send/RedesignedSendView';
-import { Assertions, Gestures, LocalNode, Matchers } from '../../framework';
+import { Assertions, Gestures, Matchers } from '../../framework';
 import BrowserView from '../../page-objects/Browser/BrowserView';
-import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
-import { AnvilManager } from '../../seeder/anvil-manager';
 import TransactionConfirmView from '../../page-objects/Send/TransactionConfirmView';
 import TokenOverview from '../../page-objects/wallet/TokenOverview';
+import { LOCAL_NODE_RPC_URL } from '../../framework/Constants';
+import NetworkListModal from '../../page-objects/Network/NetworkListModal';
 
 jest.setTimeout(150_000);
 
@@ -22,19 +22,7 @@ describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
   it('displays the resolved recipient address in the send flow', async () => {
     await withFixtures(
       {
-        fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
-          const node = localNodes?.[0] as unknown as AnvilManager;
-
-          return new FixtureBuilder()
-            .withNetworkController({
-              chainId: '0x1',
-              rpcUrl: `http://localhost:${node.getPort() ?? AnvilPort()}`,
-              type: 'custom',
-              nickname: 'Local RPC',
-              ticker: 'ETH',
-            })
-            .build();
-        },
+        fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
       },
@@ -48,7 +36,11 @@ describe.skip(FlaskBuildTests('Name Lookup Snap Tests'), () => {
         await BrowserView.tapCloseBrowserButton();
         await TabBarComponent.tapHome();
         await device.disableSynchronization();
-        await WalletView.waitForTokenToBeReady(TOKEN);
+        await WalletView.tapOnNewTokensSection();
+        await WalletView.tapTokenNetworkFilter();
+        await NetworkListModal.tapOnCustomTab();
+        await NetworkListModal.changeNetworkTo('Localhost');
+
         await WalletView.tapOnToken(TOKEN);
         await TokenOverview.tapSendButton();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the name-lookup test which had been broken by a recent commit (?). The PR makes it more stable by using the `Localhost` (1337) network for testing, which should always have a balance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
