### PR TITLE
feat(perps): create core sync skill and upgrade validate-core-sync

### DIFF
--- a/.agents/skills/perps-core-sync/SKILL.md
+++ b/.agents/skills/perps-core-sync/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: perps-core-sync
+description: Sync the perps controller from mobile to the core monorepo with change detection, automated validation, failure resolution, and post-sync commit guidance. Use after perps controller changes land in mobile.
+---
+
+# Perps Core Sync
+
+## Purpose
+
+Use this skill to sync `app/controllers/perps/` from mobile to `packages/perps-controller/src/` in the core monorepo. The sync is driven by `scripts/perps/validate-core-sync.sh` — a 9-step pipeline (preflight, conflict check, copy, install, verify, eslint fix, build, lint, write sync state).
+
+Use when:
+
+- New commits touch `app/controllers/perps/` since the last sync
+- A perps PR is merged and needs to propagate to core
+- You need to verify mobile changes are core-compatible before pushing
+
+Do not use when:
+
+- Changes are UI-only (`app/components/UI/Perps/`) — these don't sync
+- Changes are test-only (`*.test.ts`) — tests are excluded from sync
+- The core repo is not checked out locally
+
+## Pre-Sync: Detect Changes
+
+Read the sync state from core to find what changed since the last sync:
+
+```bash
+cat <core-path>/packages/perps-controller/.sync-state.json
+```
+
+Extract `lastSyncedMobileCommit` and run:
+
+```bash
+# Commits since last sync
+git log <lastSyncedMobileCommit>..HEAD --oneline -- app/controllers/perps/
+
+# File-level summary (excluding tests)
+git diff <lastSyncedMobileCommit>..HEAD --stat -- app/controllers/perps/ ':!*.test.ts'
+```
+
+Pay special attention to:
+
+- **New files** — need exports wired in core's `index.ts`, may need `tsconfig` references or new dependencies
+- **Deleted files** — rsync `--delete` handles removal, but verify no stale imports remain in core
+- **Changes to `PerpsPlatformDependencies`** — DI interface changes affect extension consumers
+- **Public API changes** — state shape, method signatures, event names affect all consumers
+
+## Execute Sync
+
+```bash
+bash scripts/perps/validate-core-sync.sh --core-path <core-path>
+```
+
+Options:
+
+- `--skip-build` — skip the build step for faster iteration when debugging lint/copy issues
+- `--skip-test` — skip the test step for faster iteration
+- `--verbose` — show full output for every step (useful for debugging)
+
+The script runs these 12 steps in order:
+
+| Step                    | What it does                                                                            |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| 1. Pre-flight checks    | Confirms mobile source, core destination, required tools                                |
+| 2. Conflict check       | Fetches origin/main, checks for upstream perps-controller changes, validates sync state |
+| 3. Copy source files    | rsync `.ts` files (excluding tests, mocks, fixtures)                                    |
+| 4. Install dependencies | `yarn install` in core                                                                  |
+| 5. Verify build fixes   | Checks for `__DEV__`, mobile imports, closure fixes                                     |
+| 6. ESLint auto-fix      | Runs `--fix`, `--suppress-all`, `--prune-suppressions`, checks suppression delta        |
+| 7. Format fix (oxfmt)   | Runs `yarn lint:misc --write` — core uses oxfmt, not prettier                           |
+| 8. Build                | `yarn workspace @metamask/perps-controller build`                                       |
+| 9. Lint                 | Final lint pass to confirm zero violations                                              |
+| 10. Test                | `yarn workspace @metamask/perps-controller test` — catches DI/fixture mismatches        |
+| 11. Changelog check     | Verifies `CHANGELOG.md` has been updated (core CI requirement)                          |
+| 12. Write sync state    | Updates `.sync-state.json` with commit hashes and checksum                              |
+
+## Failure Resolution
+
+| Failure                                                  | Cause                                                          | Fix                                                                                                                                                       |
+| -------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `__DEV__` found                                          | Mobile code uses `__DEV__` guard                               | Replace with `false` in the mobile source file, or route through `PerpsPlatformDependencies` for environment-aware behavior. Fix in mobile, then re-sync. |
+| Mobile imports (Engine, react-native, Sentry, DevLogger) | Direct platform import in controller                           | Route through `PerpsPlatformDependencies` (DI). All platform services must come through the `infrastructure` constructor param. Fix in mobile.            |
+| Suppression delta increase                               | Sync introduces new ESLint violations                          | Fix violations in mobile first (e.g., `'x' in y` → `hasProperty(y, 'x')` from `@metamask/utils`). Re-run sync after fixing.                               |
+| Build failure                                            | Missing tsconfig references, missing dependencies, type errors | Check `packages/perps-controller/tsconfig.json` references. Ensure new imports have corresponding `dependencies` in `package.json`.                       |
+| Lint failure after fix                                   | Auto-fix didn't resolve all issues                             | Re-run the eslint fix step. If persistent, check for new rule violations that need manual fixes in mobile.                                                |
+| Format fix failure                                       | oxfmt can't auto-fix some files                                | Check for syntax errors that prevent parsing. Core uses `oxfmt` (not prettier) for TS formatting.                                                         |
+| Test failure                                             | Test fixtures missing new DI dependencies                      | Add mocks for new `PerpsPlatformDependencies` fields (e.g., `diskCache`) in `tests/defer-eligibility.test.ts`.                                            |
+| Changelog check failure                                  | `CHANGELOG.md` not updated                                     | Add entries under `## [Unreleased]` with `### Added`, `### Fixed`, `### Changed` sections linking to the PR.                                              |
+| Conflict check: behind origin/main                       | Someone pushed perps-controller changes to main                | `cd <core-path> && git merge origin/main` before re-running sync.                                                                                         |
+| Conflict check: checksum mismatch                        | Core source was hand-edited since last sync                    | Review the edits. Either port them back to mobile or discard and re-sync.                                                                                 |
+
+## Post-Sync
+
+After all 12 steps pass:
+
+1. **Review the diff in core:**
+
+   ```bash
+   cd <core-path> && git diff --stat
+   ```
+
+2. **Update `CHANGELOG.md`** before committing. Core CI requires entries under `## [Unreleased]`. Sections must follow [Keep a Changelog](https://keepachangelog.com/) order:
+
+   ```
+   ### Added      — new features, exports, files
+   ### Changed    — refactors, dependency bumps
+   ### Deprecated — soon-to-be-removed features
+   ### Removed    — removed features
+   ### Fixed      — bug fixes
+   ### Security   — vulnerability fixes
+   ```
+
+   Each entry must link to the PR: `([#NNNN](https://github.com/MetaMask/core/pull/NNNN))`.
+   Validate locally: `yarn workspace @metamask/perps-controller changelog:validate`
+
+3. **Commit in core** with conventional format:
+
+   ```
+   feat(perps): sync controller from mobile
+
+   Syncs app/controllers/perps/ from mobile commit <short-hash>.
+
+   Changes:
+   - <summarize key changes from the pre-sync commit list>
+   ```
+
+4. **Verify `.sync-state.json` was updated** — it should contain the current mobile HEAD commit.
+
+5. **Check suppression count** — if non-zero, note it in the PR description. Target is zero suppressions.
+
+6. **Use `--verbose` when debugging** — without it, step output is captured to temp files and only shown on failure. With `--verbose`, all output streams to the terminal.
+
+## Portability Rules
+
+Reference: `docs/perps/perps-review-antipatterns.md` (Controller Portability section).
+
+- **No `__DEV__`** — must not appear in controller files. Core has no React Native dev mode.
+- **No mobile imports** — no `react-native`, `Engine`, `Sentry`, `DevLogger`. Everything through `PerpsPlatformDependencies` DI.
+- **No direct controller imports from app code** — app files must import from `@metamask/perps-controller`, not relative paths.
+- **Public API = publisher contract** — changing state shape, method signatures, or event names affects extension consumers. Coordinate breaking changes.
+- **New dependencies must be in DI interface** — controller code must not reach outside its boundary.

--- a/.agents/skills/perps-core-sync/agents/openai.yaml
+++ b/.agents/skills/perps-core-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Core Sync"
+  short_description: "Sync perps controller from mobile to core monorepo."
+  default_prompt: "Use $perps-core-sync to detect changes and sync app/controllers/perps/ to core."

--- a/.claude/skills/perps-core-sync/SKILL.md
+++ b/.claude/skills/perps-core-sync/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: perps-core-sync
+summary: Sync perps controller from mobile to core monorepo with change detection.
+---
+
+Follow `.agents/skills/perps-core-sync/SKILL.md`.

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -1034,14 +1034,6 @@ export class PerpsController extends BaseController<
   }
 
   /**
-   * Build a cache key for per-provider market data.
-   * Format: "providerId:network" (e.g. 'hyperliquid:mainnet', 'myx:testnet')
-   *
-   * @param providerId - The provider identifier.
-   * @param isTestnet - Whether the provider is on testnet.
-   * @returns The cache key string.
-   */
-  /**
    * Resolve the provider ids that should participate in aggregated cache reads.
    *
    * Providers can still be registering when the first render happens, so we

--- a/scripts/perps/validate-core-sync.sh
+++ b/scripts/perps/validate-core-sync.sh
@@ -555,8 +555,7 @@ step_changelog_check() {
 
   # Validate changelog format (section ordering, link format, etc.)
   local validate_output
-  validate_output=$(cd "$CORE_PATH" && yarn workspace "$WORKSPACE" changelog:validate 2>&1)
-  if [[ -n "$validate_output" ]]; then
+  if ! validate_output=$(cd "$CORE_PATH" && yarn workspace "$WORKSPACE" changelog:validate 2>&1); then
     echo "FAIL: Changelog format validation failed:"
     echo "$validate_output"
     return 1

--- a/scripts/perps/validate-core-sync.sh
+++ b/scripts/perps/validate-core-sync.sh
@@ -11,6 +11,7 @@
 # Options:
 #   --core-path <path>   Path to Core repo (required)
 #   --skip-build         Skip the build step for faster iteration
+#   --skip-test          Skip the test step for faster iteration
 #   --verbose            Show full command output for every step
 #   --help               Print this help message and exit
 #
@@ -24,13 +25,14 @@ set -euo pipefail
 MOBILE_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CORE_PATH=""
 SKIP_BUILD=false
+SKIP_TEST=false
 VERBOSE=false
 
 PERPS_SRC="app/controllers/perps"
 PERPS_DEST="packages/perps-controller/src"
 WORKSPACE="@metamask/perps-controller"
 
-STEP_COUNT=9
+STEP_COUNT=12
 STEP_RESULTS=()
 STEP_TIMES=()
 STEP_LABELS=()
@@ -154,6 +156,7 @@ while (( $# )); do
   case "$1" in
     --core-path) CORE_PATH="$2"; shift 2 ;;
     --skip-build) SKIP_BUILD=true; shift ;;
+    --skip-test) SKIP_TEST=true; shift ;;
     --verbose) VERBOSE=true; shift ;;
     --help|-h) usage ;;
     *) die "Unknown option: $1" ;;
@@ -165,8 +168,12 @@ if [[ -z "$CORE_PATH" ]]; then
   die "Missing --core-path <path>. Example: ./scripts/perps/validate-core-sync.sh --core-path ~/dev/metamask/core"
 fi
 
+# Adjust step count for skipped steps
 if $SKIP_BUILD; then
-  STEP_COUNT=8
+  STEP_COUNT=$((STEP_COUNT - 1))
+fi
+if $SKIP_TEST; then
+  STEP_COUNT=$((STEP_COUNT - 1))
 fi
 
 # ─── Step functions ─────────────────────────────────────────────────────────────
@@ -462,12 +469,99 @@ step_build() {
   cd "$MOBILE_ROOT"
 }
 
+step_format_fix() {
+  cd "$CORE_PATH"
+
+  # Core uses oxfmt (via yarn lint:misc) for TS formatting, NOT prettier.
+  # Mobile uses different formatting rules, so synced files arrive with
+  # wrong formatting. Run oxfmt --write to fix them.
+  progress "  ├─ Running oxfmt on perps-controller source"
+  yarn lint:misc --write 2>&1 | grep -E "packages/perps-controller" || true
+
+  # Verify formatting is clean
+  local fmt_issues
+  fmt_issues=$(yarn lint:misc --check 2>&1 | grep -c "packages/perps-controller" || true)
+  if (( fmt_issues > 0 )); then
+    echo "FAIL: $fmt_issues perps-controller file(s) still have formatting issues after oxfmt"
+    yarn lint:misc --check 2>&1 | grep "packages/perps-controller"
+    cd "$MOBILE_ROOT"
+    return 1
+  fi
+
+  echo "OK: All perps-controller files pass oxfmt formatting"
+  cd "$MOBILE_ROOT"
+}
+
 step_lint() {
   cd "$CORE_PATH"
   # No workspace-level lint script exists; run eslint directly to verify
   # all violations are either fixed or suppressed (exit 0 = clean).
   yarn eslint 'packages/perps-controller/src/**/*.ts'
   cd "$MOBILE_ROOT"
+}
+
+step_test() {
+  cd "$CORE_PATH"
+  yarn workspace "$WORKSPACE" test
+  cd "$MOBILE_ROOT"
+}
+
+step_changelog_check() {
+  local changelog="$CORE_PATH/packages/perps-controller/CHANGELOG.md"
+
+  if [[ ! -f "$changelog" ]]; then
+    echo "FAIL: CHANGELOG.md not found at $changelog"
+    return 1
+  fi
+
+  # Check if CHANGELOG.md differs from origin/main in any way:
+  # unstaged, staged, or already committed on this branch.
+  local changelog_modified=0
+  (
+    cd "$CORE_PATH"
+    # Unstaged or staged changes
+    local worktree_changes
+    worktree_changes=$(git diff --name-only -- packages/perps-controller/CHANGELOG.md 2>/dev/null | wc -l | tr -d ' ')
+    local staged_changes
+    staged_changes=$(git diff --cached --name-only -- packages/perps-controller/CHANGELOG.md 2>/dev/null | wc -l | tr -d ' ')
+    # Already committed on branch vs origin/main
+    local committed_changes=0
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+      committed_changes=$(git diff --name-only origin/main...HEAD -- packages/perps-controller/CHANGELOG.md 2>/dev/null | wc -l | tr -d ' ')
+    fi
+
+    if (( worktree_changes + staged_changes + committed_changes > 0 )); then
+      exit 0  # modified
+    else
+      exit 1  # not modified
+    fi
+  ) && changelog_modified=1
+
+  if (( changelog_modified == 0 )); then
+    echo "FAIL: packages/perps-controller/CHANGELOG.md has NOT been updated."
+    echo ""
+    echo "Core CI requires changelog entries for every changed package."
+    echo "Add entries under '## [Unreleased]' with sections:"
+    echo "  ### Added    — new features, exports, files"
+    echo "  ### Fixed    — bug fixes"
+    echo "  ### Changed  — refactors, dependency bumps"
+    echo ""
+    echo "Each entry must link to the PR, e.g.:"
+    echo "  - Add disk-backed cold-start cache ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))"
+    return 1
+  fi
+
+  echo "OK: CHANGELOG.md has been updated"
+
+  # Validate changelog format (section ordering, link format, etc.)
+  local validate_output
+  validate_output=$(cd "$CORE_PATH" && yarn workspace "$WORKSPACE" changelog:validate 2>&1)
+  if [[ -n "$validate_output" ]]; then
+    echo "FAIL: Changelog format validation failed:"
+    echo "$validate_output"
+    return 1
+  fi
+  echo "OK: CHANGELOG.md format is valid"
 }
 
 step_write_sync_state() {
@@ -522,6 +616,9 @@ main() {
   step=$((step + 1))
   run_step $step "ESLint auto-fix + suppressions" step_eslint_fix
 
+  step=$((step + 1))
+  run_step $step "Format fix (oxfmt)" step_format_fix
+
   if ! $SKIP_BUILD; then
     step=$((step + 1))
     run_step $step "Build" step_build
@@ -529,6 +626,14 @@ main() {
 
   step=$((step + 1))
   run_step $step "Lint" step_lint
+
+  if ! $SKIP_TEST; then
+    step=$((step + 1))
+    run_step $step "Test" step_test
+  fi
+
+  step=$((step + 1))
+  run_step $step "Changelog check" step_changelog_check
 
   step=$((step + 1))
   run_step $step "Write sync state" step_write_sync_state


### PR DESCRIPTION
## **Description**

Creates an agentic skill (`perps-core-sync`) for syncing the perps controller from mobile to the core monorepo, and upgrades `validate-core-sync.sh` from 9 to 12 steps to catch CI failures locally before pushing.

**Why:** The sync script had 3 blind spots that caused repeated CI failures on core PRs:
1. Core uses `oxfmt` for TS formatting, not prettier — synced files arrived with wrong formatting
2. Tests were never run — new DI dependencies (e.g., `diskCache`) broke test fixtures silently
3. Changelog was never checked — core CI requires `CHANGELOG.md` entries for every changed package

**Solution:**
- New skill at `.agents/skills/perps-core-sync/` with change detection, 12-step workflow, failure resolution table, changelog ordering rules, and portability guidance
- 3 new steps in `validate-core-sync.sh`: format fix (oxfmt), test, changelog check (with `changelog:validate`)
- `--skip-test` flag for faster iteration
- Fix orphaned JSDoc from deleted `#marketCacheKey` method

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2956

## **Manual testing steps**

```gherkin
Feature: Perps core sync validation

  Scenario: Run full sync with new steps
    Given core repo is checked out locally

    When user runs bash scripts/perps/validate-core-sync.sh --core-path ~/dev/metamask/core
    Then all 12 steps pass including format fix, test, and changelog check
```

## **Screenshots/Recordings**

N/A — script and skill files only, no UI changes.

### **Before**

9-step sync script. Format, test, and changelog failures only caught in CI.

### **After**

12-step sync script. All failures caught locally before pushing.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds documentation and developer tooling, with only a minor JSDoc cleanup in `PerpsController` and no runtime behavior changes.
> 
> **Overview**
> Introduces a new `perps-core-sync` skill (OpenAI + Claude entrypoints) documenting a repeatable workflow to detect perps controller changes and guide syncing `app/controllers/perps/` into Core, including failure-resolution and post-sync commit/changelog guidance.
> 
> Upgrades `scripts/perps/validate-core-sync.sh` from a 9-step flow to a **12-step** pipeline by adding `--skip-test`, an `oxfmt` formatting step (`yarn lint:misc --write` + check), running Core package tests, and enforcing/validating `packages/perps-controller/CHANGELOG.md` updates before writing `.sync-state.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671fbc8ba59e14bba67ef69582a7da5dde2cf4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->