### PR TITLE
chore: update badge color and position

### DIFF
--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -362,7 +362,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
       case 'Verified':
         return {
           icon: IconName.VerifiedFilled,
-          iconColor: IconColor.IconDefault,
+          iconColor: IconColor.PrimaryDefault,
           label: null,
           bg: null,
           textColor: undefined,
@@ -700,7 +700,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
                   </Text>
                 </Box>
                 {securityBadge && securityBadge.label === null && (
-                  <Box twClassName="shrink-0">
+                  <Box twClassName="shrink-0 pb-[2px]">
                     <TouchableOpacity
                       onPress={handleSecurityBadgePress}
                       testID="security-badge-verified"
@@ -714,7 +714,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
                   </Box>
                 )}
                 {securityBadge && securityBadge.label !== null && (
-                  <Box twClassName="shrink-0">
+                  <Box twClassName="shrink-0 pb-[2px]">
                     <TouchableOpacity
                       onPress={handleSecurityBadgePress}
                       testID={


### PR DESCRIPTION

## **Description**

Updates verified badge color and badge positions to align with new spec

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update badge color and position

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="423" height="217" alt="Screenshot 2026-04-15 at 14 40 00" src="https://github.com/user-attachments/assets/85146c2a-78b0-45fa-bb1e-19e34d56d9df" />

<img width="416" height="200" alt="Screenshot 2026-04-15 at 14 40 15" src="https://github.com/user-attachments/assets/57c4fc15-60fc-4f01-96ec-f37c41b21a9d" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks styling for the token security badge without altering data flow or business logic.
> 
> **Overview**
> Updates the token details header *security badge* to match the latest spec by changing the **Verified** icon color to `IconColor.PrimaryDefault` and slightly adjusting badge vertical alignment via `pb-[2px]` on the badge container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9910083a7423f59096d22e97685644d01d4411cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->