### PR TITLE
fix: prevent buy screen crash if selected pay token metadata incomplete cp-7.73.0

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -10,8 +10,8 @@ let mockUpdateTokenAmountCallback = jest.fn();
 let mockActiveTransactionMeta: { id?: string } | null = null;
 let mockSelectedPaymentToken:
   | {
-      address: string;
-      chainId: string;
+      address?: string;
+      chainId?: string;
     }
   | undefined;
 let mockPayToken:
@@ -693,6 +693,40 @@ describe('PredictPayWithAnyTokenInfo', () => {
     it('does not call setPayToken when selectedPaymentToken is undefined', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
       mockSelectedPaymentToken = undefined;
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockSetPayToken).not.toHaveBeenCalled();
+    });
+
+    it('does not call setPayToken when selectedPaymentToken address is missing', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+      mockSelectedPaymentToken = {
+        chainId: '0x1',
+      };
+
+      render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockSetPayToken).not.toHaveBeenCalled();
+    });
+
+    it('does not call setPayToken when selectedPaymentToken chainId is missing', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+      mockSelectedPaymentToken = {
+        address: '0xabc123',
+      };
 
       render(
         <PredictPayWithAnyTokenInfo

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -142,11 +142,16 @@ function PredictPayWithAnyTokenInfoInner({
       return;
     }
 
+    const selectedTokenAddress = selectedPaymentToken.address?.toLowerCase();
+    const selectedTokenChainId = selectedPaymentToken.chainId?.toLowerCase();
+
+    if (!selectedTokenAddress || !selectedTokenChainId) {
+      return;
+    }
+
     const hasSelectedTokenApplied =
-      payToken?.address?.toLowerCase() ===
-        selectedPaymentToken.address.toLowerCase() &&
-      payToken?.chainId?.toLowerCase() ===
-        selectedPaymentToken.chainId.toLowerCase();
+      payToken?.address?.toLowerCase() === selectedTokenAddress &&
+      payToken?.chainId?.toLowerCase() === selectedTokenChainId;
 
     if (!hasSelectedTokenApplied) {
       setPayToken({

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-native';
 import { usePredictDefaultPaymentToken } from './usePredictDefaultPaymentToken';
 import { ActiveOrderState } from '../../../types';
+import { TokenStandard } from '../../../../../Views/confirmations/types/token';
 
 let mockPredictBalance: number | undefined = 100;
 let mockIsBalanceLoading = false;
@@ -13,8 +14,29 @@ let mockTokens: {
   address?: string;
   chainId?: string;
   symbol: string;
+  accountType?: string;
+  standard?: TokenStandard;
   fiat?: { balance?: number };
 }[] = [];
+
+const createEvmErc20Token = ({
+  address,
+  chainId = '0x1',
+  symbol,
+  fiatBalance,
+}: {
+  address: string;
+  chainId?: string;
+  symbol: string;
+  fiatBalance?: number;
+}) => ({
+  address,
+  chainId,
+  symbol,
+  accountType: `eip155:1/erc20:${address.toLowerCase()}`,
+  standard: TokenStandard.ERC20,
+  fiat: fiatBalance != null ? { balance: fiatBalance } : undefined,
+});
 
 jest.mock('../../../hooks/usePredictBalance', () => ({
   usePredictBalance: () => ({
@@ -59,12 +81,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('resets to predict balance when balance >= MINIMUM_BET', () => {
     mockPredictBalance = 5;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -76,12 +93,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('resets to predict balance when balance equals MINIMUM_BET', () => {
     mockPredictBalance = 1;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -93,12 +105,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('does not auto-select when predict balance equals MINIMUM_BET', () => {
     mockPredictBalance = 1;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -109,13 +116,8 @@ describe('usePredictDefaultPaymentToken', () => {
   it('auto-selects token with highest fiat balance when predict balance < MINIMUM_BET', () => {
     mockPredictBalance = 0.5;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 500 },
-      },
-      { address: '0x2', chainId: '0x1', symbol: 'ETH', fiat: { balance: 200 } },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 500 }),
+      createEvmErc20Token({ address: '0x2', symbol: 'ETH', fiatBalance: 200 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -133,12 +135,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('auto-selects when predict balance is zero', () => {
     mockPredictBalance = 0;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'WETH',
-        fiat: { balance: 300 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'WETH', fiatBalance: 300 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -151,7 +148,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('auto-selects when predict balance is undefined', () => {
     mockPredictBalance = undefined;
     mockTokens = [
-      { address: '0x1', chainId: '0x1', symbol: 'USDC', fiat: { balance: 50 } },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 50 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -163,12 +160,7 @@ describe('usePredictDefaultPaymentToken', () => {
     mockIsBalanceLoading = true;
     mockPredictBalance = 0;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -180,12 +172,7 @@ describe('usePredictDefaultPaymentToken', () => {
     mockPredictBalance = 0.5;
     mockActiveOrder = { state: ActiveOrderState.DEPOSITING };
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -197,12 +184,7 @@ describe('usePredictDefaultPaymentToken', () => {
     mockPredictBalance = 0.5;
     mockActiveOrder = undefined;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -223,8 +205,8 @@ describe('usePredictDefaultPaymentToken', () => {
   it('falls back to predict balance when no tokens have positive fiat balance', () => {
     mockPredictBalance = 0.5;
     mockTokens = [
-      { address: '0x1', chainId: '0x1', symbol: 'USDC', fiat: { balance: 0 } },
-      { address: '0x2', chainId: '0x1', symbol: 'ETH' },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 0 }),
+      createEvmErc20Token({ address: '0x2', symbol: 'ETH' }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -236,13 +218,8 @@ describe('usePredictDefaultPaymentToken', () => {
   it('skips tokens with undefined fiat balance', () => {
     mockPredictBalance = 0.5;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'UNKNOWN',
-        fiat: { balance: undefined },
-      },
-      { address: '0x2', chainId: '0x1', symbol: 'USDC', fiat: { balance: 50 } },
+      createEvmErc20Token({ address: '0x1', symbol: 'UNKNOWN' }),
+      createEvmErc20Token({ address: '0x2', symbol: 'USDC', fiatBalance: 50 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -259,14 +236,11 @@ describe('usePredictDefaultPaymentToken', () => {
         address: '0x1',
         chainId: undefined,
         symbol: 'BROKEN',
+        accountType: 'eip155:1/erc20:0x1',
+        standard: TokenStandard.ERC20,
         fiat: { balance: 500 },
       },
-      {
-        address: '0x2',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 200 },
-      },
+      createEvmErc20Token({ address: '0x2', symbol: 'USDC', fiatBalance: 200 }),
     ];
 
     renderHook(() => usePredictDefaultPaymentToken());
@@ -287,6 +261,8 @@ describe('usePredictDefaultPaymentToken', () => {
         address: '0x1',
         chainId: undefined,
         symbol: 'BROKEN',
+        accountType: 'eip155:1/erc20:0x1',
+        standard: TokenStandard.ERC20,
         fiat: { balance: 500 },
       },
     ];
@@ -300,12 +276,7 @@ describe('usePredictDefaultPaymentToken', () => {
   it('runs only once across re-renders', () => {
     mockPredictBalance = 0.5;
     mockTokens = [
-      {
-        address: '0x1',
-        chainId: '0x1',
-        symbol: 'USDC',
-        fiat: { balance: 100 },
-      },
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
     ];
 
     const { rerender } = renderHook(() => usePredictDefaultPaymentToken());
@@ -313,5 +284,37 @@ describe('usePredictDefaultPaymentToken', () => {
     rerender({});
 
     expect(mockOnPaymentTokenChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips non-EVM or non-ERC20 tokens when auto-selecting', () => {
+    mockPredictBalance = 0.5;
+    mockTokens = [
+      {
+        address: '0x1',
+        chainId: 'solana:mainnet',
+        symbol: 'SOL',
+        accountType: 'solana:data-account',
+        fiat: { balance: 500 },
+      },
+      {
+        address: '0x2',
+        chainId: '0x1',
+        symbol: 'NFT',
+        accountType: 'eip155:1/erc721:0x2',
+        standard: TokenStandard.ERC721,
+        fiat: { balance: 400 },
+      },
+      createEvmErc20Token({ address: '0x3', symbol: 'USDC', fiatBalance: 200 }),
+    ];
+
+    renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x3',
+        chainId: '0x1',
+        symbol: 'USDC',
+      }),
+    );
   });
 });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
@@ -317,4 +317,32 @@ describe('usePredictDefaultPaymentToken', () => {
       }),
     );
   });
+
+  it('skips testnet tokens when auto-selecting', () => {
+    mockPredictBalance = 0.5;
+    mockTokens = [
+      createEvmErc20Token({
+        address: '0x1',
+        chainId: '0xaa36a7',
+        symbol: 'TEST',
+        fiatBalance: 500,
+      }),
+      createEvmErc20Token({
+        address: '0x2',
+        chainId: '0x1',
+        symbol: 'USDC',
+        fiatBalance: 200,
+      }),
+    ];
+
+    renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x2',
+        chainId: '0x1',
+        symbol: 'USDC',
+      }),
+    );
+  });
 });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
@@ -10,8 +10,8 @@ let mockActiveOrder: { state: ActiveOrderState } | undefined = {
   state: ActiveOrderState.PREVIEW,
 };
 let mockTokens: {
-  address: string;
-  chainId: string;
+  address?: string;
+  chainId?: string;
   symbol: string;
   fiat?: { balance?: number };
 }[] = [];
@@ -250,6 +250,51 @@ describe('usePredictDefaultPaymentToken', () => {
     expect(mockOnPaymentTokenChange).toHaveBeenCalledWith(
       expect.objectContaining({ address: '0x2', symbol: 'USDC' }),
     );
+  });
+
+  it('skips tokens without an address or chainId when auto-selecting', () => {
+    mockPredictBalance = 0.5;
+    mockTokens = [
+      {
+        address: '0x1',
+        chainId: undefined,
+        symbol: 'BROKEN',
+        fiat: { balance: 500 },
+      },
+      {
+        address: '0x2',
+        chainId: '0x1',
+        symbol: 'USDC',
+        fiat: { balance: 200 },
+      },
+    ];
+
+    renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x2',
+        chainId: '0x1',
+        symbol: 'USDC',
+      }),
+    );
+  });
+
+  it('falls back to predict balance when only invalid tokens have balance', () => {
+    mockPredictBalance = 0.5;
+    mockTokens = [
+      {
+        address: '0x1',
+        chainId: undefined,
+        symbol: 'BROKEN',
+        fiat: { balance: 500 },
+      },
+    ];
+
+    renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).not.toHaveBeenCalled();
+    expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
   });
 
   it('runs only once across re-renders', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
@@ -38,6 +38,7 @@ export function usePredictDefaultPaymentToken() {
 
     const bestToken = tokens.find(
       (token) =>
+        Boolean(token.address && token.chainId) &&
         token.fiat?.balance != null &&
         new BigNumber(token.fiat.balance).isGreaterThan(0),
     );

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
@@ -7,6 +7,7 @@ import { useAccountTokens } from '../../../../../Views/confirmations/hooks/send/
 import { TokenStandard } from '../../../../../Views/confirmations/types/token';
 import { MINIMUM_BET } from '../../../constants/transactions';
 import { ActiveOrderState } from '../../../types';
+import { isTestNet } from '../../../../../../util/networks';
 
 /**
  * Initializes the payment token selection on the buy screen. Waits for
@@ -41,7 +42,9 @@ export function usePredictDefaultPaymentToken() {
       (token) =>
         token.accountType?.includes('eip155') &&
         token.standard === TokenStandard.ERC20 &&
-        Boolean(token.address && token.chainId) &&
+        token.address &&
+        token.chainId &&
+        !isTestNet(token.chainId) &&
         token.fiat?.balance != null &&
         new BigNumber(token.fiat.balance).isGreaterThan(0),
     );

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
@@ -4,6 +4,7 @@ import { usePredictBalance } from '../../../hooks/usePredictBalance';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { usePredictActiveOrder } from '../../../hooks/usePredictActiveOrder';
 import { useAccountTokens } from '../../../../../Views/confirmations/hooks/send/useAccountTokens';
+import { TokenStandard } from '../../../../../Views/confirmations/types/token';
 import { MINIMUM_BET } from '../../../constants/transactions';
 import { ActiveOrderState } from '../../../types';
 
@@ -38,6 +39,8 @@ export function usePredictDefaultPaymentToken() {
 
     const bestToken = tokens.find(
       (token) =>
+        token.accountType?.includes('eip155') &&
+        token.standard === TokenStandard.ERC20 &&
         Boolean(token.address && token.chainId) &&
         token.fiat?.balance != null &&
         new BigNumber(token.fiat.balance).isGreaterThan(0),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes a Predict buy flow crash reported when a user opens the bet screen and the screen crashes a moment later with a `toLowerCase()` on `undefined` error.

The root cause was the pay-token sync effect on `PredictBuyWithAnyToken` assuming the selected payment token always had both `address` and `chainId`. In the affected flow, the screen initializes `pay with any token`, auto-selects a token after the screen transition, and can briefly receive incomplete token metadata. This PR hardens that effect to ignore incomplete payment tokens and updates the default token auto-selection to only choose tokens with both `address` and `chainId`. Regression tests were added for both cases.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-819](https://consensyssoftware.atlassian.net/browse/PRED-819?atlOrigin=eyJpIjoiNGFkNTkyY2QxYmVkNDQ1OWI0MGVhNDhmMmFhNzVhNTYiLCJwIjoiaiJ9)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-819]: https://consensyssoftware.atlassian.net/browse/PRED-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment-token auto-selection and synchronization logic in the Predict buy flow; incorrect filtering or guarding could prevent a valid token from being selected or applied, impacting purchases.
> 
> **Overview**
> Prevents a Predict buy-screen crash by hardening the pay-token sync effect in `PredictPayWithAnyTokenInfo` to **ignore `selectedPaymentToken` values missing `address` or `chainId`** before calling `toLowerCase()`/`setPayToken`.
> 
> Tightens `usePredictDefaultPaymentToken` auto-selection to only consider **valid mainnet EVM ERC-20 tokens** (requires `accountType` with `eip155`, `standard: ERC20`, non-testnet `chainId`, and present `address`/`chainId`), otherwise falling back to Predict balance. Adds regression tests covering missing metadata, invalid tokens, non-EVM/non-ERC20 tokens, and testnet skipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045a105017fd5cb25796df29666916c468cb986f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->