### PR TITLE
refactor(ramp): migrate BottomSheet to design system (phase 2)

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -22,13 +22,14 @@ import ErrorView from '../../Aggregator/components/ErrorView';
 import Logger from '../../../../../util/Logger';
 import { protectWalletModalVisible } from '../../../../../actions/user';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
-import { useStyles } from '../../../../../component-library/hooks';
+import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './Checkout.styles';
 import Device from '../../../../../util/device';
 import { shouldStartLoadWithRequest } from '../../../../../util/browser';
@@ -296,7 +297,7 @@ const Checkout = () => {
     return (
       <BottomSheet
         ref={sheetRef}
-        shouldNavigateBack
+        goBack={navigation.goBack}
         isFullscreen
         keyboardAvoidingViewEnabled={false}
       >
@@ -322,7 +323,7 @@ const Checkout = () => {
     return (
       <BottomSheet
         ref={sheetRef}
-        shouldNavigateBack
+        goBack={navigation.goBack}
         isFullscreen
         isInteractable={!Device.isAndroid()}
         keyboardAvoidingViewEnabled={false}
@@ -372,7 +373,7 @@ const Checkout = () => {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      goBack={navigation.goBack}
       isFullscreen
       keyboardAvoidingViewEnabled={false}
     >

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.test.tsx
@@ -24,11 +24,12 @@ jest.mock('react-native-inappbrowser-reborn', () => ({
   open: jest.fn(),
 }));
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         { children }: { children: React.ReactNode },
         ref: React.Ref<{ onCloseBottomSheet: () => void }>,
@@ -38,9 +39,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 const mockUseParams = jest.fn();
 jest.mock('../../../../../../util/navigation/navUtils', () => ({

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
@@ -4,6 +4,8 @@ import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { useNavigation, type ParamListBase } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import {
+  BottomSheet,
+  type BottomSheetRef,
   Text,
   TextVariant,
   TextColor,
@@ -15,9 +17,6 @@ import {
   IconSize,
   IconColor,
 } from '@metamask/design-system-react-native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useStyles } from '../../../../../hooks/useStyles';
 import {
@@ -92,7 +91,7 @@ function ErrorDetailsModal() {
   }, [navigation, amount]);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderCompactStandard
         onClose={handleClose}
         closeButtonProps={{ testID: 'error-details-close-button' }}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -38,11 +38,12 @@ const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => {
   callback?.();
 });
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -56,9 +57,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 const mockUseParams = jest.fn(() => ({}));
 jest.mock('../../../../../../util/navigation/navUtils', () => ({

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -4,10 +4,9 @@ import type { PaymentMethod } from '@metamask/ramps-controller';
 import { useWindowDimensions, View, ScrollView } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import {
+  BottomSheet,
+  type BottomSheetRef,
   Box,
   BoxAlignItems,
   BoxJustifyContent,
@@ -255,7 +254,7 @@ function PaymentSelectionModal() {
   };
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <View style={styles.containerOuter}>
         <View style={styles.paymentPanelContent}>
           <HeaderCompactStandard

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.test.tsx
@@ -12,12 +12,13 @@ const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => {
   callback?.();
 });
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    const { View } = jest.requireActual('react-native');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -33,9 +34,9 @@ jest.mock(
         }));
         return <View testID={testID}>{children}</View>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useRef } from 'react';
 import { StyleSheet } from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import {
+  BottomSheet,
+  type BottomSheetRef,
   Text,
   TextVariant,
   TextColor,
@@ -77,8 +76,8 @@ function ProcessingInfoModal() {
       await InAppBrowser.open(providerSupportUrl);
     } else {
       // Navigate without closing the sheet first. If we called handleClose() here,
-      // shouldNavigateBack would fire goBack() after the close animation and pop the
-      // Webview screen off the stack instead of the modal.
+      // goBack would run after the close animation and pop the Webview screen off the
+      // stack instead of the modal.
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',
         params: {
@@ -99,7 +98,7 @@ function ProcessingInfoModal() {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      goBack={navigation.goBack}
       isInteractable={false}
       testID={PROCESSING_INFO_MODAL_TEST_IDS.MODAL}
     >

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.test.tsx
@@ -147,11 +147,12 @@ jest.mock('../../../hooks/useRampsQuotes', () => ({
 
 let capturedOnClose: ((hasPendingAction?: boolean) => void) | undefined;
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -165,9 +166,9 @@ jest.mock(
         capturedOnClose = onClose;
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 function renderWithProvider(component: React.ComponentType) {
   return renderScreen(

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
@@ -3,9 +3,10 @@ import { useWindowDimensions, View } from 'react-native';
 import type { CaipChainId } from '@metamask/utils';
 import type { Provider } from '@metamask/ramps-controller';
 import { useSelector } from 'react-redux';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
 import { useNavigation, useNavigationState } from '@react-navigation/native';
 import {
   createNavigationDetails,
@@ -171,7 +172,11 @@ function ProviderSelectionModal() {
   );
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack onClose={handleDismiss}>
+    <BottomSheet
+      ref={sheetRef}
+      goBack={navigation.goBack}
+      onClose={handleDismiss}
+    >
       <View style={styles.container}>
         <ProviderSelection
           providers={displayProviders}

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -6,10 +6,11 @@ import React, {
   useEffect,
 } from 'react';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
-import { IconName } from '@metamask/design-system-react-native';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+  IconName,
+} from '@metamask/design-system-react-native';
 import {
   IconName as ComponentLibraryIconName,
   IconColor as ComponentLibraryIconColor,
@@ -131,8 +132,8 @@ function SettingsModal() {
         await InAppBrowser.open(supportUrl);
       } else {
         // Navigate without closing the sheet first. If we called onCloseBottomSheet() here,
-        // shouldNavigateBack would fire goBack() after the close animation and pop the
-        // Webview screen off the stack instead of the modal.
+        // goBack would run after the close animation and pop the Webview screen off the
+        // stack instead of the modal.
         navigation.navigate('Webview', {
           screen: 'SimpleWebview',
           params: { url: supportUrl },
@@ -195,7 +196,7 @@ function SettingsModal() {
   }, []);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderCompactStandard
         title={strings('fiat_on_ramp.build_quote_settings_modal.title')}
         onClose={handleClosePress}

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.test.tsx
@@ -76,11 +76,12 @@ const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => {
 
 let capturedOnClose: ((hasPendingAction?: boolean) => void) | undefined;
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -97,9 +98,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 function render(component: React.ComponentType) {
   return renderScreen(

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import {
+  BottomSheet,
+  type BottomSheetRef,
   Text,
   TextVariant,
   TextColor,
@@ -9,9 +11,6 @@ import {
   ButtonVariant,
   ButtonBaseSize,
 } from '@metamask/design-system-react-native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../../locales/i18n';
 import {
@@ -141,7 +140,7 @@ function TokenNotAvailableModal() {
         if (buyFlowOrigin === 'tokenInfo') {
           // Token Info buy flow: pop back through the ramp flow to the
           // existing Asset screen. BottomSheet already performs one goBack
-          // when shouldNavigateBack is true; we need one more to exit ramp.
+          // when goBack is set; we need one more to exit ramp.
           navigation.goBack();
         } else if (buyFlowOrigin === 'homeTokenList') {
           // Home token list buy flow: return to home screen
@@ -159,7 +158,7 @@ function TokenNotAvailableModal() {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      goBack={navigation.goBack}
       onClose={handleDismiss}
       testID={TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.MODAL}
     >

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.test.tsx
@@ -7,11 +7,12 @@ import { fireEvent } from '@testing-library/react-native';
 
 const mockOnCloseBottomSheet = jest.fn();
 
-jest.mock(
-  '../../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -25,9 +26,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 function render(component: React.ComponentType) {
   return renderScreen(

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
@@ -1,10 +1,13 @@
 import React, { useRef } from 'react';
 import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
-import { Text, TextVariant } from '@metamask/design-system-react-native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../../component-library/components/BottomSheets/BottomSheet';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../../locales/i18n';
 import styleSheet from './UnsupportedTokenModal.styles';
@@ -20,10 +23,11 @@ export const createUnsupportedTokenModalNavigationDetails =
 
 function UnsupportedTokenModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderCompactStandard
         title={strings('deposit.token_modal.unsupported_token_title')}
         onClose={() => sheetRef.current?.onCloseBottomSheet()}

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.test.tsx
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.test.tsx
@@ -15,11 +15,12 @@ jest.mock('react-native/Libraries/Linking/Linking', () => ({
   canOpenURL: jest.fn().mockResolvedValue(true),
 }));
 
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -33,9 +34,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 function render(component: React.ComponentType) {
   return renderScreen(

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.tsx
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useRef } from 'react';
 import { View, Linking } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import {
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
   Text,
   TextVariant,
   TextColor,
@@ -8,10 +12,6 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 
 import styleSheet from './EligibilityFailedModal.styles';
 import { useStyles } from '../../../../hooks/useStyles';
@@ -30,6 +30,7 @@ export const createEligibilityFailedModalNavigationDetails =
 
 function EligibilityFailedModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
 
   const navigateToContactSupport = useCallback(() => {
@@ -45,7 +46,7 @@ function EligibilityFailedModal() {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      goBack={navigation.goBack}
       isInteractable={false}
       testID={ELIGIBILITY_FAILED_MODAL_TEST_IDS.MODAL}
     >

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.test.tsx
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.test.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
-import RampUnsupportedModal from './RampUnsupportedModal';
+import RampUnsupportedModal, {
+  createRampUnsupportedModalNavigationDetails,
+} from './RampUnsupportedModal';
 import Routes from '../../../../../constants/navigation/Routes';
 import initialRootState from '../../../../../util/test/initial-root-state';
 import { fireEvent, screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
+import { RAMP_UNSUPPORTED_MODAL_TEST_IDS } from './RampUnsupportedModal.testIds';
+
 const mockOnCloseBottomSheet = jest.fn();
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
   const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
     ...actual,
@@ -16,15 +21,17 @@ jest.mock('@metamask/design-system-react-native', () => {
       (
         {
           children,
+          testID,
         }: {
           children: React.ReactNode;
+          testID?: string;
         },
         ref: React.Ref<{ onCloseBottomSheet: () => void }>,
       ) => {
         ReactActual.useImperativeHandle(ref, () => ({
           onCloseBottomSheet: mockOnCloseBottomSheet,
         }));
-        return <>{children}</>;
+        return <View testID={testID}>{children}</View>;
       },
     ),
   };
@@ -42,14 +49,30 @@ function render(component: React.ComponentType) {
   );
 }
 
+describe('createRampUnsupportedModalNavigationDetails', () => {
+  it('targets root modal flow and unsupported region sheet', () => {
+    const details = createRampUnsupportedModalNavigationDetails();
+
+    expect(details[0]).toBe(Routes.MODAL.ROOT_MODAL_FLOW);
+    expect(details[1]).toEqual(
+      expect.objectContaining({
+        screen: Routes.SHEET.UNSUPPORTED_REGION_MODAL,
+      }),
+    );
+  });
+});
+
 describe('RampUnsupportedModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders modal with title and description', () => {
+  it('renders modal with title, description, and sheet testID', () => {
     render(RampUnsupportedModal);
 
+    expect(
+      screen.getByTestId(RAMP_UNSUPPORTED_MODAL_TEST_IDS.MODAL),
+    ).toBeOnTheScreen();
     expect(
       screen.getByText(
         strings('fiat_on_ramp_aggregator.unsupported_region_modal.title'),
@@ -62,9 +85,11 @@ describe('RampUnsupportedModal', () => {
     ).toBeOnTheScreen();
   });
 
-  it('closes the modal when the close button is pressed', () => {
-    const { getByTestId } = render(RampUnsupportedModal);
-    const closeButton = getByTestId('bottomsheetheader-close-button');
+  it('closes the modal when the header close button is pressed', () => {
+    render(RampUnsupportedModal);
+    const closeButton = screen.getByTestId(
+      RAMP_UNSUPPORTED_MODAL_TEST_IDS.CLOSE_BUTTON,
+    );
 
     fireEvent.press(closeButton);
 
@@ -72,8 +97,11 @@ describe('RampUnsupportedModal', () => {
   });
 
   it('closes the modal when the got it button is pressed', () => {
-    const { getByText } = render(RampUnsupportedModal);
-    const gotItButton = getByText('Got it');
+    render(RampUnsupportedModal);
+    const gotItLabel = strings(
+      'fiat_on_ramp_aggregator.unsupported_region_modal.got_it',
+    );
+    const gotItButton = screen.getByText(gotItLabel);
 
     fireEvent.press(gotItButton);
 

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.test.tsx
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.test.tsx
@@ -7,11 +7,12 @@ import { fireEvent, screen } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 const mockOnCloseBottomSheet = jest.fn();
 
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const ReactActual = jest.requireActual('react');
-    return ReactActual.forwardRef(
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
       (
         {
           children,
@@ -25,9 +26,9 @@ jest.mock(
         }));
         return <>{children}</>;
       },
-    );
-  },
-);
+    ),
+  };
+});
 
 function render(component: React.ComponentType) {
   return renderScreen(

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.tsx
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import {
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
   Box,
   Text,
   TextVariant,
@@ -8,10 +12,6 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -26,6 +26,7 @@ export const createRampUnsupportedModalNavigationDetails =
 
 function RampUnsupportedModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -34,7 +35,7 @@ function RampUnsupportedModal() {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      goBack={navigation.goBack}
       isInteractable={false}
       testID={RAMP_UNSUPPORTED_MODAL_TEST_IDS.MODAL}
     >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Continues the Ramp design-system migration after [Phase 1](https://github.com/MetaMask/metamask-mobile/pull/28048).

This PR migrates Ramp **BottomSheet** (and **BottomSheetHeader** where used) from `app/component-library` to **`@metamask/design-system-react-native`**, scoped to `Ramp/Views` and `Ramp/components` (excluding Deposit and Aggregator per the phase plan). `shouldNavigateBack` is replaced with **`goBack={navigation.goBack}`** to match the DS API. **Checkout** also switches **`useStyles`** to `app/components/hooks/useStyles`. Unit tests mock the DS package’s **BottomSheet** while keeping the rest of the design system real.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

Refs: #28048

## **Manual testing steps**

```gherkin
Feature: Ramp buy flow sheets (design system BottomSheet)

  Scenario: Open and close payment selection sheet
    Given the user is in the unified Ramp buy flow with payment methods available
    When the user opens the payment selection modal and dismisses it with the header close control
    Then the sheet closes and navigation returns as expected

  Scenario: Open Ramp settings sheet from build quote
    Given the user is on the Ramp amount / build quote screen
    When the user opens settings from the sheet entry point and closes the sheet
    Then the sheet closes without layout or gesture regressions

  Scenario: Checkout provider WebView sheet
    Given the user reaches Checkout with a valid provider URL
    When the user loads the WebView and uses the header close control
    Then the sheet dismisses and the prior screen is shown as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="Before 1" src="https://github.com/user-attachments/assets/4f391f06-2742-4c17-8cbf-3daefa298a75" />

<img width="300" alt="Before 2" src="https://github.com/user-attachments/assets/2400860e-37cf-4483-acdf-695e1a54abfb" />

<img width="300" alt="Before 3" src="https://github.com/user-attachments/assets/7c346d69-c79c-4b1e-9006-c3b92eab519d" />

### **After**

<img width="300" alt="After 1" src="https://github.com/user-attachments/assets/4933c76f-25b7-4d98-b6d0-bee98318a9be" />

<img width="300" alt="After 2" src="https://github.com/user-attachments/assets/e003b518-53a4-4866-bb4f-9f21fb6f34b7" />

<img width="300" alt="After 3" src="https://github.com/user-attachments/assets/1427fe24-050d-4699-a3c9-128e43a1d30b" />

<img width="300" alt="After 4" src="https://github.com/user-attachments/assets/15597477-b085-4102-aae8-c5c5824d47d9" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a UI refactor, but it changes bottom-sheet dismissal/back-navigation behavior across multiple Ramp modals (swapping `shouldNavigateBack` for `goBack`), which could cause unexpected navigation pops/regressions if the new API behaves differently.
> 
> **Overview**
> Migrates Ramp buy-flow sheets from the in-app `component-library` `BottomSheet`/`BottomSheetHeader` to `@metamask/design-system-react-native`, updating all affected views/modals to pass `goBack={navigation.goBack}` instead of `shouldNavigateBack`.
> 
> Updates unit tests to mock the design-system `BottomSheet` while keeping other DS components real, and tightens coverage for `RampUnsupportedModal` by asserting navigation details and the sheet/header `testID`s. `Checkout` also switches to the shared `app/components/hooks/useStyles` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7caf50836c1bb6757dbed1f9e92b8aa325f6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->