### PR TITLE
fix: advanced chart cutting off period start and end-dot clipping

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -440,6 +440,7 @@ function handleSetOHLCVData(payload) {
     var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
+      // Discard stale callback if user switched timeframes before load completed
       if (capturedGeneration !== window.ohlcvGeneration) {
         return;
       }
@@ -448,9 +449,12 @@ function handleSetOHLCVData(payload) {
       var toSec = lastBar
         ? Math.ceil(lastBar.time / 1000)
         : Math.ceil(Date.now() / 1000);
+      // Pad `to` forward by 2 bar durations so the end dot clears the price axis.
+      // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+      var barPadSec = getApproxBarDurationSec() * 2;
       try {
         chart.setVisibleRange(
-          { from: fromSec, to: toSec },
+          { from: fromSec, to: toSec + barPadSec },
           { percentRightMargin: 0 },
         );
       } catch (e) {
@@ -750,7 +754,6 @@ function scheduleLineChartLayoutReflow() {
     if (!window.chartWidget || window.currentChartType !== 2) return;
     try {
       syncMainSeriesToRightScale();
-      syncTimeScaleRightMargin(true);
     } catch (e) {}
   }
   try {
@@ -796,7 +799,6 @@ function applyChartScaleLayout(type) {
 
   removeLineChartMarkupStyle();
   syncMainSeriesToRightScale();
-  syncTimeScaleRightMargin(isLineChart);
   if (isLineChart) {
     scheduleLineChartLayoutReflow();
   }
@@ -1415,29 +1417,6 @@ function subscribeLastCloseLabelUpdates() {
           scheduleLineEndDotAfterVisibleRangeChange();
         }
       });
-  } catch (e) {}
-}
-
-/**
- * Small right gap so the end dot/line isn't flush/clipped against the pane edge or Y-axis.
- * When visibleFromMs is set (fixed timeframe mode), use a larger offset to prevent clipping.
- * When visibleFromMs is null (free-scrolling mode), use minimal offset.
- * https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi/
- */
-var CHART_RIGHT_OFFSET_BARS_FIXED_TIMEFRAME = 3;
-var CHART_RIGHT_OFFSET_BARS_DEFAULT = 0;
-
-function syncTimeScaleRightMargin(isLineChart) {
-  if (!window.chartWidget) return;
-  try {
-    var ts = window.chartWidget.activeChart().getTimeScale();
-    ts.usePercentageRightOffset().setValue(false);
-    var offset =
-      window.visibleFromMs != null
-        ? CHART_RIGHT_OFFSET_BARS_FIXED_TIMEFRAME
-        : CHART_RIGHT_OFFSET_BARS_DEFAULT;
-    ts.defaultRightOffset().setValue(offset);
-    ts.setRightOffset(offset);
   } catch (e) {}
 }
 
@@ -3311,12 +3290,15 @@ function initChart() {
     var visibleToSec = Math.ceil(
       (window.visibleToMs != null ? window.visibleToMs : Date.now()) / 1000,
     );
+    // Pad `to` by 2 bar durations so the end dot clears the price axis.
+    // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+    var initBarPadSec = getApproxBarDurationSec() * 2;
     var tfOption =
       window.visibleFromMs != null
         ? {
             type: 'time-range',
             from: Math.floor(window.visibleFromMs / 1000),
-            to: visibleToSec,
+            to: visibleToSec + initBarPadSec,
           }
         : undefined;
 

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -449,6 +449,7 @@ function handleSetOHLCVData(payload) {
     var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
+      // Discard stale callback if user switched timeframes before load completed
       if (capturedGeneration !== window.ohlcvGeneration) {
         return;
       }
@@ -457,9 +458,12 @@ function handleSetOHLCVData(payload) {
       var toSec = lastBar
         ? Math.ceil(lastBar.time / 1000)
         : Math.ceil(Date.now() / 1000);
+      // Pad \`to\` forward by 2 bar durations so the end dot clears the price axis.
+      // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+      var barPadSec = getApproxBarDurationSec() * 2;
       try {
         chart.setVisibleRange(
-          { from: fromSec, to: toSec },
+          { from: fromSec, to: toSec + barPadSec },
           { percentRightMargin: 0 },
         );
       } catch (e) {
@@ -759,7 +763,6 @@ function scheduleLineChartLayoutReflow() {
     if (!window.chartWidget || window.currentChartType !== 2) return;
     try {
       syncMainSeriesToRightScale();
-      syncTimeScaleRightMargin(true);
     } catch (e) {}
   }
   try {
@@ -805,7 +808,6 @@ function applyChartScaleLayout(type) {
 
   removeLineChartMarkupStyle();
   syncMainSeriesToRightScale();
-  syncTimeScaleRightMargin(isLineChart);
   if (isLineChart) {
     scheduleLineChartLayoutReflow();
   }
@@ -1424,29 +1426,6 @@ function subscribeLastCloseLabelUpdates() {
           scheduleLineEndDotAfterVisibleRangeChange();
         }
       });
-  } catch (e) {}
-}
-
-/**
- * Small right gap so the end dot/line isn't flush/clipped against the pane edge or Y-axis.
- * When visibleFromMs is set (fixed timeframe mode), use a larger offset to prevent clipping.
- * When visibleFromMs is null (free-scrolling mode), use minimal offset.
- * https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi/
- */
-var CHART_RIGHT_OFFSET_BARS_FIXED_TIMEFRAME = 3;
-var CHART_RIGHT_OFFSET_BARS_DEFAULT = 0;
-
-function syncTimeScaleRightMargin(isLineChart) {
-  if (!window.chartWidget) return;
-  try {
-    var ts = window.chartWidget.activeChart().getTimeScale();
-    ts.usePercentageRightOffset().setValue(false);
-    var offset =
-      window.visibleFromMs != null
-        ? CHART_RIGHT_OFFSET_BARS_FIXED_TIMEFRAME
-        : CHART_RIGHT_OFFSET_BARS_DEFAULT;
-    ts.defaultRightOffset().setValue(offset);
-    ts.setRightOffset(offset);
   } catch (e) {}
 }
 
@@ -3320,12 +3299,15 @@ function initChart() {
     var visibleToSec = Math.ceil(
       (window.visibleToMs != null ? window.visibleToMs : Date.now()) / 1000,
     );
+    // Pad \`to\` by 2 bar durations so the end dot clears the price axis.
+    // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+    var initBarPadSec = getApproxBarDurationSec() * 2;
     var tfOption =
       window.visibleFromMs != null
         ? {
             type: 'time-range',
             from: Math.floor(window.visibleFromMs / 1000),
-            to: visibleToSec,
+            to: visibleToSec + initBarPadSec,
           }
         : undefined;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The advanced chart had two related visual bugs when a fixed timeframe (1H/1D/1W/1M/1Y) was selected:
1. **Period-start cutoff** — the chart used `setRightOffset(3 bars)` to give the line end-dot breathing room, which shifted the entire viewport left, hiding the first candle of the period. Users had to drag back to see the full range.
2. **End-dot clipping** — without that offset, the 16px end-dot was clipped by the right price axis.
**Fix**: Instead of shifting the viewport left by N bars, the visible range's `to` timestamp is now padded forward by 2× the bar duration beyond the last candle. This preserves the exact `from` boundary (period start) while giving the dot right-side space in future time. `syncTimeScaleRightMargin` and its 3 call sites were removed since the competing `setRightOffset` is no longer needed.
The header percentage (`±$X.XX (Y%)`) is now derived directly from OHLCV candle data and stays in sync with the chart's visible range and crosshair position.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed advanced chart cutting off the start of the selected time period and clipping the line end-dot on the right edge

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/e0a7c326-7e18-4a47-8885-ae6e911a5658



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
