### PR TITLE
chore: fix outline pill on scroll back token details ac

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1132,11 +1132,10 @@ function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
   if (tailSec === null || !isFinite(Number(tailSec))) {
     return true;
   }
-  var geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
-  var dataOff =
-    ohlcvData && ohlcvData.length
-      ? isSeriesTailOffScreenByData(chart, ohlcvData)
-      : null;
+  const geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
+  const dataOff = ohlcvData?.length
+    ? isSeriesTailOffScreenByData(chart, ohlcvData)
+    : null;
   if (geo === false || dataOff === true) {
     return false;
   }
@@ -1148,11 +1147,11 @@ function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
  * {@link shouldHideVisibleEdgeOutlinePill}).
  */
 function updateVisibleEdgeOutlinePriceLabel() {
-  var elOut = document.getElementById('custom-series-last-value-label');
+  const elOut = document.getElementById('custom-series-last-value-label');
   if (!elOut) {
     return;
   }
-  var w = window;
+  const w = window;
   if (
     !getLineChrome().useCustomPriceLabels ||
     !w.chartWidget ||
@@ -1163,54 +1162,54 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var ct = w.currentChartType;
+  const ct = w.currentChartType;
   if (ct !== 1 && ct !== 2) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var chart = w.chartWidget.activeChart();
-  var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
-  var tailSec = normalizeChartUnixSec(tailBar.time);
+  const chart = w.chartWidget.activeChart();
+  const tailBar = w.ohlcvData[w.ohlcvData.length - 1];
+  const tailSec = normalizeChartUnixSec(tailBar.time);
   if (shouldHideVisibleEdgeOutlinePill(chart, tailSec, w.ohlcvData)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
+  const edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
   if (!edgeBar) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var price = Number(edgeBar.close);
+  let price = Number(edgeBar.close);
   if (ct === 2) {
-    var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
+    const tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
     if (tEdgeMs !== null) {
-      var pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
+      const pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
       if (pLine !== null && isFinite(pLine)) {
         price = pLine;
       }
     }
   }
-  var y = getPriceYForLastCloseOverlay(chart, price);
+  const y = getPriceYForLastCloseOverlay(chart, price);
   if (y === null || y === undefined || isNaN(y)) {
     elOut.style.display = 'none';
     elOut.style.borderColor = '';
     elOut.style.color = '';
     return;
   }
-  var resolvedLast = resolveLineEndOverlayPoint(chart);
-  var lastClosePrice =
+  const resolvedLast = resolveLineEndOverlayPoint(chart);
+  const lastClosePrice =
     resolvedLast && isFinite(resolvedLast.price)
       ? resolvedLast.price
       : tailBar.close;
-  var yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
+  const yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
 
-  var theme = (w.CONFIG && w.CONFIG.theme) || {};
-  var upColor = theme.successColor || '#0C9F76';
-  var downColor = theme.errorColor || '#E06470';
-  var outlineColor = upColor;
+  const theme = (w.CONFIG && w.CONFIG.theme) || {};
+  const upColor = theme.successColor || '#0C9F76';
+  const downColor = theme.errorColor || '#E06470';
+  let outlineColor = upColor;
   if (ct === 1) {
-    var o = Number(edgeBar.open);
-    var c = Number(edgeBar.close);
+    const o = Number(edgeBar.open);
+    const c = Number(edgeBar.close);
     if (isFinite(o) && isFinite(c) && c < o) {
       outlineColor = downColor;
     }
@@ -1219,13 +1218,13 @@ function updateVisibleEdgeOutlinePriceLabel() {
   elOut.style.color = outlineColor;
   elOut.textContent = formatCrosshairPrice(price);
   elOut.style.display = 'flex';
-  var overlayOut = document.getElementById('custom-crosshair-overlay');
+  const overlayOut = document.getElementById('custom-crosshair-overlay');
 
-  var yPos = y;
+  let yPos = y;
   positionPricePillAtPlotPriceBoundary(elOut, overlayOut, yPos);
-  var gapPx = 4;
-  var elLast = document.getElementById('last-close-price-label');
-  var hO = elOut.offsetHeight;
+  const gapPx = 4;
+  const elLast = document.getElementById('last-close-price-label');
+  let hO = elOut.offsetHeight;
   if (!hO || hO < 8) {
     hO = 24;
   }
@@ -1238,17 +1237,17 @@ function updateVisibleEdgeOutlinePriceLabel() {
     yLastClose !== undefined &&
     !isNaN(yLastClose)
   ) {
-    var hF = elLast.offsetHeight;
-    var half = (hF + hO) / 2 + gapPx;
+    const hF = elLast.offsetHeight;
+    const half = (hF + hO) / 2 + gapPx;
     if (Math.abs(y - yLastClose) < half) {
-      var minCenter = hO / 2 + 2;
-      var maxCenter =
+      const minCenter = hO / 2 + 2;
+      const maxCenter =
         overlayOut && overlayOut.clientHeight > 0
           ? overlayOut.clientHeight - hO / 2 - 2
           : Infinity;
-      var pOut = Number(price);
-      var pLast = Number(lastClosePrice);
-      var edgeAboveFilled =
+      const pOut = Number(price);
+      const pLast = Number(lastClosePrice);
+      const edgeAboveFilled =
         isFinite(pOut) && isFinite(pLast) ? pOut > pLast : y < yLastClose;
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
@@ -1274,33 +1273,34 @@ function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
     return null;
   }
-  var p = Number(price);
+  const p = Number(price);
   try {
-    var panes = chart.getPanes();
+    const panes = chart.getPanes();
     if (!panes || !panes.length) return null;
-    var pane = panes[0];
-    var scale = pane.getMainSourcePriceScale();
+    const pane = panes[0];
+    const scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var range = scale.getVisiblePriceRange();
+    const range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
       return null;
     }
-    var lo = Math.min(range.from, range.to);
-    var hi = Math.max(range.from, range.to);
-    var h = pane.getHeight();
+    const lo = Math.min(range.from, range.to);
+    const hi = Math.max(range.from, range.to);
+    const h = pane.getHeight();
     if (!h || h <= 0) return null;
-    var pClamped = Math.min(hi, Math.max(lo, p));
-    var inverted = typeof scale.isInverted === 'function' && scale.isInverted();
-    var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+    const pClamped = Math.min(hi, Math.max(lo, p));
+    const inverted =
+      typeof scale.isInverted === 'function' && scale.isInverted();
+    const mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
     if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
-      var logLo = Math.log(lo);
-      var logHi = Math.log(hi);
-      var logP = Math.log(pClamped);
+      const logLo = Math.log(lo);
+      const logHi = Math.log(hi);
+      const logP = Math.log(pClamped);
       if (logHi === logLo) {
         return inverted ? 0 : h / 2;
       }
-      var t = (logP - logLo) / (logHi - logLo);
+      const t = (logP - logLo) / (logHi - logLo);
       return inverted ? t * h : (1 - t) * h;
     }
     if (inverted) {
@@ -2463,7 +2463,7 @@ function resolveLineEndOverlayPoint(chart) {
  * Normalize TV/chart timestamps to unix **seconds** (library mixes sec/ms in places).
  */
 function normalizeChartUnixSec(t) {
-  var n = Number(t);
+  const n = Number(t);
   if (!isFinite(n)) {
     return null;
   }
@@ -2472,7 +2472,7 @@ function normalizeChartUnixSec(t) {
 
 /** Raw TV timestamp → unix ms (keeps sub-second precision vs {@link normalizeChartUnixSec}). */
 function chartRawTimeToUnixMs(rawT) {
-  var n = Number(rawT);
+  const n = Number(rawT);
   if (!isFinite(n)) {
     return null;
   }
@@ -2486,11 +2486,11 @@ function chartRawTimeToUnixMs(rawT) {
  * Step between last two OHLCV bars in seconds (for visible-range alignment checks).
  */
 function getApproxBarDurationSec() {
-  var d = window.ohlcvData;
+  const d = window.ohlcvData;
   if (!d || d.length < 2) {
     return 300;
   }
-  var ms = Math.abs(d[d.length - 1].time - d[d.length - 2].time);
+  const ms = Math.abs(d[d.length - 1].time - d[d.length - 2].time);
   return Math.max(60, Math.round(ms / 1000));
 }
 
@@ -2505,7 +2505,7 @@ var LINE_END_ICON_MAX_PROBES = 14;
  * Skip extrapolation during interval switches / odd zoom: too few bars, incoherent visible range vs data.
  */
 function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
-  var d = window.ohlcvData;
+  const d = window.ohlcvData;
   if (!d || d.length < 2) {
     return true;
   }
@@ -2513,18 +2513,18 @@ function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
     return true;
   }
   try {
-    var br = chart.getVisibleBarsRange();
+    const br = chart.getVisibleBarsRange();
     if (!br || br.from === undefined || br.to === undefined) {
       return true;
     }
-    var brFromSec = normalizeChartUnixSec(br.from);
-    var brToSec = normalizeChartUnixSec(br.to);
+    const brFromSec = normalizeChartUnixSec(br.from);
+    const brToSec = normalizeChartUnixSec(br.to);
     if (brFromSec === null || brToSec === null) {
       return true;
     }
-    var barDur = getApproxBarDurationSec();
-    var visibleSpan = Math.abs(brToSec - brFromSec);
-    var n = d.length;
+    const barDur = getApproxBarDurationSec();
+    const visibleSpan = Math.abs(brToSec - brFromSec);
+    const n = d.length;
     if (visibleSpan > barDur * Math.max(n, 1) * 96) {
       return true;
     }
@@ -2542,15 +2542,15 @@ function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
 
 function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
   try {
-    var br = chart.getVisibleBarsRange();
+    const br = chart.getVisibleBarsRange();
     if (!br || br.to === undefined || br.to === null) {
       return false;
     }
-    var brToSec = normalizeChartUnixSec(br.to);
+    const brToSec = normalizeChartUnixSec(br.to);
     if (brToSec === null) {
       return false;
     }
-    var barDur = getApproxBarDurationSec();
+    const barDur = getApproxBarDurationSec();
     return (
       lastBarTimeSec <= brToSec + barDur &&
       lastBarTimeSec >= brToSec - 2 * barDur
@@ -2568,7 +2568,7 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
  * @returns {number | null} unix seconds
  */
 function timeScaleCoordinateToTimeSec(ts, x) {
-  var raw = ts.coordinateToTime(x);
+  const raw = ts.coordinateToTime(x);
   if (raw == null || raw === undefined) {
     return null;
   }
@@ -2581,8 +2581,8 @@ function timeScaleCoordinateToTimeSec(ts, x) {
  * @returns {number | null}
  */
 function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
-  var tLo = timeScaleCoordinateToTimeSec(ts, 0);
-  var tHi = timeScaleCoordinateToTimeSec(ts, maxX);
+  const tLo = timeScaleCoordinateToTimeSec(ts, 0);
+  const tHi = timeScaleCoordinateToTimeSec(ts, maxX);
   if (tLo === null || tHi === null) {
     return null;
   }
@@ -2592,11 +2592,11 @@ function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
   if (tLo >= tNorm) {
     return 0;
   }
-  var lo = 0;
-  var hi = maxX;
+  let lo = 0;
+  let hi = maxX;
   while (lo < hi) {
-    var mid = (lo + hi) >> 1;
-    var tm = timeScaleCoordinateToTimeSec(ts, mid);
+    const mid = (lo + hi) >> 1;
+    const tm = timeScaleCoordinateToTimeSec(ts, mid);
     if (tm === null) {
       return null;
     }
@@ -2623,7 +2623,7 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
     return null;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2631,20 +2631,23 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
     ) {
       return null;
     }
-    var plotW = ts.width();
+    const plotW = ts.width();
     if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    var markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
-    var tNorm = normalizeChartUnixSec(markerTimeSec);
+    const markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
+    const tNorm = normalizeChartUnixSec(markerTimeSec);
     if (tNorm === null) {
       return null;
     }
-    var xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
-    var maxX = Math.max(0, Math.floor(plotW - 1));
+    const xCut = Math.max(
+      0,
+      Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1),
+    );
+    const maxX = Math.max(0, Math.floor(plotW - 1));
 
-    var tMax = timeScaleCoordinateToTimeSec(ts, maxX);
-    var tMin = timeScaleCoordinateToTimeSec(ts, 0);
+    const tMax = timeScaleCoordinateToTimeSec(ts, maxX);
+    const tMin = timeScaleCoordinateToTimeSec(ts, 0);
     if (tMin === null || tMax === null) {
       return null;
     }
@@ -2657,7 +2660,7 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
       return true;
     }
 
-    var xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
+    const xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
     if (xFirst === null) {
       return null;
     }
@@ -2675,11 +2678,11 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
  * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
  */
 function getVisibleTimeRangeSecFromChart(chart) {
-  var fromSec;
-  var toSec;
+  let fromSec;
+  let toSec;
   try {
-    var br = chart.getVisibleBarsRange();
-    if (br && br.from !== undefined && br.to !== undefined) {
+    const br = chart.getVisibleBarsRange();
+    if (br?.from !== undefined && br?.to !== undefined) {
       fromSec = normalizeChartUnixSec(br.from);
       toSec = normalizeChartUnixSec(br.to);
       if (fromSec !== null && toSec !== null) {
@@ -2690,11 +2693,11 @@ function getVisibleTimeRangeSecFromChart(chart) {
       }
     }
   } catch (eBr) {
-    /* fall through — bars range often null mid-gesture; try visible time range */
+    void eBr;
   }
   try {
-    var vr = chart.getVisibleRange && chart.getVisibleRange();
-    if (vr && vr.from !== undefined && vr.to !== undefined) {
+    const vr = chart.getVisibleRange?.();
+    if (vr?.from !== undefined && vr?.to !== undefined) {
       fromSec = normalizeChartUnixSec(vr.from);
       toSec = normalizeChartUnixSec(vr.to);
       if (fromSec !== null && toSec !== null) {
@@ -2721,18 +2724,17 @@ function getVisibleTimeRangeSecFromChart(chart) {
  * @returns {object | null} bar object or null if none intersect
  */
 function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
-  var range = getVisibleTimeRangeSecFromChart(chart);
+  const range = getVisibleTimeRangeSecFromChart(chart);
   if (!range || !data || !data.length) {
     return null;
   }
-  var slackSec = getApproxBarDurationSec() * 2;
-  var loMs = (range.lo - slackSec) * 1000;
-  var hiMs = (range.hi + slackSec) * 1000;
-  var best = null;
-  var i;
-  for (i = 0; i < data.length; i++) {
-    var b = data[i];
-    var t = b.time;
+  const slackSec = getApproxBarDurationSec() * 2;
+  const loMs = (range.lo - slackSec) * 1000;
+  const hiMs = (range.hi + slackSec) * 1000;
+  let best = null;
+  for (let i = 0; i < data.length; i++) {
+    const b = data[i];
+    const t = b.time;
     if (t >= loMs && t <= hiMs) {
       if (!best || t > best.time) {
         best = b;
@@ -2754,17 +2756,17 @@ function isSeriesTailOffScreenByData(chart, data) {
   if (!chart || !data || !data.length) {
     return null;
   }
-  var tail = data[data.length - 1];
-  var tailMs = tail.time;
-  var rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  const tail = data[data.length - 1];
+  const tailMs = tail.time;
+  const rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
   if (!rightmost) {
     return null;
   }
   if (rightmost === tail || rightmost.time === tailMs) {
     return false;
   }
-  var barDurMs = getApproxBarDurationSec() * 1000;
-  var halfBarSlackMs = Math.max(1, barDurMs * 0.5);
+  const barDurMs = getApproxBarDurationSec() * 1000;
+  const halfBarSlackMs = Math.max(1, barDurMs * 0.5);
   if (tailMs - rightmost.time <= halfBarSlackMs) {
     return false;
   }
@@ -2781,23 +2783,22 @@ function isSeriesTailOffScreenByData(chart, data) {
  * @returns {object | null}
  */
 function getVisibleEdgeOutlineBar(chart, data) {
-  var primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  const primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
   if (primary) {
     return primary;
   }
-  var range = getVisibleTimeRangeSecFromChart(chart);
+  const range = getVisibleTimeRangeSecFromChart(chart);
   if (!range || !data || !data.length) {
     return null;
   }
-  var barDur = getApproxBarDurationSec();
-  var looseSlackSec = barDur * 6;
-  var loMs = (range.lo - looseSlackSec) * 1000;
-  var hiMs = (range.hi + looseSlackSec) * 1000;
-  var best = null;
-  var i;
-  for (i = 0; i < data.length; i++) {
-    var b = data[i];
-    var t = b.time;
+  const barDur = getApproxBarDurationSec();
+  const looseSlackSec = barDur * 6;
+  const loMs = (range.lo - looseSlackSec) * 1000;
+  const hiMs = (range.hi + looseSlackSec) * 1000;
+  let best = null;
+  for (let i = 0; i < data.length; i++) {
+    const b = data[i];
+    const t = b.time;
     if (t >= loMs && t <= hiMs) {
       if (!best || t > best.time) {
         best = b;
@@ -2813,7 +2814,7 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
     return null;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2821,22 +2822,22 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
     ) {
       return null;
     }
-    var w = ts.width();
+    const w = ts.width();
     if (!(w > OUTLINE_EDGE_TIME_INSET_PX + 2)) {
       return null;
     }
-    var x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
-    var rawT = ts.coordinateToTime(x);
+    const x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
+    const rawT = ts.coordinateToTime(x);
     if (rawT === null || rawT === undefined) {
       return null;
     }
-    var tMs = chartRawTimeToUnixMs(rawT);
+    let tMs = chartRawTimeToUnixMs(rawT);
     if (tMs === null) {
       return null;
     }
-    var vr = chart.getVisibleRange && chart.getVisibleRange();
-    if (vr && vr.to !== undefined && vr.to !== null) {
-      var capMs = chartRawTimeToUnixMs(vr.to);
+    const vr = chart.getVisibleRange?.();
+    if (vr?.to !== undefined && vr?.to !== null) {
+      const capMs = chartRawTimeToUnixMs(vr.to);
       if (capMs !== null && tMs > capMs) {
         tMs = capMs;
       }
@@ -2852,23 +2853,22 @@ function interpolateCloseAlongLineAtTimeMs(data, tMs) {
   if (!data || !data.length || !isFinite(tMs)) {
     return null;
   }
-  var first = data[0];
-  var last = data[data.length - 1];
+  const first = data[0];
+  const last = data[data.length - 1];
   if (tMs <= first.time) {
-    var c0 = Number(first.close);
+    const c0 = Number(first.close);
     return isFinite(c0) ? c0 : null;
   }
   if (tMs >= last.time) {
-    var cL = Number(last.close);
+    const cL = Number(last.close);
     return isFinite(cL) ? cL : null;
   }
-  var i;
-  for (i = 0; i < data.length - 1; i++) {
-    var t0 = data[i].time;
-    var t1 = data[i + 1].time;
+  for (let i = 0; i < data.length - 1; i++) {
+    const t0 = data[i].time;
+    const t1 = data[i + 1].time;
     if (tMs >= t0 && tMs <= t1) {
-      var a = Number(data[i].close);
-      var b = Number(data[i + 1].close);
+      const a = Number(data[i].close);
+      const b = Number(data[i + 1].close);
       if (!isFinite(a) || !isFinite(b)) {
         return null;
       }
@@ -2896,7 +2896,7 @@ function getLineEndIconTimeSec(chart, lastBarTimeSec) {
     return lastBarTimeSec;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2904,32 +2904,31 @@ function getLineEndIconTimeSec(chart, lastBarTimeSec) {
     ) {
       return lastBarTimeSec;
     }
-    var w = ts.width();
+    const w = ts.width();
     if (!(w > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return lastBarTimeSec;
     }
-    var vr = chart.getVisibleRange();
-    var capSec =
-      vr && vr.to !== undefined && vr.to !== null
+    const vr = chart.getVisibleRange?.();
+    const capSec =
+      vr?.to !== undefined && vr?.to !== null
         ? normalizeChartUnixSec(vr.to)
         : null;
-    var k;
-    for (k = 0; k < LINE_END_ICON_MAX_PROBES; k++) {
-      var x = Math.max(
+    for (let k = 0; k < LINE_END_ICON_MAX_PROBES; k++) {
+      const x = Math.max(
         0,
         Math.floor(
           w - LINE_END_ICON_TIME_INSET_PX - k * LINE_END_ICON_PROBE_STEP_PX,
         ),
       );
-      var rawT = ts.coordinateToTime(x);
+      const rawT = ts.coordinateToTime(x);
       if (rawT === null || rawT === undefined) {
         continue;
       }
-      var numT = Number(rawT);
+      const numT = Number(rawT);
       if (!isFinite(numT)) {
         continue;
       }
-      var tNorm = normalizeChartUnixSec(numT);
+      let tNorm = normalizeChartUnixSec(numT);
       if (tNorm === null) {
         continue;
       }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1264,23 +1264,20 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Tries main price scale APIs; returns pixel Y or `null`.
+ * Uses `priceToCoordinate` on the main source price scale when present (not listed on IPriceScaleApi
+ * in Advanced Charts docs; fallback is `getVisiblePriceRange` + linear map in the caller).
  */
 function priceScalePriceToY(scale, p) {
   if (typeof scale.priceToCoordinate === 'function') {
     var y = scale.priceToCoordinate(p);
     if (y !== null && y !== undefined && !isNaN(y)) return y;
   }
-  if (typeof scale.priceToPixels === 'function') {
-    y = scale.priceToPixels(p);
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
-  }
   return null;
 }
 
 /**
- * Y pixel for a price (same space as crosshair `offsetY`). Uses
- * `priceToCoordinate` / `priceToPixels` when present; else visible range → pane height.
+ * Y pixel for a price (same space as crosshair `offsetY`). Prefers `priceToCoordinate` when
+ * present; else maps using `getVisiblePriceRange` and pane height (including clamped price).
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1124,20 +1124,10 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
- * Updates `#custom-series-last-value-label`: **close price of the rightmost OHLCV bar whose time
- * still lies inside the chart’s visible bars range**, positioned on the price scale like the
- * last-close pill. Shown only when:
- * - `getLineChrome().useCustomPriceLabels`, and
- * - chart is ready with data, and
- * - chart type is candle or line, and
- * - the **series tail** (latest bar) is **not** in the visible time window (e.g. user panned left),
- * - and we successfully resolve a visible-edge bar and a Y coordinate.
- *
- * When the outline’s chart Y would overlap the filled last-close pill, nudges the outline
- * **up or down** (smaller vs larger Y) so the higher price stays above the lower on the pane.
- *
- * Candlestick: outline border + text use theme success (close >= open) or error (down bar).
- * Line chart: success color only (matches single-series stroke).
+ * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
+ * scrolled off the right (`coordinateToTime` at right inset), subject to
+ * `isSeriesLastCoveredByVisibleRangeRightBound` (padding / first load) and
+ * `trailingVisibleBarMatchesSeriesLast` when the inset probe is unavailable.
  */
 function updateVisibleEdgeOutlinePriceLabel() {
   var elOut = document.getElementById('custom-series-last-value-label');
@@ -1162,11 +1152,32 @@ function updateVisibleEdgeOutlinePriceLabel() {
   }
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
-  if (isSeriesTailBarTimeVisibleOnChart(chart, tailBar.time)) {
+  var tailSec = normalizeChartUnixSec(tailBar.time);
+  var tailOffRight =
+    tailSec !== null
+      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+      : null;
+  var trailingMatch =
+    tailOffRight === null && tailSec !== null
+      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
+      : false;
+  if (tailOffRight === false) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var edgeBar = getRightmostOhlcvBarInVisibleTimeRange(chart, w.ohlcvData);
+  if (tailOffRight === null && trailingMatch) {
+    hideCustomSeriesLastValueLabelDom();
+    return;
+  }
+  if (
+    tailOffRight === true &&
+    tailSec !== null &&
+    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
+  ) {
+    hideCustomSeriesLastValueLabelDom();
+    return;
+  }
+  var edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
   if (!edgeBar) {
     hideCustomSeriesLastValueLabelDom();
     return;
@@ -1278,10 +1289,18 @@ function getPriceYForLastCloseOverlay(chart, price) {
     }
     var lo = Math.min(range.from, range.to);
     var hi = Math.max(range.from, range.to);
-    if (p < lo || p > hi) return null;
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
-    return ((hi - p) / (hi - lo)) * h;
+    /* Clamp so the pill stays at the plot top/bottom when close is outside auto-scale (pan/zoom). */
+    var pClamped = Math.min(hi, Math.max(lo, p));
+    if (typeof scale.priceToCoordinate === 'function') {
+      y = scale.priceToCoordinate(pClamped);
+      if (y !== null && y !== undefined && !isNaN(y)) return y;
+    } else if (typeof scale.priceToPixels === 'function') {
+      y = scale.priceToPixels(pClamped);
+      if (y !== null && y !== undefined && !isNaN(y)) return y;
+    }
+    return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;
   }
@@ -2522,58 +2541,133 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
 }
 
 /**
- * Reads TradingView’s current visible bars range and returns normalized **Unix seconds** bounds
- * `{ lo, hi }` (always `lo <= hi`). Used by both “is tail visible?” and “which bars intersect?”.
+ * True when the visible time window’s **right** bound still reaches the series last bar (last bar
+ * time ≤ right bound). Then the newest candle is still in the chart’s visible range, even if
+ * {@link isSeriesLastBarOffRightOfVisiblePlot} is true because `coordinateToTime` at the right inset
+ * samples empty padding to the right of the last bar (first load / default anchoring).
  *
  * @param {object} chart - `widget.activeChart()`
- * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
+ * @param {number} lastBarTimeSec - unix seconds for the last OHLCV bar
+ * @returns {boolean}
  */
-function getVisibleTimeRangeSecFromChart(chart) {
+function isSeriesLastCoveredByVisibleRangeRightBound(chart, lastBarTimeSec) {
+  var brToSec = null;
   try {
     var br = chart.getVisibleBarsRange();
-    if (!br || br.from === undefined || br.to === undefined) {
+    if (br && br.to !== undefined && br.to !== null) {
+      brToSec = normalizeChartUnixSec(br.to);
+    }
+  } catch (eBr) {
+    brToSec = null;
+  }
+  if (brToSec === null) {
+    var r = getVisibleTimeRangeSecFromChart(chart);
+    if (r) {
+      brToSec = r.hi;
+    }
+  }
+  if (
+    brToSec === null ||
+    lastBarTimeSec == null ||
+    !isFinite(Number(lastBarTimeSec))
+  ) {
+    return false;
+  }
+  return Number(lastBarTimeSec) <= brToSec;
+}
+
+/**
+ * True if the **last OHLCV bar’s time** is to the **right** of the time painted at the plot’s
+ * right edge—i.e. the series end is scrolled off-screen to the right (outline pill should show).
+ * False if the time at the right edge is at or past the last bar (end is in view). Null if unknown.
+ *
+ * Uses {@link ITimeScaleApi.coordinateToTime} at the right inset so we don’t rely on
+ * `getVisibleBarsRange().to`, which can still “match” the last bar’s timestamp while the oldest bar
+ * is visible on the left and the newest is not drawn at the right edge.
+ *
+ * @param {object} chart
+ * @param {number} lastBarTimeSec — unix **seconds** (same as `normalizeChartUnixSec` of tail)
+ * @returns {boolean | null}
+ */
+function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
+  if (!chart || lastBarTimeSec == null || !isFinite(Number(lastBarTimeSec))) {
+    return null;
+  }
+  try {
+    var ts = chart.getTimeScale();
+    if (
+      !ts ||
+      typeof ts.coordinateToTime !== 'function' ||
+      typeof ts.width !== 'function'
+    ) {
       return null;
     }
-    var fromSec = normalizeChartUnixSec(br.from);
-    var toSec = normalizeChartUnixSec(br.to);
-    if (fromSec === null || toSec === null) {
+    var plotW = ts.width();
+    if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    return {
-      lo: Math.min(fromSec, toSec),
-      hi: Math.max(fromSec, toSec),
-    };
+    var x = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    var rawT = ts.coordinateToTime(x);
+    if (rawT == null || rawT === undefined) {
+      return null;
+    }
+    var tRightEdge = normalizeChartUnixSec(rawT);
+    if (tRightEdge === null) {
+      return null;
+    }
+    var barDur = getApproxBarDurationSec();
+    return lastBarTimeSec > tRightEdge + barDur;
   } catch (e) {
     return null;
   }
 }
 
 /**
- * True if the **dataset’s last bar** (by time) lies inside—or immediately adjacent to—the visible
- * bars range (using `getApproxBarDurationSec` slack). When false, the user has panned/zoomed so the
- * “current” candle/line endpoint is no longer on-screen (typical: panned left, tail off the right).
+ * Reads TradingView’s visible time window as **Unix seconds** `{ lo, hi }` (`lo <= hi`).
+ * Prefer `getVisibleBarsRange()`; if it is null mid-scroll, fall back to `getVisibleRange()`.
  *
- * Returns **true** if we cannot read the range (fail-safe: do not show the outline pill).
- *
- * @param {object} chart
- * @param {number} lastBarTimeMs - `ohlcvData` tail `.time` (milliseconds)
+ * @param {object} chart - `widget.activeChart()`
+ * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
  */
-function isSeriesTailBarTimeVisibleOnChart(chart, lastBarTimeMs) {
-  var range = getVisibleTimeRangeSecFromChart(chart);
-  if (!range) {
-    return true;
+function getVisibleTimeRangeSecFromChart(chart) {
+  var fromSec;
+  var toSec;
+  try {
+    var br = chart.getVisibleBarsRange();
+    if (br && br.from !== undefined && br.to !== undefined) {
+      fromSec = normalizeChartUnixSec(br.from);
+      toSec = normalizeChartUnixSec(br.to);
+      if (fromSec !== null && toSec !== null) {
+        return {
+          lo: Math.min(fromSec, toSec),
+          hi: Math.max(fromSec, toSec),
+        };
+      }
+    }
+  } catch (eBr) {
+    /* fall through — bars range often null mid-gesture; try visible time range */
   }
-  var lastSec = normalizeChartUnixSec(lastBarTimeMs);
-  if (lastSec === null) {
-    return true;
+  try {
+    var vr = chart.getVisibleRange && chart.getVisibleRange();
+    if (vr && vr.from !== undefined && vr.to !== undefined) {
+      fromSec = normalizeChartUnixSec(vr.from);
+      toSec = normalizeChartUnixSec(vr.to);
+      if (fromSec !== null && toSec !== null) {
+        return {
+          lo: Math.min(fromSec, toSec),
+          hi: Math.max(fromSec, toSec),
+        };
+      }
+    }
+  } catch (eVr) {
+    return null;
   }
-  var slack = getApproxBarDurationSec() * 2;
-  return lastSec >= range.lo - slack && lastSec <= range.hi + slack;
+  return null;
 }
 
 /**
  * Among bars in `data`, returns the one with the **maximum `time`** that still falls inside the
- * visible range (milliseconds, with the same slack as `isSeriesTailBarTimeVisibleOnChart`). This is
+ * visible range (milliseconds, slack from `getApproxBarDurationSec`). This is
  * the **rightmost historical bar still drawn** in the viewport—the “visible edge” for the outline
  * pill’s close price.
  *
@@ -2589,6 +2683,42 @@ function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
   var slackSec = getApproxBarDurationSec() * 2;
   var loMs = (range.lo - slackSec) * 1000;
   var hiMs = (range.hi + slackSec) * 1000;
+  var best = null;
+  var i;
+  for (i = 0; i < data.length; i++) {
+    var b = data[i];
+    var t = b.time;
+    if (t >= loMs && t <= hiMs) {
+      if (!best || t > best.time) {
+        best = b;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Bar for the outline pill’s price: same as {@link getRightmostOhlcvBarInVisibleTimeRange}, then
+ * if that is null (gaps at scroll limits), retry with looser slack so the pill does not vanish
+ * when the tail is still off-screen.
+ *
+ * @param {object} chart
+ * @param {Array<{ time: number, close: number }>} data - `window.ohlcvData`
+ * @returns {object | null}
+ */
+function getVisibleEdgeOutlineBar(chart, data) {
+  var primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  if (primary) {
+    return primary;
+  }
+  var range = getVisibleTimeRangeSecFromChart(chart);
+  if (!range || !data || !data.length) {
+    return null;
+  }
+  var barDur = getApproxBarDurationSec();
+  var looseSlackSec = barDur * 6;
+  var loMs = (range.lo - looseSlackSec) * 1000;
+  var hiMs = (range.hi + looseSlackSec) * 1000;
   var best = null;
   var i;
   for (i = 0; i < data.length; i++) {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1124,6 +1124,31 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
+ * True when the outline pill should not show based on tail vs viewport (inset probe + fallbacks).
+ */
+function shouldHideVisibleEdgeOutlinePill(chart, tailSec) {
+  var offRight =
+    tailSec !== null
+      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+      : null;
+  var trailing =
+    offRight === null && tailSec !== null
+      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
+      : false;
+  if (offRight === false) {
+    return true;
+  }
+  if (offRight === null && trailing) {
+    return true;
+  }
+  return (
+    offRight === true &&
+    tailSec !== null &&
+    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
+  );
+}
+
+/**
  * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
  * scrolled off the right (`coordinateToTime` at right inset), subject to
  * `isSeriesLastCoveredByVisibleRangeRightBound` (padding / first load) and
@@ -1153,27 +1178,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
   var tailSec = normalizeChartUnixSec(tailBar.time);
-  var tailOffRight =
-    tailSec !== null
-      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
-      : null;
-  var trailingMatch =
-    tailOffRight === null && tailSec !== null
-      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
-      : false;
-  if (tailOffRight === false) {
-    hideCustomSeriesLastValueLabelDom();
-    return;
-  }
-  if (tailOffRight === null && trailingMatch) {
-    hideCustomSeriesLastValueLabelDom();
-    return;
-  }
-  if (
-    tailOffRight === true &&
-    tailSec !== null &&
-    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
-  ) {
+  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
@@ -1190,12 +1195,11 @@ function updateVisibleEdgeOutlinePriceLabel() {
     elOut.style.color = '';
     return;
   }
-  var lastBarClose = w.ohlcvData[w.ohlcvData.length - 1];
   var resolvedLast = resolveLineEndOverlayPoint(chart);
   var lastClosePrice =
     resolvedLast && isFinite(resolvedLast.price)
       ? resolvedLast.price
-      : lastBarClose.close;
+      : tailBar.close;
   var yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
 
   var theme = (w.CONFIG && w.CONFIG.theme) || {};
@@ -1260,6 +1264,21 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
+ * Tries main price scale APIs; returns pixel Y or `null`.
+ */
+function priceScalePriceToY(scale, p) {
+  if (typeof scale.priceToCoordinate === 'function') {
+    var y = scale.priceToCoordinate(p);
+    if (y !== null && y !== undefined && !isNaN(y)) return y;
+  }
+  if (typeof scale.priceToPixels === 'function') {
+    y = scale.priceToPixels(p);
+    if (y !== null && y !== undefined && !isNaN(y)) return y;
+  }
+  return null;
+}
+
+/**
  * Y pixel for a price (same space as crosshair `offsetY`). Uses
  * `priceToCoordinate` / `priceToPixels` when present; else visible range → pane height.
  */
@@ -1275,13 +1294,8 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var y;
-    if (typeof scale.priceToCoordinate === 'function') {
-      y = scale.priceToCoordinate(p);
-    } else if (typeof scale.priceToPixels === 'function') {
-      y = scale.priceToPixels(p);
-    }
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
+    var y = priceScalePriceToY(scale, p);
+    if (y !== null) return y;
 
     var range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
@@ -1291,15 +1305,9 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var hi = Math.max(range.from, range.to);
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
-    /* Clamp so the pill stays at the plot top/bottom when close is outside auto-scale (pan/zoom). */
     var pClamped = Math.min(hi, Math.max(lo, p));
-    if (typeof scale.priceToCoordinate === 'function') {
-      y = scale.priceToCoordinate(pClamped);
-      if (y !== null && y !== undefined && !isNaN(y)) return y;
-    } else if (typeof scale.priceToPixels === 'function') {
-      y = scale.priceToPixels(pClamped);
-      if (y !== null && y !== undefined && !isNaN(y)) return y;
-    }
+    y = priceScalePriceToY(scale, pClamped);
+    if (y !== null) return y;
     return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1180,7 +1180,6 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  /** Line chart: price/Y at the plot’s right edge matches the drawn segment (interpolate closes). */
   var price = Number(edgeBar.close);
   if (ct === 2) {
     var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
@@ -1230,11 +1229,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   if (!hO || hO < 8) {
     hO = 24;
   }
-  /**
-   * When outline and last-close pills overlap, separate with minimum gap (TradingView-style stack).
-   * Stack direction: higher outline **price** → outline above filled (smaller y); lower → below.
-   * Equal prices → outline below filled so the solid last-price pill stays primary.
-   */
+  /* Nudge outline if it overlaps last-close pill: higher price → above, else below (ties = below). */
   if (
     elLast &&
     elLast.style.display !== 'none' &&
@@ -1253,19 +1248,8 @@ function updateVisibleEdgeOutlinePriceLabel() {
           : Infinity;
       var pOut = Number(price);
       var pLast = Number(lastClosePrice);
-      var edgeAboveFilled;
-      if (isFinite(pOut) && isFinite(pLast)) {
-        if (pOut > pLast) {
-          edgeAboveFilled = true;
-        } else if (pOut < pLast) {
-          edgeAboveFilled = false;
-        } else {
-          edgeAboveFilled = false;
-        }
-      } else {
-        edgeAboveFilled =
-          y < yLastClose || (Math.abs(y - yLastClose) < 1 && pOut > pLast);
-      }
+      var edgeAboveFilled =
+        isFinite(pOut) && isFinite(pLast) ? pOut > pLast : y < yLastClose;
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
         if (yPos < minCenter) {
@@ -1283,44 +1267,8 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Maps a clamped price to Y in pane coordinates. Uses {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getmode IPriceScaleApi.getMode}
- * so **Log** scales match the chart (Charting_Library.PriceScaleMode.Log = 1); other modes use linear mapping.
- *
- * @param {object} scale - IPriceScaleApi
- * @param {number} lo
- * @param {number} hi
- * @param {number} h
- * @param {number} pClamped
- * @param {boolean} inverted
- * @returns {number | null}
- */
-function mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted) {
-  var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
-  /* Log = 1 — https://www.tradingview.com/charting-library-docs/latest/api/enums/Charting_Library.PriceScaleMode/ */
-  if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
-    var logLo = Math.log(lo);
-    var logHi = Math.log(hi);
-    var logP = Math.log(pClamped);
-    if (logHi === logLo) {
-      return inverted ? 0 : h / 2;
-    }
-    var t = (logP - logLo) / (logHi - logLo);
-    if (inverted) {
-      return t * h;
-    }
-    return (1 - t) * h;
-  }
-  if (inverted) {
-    return ((pClamped - lo) / (hi - lo)) * h;
-  }
-  return ((hi - pClamped) / (hi - lo)) * h;
-}
-
-/**
- * Y pixel for a price (same space as crosshair `offsetY`).
- * Uses documented {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getvisiblepricerange IPriceScaleApi.getVisiblePriceRange},
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPaneApi#getheight IPaneApi.getHeight}, and
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#isinverted IPriceScaleApi.isInverted} — not undocumented coordinate helpers.
+ * Y pixel for a price (crosshair overlay space). `getVisiblePriceRange` + `getHeight` + `isInverted`;
+ * `getMode() === 1` (log) uses log mapping.
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
@@ -1344,7 +1292,21 @@ function getPriceYForLastCloseOverlay(chart, price) {
     if (!h || h <= 0) return null;
     var pClamped = Math.min(hi, Math.max(lo, p));
     var inverted = typeof scale.isInverted === 'function' && scale.isInverted();
-    return mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted);
+    var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+    if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
+      var logLo = Math.log(lo);
+      var logHi = Math.log(hi);
+      var logP = Math.log(pClamped);
+      if (logHi === logLo) {
+        return inverted ? 0 : h / 2;
+      }
+      var t = (logP - logLo) / (logHi - logLo);
+      return inverted ? t * h : (1 - t) * h;
+    }
+    if (inverted) {
+      return ((pClamped - lo) / (hi - lo)) * h;
+    }
+    return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;
   }
@@ -2508,13 +2470,7 @@ function normalizeChartUnixSec(t) {
   return n >= 1e12 ? Math.floor(n / 1000) : Math.floor(n);
 }
 
-/**
- * Unix **milliseconds** from raw TradingView time (`coordinateToTime`, `getVisibleRange`, etc.).
- * Preserves sub-second precision for interpolation (unlike {@link normalizeChartUnixSec}).
- *
- * @param {number | string} rawT
- * @returns {number | null}
- */
+/** Raw TV timestamp → unix ms (keeps sub-second precision vs {@link normalizeChartUnixSec}). */
 function chartRawTimeToUnixMs(rawT) {
   var n = Number(rawT);
   if (!isFinite(n)) {
@@ -2538,9 +2494,9 @@ function getApproxBarDurationSec() {
   return Math.max(60, Math.round(ms / 1000));
 }
 
-/** Pixels inset from time-scale right so `coordinateToTime` samples left of the price scale (16px dot + margin). */
+/** Time-scale inset from right so line-end icon stays on-screen (not under price scale). */
 var LINE_END_ICON_TIME_INSET_PX = 40;
-/** Plot’s right edge for outline pill time — must not reuse {@link LINE_END_ICON_TIME_INSET_PX} (samples too far left vs drawn line). `0` = rightmost pixel (`w - 1`). */
+/** Outline edge sample inset (0 = rightmost pixel; not the line-icon inset). */
 var OUTLINE_EDGE_TIME_INSET_PX = 0;
 var LINE_END_ICON_PROBE_STEP_PX = 8;
 var LINE_END_ICON_MAX_PROBES = 14;
@@ -2851,14 +2807,7 @@ function getVisibleEdgeOutlineBar(chart, data) {
   return best;
 }
 
-/**
- * Unix **milliseconds** at the plot’s right edge (minimal inset vs line-icon), via
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi#coordinatetotime ITimeScaleApi.coordinateToTime}.
- * Capped to `getVisibleRange().to`. Uses {@link OUTLINE_EDGE_TIME_INSET_PX}, not {@link LINE_END_ICON_TIME_INSET_PX}.
- *
- * @param {object} chart - `widget.activeChart()`
- * @returns {number | null}
- */
+/** `coordinateToTime` at plot right edge (see {@link OUTLINE_EDGE_TIME_INSET_PX}); capped to `visibleRange.to`. */
 function getVisiblePlotRightEdgeTimeMs(chart) {
   if (!chart) {
     return null;
@@ -2898,13 +2847,7 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
   }
 }
 
-/**
- * Linear interpolation of `close` between adjacent OHLCV bars (line chart path between closes).
- *
- * @param {Array<{ time: number, close: number }>} data - ascending `time` (ms), `window.ohlcvData`
- * @param {number} tMs
- * @returns {number | null}
- */
+/** Interpolate close between consecutive bars (line chart path). */
 function interpolateCloseAlongLineAtTimeMs(data, tMs) {
   if (!data || !data.length || !isFinite(tMs)) {
     return null;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1124,35 +1124,28 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
- * True when the outline pill should not show based on tail vs viewport (inset probe + fallbacks).
+ * Whether to hide the outline price pill: {@link isCustomLineEndMarkerVisibleInPlot} (geometry) plus
+ * {@link isSeriesTailOffScreenByData} so panning to old history (newest bar not in visible window) still
+ * shows the outline when coordinateToTime alone would wrongly hide it.
  */
-function shouldHideVisibleEdgeOutlinePill(chart, tailSec) {
-  var offRight =
-    tailSec !== null
-      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
+  if (tailSec === null || !isFinite(Number(tailSec))) {
+    return true;
+  }
+  var geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
+  var dataOff =
+    ohlcvData && ohlcvData.length
+      ? isSeriesTailOffScreenByData(chart, ohlcvData)
       : null;
-  var trailing =
-    offRight === null && tailSec !== null
-      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
-      : false;
-  if (offRight === false) {
-    return true;
+  if (geo === false || dataOff === true) {
+    return false;
   }
-  if (offRight === null && trailing) {
-    return true;
-  }
-  return (
-    offRight === true &&
-    tailSec !== null &&
-    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
-  );
+  return true;
 }
 
 /**
- * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
- * scrolled off the right (`coordinateToTime` at right inset), subject to
- * `isSeriesLastCoveredByVisibleRangeRightBound` (padding / first load) and
- * `trailingVisibleBarMatchesSeriesLast` when the inset probe is unavailable.
+ * Outline pill: shown when geometry or data says the series tail is off-screen (see
+ * {@link shouldHideVisibleEdgeOutlinePill}).
  */
 function updateVisibleEdgeOutlinePriceLabel() {
   var elOut = document.getElementById('custom-series-last-value-label');
@@ -1178,7 +1171,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
   var tailSec = normalizeChartUnixSec(tailBar.time);
-  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec)) {
+  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec, w.ohlcvData)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
@@ -2545,56 +2538,65 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
   }
 }
 
+/** Helpers for {@link isCustomLineEndMarkerVisibleInPlot} (time ↔ x on the time scale). */
+
 /**
- * True when the visible time window’s **right** bound still reaches the series last bar (last bar
- * time ≤ right bound). Then the newest candle is still in the chart’s visible range, even if
- * {@link isSeriesLastBarOffRightOfVisiblePlot} is true because `coordinateToTime` at the right inset
- * samples empty padding to the right of the last bar (first load / default anchoring).
- *
- * @param {object} chart - `widget.activeChart()`
- * @param {number} lastBarTimeSec - unix seconds for the last OHLCV bar
- * @returns {boolean}
+ * @param {object} ts - `chart.getTimeScale()`
+ * @param {number} x
+ * @returns {number | null} unix seconds
  */
-function isSeriesLastCoveredByVisibleRangeRightBound(chart, lastBarTimeSec) {
-  var brToSec = null;
-  try {
-    var br = chart.getVisibleBarsRange();
-    if (br && br.to !== undefined && br.to !== null) {
-      brToSec = normalizeChartUnixSec(br.to);
-    }
-  } catch (eBr) {
-    brToSec = null;
+function timeScaleCoordinateToTimeSec(ts, x) {
+  var raw = ts.coordinateToTime(x);
+  if (raw == null || raw === undefined) {
+    return null;
   }
-  if (brToSec === null) {
-    var r = getVisibleTimeRangeSecFromChart(chart);
-    if (r) {
-      brToSec = r.hi;
-    }
-  }
-  if (
-    brToSec === null ||
-    lastBarTimeSec == null ||
-    !isFinite(Number(lastBarTimeSec))
-  ) {
-    return false;
-  }
-  return Number(lastBarTimeSec) <= brToSec;
+  return normalizeChartUnixSec(raw);
 }
 
 /**
- * True if the **last OHLCV bar’s time** is to the **right** of the time painted at the plot’s
- * right edge—i.e. the series end is scrolled off-screen to the right (outline pill should show).
- * False if the time at the right edge is at or past the last bar (end is in view). Null if unknown.
+ * Smallest x in [0, maxX] with coordinate time ≥ tNorm (binary search; assumes time increases with x).
  *
- * Uses {@link ITimeScaleApi.coordinateToTime} at the right inset so we don’t rely on
- * `getVisibleBarsRange().to`, which can still “match” the last bar’s timestamp while the oldest bar
- * is visible on the left and the newest is not drawn at the right edge.
- *
- * @param {object} chart
- * @param {number} lastBarTimeSec — unix **seconds** (same as `normalizeChartUnixSec` of tail)
- * @returns {boolean | null}
+ * @returns {number | null}
  */
-function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
+function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
+  var tLo = timeScaleCoordinateToTimeSec(ts, 0);
+  var tHi = timeScaleCoordinateToTimeSec(ts, maxX);
+  if (tLo === null || tHi === null) {
+    return null;
+  }
+  if (tHi < tNorm) {
+    return null;
+  }
+  if (tLo >= tNorm) {
+    return 0;
+  }
+  var lo = 0;
+  var hi = maxX;
+  while (lo < hi) {
+    var mid = (lo + hi) >> 1;
+    var tm = timeScaleCoordinateToTimeSec(ts, mid);
+    if (tm === null) {
+      return null;
+    }
+    if (tm < tNorm) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Single source of truth for “would the custom line-end marker appear in the plot before the chrome
+ * inset?” — same horizontal rules as {@link getLineEndIconTimeSec} + {@link LINE_END_ICON_TIME_INSET_PX}
+ * (inverse of `coordinateToTime` via {@link findSmallestXWhereTimeGte}).
+ *
+ * @param {object} chart - `widget.activeChart()`
+ * @param {number} lastBarTimeSec - unix seconds, OHLCV tail (same as line overlay)
+ * @returns {boolean | null} true = marker visible in plot (hide outline pill), false = not visible (show outline), null = unknown (hide outline)
+ */
+function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
   if (!chart || lastBarTimeSec == null || !isFinite(Number(lastBarTimeSec))) {
     return null;
   }
@@ -2611,17 +2613,33 @@ function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
     if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    var x = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
-    var rawT = ts.coordinateToTime(x);
-    if (rawT == null || rawT === undefined) {
+    var markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
+    var tNorm = normalizeChartUnixSec(markerTimeSec);
+    if (tNorm === null) {
       return null;
     }
-    var tRightEdge = normalizeChartUnixSec(rawT);
-    if (tRightEdge === null) {
+    var xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    var maxX = Math.max(0, Math.floor(plotW - 1));
+
+    var tMax = timeScaleCoordinateToTimeSec(ts, maxX);
+    var tMin = timeScaleCoordinateToTimeSec(ts, 0);
+    if (tMin === null || tMax === null) {
       return null;
     }
-    var barDur = getApproxBarDurationSec();
-    return lastBarTimeSec > tRightEdge + barDur;
+    /* Marker time past the right edge of the plot → not visible (panned off). */
+    if (tNorm > tMax) {
+      return false;
+    }
+    /* Same conservative branch as before: treat as visible for outline (hide pill). */
+    if (tNorm < tMin) {
+      return true;
+    }
+
+    var xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
+    if (xFirst === null) {
+      return null;
+    }
+    return xFirst <= xCut;
   } catch (e) {
     return null;
   }
@@ -2700,6 +2718,35 @@ function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
     }
   }
   return best;
+}
+
+/**
+ * True when the **newest** OHLCV bar is **not** among the bars intersecting the visible time range:
+ * the rightmost visible bar is strictly older than the series tail (user panned the tail off-screen).
+ *
+ * @param {object} chart - `widget.activeChart()`
+ * @param {Array<{ time: number }>} data - `window.ohlcvData`
+ * @returns {boolean | null} true = tail off-screen by data, false = tail still in range, null = unknown
+ */
+function isSeriesTailOffScreenByData(chart, data) {
+  if (!chart || !data || !data.length) {
+    return null;
+  }
+  var tail = data[data.length - 1];
+  var tailMs = tail.time;
+  var rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  if (!rightmost) {
+    return null;
+  }
+  if (rightmost === tail || rightmost.time === tailMs) {
+    return false;
+  }
+  var barDurMs = getApproxBarDurationSec() * 1000;
+  var halfBarSlackMs = Math.max(1, barDurMs * 0.5);
+  if (tailMs - rightmost.time <= halfBarSlackMs) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1180,7 +1180,17 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var price = edgeBar.close;
+  /** Line chart: price/Y at the plot’s right edge matches the drawn segment (interpolate closes). */
+  var price = Number(edgeBar.close);
+  if (ct === 2) {
+    var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
+    if (tEdgeMs !== null) {
+      var pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
+      if (pLine !== null && isFinite(pLine)) {
+        price = pLine;
+      }
+    }
+  }
   var y = getPriceYForLastCloseOverlay(chart, price);
   if (y === null || y === undefined || isNaN(y)) {
     elOut.style.display = 'none';
@@ -1220,6 +1230,11 @@ function updateVisibleEdgeOutlinePriceLabel() {
   if (!hO || hO < 8) {
     hO = 24;
   }
+  /**
+   * When outline and last-close pills overlap, separate with minimum gap (TradingView-style stack).
+   * Stack direction: higher outline **price** → outline above filled (smaller y); lower → below.
+   * Equal prices → outline below filled so the solid last-price pill stays primary.
+   */
   if (
     elLast &&
     elLast.style.display !== 'none' &&
@@ -1236,10 +1251,21 @@ function updateVisibleEdgeOutlinePriceLabel() {
         overlayOut && overlayOut.clientHeight > 0
           ? overlayOut.clientHeight - hO / 2 - 2
           : Infinity;
-      var edgeAboveFilled =
-        y < yLastClose ||
-        (Math.abs(y - yLastClose) < 1 &&
-          Number(price) > Number(lastClosePrice));
+      var pOut = Number(price);
+      var pLast = Number(lastClosePrice);
+      var edgeAboveFilled;
+      if (isFinite(pOut) && isFinite(pLast)) {
+        if (pOut > pLast) {
+          edgeAboveFilled = true;
+        } else if (pOut < pLast) {
+          edgeAboveFilled = false;
+        } else {
+          edgeAboveFilled = false;
+        }
+      } else {
+        edgeAboveFilled =
+          y < yLastClose || (Math.abs(y - yLastClose) < 1 && pOut > pLast);
+      }
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
         if (yPos < minCenter) {
@@ -1257,20 +1283,44 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Uses `priceToCoordinate` on the main source price scale when present (not listed on IPriceScaleApi
- * in Advanced Charts docs; fallback is `getVisiblePriceRange` + linear map in the caller).
+ * Maps a clamped price to Y in pane coordinates. Uses {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getmode IPriceScaleApi.getMode}
+ * so **Log** scales match the chart (Charting_Library.PriceScaleMode.Log = 1); other modes use linear mapping.
+ *
+ * @param {object} scale - IPriceScaleApi
+ * @param {number} lo
+ * @param {number} hi
+ * @param {number} h
+ * @param {number} pClamped
+ * @param {boolean} inverted
+ * @returns {number | null}
  */
-function priceScalePriceToY(scale, p) {
-  if (typeof scale.priceToCoordinate === 'function') {
-    var y = scale.priceToCoordinate(p);
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
+function mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted) {
+  var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+  /* Log = 1 — https://www.tradingview.com/charting-library-docs/latest/api/enums/Charting_Library.PriceScaleMode/ */
+  if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
+    var logLo = Math.log(lo);
+    var logHi = Math.log(hi);
+    var logP = Math.log(pClamped);
+    if (logHi === logLo) {
+      return inverted ? 0 : h / 2;
+    }
+    var t = (logP - logLo) / (logHi - logLo);
+    if (inverted) {
+      return t * h;
+    }
+    return (1 - t) * h;
   }
-  return null;
+  if (inverted) {
+    return ((pClamped - lo) / (hi - lo)) * h;
+  }
+  return ((hi - pClamped) / (hi - lo)) * h;
 }
 
 /**
- * Y pixel for a price (same space as crosshair `offsetY`). Prefers `priceToCoordinate` when
- * present; else maps using `getVisiblePriceRange` and pane height (including clamped price).
+ * Y pixel for a price (same space as crosshair `offsetY`).
+ * Uses documented {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getvisiblepricerange IPriceScaleApi.getVisiblePriceRange},
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPaneApi#getheight IPaneApi.getHeight}, and
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#isinverted IPriceScaleApi.isInverted} — not undocumented coordinate helpers.
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
@@ -1284,9 +1334,6 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var y = priceScalePriceToY(scale, p);
-    if (y !== null) return y;
-
     var range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
       return null;
@@ -1296,9 +1343,8 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
     var pClamped = Math.min(hi, Math.max(lo, p));
-    y = priceScalePriceToY(scale, pClamped);
-    if (y !== null) return y;
-    return ((hi - pClamped) / (hi - lo)) * h;
+    var inverted = typeof scale.isInverted === 'function' && scale.isInverted();
+    return mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted);
   } catch (e) {
     return null;
   }
@@ -2463,6 +2509,24 @@ function normalizeChartUnixSec(t) {
 }
 
 /**
+ * Unix **milliseconds** from raw TradingView time (`coordinateToTime`, `getVisibleRange`, etc.).
+ * Preserves sub-second precision for interpolation (unlike {@link normalizeChartUnixSec}).
+ *
+ * @param {number | string} rawT
+ * @returns {number | null}
+ */
+function chartRawTimeToUnixMs(rawT) {
+  var n = Number(rawT);
+  if (!isFinite(n)) {
+    return null;
+  }
+  if (n >= 1e12) {
+    return n;
+  }
+  return n * 1000;
+}
+
+/**
  * Step between last two OHLCV bars in seconds (for visible-range alignment checks).
  */
 function getApproxBarDurationSec() {
@@ -2476,6 +2540,8 @@ function getApproxBarDurationSec() {
 
 /** Pixels inset from time-scale right so `coordinateToTime` samples left of the price scale (16px dot + margin). */
 var LINE_END_ICON_TIME_INSET_PX = 40;
+/** Plot’s right edge for outline pill time — must not reuse {@link LINE_END_ICON_TIME_INSET_PX} (samples too far left vs drawn line). `0` = rightmost pixel (`w - 1`). */
+var OUTLINE_EDGE_TIME_INSET_PX = 0;
 var LINE_END_ICON_PROBE_STEP_PX = 8;
 var LINE_END_ICON_MAX_PROBES = 14;
 
@@ -2783,6 +2849,93 @@ function getVisibleEdgeOutlineBar(chart, data) {
     }
   }
   return best;
+}
+
+/**
+ * Unix **milliseconds** at the plot’s right edge (minimal inset vs line-icon), via
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi#coordinatetotime ITimeScaleApi.coordinateToTime}.
+ * Capped to `getVisibleRange().to`. Uses {@link OUTLINE_EDGE_TIME_INSET_PX}, not {@link LINE_END_ICON_TIME_INSET_PX}.
+ *
+ * @param {object} chart - `widget.activeChart()`
+ * @returns {number | null}
+ */
+function getVisiblePlotRightEdgeTimeMs(chart) {
+  if (!chart) {
+    return null;
+  }
+  try {
+    var ts = chart.getTimeScale();
+    if (
+      !ts ||
+      typeof ts.coordinateToTime !== 'function' ||
+      typeof ts.width !== 'function'
+    ) {
+      return null;
+    }
+    var w = ts.width();
+    if (!(w > OUTLINE_EDGE_TIME_INSET_PX + 2)) {
+      return null;
+    }
+    var x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
+    var rawT = ts.coordinateToTime(x);
+    if (rawT === null || rawT === undefined) {
+      return null;
+    }
+    var tMs = chartRawTimeToUnixMs(rawT);
+    if (tMs === null) {
+      return null;
+    }
+    var vr = chart.getVisibleRange && chart.getVisibleRange();
+    if (vr && vr.to !== undefined && vr.to !== null) {
+      var capMs = chartRawTimeToUnixMs(vr.to);
+      if (capMs !== null && tMs > capMs) {
+        tMs = capMs;
+      }
+    }
+    return tMs;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Linear interpolation of `close` between adjacent OHLCV bars (line chart path between closes).
+ *
+ * @param {Array<{ time: number, close: number }>} data - ascending `time` (ms), `window.ohlcvData`
+ * @param {number} tMs
+ * @returns {number | null}
+ */
+function interpolateCloseAlongLineAtTimeMs(data, tMs) {
+  if (!data || !data.length || !isFinite(tMs)) {
+    return null;
+  }
+  var first = data[0];
+  var last = data[data.length - 1];
+  if (tMs <= first.time) {
+    var c0 = Number(first.close);
+    return isFinite(c0) ? c0 : null;
+  }
+  if (tMs >= last.time) {
+    var cL = Number(last.close);
+    return isFinite(cL) ? cL : null;
+  }
+  var i;
+  for (i = 0; i < data.length - 1; i++) {
+    var t0 = data[i].time;
+    var t1 = data[i + 1].time;
+    if (tMs >= t0 && tMs <= t1) {
+      var a = Number(data[i].close);
+      var b = Number(data[i + 1].close);
+      if (!isFinite(a) || !isFinite(b)) {
+        return null;
+      }
+      if (t1 === t0) {
+        return a;
+      }
+      return a + ((b - a) * (tMs - t0)) / (t1 - t0);
+    }
+  }
+  return null;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1133,35 +1133,28 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
- * True when the outline pill should not show based on tail vs viewport (inset probe + fallbacks).
+ * Whether to hide the outline price pill: {@link isCustomLineEndMarkerVisibleInPlot} (geometry) plus
+ * {@link isSeriesTailOffScreenByData} so panning to old history (newest bar not in visible window) still
+ * shows the outline when coordinateToTime alone would wrongly hide it.
  */
-function shouldHideVisibleEdgeOutlinePill(chart, tailSec) {
-  var offRight =
-    tailSec !== null
-      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
+  if (tailSec === null || !isFinite(Number(tailSec))) {
+    return true;
+  }
+  var geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
+  var dataOff =
+    ohlcvData && ohlcvData.length
+      ? isSeriesTailOffScreenByData(chart, ohlcvData)
       : null;
-  var trailing =
-    offRight === null && tailSec !== null
-      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
-      : false;
-  if (offRight === false) {
-    return true;
+  if (geo === false || dataOff === true) {
+    return false;
   }
-  if (offRight === null && trailing) {
-    return true;
-  }
-  return (
-    offRight === true &&
-    tailSec !== null &&
-    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
-  );
+  return true;
 }
 
 /**
- * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
- * scrolled off the right (\`coordinateToTime\` at right inset), subject to
- * \`isSeriesLastCoveredByVisibleRangeRightBound\` (padding / first load) and
- * \`trailingVisibleBarMatchesSeriesLast\` when the inset probe is unavailable.
+ * Outline pill: shown when geometry or data says the series tail is off-screen (see
+ * {@link shouldHideVisibleEdgeOutlinePill}).
  */
 function updateVisibleEdgeOutlinePriceLabel() {
   var elOut = document.getElementById('custom-series-last-value-label');
@@ -1187,7 +1180,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
   var tailSec = normalizeChartUnixSec(tailBar.time);
-  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec)) {
+  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec, w.ohlcvData)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
@@ -2554,56 +2547,65 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
   }
 }
 
+/** Helpers for {@link isCustomLineEndMarkerVisibleInPlot} (time ↔ x on the time scale). */
+
 /**
- * True when the visible time window’s **right** bound still reaches the series last bar (last bar
- * time ≤ right bound). Then the newest candle is still in the chart’s visible range, even if
- * {@link isSeriesLastBarOffRightOfVisiblePlot} is true because \`coordinateToTime\` at the right inset
- * samples empty padding to the right of the last bar (first load / default anchoring).
- *
- * @param {object} chart - \`widget.activeChart()\`
- * @param {number} lastBarTimeSec - unix seconds for the last OHLCV bar
- * @returns {boolean}
+ * @param {object} ts - \`chart.getTimeScale()\`
+ * @param {number} x
+ * @returns {number | null} unix seconds
  */
-function isSeriesLastCoveredByVisibleRangeRightBound(chart, lastBarTimeSec) {
-  var brToSec = null;
-  try {
-    var br = chart.getVisibleBarsRange();
-    if (br && br.to !== undefined && br.to !== null) {
-      brToSec = normalizeChartUnixSec(br.to);
-    }
-  } catch (eBr) {
-    brToSec = null;
+function timeScaleCoordinateToTimeSec(ts, x) {
+  var raw = ts.coordinateToTime(x);
+  if (raw == null || raw === undefined) {
+    return null;
   }
-  if (brToSec === null) {
-    var r = getVisibleTimeRangeSecFromChart(chart);
-    if (r) {
-      brToSec = r.hi;
-    }
-  }
-  if (
-    brToSec === null ||
-    lastBarTimeSec == null ||
-    !isFinite(Number(lastBarTimeSec))
-  ) {
-    return false;
-  }
-  return Number(lastBarTimeSec) <= brToSec;
+  return normalizeChartUnixSec(raw);
 }
 
 /**
- * True if the **last OHLCV bar’s time** is to the **right** of the time painted at the plot’s
- * right edge—i.e. the series end is scrolled off-screen to the right (outline pill should show).
- * False if the time at the right edge is at or past the last bar (end is in view). Null if unknown.
+ * Smallest x in [0, maxX] with coordinate time ≥ tNorm (binary search; assumes time increases with x).
  *
- * Uses {@link ITimeScaleApi.coordinateToTime} at the right inset so we don’t rely on
- * \`getVisibleBarsRange().to\`, which can still “match” the last bar’s timestamp while the oldest bar
- * is visible on the left and the newest is not drawn at the right edge.
- *
- * @param {object} chart
- * @param {number} lastBarTimeSec — unix **seconds** (same as \`normalizeChartUnixSec\` of tail)
- * @returns {boolean | null}
+ * @returns {number | null}
  */
-function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
+function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
+  var tLo = timeScaleCoordinateToTimeSec(ts, 0);
+  var tHi = timeScaleCoordinateToTimeSec(ts, maxX);
+  if (tLo === null || tHi === null) {
+    return null;
+  }
+  if (tHi < tNorm) {
+    return null;
+  }
+  if (tLo >= tNorm) {
+    return 0;
+  }
+  var lo = 0;
+  var hi = maxX;
+  while (lo < hi) {
+    var mid = (lo + hi) >> 1;
+    var tm = timeScaleCoordinateToTimeSec(ts, mid);
+    if (tm === null) {
+      return null;
+    }
+    if (tm < tNorm) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Single source of truth for “would the custom line-end marker appear in the plot before the chrome
+ * inset?” — same horizontal rules as {@link getLineEndIconTimeSec} + {@link LINE_END_ICON_TIME_INSET_PX}
+ * (inverse of \`coordinateToTime\` via {@link findSmallestXWhereTimeGte}).
+ *
+ * @param {object} chart - \`widget.activeChart()\`
+ * @param {number} lastBarTimeSec - unix seconds, OHLCV tail (same as line overlay)
+ * @returns {boolean | null} true = marker visible in plot (hide outline pill), false = not visible (show outline), null = unknown (hide outline)
+ */
+function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
   if (!chart || lastBarTimeSec == null || !isFinite(Number(lastBarTimeSec))) {
     return null;
   }
@@ -2620,17 +2622,33 @@ function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
     if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    var x = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
-    var rawT = ts.coordinateToTime(x);
-    if (rawT == null || rawT === undefined) {
+    var markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
+    var tNorm = normalizeChartUnixSec(markerTimeSec);
+    if (tNorm === null) {
       return null;
     }
-    var tRightEdge = normalizeChartUnixSec(rawT);
-    if (tRightEdge === null) {
+    var xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    var maxX = Math.max(0, Math.floor(plotW - 1));
+
+    var tMax = timeScaleCoordinateToTimeSec(ts, maxX);
+    var tMin = timeScaleCoordinateToTimeSec(ts, 0);
+    if (tMin === null || tMax === null) {
       return null;
     }
-    var barDur = getApproxBarDurationSec();
-    return lastBarTimeSec > tRightEdge + barDur;
+    /* Marker time past the right edge of the plot → not visible (panned off). */
+    if (tNorm > tMax) {
+      return false;
+    }
+    /* Same conservative branch as before: treat as visible for outline (hide pill). */
+    if (tNorm < tMin) {
+      return true;
+    }
+
+    var xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
+    if (xFirst === null) {
+      return null;
+    }
+    return xFirst <= xCut;
   } catch (e) {
     return null;
   }
@@ -2709,6 +2727,35 @@ function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
     }
   }
   return best;
+}
+
+/**
+ * True when the **newest** OHLCV bar is **not** among the bars intersecting the visible time range:
+ * the rightmost visible bar is strictly older than the series tail (user panned the tail off-screen).
+ *
+ * @param {object} chart - \`widget.activeChart()\`
+ * @param {Array<{ time: number }>} data - \`window.ohlcvData\`
+ * @returns {boolean | null} true = tail off-screen by data, false = tail still in range, null = unknown
+ */
+function isSeriesTailOffScreenByData(chart, data) {
+  if (!chart || !data || !data.length) {
+    return null;
+  }
+  var tail = data[data.length - 1];
+  var tailMs = tail.time;
+  var rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  if (!rightmost) {
+    return null;
+  }
+  if (rightmost === tail || rightmost.time === tailMs) {
+    return false;
+  }
+  var barDurMs = getApproxBarDurationSec() * 1000;
+  var halfBarSlackMs = Math.max(1, barDurMs * 0.5);
+  if (tailMs - rightmost.time <= halfBarSlackMs) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1133,20 +1133,10 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
- * Updates \`#custom-series-last-value-label\`: **close price of the rightmost OHLCV bar whose time
- * still lies inside the chart’s visible bars range**, positioned on the price scale like the
- * last-close pill. Shown only when:
- * - \`getLineChrome().useCustomPriceLabels\`, and
- * - chart is ready with data, and
- * - chart type is candle or line, and
- * - the **series tail** (latest bar) is **not** in the visible time window (e.g. user panned left),
- * - and we successfully resolve a visible-edge bar and a Y coordinate.
- *
- * When the outline’s chart Y would overlap the filled last-close pill, nudges the outline
- * **up or down** (smaller vs larger Y) so the higher price stays above the lower on the pane.
- *
- * Candlestick: outline border + text use theme success (close >= open) or error (down bar).
- * Line chart: success color only (matches single-series stroke).
+ * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
+ * scrolled off the right (\`coordinateToTime\` at right inset), subject to
+ * \`isSeriesLastCoveredByVisibleRangeRightBound\` (padding / first load) and
+ * \`trailingVisibleBarMatchesSeriesLast\` when the inset probe is unavailable.
  */
 function updateVisibleEdgeOutlinePriceLabel() {
   var elOut = document.getElementById('custom-series-last-value-label');
@@ -1171,11 +1161,32 @@ function updateVisibleEdgeOutlinePriceLabel() {
   }
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
-  if (isSeriesTailBarTimeVisibleOnChart(chart, tailBar.time)) {
+  var tailSec = normalizeChartUnixSec(tailBar.time);
+  var tailOffRight =
+    tailSec !== null
+      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+      : null;
+  var trailingMatch =
+    tailOffRight === null && tailSec !== null
+      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
+      : false;
+  if (tailOffRight === false) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var edgeBar = getRightmostOhlcvBarInVisibleTimeRange(chart, w.ohlcvData);
+  if (tailOffRight === null && trailingMatch) {
+    hideCustomSeriesLastValueLabelDom();
+    return;
+  }
+  if (
+    tailOffRight === true &&
+    tailSec !== null &&
+    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
+  ) {
+    hideCustomSeriesLastValueLabelDom();
+    return;
+  }
+  var edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
   if (!edgeBar) {
     hideCustomSeriesLastValueLabelDom();
     return;
@@ -1287,10 +1298,18 @@ function getPriceYForLastCloseOverlay(chart, price) {
     }
     var lo = Math.min(range.from, range.to);
     var hi = Math.max(range.from, range.to);
-    if (p < lo || p > hi) return null;
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
-    return ((hi - p) / (hi - lo)) * h;
+    /* Clamp so the pill stays at the plot top/bottom when close is outside auto-scale (pan/zoom). */
+    var pClamped = Math.min(hi, Math.max(lo, p));
+    if (typeof scale.priceToCoordinate === 'function') {
+      y = scale.priceToCoordinate(pClamped);
+      if (y !== null && y !== undefined && !isNaN(y)) return y;
+    } else if (typeof scale.priceToPixels === 'function') {
+      y = scale.priceToPixels(pClamped);
+      if (y !== null && y !== undefined && !isNaN(y)) return y;
+    }
+    return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;
   }
@@ -2531,58 +2550,129 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
 }
 
 /**
- * Reads TradingView’s current visible bars range and returns normalized **Unix seconds** bounds
- * \`{ lo, hi }\` (always \`lo <= hi\`). Used by both “is tail visible?” and “which bars intersect?”.
+ * True when the visible time window’s **right** bound still reaches the series last bar (last bar
+ * time ≤ right bound). Then the newest candle is still in the chart’s visible range, even if
+ * {@link isSeriesLastBarOffRightOfVisiblePlot} is true because \`coordinateToTime\` at the right inset
+ * samples empty padding to the right of the last bar (first load / default anchoring).
  *
  * @param {object} chart - \`widget.activeChart()\`
- * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
+ * @param {number} lastBarTimeSec - unix seconds for the last OHLCV bar
+ * @returns {boolean}
  */
-function getVisibleTimeRangeSecFromChart(chart) {
+function isSeriesLastCoveredByVisibleRangeRightBound(chart, lastBarTimeSec) {
+  var brToSec = null;
   try {
     var br = chart.getVisibleBarsRange();
-    if (!br || br.from === undefined || br.to === undefined) {
+    if (br && br.to !== undefined && br.to !== null) {
+      brToSec = normalizeChartUnixSec(br.to);
+    }
+  } catch (eBr) {
+    brToSec = null;
+  }
+  if (brToSec === null) {
+    var r = getVisibleTimeRangeSecFromChart(chart);
+    if (r) {
+      brToSec = r.hi;
+    }
+  }
+  if (
+    brToSec === null ||
+    lastBarTimeSec == null ||
+    !isFinite(Number(lastBarTimeSec))
+  ) {
+    return false;
+  }
+  return Number(lastBarTimeSec) <= brToSec;
+}
+
+/**
+ * True if the **last OHLCV bar’s time** is to the **right** of the time painted at the plot’s
+ * right edge—i.e. the series end is scrolled off-screen to the right (outline pill should show).
+ * False if the time at the right edge is at or past the last bar (end is in view). Null if unknown.
+ *
+ * Uses {@link ITimeScaleApi.coordinateToTime} at the right inset so we don’t rely on
+ * \`getVisibleBarsRange().to\`, which can still “match” the last bar’s timestamp while the oldest bar
+ * is visible on the left and the newest is not drawn at the right edge.
+ *
+ * @param {object} chart
+ * @param {number} lastBarTimeSec — unix **seconds** (same as \`normalizeChartUnixSec\` of tail)
+ * @returns {boolean | null}
+ */
+function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
+  if (!chart || lastBarTimeSec == null || !isFinite(Number(lastBarTimeSec))) {
+    return null;
+  }
+  try {
+    var ts = chart.getTimeScale();
+    if (!ts || typeof ts.coordinateToTime !== 'function' || typeof ts.width !== 'function') {
       return null;
     }
-    var fromSec = normalizeChartUnixSec(br.from);
-    var toSec = normalizeChartUnixSec(br.to);
-    if (fromSec === null || toSec === null) {
+    var plotW = ts.width();
+    if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    return {
-      lo: Math.min(fromSec, toSec),
-      hi: Math.max(fromSec, toSec),
-    };
+    var x = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    var rawT = ts.coordinateToTime(x);
+    if (rawT == null || rawT === undefined) {
+      return null;
+    }
+    var tRightEdge = normalizeChartUnixSec(rawT);
+    if (tRightEdge === null) {
+      return null;
+    }
+    var barDur = getApproxBarDurationSec();
+    return lastBarTimeSec > tRightEdge + barDur;
   } catch (e) {
     return null;
   }
 }
 
 /**
- * True if the **dataset’s last bar** (by time) lies inside—or immediately adjacent to—the visible
- * bars range (using \`getApproxBarDurationSec\` slack). When false, the user has panned/zoomed so the
- * “current” candle/line endpoint is no longer on-screen (typical: panned left, tail off the right).
+ * Reads TradingView’s visible time window as **Unix seconds** \`{ lo, hi }\` (\`lo <= hi\`).
+ * Prefer \`getVisibleBarsRange()\`; if it is null mid-scroll, fall back to \`getVisibleRange()\`.
  *
- * Returns **true** if we cannot read the range (fail-safe: do not show the outline pill).
- *
- * @param {object} chart
- * @param {number} lastBarTimeMs - \`ohlcvData\` tail \`.time\` (milliseconds)
+ * @param {object} chart - \`widget.activeChart()\`
+ * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
  */
-function isSeriesTailBarTimeVisibleOnChart(chart, lastBarTimeMs) {
-  var range = getVisibleTimeRangeSecFromChart(chart);
-  if (!range) {
-    return true;
+function getVisibleTimeRangeSecFromChart(chart) {
+  var fromSec;
+  var toSec;
+  try {
+    var br = chart.getVisibleBarsRange();
+    if (br && br.from !== undefined && br.to !== undefined) {
+      fromSec = normalizeChartUnixSec(br.from);
+      toSec = normalizeChartUnixSec(br.to);
+      if (fromSec !== null && toSec !== null) {
+        return {
+          lo: Math.min(fromSec, toSec),
+          hi: Math.max(fromSec, toSec),
+        };
+      }
+    }
+  } catch (eBr) {
+    /* fall through — bars range often null mid-gesture; try visible time range */
   }
-  var lastSec = normalizeChartUnixSec(lastBarTimeMs);
-  if (lastSec === null) {
-    return true;
+  try {
+    var vr = chart.getVisibleRange && chart.getVisibleRange();
+    if (vr && vr.from !== undefined && vr.to !== undefined) {
+      fromSec = normalizeChartUnixSec(vr.from);
+      toSec = normalizeChartUnixSec(vr.to);
+      if (fromSec !== null && toSec !== null) {
+        return {
+          lo: Math.min(fromSec, toSec),
+          hi: Math.max(fromSec, toSec),
+        };
+      }
+    }
+  } catch (eVr) {
+    return null;
   }
-  var slack = getApproxBarDurationSec() * 2;
-  return lastSec >= range.lo - slack && lastSec <= range.hi + slack;
+  return null;
 }
 
 /**
  * Among bars in \`data\`, returns the one with the **maximum \`time\`** that still falls inside the
- * visible range (milliseconds, with the same slack as \`isSeriesTailBarTimeVisibleOnChart\`). This is
+ * visible range (milliseconds, slack from \`getApproxBarDurationSec\`). This is
  * the **rightmost historical bar still drawn** in the viewport—the “visible edge” for the outline
  * pill’s close price.
  *
@@ -2598,6 +2688,42 @@ function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
   var slackSec = getApproxBarDurationSec() * 2;
   var loMs = (range.lo - slackSec) * 1000;
   var hiMs = (range.hi + slackSec) * 1000;
+  var best = null;
+  var i;
+  for (i = 0; i < data.length; i++) {
+    var b = data[i];
+    var t = b.time;
+    if (t >= loMs && t <= hiMs) {
+      if (!best || t > best.time) {
+        best = b;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Bar for the outline pill’s price: same as {@link getRightmostOhlcvBarInVisibleTimeRange}, then
+ * if that is null (gaps at scroll limits), retry with looser slack so the pill does not vanish
+ * when the tail is still off-screen.
+ *
+ * @param {object} chart
+ * @param {Array<{ time: number, close: number }>} data - \`window.ohlcvData\`
+ * @returns {object | null}
+ */
+function getVisibleEdgeOutlineBar(chart, data) {
+  var primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  if (primary) {
+    return primary;
+  }
+  var range = getVisibleTimeRangeSecFromChart(chart);
+  if (!range || !data || !data.length) {
+    return null;
+  }
+  var barDur = getApproxBarDurationSec();
+  var looseSlackSec = barDur * 6;
+  var loMs = (range.lo - looseSlackSec) * 1000;
+  var hiMs = (range.hi + looseSlackSec) * 1000;
   var best = null;
   var i;
   for (i = 0; i < data.length; i++) {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1141,11 +1141,10 @@ function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
   if (tailSec === null || !isFinite(Number(tailSec))) {
     return true;
   }
-  var geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
-  var dataOff =
-    ohlcvData && ohlcvData.length
-      ? isSeriesTailOffScreenByData(chart, ohlcvData)
-      : null;
+  const geo = isCustomLineEndMarkerVisibleInPlot(chart, Number(tailSec));
+  const dataOff = ohlcvData?.length
+    ? isSeriesTailOffScreenByData(chart, ohlcvData)
+    : null;
   if (geo === false || dataOff === true) {
     return false;
   }
@@ -1157,11 +1156,11 @@ function shouldHideVisibleEdgeOutlinePill(chart, tailSec, ohlcvData) {
  * {@link shouldHideVisibleEdgeOutlinePill}).
  */
 function updateVisibleEdgeOutlinePriceLabel() {
-  var elOut = document.getElementById('custom-series-last-value-label');
+  const elOut = document.getElementById('custom-series-last-value-label');
   if (!elOut) {
     return;
   }
-  var w = window;
+  const w = window;
   if (
     !getLineChrome().useCustomPriceLabels ||
     !w.chartWidget ||
@@ -1172,54 +1171,54 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var ct = w.currentChartType;
+  const ct = w.currentChartType;
   if (ct !== 1 && ct !== 2) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var chart = w.chartWidget.activeChart();
-  var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
-  var tailSec = normalizeChartUnixSec(tailBar.time);
+  const chart = w.chartWidget.activeChart();
+  const tailBar = w.ohlcvData[w.ohlcvData.length - 1];
+  const tailSec = normalizeChartUnixSec(tailBar.time);
   if (shouldHideVisibleEdgeOutlinePill(chart, tailSec, w.ohlcvData)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
+  const edgeBar = getVisibleEdgeOutlineBar(chart, w.ohlcvData);
   if (!edgeBar) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var price = Number(edgeBar.close);
+  let price = Number(edgeBar.close);
   if (ct === 2) {
-    var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
+    const tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
     if (tEdgeMs !== null) {
-      var pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
+      const pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
       if (pLine !== null && isFinite(pLine)) {
         price = pLine;
       }
     }
   }
-  var y = getPriceYForLastCloseOverlay(chart, price);
+  const y = getPriceYForLastCloseOverlay(chart, price);
   if (y === null || y === undefined || isNaN(y)) {
     elOut.style.display = 'none';
     elOut.style.borderColor = '';
     elOut.style.color = '';
     return;
   }
-  var resolvedLast = resolveLineEndOverlayPoint(chart);
-  var lastClosePrice =
+  const resolvedLast = resolveLineEndOverlayPoint(chart);
+  const lastClosePrice =
     resolvedLast && isFinite(resolvedLast.price)
       ? resolvedLast.price
       : tailBar.close;
-  var yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
+  const yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
 
-  var theme = (w.CONFIG && w.CONFIG.theme) || {};
-  var upColor = theme.successColor || '#0C9F76';
-  var downColor = theme.errorColor || '#E06470';
-  var outlineColor = upColor;
+  const theme = (w.CONFIG && w.CONFIG.theme) || {};
+  const upColor = theme.successColor || '#0C9F76';
+  const downColor = theme.errorColor || '#E06470';
+  let outlineColor = upColor;
   if (ct === 1) {
-    var o = Number(edgeBar.open);
-    var c = Number(edgeBar.close);
+    const o = Number(edgeBar.open);
+    const c = Number(edgeBar.close);
     if (isFinite(o) && isFinite(c) && c < o) {
       outlineColor = downColor;
     }
@@ -1228,13 +1227,13 @@ function updateVisibleEdgeOutlinePriceLabel() {
   elOut.style.color = outlineColor;
   elOut.textContent = formatCrosshairPrice(price);
   elOut.style.display = 'flex';
-  var overlayOut = document.getElementById('custom-crosshair-overlay');
+  const overlayOut = document.getElementById('custom-crosshair-overlay');
 
-  var yPos = y;
+  let yPos = y;
   positionPricePillAtPlotPriceBoundary(elOut, overlayOut, yPos);
-  var gapPx = 4;
-  var elLast = document.getElementById('last-close-price-label');
-  var hO = elOut.offsetHeight;
+  const gapPx = 4;
+  const elLast = document.getElementById('last-close-price-label');
+  let hO = elOut.offsetHeight;
   if (!hO || hO < 8) {
     hO = 24;
   }
@@ -1247,17 +1246,18 @@ function updateVisibleEdgeOutlinePriceLabel() {
     yLastClose !== undefined &&
     !isNaN(yLastClose)
   ) {
-    var hF = elLast.offsetHeight;
-    var half = (hF + hO) / 2 + gapPx;
+    const hF = elLast.offsetHeight;
+    const half = (hF + hO) / 2 + gapPx;
     if (Math.abs(y - yLastClose) < half) {
-      var minCenter = hO / 2 + 2;
-      var maxCenter =
+      const minCenter = hO / 2 + 2;
+      const maxCenter =
         overlayOut && overlayOut.clientHeight > 0
           ? overlayOut.clientHeight - hO / 2 - 2
           : Infinity;
-      var pOut = Number(price);
-      var pLast = Number(lastClosePrice);
-      var edgeAboveFilled = isFinite(pOut) && isFinite(pLast) ? pOut > pLast : y < yLastClose;
+      const pOut = Number(price);
+      const pLast = Number(lastClosePrice);
+      const edgeAboveFilled =
+        isFinite(pOut) && isFinite(pLast) ? pOut > pLast : y < yLastClose;
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
         if (yPos < minCenter) {
@@ -1282,33 +1282,34 @@ function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
     return null;
   }
-  var p = Number(price);
+  const p = Number(price);
   try {
-    var panes = chart.getPanes();
+    const panes = chart.getPanes();
     if (!panes || !panes.length) return null;
-    var pane = panes[0];
-    var scale = pane.getMainSourcePriceScale();
+    const pane = panes[0];
+    const scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var range = scale.getVisiblePriceRange();
+    const range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
       return null;
     }
-    var lo = Math.min(range.from, range.to);
-    var hi = Math.max(range.from, range.to);
-    var h = pane.getHeight();
+    const lo = Math.min(range.from, range.to);
+    const hi = Math.max(range.from, range.to);
+    const h = pane.getHeight();
     if (!h || h <= 0) return null;
-    var pClamped = Math.min(hi, Math.max(lo, p));
-    var inverted = typeof scale.isInverted === 'function' && scale.isInverted();
-    var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+    const pClamped = Math.min(hi, Math.max(lo, p));
+    const inverted =
+      typeof scale.isInverted === 'function' && scale.isInverted();
+    const mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
     if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
-      var logLo = Math.log(lo);
-      var logHi = Math.log(hi);
-      var logP = Math.log(pClamped);
+      const logLo = Math.log(lo);
+      const logHi = Math.log(hi);
+      const logP = Math.log(pClamped);
       if (logHi === logLo) {
         return inverted ? 0 : h / 2;
       }
-      var t = (logP - logLo) / (logHi - logLo);
+      const t = (logP - logLo) / (logHi - logLo);
       return inverted ? t * h : (1 - t) * h;
     }
     if (inverted) {
@@ -2471,7 +2472,7 @@ function resolveLineEndOverlayPoint(chart) {
  * Normalize TV/chart timestamps to unix **seconds** (library mixes sec/ms in places).
  */
 function normalizeChartUnixSec(t) {
-  var n = Number(t);
+  const n = Number(t);
   if (!isFinite(n)) {
     return null;
   }
@@ -2480,7 +2481,7 @@ function normalizeChartUnixSec(t) {
 
 /** Raw TV timestamp → unix ms (keeps sub-second precision vs {@link normalizeChartUnixSec}). */
 function chartRawTimeToUnixMs(rawT) {
-  var n = Number(rawT);
+  const n = Number(rawT);
   if (!isFinite(n)) {
     return null;
   }
@@ -2494,11 +2495,11 @@ function chartRawTimeToUnixMs(rawT) {
  * Step between last two OHLCV bars in seconds (for visible-range alignment checks).
  */
 function getApproxBarDurationSec() {
-  var d = window.ohlcvData;
+  const d = window.ohlcvData;
   if (!d || d.length < 2) {
     return 300;
   }
-  var ms = Math.abs(d[d.length - 1].time - d[d.length - 2].time);
+  const ms = Math.abs(d[d.length - 1].time - d[d.length - 2].time);
   return Math.max(60, Math.round(ms / 1000));
 }
 
@@ -2513,7 +2514,7 @@ var LINE_END_ICON_MAX_PROBES = 14;
  * Skip extrapolation during interval switches / odd zoom: too few bars, incoherent visible range vs data.
  */
 function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
-  var d = window.ohlcvData;
+  const d = window.ohlcvData;
   if (!d || d.length < 2) {
     return true;
   }
@@ -2521,18 +2522,18 @@ function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
     return true;
   }
   try {
-    var br = chart.getVisibleBarsRange();
+    const br = chart.getVisibleBarsRange();
     if (!br || br.from === undefined || br.to === undefined) {
       return true;
     }
-    var brFromSec = normalizeChartUnixSec(br.from);
-    var brToSec = normalizeChartUnixSec(br.to);
+    const brFromSec = normalizeChartUnixSec(br.from);
+    const brToSec = normalizeChartUnixSec(br.to);
     if (brFromSec === null || brToSec === null) {
       return true;
     }
-    var barDur = getApproxBarDurationSec();
-    var visibleSpan = Math.abs(brToSec - brFromSec);
-    var n = d.length;
+    const barDur = getApproxBarDurationSec();
+    const visibleSpan = Math.abs(brToSec - brFromSec);
+    const n = d.length;
     if (visibleSpan > barDur * Math.max(n, 1) * 96) {
       return true;
     }
@@ -2550,15 +2551,15 @@ function shouldSkipLineEndIconTimeExtrapolation(chart, lastBarTimeSec) {
 
 function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
   try {
-    var br = chart.getVisibleBarsRange();
+    const br = chart.getVisibleBarsRange();
     if (!br || br.to === undefined || br.to === null) {
       return false;
     }
-    var brToSec = normalizeChartUnixSec(br.to);
+    const brToSec = normalizeChartUnixSec(br.to);
     if (brToSec === null) {
       return false;
     }
-    var barDur = getApproxBarDurationSec();
+    const barDur = getApproxBarDurationSec();
     return (
       lastBarTimeSec <= brToSec + barDur &&
       lastBarTimeSec >= brToSec - 2 * barDur
@@ -2576,7 +2577,7 @@ function trailingVisibleBarMatchesSeriesLast(chart, lastBarTimeSec) {
  * @returns {number | null} unix seconds
  */
 function timeScaleCoordinateToTimeSec(ts, x) {
-  var raw = ts.coordinateToTime(x);
+  const raw = ts.coordinateToTime(x);
   if (raw == null || raw === undefined) {
     return null;
   }
@@ -2589,8 +2590,8 @@ function timeScaleCoordinateToTimeSec(ts, x) {
  * @returns {number | null}
  */
 function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
-  var tLo = timeScaleCoordinateToTimeSec(ts, 0);
-  var tHi = timeScaleCoordinateToTimeSec(ts, maxX);
+  const tLo = timeScaleCoordinateToTimeSec(ts, 0);
+  const tHi = timeScaleCoordinateToTimeSec(ts, maxX);
   if (tLo === null || tHi === null) {
     return null;
   }
@@ -2600,11 +2601,11 @@ function findSmallestXWhereTimeGte(ts, maxX, tNorm) {
   if (tLo >= tNorm) {
     return 0;
   }
-  var lo = 0;
-  var hi = maxX;
+  let lo = 0;
+  let hi = maxX;
   while (lo < hi) {
-    var mid = (lo + hi) >> 1;
-    var tm = timeScaleCoordinateToTimeSec(ts, mid);
+    const mid = (lo + hi) >> 1;
+    const tm = timeScaleCoordinateToTimeSec(ts, mid);
     if (tm === null) {
       return null;
     }
@@ -2631,7 +2632,7 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
     return null;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2639,20 +2640,20 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
     ) {
       return null;
     }
-    var plotW = ts.width();
+    const plotW = ts.width();
     if (!(plotW > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return null;
     }
-    var markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
-    var tNorm = normalizeChartUnixSec(markerTimeSec);
+    const markerTimeSec = getLineEndIconTimeSec(chart, Number(lastBarTimeSec));
+    const tNorm = normalizeChartUnixSec(markerTimeSec);
     if (tNorm === null) {
       return null;
     }
-    var xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
-    var maxX = Math.max(0, Math.floor(plotW - 1));
+    const xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    const maxX = Math.max(0, Math.floor(plotW - 1));
 
-    var tMax = timeScaleCoordinateToTimeSec(ts, maxX);
-    var tMin = timeScaleCoordinateToTimeSec(ts, 0);
+    const tMax = timeScaleCoordinateToTimeSec(ts, maxX);
+    const tMin = timeScaleCoordinateToTimeSec(ts, 0);
     if (tMin === null || tMax === null) {
       return null;
     }
@@ -2665,7 +2666,7 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
       return true;
     }
 
-    var xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
+    const xFirst = findSmallestXWhereTimeGte(ts, maxX, tNorm);
     if (xFirst === null) {
       return null;
     }
@@ -2683,11 +2684,11 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
  * @returns {{ lo: number, hi: number } | null} null if range unavailable or timestamps invalid
  */
 function getVisibleTimeRangeSecFromChart(chart) {
-  var fromSec;
-  var toSec;
+  let fromSec;
+  let toSec;
   try {
-    var br = chart.getVisibleBarsRange();
-    if (br && br.from !== undefined && br.to !== undefined) {
+    const br = chart.getVisibleBarsRange();
+    if (br?.from !== undefined && br?.to !== undefined) {
       fromSec = normalizeChartUnixSec(br.from);
       toSec = normalizeChartUnixSec(br.to);
       if (fromSec !== null && toSec !== null) {
@@ -2698,11 +2699,11 @@ function getVisibleTimeRangeSecFromChart(chart) {
       }
     }
   } catch (eBr) {
-    /* fall through — bars range often null mid-gesture; try visible time range */
+    void eBr;
   }
   try {
-    var vr = chart.getVisibleRange && chart.getVisibleRange();
-    if (vr && vr.from !== undefined && vr.to !== undefined) {
+    const vr = chart.getVisibleRange?.();
+    if (vr?.from !== undefined && vr?.to !== undefined) {
       fromSec = normalizeChartUnixSec(vr.from);
       toSec = normalizeChartUnixSec(vr.to);
       if (fromSec !== null && toSec !== null) {
@@ -2729,18 +2730,17 @@ function getVisibleTimeRangeSecFromChart(chart) {
  * @returns {object | null} bar object or null if none intersect
  */
 function getRightmostOhlcvBarInVisibleTimeRange(chart, data) {
-  var range = getVisibleTimeRangeSecFromChart(chart);
+  const range = getVisibleTimeRangeSecFromChart(chart);
   if (!range || !data || !data.length) {
     return null;
   }
-  var slackSec = getApproxBarDurationSec() * 2;
-  var loMs = (range.lo - slackSec) * 1000;
-  var hiMs = (range.hi + slackSec) * 1000;
-  var best = null;
-  var i;
-  for (i = 0; i < data.length; i++) {
-    var b = data[i];
-    var t = b.time;
+  const slackSec = getApproxBarDurationSec() * 2;
+  const loMs = (range.lo - slackSec) * 1000;
+  const hiMs = (range.hi + slackSec) * 1000;
+  let best = null;
+  for (let i = 0; i < data.length; i++) {
+    const b = data[i];
+    const t = b.time;
     if (t >= loMs && t <= hiMs) {
       if (!best || t > best.time) {
         best = b;
@@ -2762,17 +2762,17 @@ function isSeriesTailOffScreenByData(chart, data) {
   if (!chart || !data || !data.length) {
     return null;
   }
-  var tail = data[data.length - 1];
-  var tailMs = tail.time;
-  var rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  const tail = data[data.length - 1];
+  const tailMs = tail.time;
+  const rightmost = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
   if (!rightmost) {
     return null;
   }
   if (rightmost === tail || rightmost.time === tailMs) {
     return false;
   }
-  var barDurMs = getApproxBarDurationSec() * 1000;
-  var halfBarSlackMs = Math.max(1, barDurMs * 0.5);
+  const barDurMs = getApproxBarDurationSec() * 1000;
+  const halfBarSlackMs = Math.max(1, barDurMs * 0.5);
   if (tailMs - rightmost.time <= halfBarSlackMs) {
     return false;
   }
@@ -2789,23 +2789,22 @@ function isSeriesTailOffScreenByData(chart, data) {
  * @returns {object | null}
  */
 function getVisibleEdgeOutlineBar(chart, data) {
-  var primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
+  const primary = getRightmostOhlcvBarInVisibleTimeRange(chart, data);
   if (primary) {
     return primary;
   }
-  var range = getVisibleTimeRangeSecFromChart(chart);
+  const range = getVisibleTimeRangeSecFromChart(chart);
   if (!range || !data || !data.length) {
     return null;
   }
-  var barDur = getApproxBarDurationSec();
-  var looseSlackSec = barDur * 6;
-  var loMs = (range.lo - looseSlackSec) * 1000;
-  var hiMs = (range.hi + looseSlackSec) * 1000;
-  var best = null;
-  var i;
-  for (i = 0; i < data.length; i++) {
-    var b = data[i];
-    var t = b.time;
+  const barDur = getApproxBarDurationSec();
+  const looseSlackSec = barDur * 6;
+  const loMs = (range.lo - looseSlackSec) * 1000;
+  const hiMs = (range.hi + looseSlackSec) * 1000;
+  let best = null;
+  for (let i = 0; i < data.length; i++) {
+    const b = data[i];
+    const t = b.time;
     if (t >= loMs && t <= hiMs) {
       if (!best || t > best.time) {
         best = b;
@@ -2821,7 +2820,7 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
     return null;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2829,22 +2828,22 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
     ) {
       return null;
     }
-    var w = ts.width();
+    const w = ts.width();
     if (!(w > OUTLINE_EDGE_TIME_INSET_PX + 2)) {
       return null;
     }
-    var x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
-    var rawT = ts.coordinateToTime(x);
+    const x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
+    const rawT = ts.coordinateToTime(x);
     if (rawT === null || rawT === undefined) {
       return null;
     }
-    var tMs = chartRawTimeToUnixMs(rawT);
+    let tMs = chartRawTimeToUnixMs(rawT);
     if (tMs === null) {
       return null;
     }
-    var vr = chart.getVisibleRange && chart.getVisibleRange();
-    if (vr && vr.to !== undefined && vr.to !== null) {
-      var capMs = chartRawTimeToUnixMs(vr.to);
+    const vr = chart.getVisibleRange?.();
+    if (vr?.to !== undefined && vr?.to !== null) {
+      const capMs = chartRawTimeToUnixMs(vr.to);
       if (capMs !== null && tMs > capMs) {
         tMs = capMs;
       }
@@ -2860,23 +2859,22 @@ function interpolateCloseAlongLineAtTimeMs(data, tMs) {
   if (!data || !data.length || !isFinite(tMs)) {
     return null;
   }
-  var first = data[0];
-  var last = data[data.length - 1];
+  const first = data[0];
+  const last = data[data.length - 1];
   if (tMs <= first.time) {
-    var c0 = Number(first.close);
+    const c0 = Number(first.close);
     return isFinite(c0) ? c0 : null;
   }
   if (tMs >= last.time) {
-    var cL = Number(last.close);
+    const cL = Number(last.close);
     return isFinite(cL) ? cL : null;
   }
-  var i;
-  for (i = 0; i < data.length - 1; i++) {
-    var t0 = data[i].time;
-    var t1 = data[i + 1].time;
+  for (let i = 0; i < data.length - 1; i++) {
+    const t0 = data[i].time;
+    const t1 = data[i + 1].time;
     if (tMs >= t0 && tMs <= t1) {
-      var a = Number(data[i].close);
-      var b = Number(data[i + 1].close);
+      const a = Number(data[i].close);
+      const b = Number(data[i + 1].close);
       if (!isFinite(a) || !isFinite(b)) {
         return null;
       }
@@ -2904,7 +2902,7 @@ function getLineEndIconTimeSec(chart, lastBarTimeSec) {
     return lastBarTimeSec;
   }
   try {
-    var ts = chart.getTimeScale();
+    const ts = chart.getTimeScale();
     if (
       !ts ||
       typeof ts.coordinateToTime !== 'function' ||
@@ -2912,32 +2910,31 @@ function getLineEndIconTimeSec(chart, lastBarTimeSec) {
     ) {
       return lastBarTimeSec;
     }
-    var w = ts.width();
+    const w = ts.width();
     if (!(w > LINE_END_ICON_TIME_INSET_PX + 4)) {
       return lastBarTimeSec;
     }
-    var vr = chart.getVisibleRange();
-    var capSec =
-      vr && vr.to !== undefined && vr.to !== null
+    const vr = chart.getVisibleRange?.();
+    const capSec =
+      vr?.to !== undefined && vr?.to !== null
         ? normalizeChartUnixSec(vr.to)
         : null;
-    var k;
-    for (k = 0; k < LINE_END_ICON_MAX_PROBES; k++) {
-      var x = Math.max(
+    for (let k = 0; k < LINE_END_ICON_MAX_PROBES; k++) {
+      const x = Math.max(
         0,
         Math.floor(
           w - LINE_END_ICON_TIME_INSET_PX - k * LINE_END_ICON_PROBE_STEP_PX,
         ),
       );
-      var rawT = ts.coordinateToTime(x);
+      const rawT = ts.coordinateToTime(x);
       if (rawT === null || rawT === undefined) {
         continue;
       }
-      var numT = Number(rawT);
+      const numT = Number(rawT);
       if (!isFinite(numT)) {
         continue;
       }
-      var tNorm = normalizeChartUnixSec(numT);
+      let tNorm = normalizeChartUnixSec(numT);
       if (tNorm === null) {
         continue;
       }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1189,7 +1189,6 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  /** Line chart: price/Y at the plot’s right edge matches the drawn segment (interpolate closes). */
   var price = Number(edgeBar.close);
   if (ct === 2) {
     var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
@@ -1239,11 +1238,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   if (!hO || hO < 8) {
     hO = 24;
   }
-  /**
-   * When outline and last-close pills overlap, separate with minimum gap (TradingView-style stack).
-   * Stack direction: higher outline **price** → outline above filled (smaller y); lower → below.
-   * Equal prices → outline below filled so the solid last-price pill stays primary.
-   */
+  /* Nudge outline if it overlaps last-close pill: higher price → above, else below (ties = below). */
   if (
     elLast &&
     elLast.style.display !== 'none' &&
@@ -1262,20 +1257,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
           : Infinity;
       var pOut = Number(price);
       var pLast = Number(lastClosePrice);
-      var edgeAboveFilled;
-      if (isFinite(pOut) && isFinite(pLast)) {
-        if (pOut > pLast) {
-          edgeAboveFilled = true;
-        } else if (pOut < pLast) {
-          edgeAboveFilled = false;
-        } else {
-          edgeAboveFilled = false;
-        }
-      } else {
-        edgeAboveFilled =
-          y < yLastClose ||
-          (Math.abs(y - yLastClose) < 1 && pOut > pLast);
-      }
+      var edgeAboveFilled = isFinite(pOut) && isFinite(pLast) ? pOut > pLast : y < yLastClose;
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
         if (yPos < minCenter) {
@@ -1293,44 +1275,8 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Maps a clamped price to Y in pane coordinates. Uses {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getmode IPriceScaleApi.getMode}
- * so **Log** scales match the chart (Charting_Library.PriceScaleMode.Log = 1); other modes use linear mapping.
- *
- * @param {object} scale - IPriceScaleApi
- * @param {number} lo
- * @param {number} hi
- * @param {number} h
- * @param {number} pClamped
- * @param {boolean} inverted
- * @returns {number | null}
- */
-function mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted) {
-  var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
-  /* Log = 1 — https://www.tradingview.com/charting-library-docs/latest/api/enums/Charting_Library.PriceScaleMode/ */
-  if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
-    var logLo = Math.log(lo);
-    var logHi = Math.log(hi);
-    var logP = Math.log(pClamped);
-    if (logHi === logLo) {
-      return inverted ? 0 : h / 2;
-    }
-    var t = (logP - logLo) / (logHi - logLo);
-    if (inverted) {
-      return t * h;
-    }
-    return (1 - t) * h;
-  }
-  if (inverted) {
-    return ((pClamped - lo) / (hi - lo)) * h;
-  }
-  return ((hi - pClamped) / (hi - lo)) * h;
-}
-
-/**
- * Y pixel for a price (same space as crosshair \`offsetY\`).
- * Uses documented {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getvisiblepricerange IPriceScaleApi.getVisiblePriceRange},
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPaneApi#getheight IPaneApi.getHeight}, and
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#isinverted IPriceScaleApi.isInverted} — not undocumented coordinate helpers.
+ * Y pixel for a price (crosshair overlay space). \`getVisiblePriceRange\` + \`getHeight\` + \`isInverted\`;
+ * \`getMode() === 1\` (log) uses log mapping.
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
@@ -1353,9 +1299,22 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
     var pClamped = Math.min(hi, Math.max(lo, p));
-    var inverted =
-      typeof scale.isInverted === 'function' && scale.isInverted();
-    return mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted);
+    var inverted = typeof scale.isInverted === 'function' && scale.isInverted();
+    var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+    if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
+      var logLo = Math.log(lo);
+      var logHi = Math.log(hi);
+      var logP = Math.log(pClamped);
+      if (logHi === logLo) {
+        return inverted ? 0 : h / 2;
+      }
+      var t = (logP - logLo) / (logHi - logLo);
+      return inverted ? t * h : (1 - t) * h;
+    }
+    if (inverted) {
+      return ((pClamped - lo) / (hi - lo)) * h;
+    }
+    return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;
   }
@@ -2519,13 +2478,7 @@ function normalizeChartUnixSec(t) {
   return n >= 1e12 ? Math.floor(n / 1000) : Math.floor(n);
 }
 
-/**
- * Unix **milliseconds** from raw TradingView time (\`coordinateToTime\`, \`getVisibleRange\`, etc.).
- * Preserves sub-second precision for interpolation (unlike {@link normalizeChartUnixSec}).
- *
- * @param {number | string} rawT
- * @returns {number | null}
- */
+/** Raw TV timestamp → unix ms (keeps sub-second precision vs {@link normalizeChartUnixSec}). */
 function chartRawTimeToUnixMs(rawT) {
   var n = Number(rawT);
   if (!isFinite(n)) {
@@ -2549,9 +2502,9 @@ function getApproxBarDurationSec() {
   return Math.max(60, Math.round(ms / 1000));
 }
 
-/** Pixels inset from time-scale right so \`coordinateToTime\` samples left of the price scale (16px dot + margin). */
+/** Time-scale inset from right so line-end icon stays on-screen (not under price scale). */
 var LINE_END_ICON_TIME_INSET_PX = 40;
-/** Plot’s right edge for outline pill time — must not reuse {@link LINE_END_ICON_TIME_INSET_PX} (samples too far left vs drawn line). \`0\` = rightmost pixel (\`w - 1\`). */
+/** Outline edge sample inset (0 = rightmost pixel; not the line-icon inset). */
 var OUTLINE_EDGE_TIME_INSET_PX = 0;
 var LINE_END_ICON_PROBE_STEP_PX = 8;
 var LINE_END_ICON_MAX_PROBES = 14;
@@ -2862,14 +2815,7 @@ function getVisibleEdgeOutlineBar(chart, data) {
   return best;
 }
 
-/**
- * Unix **milliseconds** at the plot’s right edge (minimal inset vs line-icon), via
- * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi#coordinatetotime ITimeScaleApi.coordinateToTime}.
- * Capped to \`getVisibleRange().to\`. Uses {@link OUTLINE_EDGE_TIME_INSET_PX}, not {@link LINE_END_ICON_TIME_INSET_PX}.
- *
- * @param {object} chart - \`widget.activeChart()\`
- * @returns {number | null}
- */
+/** \`coordinateToTime\` at plot right edge (see {@link OUTLINE_EDGE_TIME_INSET_PX}); capped to \`visibleRange.to\`. */
 function getVisiblePlotRightEdgeTimeMs(chart) {
   if (!chart) {
     return null;
@@ -2909,13 +2855,7 @@ function getVisiblePlotRightEdgeTimeMs(chart) {
   }
 }
 
-/**
- * Linear interpolation of \`close\` between adjacent OHLCV bars (line chart path between closes).
- *
- * @param {Array<{ time: number, close: number }>} data - ascending \`time\` (ms), \`window.ohlcvData\`
- * @param {number} tMs
- * @returns {number | null}
- */
+/** Interpolate close between consecutive bars (line chart path). */
 function interpolateCloseAlongLineAtTimeMs(data, tMs) {
   if (!data || !data.length || !isFinite(tMs)) {
     return null;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1133,6 +1133,29 @@ function hideCustomSeriesLastValueLabelDom() {
 }
 
 /**
+ * True when the outline pill should not show based on tail vs viewport (inset probe + fallbacks).
+ */
+function shouldHideVisibleEdgeOutlinePill(chart, tailSec) {
+  var offRight =
+    tailSec !== null ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec) : null;
+  var trailing =
+    offRight === null && tailSec !== null
+      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
+      : false;
+  if (offRight === false) {
+    return true;
+  }
+  if (offRight === null && trailing) {
+    return true;
+  }
+  return (
+    offRight === true &&
+    tailSec !== null &&
+    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
+  );
+}
+
+/**
  * Outline pill: close of the rightmost visible OHLCV bar. Shown only when the series tail is
  * scrolled off the right (\`coordinateToTime\` at right inset), subject to
  * \`isSeriesLastCoveredByVisibleRangeRightBound\` (padding / first load) and
@@ -1162,27 +1185,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
   var chart = w.chartWidget.activeChart();
   var tailBar = w.ohlcvData[w.ohlcvData.length - 1];
   var tailSec = normalizeChartUnixSec(tailBar.time);
-  var tailOffRight =
-    tailSec !== null
-      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
-      : null;
-  var trailingMatch =
-    tailOffRight === null && tailSec !== null
-      ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
-      : false;
-  if (tailOffRight === false) {
-    hideCustomSeriesLastValueLabelDom();
-    return;
-  }
-  if (tailOffRight === null && trailingMatch) {
-    hideCustomSeriesLastValueLabelDom();
-    return;
-  }
-  if (
-    tailOffRight === true &&
-    tailSec !== null &&
-    isSeriesLastCoveredByVisibleRangeRightBound(chart, tailSec)
-  ) {
+  if (shouldHideVisibleEdgeOutlinePill(chart, tailSec)) {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
@@ -1199,12 +1202,11 @@ function updateVisibleEdgeOutlinePriceLabel() {
     elOut.style.color = '';
     return;
   }
-  var lastBarClose = w.ohlcvData[w.ohlcvData.length - 1];
   var resolvedLast = resolveLineEndOverlayPoint(chart);
   var lastClosePrice =
     resolvedLast && isFinite(resolvedLast.price)
       ? resolvedLast.price
-      : lastBarClose.close;
+      : tailBar.close;
   var yLastClose = getPriceYForLastCloseOverlay(chart, lastClosePrice);
 
   var theme = (w.CONFIG && w.CONFIG.theme) || {};
@@ -1269,6 +1271,21 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
+ * Tries main price scale APIs; returns pixel Y or \`null\`.
+ */
+function priceScalePriceToY(scale, p) {
+  if (typeof scale.priceToCoordinate === 'function') {
+    var y = scale.priceToCoordinate(p);
+    if (y !== null && y !== undefined && !isNaN(y)) return y;
+  }
+  if (typeof scale.priceToPixels === 'function') {
+    y = scale.priceToPixels(p);
+    if (y !== null && y !== undefined && !isNaN(y)) return y;
+  }
+  return null;
+}
+
+/**
  * Y pixel for a price (same space as crosshair \`offsetY\`). Uses
  * \`priceToCoordinate\` / \`priceToPixels\` when present; else visible range → pane height.
  */
@@ -1284,13 +1301,8 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var y;
-    if (typeof scale.priceToCoordinate === 'function') {
-      y = scale.priceToCoordinate(p);
-    } else if (typeof scale.priceToPixels === 'function') {
-      y = scale.priceToPixels(p);
-    }
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
+    var y = priceScalePriceToY(scale, p);
+    if (y !== null) return y;
 
     var range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
@@ -1300,15 +1312,9 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var hi = Math.max(range.from, range.to);
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
-    /* Clamp so the pill stays at the plot top/bottom when close is outside auto-scale (pan/zoom). */
     var pClamped = Math.min(hi, Math.max(lo, p));
-    if (typeof scale.priceToCoordinate === 'function') {
-      y = scale.priceToCoordinate(pClamped);
-      if (y !== null && y !== undefined && !isNaN(y)) return y;
-    } else if (typeof scale.priceToPixels === 'function') {
-      y = scale.priceToPixels(pClamped);
-      if (y !== null && y !== undefined && !isNaN(y)) return y;
-    }
+    y = priceScalePriceToY(scale, pClamped);
+    if (y !== null) return y;
     return ((hi - pClamped) / (hi - lo)) * h;
   } catch (e) {
     return null;
@@ -2604,7 +2610,11 @@ function isSeriesLastBarOffRightOfVisiblePlot(chart, lastBarTimeSec) {
   }
   try {
     var ts = chart.getTimeScale();
-    if (!ts || typeof ts.coordinateToTime !== 'function' || typeof ts.width !== 'function') {
+    if (
+      !ts ||
+      typeof ts.coordinateToTime !== 'function' ||
+      typeof ts.width !== 'function'
+    ) {
       return null;
     }
     var plotW = ts.width();

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1189,7 +1189,17 @@ function updateVisibleEdgeOutlinePriceLabel() {
     hideCustomSeriesLastValueLabelDom();
     return;
   }
-  var price = edgeBar.close;
+  /** Line chart: price/Y at the plot’s right edge matches the drawn segment (interpolate closes). */
+  var price = Number(edgeBar.close);
+  if (ct === 2) {
+    var tEdgeMs = getVisiblePlotRightEdgeTimeMs(chart);
+    if (tEdgeMs !== null) {
+      var pLine = interpolateCloseAlongLineAtTimeMs(w.ohlcvData, tEdgeMs);
+      if (pLine !== null && isFinite(pLine)) {
+        price = pLine;
+      }
+    }
+  }
   var y = getPriceYForLastCloseOverlay(chart, price);
   if (y === null || y === undefined || isNaN(y)) {
     elOut.style.display = 'none';
@@ -1229,6 +1239,11 @@ function updateVisibleEdgeOutlinePriceLabel() {
   if (!hO || hO < 8) {
     hO = 24;
   }
+  /**
+   * When outline and last-close pills overlap, separate with minimum gap (TradingView-style stack).
+   * Stack direction: higher outline **price** → outline above filled (smaller y); lower → below.
+   * Equal prices → outline below filled so the solid last-price pill stays primary.
+   */
   if (
     elLast &&
     elLast.style.display !== 'none' &&
@@ -1245,10 +1260,22 @@ function updateVisibleEdgeOutlinePriceLabel() {
         overlayOut && overlayOut.clientHeight > 0
           ? overlayOut.clientHeight - hO / 2 - 2
           : Infinity;
-      var edgeAboveFilled =
-        y < yLastClose ||
-        (Math.abs(y - yLastClose) < 1 &&
-          Number(price) > Number(lastClosePrice));
+      var pOut = Number(price);
+      var pLast = Number(lastClosePrice);
+      var edgeAboveFilled;
+      if (isFinite(pOut) && isFinite(pLast)) {
+        if (pOut > pLast) {
+          edgeAboveFilled = true;
+        } else if (pOut < pLast) {
+          edgeAboveFilled = false;
+        } else {
+          edgeAboveFilled = false;
+        }
+      } else {
+        edgeAboveFilled =
+          y < yLastClose ||
+          (Math.abs(y - yLastClose) < 1 && pOut > pLast);
+      }
       if (edgeAboveFilled) {
         yPos = yLastClose - hF / 2 - gapPx - hO / 2;
         if (yPos < minCenter) {
@@ -1266,20 +1293,44 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Uses \`priceToCoordinate\` on the main source price scale when present (not listed on IPriceScaleApi
- * in Advanced Charts docs; fallback is \`getVisiblePriceRange\` + linear map in the caller).
+ * Maps a clamped price to Y in pane coordinates. Uses {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getmode IPriceScaleApi.getMode}
+ * so **Log** scales match the chart (Charting_Library.PriceScaleMode.Log = 1); other modes use linear mapping.
+ *
+ * @param {object} scale - IPriceScaleApi
+ * @param {number} lo
+ * @param {number} hi
+ * @param {number} h
+ * @param {number} pClamped
+ * @param {boolean} inverted
+ * @returns {number | null}
  */
-function priceScalePriceToY(scale, p) {
-  if (typeof scale.priceToCoordinate === 'function') {
-    var y = scale.priceToCoordinate(p);
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
+function mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted) {
+  var mode = typeof scale.getMode === 'function' ? scale.getMode() : 0;
+  /* Log = 1 — https://www.tradingview.com/charting-library-docs/latest/api/enums/Charting_Library.PriceScaleMode/ */
+  if (mode === 1 && lo > 0 && hi > 0 && pClamped > 0) {
+    var logLo = Math.log(lo);
+    var logHi = Math.log(hi);
+    var logP = Math.log(pClamped);
+    if (logHi === logLo) {
+      return inverted ? 0 : h / 2;
+    }
+    var t = (logP - logLo) / (logHi - logLo);
+    if (inverted) {
+      return t * h;
+    }
+    return (1 - t) * h;
   }
-  return null;
+  if (inverted) {
+    return ((pClamped - lo) / (hi - lo)) * h;
+  }
+  return ((hi - pClamped) / (hi - lo)) * h;
 }
 
 /**
- * Y pixel for a price (same space as crosshair \`offsetY\`). Prefers \`priceToCoordinate\` when
- * present; else maps using \`getVisiblePriceRange\` and pane height (including clamped price).
+ * Y pixel for a price (same space as crosshair \`offsetY\`).
+ * Uses documented {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#getvisiblepricerange IPriceScaleApi.getVisiblePriceRange},
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPaneApi#getheight IPaneApi.getHeight}, and
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IPriceScaleApi#isinverted IPriceScaleApi.isInverted} — not undocumented coordinate helpers.
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {
@@ -1293,9 +1344,6 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var scale = pane.getMainSourcePriceScale();
     if (!scale) return null;
 
-    var y = priceScalePriceToY(scale, p);
-    if (y !== null) return y;
-
     var range = scale.getVisiblePriceRange();
     if (!range || range.from === undefined || range.to === undefined) {
       return null;
@@ -1305,9 +1353,9 @@ function getPriceYForLastCloseOverlay(chart, price) {
     var h = pane.getHeight();
     if (!h || h <= 0) return null;
     var pClamped = Math.min(hi, Math.max(lo, p));
-    y = priceScalePriceToY(scale, pClamped);
-    if (y !== null) return y;
-    return ((hi - pClamped) / (hi - lo)) * h;
+    var inverted =
+      typeof scale.isInverted === 'function' && scale.isInverted();
+    return mapClampedPriceToPaneY(scale, lo, hi, h, pClamped, inverted);
   } catch (e) {
     return null;
   }
@@ -2472,6 +2520,24 @@ function normalizeChartUnixSec(t) {
 }
 
 /**
+ * Unix **milliseconds** from raw TradingView time (\`coordinateToTime\`, \`getVisibleRange\`, etc.).
+ * Preserves sub-second precision for interpolation (unlike {@link normalizeChartUnixSec}).
+ *
+ * @param {number | string} rawT
+ * @returns {number | null}
+ */
+function chartRawTimeToUnixMs(rawT) {
+  var n = Number(rawT);
+  if (!isFinite(n)) {
+    return null;
+  }
+  if (n >= 1e12) {
+    return n;
+  }
+  return n * 1000;
+}
+
+/**
  * Step between last two OHLCV bars in seconds (for visible-range alignment checks).
  */
 function getApproxBarDurationSec() {
@@ -2485,6 +2551,8 @@ function getApproxBarDurationSec() {
 
 /** Pixels inset from time-scale right so \`coordinateToTime\` samples left of the price scale (16px dot + margin). */
 var LINE_END_ICON_TIME_INSET_PX = 40;
+/** Plot’s right edge for outline pill time — must not reuse {@link LINE_END_ICON_TIME_INSET_PX} (samples too far left vs drawn line). \`0\` = rightmost pixel (\`w - 1\`). */
+var OUTLINE_EDGE_TIME_INSET_PX = 0;
 var LINE_END_ICON_PROBE_STEP_PX = 8;
 var LINE_END_ICON_MAX_PROBES = 14;
 
@@ -2792,6 +2860,93 @@ function getVisibleEdgeOutlineBar(chart, data) {
     }
   }
   return best;
+}
+
+/**
+ * Unix **milliseconds** at the plot’s right edge (minimal inset vs line-icon), via
+ * {@link https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.ITimeScaleApi#coordinatetotime ITimeScaleApi.coordinateToTime}.
+ * Capped to \`getVisibleRange().to\`. Uses {@link OUTLINE_EDGE_TIME_INSET_PX}, not {@link LINE_END_ICON_TIME_INSET_PX}.
+ *
+ * @param {object} chart - \`widget.activeChart()\`
+ * @returns {number | null}
+ */
+function getVisiblePlotRightEdgeTimeMs(chart) {
+  if (!chart) {
+    return null;
+  }
+  try {
+    var ts = chart.getTimeScale();
+    if (
+      !ts ||
+      typeof ts.coordinateToTime !== 'function' ||
+      typeof ts.width !== 'function'
+    ) {
+      return null;
+    }
+    var w = ts.width();
+    if (!(w > OUTLINE_EDGE_TIME_INSET_PX + 2)) {
+      return null;
+    }
+    var x = Math.max(0, Math.floor(w - OUTLINE_EDGE_TIME_INSET_PX - 1));
+    var rawT = ts.coordinateToTime(x);
+    if (rawT === null || rawT === undefined) {
+      return null;
+    }
+    var tMs = chartRawTimeToUnixMs(rawT);
+    if (tMs === null) {
+      return null;
+    }
+    var vr = chart.getVisibleRange && chart.getVisibleRange();
+    if (vr && vr.to !== undefined && vr.to !== null) {
+      var capMs = chartRawTimeToUnixMs(vr.to);
+      if (capMs !== null && tMs > capMs) {
+        tMs = capMs;
+      }
+    }
+    return tMs;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Linear interpolation of \`close\` between adjacent OHLCV bars (line chart path between closes).
+ *
+ * @param {Array<{ time: number, close: number }>} data - ascending \`time\` (ms), \`window.ohlcvData\`
+ * @param {number} tMs
+ * @returns {number | null}
+ */
+function interpolateCloseAlongLineAtTimeMs(data, tMs) {
+  if (!data || !data.length || !isFinite(tMs)) {
+    return null;
+  }
+  var first = data[0];
+  var last = data[data.length - 1];
+  if (tMs <= first.time) {
+    var c0 = Number(first.close);
+    return isFinite(c0) ? c0 : null;
+  }
+  if (tMs >= last.time) {
+    var cL = Number(last.close);
+    return isFinite(cL) ? cL : null;
+  }
+  var i;
+  for (i = 0; i < data.length - 1; i++) {
+    var t0 = data[i].time;
+    var t1 = data[i + 1].time;
+    if (tMs >= t0 && tMs <= t1) {
+      var a = Number(data[i].close);
+      var b = Number(data[i + 1].close);
+      if (!isFinite(a) || !isFinite(b)) {
+        return null;
+      }
+      if (t1 === t0) {
+        return a;
+      }
+      return a + ((b - a) * (tMs - t0)) / (t1 - t0);
+    }
+  }
+  return null;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1137,7 +1137,9 @@ function hideCustomSeriesLastValueLabelDom() {
  */
 function shouldHideVisibleEdgeOutlinePill(chart, tailSec) {
   var offRight =
-    tailSec !== null ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec) : null;
+    tailSec !== null
+      ? isSeriesLastBarOffRightOfVisiblePlot(chart, tailSec)
+      : null;
   var trailing =
     offRight === null && tailSec !== null
       ? trailingVisibleBarMatchesSeriesLast(chart, tailSec)
@@ -1271,23 +1273,20 @@ function updateVisibleEdgeOutlinePriceLabel() {
 }
 
 /**
- * Tries main price scale APIs; returns pixel Y or \`null\`.
+ * Uses \`priceToCoordinate\` on the main source price scale when present (not listed on IPriceScaleApi
+ * in Advanced Charts docs; fallback is \`getVisiblePriceRange\` + linear map in the caller).
  */
 function priceScalePriceToY(scale, p) {
   if (typeof scale.priceToCoordinate === 'function') {
     var y = scale.priceToCoordinate(p);
     if (y !== null && y !== undefined && !isNaN(y)) return y;
   }
-  if (typeof scale.priceToPixels === 'function') {
-    y = scale.priceToPixels(p);
-    if (y !== null && y !== undefined && !isNaN(y)) return y;
-  }
   return null;
 }
 
 /**
- * Y pixel for a price (same space as crosshair \`offsetY\`). Uses
- * \`priceToCoordinate\` / \`priceToPixels\` when present; else visible range → pane height.
+ * Y pixel for a price (same space as crosshair \`offsetY\`). Prefers \`priceToCoordinate\` when
+ * present; else maps using \`getVisiblePriceRange\` and pane height (including clamped price).
  */
 function getPriceYForLastCloseOverlay(chart, price) {
   if (!chart || price === undefined || price === null || isNaN(Number(price))) {


### PR DESCRIPTION

## **Description**

Fix advanced chart outline pill when panning / first load.

This updates the TradingView webview script (chartLogic.js) that drives the custom outline price pill (the hollow label on the price axis) so it shows and hides at the right times and doesn’t flicker when you scroll or when the chart first loads.

- Panning to old history (oldest bars on the left)
You’re looking at old bars; the newest bar is off the right. The outline should show.
On main, sometimes the geometry still said “the marker would be in the plot” (or didn’t line up with which bars are actually loaded), so the app thought: “dot is still ‘there’, hide the outline.” (when it shouldn't) => cause regression
So the outline disappeared when it should stay.

What the new code adds (why it fixes that)
`isSeriesTailOffScreenByData` — Looks at actual OHLCV: “Is the newest bar outside what counts as visible for the bars we have?” If yes, treat the tail as off-screen.
`shouldHideVisibleEdgeOutlinePill` — Show the outline if either geometry says the dot isn’t in the plot or data says the tail is off-screen (so you don’t rely on only coordinateToTime).


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix showing outline pill on advanced charts on old history when chart head is visible.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches time/price scale math and visibility heuristics for TradingView overlays; bugs could cause the outline/last-close pills to misrender or flicker during pan/zoom and first load.
> 
> **Overview**
> Fixes the advanced chart outline price pill so it shows reliably when users pan away from the latest bar and stops disappearing/flickering due to inconsistent time-scale geometry.
> 
> The outline pill visibility logic is reworked to combine a new plot-geometry check (`isCustomLineEndMarkerVisibleInPlot`) with a data-based fallback (`isSeriesTailOffScreenByData`), plus a more resilient “visible edge” bar selection (`getVisibleEdgeOutlineBar`). Line charts also now compute the outline price by interpolating the close at the plot’s right edge, and Y-coordinate mapping for pills is updated to support inverted and log price scales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d31807047c4692a4747440bc5d42b0b68f86303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->