### PR TITLE
fix(swaps): prevent max quick-pick overflow on small screens

### DIFF
--- a/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/QuickPickButtons.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { QuickPickButtons } from './QuickPickButtons';
 import { QuickPickButtonOption } from './types';
 
@@ -302,6 +303,25 @@ describe('QuickPickButtons', () => {
 
       buttons.forEach((button) => {
         expect(button).toBeTruthy();
+      });
+    });
+
+    it('applies shrink-safe styles so all quick-pick buttons stay visible', () => {
+      const { getAllByRole } = render(
+        <QuickPickButtons options={defaultOptions} show />,
+      );
+
+      const buttons = getAllByRole('button');
+
+      buttons.forEach((button) => {
+        const flattenedStyle = StyleSheet.flatten(button.props.style);
+
+        expect(flattenedStyle).toMatchObject({
+          flex: 1,
+          flexBasis: 0,
+          flexShrink: 1,
+          minWidth: 0,
+        });
       });
     });
   });

--- a/app/components/UI/Bridge/components/SwapsKeypad/styles.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/styles.tsx
@@ -18,11 +18,14 @@ export const createSwapsKeypadStyles = (theme: Theme) =>
 export const quickPickButtonsStyles = StyleSheet.create({
   container: {
     display: 'flex',
-    justifyContent: 'space-between',
-    gap: 12,
     flexDirection: 'row',
+    gap: 12,
+    width: '100%',
   },
   button: {
     flex: 1,
+    flexBasis: 0,
+    flexShrink: 1,
+    minWidth: 0,
   },
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes the Swap numpad quick-pick layout on smaller screens where the `Max` option could overflow past the right edge and become partially hidden.

Updates the quick-pick row to use full-width, shrink-safe flex sizing so all preset buttons remain visible without changing the existing interaction flow. Adds a regression test to lock in the button sizing behavior.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Swap Max quick-pick button overflowing on smaller screens

## **Related issues**

Fixes: #28846

## **Manual testing steps**

```gherkin
Feature: Swap quick-pick button layout

  Background:
    Given I am logged into MetaMask Mobile
    And I have a wallet with a non-zero balance for a token that shows the "Max" quick-pick option

  Scenario: user opens the swap amount keypad on a small device
    Given I am using a small-screen device or simulator in portrait mode
    And I am on the Swap screen with a source token selected

    When user taps the source amount input
    Then the quick-pick row should appear above the numpad
    And the "Max" quick-pick should be fully visible
    And the "Max" quick-pick should be tappable
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/5670e33a-fcba-4382-a543-12fe2b9b546f" />


### **After**
iPhone 13 mini:
<img width="306" height="655" alt="Screenshot 2026-04-15 at 14 48 39" src="https://github.com/user-attachments/assets/78ea40b3-cd88-4bb9-a0b3-2c43d5778016" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
