### PR TITLE
refactor(homepage): replace assetsDefiPositions selector with deFiPositionsSectionEnabled

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -168,12 +168,9 @@ jest.mock('../../UI/Predict/hooks/usePredictMarketData', () => ({
   }),
 }));
 
-jest.mock(
-  '../../../selectors/featureFlagController/assetsDefiPositions',
-  () => ({
-    selectAssetsDefiPositionsEnabled: jest.fn(() => true),
-  }),
-);
+jest.mock('../../../selectors/deFiPositionsSectionEnabled', () => ({
+  selectDeFiPositionsSectionEnabled: jest.fn(() => true),
+}));
 
 jest.mock('../../../selectors/featureFlagController/whatsHappening', () => ({
   selectWhatsHappeningEnabled: jest.fn(() => false),
@@ -301,10 +298,8 @@ describe('Homepage', () => {
       .requireMock('../../UI/Predict/selectors/featureFlags')
       .selectPredictEnabledFlag.mockReturnValue(true);
     jest
-      .requireMock(
-        '../../../selectors/featureFlagController/assetsDefiPositions',
-      )
-      .selectAssetsDefiPositionsEnabled.mockReturnValue(true);
+      .requireMock('../../../selectors/deFiPositionsSectionEnabled')
+      .selectDeFiPositionsSectionEnabled.mockReturnValue(true);
     jest
       .requireMock('../../../selectors/featureFlagController/whatsHappening')
       .selectWhatsHappeningEnabled.mockReturnValue(false);
@@ -420,10 +415,8 @@ describe('Homepage', () => {
         .requireMock('../../UI/Predict/selectors/featureFlags')
         .selectPredictEnabledFlag.mockReturnValue(false);
       jest
-        .requireMock(
-          '../../../selectors/featureFlagController/assetsDefiPositions',
-        )
-        .selectAssetsDefiPositionsEnabled.mockReturnValue(false);
+        .requireMock('../../../selectors/deFiPositionsSectionEnabled')
+        .selectDeFiPositionsSectionEnabled.mockReturnValue(false);
     });
 
     it('passes totalSectionsLoaded=2 when only Tokens and NFTs are enabled', () => {

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -21,7 +21,7 @@ import { SectionRefreshHandle } from './types';
 import { WalletViewSelectorsIDs } from '../Wallet/WalletView.testIds';
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
-import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
+import { selectDeFiPositionsSectionEnabled } from '../../../selectors/deFiPositionsSectionEnabled';
 import { selectWhatsHappeningEnabled } from '../../../selectors/featureFlagController/whatsHappening';
 import { selectSocialLeaderboardEnabled } from '../../../selectors/featureFlagController/socialLeaderboard';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
@@ -60,7 +60,7 @@ const Homepage = forwardRef<SectionRefreshHandle>((_, ref) => {
 
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-  const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+  const isDeFiEnabled = useSelector(selectDeFiPositionsSectionEnabled);
   const isWhatsHappeningEnabled = useSelector(selectWhatsHappeningEnabled);
   const isTopTradersEnabled = useSelector(selectSocialLeaderboardEnabled);
   const isMusdConversionEnabled = useSelector(

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.test.tsx
@@ -8,12 +8,23 @@ import Routes from '../../../../../constants/navigation/Routes';
 const mockNavigate = jest.fn();
 const mockExecutePoll = jest.fn().mockResolvedValue(undefined);
 
-jest.mock('@react-navigation/native', () => ({
-  ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    navigate: mockNavigate,
-  }),
-}));
+jest.mock('@react-navigation/native', () => {
+  const ReactActual = jest.requireActual<typeof import('react')>('react');
+  return {
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+    useFocusEffect: (callback: () => void | (() => void)) => {
+      ReactActual.useEffect(() => {
+        const cleanup = callback();
+        return typeof cleanup === 'function' ? cleanup : undefined;
+        // Intentionally run once on mount to mirror initial screen focus in tests.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+    },
+  };
+});
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -23,12 +34,9 @@ jest.mock('../../../../../core/Engine', () => ({
   },
 }));
 
-jest.mock(
-  '../../../../../selectors/featureFlagController/assetsDefiPositions',
-  () => ({
-    selectAssetsDefiPositionsEnabled: jest.fn(() => true),
-  }),
-);
+jest.mock('../../../../../selectors/deFiPositionsSectionEnabled', () => ({
+  selectDeFiPositionsSectionEnabled: jest.fn(() => true),
+}));
 
 jest.mock('../../../../../selectors/preferencesController', () => ({
   selectPrivacyMode: jest.fn(() => false),
@@ -90,10 +98,8 @@ describe('DeFiSection', () => {
     jest.clearAllMocks();
     // Reset mock return values to defaults
     jest
-      .requireMock(
-        '../../../../../selectors/featureFlagController/assetsDefiPositions',
-      )
-      .selectAssetsDefiPositionsEnabled.mockReturnValue(true);
+      .requireMock('../../../../../selectors/deFiPositionsSectionEnabled')
+      .selectDeFiPositionsSectionEnabled.mockReturnValue(true);
 
     mockUseDeFiPositionsForHomepage.mockReturnValue({
       positions: [],
@@ -120,10 +126,8 @@ describe('DeFiSection', () => {
 
   it('returns null when DeFi is disabled', () => {
     jest
-      .requireMock(
-        '../../../../../selectors/featureFlagController/assetsDefiPositions',
-      )
-      .selectAssetsDefiPositionsEnabled.mockReturnValue(false);
+      .requireMock('../../../../../selectors/deFiPositionsSectionEnabled')
+      .selectDeFiPositionsSectionEnabled.mockReturnValue(false);
 
     const { toJSON } = renderWithProvider(
       <DeFiSection sectionIndex={0} totalSectionsLoaded={1} />,

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
 } from 'react';
 import { View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { Box } from '@metamask/design-system-react-native';
@@ -18,7 +18,7 @@ import { SectionRefreshHandle } from '../../types';
 import { useDeFiPositionsForHomepage, DeFiPositionEntry } from './hooks';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import DeFiPositionsListItem from '../../../../UI/DeFiPositions/DeFiPositionsListItem';
-import { selectAssetsDefiPositionsEnabled } from '../../../../../selectors/featureFlagController/assetsDefiPositions';
+import { selectDeFiPositionsSectionEnabled } from '../../../../../selectors/deFiPositionsSectionEnabled';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import Engine from '../../../../../core/Engine';
@@ -78,7 +78,18 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
   ({ sectionIndex, totalSectionsLoaded }, ref) => {
     const sectionViewRef = useRef<View>(null);
     const navigation = useNavigation();
-    const isDeFiEnabled = useSelector(selectAssetsDefiPositionsEnabled);
+    const isDeFiEnabled = useSelector(selectDeFiPositionsSectionEnabled);
+
+    useFocusEffect(
+      useCallback(() => {
+        if (!isDeFiEnabled) {
+          return;
+        }
+        Engine.context.DeFiPositionsController?._executePoll()?.catch(
+          () => undefined,
+        );
+      }, [isDeFiEnabled]),
+    );
     const privacyMode = useSelector(selectPrivacyMode);
     const title = strings('homepage.sections.defi');
 

--- a/app/selectors/deFiPositionsSectionEnabled.test.ts
+++ b/app/selectors/deFiPositionsSectionEnabled.test.ts
@@ -1,0 +1,16 @@
+import { selectDeFiPositionsSectionEnabled } from './deFiPositionsSectionEnabled';
+
+describe('selectDeFiPositionsSectionEnabled', () => {
+  it('returns true only when remote flag and basic functionality are true', () => {
+    expect(selectDeFiPositionsSectionEnabled.resultFunc(true, true)).toBe(true);
+    expect(selectDeFiPositionsSectionEnabled.resultFunc(true, false)).toBe(
+      false,
+    );
+    expect(selectDeFiPositionsSectionEnabled.resultFunc(false, true)).toBe(
+      false,
+    );
+    expect(selectDeFiPositionsSectionEnabled.resultFunc(false, false)).toBe(
+      false,
+    );
+  });
+});

--- a/app/selectors/deFiPositionsSectionEnabled.ts
+++ b/app/selectors/deFiPositionsSectionEnabled.ts
@@ -1,0 +1,17 @@
+import { createSelector } from 'reselect';
+import { selectAssetsDefiPositionsEnabled } from './featureFlagController/assetsDefiPositions';
+import { selectBasicFunctionalityEnabled } from './settings';
+
+/**
+ * Whether the homepage / DeFi UI should offer DeFi positions.
+ * Matches {@link DeFiPositionsController} `isEnabled()` (remote flag + basic functionality).
+ *
+ * Kept out of `featureFlagController/assetsDefiPositions` to avoid importing `settings`
+ * there (circular init with Wallet → selectors can leave Hermes without that export).
+ */
+export const selectDeFiPositionsSectionEnabled = createSelector(
+  selectAssetsDefiPositionsEnabled,
+  selectBasicFunctionalityEnabled,
+  (assetsDefiPositionsEnabled, basicFunctionalityEnabled) =>
+    assetsDefiPositionsEnabled && basicFunctionalityEnabled,
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason (TMCU-629):** The homepage DeFi block used only the remote feature flag to decide visibility, while `DeFiPositionsController` only fetches when both that flag **and** basic functionality are enabled. When the controller never wrote `allDeFiPositions` for the selected account, `useDeFiPositionsForHomepage` kept treating the result as “still loading” (`undefined`), so the skeleton could stay forever—especially on new/empty wallets or when opening the wallet without another trigger to poll. Putting a “combined” selector inside `featureFlagController/assetsDefiPositions` also risked pulling `settings`/reducer types during module init and caused a Hermes `ReferenceError` for missing exports.

**Solution:**

1. **`selectDeFiPositionsSectionEnabled`** (`app/selectors/deFiPositionsSectionEnabled.ts`) — `createSelector` over `selectAssetsDefiPositionsEnabled` and `selectBasicFunctionalityEnabled`, matching controller gating without importing `settings` into the assets-defi feature-flag module.
2. **`Homepage.tsx` and `DeFiSection.tsx`** — gate the DeFi section with `selectDeFiPositionsSectionEnabled` instead of `selectAssetsDefiPositionsEnabled` alone.
3. **`DeFiSection.tsx`** — `useFocusEffect` to call `DeFiPositionsController._executePoll()` when the screen is focused and the section is enabled, so positions (including empty) load even if event-driven updates were missed; optional chaining on the controller for test environments.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the wallet homepage DeFi section sometimes staying on a loading skeleton indefinitely.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28462
Refs: https://consensyssoftware.atlassian.net/browse/TMCU-629

## **Manual testing steps**

```gherkin
Feature: Homepage DeFi section loading

  Scenario: Homepage shows DeFi after focus when user has no positions
    Given the user is unlocked with an EVM account and homepage sections v1 enabled
    And the remote DeFi positions feature flag is on
    And basic functionality is enabled
    When the user opens or focuses the Wallet tab showing the homepage
    Then the DeFi section should not show an endless skeleton
    And the section should either show positions or hide when there are none after load

  Scenario: DeFi section hidden when basic functionality is off
    Given basic functionality is disabled
    And the remote DeFi positions feature flag is still on
    When the user opens the homepage
    Then the DeFi section should not appear as a perpetual loading block

  Scenario: No crash on Wallet after cold start
    Given a fresh app launch into the wallet
    When the homepage renders with DeFi enabled per flags and settings
    Then the app should not hit the Wallet error boundary for missing selector exports
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches homepage DeFi visibility and introduces focus-triggered polling, which could affect UI rendering and controller load frequency but is limited to one section and guarded by enablement checks.
> 
> **Overview**
> Fixes homepage DeFi section enablement by replacing the remote-flag-only check with a new combined selector, `selectDeFiPositionsSectionEnabled` (remote flag + basic functionality), and updates Homepage/DeFi tests accordingly.
> 
> Adds a `useFocusEffect` in `DeFiSection` to trigger `DeFiPositionsController._executePoll()` when the wallet screen is focused and DeFi is enabled, reducing cases where the section can remain stuck in a loading skeleton due to missing/never-fetched position state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8b34b7348e89e59cb4175b0f81ae63598f2f388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->