### PR TITLE
chore: upgrade design system packages (v32.0.0)

### DIFF
--- a/.cursor/rules/ui-development-guidelines.mdc
+++ b/.cursor/rules/ui-development-guidelines.mdc
@@ -17,19 +17,19 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 **Before writing any new component or choosing what to use, ask: "Does @metamask/design-system-react-native have this?"**
 
 1. **FIRST**: Use `@metamask/design-system-react-native` components
-   - **Always use for**: Box (layout), BoxRow, BoxColumn, Text, SensitiveText, TextButton
+   - **Always use for**: Box (layout), Text, SensitiveText, TextButton (inline links only)
    - **Always use for**: Button, ButtonBase, ButtonIcon, ButtonSemantic, Icon, Checkbox, RadioButton
    - **Always use for**: Avatar variants (Account, Base, Favicon, Group, Icon, Network, Token)
    - **Always use for**: Badge variants (Count, Icon, Network, Status, Wrapper)
    - **Always use for**: BottomSheet, BottomSheetFooter, BottomSheetHeader, BottomSheetDialog, BottomSheetOverlay
    - **Always use for**: HeaderBase, HeaderRoot, HeaderSearch, HeaderStandard
-   - **Always use for**: BannerBase, Card, ListItem, Skeleton, Label, Input, TextField
+   - **Always use for**: Card, ListItem, Skeleton, Label, Input, TextField
    - **Always use for**: KeyValueRow, KeyValueColumn, ActionListItem, MainActionButton, TabEmptyState
 
    - **Rule**: If it exists in the design system, you MUST use it
 
 2. **SECOND**: Use `app/component-library` ONLY if design system lacks it
-   - **Use for**: BannerAlert, BannerTip, Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet/SheetHeader, etc.
+   - **Use for**: BannerAlert, Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet/SheetHeader, etc.
    - **Rule**: These are MetaMask-specific implementations not (yet) in the design system
    - **Important**: component-library components should themselves use design system primitives internally
 
@@ -47,12 +47,12 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 ```
 Need a component?
   ├─ Is it Box, Text, Button, Icon, Avatar, Badge, Checkbox, RadioButton,
-  │  BottomSheet, Header, BannerBase, Card, ListItem, Skeleton, Label,
-  │  TextField, Input, KeyValueRow, SensitiveText, TextButton, or ActionListItem?
+  │  BottomSheet, Header, Card, ListItem, Skeleton, Label, TextField,
+  │  Input, KeyValueRow, SensitiveText, TextButton, or ActionListItem?
   │  └─ YES → Use @metamask/design-system-react-native [STOP]
   │
-  ├─ Is it BannerAlert, BannerTip, Tabs, Tags, Cells, Modal, Overlay,
-  │  Toast, Pickers, Select, Sheet?
+  ├─ Is it BannerAlert, Tabs, Tags, Cells, Modal, Overlay, Toast,
+  │  Pickers, Select, Sheet?
   │  └─ YES → Use app/component-library [STOP]
   │
   ├─ Is it feature-specific UI (e.g., BridgeInputSelector, StakeInputView)?

--- a/.cursor/rules/ui-development-guidelines.mdc
+++ b/.cursor/rules/ui-development-guidelines.mdc
@@ -17,13 +17,19 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 **Before writing any new component or choosing what to use, ask: "Does @metamask/design-system-react-native have this?"**
 
 1. **FIRST**: Use `@metamask/design-system-react-native` components
-   - **Always use for**: Box (layout), Text (typography), Button/ButtonBase/ButtonIcon, Icon, Checkbox
+   - **Always use for**: Box (layout), BoxRow, BoxColumn, Text, SensitiveText, TextButton
+   - **Always use for**: Button, ButtonBase, ButtonIcon, ButtonSemantic, Icon, Checkbox, RadioButton
    - **Always use for**: Avatar variants (Account, Base, Favicon, Group, Icon, Network, Token)
    - **Always use for**: Badge variants (Count, Icon, Network, Status, Wrapper)
+   - **Always use for**: BottomSheet, BottomSheetFooter, BottomSheetHeader, BottomSheetDialog, BottomSheetOverlay
+   - **Always use for**: HeaderBase, HeaderRoot, HeaderSearch, HeaderStandard
+   - **Always use for**: BannerBase, Card, ListItem, Skeleton, Label, Input, TextField
+   - **Always use for**: KeyValueRow, KeyValueColumn, ActionListItem, MainActionButton, TabEmptyState
+
    - **Rule**: If it exists in the design system, you MUST use it
 
 2. **SECOND**: Use `app/component-library` ONLY if design system lacks it
-   - **Use for**: BottomSheet, Tabs, Headers, ListItems, Skeleton, Tags, Modal, Overlay, Toast, RadioButton, etc.
+   - **Use for**: BannerAlert, BannerTip, Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet/SheetHeader, etc.
    - **Rule**: These are MetaMask-specific implementations not (yet) in the design system
    - **Important**: component-library components should themselves use design system primitives internally
 
@@ -40,10 +46,13 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 ### Decision Tree
 ```
 Need a component?
-  ├─ Is it Box, Text, Button, Icon, Avatar, Badge, or Checkbox?
+  ├─ Is it Box, Text, Button, Icon, Avatar, Badge, Checkbox, RadioButton,
+  │  BottomSheet, Header, BannerBase, Card, ListItem, Skeleton, Label,
+  │  TextField, Input, KeyValueRow, SensitiveText, TextButton, or ActionListItem?
   │  └─ YES → Use @metamask/design-system-react-native [STOP]
   │
-  ├─ Is it BottomSheet, Tabs, Header, ListItem, Skeleton, Tag, Modal, etc?
+  ├─ Is it BannerAlert, BannerTip, Tabs, Tags, Cells, Modal, Overlay,
+  │  Toast, Pickers, Select, Sheet?
   │  └─ YES → Use app/component-library [STOP]
   │
   ├─ Is it feature-specific UI (e.g., BridgeInputSelector, StakeInputView)?

--- a/.cursor/rules/ui-development-guidelines.mdc
+++ b/.cursor/rules/ui-development-guidelines.mdc
@@ -23,13 +23,13 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
    - **Always use for**: Badge variants (Count, Icon, Network, Status, Wrapper)
    - **Always use for**: BottomSheet, BottomSheetFooter, BottomSheetHeader, BottomSheetDialog, BottomSheetOverlay
    - **Always use for**: HeaderBase, HeaderRoot, HeaderSearch, HeaderStandard
-   - **Always use for**: Card, ListItem, Skeleton, Label, Input, TextField
+   - **Always use for**: BannerAlert, Card, ListItem, Skeleton, Label, Input, TextField
    - **Always use for**: KeyValueRow, KeyValueColumn, ActionListItem, MainActionButton, TabEmptyState
 
    - **Rule**: If it exists in the design system, you MUST use it
 
 2. **SECOND**: Use `app/component-library` ONLY if design system lacks it
-   - **Use for**: BannerAlert, Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet/SheetHeader, etc.
+   - **Use for**: Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet/SheetHeader, etc.
    - **Rule**: These are MetaMask-specific implementations not (yet) in the design system
    - **Important**: component-library components should themselves use design system primitives internally
 
@@ -47,12 +47,11 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 ```
 Need a component?
   ├─ Is it Box, Text, Button, Icon, Avatar, Badge, Checkbox, RadioButton,
-  │  BottomSheet, Header, Card, ListItem, Skeleton, Label, TextField,
-  │  Input, KeyValueRow, SensitiveText, TextButton, or ActionListItem?
+  │  BottomSheet, Header, BannerAlert, Card, ListItem, Skeleton, Label,
+  │  TextField, Input, KeyValueRow, SensitiveText, TextButton, or ActionListItem?
   │  └─ YES → Use @metamask/design-system-react-native [STOP]
   │
-  ├─ Is it BannerAlert, Tabs, Tags, Cells, Modal, Overlay, Toast,
-  │  Pickers, Select, Sheet?
+  ├─ Is it Tabs, Tags, Cells, Modal, Overlay, Toast, Pickers, Select, Sheet?
   │  └─ YES → Use app/component-library [STOP]
   │
   ├─ Is it feature-specific UI (e.g., BridgeInputSelector, StakeInputView)?

--- a/app/components/UI/Charts/AdvancedChart/OHLCVBar/OHLCVBar.tsx
+++ b/app/components/UI/Charts/AdvancedChart/OHLCVBar/OHLCVBar.tsx
@@ -72,7 +72,7 @@ export const OHLCVBar: React.FC<OHLCVBarProps> = ({
           <Box key={key} twClassName="flex-1">
             <Text
               variant={TextVariant.BodySm}
-              style={{ fontWeight: FontWeight.Medium }}
+              fontWeight={FontWeight.Medium}
               color={TextColor.TextDefault}
               numberOfLines={1}
               adjustsFontSizeToFit
@@ -85,7 +85,7 @@ export const OHLCVBar: React.FC<OHLCVBarProps> = ({
           <Box twClassName="flex-1">
             <Text
               variant={TextVariant.BodySm}
-              style={{ fontWeight: FontWeight.Medium }}
+              fontWeight={FontWeight.Medium}
               color={TextColor.TextDefault}
               numberOfLines={1}
             >

--- a/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
+++ b/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
@@ -113,7 +113,7 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
           >
             <Text
               variant={TextVariant.BodySm}
-              style={{ fontWeight: FontWeight.Medium }}
+              fontWeight={FontWeight.Medium}
               twClassName={
                 isSelected ? 'text-text-default' : 'text-text-alternative'
               }

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "@metamask/core-backend": "^6.2.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.16.0",
+    "@metamask/design-system-react-native": "^0.17.0",
     "@metamask/design-system-twrnc-preset": "^0.4.1",
     "@metamask/design-tokens": "^8.3.0",
     "@metamask/earn-controller": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,11 +8181,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "@metamask/design-system-react-native@npm:0.16.0"
+"@metamask/design-system-react-native@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@metamask/design-system-react-native@npm:0.17.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.9.0"
+    "@metamask/design-system-shared": "npm:^0.10.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8198,18 +8198,18 @@ __metadata:
     react-native-gesture-handler: ">=1.10.3"
     react-native-reanimated: ">=3.3.0"
     react-native-safe-area-context: ">=4.0.0"
-  checksum: 10/64693d417d266793d5ebc80c4e112913af1223a827ac670ff004b4664904c3cedbd14bd08f1929ddc8b5f07861cc26c22ad0b49da064b820ba546287e0e1f19b
+  checksum: 10/21ff5fda446c57425385285c4080fd3a77549d8c71053570d413aeaec7bd07450ada0ac82ae74084423a72df70e5fa4fabc541dd5bcfa3de659d76691b035896
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@metamask/design-system-shared@npm:0.9.0"
+"@metamask/design-system-shared@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@metamask/design-system-shared@npm:0.10.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
-  checksum: 10/d1c7d54fac099b119b9f4ad6580289abba3fdbc699db13ebceb23c17c1d162987237625e3bf67397bf869e286951cc8edf9879c600f74dfef50f5447b898d61f
+  checksum: 10/d61374fb2c22bc4110b59b4e8ea982257543f5b4c4367cc5f4ccb8c75f4b5a8a6e2e5e928bc85086ed9d28b0281b1481b9aa3e202397651e40b95edd59580811
   languageName: node
   linkType: hard
 
@@ -10214,25 +10214,6 @@ __metadata:
   linkType: hard
 
 "@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.5.0, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.11.0
-  resolution: "@metamask/utils@npm:11.11.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@noble/hashes": "npm:^1.3.1"
-    "@scure/base": "npm:^1.1.3"
-    "@types/debug": "npm:^4.1.7"
-    "@types/lodash": "npm:^4.17.20"
-    debug: "npm:^4.3.4"
-    lodash: "npm:^4.17.21"
-    pony-cause: "npm:^2.1.10"
-    semver: "npm:^7.5.4"
-    uuid: "npm:^9.0.1"
-  checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^11.11.0":
   version: 11.11.0
   resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
@@ -35600,7 +35581,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.2.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.16.0"
+    "@metamask/design-system-react-native": "npm:^0.17.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.4.1"
     "@metamask/design-tokens": "npm:^8.3.0"
     "@metamask/earn-controller": "npm:^12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10232,6 +10232,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/utils@npm:^11.11.0":
+  version: 11.11.0
+  resolution: "@metamask/utils@npm:11.11.0"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    "@types/lodash": "npm:^4.17.20"
+    debug: "npm:^4.3.4"
+    lodash: "npm:^4.17.21"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
+  languageName: node
+  linkType: hard
+
 "@metamask/utils@npm:^8.2.0":
   version: 8.5.0
   resolution: "@metamask/utils@npm:8.5.0"


### PR DESCRIPTION
## **Description**

Upgrades design system packages to align with the [v32.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v32.0.0).

**Packages upgraded:**
- `@metamask/design-system-react-native`: `^0.16.0` → `^0.17.0`
- `@metamask/design-system-shared`: `0.9.0` → `0.10.0` (transitive via design-system-react-native)

**Breaking changes addressed:**

### FontWeight values changed from numeric to semantic strings

The `FontWeight` const object values changed from numeric strings (`'600'`, `'500'`, `'400'`) to semantic identifiers (`'bold'`, `'medium'`, `'regular'`). Idiomatic usage like `FontWeight.Bold` is unaffected, but using `FontWeight.Medium` in a React Native `style` prop caused TS errors because `'medium'` is not a valid `TextStyle.fontWeight` value.

**Migration:** Replaced `style={{ fontWeight: FontWeight.Medium }}` with the `fontWeight={FontWeight.Medium}` prop on `Text` components, which the design system handles internally.

- `app/components/UI/Charts/AdvancedChart/OHLCVBar/OHLCVBar.tsx`: Migrated two `style` overrides to `fontWeight` prop
- `app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx`: Migrated one `style` override to `fontWeight` prop

### Typography constants relocated to @metamask/design-system-shared (no code changes needed)

`TextVariant`, `TextColor`, `FontWeight`, `FontStyle`, `FontFamily` moved to `@metamask/design-system-shared` but remain re-exported from `@metamask/design-system-react-native` — all existing import paths continue to work.

**New additions available for future use:**
- `TextColor.PrimaryDefaultHover`, `ErrorDefaultHover`, `SuccessDefaultHover`, `WarningDefaultHover` — hover-state color keys (use `*Pressed` variants on RN)

**Legacy component deprecations:**
- All matching legacy components in `app/component-library/components/` already have `@deprecated` JSDoc notices from prior upgrades — no new deprecations needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Design system upgrade to v32.0.0

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows
    Then the UI renders correctly with no visual regressions

  Scenario: OHLCV bar displays correctly in advanced chart
    Given I am viewing a token with an advanced chart
    When I tap to see crosshair/OHLCV data
    Then the OHLCV bar text renders with correct medium font weight

  Scenario: Time range selector renders correctly
    Given I am viewing an advanced chart
    When I see the time range selector (1H, 1D, 1W, 1M, 1Y)
    Then the labels render with correct medium font weight
```

## **Screenshots/Recordings**

### **Before**

N/A – dependency upgrade with minor prop migration

### **After**

No visual regressions 


https://github.com/user-attachments/assets/8064d817-cf9f-44e3-ab45-3f327fcab3fb



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a shared UI dependency (`@metamask/design-system-react-native`), which can introduce subtle visual/behavior regressions across the app; code changes are limited to straightforward prop migrations to keep TS/build passing.
> 
> **Overview**
> Upgrades `@metamask/design-system-react-native` to `^0.17.0` (and bumps transitive `@metamask/design-system-shared` in `yarn.lock`).
> 
> Migrates a few chart UI `Text` usages to pass `FontWeight` via the design-system `fontWeight` prop (instead of `style.fontWeight`) to stay compatible with updated `FontWeight` semantics.
> 
> Updates the internal UI guidelines doc to reflect a broader set of design-system-first components and a revised decision tree for when to use `app/component-library`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825436a26fa67f2b8eca53075174ca20654c07f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->