### PR TITLE
fix: tempo useHasInsufficientBalance return false non-7702

### DIFF
--- a/app/components/Views/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/app/components/Views/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -124,4 +124,58 @@ describe('useHasInsufficientBalance', () => {
     const { result } = renderHook(() => useHasInsufficientBalance());
     expect(result.current.nativeCurrency).toBe('ETH');
   });
+
+  it('returns insufficient = true for Tempo if `excludeNativeTokenForFee` is true', () => {
+    mockUseAccountNativeBalance.mockReturnValue({
+      balanceWeiInHex: '0xC',
+    } as unknown as ReturnType<typeof useAccountNativeBalance>);
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      ...baseTx,
+      chainId: '0x1079',
+      excludeNativeTokenForFee: true,
+    } as unknown as TransactionMeta);
+    const { result } = renderHook(() => useHasInsufficientBalance());
+    expect(result.current.hasInsufficientBalance).toBe(true);
+    expect(result.current.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('returns insufficient = false for Tempo if `excludeNativeTokenForFee` is unset', () => {
+    mockUseAccountNativeBalance.mockReturnValue({
+      balanceWeiInHex: '0xC',
+    } as unknown as ReturnType<typeof useAccountNativeBalance>);
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      ...baseTx,
+      chainId: '0x1079',
+    } as unknown as TransactionMeta);
+    const { result } = renderHook(() => useHasInsufficientBalance());
+    expect(result.current.hasInsufficientBalance).toBe(false);
+    expect(result.current.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('returns insufficient = true for Tempo Testnet if `excludeNativeTokenForFee` is true', () => {
+    mockUseAccountNativeBalance.mockReturnValue({
+      balanceWeiInHex: '0xC',
+    } as unknown as ReturnType<typeof useAccountNativeBalance>);
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      ...baseTx,
+      chainId: '0xa5bf',
+      excludeNativeTokenForFee: true,
+    } as unknown as TransactionMeta);
+    const { result } = renderHook(() => useHasInsufficientBalance());
+    expect(result.current.hasInsufficientBalance).toBe(true);
+    expect(result.current.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('returns insufficient = false for Tempo Testnet if `excludeNativeTokenForFee` is unset', () => {
+    mockUseAccountNativeBalance.mockReturnValue({
+      balanceWeiInHex: '0xC',
+    } as unknown as ReturnType<typeof useAccountNativeBalance>);
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      ...baseTx,
+      chainId: '0xa5bf',
+    } as unknown as TransactionMeta);
+    const { result } = renderHook(() => useHasInsufficientBalance());
+    expect(result.current.hasInsufficientBalance).toBe(false);
+    expect(result.current.nativeCurrency).toBe('pathUSD');
+  });
 });

--- a/app/components/Views/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/app/components/Views/confirmations/hooks/useHasInsufficientBalance.ts
@@ -11,6 +11,8 @@ import { useNativeCurrencySymbol } from './useNativeCurrencySymbol';
 
 const HEX_ZERO = '0x0';
 
+const NO_NATIVE_ASSET_CHAIN_IDS = new Set(['0x1079', '0xa5bf']);
+
 export function useHasInsufficientBalance(): {
   hasInsufficientBalance: boolean;
   nativeCurrency?: string;
@@ -21,7 +23,8 @@ export function useHasInsufficientBalance(): {
     transactionMetadata?.txParams?.from as string,
   );
 
-  const { txParams } = transactionMetadata ?? {};
+  const { txParams, chainId, excludeNativeTokenForFee } =
+    transactionMetadata ?? {};
   const { maxFeePerGas, gas, gasPrice } = txParams || {};
   const { nativeCurrencySymbol: nativeCurrency } = useNativeCurrencySymbol(
     transactionMetadata?.chainId,
@@ -38,7 +41,16 @@ export function useHasInsufficientBalance(): {
   const balanceWeiInHexBN = new BigNumber(balanceWeiInHex ?? '0x0');
   const totalTransactionValueBN = new BigNumber(totalTransactionInHex ?? '0x0');
 
-  const hasInsufficientBalance = balanceWeiInHexBN.lt(totalTransactionValueBN);
+  const hasNoNativeAsset = chainId && NO_NATIVE_ASSET_CHAIN_IDS.has(chainId);
+  /**
+   * Tempo (7702) special case: Force "enough native balance" in legacy flow
+   * (when `excludeNativeTokenForFee` is false) to restore old MetaMask behavior.
+   * New MM reports "0" balance, breaking legacy flow. Temporary fix until HW
+   * supports gasless/7702.
+   */
+  const hasInsufficientBalance = hasNoNativeAsset
+    ? Boolean(excludeNativeTokenForFee)
+    : balanceWeiInHexBN.lt(totalTransactionValueBN);
 
   return { hasInsufficientBalance, nativeCurrency };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When signing a tx on Tempo:
- Before the recent Tempo changes, MetaMask assumed that the native token supply was unlimited (RPC returning a balance of ``424242424242...`, which resulted in a degraded - but working in the right conditions - transaction UX.
- Now that we’ve defined “no native token for Tempo,” native balance is always seen as `0`, since we using a 7702 gasless flow, this has only positive impact on UX.
- However, since Hardware Wallets aren't supported in our gasless flow, we make those fallback to "normal transactions", which is a problem because MetaMask now sees the native balance as always `0` throwing an error.

The issue is that some hardware wallet users may have already interacted with Tempo before the recent changes. On the current Extension release, those users may not be able to transact on Tempo anymore, making it a regression.

This PR introduces a quick fix, strictly scoped to Hardware Wallets on Tempo chains so it doesn't affect other flows. It modifies `useHasInsufficientBalance` hook to override balance checks on Tempo, and instead do:
- If gasless/7702 flow, assume no native balance.
- If "normal flow" (forced when using a Hardware Wallet), assume unlimited balance (retro-compatibility with how it was before).


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: useHasInsufficientBalance to skip native balance checks on Tempo

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```
Use Tempo on Mobile, using an Hardware Wallet.
Transactions should be optimistic, showing an estimate of `pathUSD` gas fees, regardless of user `pathUSD` balance.
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the insufficient-balance gating logic used to block transactions; although scoped to Tempo chain IDs, a mistake could incorrectly allow/deny sends on those networks or affect related confirmation alerts.
> 
> **Overview**
> Adjusts `useHasInsufficientBalance` to special-case Tempo mainnet/testnet (`0x1079`, `0xa5bf`) so native-balance insufficiency is driven solely by `excludeNativeTokenForFee` (treating legacy/non-gasless flows as having sufficient native balance).
> 
> Adds unit coverage for the new Tempo behavior, and bumps mobile build numbers to `4519` across Android (`versionCode`), iOS (`CURRENT_PROJECT_VERSION`), and Bitrise (`VERSION_NUMBER`/`FLASK_VERSION_NUMBER`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9eecabcbc2fa321eb7964b88a91b2925f3f6751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->