### PR TITLE
fix(earn): prevent swipe gesture conflict in earn screen stack navigator cp-7.73.0

### DIFF
--- a/app/components/UI/Earn/routes/index.tsx
+++ b/app/components/UI/Earn/routes/index.tsx
@@ -18,7 +18,7 @@ const EarnScreenStack = () => {
   const emptyNavHeaderOptions = useEmptyNavHeaderForConfirmations();
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator screenOptions={{ presentation: 'transparentModal' }}>
       <Stack.Screen
         name={Routes.EARN.LENDING_DEPOSIT_CONFIRMATION}
         component={EarnLendingDepositConfirmationView}


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `EarnScreenStack` navigator was using the default stack presentation mode, which enables a swipe-back gesture on the entire screen. This conflicted with swipe interactions inside the `MusdQuickConvertView` (the quick convert button), causing the screen to dismiss unintentionally when users tried to swipe within the view.

The fix adds `screenOptions={{ presentation: 'transparentModal' }}` to the `EarnScreenStack` navigator, which disables the swipe-to-dismiss gesture at the navigator level. This is consistent with how the `EarnModalStack` is already configured.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed swipe gesture conflict that caused the earn quick convert screen to dismiss unintentionally

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Earn mUSD quick convert swipe interaction

  Background:
    Given I am logged into MetaMask Mobile
    And I have mUSD in my earn portfolio

  Scenario: user swipes on the quick convert button without dismissing the screen
    Given I am on the mUSD quick convert screen

    When user swipes left or right on the quick convert input or button
    Then the screen should remain open
    And the swipe interaction should be handled by the component correctly

  Scenario: user navigates back from the earn screen using the back button
    Given I am on any earn screen (deposit confirmation, withdrawal confirmation, or quick convert)

    When user taps the back button or header back navigation
    Then I should be navigated back to the previous screen
    And the screen should not dismiss via swipe gesture
```




## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/8e1142bc-2958-408d-841a-91fb9fb1a0e4
N/A

### **After**

https://github.com/user-attachments/assets/926d35a9-ab7c-4653-8cdb-a9eb771ce5d4



N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation config change; it only adjusts stack presentation/gestures and may subtly affect transition/overlay behavior for Earn screens.
> 
> **Overview**
> Updates `EarnScreenStack` to use `screenOptions={{ presentation: 'transparentModal' }}`, preventing the default swipe-back gesture from conflicting with swipe interactions (e.g., in `MusdQuickConvertView`) and aligning its behavior with the existing modal stack configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738ece451660a58a4e7cdbd59ce0902b245920be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->