### PR TITLE
fix(ramp): move Build Quote header inside ScreenLayout body (TRAM-3444)

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -857,8 +857,7 @@ function BuildQuote() {
     : strings('fiat_on_ramp.no_quotes_available');
 
   return (
-    <>
-      <ScreenLayout>
+    <ScreenLayout>
         <ScreenLayout.Body>
           <HeaderCompactStandard
             title={
@@ -1014,7 +1013,6 @@ function BuildQuote() {
           </ScreenLayout.Content>
         </ScreenLayout.Body>
       </ScreenLayout>
-    </>
   );
 }
 

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -858,37 +858,61 @@ function BuildQuote() {
 
   return (
     <ScreenLayout>
-        <ScreenLayout.Body>
-          <HeaderCompactStandard
-            title={
-              selectedToken?.symbol
-                ? strings('fiat_on_ramp.buy', { ticker: selectedToken.symbol })
-                : undefined
-            }
-            subtitle={
-              networkInfo?.networkName
-                ? strings('fiat_on_ramp.on_network', {
-                    networkName: networkInfo.networkName,
-                  })
-                : undefined
-            }
-            onBack={handleBackPress}
-            backButtonProps={{ testID: BUILD_QUOTE_TEST_IDS.BACK_BUTTON }}
-            endButtonIconProps={[
-              {
-                iconName: IconName.Setting,
-                onPress: handleSettingsPress,
-                testID: BUILD_QUOTE_TEST_IDS.SETTINGS_BUTTON,
-              },
-            ]}
-            includesTopInset
-          />
-          <ScreenLayout.Content style={styles.content}>
-            <View style={styles.centerGroup}>
-              <View style={styles.amountContainer}>
-                <View style={styles.amountRow}>
+      <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={
+            selectedToken?.symbol
+              ? strings('fiat_on_ramp.buy', { ticker: selectedToken.symbol })
+              : undefined
+          }
+          subtitle={
+            networkInfo?.networkName
+              ? strings('fiat_on_ramp.on_network', {
+                  networkName: networkInfo.networkName,
+                })
+              : undefined
+          }
+          onBack={handleBackPress}
+          backButtonProps={{ testID: BUILD_QUOTE_TEST_IDS.BACK_BUTTON }}
+          endButtonIconProps={[
+            {
+              iconName: IconName.Setting,
+              onPress: handleSettingsPress,
+              testID: BUILD_QUOTE_TEST_IDS.SETTINGS_BUTTON,
+            },
+          ]}
+          includesTopInset
+        />
+        <ScreenLayout.Content style={styles.content}>
+          <View style={styles.centerGroup}>
+            <View style={styles.amountContainer}>
+              <View style={styles.amountRow}>
+                <Text
+                  testID={BuildQuoteSelectors.AMOUNT_INPUT}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Regular}
+                  color={
+                    rampsError || hasNoQuotes || quoteFetchError
+                      ? TextColor.ErrorDefault
+                      : undefined
+                  }
+                  twClassName={`text-[${amountFontSize}px] tracking-tight leading-[${amountLineHeight}px] font-normal text-center`}
+                  numberOfLines={1}
+                >
+                  {currencyPrefix}
+                  {amount}
+                </Text>
+                <Animated.View
+                  style={[
+                    styles.cursor,
+                    {
+                      height: Math.max(amountLineHeight - 4, 16),
+                      opacity: cursorOpacity,
+                    },
+                  ]}
+                />
+                {currencySuffix ? (
                   <Text
-                    testID={BuildQuoteSelectors.AMOUNT_INPUT}
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Regular}
                     color={
@@ -897,122 +921,98 @@ function BuildQuote() {
                         : undefined
                     }
                     twClassName={`text-[${amountFontSize}px] tracking-tight leading-[${amountLineHeight}px] font-normal text-center`}
-                    numberOfLines={1}
                   >
-                    {currencyPrefix}
-                    {amount}
+                    {currencySuffix}
                   </Text>
-                  <Animated.View
-                    style={[
-                      styles.cursor,
-                      {
-                        height: Math.max(amountLineHeight - 4, 16),
-                        opacity: cursorOpacity,
-                      },
-                    ]}
-                  />
-                  {currencySuffix ? (
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      fontWeight={FontWeight.Regular}
-                      color={
-                        rampsError || hasNoQuotes || quoteFetchError
-                          ? TextColor.ErrorDefault
-                          : undefined
-                      }
-                      twClassName={`text-[${amountFontSize}px] tracking-tight leading-[${amountLineHeight}px] font-normal text-center`}
-                    >
-                      {currencySuffix}
-                    </Text>
-                  ) : null}
-                </View>
-                <PaymentMethodPill
-                  label={
-                    selectedPaymentMethod?.name ||
-                    strings('fiat_on_ramp.select_payment_method')
-                  }
-                  paymentMethod={selectedPaymentMethod}
-                  isLoading={paymentMethodsLoading}
-                  onPress={
-                    isTokenUnavailable ? undefined : handlePaymentPillPress
-                  }
-                  testID="build-quote-payment-pill"
-                />
+                ) : null}
               </View>
-            </View>
-
-            {quoteFetchError && (
-              <BannerAlert
-                severity={BannerAlertSeverity.Error}
-                description={parseUserFacingError(
-                  quoteFetchError,
-                  strings('deposit.buildQuote.quoteFetchError'),
-                )}
+              <PaymentMethodPill
+                label={
+                  selectedPaymentMethod?.name ||
+                  strings('fiat_on_ramp.select_payment_method')
+                }
+                paymentMethod={selectedPaymentMethod}
+                isLoading={paymentMethodsLoading}
+                onPress={
+                  isTokenUnavailable ? undefined : handlePaymentPillPress
+                }
+                testID="build-quote-payment-pill"
               />
-            )}
-
-            <View style={styles.actionSection}>
-              {hasAmount ? (
-                <>
-                  {rampsError ? (
-                    <TruncatedError
-                      error={rampsError}
-                      providerName={selectedProvider?.name}
-                      providerSupportUrl={
-                        selectedProvider?.links?.find(
-                          (link) => link.name === PROVIDER_LINKS.SUPPORT,
-                        )?.url
-                      }
-                    />
-                  ) : hasNoQuotes ? (
-                    <TruncatedError
-                      error={strings('fiat_on_ramp.encountered_error')}
-                      errorDetails={noQuotesErrorMessage}
-                      showChangeProvider
-                      amount={amountAsNumber}
-                    />
-                  ) : (
-                    selectedProvider && (
-                      <Text
-                        variant={TextVariant.BodySm}
-                        style={styles.poweredByText}
-                      >
-                        {strings('fiat_on_ramp.powered_by_provider', {
-                          provider: selectedProvider.name,
-                        })}
-                      </Text>
-                    )
-                  )}
-                  <Button
-                    variant={ButtonVariant.Primary}
-                    size={ButtonSize.Lg}
-                    onPress={handleContinuePress}
-                    isFullWidth
-                    isDisabled={!canContinue}
-                    isLoading={selectedQuoteLoading || isContinueLoading}
-                    testID={BuildQuoteSelectors.CONTINUE_BUTTON}
-                  >
-                    {strings('fiat_on_ramp.continue')}
-                  </Button>
-                </>
-              ) : (
-                quickAmounts.length > 0 && (
-                  <QuickAmounts
-                    amounts={quickAmounts}
-                    currency={currency}
-                    onAmountPress={handleQuickAmountPress}
-                  />
-                )
-              )}
             </View>
-            <Keypad
-              currency={currency}
-              value={amount}
-              onChange={handleKeypadChange}
+          </View>
+
+          {quoteFetchError && (
+            <BannerAlert
+              severity={BannerAlertSeverity.Error}
+              description={parseUserFacingError(
+                quoteFetchError,
+                strings('deposit.buildQuote.quoteFetchError'),
+              )}
             />
-          </ScreenLayout.Content>
-        </ScreenLayout.Body>
-      </ScreenLayout>
+          )}
+
+          <View style={styles.actionSection}>
+            {hasAmount ? (
+              <>
+                {rampsError ? (
+                  <TruncatedError
+                    error={rampsError}
+                    providerName={selectedProvider?.name}
+                    providerSupportUrl={
+                      selectedProvider?.links?.find(
+                        (link) => link.name === PROVIDER_LINKS.SUPPORT,
+                      )?.url
+                    }
+                  />
+                ) : hasNoQuotes ? (
+                  <TruncatedError
+                    error={strings('fiat_on_ramp.encountered_error')}
+                    errorDetails={noQuotesErrorMessage}
+                    showChangeProvider
+                    amount={amountAsNumber}
+                  />
+                ) : (
+                  selectedProvider && (
+                    <Text
+                      variant={TextVariant.BodySm}
+                      style={styles.poweredByText}
+                    >
+                      {strings('fiat_on_ramp.powered_by_provider', {
+                        provider: selectedProvider.name,
+                      })}
+                    </Text>
+                  )
+                )}
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  onPress={handleContinuePress}
+                  isFullWidth
+                  isDisabled={!canContinue}
+                  isLoading={selectedQuoteLoading || isContinueLoading}
+                  testID={BuildQuoteSelectors.CONTINUE_BUTTON}
+                >
+                  {strings('fiat_on_ramp.continue')}
+                </Button>
+              </>
+            ) : (
+              quickAmounts.length > 0 && (
+                <QuickAmounts
+                  amounts={quickAmounts}
+                  currency={currency}
+                  onAmountPress={handleQuickAmountPress}
+                />
+              )
+            )}
+          </View>
+          <Keypad
+            currency={currency}
+            value={amount}
+            onChange={handleKeypadChange}
+          />
+        </ScreenLayout.Content>
+      </ScreenLayout.Body>
+    </ScreenLayout>
   );
 }
 

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -858,32 +858,32 @@ function BuildQuote() {
 
   return (
     <>
-      <HeaderCompactStandard
-        title={
-          selectedToken?.symbol
-            ? strings('fiat_on_ramp.buy', { ticker: selectedToken.symbol })
-            : undefined
-        }
-        subtitle={
-          networkInfo?.networkName
-            ? strings('fiat_on_ramp.on_network', {
-                networkName: networkInfo.networkName,
-              })
-            : undefined
-        }
-        onBack={handleBackPress}
-        backButtonProps={{ testID: BUILD_QUOTE_TEST_IDS.BACK_BUTTON }}
-        endButtonIconProps={[
-          {
-            iconName: IconName.Setting,
-            onPress: handleSettingsPress,
-            testID: BUILD_QUOTE_TEST_IDS.SETTINGS_BUTTON,
-          },
-        ]}
-        includesTopInset
-      />
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={
+              selectedToken?.symbol
+                ? strings('fiat_on_ramp.buy', { ticker: selectedToken.symbol })
+                : undefined
+            }
+            subtitle={
+              networkInfo?.networkName
+                ? strings('fiat_on_ramp.on_network', {
+                    networkName: networkInfo.networkName,
+                  })
+                : undefined
+            }
+            onBack={handleBackPress}
+            backButtonProps={{ testID: BUILD_QUOTE_TEST_IDS.BACK_BUTTON }}
+            endButtonIconProps={[
+              {
+                iconName: IconName.Setting,
+                onPress: handleSettingsPress,
+                testID: BUILD_QUOTE_TEST_IDS.SETTINGS_BUTTON,
+              },
+            ]}
+            includesTopInset
+          />
           <ScreenLayout.Content style={styles.content}>
             <View style={styles.centerGroup}>
               <View style={styles.amountContainer}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Internal ticket **TRAM-3444**: during navigation from token selection to the unified buy **Build Quote** screen (`Routes.RAMP.AMOUNT_INPUT`), the Build Quote header could appear visually “see-through” and overlap the previous screen’s header during the transition.

The screen already uses `headerShown: false` on the stack and renders `HeaderCompactStandard` in the tree. Moving that header **inside** `ScreenLayout.Body` (with the rest of the screen content) keeps it on the same surface as the body during the transition and removes the overlapping header artifact.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed unified buy Build Quote header overlapping the token selection screen during navigation transitions

## **Related issues**

Fixes:

<!-- TRAM-3444 (Jira); add GitHub issue number above if one exists -->

## **Manual testing steps**

```gherkin
Feature: Unified buy navigation header (TRAM-3444)

  Scenario: Build Quote header does not bleed over token selection during transition
    Given the unified buy (v2) flow is enabled and the user opens Buy
    And the user is on the token selection screen

    When the user selects a token and navigates to the Build Quote (amount) screen
    Then the transition completes without the Build Quote header appearing transparently over the token selection header
    And the Build Quote header (title, back, settings) displays correctly with the rest of the screen content
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/112d54c8-5532-4550-bfb7-5ba41475c8b1



### **After**


https://github.com/user-attachments/assets/8592ac53-d2d9-4a27-8eb0-c271719782da



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI layout-only change that reorders the component tree for the Build Quote screen; minimal chance of regressions beyond header spacing/safe-area rendering.
> 
> **Overview**
> Fixes a navigation transition visual artifact on the unified buy *Build Quote* screen by moving `HeaderCompactStandard` inside `ScreenLayout.Body` so it renders on the same surface as the rest of the screen content.
> 
> The rest of the screen UI (amount display, payment method pill, errors, quick amounts, continue button, keypad) is unchanged, just re-wrapped to match the new layout hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379388872baabf8a5663e0c5e79e400992e51ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->