### PR TITLE
test: migrate browser security E2E tests to local fixtures

### DIFF
--- a/tests/fixtures/security/camera.html
+++ b/tests/fixtures/security/camera.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Camera Permission Test</title>
+</head>
+<body>
+  <h1>Camera Permission Test</h1>
+  <p id="status">Requesting camera access...</p>
+
+  <script>
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(function(stream) {
+        document.getElementById('status').textContent = 'Camera access granted';
+      })
+      .catch(function(error) {
+        document.getElementById('status').textContent = 'Camera access denied: ' + error.message;
+      });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/security/history-disclosure.html
+++ b/tests/fixtures/security/history-disclosure.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>History Disclosure Test</title>
+  <style>
+    a:visited { color: rgb(255, 0, 0); }
+    a:link { color: rgb(0, 0, 255); }
+  </style>
+</head>
+<body>
+  <h1>History Disclosure Test</h1>
+  <a id="target-link" href="visited-target.html">Target Page</a>
+  <p id="result"></p>
+
+  <script>
+    var link = document.getElementById('target-link');
+    var color = getComputedStyle(link).color;
+    var resultEl = document.getElementById('result');
+    if (color === 'rgb(255, 0, 0)') {
+      resultEl.textContent = 'visited-target.html was visited';
+    } else {
+      resultEl.textContent = 'No history leaked';
+    }
+  </script>
+</body>
+</html>

--- a/tests/fixtures/security/visited-target.html
+++ b/tests/fixtures/security/visited-target.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Target Page</title>
+</head>
+<body>
+  <h1>Target Page</h1>
+  <p>This page seeds the browser history for the history disclosure test.</p>
+</body>
+</html>

--- a/tests/page-objects/Browser/ExternalWebsites/Security/CameraWebsite.ts
+++ b/tests/page-objects/Browser/ExternalWebsites/Security/CameraWebsite.ts
@@ -22,7 +22,10 @@ class CameraWebsite {
           BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
           "//p[@id='status' and contains(text(), 'Camera access granted')]",
         ),
-        { timeout: 5000 },
+        {
+          timeout: 5000,
+          description: 'Camera access granted status text is visible (iOS)',
+        },
       );
     } else {
       // On Android, the WebView shows its own permission dialog.
@@ -39,7 +42,10 @@ class CameraWebsite {
           BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
           "//p[@id='status' and contains(text(), 'Camera access granted')]",
         ),
-        { timeout: 5000 },
+        {
+          timeout: 5000,
+          description: 'Camera access granted status text is visible (Android)',
+        },
       );
     }
   }

--- a/tests/page-objects/Browser/ExternalWebsites/Security/CameraWebsite.ts
+++ b/tests/page-objects/Browser/ExternalWebsites/Security/CameraWebsite.ts
@@ -1,20 +1,46 @@
 import Matchers from '../../../../framework/Matchers';
+import { BrowserViewSelectorsIDs } from '../../../../../app/components/Views/BrowserTab/BrowserView.testIds';
+import Assertions from '../../../../framework/Assertions';
 import { waitFor } from 'detox';
 
 class CameraWebsite {
   async verifyRequestPermissionDialogVisible(): Promise<void> {
     if (device.getPlatform() === 'ios') {
-      waitFor(
+      await waitFor(
         await Matchers.getElementByLabel(
-          'Allow "tyschenko.github.io" to use your camera?',
+          'Allow "localhost" to use your camera?',
         ),
       ).toExist();
+      // The WKWebView permission prompt is part of the app view hierarchy,
+      // not a system alert. Multiple elements may match "Allow", so pick
+      // the first visible one (the dialog button on top).
+      const allowButton = element(by.label('Allow')).atIndex(0);
+      await allowButton.tap();
+      await device.disableSynchronization();
+      await Assertions.expectElementToBeVisible(
+        Matchers.getElementByXPath(
+          BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+          "//p[@id='status' and contains(text(), 'Camera access granted')]",
+        ),
+        { timeout: 5000 },
+      );
     } else {
-      waitFor(
-        await Matchers.getElementByText(
-          'Allow tyschenko.github.io to use your camera?',
+      // On Android, the WebView shows its own permission dialog.
+      // Verify it appears, tap ALLOW, then confirm camera access succeeded.
+      // OS-level camera permission is pre-granted via withFixtures.
+      const allowButton = element(by.text('ALLOW'));
+      await waitFor(allowButton).toBeVisible().withTimeout(10000);
+      await allowButton.tap();
+      // After tapping ALLOW the camera stream starts, keeping the app
+      // perpetually "busy" for Detox. Disable sync so assertions don't hang.
+      await device.disableSynchronization();
+      await Assertions.expectElementToBeVisible(
+        Matchers.getElementByXPath(
+          BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+          "//p[@id='status' and contains(text(), 'Camera access granted')]",
         ),
-      ).toExist();
+        { timeout: 5000 },
+      );
     }
   }
 }

--- a/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
+++ b/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
@@ -3,11 +3,11 @@ import { BrowserViewSelectorsIDs } from '../../../../../app/components/Views/Bro
 import Assertions from '../../../../framework/Assertions';
 
 class HistoryDisclosureWebsite {
-  async verifyUniswapElementNotExist(): Promise<void> {
+  async verifyVisitedTargetNotLeaked(): Promise<void> {
     await Assertions.expectElementToNotBeVisible(
       Matchers.getElementByXPath(
         BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-        "//*[contains(text(), 'uniswap.org')]",
+        "//p[@id='result' and contains(text(), 'visited-target.html was visited')]",
       ),
       { timeout: 3000 },
     );

--- a/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
+++ b/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
@@ -3,6 +3,16 @@ import { BrowserViewSelectorsIDs } from '../../../../../app/components/Views/Bro
 import Assertions from '../../../../framework/Assertions';
 
 class HistoryDisclosureWebsite {
+  async verifyUniswapElementNotExist(): Promise<void> {
+    await Assertions.expectElementToNotBeVisible(
+      Matchers.getElementByXPath(
+        BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+        "//p[@id='result' and contains(text(), 'uniswap.org was visited')]",
+      ),
+      { timeout: 3000 },
+    );
+  }
+
   async verifyVisitedTargetNotLeaked(): Promise<void> {
     await Assertions.expectElementToNotBeVisible(
       Matchers.getElementByXPath(

--- a/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
+++ b/tests/page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite.ts
@@ -9,7 +9,10 @@ class HistoryDisclosureWebsite {
         BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
         "//p[@id='result' and contains(text(), 'uniswap.org was visited')]",
       ),
-      { timeout: 3000 },
+      {
+        timeout: 3000,
+        description: 'Uniswap visited indicator is not visible',
+      },
     );
   }
 
@@ -19,7 +22,10 @@ class HistoryDisclosureWebsite {
         BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
         "//p[@id='result' and contains(text(), 'visited-target.html was visited')]",
       ),
-      { timeout: 3000 },
+      {
+        timeout: 3000,
+        description: 'Visited target page indicator is not visible',
+      },
     );
   }
 }

--- a/tests/smoke/wallet/browser/browser-security.spec.ts
+++ b/tests/smoke/wallet/browser/browser-security.spec.ts
@@ -1,0 +1,80 @@
+// eslint-disable-next-line import-x/no-nodejs-modules
+import path from 'path';
+import { SmokeWalletPlatform } from '../../../tags.js';
+import { loginToApp } from '../../../flows/wallet.flow';
+import { navigateToBrowserView } from '../../../flows/browser.flow';
+import FixtureBuilder from '../../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../../framework/fixtures/FixtureHelper';
+import { getDappUrl } from '../../../framework/fixtures/FixtureUtils';
+import { DappVariants } from '../../../framework/Constants';
+import Browser from '../../../page-objects/Browser/BrowserView';
+import CameraWebsite from '../../../page-objects/Browser/ExternalWebsites/Security/CameraWebsite';
+import HistoryDisclosureWebsite from '../../../page-objects/Browser/ExternalWebsites/Security/HistoryDisclosureWebsite';
+
+const SECURITY_FIXTURES_PATH = path.resolve(
+  __dirname,
+  '../../../fixtures/security',
+);
+
+describe(SmokeWalletPlatform('Browser Security'), () => {
+  beforeEach(() => {
+    jest.setTimeout(150000);
+  });
+
+  it('should show camera permission dialog when page requests camera access', async () => {
+    // On Android, pre-grant the OS-level camera permission so only the
+    // WebView permission dialog remains (Detox can interact with that one).
+    const isAndroid = device.getPlatform() === 'android';
+    await withFixtures(
+      {
+        dapps: [
+          {
+            dappVariant: DappVariants.TEST_DAPP,
+            dappPath: SECURITY_FIXTURES_PATH,
+          },
+        ],
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+        ...(isAndroid && { permissions: { camera: 'YES' } }),
+      },
+      async () => {
+        await loginToApp();
+        await navigateToBrowserView();
+        await Browser.tapUrlInputBox();
+        await Browser.navigateToURL(`${getDappUrl(0)}/camera.html`);
+        await CameraWebsite.verifyRequestPermissionDialogVisible();
+        await device.enableSynchronization();
+      },
+    );
+  });
+
+  it('should not disclose history of visited pages', async () => {
+    await withFixtures(
+      {
+        dapps: [
+          {
+            dappVariant: DappVariants.TEST_DAPP,
+            dappPath: SECURITY_FIXTURES_PATH,
+          },
+        ],
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+        await navigateToBrowserView();
+
+        // Visit the target page first to seed browser history
+        await Browser.tapUrlInputBox();
+        await Browser.navigateToURL(`${getDappUrl(0)}/visited-target.html`);
+
+        // Navigate to the attack page that attempts :visited CSS sniffing
+        await Browser.tapUrlInputBox();
+        await Browser.navigateToURL(`${getDappUrl(0)}/history-disclosure.html`);
+
+        // Verify the browser did NOT leak that visited-target.html was visited
+        await HistoryDisclosureWebsite.verifyVisitedTargetNotLeaked();
+      },
+    );
+  });
+});

--- a/tests/smoke/wallet/browser/browser-security.spec.ts
+++ b/tests/smoke/wallet/browser/browser-security.spec.ts
@@ -21,7 +21,7 @@ describe(SmokeWalletPlatform('Browser Security'), () => {
     jest.setTimeout(150000);
   });
 
-  it('should show camera permission dialog when page requests camera access', async () => {
+  it('shows camera permission dialog when page requests camera access', async () => {
     // On Android, pre-grant the OS-level camera permission so only the
     // WebView permission dialog remains (Detox can interact with that one).
     const isAndroid = device.getPlatform() === 'android';
@@ -48,7 +48,7 @@ describe(SmokeWalletPlatform('Browser Security'), () => {
     );
   });
 
-  it('should not disclose history of visited pages', async () => {
+  it('does not disclose history of visited pages', async () => {
     await withFixtures(
       {
         dapps: [


### PR DESCRIPTION
## **Description**

Migrates two quarantined browser security E2E tests from external URLs to local HTML fixtures served by DappServer. This eliminates flakiness caused by relying on live third-party websites.

**Camera permission test:** Navigates to a local `camera.html` page that calls `getUserMedia`, verifies the permission dialog appears, taps Allow, and confirms camera access is granted. On Android, OS-level camera permission is pre-granted via `withFixtures` so only the WebView dialog remains.

**History disclosure test:** Seeds browser history by visiting a local target page, then navigates to an attack page that attempts CSS `:visited` sniffing. Verifies the browser does not leak which pages were previously visited.

Both tests pass on iOS (iPhone 16 Pro simulator) and Android (Pixel 9 emulator).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1717](https://consensyssoftware.atlassian.net/browse/MMQA-1717)

## **Manual testing steps**

```gherkin
Feature: Browser Security Tests

  Scenario: Camera permission dialog grants access
    Given the app is logged in and on the browser view

    When user navigates to the local camera.html fixture
    Then a permission dialog appears asking to allow camera access
    When user taps Allow
    Then the page shows "Camera access granted"

  Scenario: Browser does not disclose visited page history
    Given the app is logged in and on the browser view

    When user visits the target page to seed browser history
    And user navigates to the history disclosure attack page
    Then the attack page does not detect that the target was visited
```

## **Screenshots/Recordings**

### **Before**

N/A — tests were quarantined and not running

### **After**

**iOS (full suite):**
```
PASS tests/smoke/wallet/browser/browser-security.spec.ts (179.557 s)
  SmokeWalletPlatform: Browser Security
    ✓ should show camera permission dialog when page requests camera access (87093 ms)
    ✓ should not disclose history of visited pages (84538 ms)

Tests: 2 passed, 2 total
```

**Android (full suite):**
```
PASS tests/smoke/wallet/browser/browser-security.spec.ts (222.631 s)
  SmokeWalletPlatform: Browser Security
    ✓ should show camera permission dialog when page requests camera access (123241 ms)
    ✓ should not disclose history of visited pages (93572 ms)

Tests: 2 passed, 2 total
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-1717]: https://consensyssoftware.atlassian.net/browse/MMQA-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds/updates Detox smoke tests and local HTML fixtures only, with no production code or security-sensitive runtime logic changes.
> 
> **Overview**
> Migrates two browser security E2E checks away from third-party sites by adding local HTML fixtures (`camera.html`, `history-disclosure.html`, `visited-target.html`) served via the test dapp server.
> 
> Adds a new `browser-security.spec.ts` smoke suite that loads these local pages to verify (1) camera permission prompts and successful `getUserMedia` access (including Android pre-granted OS permission and Detox sync toggling), and (2) lack of CSS `:visited` history leakage after seeding history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb156ab2ee8dbe1823dce1986b6560c145bef9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->