### PR TITLE
fix(TRAM-3445): quotes should not be fetched when there's already a pending quote selection

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
@@ -879,6 +879,61 @@ describe('Quotes', () => {
     });
   });
 
+  it('does not fetch new quotes while a quote is being processed', async () => {
+    const mockedRecommendedQuote =
+      mockUseQuotesAndCustomActionsInitialValues.recommendedQuote;
+
+    if (!mockedRecommendedQuote) {
+      throw new Error('No recommended quote found');
+    }
+
+    const mockQuoteProviderName = mockedRecommendedQuote.provider
+      ?.name as string;
+
+    (mockedRecommendedQuote as QuoteResponse).buy = () =>
+      new Promise(() => {
+        // Never resolves — keeps isQuoteLoading true for the duration of the test
+      });
+
+    mockUseQuotesAndCustomActionsValues = {
+      ...mockUseQuotesAndCustomActionsInitialValues,
+      recommendedQuote: mockedRecommendedQuote,
+    };
+
+    render(Quotes);
+
+    // Advance past loading animation so polling starts
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    const quoteToSelect = screen.getByLabelText(mockQuoteProviderName);
+    fireEvent.press(quoteToSelect);
+
+    const quoteContinueButton = screen.getByRole('button', {
+      name: `Continue with ${mockQuoteProviderName}`,
+    });
+
+    // Press Continue — this sets isQuoteLoading to true, pausing the timer
+    await act(async () => {
+      fireEvent.press(quoteContinueButton);
+    });
+
+    mockQueryGetQuotes.mockClear();
+
+    // Advance well past the polling interval; timer should NOT trigger a fetch
+    act(() => {
+      jest.advanceTimersByTime(15000);
+      jest.clearAllTimers();
+    });
+
+    expect(mockQueryGetQuotes).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.useFakeTimers({ legacyFakeTimers: true });
+    });
+  });
+
   it('renders "quotes expire" text in the last cycle', async () => {
     render(Quotes);
     act(() => {

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.test.tsx
@@ -880,20 +880,18 @@ describe('Quotes', () => {
   });
 
   it('does not fetch new quotes while a quote is being processed', async () => {
-    const mockedRecommendedQuote =
-      mockUseQuotesAndCustomActionsInitialValues.recommendedQuote;
-
-    if (!mockedRecommendedQuote) {
+    if (!mockUseQuotesAndCustomActionsInitialValues.recommendedQuote) {
       throw new Error('No recommended quote found');
     }
+
+    const mockedRecommendedQuote = {
+      ...mockUseQuotesAndCustomActionsInitialValues.recommendedQuote,
+    } as QuoteResponse;
 
     const mockQuoteProviderName = mockedRecommendedQuote.provider
       ?.name as string;
 
-    (mockedRecommendedQuote as QuoteResponse).buy = () =>
-      new Promise(() => {
-        // Never resolves — keeps isQuoteLoading true for the duration of the test
-      });
+    mockedRecommendedQuote.buy = () => new Promise(() => undefined);
 
     mockUseQuotesAndCustomActionsValues = {
       ...mockUseQuotesAndCustomActionsInitialValues,

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx
@@ -280,16 +280,18 @@ function Quotes() {
 
   const handleOnCustomActionPress = useCallback(
     (customAction: PaymentCustomAction) => {
+      if (isQuoteLoading) return;
       setProviderId(customAction?.buy?.provider.id);
     },
-    [],
+    [isQuoteLoading],
   );
 
   const handleOnQuotePress = useCallback(
     (quote: QuoteResponse | SellQuoteResponse) => {
+      if (isQuoteLoading) return;
       setProviderId(quote.provider.id);
     },
-    [],
+    [isQuoteLoading],
   );
 
   const handleInfoPress = useCallback(
@@ -547,7 +549,9 @@ function Quotes() {
           : appConfig.POLLING_INTERVAL;
       });
     },
-    { delay: isInPolling && !isFetchingQuotes ? 1000 : null },
+    {
+      delay: isInPolling && !isFetchingQuotes && !isQuoteLoading ? 1000 : null,
+    },
   );
 
   useEffect(() => {

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.test.tsx
@@ -83,6 +83,22 @@ describe('CustomAction Component', () => {
     expect(onPressMock).toHaveBeenCalled();
   });
 
+  it('does not call onPress when isLoading is true', () => {
+    const onPressMock = jest.fn();
+    const { getByLabelText } = renderWithProvider(
+      <CustomAction
+        customAction={mockCustomAction}
+        showInfo={jest.fn()}
+        onPress={onPressMock}
+        isLoading
+      />,
+      { state: defaultState },
+    );
+
+    const customActionRow = getByLabelText('Paypal (Staging)');
+    expect(customActionRow.props.onPress).toBeUndefined();
+  });
+
   it('shows loading indicator when isLoading is true', () => {
     const { queryByText } = renderWithProvider(
       <CustomAction

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
@@ -91,7 +91,7 @@ const CustomAction: React.FC<Props> = ({
         onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
-        accessible={!highlighted && !isLoading}
+        accessible={!highlighted}
         accessibilityLabel={provider?.name}
         compact
       >

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
@@ -88,7 +88,7 @@ const CustomAction: React.FC<Props> = ({
       testID={CUSTOM_ACTION_TEST_IDS.ANIMATED_VIEW_OPACITY}
     >
       <Box
-        onPress={highlighted ? undefined : onPress}
+        onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
         accessible={!highlighted}

--- a/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/CustomAction/CustomAction.tsx
@@ -91,7 +91,7 @@ const CustomAction: React.FC<Props> = ({
         onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
-        accessible={!highlighted}
+        accessible={!highlighted && !isLoading}
         accessibilityLabel={provider?.name}
         compact
       >
@@ -109,8 +109,8 @@ const CustomAction: React.FC<Props> = ({
                 </View>
               )}
               <TouchableOpacity
-                onPress={highlighted ? showInfo : undefined}
-                disabled={!highlighted}
+                onPress={highlighted && !isLoading ? showInfo : undefined}
+                disabled={!highlighted || isLoading}
                 accessibilityLabel={`${provider?.name} logo`}
                 accessibilityHint="Shows provider details"
               >

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.test.tsx
@@ -123,6 +123,23 @@ describe('Quote Component', () => {
     expect(onPressMock).toHaveBeenCalled();
   });
 
+  it('does not call onPress when isLoading is true', () => {
+    const onPressMock = jest.fn();
+    const { getByLabelText } = renderWithProvider(
+      <Quote
+        quote={mockQuote}
+        onPress={onPressMock}
+        showInfo={jest.fn()}
+        rampType={RampType.BUY}
+        isLoading
+      />,
+      { state: defaultState },
+    );
+
+    const quoteRow = getByLabelText('Mock Provider');
+    expect(quoteRow.props.onPress).toBeUndefined();
+  });
+
   it('shows loading indicator when isLoading is true', () => {
     const { queryByText } = renderWithProvider(
       <Quote

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -124,7 +124,7 @@ const Quote: React.FC<Props> = ({
       testID={QUOTE_TEST_IDS.ANIMATED_VIEW_OPACITY}
     >
       <Box
-        onPress={highlighted ? undefined : onPress}
+        onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
         accessible={!highlighted}

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -127,7 +127,7 @@ const Quote: React.FC<Props> = ({
         onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
-        accessible={!highlighted && !isLoading}
+        accessible={!highlighted}
         accessibilityLabel={quote.provider?.name}
         compact
       >

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -127,7 +127,7 @@ const Quote: React.FC<Props> = ({
         onPress={highlighted || isLoading ? undefined : onPress}
         highlighted={highlighted}
         activeOpacity={0.8}
-        accessible={!highlighted}
+        accessible={!highlighted && !isLoading}
         accessibilityLabel={quote.provider?.name}
         compact
       >
@@ -157,8 +157,8 @@ const Quote: React.FC<Props> = ({
                 </View>
               )}
               <TouchableOpacity
-                onPress={highlighted ? showInfo : undefined}
-                disabled={!highlighted}
+                onPress={highlighted && !isLoading ? showInfo : undefined}
+                disabled={!highlighted || isLoading}
                 accessibilityLabel={`${quote.provider?.name} logo`}
                 accessibilityHint="Shows provider details"
               >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a user selects a quote and presses "Continue with {provider}" on the Ramp quotes screen, the polling timer that refreshes quotes continues to tick in the background. This can cause new quotes to be fetched while the checkout process is already underway, which is unnecessary and potentially disruptive. Additionally, users can tap on other quote rows to expand them while a quote is already being processed, which is confusing UX.

**Changes:**
- **Pause the polling timer** during quote processing by adding `!isQuoteLoading` to the `useInterval` delay condition — the timer stops immediately when "Continue" is pressed and resumes only if the checkout fails
- **Block quote row selection** while a quote is loading — both `Quote` and `CustomAction` components now disable their `onPress` handler when `isLoading` is true, and the parent `handleOnQuotePress` / `handleOnCustomActionPress` callbacks early-return during loading as an extra safeguard

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: stop quote polling timer and block interactions while a quote is being processed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3445

## **Manual testing steps**

```gherkin
Feature: Ramp quote selection stops polling timer

  Scenario: user selects a quote and timer stops
    Given the user is on the Ramp quotes screen with quotes loaded
    And the polling timer is counting down

    When user taps on a quote to expand it
    And user taps "Continue with {provider}"
    Then the polling timer should stop counting down
    And no new quote fetch should be triggered while the checkout is processing

  Scenario: user cannot select another quote while one is loading
    Given the user is on the Ramp quotes screen with quotes loaded
    And the user has pressed "Continue with {provider}" on a quote

    When user taps on a different quote row
    Then the quote row should not expand
    And the previously selected quote should remain in loading state
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/89088301-c5c4-4c79-9a53-eb3d9943cb6f

### **After**

https://github.com/user-attachments/assets/888282c3-7fd0-469f-b565-1a9ceb36f861

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quote polling/selection timing on the Ramp quotes screen; mistakes could stall refreshes or prevent selecting providers during normal flows.
> 
> **Overview**
> Prevents quote refresh polling from running while a quote/custom action checkout is in progress by gating the `useInterval` timer on `isQuoteLoading`.
> 
> Disables quote/custom-action row interactions during loading (guards in `handleOnQuotePress`/`handleOnCustomActionPress` plus `Quote`/`CustomAction` `onPress`/info handlers), and adds tests to assert no polling fetches occur mid-checkout and rows don’t respond while loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e790298eac0b6a487fd31cfac6f17c541b69ed84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->