### PR TITLE
chore: adds navigation to profile from TopTraderCard

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -121,8 +121,21 @@ describe('TopTradersSection', () => {
 
   it('navigates to the Top Traders view when the section header is pressed', () => {
     renderWithProvider(<TopTradersSection {...defaultProps} />);
+
     fireEvent.press(screen.getByText('Top Traders'));
+
     expect(mockNavigate).toHaveBeenCalledWith(Routes.SOCIAL_LEADERBOARD.VIEW);
+  });
+
+  it('navigates to the trader profile with correct params when a card is tapped', () => {
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.SOCIAL_LEADERBOARD.PROFILE,
+      { traderId: 'trader-1', traderName: 'alice' },
+    );
   });
 
   it('exposes refresh via ref and resolves when called', async () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -7,6 +7,8 @@ import React, {
 import { View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
+import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -45,7 +47,7 @@ const TopTradersSection = forwardRef<
   TopTradersSectionProps
 >(({ sectionIndex, totalSectionsLoaded }, ref) => {
   const sectionViewRef = useRef<View>(null);
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const tw = useTailwind();
   const isEnabled = useSelector(selectSocialLeaderboardEnabled);
   const title = strings('homepage.sections.top_traders');
@@ -82,8 +84,18 @@ const TopTradersSection = forwardRef<
   });
 
   const handleViewAll = useCallback(() => {
-    navigation.navigate(Routes.SOCIAL_LEADERBOARD.VIEW as never);
+    navigation.navigate(Routes.SOCIAL_LEADERBOARD.VIEW);
   }, [navigation]);
+
+  const handleTraderPress = useCallback(
+    (traderId: string, traderName: string) => {
+      navigation.navigate(Routes.SOCIAL_LEADERBOARD.PROFILE, {
+        traderId,
+        traderName,
+      });
+    },
+    [navigation],
+  );
 
   if (!isEnabled || (!isLoading && traders.length === 0)) {
     return null;
@@ -111,6 +123,7 @@ const TopTradersSection = forwardRef<
                   key={trader.id}
                   trader={trader}
                   onFollowPress={toggleFollow}
+                  onTraderPress={handleTraderPress}
                 />
               ))}
         </ScrollView>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -89,7 +89,9 @@ describe('TopTraderCard', () => {
     renderWithProvider(
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
+
     fireEvent.press(screen.getByText('Follow'));
+
     expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
   });
 
@@ -101,7 +103,9 @@ describe('TopTraderCard', () => {
         onTraderPress={mockOnTraderPress}
       />,
     );
+
     fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+
     expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'sniperliquid');
   });
 
@@ -109,7 +113,9 @@ describe('TopTraderCard', () => {
     renderWithProvider(
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
+
     fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+
     expect(mockOnTraderPress).not.toHaveBeenCalled();
   });
 
@@ -121,7 +127,9 @@ describe('TopTraderCard', () => {
         onTraderPress={mockOnTraderPress}
       />,
     );
+
     fireEvent.press(screen.getByText('Follow'));
+
     expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
     expect(mockOnTraderPress).not.toHaveBeenCalled();
   });

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -1,149 +1,144 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TopTraderCard from './TopTraderCard';
 import type { TopTrader } from '../types';
 
 const baseTrader: TopTrader = {
   id: 'trader-1',
   rank: 1,
-  username: 'alice',
-  percentageChange: 96.2,
-  pnlValue: 963000,
+  username: 'sniperliquid',
+  avatarUri: 'https://example.com/avatar.png',
+  percentageChange: 43,
+  pnlValue: 963146.8,
   isFollowing: false,
 };
 
+const mockOnFollowPress = jest.fn();
+const mockOnTraderPress = jest.fn();
+
 describe('TopTraderCard', () => {
-  it('calls onFollowPress with the trader id when the Follow button is pressed', () => {
-    const onFollowPress = jest.fn();
-    const { getByText } = render(
-      <TopTraderCard trader={baseTrader} onFollowPress={onFollowPress} />,
-    );
-
-    fireEvent.press(getByText('Follow'));
-
-    expect(onFollowPress).toHaveBeenCalledTimes(1);
-    expect(onFollowPress).toHaveBeenCalledWith('trader-1');
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('calls onFollowPress with the trader id when the Following button is pressed', () => {
-    const onFollowPress = jest.fn();
-    const followingTrader = { ...baseTrader, isFollowing: true };
-    const { getByText } = render(
-      <TopTraderCard trader={followingTrader} onFollowPress={onFollowPress} />,
+  it('renders username, ROI, and PnL', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
-
-    fireEvent.press(getByText('Following'));
-
-    expect(onFollowPress).toHaveBeenCalledWith('trader-1');
+    expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
+    expect(screen.getByText('+43.0%')).toBeOnTheScreen();
+    expect(screen.getByText('+$963K')).toBeOnTheScreen();
   });
 
-  it('shows the Follow button when the trader is not followed', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, isFollowing: false }}
-        onFollowPress={jest.fn()}
-      />,
+  it('renders with default testID when none is provided', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
-
-    expect(getByText('Follow')).toBeOnTheScreen();
+    expect(screen.getByTestId('top-trader-card-trader-1')).toBeOnTheScreen();
   });
 
-  it('shows the Following button when the trader is already followed', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, isFollowing: true }}
-        onFollowPress={jest.fn()}
-      />,
-    );
-
-    expect(getByText('Following')).toBeOnTheScreen();
-  });
-
-  it('renders the avatar image when avatarUri is provided', () => {
-    const traderWithAvatar = {
-      ...baseTrader,
-      avatarUri: 'https://example.com/avatar.png',
-    };
-    const { getByTestId, queryByText } = render(
-      <TopTraderCard trader={traderWithAvatar} onFollowPress={jest.fn()} />,
-    );
-
-    expect(getByTestId('top-trader-avatar-trader-1')).toBeOnTheScreen();
-    // The fallback letter should not be shown when avatarUri is supplied
-    expect(queryByText('A')).not.toBeOnTheScreen();
-  });
-
-  it('renders the fallback AvatarBase when avatarUri is not provided', () => {
-    const traderNoAvatar = { ...baseTrader, avatarUri: undefined };
-    const { getByText } = render(
-      <TopTraderCard trader={traderNoAvatar} onFollowPress={jest.fn()} />,
-    );
-
-    // AvatarBase shows the first letter of the username as fallback text
-    expect(getByText('A')).toBeOnTheScreen();
-  });
-
-  it('displays ROI with a leading + sign for a positive percentage change', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, percentageChange: 96.2 }}
-        onFollowPress={jest.fn()}
-      />,
-    );
-
-    expect(getByText('+96.2%')).toBeOnTheScreen();
-  });
-
-  it('displays ROI without a + sign for a negative percentage change', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, percentageChange: -12.5 }}
-        onFollowPress={jest.fn()}
-      />,
-    );
-
-    expect(getByText('-12.5%')).toBeOnTheScreen();
-  });
-
-  it('displays a positive PnL value', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, pnlValue: 963000 }}
-        onFollowPress={jest.fn()}
-      />,
-    );
-
-    expect(getByText('+$963K')).toBeOnTheScreen();
-  });
-
-  it('displays a negative PnL value', () => {
-    const { getByText } = render(
-      <TopTraderCard
-        trader={{ ...baseTrader, pnlValue: -1200 }}
-        onFollowPress={jest.fn()}
-      />,
-    );
-
-    expect(getByText('-$1K')).toBeOnTheScreen();
-  });
-
-  it('applies the custom testID when provided', () => {
-    const { getByTestId } = render(
+  it('uses custom testID when provided', () => {
+    renderWithProvider(
       <TopTraderCard
         trader={baseTrader}
-        onFollowPress={jest.fn()}
-        testID="custom-card-id"
+        onFollowPress={mockOnFollowPress}
+        testID="custom-test-id"
       />,
     );
-
-    expect(getByTestId('custom-card-id')).toBeOnTheScreen();
+    expect(screen.getByTestId('custom-test-id')).toBeOnTheScreen();
   });
 
-  it('uses the default testID based on trader id when no testID prop is provided', () => {
-    const { getByTestId } = render(
-      <TopTraderCard trader={baseTrader} onFollowPress={jest.fn()} />,
+  it('renders avatar image when avatarUri is present', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
+    expect(screen.getByTestId('top-trader-avatar-trader-1')).toBeOnTheScreen();
+  });
 
-    expect(getByTestId('top-trader-card-trader-1')).toBeOnTheScreen();
+  it('renders fallback AvatarBase when avatarUri is absent', () => {
+    const traderNoAvatar = { ...baseTrader, avatarUri: undefined };
+    renderWithProvider(
+      <TopTraderCard
+        trader={traderNoAvatar}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+    expect(screen.getByText('S')).toBeOnTheScreen();
+  });
+
+  it('shows Follow when not following', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+    expect(screen.getByText('Follow')).toBeOnTheScreen();
+  });
+
+  it('shows Following when isFollowing is true', () => {
+    const followingTrader = { ...baseTrader, isFollowing: true };
+    renderWithProvider(
+      <TopTraderCard
+        trader={followingTrader}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+    expect(screen.getByText('Following')).toBeOnTheScreen();
+  });
+
+  it('calls onFollowPress with trader.id when Follow button is tapped', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+    fireEvent.press(screen.getByText('Follow'));
+    expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
+  });
+
+  it('calls onTraderPress with trader.id and username when card content is tapped', () => {
+    renderWithProvider(
+      <TopTraderCard
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'sniperliquid');
+  });
+
+  it('does not call onTraderPress when the prop is not provided', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    expect(mockOnTraderPress).not.toHaveBeenCalled();
+  });
+
+  it('Follow button fires onFollowPress independently of onTraderPress', () => {
+    renderWithProvider(
+      <TopTraderCard
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+    fireEvent.press(screen.getByText('Follow'));
+    expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
+    expect(mockOnTraderPress).not.toHaveBeenCalled();
+  });
+
+  it('displays negative ROI and PnL values with correct sign', () => {
+    const negativeTrader: TopTrader = {
+      ...baseTrader,
+      percentageChange: -15.3,
+      pnlValue: -500,
+    };
+    renderWithProvider(
+      <TopTraderCard
+        trader={negativeTrader}
+        onFollowPress={mockOnFollowPress}
+      />,
+    );
+    expect(screen.getByText('-15.3%')).toBeOnTheScreen();
+    expect(screen.getByText('-$500')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image } from 'react-native';
+import { Image, TouchableOpacity } from 'react-native';
 import {
   Box,
   Text,
@@ -7,7 +7,6 @@ import {
   FontWeight,
   TextColor,
   BoxAlignItems,
-  BoxJustifyContent,
   AvatarBase,
   AvatarBaseSize,
   Button,
@@ -22,6 +21,7 @@ import { formatPnl } from '../utils/formatPnl';
 export interface TopTraderCardProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
+  onTraderPress?: (traderId: string, traderName: string) => void;
   testID?: string;
 }
 
@@ -36,6 +36,7 @@ const AVATAR_SIZE = 40;
 const TopTraderCard: React.FC<TopTraderCardProps> = ({
   trader,
   onFollowPress,
+  onTraderPress,
   testID,
 }) => {
   const tw = useTailwind();
@@ -52,70 +53,81 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
       testID={testID ?? `top-trader-card-${trader.id}`}
     >
       {/* Top content: avatar + name + stats */}
-      <Box alignItems={BoxAlignItems.Center} twClassName="flex-1 gap-2 mb-3">
-        {/* Avatar */}
-        {trader.avatarUri ? (
-          <Image
-            source={{ uri: trader.avatarUri }}
-            style={tw.style(
-              `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-            )}
-            resizeMode="cover"
-            testID={`top-trader-avatar-${trader.id}`}
-          />
-        ) : (
-          <AvatarBase
-            size={AvatarBaseSize.Lg}
-            fallbackText={trader.username.charAt(0).toUpperCase()}
-          />
-        )}
+      <TouchableOpacity
+        activeOpacity={onTraderPress ? 0.7 : 1}
+        onPress={
+          onTraderPress
+            ? () => onTraderPress(trader.id, trader.username)
+            : undefined
+        }
+        disabled={!onTraderPress}
+        testID={`top-trader-card-pressable-${trader.id}`}
+      >
+        <Box alignItems={BoxAlignItems.Center} twClassName="flex-1 gap-2 mb-3">
+          {/* Avatar */}
+          {trader.avatarUri ? (
+            <Image
+              source={{ uri: trader.avatarUri }}
+              style={tw.style(
+                `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
+              )}
+              resizeMode="cover"
+              testID={`top-trader-avatar-${trader.id}`}
+            />
+          ) : (
+            <AvatarBase
+              size={AvatarBaseSize.Lg}
+              fallbackText={trader.username.charAt(0).toUpperCase()}
+            />
+          )}
 
-        {/* Username */}
-        <Text
-          variant={TextVariant.HeadingSm}
-          fontWeight={FontWeight.Bold}
-          color={TextColor.TextDefault}
-          numberOfLines={1}
-        >
-          {trader.username}
-        </Text>
-
-        {/* Stats: +96.2% · +$963K 30D */}
-        <Text variant={TextVariant.BodyXs} fontWeight={FontWeight.Medium}>
+          {/* Username */}
           <Text
-            variant={TextVariant.BodyXs}
-            fontWeight={FontWeight.Medium}
-            twClassName={
-              isRoiPositive ? 'text-success-default' : 'text-error-default'
-            }
-          >
-            {roiText}
-          </Text>
-          <Text
-            variant={TextVariant.BodyXs}
-            fontWeight={FontWeight.Medium}
+            variant={TextVariant.HeadingSm}
+            fontWeight={FontWeight.Bold}
             color={TextColor.TextDefault}
+            numberOfLines={1}
           >
-            {' \u00B7 '}
+            {trader.username}
           </Text>
-          <Text
-            variant={TextVariant.BodyXs}
-            fontWeight={FontWeight.Medium}
-            twClassName={
-              isPnlPositive ? 'text-success-default' : 'text-error-default'
-            }
-          >
-            {pnlText}
+
+          {/* Stats: +96.2% · +$963K 30D */}
+          <Text variant={TextVariant.BodyXs} fontWeight={FontWeight.Medium}>
+            <Text
+              variant={TextVariant.BodyXs}
+              fontWeight={FontWeight.Medium}
+              twClassName={
+                isRoiPositive ? 'text-success-default' : 'text-error-default'
+              }
+            >
+              {roiText}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
+              {' \u00B7 '}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              fontWeight={FontWeight.Medium}
+              twClassName={
+                isPnlPositive ? 'text-success-default' : 'text-error-default'
+              }
+            >
+              {pnlText}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextMuted}
+            >
+              {' 30D'}
+            </Text>
           </Text>
-          <Text
-            variant={TextVariant.BodyXs}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextMuted}
-          >
-            {' 30D'}
-          </Text>
-        </Text>
-      </Box>
+        </Box>
+      </TouchableOpacity>
 
       {/* Follow / Following button pinned to bottom */}
       <Button


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tapping a `TopTraderCard` on the homepage carousel now navigates to the trader's profile view, matching the existing `TraderRow` behaviour in the full leaderboard view.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new press target and typed navigation call from the homepage carousel, with minimal logic changes and updated tests to cover the new behavior.
> 
> **Overview**
> Enables navigation from the homepage Top Traders carousel directly into a trader’s profile: `TopTraderCard` now supports an optional `onTraderPress` and wraps its content in a `TouchableOpacity`, while the Follow button behavior remains independent.
> 
> `TopTradersSection` wires card taps to `Routes.SOCIAL_LEADERBOARD.PROFILE` (passing `traderId` and `traderName`) and tightens navigation typing; tests are expanded/updated to assert header navigation, card navigation params, and the new pressable/testID behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948e8a0cd01fdbfd1c49954dfe49a6133e1afb3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->