### PR TITLE
ci: add conditions to safely determine ota updates in Runway workflow

### DIFF
--- a/.github/workflows/runway-ota-build-core.yml
+++ b/.github/workflows/runway-ota-build-core.yml
@@ -124,6 +124,21 @@ jobs:
           CURRENT_OTA=$(extract_ota app/constants/ota.ts)
           echo "ota_version=${CURRENT_OTA}" >> "$GITHUB_OUTPUT"
 
+          # Early exit 1: sentinel means no OTA has been configured for this release
+          if [[ "$CURRENT_OTA" == "vX.XX.X" ]]; then
+            echo "ota_bump=false" >> "$GITHUB_OUTPUT"
+            echo "OTA_VERSION is sentinel ($CURRENT_OTA) → will trigger build"
+            exit 0
+          fi
+
+          # Early exit 2: if a tag for this OTA_VERSION already exists, the OTA was
+          # already shipped (e.g. merged from a prior release branch) — treat as stale.
+          if git rev-parse "refs/tags/${CURRENT_OTA}" >/dev/null 2>&1; then
+            echo "ota_bump=false" >> "$GITHUB_OUTPUT"
+            echo "OTA tag ${CURRENT_OTA} already exists (already shipped) → stale, will trigger build"
+            exit 0
+          fi
+
           # Ref to compare against for detecting bump: use release tag if it exists, else main
           if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
             COMPARE_REF="$RELEASE_TAG"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When a prior OTA release (e.g. 7.72.01) is merged into a newer release branch (e.g. 7.73.0) before the new release tag exists, the merged OTA_VERSION (e.g. v7.72.01) differs from origin/main's sentinel, causing the workflow to incorrectly trigger an OTA update instead of a binary build.

This PR adds two early-exit checks to the decide step in runway-ota-build-core.yml:

Sentinel check — if OTA_VERSION is the default vX.XX.X, skip comparison and trigger a binary build immediately.
Tag-exists check — if a git tag for the current OTA_VERSION already exists, the OTA was already shipped from a prior release and is stale; trigger a binary build instead.
The existing comparison logic is unchanged and only reached when neither early exit fires.

<img width="717" height="296" alt="Screenshot 2026-04-14 at 10 59 07 AM" src="https://github.com/user-attachments/assets/611af2bf-7357-4caf-afc8-c80822be384a" />



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it affects release automation paths that decide between triggering an OTA update vs a full binary build.
> 
> **Overview**
> Prevents Runway from incorrectly triggering an OTA update in `.github/workflows/runway-ota-build-core.yml` by adding two **early-exit** guards in the decide step.
> 
> If `OTA_VERSION` is the sentinel `vX.XX.X` *or* a git tag for the current `OTA_VERSION` already exists (indicating it was already shipped), the workflow now forces `ota_bump=false` and proceeds with a binary build; otherwise it falls back to the existing compare-to-release-tag/main bump detection logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e2e8c1d26dfb19db524b6aa40be926a002efce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->