### PR TITLE
feat: add gas fees sponsored message in the transaction activity tab

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -474,6 +474,7 @@ class TransactionDetails extends PureComponent {
             gasEstimationReady
             transactionType={updatedTransactionDetails.transactionType}
             chainId={chainId}
+            isGasFeeSponsored={transactionObject.isGasFeeSponsored}
           />
         </View>
         {updatedTransactionDetails.hash &&

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -493,8 +493,8 @@ describe('TransactionDetails', () => {
       transactionObj: { isGasFeeSponsored: true },
     });
 
-    expect(screen.getByTestId('paid-by-metamask')).toBeTruthy();
-    expect(screen.getByText('Paid by MetaMask')).toBeTruthy();
+    expect(screen.getByTestId('paid-by-metamask')).toBeOnTheScreen();
+    expect(screen.getByText('Paid by MetaMask')).toBeOnTheScreen();
   });
 
   it('does not show "Paid by MetaMask" when isGasFeeSponsored is false', () => {
@@ -502,6 +502,6 @@ describe('TransactionDetails', () => {
       state: initialState,
     });
 
-    expect(screen.queryByText('Paid by MetaMask')).toBeNull();
+    expect(screen.queryByText('Paid by MetaMask')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -486,4 +486,22 @@ describe('TransactionDetails', () => {
 
     expect(getByText('Batched transactions')).toBeTruthy();
   });
+
+  it('passes isGasFeeSponsored to TransactionSummary when true', () => {
+    renderComponent({
+      state: initialState,
+      transactionObj: { isGasFeeSponsored: true },
+    });
+
+    expect(screen.getByTestId('paid-by-metamask')).toBeTruthy();
+    expect(screen.getByText('Paid by MetaMask')).toBeTruthy();
+  });
+
+  it('does not show "Paid by MetaMask" when isGasFeeSponsored is false', () => {
+    renderComponent({
+      state: initialState,
+    });
+
+    expect(screen.queryByText('Paid by MetaMask')).toBeNull();
+  });
 });

--- a/app/components/Views/TransactionSummary/index.js
+++ b/app/components/Views/TransactionSummary/index.js
@@ -168,13 +168,15 @@ export default class TransactionSummary extends PureComponent {
             </Text>,
           )}
         </Summary.Row>
-        <Summary.Row end last>
-          {this.renderIfGastEstimationReady(
-            <Text small right upper={!isTestNetResult}>
-              {secondaryTotalAmount}
-            </Text>,
-          )}
-        </Summary.Row>
+        {!isGasFeeSponsored && (
+          <Summary.Row end last>
+            {this.renderIfGastEstimationReady(
+              <Text small right upper={!isTestNetResult}>
+                {secondaryTotalAmount}
+              </Text>,
+            )}
+          </Summary.Row>
+        )}
       </Summary>
     );
   };

--- a/app/components/Views/TransactionSummary/index.js
+++ b/app/components/Views/TransactionSummary/index.js
@@ -12,6 +12,10 @@ import Summary from '../../Base/Summary';
 import Text from '../../Base/Text';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { isTestNet } from '../../../util/networks';
+import TagColored, {
+  TagColor,
+} from '../../../component-library/components-temp/TagColored';
+import { TextVariant } from '../../../component-library/components/Texts/Text/Text.types';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -31,6 +35,7 @@ export default class TransactionSummary extends PureComponent {
     onEditPress: PropTypes.func,
     transactionType: PropTypes.string,
     chainId: PropTypes.string,
+    isGasFeeSponsored: PropTypes.bool,
   };
 
   renderIfGastEstimationReady = (children) => {
@@ -67,6 +72,7 @@ export default class TransactionSummary extends PureComponent {
       gasEstimationReady,
       onEditPress,
       chainId,
+      isGasFeeSponsored,
     } = this.props;
 
     const isTestNetResult = isTestNet(chainId);
@@ -126,12 +132,30 @@ export default class TransactionSummary extends PureComponent {
               </TouchableOpacity>
             )}
           </Summary.Col>
-          {!!fee &&
+          {isGasFeeSponsored ? (
+            <TagColored
+              color={TagColor.Success}
+              labelProps={{
+                variant: TextVariant.BodySM,
+                style: {
+                  textTransform: 'none',
+                  textAlign: 'center',
+                  bottom: 1,
+                  fontWeight: 'normal',
+                },
+                testID: 'paid-by-metamask',
+              }}
+            >
+              {strings('transactions.paid_by_metamask')}
+            </TagColored>
+          ) : (
+            !!fee &&
             this.renderIfGastEstimationReady(
               <Text small primary upper={!isTestNetResult}>
                 {fee}
               </Text>,
-            )}
+            )
+          )}
         </Summary.Row>
         <Summary.Separator />
         <Summary.Row>
@@ -140,7 +164,7 @@ export default class TransactionSummary extends PureComponent {
           </Text>
           {this.renderIfGastEstimationReady(
             <Text small bold primary upper={!isTestNetResult}>
-              {totalAmount}
+              {isGasFeeSponsored ? amount : totalAmount}
             </Text>,
           )}
         </Summary.Row>

--- a/app/components/Views/TransactionSummary/index.test.tsx
+++ b/app/components/Views/TransactionSummary/index.test.tsx
@@ -24,11 +24,11 @@ describe('TransactionSummary', () => {
   it('renders amount, fee, and total amount', () => {
     renderWithTheme(defaultProps);
 
-    expect(screen.getByText('Amount')).toBeTruthy();
-    expect(screen.getByText('0.5 ETH')).toBeTruthy();
-    expect(screen.getByText('0.001 ETH')).toBeTruthy();
-    expect(screen.getByText('Total amount')).toBeTruthy();
-    expect(screen.getByText('0.501 ETH')).toBeTruthy();
+    expect(screen.getByText('Amount')).toBeOnTheScreen();
+    expect(screen.getByText('0.5 ETH')).toBeOnTheScreen();
+    expect(screen.getByText('0.001 ETH')).toBeOnTheScreen();
+    expect(screen.getByText('Total amount')).toBeOnTheScreen();
+    expect(screen.getByText('0.501 ETH')).toBeOnTheScreen();
   });
 
   it('displays "Paid by MetaMask" tag instead of fee when gas is sponsored', () => {
@@ -37,9 +37,9 @@ describe('TransactionSummary', () => {
       isGasFeeSponsored: true,
     });
 
-    expect(screen.getByTestId('paid-by-metamask')).toBeTruthy();
-    expect(screen.getByText('Paid by MetaMask')).toBeTruthy();
-    expect(screen.queryByText('0.001 ETH')).toBeNull();
+    expect(screen.getByTestId('paid-by-metamask')).toBeOnTheScreen();
+    expect(screen.getByText('Paid by MetaMask')).toBeOnTheScreen();
+    expect(screen.queryByText('0.001 ETH')).not.toBeOnTheScreen();
   });
 
   it('displays amount instead of totalAmount in total row when gas is sponsored', () => {
@@ -48,10 +48,9 @@ describe('TransactionSummary', () => {
       isGasFeeSponsored: true,
     });
 
-    const totalRow = screen.getByText('Total amount');
-    expect(totalRow).toBeTruthy();
+    expect(screen.getByText('Total amount')).toBeOnTheScreen();
     // The total row should show the amount (0.5 ETH), not totalAmount (0.501 ETH)
-    expect(screen.queryByText('0.501 ETH')).toBeNull();
+    expect(screen.queryByText('0.501 ETH')).not.toBeOnTheScreen();
     // Amount appears twice: once in the Amount row, once in the Total amount row
     expect(screen.getAllByText('0.5 ETH')).toHaveLength(2);
   });
@@ -62,7 +61,7 @@ describe('TransactionSummary', () => {
       isGasFeeSponsored: true,
     });
 
-    expect(screen.queryByText('$1,000.00')).toBeNull();
+    expect(screen.queryByText('$1,000.00')).not.toBeOnTheScreen();
   });
 
   it('shows secondary total amount row when gas is not sponsored', () => {
@@ -71,7 +70,7 @@ describe('TransactionSummary', () => {
       isGasFeeSponsored: false,
     });
 
-    expect(screen.getByText('$1,000.00')).toBeTruthy();
+    expect(screen.getByText('$1,000.00')).toBeOnTheScreen();
   });
 
   it('displays fee and totalAmount when gas is not sponsored', () => {
@@ -80,9 +79,9 @@ describe('TransactionSummary', () => {
       isGasFeeSponsored: false,
     });
 
-    expect(screen.getByText('0.001 ETH')).toBeTruthy();
-    expect(screen.getByText('0.501 ETH')).toBeTruthy();
-    expect(screen.queryByText('Paid by MetaMask')).toBeNull();
+    expect(screen.getByText('0.001 ETH')).toBeOnTheScreen();
+    expect(screen.getByText('0.501 ETH')).toBeOnTheScreen();
+    expect(screen.queryByText('Paid by MetaMask')).not.toBeOnTheScreen();
   });
 
   it('renders received transaction without fee row', () => {
@@ -91,7 +90,7 @@ describe('TransactionSummary', () => {
       transactionType: TRANSACTION_TYPES.RECEIVED,
     });
 
-    expect(screen.getByText('Amount')).toBeTruthy();
-    expect(screen.queryByText('Total amount')).toBeNull();
+    expect(screen.getByText('Amount')).toBeOnTheScreen();
+    expect(screen.queryByText('Total amount')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/TransactionSummary/index.test.tsx
+++ b/app/components/Views/TransactionSummary/index.test.tsx
@@ -56,6 +56,24 @@ describe('TransactionSummary', () => {
     expect(screen.getAllByText('0.5 ETH')).toHaveLength(2);
   });
 
+  it('hides secondary total amount row when gas is sponsored', () => {
+    renderWithTheme({
+      ...defaultProps,
+      isGasFeeSponsored: true,
+    });
+
+    expect(screen.queryByText('$1,000.00')).toBeNull();
+  });
+
+  it('shows secondary total amount row when gas is not sponsored', () => {
+    renderWithTheme({
+      ...defaultProps,
+      isGasFeeSponsored: false,
+    });
+
+    expect(screen.getByText('$1,000.00')).toBeTruthy();
+  });
+
   it('displays fee and totalAmount when gas is not sponsored', () => {
     renderWithTheme({
       ...defaultProps,

--- a/app/components/Views/TransactionSummary/index.test.tsx
+++ b/app/components/Views/TransactionSummary/index.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import TransactionSummary from './';
+import { ThemeContext, mockTheme } from '../../../util/theme';
+import { TRANSACTION_TYPES } from '../../../util/transactions';
+
+const renderWithTheme = (props: Record<string, unknown>) =>
+  render(
+    <ThemeContext.Provider value={mockTheme}>
+      <TransactionSummary {...props} />
+    </ThemeContext.Provider>,
+  );
+
+describe('TransactionSummary', () => {
+  const defaultProps = {
+    amount: '0.5 ETH',
+    fee: '0.001 ETH',
+    totalAmount: '0.501 ETH',
+    secondaryTotalAmount: '$1,000.00',
+    gasEstimationReady: true,
+    chainId: '0x1',
+  };
+
+  it('renders amount, fee, and total amount', () => {
+    renderWithTheme(defaultProps);
+
+    expect(screen.getByText('Amount')).toBeTruthy();
+    expect(screen.getByText('0.5 ETH')).toBeTruthy();
+    expect(screen.getByText('0.001 ETH')).toBeTruthy();
+    expect(screen.getByText('Total amount')).toBeTruthy();
+    expect(screen.getByText('0.501 ETH')).toBeTruthy();
+  });
+
+  it('displays "Paid by MetaMask" tag instead of fee when gas is sponsored', () => {
+    renderWithTheme({
+      ...defaultProps,
+      isGasFeeSponsored: true,
+    });
+
+    expect(screen.getByTestId('paid-by-metamask')).toBeTruthy();
+    expect(screen.getByText('Paid by MetaMask')).toBeTruthy();
+    expect(screen.queryByText('0.001 ETH')).toBeNull();
+  });
+
+  it('displays amount instead of totalAmount in total row when gas is sponsored', () => {
+    renderWithTheme({
+      ...defaultProps,
+      isGasFeeSponsored: true,
+    });
+
+    const totalRow = screen.getByText('Total amount');
+    expect(totalRow).toBeTruthy();
+    // The total row should show the amount (0.5 ETH), not totalAmount (0.501 ETH)
+    expect(screen.queryByText('0.501 ETH')).toBeNull();
+    // Amount appears twice: once in the Amount row, once in the Total amount row
+    expect(screen.getAllByText('0.5 ETH')).toHaveLength(2);
+  });
+
+  it('displays fee and totalAmount when gas is not sponsored', () => {
+    renderWithTheme({
+      ...defaultProps,
+      isGasFeeSponsored: false,
+    });
+
+    expect(screen.getByText('0.001 ETH')).toBeTruthy();
+    expect(screen.getByText('0.501 ETH')).toBeTruthy();
+    expect(screen.queryByText('Paid by MetaMask')).toBeNull();
+  });
+
+  it('renders received transaction without fee row', () => {
+    renderWithTheme({
+      ...defaultProps,
+      transactionType: TRANSACTION_TYPES.RECEIVED,
+    });
+
+    expect(screen.getByText('Amount')).toBeTruthy();
+    expect(screen.queryByText('Total amount')).toBeNull();
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request introduces support for sponsored gas fees in the transaction summary UI, ensuring that when a transaction's gas fee is covered by MetaMask, the UI reflects this with a clear tag and adjusts the displayed totals accordingly. It also adds comprehensive tests to verify the new behavior.

**UI Enhancements for Sponsored Gas Fees:**

* The `TransactionSummary` component now accepts a new prop, `isGasFeeSponsored`, which determines if the gas fee is covered by MetaMask. When true, a "Paid by MetaMask" tag is shown instead of the fee, and the total amount row displays only the transaction amount (not amount + fee).
* The `TransactionDetails` component passes the `isGasFeeSponsored` flag from the transaction object down to `TransactionSummary`.

**Testing Improvements:**

* New tests in `TransactionSummary/index.test.tsx` verify correct rendering of the sponsored fee tag, the absence of the fee when sponsored, and adjusted total amount logic.
* Additional tests in `TransactionDetails/index.test.tsx` ensure the `isGasFeeSponsored` prop is properly passed and the "Paid by MetaMask" tag appears only when appropriate.

**Component and Prop Updates:**

* The `TransactionSummary` component imports and uses the new `TagColored` UI component to display the sponsorship tag.
* PropTypes for `TransactionSummary` are updated to include the new `isGasFeeSponsored` boolean prop.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add gas fees sponsored message in the transaction activity tab

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<img width="500" height="1250" alt="paid-by-mm" src="https://github.com/user-attachments/assets/574cc427-a93f-4752-9cc1-143e809d10bb" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to transaction activity rendering plus new tests; low risk aside from potential display regressions in the summary totals when `isGasFeeSponsored` is set incorrectly.
> 
> **Overview**
> Adds support for **sponsored gas fees** in the transaction activity details summary. `TransactionDetails` now passes `transactionObject.isGasFeeSponsored` into `TransactionSummary`, which conditionally replaces the fee value with a success `TagColored` “Paid by MetaMask” label, shows *amount* instead of *amount+fee* in the total row, and hides the secondary total row when sponsored.
> 
> Adds coverage for this behavior via new `TransactionSummary` unit tests and additional `TransactionDetails` assertions ensuring the tag appears only when sponsorship is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c38342225e5b2fd60dddd813b7ab3e4ef334b902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->