### PR TITLE
feat(predict): add PredictSportOutcomeCard and inline layout for PredictBetButton

### DIFF
--- a/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictActionButtons.types.ts
@@ -7,6 +7,8 @@ import { ButtonBaseSize } from '@metamask/design-system-react-native';
 
 export type PredictBetButtonVariant = 'yes' | 'no' | 'draw';
 
+export type PredictBetButtonLayout = 'inline' | 'stacked';
+
 export interface PredictBetButtonProps {
   label: string;
   price: number;
@@ -16,6 +18,7 @@ export interface PredictBetButtonProps {
   disabled?: boolean;
   testID?: string;
   size?: ButtonBaseSize;
+  layout?: PredictBetButtonLayout;
 }
 
 export interface PredictBetButtonsProps {

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.test.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.test.tsx
@@ -148,6 +148,42 @@ describe('PredictBetButton', () => {
     });
   });
 
+  describe('inline layout', () => {
+    it('renders label and price on a single line with dot separator', () => {
+      const props = createDefaultProps({
+        label: 'SEA',
+        price: 70,
+        layout: 'inline',
+      });
+
+      renderWithProvider(<PredictBetButton {...props} />);
+
+      expect(screen.getByText('SEA · 70¢')).toBeOnTheScreen();
+    });
+
+    it('renders inline with draw variant', () => {
+      const props = createDefaultProps({
+        label: 'Draw',
+        price: 20,
+        variant: 'draw',
+        layout: 'inline',
+      });
+
+      renderWithProvider(<PredictBetButton {...props} />);
+
+      expect(screen.getByText('DRAW · 20¢')).toBeOnTheScreen();
+    });
+
+    it('defaults to stacked layout when layout prop is omitted', () => {
+      const props = createDefaultProps({ label: 'Yes', price: 65 });
+
+      renderWithProvider(<PredictBetButton {...props} />);
+
+      expect(screen.getByText('YES')).toBeOnTheScreen();
+      expect(screen.getByText('65¢')).toBeOnTheScreen();
+    });
+  });
+
   describe('edge cases', () => {
     it('renders with zero price', () => {
       const props = createDefaultProps({ price: 0 });

--- a/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
+++ b/app/components/UI/Predict/components/PredictActionButtons/PredictBetButton.tsx
@@ -13,6 +13,7 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
   disabled = false,
   testID,
   size,
+  layout = 'stacked',
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
@@ -39,6 +40,8 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
     return variant === 'yes' ? 'text-success-default' : 'text-error-default';
   };
 
+  const textStyle = tw.style('font-medium text-center', getTextColor());
+
   return (
     <Button
       onPress={onPress}
@@ -48,15 +51,18 @@ const PredictBetButton: React.FC<PredictBetButtonProps> = ({
       isFullWidth
       size={size}
     >
-      <Text
-        style={tw.style('font-medium text-center', getTextColor())}
-        numberOfLines={1}
-      >
-        {label.toUpperCase()}
-      </Text>
-      <Text style={tw.style('font-medium text-center', getTextColor())}>
-        {price}¢
-      </Text>
+      {layout === 'inline' ? (
+        <Text style={textStyle} numberOfLines={1}>
+          {label.toUpperCase()} · {price}¢
+        </Text>
+      ) : (
+        <>
+          <Text style={textStyle} numberOfLines={1}>
+            {label.toUpperCase()}
+          </Text>
+          <Text style={textStyle}>{price}¢</Text>
+        </>
+      )}
     </Button>
   );
 };

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import PredictSportOutcomeCard, {
+  type PredictSportOutcomeButton,
+} from './PredictSportOutcomeCard';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
+import { PREDICT_SPORT_OUTCOME_CARD_TEST_IDS } from './PredictSportOutcomeCard.testIds';
+
+const createButtons = (
+  overrides: Partial<PredictSportOutcomeButton>[] = [],
+): PredictSportOutcomeButton[] => {
+  const defaults: PredictSportOutcomeButton[] = [
+    {
+      label: 'SEA',
+      price: 70,
+      onPress: jest.fn(),
+      variant: 'yes',
+      teamColor: TEST_HEX_COLORS.TEAM_SEA,
+    },
+    {
+      label: 'DEN',
+      price: 30,
+      onPress: jest.fn(),
+      variant: 'no',
+      teamColor: TEST_HEX_COLORS.TEAM_DEN,
+    },
+  ];
+
+  return defaults.map((btn, i) => ({ ...btn, ...overrides[i] }));
+};
+
+const createDefaultProps = (overrides = {}) => ({
+  title: 'Moneyline',
+  subtitle: '$845.21k Vol',
+  buttons: createButtons(),
+  ...overrides,
+});
+
+describe('PredictSportOutcomeCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders title and subtitle', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE),
+      ).toHaveTextContent('Moneyline');
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.SUBTITLE),
+      ).toHaveTextContent('$845.21k Vol');
+    });
+
+    it('renders without subtitle when not provided', () => {
+      const props = createDefaultProps({ subtitle: undefined });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.SUBTITLE),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders two buttons with inline layout', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(screen.getByText('SEA · 70¢')).toBeOnTheScreen();
+      expect(screen.getByText('DEN · 30¢')).toBeOnTheScreen();
+    });
+
+    it('renders three buttons for draw-capable markets', () => {
+      const buttons: PredictSportOutcomeButton[] = [
+        {
+          label: 'LIV',
+          price: 45,
+          onPress: jest.fn(),
+          variant: 'yes',
+          teamColor: TEST_HEX_COLORS.PURE_RED,
+        },
+        {
+          label: 'Draw',
+          price: 25,
+          onPress: jest.fn(),
+          variant: 'draw',
+        },
+        {
+          label: 'ARS',
+          price: 30,
+          onPress: jest.fn(),
+          variant: 'no',
+          teamColor: TEST_HEX_COLORS.PURE_BLUE,
+        },
+      ];
+      const props = createDefaultProps({ buttons });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(screen.getByText('LIV · 45¢')).toBeOnTheScreen();
+      expect(screen.getByText('DRAW · 25¢')).toBeOnTheScreen();
+      expect(screen.getByText('ARS · 30¢')).toBeOnTheScreen();
+    });
+
+    it('renders with custom testID', () => {
+      const props = createDefaultProps({ testID: 'custom-card' });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(screen.getByTestId('custom-card')).toBeOnTheScreen();
+    });
+
+    it('assigns indexed testIDs to each button', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-0`,
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-1`,
+        ),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('press handling', () => {
+    it('calls button onPress when pressed', () => {
+      const buttons = createButtons();
+      const props = createDefaultProps({ buttons });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+      fireEvent.press(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-0`,
+        ),
+      );
+
+      expect(buttons[0].onPress).toHaveBeenCalledTimes(1);
+      expect(buttons[1].onPress).not.toHaveBeenCalled();
+    });
+
+    it('calls second button onPress when pressed', () => {
+      const buttons = createButtons();
+      const props = createDefaultProps({ buttons });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+      fireEvent.press(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-1`,
+        ),
+      );
+
+      expect(buttons[1].onPress).toHaveBeenCalledTimes(1);
+      expect(buttons[0].onPress).not.toHaveBeenCalled();
+    });
+
+    it('calls draw button onPress in three-way market', () => {
+      const drawOnPress = jest.fn();
+      const buttons: PredictSportOutcomeButton[] = [
+        { label: 'Home', price: 40, onPress: jest.fn(), variant: 'yes' },
+        { label: 'Draw', price: 30, onPress: drawOnPress, variant: 'draw' },
+        { label: 'Away', price: 30, onPress: jest.fn(), variant: 'no' },
+      ];
+      const props = createDefaultProps({ buttons });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+      fireEvent.press(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-1`,
+        ),
+      );
+
+      expect(drawOnPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call handlers when disabled', () => {
+      const buttons = createButtons();
+      const props = createDefaultProps({ buttons, disabled: true });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+      fireEvent.press(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-0`,
+        ),
+      );
+      fireEvent.press(
+        screen.getByTestId(
+          `${PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER}-button-1`,
+        ),
+      );
+
+      expect(buttons[0].onPress).not.toHaveBeenCalled();
+      expect(buttons[1].onPress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('market type variants', () => {
+    it('renders BTTS card with neutral Yes/No buttons', () => {
+      const buttons: PredictSportOutcomeButton[] = [
+        { label: 'Yes', price: 55, onPress: jest.fn(), variant: 'yes' },
+        { label: 'No', price: 45, onPress: jest.fn(), variant: 'no' },
+      ];
+      const props = createDefaultProps({
+        title: 'Both Teams to Score',
+        subtitle: '$120.5k Vol',
+        buttons,
+      });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE),
+      ).toHaveTextContent('Both Teams to Score');
+      expect(screen.getByText('YES · 55¢')).toBeOnTheScreen();
+      expect(screen.getByText('NO · 45¢')).toBeOnTheScreen();
+    });
+
+    it('renders player prop card with Over/Under buttons', () => {
+      const buttons: PredictSportOutcomeButton[] = [
+        { label: 'Over', price: 48, onPress: jest.fn(), variant: 'yes' },
+        { label: 'Under', price: 52, onPress: jest.fn(), variant: 'no' },
+      ];
+      const props = createDefaultProps({
+        title: 'LeBron James',
+        subtitle: '$50.3k Vol',
+        buttons,
+      });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE),
+      ).toHaveTextContent('LeBron James');
+      expect(screen.getByText('OVER · 48¢')).toBeOnTheScreen();
+      expect(screen.getByText('UNDER · 52¢')).toBeOnTheScreen();
+    });
+
+    it('renders halftime result with three-way neutral buttons', () => {
+      const buttons: PredictSportOutcomeButton[] = [
+        { label: 'Home', price: 40, onPress: jest.fn(), variant: 'yes' },
+        { label: 'Draw', price: 35, onPress: jest.fn(), variant: 'draw' },
+        { label: 'Away', price: 25, onPress: jest.fn(), variant: 'no' },
+      ];
+      const props = createDefaultProps({
+        title: 'Halftime Result',
+        subtitle: '$30k Vol',
+        buttons,
+      });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(screen.getByText('HOME · 40¢')).toBeOnTheScreen();
+      expect(screen.getByText('DRAW · 35¢')).toBeOnTheScreen();
+      expect(screen.getByText('AWAY · 25¢')).toBeOnTheScreen();
+    });
+  });
+});

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.testIds.ts
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.testIds.ts
@@ -1,0 +1,6 @@
+export const PREDICT_SPORT_OUTCOME_CARD_TEST_IDS = {
+  CONTAINER: 'predict-sport-outcome-card',
+  TITLE: 'predict-sport-outcome-card-title',
+  SUBTITLE: 'predict-sport-outcome-card-subtitle',
+  BUTTONS: 'predict-sport-outcome-card-buttons',
+} as const;

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  Text,
+  TextColor,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import PredictBetButton from '../PredictActionButtons/PredictBetButton';
+import type { PredictBetButtonVariant } from '../PredictActionButtons/PredictActionButtons.types';
+import { PREDICT_SPORT_OUTCOME_CARD_TEST_IDS } from './PredictSportOutcomeCard.testIds';
+
+export interface PredictSportOutcomeButton {
+  label: string;
+  price: number;
+  onPress: () => void;
+  variant: PredictBetButtonVariant;
+  teamColor?: string;
+}
+
+interface PredictSportOutcomeCardProps {
+  title: string;
+  subtitle?: string;
+  buttons: PredictSportOutcomeButton[];
+  disabled?: boolean;
+  testID?: string;
+}
+
+const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
+  title,
+  subtitle,
+  buttons,
+  disabled = false,
+  testID = PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER,
+}) => (
+  <Box testID={testID} twClassName="w-full bg-muted rounded-2xl p-4 mb-4">
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="justify-between mb-3"
+    >
+      <Box twClassName="flex-1">
+        <Text
+          testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE}
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text
+            testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.SUBTITLE}
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+          >
+            {subtitle}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+
+    <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-3">
+      {buttons.map((button, index) => (
+        <Box key={`${button.label}-${button.variant}`} twClassName="flex-1">
+          <PredictBetButton
+            label={button.label}
+            price={button.price}
+            onPress={button.onPress}
+            variant={button.variant}
+            teamColor={button.teamColor}
+            disabled={disabled}
+            layout="inline"
+            testID={`${testID}-button-${index}`}
+          />
+        </Box>
+      ))}
+    </Box>
+  </Box>
+);
+
+export default PredictSportOutcomeCard;

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/index.ts
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/index.ts
@@ -1,0 +1,3 @@
+export { default } from './PredictSportOutcomeCard';
+export type { PredictSportOutcomeButton } from './PredictSportOutcomeCard';
+export { PREDICT_SPORT_OUTCOME_CARD_TEST_IDS } from './PredictSportOutcomeCard.testIds';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The sports game detail Outcomes tab needs outcome cards for moneyline, BTTS, player props, goalscorers, and other market types (Phases 6a/6d). The existing `PredictMarketOutcome` component is built for regular markets (politics, crypto) with hardcoded image + percentage + legacy `StyleSheet.create()` buttons — it cannot be cleanly extended for the sport card design which requires team-colored buttons, optional draw support, and an inline `LABEL · PRICE¢` button format.

### What changed

- **`PredictBetButton`** — Added a `layout` prop (`'inline' | 'stacked'`, default `'stacked'`). When `inline`, renders `LABEL · PRICE¢` on a single line with a `·` separator. Existing consumers are unaffected (stacked remains the default).

- **`PredictSportOutcomeCard`** (new) — A dumb presentational card component that renders a title, optional subtitle, and an array of `PredictSportOutcomeButton` configs as `PredictBetButton` instances in inline layout. Supports 2-way (NBA home/away), 3-way (soccer home/draw/away), and any arbitrary button count. The card owns no data fetching or market logic — the caller computes all props.

- **`PredictBetButtonLayout` type** — Added to `PredictActionButtons.types.ts` for the new layout discriminant.

No integration into the Outcomes tab yet — the card is built and tested in isolation. Wiring into `OutcomesContent` with live prices and buy flow is Phase 7.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-806
Fixes: https://consensyssoftware.atlassian.net/browse/PRED-809

## **Manual testing steps**

```gherkin
Feature: PredictSportOutcomeCard renders sport outcome markets

  Scenario: moneyline card renders two team-colored buttons (NBA)
    Given a PredictSportOutcomeCard with title "Money line", subtitle "$845k Vol"
    And buttons array with two entries: SEA (yes variant, team color) and DEN (no variant, team color)

    When the card renders
    Then the title "Money line" and subtitle "$845k Vol" are visible
    And two inline buttons "SEA · 70¢" and "DEN · 30¢" render with team background colors

  Scenario: moneyline card renders three buttons for draw-capable leagues (soccer)
    Given a PredictSportOutcomeCard with title "Money line"
    And buttons array with three entries: LIV (yes), Draw (draw), ARS (no)

    When the card renders
    Then three inline buttons "LIV · 45¢", "DRAW · 27¢", and "ARS · 28¢" are visible
    And the draw button uses neutral muted background

  Scenario: generic card renders BTTS with neutral Yes/No
    Given a PredictSportOutcomeCard with title "Both Teams to Score"
    And buttons array with Yes (yes variant) and No (no variant), no team colors

    When the card renders
    Then two inline buttons "YES · 55¢" and "NO · 45¢" render with green/red muted backgrounds

  Scenario: inline layout on PredictBetButton
    Given a PredictBetButton with layout="inline", label "SEA", price 70

    When the button renders
    Then it displays "SEA · 70¢" on a single line

  Scenario: stacked layout remains default
    Given a PredictBetButton with no layout prop, label "Yes", price 65

    When the button renders
    Then it displays "YES" on the first line and "65¢" on the second line
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="433" height="932" alt="Screenshot 2026-04-14 at 12 19 25" src="https://github.com/user-attachments/assets/1c38abac-79f6-4dbb-9925-137fe1bebd64" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds a new presentational card component and an optional `PredictBetButton` layout prop with a backwards-compatible default.
> 
> **Overview**
> Adds an optional `layout` prop to `PredictBetButton` to support an **inline** single-line rendering (`LABEL · PRICE¢`) while keeping the existing stacked label/price layout as the default.
> 
> Introduces `PredictSportOutcomeCard`, a new presentational component that renders a title, optional subtitle, and 2–3+ outcome buttons (including optional draw) using `PredictBetButton` in inline layout with indexed `testID`s; includes comprehensive unit tests and exported test IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cab5496b6b3f0c2024c552b9aeaa4b424f667262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->