### PR TITLE
test: update logs and add unit test

### DIFF
--- a/tests/controller-mocking/mock-config/perps-controller-mixin.test.ts
+++ b/tests/controller-mocking/mock-config/perps-controller-mixin.test.ts
@@ -1,0 +1,80 @@
+import { createE2EMockStreamManager } from './perps-controller-mixin';
+
+/**
+ * Contract tests for the E2E Perps stream manager stub.
+ *
+ * Production `PerpsStreamManager` channels expose sync `getSnapshot()` for cold-start reads.
+ * Hooks such as `usePerpsMarkets`, `usePerpsLivePositions`, and `usePerpsLiveAccount` call
+ * these on render. If the E2E mock omits them, the app throws `TypeError: undefined is not a function`
+ * after login (see PR #27898).
+ */
+
+/** Root keys on `PerpsStreamManager` that the E2E plain-object mock must provide. */
+const EXPECTED_E2E_STREAM_ROOT_KEYS = [
+  'account',
+  'candles',
+  'fills',
+  'marketData',
+  'oiCaps',
+  'orders',
+  'positions',
+  'prices',
+  'topOfBook',
+] as const;
+
+/**
+ * Channels that must implement synchronous `getSnapshot()` like `StreamChannel` in production.
+ * Keep aligned with hooks that read `streamManager.<channel>.getSnapshot()` on mount.
+ */
+const CHANNELS_REQUIRING_GET_SNAPSHOT = [
+  'prices',
+  'marketData',
+  'account',
+  'orders',
+  'positions',
+] as const;
+
+describe('createE2EMockStreamManager', () => {
+  const mockConsoleLog = jest
+    .spyOn(console, 'log')
+    .mockImplementation(() => undefined);
+
+  afterAll(() => {
+    mockConsoleLog.mockRestore();
+  });
+
+  it('returns an object whose top-level keys match the real PerpsStreamManager channel surface', () => {
+    const manager = createE2EMockStreamManager() as Record<string, unknown>;
+
+    const keys = Object.keys(manager).sort((a, b) => a.localeCompare(b));
+    const expected = [...EXPECTED_E2E_STREAM_ROOT_KEYS].sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    expect(keys).toEqual(expected);
+  });
+
+  it.each(CHANNELS_REQUIRING_GET_SNAPSHOT)(
+    'channel %s exposes synchronous getSnapshot callable without throwing',
+    (channel) => {
+      const manager = createE2EMockStreamManager() as Record<
+        string,
+        { getSnapshot?: unknown }
+      >;
+
+      const snap = manager[channel]?.getSnapshot;
+
+      expect(typeof snap).toBe('function');
+
+      expect(() => (snap as () => unknown)()).not.toThrow();
+    },
+  );
+
+  it('exposes marketData.refresh like production MarketDataChannel', () => {
+    const manager = createE2EMockStreamManager() as {
+      marketData: { refresh?: unknown };
+    };
+
+    expect(typeof manager.marketData.refresh).toBe('function');
+  });
+});

--- a/tests/controller-mocking/mock-config/perps-controller-mixin.ts
+++ b/tests/controller-mocking/mock-config/perps-controller-mixin.ts
@@ -75,13 +75,17 @@ export class E2EControllerOverrides {
     // Update Redux state to reflect the new position/balance
     const mockAccount = this.mockService.getMockAccountState();
 
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.accountState = mockAccount;
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.accountState = mockAccount;
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error('E2E Mock: placeOrder — controller.update() failed:', e);
+    }
 
     return result;
   }
@@ -161,18 +165,29 @@ export class E2EControllerOverrides {
             maybeAddResult?.id ??
             fallbackTxId;
         }
-      } catch {
+      } catch (e) {
+        console.warn(
+          'E2E Mock: mockPerpsDepositTransaction messenger call failed, using fallback txId:',
+          e,
+        );
         resolvedTxId = fallbackTxId;
       }
     }
 
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.lastDepositTransactionId = resolvedTxId;
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.lastDepositTransactionId = resolvedTxId;
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error(
+        'E2E Mock: mockPerpsDepositTransaction — controller.update() failed:',
+        e,
+      );
+    }
 
     return { result: Promise.resolve(resolvedTxId) };
   }
@@ -237,13 +252,20 @@ export class E2EControllerOverrides {
     const mockAccount = this.mockService.getMockAccountState();
 
     // Update Redux state just like the real controller does
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.accountState = mockAccount;
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.accountState = mockAccount;
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error(
+        'E2E Mock: getAccountState — controller.update() failed:',
+        e,
+      );
+    }
 
     return mockAccount;
   }
@@ -274,12 +296,16 @@ export class E2EControllerOverrides {
     const mockPositions = this.mockService.getMockPositions();
 
     // Update Redux state
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error('E2E Mock: getPositions — controller.update() failed:', e);
+    }
 
     return mockPositions;
   }
@@ -300,13 +326,17 @@ export class E2EControllerOverrides {
     // Update Redux state to reflect the position closure
     const mockAccount = this.mockService.getMockAccountState();
 
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.accountState = mockAccount;
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.accountState = mockAccount;
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error('E2E Mock: closePosition — controller.update() failed:', e);
+    }
 
     return result;
   }
@@ -326,12 +356,19 @@ export class E2EControllerOverrides {
   ): Promise<OrderResult> {
     const result = this.mockService.mockUpdatePositionTPSL(params);
     // Refresh Redux timestamp after TP/SL changes
-    (this.controller as ControllerWithUpdate).update(
-      (state: PerpsControllerState) => {
-        state.lastUpdateTimestamp = Date.now();
-        state.lastError = null;
-      },
-    );
+    try {
+      (this.controller as ControllerWithUpdate).update(
+        (state: PerpsControllerState) => {
+          state.lastUpdateTimestamp = Date.now();
+          state.lastError = null;
+        },
+      );
+    } catch (e) {
+      console.error(
+        'E2E Mock: updatePositionTPSL — controller.update() failed:',
+        e,
+      );
+    }
     return result;
   }
 
@@ -432,18 +469,29 @@ export function applyE2EPerpsControllerMocks(controller: unknown): void {
   ];
 
   methodsToOverride.forEach((method) => {
-    const controllerRecord = controller as unknown as Record<string, unknown>;
-    const overridesRecord = overrides as unknown as Record<string, unknown>;
-    if (overridesRecord[method]) {
-      // Store original if it exists
-      if (controllerRecord[method]) {
-        controllerRecord[`_original_${method}`] = controllerRecord[method];
+    try {
+      const controllerRecord = controller as unknown as Record<string, unknown>;
+      const overridesRecord = overrides as unknown as Record<string, unknown>;
+      if (overridesRecord[method]) {
+        // Store original if it exists
+        if (controllerRecord[method]) {
+          controllerRecord[`_original_${method}`] = controllerRecord[method];
+        }
+        // Apply mock override (also adds method if it didn't exist)
+        controllerRecord[method] = (
+          overridesRecord[method] as (...args: unknown[]) => unknown
+        ).bind(overrides);
+        console.log(`Mocked ${method} method`);
+      } else {
+        console.warn(
+          `E2E Mock: Override for '${method}' not found in E2EControllerOverrides — skipping`,
+        );
       }
-      // Apply mock override (also adds method if it didn't exist)
-      controllerRecord[method] = (
-        overridesRecord[method] as (...args: unknown[]) => unknown
-      ).bind(overrides);
-      console.log(`Mocked ${method} method`);
+    } catch (e) {
+      console.error(
+        `E2E Mock: Failed to override '${method}' on PerpsController:`,
+        e,
+      );
     }
   });
 
@@ -508,7 +556,10 @@ export function applyE2EPerpsControllerMocks(controller: unknown): void {
       mockService.reset();
     }
   } catch (e) {
-    // no-op if structure differs
+    console.warn(
+      'E2E Mock: Failed to read mockProfile from controller state — using default profile:',
+      e,
+    );
   }
   const mockAccount = mockService.getMockAccountState();
   const mockPositions = mockService.getMockPositions();
@@ -519,22 +570,33 @@ export function applyE2EPerpsControllerMocks(controller: unknown): void {
     positionsCount: mockPositions.length,
   });
 
-  (controller as ControllerWithUpdate).update((state: PerpsControllerState) => {
-    state.accountState = mockAccount;
-    state.lastUpdateTimestamp = Date.now();
-    state.lastError = null;
-    state.isEligible = true;
-  });
+  try {
+    (controller as ControllerWithUpdate).update(
+      (state: PerpsControllerState) => {
+        state.accountState = mockAccount;
+        state.lastUpdateTimestamp = Date.now();
+        state.lastError = null;
+        state.isEligible = true;
+      },
+    );
+  } catch (e) {
+    console.error(
+      'E2E Mock: applyE2EPerpsControllerMocks — initial controller.update() failed. ' +
+        'This may cause the app to crash or display stale state:',
+      e,
+    );
+  }
 
   console.log('✅ E2E PerpsController mocks applied with initial state');
 }
 
 /**
- * Create E2E mock stream manager for PerpsStreamProvider
+ * Plain channel map before Proxy wrapping (used for contract checks and stream mock shape).
  */
-export function createE2EMockStreamManager(): unknown {
-  console.log('Creating E2E mock stream manager');
-
+export function buildE2EMockStreamManagerPlain(): Record<
+  string,
+  Record<string, unknown>
+> {
   // Use centralized E2E mock service for consistent state
   const mockService = PerpsE2EMockService.getInstance();
   const mockMarkets = mockService.getMockMarkets();
@@ -626,6 +688,13 @@ export function createE2EMockStreamManager(): unknown {
         setTimeout(() => params.callback(mockService.getMockPositions()), 0);
         return () => mockService.unregisterPositionCallback(params.callback);
       },
+      updatePositionTPSLOptimistic: (
+        _coin: string,
+        _takeProfitPrice: string | undefined,
+        _stopLossPrice: string | undefined,
+      ): void => {
+        // No-op: E2E mock has no WebSocket position cache like production.
+      },
     },
     fills: {
       subscribe: (params: { callback: (data: OrderFill[]) => void }) => {
@@ -661,8 +730,57 @@ export function createE2EMockStreamManager(): unknown {
         setTimeout(() => params.callback({ candles: [] }), 0);
         return () => undefined;
       },
+      fetchHistoricalCandles: async (
+        _symbol: string,
+        _interval: unknown,
+        _duration: unknown,
+      ): Promise<void> => {
+        await Promise.resolve();
+      },
     },
   };
+}
+
+/**
+ * Create E2E mock stream manager for PerpsStreamProvider
+ */
+export function createE2EMockStreamManager(): unknown {
+  console.log('Creating E2E mock stream manager');
+
+  const streamManager = buildE2EMockStreamManagerPlain();
+
+  // Wrap each channel in a Proxy so any missing property access is logged
+  // immediately — no static list to maintain, catches anything production
+  // hooks call regardless of when new methods are added.
+  const wrapChannel = (
+    channel: Record<string, unknown>,
+    channelName: string,
+  ): Record<string, unknown> =>
+    new Proxy(channel, {
+      get(target, prop: string | symbol) {
+        const value = Reflect.get(target, prop);
+        if (typeof prop === 'string' && value === undefined) {
+          console.error(
+            `E2E Mock: createE2EMockStreamManager — '${channelName}.${prop}' is missing. ` +
+              'This will crash when production hooks call it.',
+          );
+        }
+        return value;
+      },
+    });
+
+  const managerRecord = streamManager as Record<
+    string,
+    Record<string, unknown>
+  >;
+  for (const channelName of Object.keys(managerRecord)) {
+    managerRecord[channelName] = wrapChannel(
+      managerRecord[channelName],
+      channelName,
+    );
+  }
+
+  return streamManager;
 }
 
 export default {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Reason:** Perps E2E runs were hard to debug when mocks failed silently or when the app crashed with `TypeError: undefined is not a function` during early render (for example after rehydration), because there was little context in logs and the stream mock could lag behind production channel APIs.
**Solution:**
- Wrap `PerpsController`-related `update()` calls and mock wiring in **try/catch** and emit **`console.error` / `console.warn`** with a clear prefix (`E2E Mock: …`) so failures show up in Detox / device logs.
- Log messenger failures in **`mockPerpsDepositTransaction`** instead of swallowing them.
- Warn when **`mockProfile`** cannot be read from fixture state.
- Split the stream mock into **`buildE2EMockStreamManagerPlain()`** (plain channel map) and **`createE2EMockStreamManager()`**, which wraps each channel in a **Proxy** that **`console.error`s** when a **string** property is accessed but **undefined** (helps pinpoint the next missing API without guessing).
- Add **no-op** stubs for **`positions.updatePositionTPSLOptimistic`** and **`candles.fetchHistoricalCandles`** so hooks that call them in production do not invoke `undefined` in E2E.
- Add **Jest contract tests** (`perps-controller-mixin.test.ts`) that assert top-level stream channels, synchronous **`getSnapshot`** where required, and **`marketData.refresh`**.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
