### PR TITLE
feat(social): add TraderPositionView screen and navigation wiring

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -122,6 +122,7 @@ import { selectMarketInsightsPerpsEnabled } from '../../../selectors/featureFlag
 import {
   TopTradersView,
   TraderProfileView,
+  TraderPositionView,
 } from '../../Views/SocialLeaderboard';
 import { selectSocialLeaderboardEnabled } from '../../../selectors/featureFlagController/socialLeaderboard';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
@@ -1292,6 +1293,13 @@ const MainNavigator = () => {
         <Stack.Screen
           name={Routes.SOCIAL_LEADERBOARD.PROFILE}
           component={TraderProfileView}
+          options={{ headerShown: false, ...slideFromRightAnimation }}
+        />
+      )}
+      {isSocialLeaderboardEnabled && (
+        <Stack.Screen
+          name={Routes.SOCIAL_LEADERBOARD.POSITION}
+          component={TraderPositionView}
           options={{ headerShown: false, ...slideFromRightAnimation }}
         />
       )}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -128,7 +128,7 @@ describe('TraderPositionView', () => {
 
     expect(mockGetAssetImageUrl).toHaveBeenCalledWith(
       '0x1234567890123456789012345678901234567890',
-      '0x2105',
+      'eip155:8453',
     );
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import TraderPositionView from './TraderPositionView';
+import { TraderPositionViewSelectorsIDs } from './TraderPositionView.testIds';
+import type { Position } from '@metamask/social-controllers';
+
+const mockGoBack = jest.fn();
+const mockGetAssetImageUrl = jest.fn();
+
+interface MockRouteParams {
+  traderId: string;
+  traderName: string;
+  tokenSymbol: string;
+  position?: Position;
+}
+
+let mockRouteParams: MockRouteParams = {
+  traderId: 'trader-1',
+  traderName: 'dutchiono',
+  tokenSymbol: 'PEPE',
+  position: {
+    tokenSymbol: 'PEPE',
+    tokenName: 'Pepe',
+    tokenAddress: '0x1234567890123456789012345678901234567890',
+    chain: 'base',
+    positionAmount: 1000,
+    boughtUsd: 500,
+    soldUsd: 0,
+    realizedPnl: 0,
+    costBasis: 500,
+    trades: [],
+    lastTradeAt: Date.now(),
+    currentValueUSD: 900,
+    pnlValueUsd: 400,
+    pnlPercent: 80,
+  },
+};
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+
+  return {
+    ...actual,
+    useNavigation: () => ({ goBack: mockGoBack }),
+    useRoute: () => ({
+      params: mockRouteParams,
+    }),
+  };
+});
+
+jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
+  getAssetImageUrl: (...args: unknown[]) => mockGetAssetImageUrl(...args),
+}));
+
+describe('TraderPositionView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAssetImageUrl.mockReturnValue('https://example.com/token.png');
+    mockRouteParams = {
+      traderId: 'trader-1',
+      traderName: 'dutchiono',
+      tokenSymbol: 'PEPE',
+      position: {
+        tokenSymbol: 'PEPE',
+        tokenName: 'Pepe',
+        tokenAddress: '0x1234567890123456789012345678901234567890',
+        chain: 'base',
+        positionAmount: 1000,
+        boughtUsd: 500,
+        soldUsd: 0,
+        realizedPnl: 0,
+        costBasis: 500,
+        trades: [],
+        lastTradeAt: Date.now(),
+        currentValueUSD: 900,
+        pnlValueUsd: 400,
+        pnlPercent: 80,
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the container, route content, and mock trade rows', () => {
+    renderWithProvider(<TraderPositionView />);
+
+    expect(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getAllByText('PEPE').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('$14,670')).toBeOnTheScreen();
+    expect(screen.getByTestId('trade-row-1')).toBeOnTheScreen();
+    expect(screen.getByTestId('trade-row-2')).toBeOnTheScreen();
+  });
+
+  it('calls goBack when the close button is pressed', () => {
+    renderWithProvider(<TraderPositionView />);
+
+    fireEvent.press(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the mock token symbol when the route token symbol is empty', () => {
+    mockRouteParams.tokenSymbol = '';
+
+    renderWithProvider(<TraderPositionView />);
+
+    expect(screen.getByText('PUNCH')).toBeOnTheScreen();
+  });
+
+  it('renders the buy button', () => {
+    renderWithProvider(<TraderPositionView />);
+
+    expect(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('builds the token image URL when the position chain is supported', () => {
+    renderWithProvider(<TraderPositionView />);
+
+    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      '0x2105',
+    );
+  });
+
+  it('skips token image URL resolution when the position chain is unsupported', () => {
+    mockRouteParams.position = {
+      ...mockRouteParams.position,
+      chain: 'unsupported-chain',
+    } as Position;
+
+    renderWithProvider(<TraderPositionView />);
+
+    expect(mockGetAssetImageUrl).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
@@ -1,0 +1,5 @@
+export const TraderPositionViewSelectorsIDs = {
+  CONTAINER: 'trader-position-view-container',
+  CLOSE_BUTTON: 'trader-position-view-close-button',
+  BUY_BUTTON: 'trader-position-view-buy-button',
+};

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -1,0 +1,406 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import {
+  useNavigation,
+  useRoute,
+  type NavigationProp,
+  type RouteProp,
+} from '@react-navigation/native';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  AvatarBase,
+  AvatarBaseSize,
+  AvatarToken,
+  AvatarTokenSize,
+} from '@metamask/design-system-react-native';
+import type { Position } from '@metamask/social-controllers';
+import { strings } from '../../../../../locales/i18n';
+import { TraderPositionViewSelectorsIDs } from './TraderPositionView.testIds';
+import { chainNameToId } from '../utils/chainMapping';
+import { getAssetImageUrl } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const TIME_PERIODS = ['1H', '1D', '1W', '1M', 'All'] as const;
+type TimePeriod = (typeof TIME_PERIODS)[number];
+
+const MOCK_TOKEN = {
+  symbol: 'PUNCH',
+  priceChange: '+$0.0000981 (7.2%)',
+  priceChangePeriod: '1H',
+  marketCap: '$11.7M',
+};
+
+const MOCK_POSITION = {
+  value: '$14,670',
+  pnlValue: '+$790.65',
+  pnlPercent: '+5.08%',
+  isPositive: true,
+};
+
+interface MockTrade {
+  id: string;
+  direction: 'buy' | 'sell';
+  traderName: string;
+  timestamp: string;
+  usdValue: string;
+  percentage: string;
+  isPositive: boolean;
+}
+
+const MOCK_TRADES: MockTrade[] = [
+  {
+    id: '1',
+    direction: 'buy',
+    traderName: 'dutchiono',
+    timestamp: 'March 4 at 9:15am',
+    usdValue: '$2.2K',
+    percentage: '+5%',
+    isPositive: true,
+  },
+  {
+    id: '2',
+    direction: 'sell',
+    traderName: 'dutchiono',
+    timestamp: 'March 4 at 8:02am',
+    usdValue: '-$1.1K',
+    percentage: '-79%',
+    isPositive: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface TimePeriodButtonProps {
+  label: string;
+  isActive: boolean;
+  onPress: () => void;
+}
+
+const TimePeriodButton: React.FC<TimePeriodButtonProps> = ({
+  label,
+  isActive,
+  onPress,
+}) => (
+  <TouchableOpacity onPress={onPress}>
+    <Box
+      twClassName={`flex-1 items-center justify-center px-2 py-1 rounded ${
+        isActive ? 'bg-muted' : ''
+      }`}
+    >
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={isActive ? TextColor.TextDefault : TextColor.TextAlternative}
+      >
+        {label}
+      </Text>
+    </Box>
+  </TouchableOpacity>
+);
+
+interface TradeRowProps {
+  trade: MockTrade;
+}
+
+const TradeRow: React.FC<TradeRowProps> = ({ trade }) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="px-4 py-3"
+    testID={`trade-row-${trade.id}`}
+  >
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={4}
+      twClassName="flex-1 min-w-0 mr-3"
+    >
+      <AvatarBase
+        size={AvatarBaseSize.Md}
+        fallbackText={trade.traderName.charAt(0).toUpperCase()}
+      />
+      <Box twClassName="flex-1 min-w-0">
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+          numberOfLines={1}
+        >
+          {trade.direction === 'buy'
+            ? strings('social_leaderboard.trader_position.bought', {
+                name: trade.traderName,
+              })
+            : strings('social_leaderboard.trader_position.sold', {
+                name: trade.traderName,
+              })}
+        </Text>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          numberOfLines={1}
+        >
+          {trade.timestamp}
+        </Text>
+      </Box>
+    </Box>
+
+    <Box alignItems={BoxAlignItems.End}>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        twClassName={
+          trade.isPositive ? 'text-success-default' : 'text-error-default'
+        }
+      >
+        {trade.usdValue}
+      </Text>
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        {trade.percentage}
+      </Text>
+    </Box>
+  </Box>
+);
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+const TraderPositionView = () => {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'TraderPositionView'>>();
+  const tw = useTailwind();
+
+  const { traderName, tokenSymbol, position: positionParam } = route.params;
+
+  const [activeTimePeriod, setActiveTimePeriod] = useState<TimePeriod>('1D');
+
+  const tokenImageUrl = useMemo(() => {
+    if (!positionParam) return undefined;
+    const chainId = chainNameToId(positionParam.chain);
+    if (!chainId) return undefined;
+    return getAssetImageUrl(positionParam.tokenAddress, chainId);
+  }, [positionParam]);
+
+  const handleClose = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const symbol = tokenSymbol || MOCK_TOKEN.symbol;
+
+  return (
+    <SafeAreaView
+      style={tw.style('flex-1 bg-default')}
+      testID={TraderPositionViewSelectorsIDs.CONTAINER}
+    >
+      {/* Header */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="px-2 py-2"
+      >
+        <Box twClassName="w-10" />
+        <Text
+          variant={TextVariant.HeadingSm}
+          fontWeight={FontWeight.Bold}
+          color={TextColor.TextDefault}
+          numberOfLines={1}
+        >
+          {traderName}
+        </Text>
+        <Box twClassName="w-10 items-end">
+          <ButtonIcon
+            iconName={IconName.Close}
+            size={ButtonIconSize.Md}
+            onPress={handleClose}
+            testID={TraderPositionViewSelectorsIDs.CLOSE_BUTTON}
+          />
+        </Box>
+      </Box>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={tw.style('pb-6')}
+      >
+        {/* Token Info Row */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="px-4 py-3"
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={4}
+            twClassName="flex-1 min-w-0 mr-3"
+          >
+            <AvatarToken
+              name={symbol}
+              src={tokenImageUrl ? { uri: tokenImageUrl } : undefined}
+              size={AvatarTokenSize.Lg}
+            />
+            <Box twClassName="flex-1 min-w-0">
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+                numberOfLines={1}
+              >
+                {symbol}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                twClassName="text-success-default"
+                numberOfLines={1}
+              >
+                {`${MOCK_TOKEN.priceChange} `}
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {MOCK_TOKEN.priceChangePeriod}
+                </Text>
+              </Text>
+            </Box>
+          </Box>
+
+          <Box alignItems={BoxAlignItems.End}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
+              {MOCK_TOKEN.marketCap}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {strings('social_leaderboard.trader_position.market_cap')}
+            </Text>
+          </Box>
+        </Box>
+
+        {/* Chart Placeholder */}
+        <View style={tw.style('mx-4 my-3 h-48 bg-muted rounded-xl')} />
+
+        {/* Timeline Selector */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="px-4 pb-3"
+          gap={3}
+        >
+          {TIME_PERIODS.map((period) => (
+            <TimePeriodButton
+              key={period}
+              label={period}
+              isActive={activeTimePeriod === period}
+              onPress={() => setActiveTimePeriod(period)}
+            />
+          ))}
+        </Box>
+
+        {/* Position Card */}
+        <Box twClassName="mx-4 p-4 bg-muted rounded-2xl">
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
+            alignItems={BoxAlignItems.Start}
+          >
+            <Box>
+              <Text
+                variant={TextVariant.HeadingMd}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextDefault}
+              >
+                {MOCK_POSITION.value}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+              >
+                {strings('social_leaderboard.trader_position.position')}
+              </Text>
+            </Box>
+            <Box alignItems={BoxAlignItems.End}>
+              <Text
+                variant={TextVariant.HeadingMd}
+                fontWeight={FontWeight.Bold}
+                twClassName={
+                  MOCK_POSITION.isPositive
+                    ? 'text-success-default'
+                    : 'text-error-default'
+                }
+              >
+                {MOCK_POSITION.pnlValue}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+              >
+                {MOCK_POSITION.pnlPercent}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+
+        {/* Trades Tab Header */}
+        <Box twClassName="px-4 mt-5">
+          <Box twClassName="self-start pb-2 border-b-2 border-white">
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Bold}
+              color={TextColor.TextDefault}
+            >
+              {strings('social_leaderboard.trader_position.trades')}
+            </Text>
+          </Box>
+          <Box twClassName="h-px bg-muted -mt-0.5" />
+        </Box>
+
+        {/* Trade History */}
+        {MOCK_TRADES.map((trade) => (
+          <TradeRow key={trade.id} trade={trade} />
+        ))}
+      </ScrollView>
+
+      {/* Buy Button — pinned at bottom */}
+      <Box twClassName="px-4 py-3">
+        <Button
+          variant={ButtonVariant.Secondary}
+          isFullWidth
+          onPress={() => undefined}
+          testID={TraderPositionViewSelectorsIDs.BUY_BUTTON}
+        >
+          {strings('social_leaderboard.trader_position.buy')}
+        </Button>
+      </Box>
+    </SafeAreaView>
+  );
+};
+
+export default TraderPositionView;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/index.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TraderPositionView';

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import TraderProfileView from './TraderProfileView';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
+import Routes from '../../../../constants/navigation/Routes';
 import type { UseTraderProfileResult } from './hooks/useTraderProfile';
 import type { UseTraderPositionsResult } from './hooks/useTraderPositions';
 import type {
@@ -11,6 +12,7 @@ import type {
 } from '@metamask/social-controllers';
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 const mockToggleFollow = jest.fn();
 const mockRefresh = jest.fn();
 
@@ -22,7 +24,7 @@ jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
     ...actual,
-    useNavigation: () => ({ goBack: mockGoBack }),
+    useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
     useRoute: () => ({
       params: { traderId: 'trader-1', traderName: 'dutchiono' },
     }),
@@ -165,6 +167,22 @@ describe('TraderProfileView', () => {
     renderWithProvider(<TraderProfileView />);
     expect(screen.getByText('STARKBOT')).toBeOnTheScreen();
     expect(screen.getByText('$2,259.96')).toBeOnTheScreen();
+  });
+
+  it('navigates to the trader position view when a position is pressed', () => {
+    renderWithProvider(<TraderProfileView />);
+
+    fireEvent.press(screen.getByTestId('position-row-STARKBOT'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.SOCIAL_LEADERBOARD.POSITION,
+      {
+        traderId: 'trader-1',
+        traderName: 'dutchiono',
+        tokenSymbol: fixtureOpenPositions[0].tokenSymbol,
+        position: fixtureOpenPositions[0],
+      },
+    );
   });
 
   it('shows empty state when no positions', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -4,6 +4,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import {
   useNavigation,
   useRoute,
+  type NavigationProp,
   type RouteProp,
 } from '@react-navigation/native';
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
@@ -25,8 +26,10 @@ import {
   ButtonVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
+import Routes from '../../../../constants/navigation/Routes';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
 import { useTraderProfile, useTraderPositions } from './hooks';
+import type { Position } from '@metamask/social-controllers';
 import ProfileHeader from './components/ProfileHeader';
 import StatsRow from './components/StatsRow';
 import PositionRow from './components/PositionRow';
@@ -74,7 +77,7 @@ const TabButton: React.FC<TabButtonProps> = ({
 // ---------------------------------------------------------------------------
 
 const TraderProfileView = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const route = useRoute<RouteProp<RootStackParamList, 'TraderProfileView'>>();
   const tw = useTailwind();
 
@@ -101,6 +104,17 @@ const TraderProfileView = () => {
     // TBD — notification preferences not yet wired
   }, []);
 
+  const handlePositionPress = useCallback(
+    (position: Position) => {
+      navigation.navigate(Routes.SOCIAL_LEADERBOARD.POSITION, {
+        traderId,
+        traderName,
+        tokenSymbol: position.tokenSymbol,
+        position,
+      });
+    },
+    [navigation, traderId, traderName],
+  );
   const positions = activeTab === 'open' ? openPositions : closedPositions;
   const isLoadingPositions =
     activeTab === 'open' ? isLoadingOpen : isLoadingClosed;
@@ -235,6 +249,7 @@ const TraderProfileView = () => {
                     <PositionRow
                       key={`${position.tokenAddress}-${position.chain}-${index}`}
                       position={position}
+                      onPress={handlePositionPress}
                     />
                   ))
                 )}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PositionRow from './PositionRow';
 import type { Position } from '@metamask/social-controllers';
@@ -15,11 +15,11 @@ jest.mock('../../utils/chainMapping', () => ({
 }));
 
 const basePosition: Position = {
-  tokenSymbol: 'ETH',
-  tokenName: 'Ethereum',
+  tokenSymbol: 'STARKBOT',
+  tokenName: 'Starkbot',
   tokenAddress: '0x123',
-  chain: 'ethereum',
-  positionAmount: 1500000,
+  chain: 'base',
+  positionAmount: 1500000000,
   boughtUsd: 1200,
   soldUsd: 0,
   realizedPnl: 0,
@@ -32,14 +32,22 @@ const basePosition: Position = {
 };
 
 describe('PositionRow', () => {
+  it('renders the row testID', () => {
+    renderWithProvider(<PositionRow position={basePosition} />);
+
+    expect(screen.getByTestId('position-row-STARKBOT')).toBeOnTheScreen();
+  });
+
   it('renders the token symbol', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    expect(screen.getAllByText('ETH')[0]).toBeOnTheScreen();
+
+    expect(screen.getAllByText('STARKBOT')[0]).toBeOnTheScreen();
   });
 
   it('renders formatted token amount', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    expect(screen.getByText('1,500,000 ETH')).toBeOnTheScreen();
+
+    expect(screen.getByText('1,500,000,000 STARKBOT')).toBeOnTheScreen();
   });
 
   it('renders current value formatted as USD', () => {
@@ -54,6 +62,7 @@ describe('PositionRow', () => {
 
   it('renders negative PnL percent', () => {
     const position = { ...basePosition, pnlPercent: -25 };
+
     renderWithProvider(<PositionRow position={position} />);
     expect(screen.getByText('-25%')).toBeOnTheScreen();
   });
@@ -63,6 +72,7 @@ describe('PositionRow', () => {
       ...basePosition,
       pnlPercent: null,
     } as unknown as Position;
+
     renderWithProvider(<PositionRow position={position} />);
     expect(screen.getByText('\u2014')).toBeOnTheScreen();
   });
@@ -72,50 +82,84 @@ describe('PositionRow', () => {
       ...basePosition,
       currentValueUSD: null,
     } as unknown as Position;
+
     renderWithProvider(<PositionRow position={position} />);
+
     const dashes = screen.getAllByText('\u2014');
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders zero PnL percent with plus sign', () => {
     const position = { ...basePosition, pnlPercent: 0 };
+
     renderWithProvider(<PositionRow position={position} />);
     expect(screen.getByText('+0%')).toBeOnTheScreen();
   });
 
   it('renders negative USD value', () => {
     const position = { ...basePosition, currentValueUSD: -150.5 };
+
     renderWithProvider(<PositionRow position={position} />);
     expect(screen.getByText('-$150.50')).toBeOnTheScreen();
   });
 
   it('renders zero USD value', () => {
     const position = { ...basePosition, currentValueUSD: 0 };
+
     renderWithProvider(<PositionRow position={position} />);
     expect(screen.getByText('$0.00')).toBeOnTheScreen();
   });
 
   it('renders token amount with decimals', () => {
     const position = { ...basePosition, positionAmount: 1.5 };
+
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('1.5 ETH')).toBeOnTheScreen();
+
+    expect(screen.getByText('1.5 STARKBOT')).toBeOnTheScreen();
   });
 
   it('renders negative token amount', () => {
     const position = { ...basePosition, positionAmount: -500 };
+
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('-500 ETH')).toBeOnTheScreen();
+
+    expect(screen.getByText('-500 STARKBOT')).toBeOnTheScreen();
+  });
+
+  it('calls onPress with the position when tapped', () => {
+    const onPress = jest.fn();
+
+    renderWithProvider(
+      <PositionRow position={basePosition} onPress={onPress} />,
+    );
+
+    fireEvent.press(screen.getByTestId('position-row-STARKBOT'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(basePosition);
   });
 
   it('renders the row without a token image when the chain is not recognized', () => {
     const position = { ...basePosition, chain: 'unknown' };
+
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByTestId('position-row-ETH')).toBeOnTheScreen();
+
+    expect(screen.getByTestId('position-row-STARKBOT')).toBeOnTheScreen();
   });
 
   it('formats large USD values with commas', () => {
     const position = { ...basePosition, currentValueUSD: 1234567.89 };
+
     renderWithProvider(<PositionRow position={position} />);
+
     expect(screen.getByText('$1,234,567.89')).toBeOnTheScreen();
+  });
+
+  it('uses the token symbol in the testID', () => {
+    const position = { ...basePosition, tokenSymbol: 'PEPE' };
+
+    renderWithProvider(<PositionRow position={position} />);
+
+    expect(screen.getByTestId('position-row-PEPE')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { TouchableOpacity } from 'react-native';
 import {
   Box,
   Text,
@@ -22,6 +23,7 @@ import {
 
 export interface PositionRowProps {
   position: Position;
+  onPress?: (position: Position) => void;
 }
 
 function formatUsd(value: number | null | undefined): string {
@@ -43,9 +45,10 @@ function formatPercent(value: number | null | undefined): string {
   return formatPercentage(value, 0);
 }
 
-const PositionRow: React.FC<PositionRowProps> = ({ position }) => {
+const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
   const hasPnl = position.pnlPercent != null;
   const isPnlPositive = hasPnl && (position.pnlPercent ?? 0) >= 0;
+  const testID = `position-row-${position.tokenSymbol}`;
 
   const tokenImageUrl = useMemo(() => {
     const chainId = chainNameToId(position.chain);
@@ -53,13 +56,13 @@ const PositionRow: React.FC<PositionRowProps> = ({ position }) => {
     return getAssetImageUrl(position.tokenAddress, chainId);
   }, [position.chain, position.tokenAddress]);
 
-  return (
+  const content = (
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
       twClassName="px-4 py-3"
-      testID={`position-row-${position.tokenSymbol}`}
+      testID={onPress ? undefined : testID}
     >
       <Box
         flexDirection={BoxFlexDirection.Row}
@@ -116,6 +119,16 @@ const PositionRow: React.FC<PositionRowProps> = ({ position }) => {
       </Box>
     </Box>
   );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={() => onPress(position)} testID={testID}>
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return content;
 };
 
 export default PositionRow;

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
@@ -67,4 +67,30 @@ describe('ProfileHeader', () => {
     );
     expect(screen.getByText('0 followers')).toBeOnTheScreen();
   });
+
+  it('renders the fallback letter when imageUrl is undefined', () => {
+    const profileWithoutImage: TraderProfile = {
+      ...baseProfile,
+      imageUrl: undefined,
+    };
+
+    renderWithProvider(
+      <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
+    );
+
+    expect(screen.getByText('D')).toBeOnTheScreen();
+  });
+
+  it('renders the fallback letter when imageUrl is empty', () => {
+    const profileWithoutImage: TraderProfile = {
+      ...baseProfile,
+      imageUrl: '',
+    };
+
+    renderWithProvider(
+      <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
+    );
+
+    expect(screen.getByText('D')).toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import StatsRow from './StatsRow';
 import type { TraderStats } from '@metamask/social-controllers';
+import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 
 const baseStats: TraderStats = {
   pnl30d: 20610,
@@ -12,6 +13,14 @@ const baseStats: TraderStats = {
 };
 
 describe('StatsRow', () => {
+  it('renders the stats row container', () => {
+    renderWithProvider(<StatsRow stats={baseStats} />);
+
+    expect(
+      screen.getByTestId(TraderProfileViewSelectorsIDs.STATS_ROW),
+    ).toBeOnTheScreen();
+  });
+
   it('renders win rate as percentage when winRate30d is non-null and positive', () => {
     renderWithProvider(<StatsRow stats={baseStats} />);
     expect(screen.getByText('92%')).toBeOnTheScreen();
@@ -60,8 +69,11 @@ describe('StatsRow', () => {
       winRate30d: null,
       pnl30d: null,
     } as unknown as TraderStats;
+
     renderWithProvider(<StatsRow stats={stats} />);
+
     const dashes = screen.getAllByText('\u2014');
+
     expect(dashes.length).toBeGreaterThanOrEqual(3);
   });
 
@@ -89,5 +101,23 @@ describe('StatsRow', () => {
 
       expect(screen.getByText('2 days')).toBeOnTheScreen();
     });
+  });
+
+  it('renders win rate label', () => {
+    renderWithProvider(<StatsRow stats={baseStats} />);
+
+    expect(screen.getByText('win rate')).toBeOnTheScreen();
+  });
+
+  it('renders 30D P&L label', () => {
+    renderWithProvider(<StatsRow stats={baseStats} />);
+
+    expect(screen.getByText('30D P&L')).toBeOnTheScreen();
+  });
+
+  it('renders avg hold label', () => {
+    renderWithProvider(<StatsRow stats={baseStats} />);
+
+    expect(screen.getByText('avg. hold')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderPositions.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderPositions.test.ts
@@ -22,47 +22,43 @@ const makeQueryResult = (
     ...overrides,
   }) as ReturnType<typeof useQuery>;
 
-const fixtureOpenPositions = {
-  positions: [
-    {
-      tokenSymbol: 'ETH',
-      tokenName: 'Ethereum',
-      tokenAddress: '0x1',
-      chain: 'ethereum',
-      positionAmount: 5,
-      boughtUsd: 10000,
-      soldUsd: 0,
-      realizedPnl: 0,
-      costBasis: 10000,
-      trades: [],
-      lastTradeAt: Date.now(),
-      currentValueUSD: 15000,
-      pnlValueUsd: 5000,
-      pnlPercent: 50,
-    },
-  ],
-};
+const mockOpenPositions = [
+  {
+    tokenSymbol: 'ETH',
+    tokenName: 'Ethereum',
+    tokenAddress: '0x1',
+    chain: 'ethereum',
+    positionAmount: 5,
+    boughtUsd: 10000,
+    soldUsd: 0,
+    realizedPnl: 0,
+    costBasis: 10000,
+    trades: [],
+    lastTradeAt: Date.now(),
+    currentValueUSD: 15000,
+    pnlValueUsd: 5000,
+    pnlPercent: 50,
+  },
+];
 
-const fixtureClosedPositions = {
-  positions: [
-    {
-      tokenSymbol: 'USDC',
-      tokenName: 'USD Coin',
-      tokenAddress: '0x2',
-      chain: 'base',
-      positionAmount: 1000,
-      boughtUsd: 1000,
-      soldUsd: 1100,
-      realizedPnl: 100,
-      costBasis: 1000,
-      trades: [],
-      lastTradeAt: Date.now(),
-      currentValueUSD: 0,
-      pnlValueUsd: 100,
-      pnlPercent: 10,
-    },
-  ],
-};
+const mockClosedPositions = [
+  {
+    tokenSymbol: 'USDC',
+    tokenName: 'USD Coin',
+    tokenAddress: '0x2',
+    chain: 'base',
+    positionAmount: 1000,
+    boughtUsd: 1000,
+    soldUsd: 1100,
+    realizedPnl: 100,
+    costBasis: 1000,
+    trades: [],
+    lastTradeAt: Date.now(),
+    currentValueUSD: 0,
+    pnlValueUsd: 100,
+    pnlPercent: 10,
+  },
+];
 
 describe('useTraderPositions', () => {
   beforeEach(() => {
@@ -74,7 +70,8 @@ describe('useTraderPositions', () => {
     it('passes the correct queryKeys for open and closed positions', () => {
       renderHook(() => useTraderPositions('trader-1'));
 
-      expect(mockUseQuery).toHaveBeenCalledWith(
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           queryKey: [
             'SocialService:fetchOpenPositions',
@@ -82,7 +79,8 @@ describe('useTraderPositions', () => {
           ],
         }),
       );
-      expect(mockUseQuery).toHaveBeenCalledWith(
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           queryKey: [
             'SocialService:fetchClosedPositions',
@@ -95,17 +93,23 @@ describe('useTraderPositions', () => {
     it('enables both queries when addressOrId is non-empty', () => {
       renderHook(() => useTraderPositions('trader-1'));
 
-      const calls = mockUseQuery.mock.calls;
-      expect(calls[0][0]).toEqual(expect.objectContaining({ enabled: true }));
-      expect(calls[1][0]).toEqual(expect.objectContaining({ enabled: true }));
+      expect(mockUseQuery.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ enabled: true }),
+      );
+      expect(mockUseQuery.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ enabled: true }),
+      );
     });
 
     it('disables both queries when addressOrId is empty', () => {
       renderHook(() => useTraderPositions(''));
 
-      const calls = mockUseQuery.mock.calls;
-      expect(calls[0][0]).toEqual(expect.objectContaining({ enabled: false }));
-      expect(calls[1][0]).toEqual(expect.objectContaining({ enabled: false }));
+      expect(mockUseQuery.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ enabled: false }),
+      );
+      expect(mockUseQuery.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ enabled: false }),
+      );
     });
 
     it('forwards refetchInterval only to the open positions query', () => {
@@ -136,55 +140,51 @@ describe('useTraderPositions', () => {
   });
 
   describe('position data', () => {
-    it('returns empty arrays when data is undefined', () => {
+    it('returns empty arrays when both queries return undefined data', () => {
       const { result } = renderHook(() => useTraderPositions('trader-1'));
+
       expect(result.current.openPositions).toEqual([]);
       expect(result.current.closedPositions).toEqual([]);
     });
 
-    it('returns open positions from first query', () => {
+    it('returns open positions from the open query', () => {
       mockUseQuery
         .mockReturnValueOnce(
-          makeQueryResult({ data: fixtureOpenPositions as never }),
+          makeQueryResult({ data: { positions: mockOpenPositions } as never }),
         )
         .mockReturnValueOnce(makeQueryResult());
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.openPositions).toEqual(
-        fixtureOpenPositions.positions,
-      );
+
+      expect(result.current.openPositions).toEqual(mockOpenPositions);
     });
 
-    it('returns closed positions from second query', () => {
-      mockUseQuery
-        .mockReturnValueOnce(makeQueryResult())
-        .mockReturnValueOnce(
-          makeQueryResult({ data: fixtureClosedPositions as never }),
-        );
+    it('returns closed positions from the closed query', () => {
+      mockUseQuery.mockReturnValueOnce(makeQueryResult()).mockReturnValueOnce(
+        makeQueryResult({
+          data: { positions: mockClosedPositions } as never,
+        }),
+      );
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.closedPositions).toEqual(
-        fixtureClosedPositions.positions,
-      );
+
+      expect(result.current.closedPositions).toEqual(mockClosedPositions);
     });
 
-    it('returns both open and closed positions', () => {
+    it('falls back to empty arrays when positions is missing', () => {
       mockUseQuery
-        .mockReturnValueOnce(
-          makeQueryResult({ data: fixtureOpenPositions as never }),
-        )
-        .mockReturnValueOnce(
-          makeQueryResult({ data: fixtureClosedPositions as never }),
-        );
+        .mockReturnValueOnce(makeQueryResult({ data: {} as never }))
+        .mockReturnValueOnce(makeQueryResult({ data: {} as never }));
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.openPositions).toHaveLength(1);
-      expect(result.current.closedPositions).toHaveLength(1);
+
+      expect(result.current.openPositions).toEqual([]);
+      expect(result.current.closedPositions).toEqual([]);
     });
   });
 
   describe('loading states', () => {
-    it('exposes isLoadingOpen from first query', () => {
+    it('exposes isLoadingOpen from the open query', () => {
       mockUseQuery
         .mockReturnValueOnce(makeQueryResult({ isLoading: true }))
         .mockReturnValueOnce(makeQueryResult());
@@ -194,7 +194,7 @@ describe('useTraderPositions', () => {
       expect(result.current.isLoadingClosed).toBe(false);
     });
 
-    it('exposes isLoadingClosed from second query', () => {
+    it('exposes isLoadingClosed from the closed query', () => {
       mockUseQuery
         .mockReturnValueOnce(makeQueryResult())
         .mockReturnValueOnce(makeQueryResult({ isLoading: true }));
@@ -206,18 +206,27 @@ describe('useTraderPositions', () => {
   });
 
   describe('error handling', () => {
-    it('returns error from open query', () => {
+    it('returns null when there are no errors', () => {
+      const { result } = renderHook(() => useTraderPositions('trader-1'));
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('returns the open query error before the closed query error', () => {
       mockUseQuery
         .mockReturnValueOnce(
           makeQueryResult({ error: new Error('open error') }),
         )
-        .mockReturnValueOnce(makeQueryResult());
+        .mockReturnValueOnce(
+          makeQueryResult({ error: new Error('closed error') }),
+        );
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
+
       expect(result.current.error).toBe('open error');
     });
 
-    it('returns error from closed query when open has none', () => {
+    it('returns the closed query error when the open query succeeds', () => {
       mockUseQuery
         .mockReturnValueOnce(makeQueryResult())
         .mockReturnValueOnce(
@@ -225,45 +234,31 @@ describe('useTraderPositions', () => {
         );
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
+
       expect(result.current.error).toBe('closed error');
     });
 
-    it('prefers open error when both queries fail', () => {
+    it('converts non-Error values to strings', () => {
       mockUseQuery
-        .mockReturnValueOnce(
-          makeQueryResult({ error: new Error('open error') }),
-        )
-        .mockReturnValueOnce(
-          makeQueryResult({ error: new Error('closed error') }),
-        );
-
-      const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.error).toBe('open error');
-    });
-
-    it('returns null when both queries succeed', () => {
-      const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.error).toBeNull();
-    });
-
-    it('converts non-Error to string', () => {
-      mockUseQuery
-        .mockReturnValueOnce(makeQueryResult({ error: 'raw string' as never }))
+        .mockReturnValueOnce(makeQueryResult({ error: 'raw error' as never }))
         .mockReturnValueOnce(makeQueryResult());
 
       const { result } = renderHook(() => useTraderPositions('trader-1'));
-      expect(result.current.error).toBe('raw string');
+
+      expect(result.current.error).toBe('raw error');
     });
 
-    it('logs combined error via Logger.error', () => {
-      const err = new Error('fetch failed');
+    it('logs the combined error', () => {
+      const error = new Error('fetch failed');
+
       mockUseQuery
-        .mockReturnValueOnce(makeQueryResult({ error: err }))
+        .mockReturnValueOnce(makeQueryResult({ error }))
         .mockReturnValueOnce(makeQueryResult());
 
       renderHook(() => useTraderPositions('trader-1'));
+
       expect(Logger.error).toHaveBeenCalledWith(
-        err,
+        error,
         'useTraderPositions: positions fetch failed',
       );
     });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
@@ -101,6 +101,11 @@ describe('useTraderProfile', () => {
       const { result } = renderHook(() => useTraderProfile('trader-1'));
       expect(result.current.isLoading).toBe(true);
     });
+
+    it('returns false when useQuery is not loading', () => {
+      const { result } = renderHook(() => useTraderProfile('trader-1'));
+      expect(result.current.isLoading).toBe(false);
+    });
   });
 
   describe('error handling', () => {
@@ -112,7 +117,7 @@ describe('useTraderProfile', () => {
       expect(result.current.error).toBe('Network error');
     });
 
-    it('converts non-Error values to string', () => {
+    it('converts non-Error values to strings', () => {
       mockUseQuery.mockReturnValue(
         makeQueryResult({ error: 'raw error' as never }),
       );
@@ -125,12 +130,12 @@ describe('useTraderProfile', () => {
       expect(result.current.error).toBeNull();
     });
 
-    it('logs errors via Logger.error when error is present', () => {
-      const err = new Error('fetch failed');
-      mockUseQuery.mockReturnValue(makeQueryResult({ error: err }));
+    it('logs errors when error is present', () => {
+      const error = new Error('fetch failed');
+      mockUseQuery.mockReturnValue(makeQueryResult({ error }));
       renderHook(() => useTraderProfile('trader-1'));
       expect(Logger.error).toHaveBeenCalledWith(
-        err,
+        error,
         'useTraderProfile: profile fetch failed',
       );
     });
@@ -157,11 +162,15 @@ describe('useTraderProfile', () => {
       expect(result.current.isFollowing).toBe(true);
     });
 
-    it('toggles isFollowing back to false on a second call', () => {
+    it('toggles isFollowing back to false on the second call', () => {
       const { result } = renderHook(() => useTraderProfile('trader-1'));
 
-      act(() => result.current.toggleFollow());
-      act(() => result.current.toggleFollow());
+      act(() => {
+        result.current.toggleFollow();
+      });
+      act(() => {
+        result.current.toggleFollow();
+      });
 
       expect(result.current.isFollowing).toBe(false);
     });
@@ -179,9 +188,10 @@ describe('useTraderProfile', () => {
       expect(mockRefetch).toHaveBeenCalledTimes(1);
     });
 
-    it('logs and re-throws when refetch rejects', async () => {
-      const err = new Error('Network failure');
-      mockRefetch.mockRejectedValue(err);
+    it('logs and rethrows when refetch rejects', async () => {
+      const error = new Error('Network failure');
+
+      mockRefetch.mockRejectedValue(error);
       const { result } = renderHook(() => useTraderProfile('trader-1'));
 
       await expect(
@@ -191,7 +201,7 @@ describe('useTraderProfile', () => {
       ).rejects.toThrow('Network failure');
 
       expect(Logger.error).toHaveBeenCalledWith(
-        err,
+        error,
         'useTraderProfile: refresh failed',
       );
     });

--- a/app/components/Views/SocialLeaderboard/index.ts
+++ b/app/components/Views/SocialLeaderboard/index.ts
@@ -1,2 +1,3 @@
 export { default as TopTradersView } from './TopTradersView';
 export { default as TraderProfileView } from './TraderProfileView';
+export { default as TraderPositionView } from './TraderPositionView';

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
@@ -2,13 +2,13 @@ import { chainNameToId, isSupportedChain } from './chainMapping';
 
 describe('chainNameToId', () => {
   it.each([
-    ['ethereum', '0x1'],
-    ['base', '0x2105'],
-    ['arbitrum', '0xa4b1'],
-    ['optimism', '0xa'],
-    ['polygon', '0x89'],
-    ['linea', '0xe708'],
-    ['bsc', '0x38'],
+    ['ethereum', 'eip155:1'],
+    ['base', 'eip155:8453'],
+    ['arbitrum', 'eip155:42161'],
+    ['optimism', 'eip155:10'],
+    ['polygon', 'eip155:137'],
+    ['linea', 'eip155:59144'],
+    ['bsc', 'eip155:56'],
     ['solana', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
   ])('maps %s to %s', (chainName, expectedId) => {
     expect(chainNameToId(chainName)).toBe(expectedId);
@@ -23,15 +23,15 @@ describe('chainNameToId', () => {
   });
 
   it('is case-insensitive for lowercase input', () => {
-    expect(chainNameToId('ethereum')).toBe('0x1');
+    expect(chainNameToId('ethereum')).toBe('eip155:1');
   });
 
   it('is case-insensitive for uppercase input', () => {
-    expect(chainNameToId('ETHEREUM')).toBe('0x1');
+    expect(chainNameToId('ETHEREUM')).toBe('eip155:1');
   });
 
   it('is case-insensitive for mixed-case input', () => {
-    expect(chainNameToId('Base')).toBe('0x2105');
+    expect(chainNameToId('Base')).toBe('eip155:8453');
   });
 });
 

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
@@ -1,0 +1,74 @@
+import { chainNameToId, isSupportedChain } from './chainMapping';
+
+describe('chainNameToId', () => {
+  it.each([
+    ['ethereum', '0x1'],
+    ['base', '0x2105'],
+    ['arbitrum', '0xa4b1'],
+    ['optimism', '0xa'],
+    ['polygon', '0x89'],
+    ['linea', '0xe708'],
+    ['bsc', '0x38'],
+    ['solana', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+  ])('maps %s to %s', (chainName, expectedId) => {
+    expect(chainNameToId(chainName)).toBe(expectedId);
+  });
+
+  it('returns undefined for an unsupported chain name', () => {
+    expect(chainNameToId('avalanche')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(chainNameToId('')).toBeUndefined();
+  });
+
+  it('is case-insensitive for lowercase input', () => {
+    expect(chainNameToId('ethereum')).toBe('0x1');
+  });
+
+  it('is case-insensitive for uppercase input', () => {
+    expect(chainNameToId('ETHEREUM')).toBe('0x1');
+  });
+
+  it('is case-insensitive for mixed-case input', () => {
+    expect(chainNameToId('Base')).toBe('0x2105');
+  });
+});
+
+describe('isSupportedChain', () => {
+  it('returns true for a known chain', () => {
+    expect(isSupportedChain('ethereum')).toBe(true);
+  });
+
+  it('returns true for all supported chains', () => {
+    const supported = [
+      'ethereum',
+      'base',
+      'arbitrum',
+      'optimism',
+      'polygon',
+      'linea',
+      'bsc',
+      'solana',
+    ];
+    supported.forEach((chain) => {
+      expect(isSupportedChain(chain)).toBe(true);
+    });
+  });
+
+  it('returns false for an unknown chain', () => {
+    expect(isSupportedChain('avalanche')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isSupportedChain('')).toBe(false);
+  });
+
+  it('is case-insensitive — returns true for uppercase input', () => {
+    expect(isSupportedChain('ETHEREUM')).toBe(true);
+  });
+
+  it('is case-insensitive — returns true for mixed-case input', () => {
+    expect(isSupportedChain('BASE')).toBe(true);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
@@ -1,10 +1,19 @@
-import type { CaipChainId } from '@metamask/utils';
+import type { CaipChainId, Hex } from '@metamask/utils';
 
-const CHAIN_NAME_TO_ID: Record<string, CaipChainId> = {
-  ethereum: 'eip155:1',
-  base: 'eip155:8453',
+const CHAIN_NAME_TO_ID: Record<string, Hex | CaipChainId> = {
+  ethereum: '0x1',
+  base: '0x2105',
+  arbitrum: '0xa4b1',
+  optimism: '0xa',
+  polygon: '0x89',
+  linea: '0xe708',
+  bsc: '0x38',
   solana: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
 };
 
-export const chainNameToId = (chainName: string): CaipChainId | undefined =>
-  CHAIN_NAME_TO_ID[chainName.toLowerCase()];
+export const chainNameToId = (
+  chainName: string,
+): Hex | CaipChainId | undefined => CHAIN_NAME_TO_ID[chainName.toLowerCase()];
+
+export const isSupportedChain = (chainName: string): boolean =>
+  chainName.toLowerCase() in CHAIN_NAME_TO_ID;

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
@@ -1,19 +1,18 @@
-import type { CaipChainId, Hex } from '@metamask/utils';
+import type { CaipChainId } from '@metamask/utils';
 
-const CHAIN_NAME_TO_ID: Record<string, Hex | CaipChainId> = {
-  ethereum: '0x1',
-  base: '0x2105',
-  arbitrum: '0xa4b1',
-  optimism: '0xa',
-  polygon: '0x89',
-  linea: '0xe708',
-  bsc: '0x38',
+const CHAIN_NAME_TO_ID: Record<string, CaipChainId> = {
+  ethereum: 'eip155:1',
+  base: 'eip155:8453',
+  arbitrum: 'eip155:42161',
+  optimism: 'eip155:10',
+  polygon: 'eip155:137',
+  linea: 'eip155:59144',
+  bsc: 'eip155:56',
   solana: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
 };
 
-export const chainNameToId = (
-  chainName: string,
-): Hex | CaipChainId | undefined => CHAIN_NAME_TO_ID[chainName.toLowerCase()];
+export const chainNameToId = (chainName: string): CaipChainId | undefined =>
+  CHAIN_NAME_TO_ID[chainName.toLowerCase()];
 
 export const isSupportedChain = (chainName: string): boolean =>
   chainName.toLowerCase() in CHAIN_NAME_TO_ID;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -354,6 +354,7 @@ const Routes = {
     ROOT: 'SocialLeaderboard',
     VIEW: 'TopTradersView',
     PROFILE: 'TraderProfileView',
+    POSITION: 'TraderPositionView',
   },
   PREDICT: {
     ROOT: 'Predict',

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -556,6 +556,12 @@ export interface RootStackParamList extends ParamListBase {
   // Social Leaderboard routes
   TopTradersView: undefined;
   TraderProfileView: { traderId: string; traderName: string };
+  TraderPositionView: {
+    traderId: string;
+    traderName: string;
+    tokenSymbol: string;
+    position?: import('@metamask/social-controllers').Position;
+  };
 
   // Misc routes
   LockScreen: undefined;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1033,6 +1033,14 @@
       "closed": "Closed",
       "no_positions": "No positions yet",
       "error_loading_profile": "Couldn't load profile"
+    },
+    "trader_position": {
+      "market_cap": "Market cap",
+      "position": "Position",
+      "trades": "Trades",
+      "buy": "Buy",
+      "bought": "{{name}} bought",
+      "sold": "{{name}} sold"
     }
   },
   "perps": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Adds `TraderPositionView` screen with token info row, chart placeholder, position card, trade history, and a Buy button (stubbed for now)
- Wires navigation from `TraderProfileView` → `TraderPositionView` via `PositionRow.onPress` and the new `Routes.SOCIAL_LEADERBOARD.POSITION` route
- Adds `chainMapping.ts` utility for social API chain name → hex/CAIP chain ID resolution
- Registers the new screen in `MainNavigator.js`

> **Note:** The Buy button is intentionally a no-op in this PR. QuickBuyBottomSheet integration follows in the next PR (stacked on this one).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added trader position view

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation change behind the Social Leaderboard feature flag, plus new unit tests and i18n strings; no sensitive auth or transaction logic is implemented (buy action remains a no-op).
> 
> **Overview**
> Adds a new **Social Leaderboard** detail screen, `TraderPositionView`, showing token/market info, a chart placeholder, position summary, and mock trade history, with a stubbed Buy action.
> 
> Wires navigation from `TraderProfileView` position rows into the new route `Routes.SOCIAL_LEADERBOARD.POSITION`, registers the screen in `MainNavigator`, and updates navigation types/route constants accordingly.
> 
> Expands chain-name → CAIP chain-id mapping (and adds `isSupportedChain`) to support token image resolution, and adds/updates tests for the new screen, navigation tap behavior, and chain mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c6cb6a4c649aeee43128fa17d0609fa6fc39c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->