### PR TITLE
feat: migrate `TextField` component (web3auth)

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -58,6 +58,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  TextField,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Authentication } from '../../../core';
@@ -78,7 +79,6 @@ import Icon, {
 } from '../../../component-library/components/Icons/Icon';
 import { ToastContext } from '../../../component-library/components/Toast/Toast.context';
 import { ToastVariants } from '../../../component-library/components/Toast/Toast.types';
-import TextField from '../../../component-library/components/Form/TextField/TextField';
 import { CommonActions } from '@react-navigation/native';
 import { SRP_LENGTHS, SPACE_CHAR, PASSCODE_NOT_SET_ERROR } from './constant';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -60,6 +60,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  TextField,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Authentication } from '../../../core';
@@ -82,7 +83,6 @@ import Icon, {
 } from '../../../component-library/components/Icons/Icon';
 import { ToastContext } from '../../../component-library/components/Toast/Toast.context';
 import { ToastVariants } from '../../../component-library/components/Toast/Toast.types';
-import TextField from '../../../component-library/components/Form/TextField/TextField';
 import { CommonActions } from '@react-navigation/native';
 import { SRP_LENGTHS, SPACE_CHAR, PASSCODE_NOT_SET_ERROR } from './constant';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -13,7 +13,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { MIN_PASSWORD_LENGTH } from '../../../util/password';
 import { BIOMETRY_TYPE } from 'react-native-keychain';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
-import { Alert, InteractionManager } from 'react-native';
+import { Alert, InteractionManager, TextInput } from 'react-native';
 import { QRTabSwitcherScreens } from '../QRTabSwitcher';
 import { createStackNavigator } from '@react-navigation/stack';
 import { NavigationContainer } from '@react-navigation/native';
@@ -1280,16 +1280,24 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       );
 
       // Initially passwords should be hidden
-      expect(passwordInput.props.secureTextEntry).toBe(true);
-      expect(confirmPasswordInput.props.secureTextEntry).toBe(true);
+      expect(passwordInput.findByType(TextInput).props.secureTextEntry).toBe(
+        true,
+      );
+      expect(
+        confirmPasswordInput.findByType(TextInput).props.secureTextEntry,
+      ).toBe(true);
 
       // Toggle visibility for new password
       fireEvent.press(newPasswordVisibilityIcon);
-      expect(passwordInput.props.secureTextEntry).toBe(false);
+      expect(passwordInput.findByType(TextInput).props.secureTextEntry).toBe(
+        false,
+      );
 
       // Toggle visibility for confirm password
       fireEvent.press(confirmPasswordVisibilityIcon);
-      expect(confirmPasswordInput.props.secureTextEntry).toBe(false);
+      expect(
+        confirmPasswordInput.findByType(TextInput).props.secureTextEntry,
+      ).toBe(false);
     });
 
     it('error message is shown when passwords do not match', async () => {
@@ -1318,7 +1326,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       const confirmPasswordInput = getByTestId(
         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
       );
-      expect(confirmPasswordInput.props.editable).toBe(false);
+      expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+        false,
+      );
 
       const passwordInput = getByTestId(
         ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
@@ -1326,7 +1336,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       fireEvent.changeText(passwordInput, 'StrongPass123!');
 
       await waitFor(() => {
-        expect(confirmPasswordInput.props.editable).toBe(true);
+        expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+          true,
+        );
       });
     });
 
@@ -1341,7 +1353,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         fireEvent.changeText(passwordInput, 'StrongPass123!');
       });
 
-      expect(passwordInput.props.value).toBe('StrongPass123!');
+      expect(passwordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       const confirmPasswordInput = getByTestId(
         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
@@ -1351,19 +1365,23 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         fireEvent.changeText(confirmPasswordInput, 'StrongPass123!');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('StrongPass123!');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'StrongPass12');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('StrongPass123!');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       await act(async () => {
         fireEvent.changeText(passwordInput, '');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe('');
     });
 
     it('minimum password length requirement message shown when create new password field value is less than 8 characters', async () => {
@@ -1508,8 +1526,10 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       fireEvent(passwordInput, 'submitEditing');
 
       // Verify that confirm password field is enabled and ready for input
-      expect(confirmPasswordInput.props.editable).toBe(true);
-      expect(confirmPasswordInput.props.value).toBe('');
+      expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+        true,
+      );
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe('');
     });
 
     it('navigates to Import Wallet UI when back button is pressed', async () => {

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -1321,7 +1321,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         fireEvent.changeText(passwordInput, 'StrongPass123!');
       });
 
-      expect(passwordInput.props.value).toBe('StrongPass123!');
+      expect(passwordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       const confirmPasswordInput = getByTestId(
         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
@@ -1331,19 +1333,23 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         fireEvent.changeText(confirmPasswordInput, 'StrongPass123!');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('StrongPass123!');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'StrongPass12');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('StrongPass123!');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe(
+        'StrongPass123!',
+      );
 
       await act(async () => {
         fireEvent.changeText(passwordInput, '');
       });
 
-      expect(confirmPasswordInput.props.value).toBe('');
+      expect(confirmPasswordInput.findByType(TextInput).props.value).toBe('');
     });
 
     it('minimum password length requirement message shown when create new password field value is less than 8 characters', async () => {

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -16,7 +16,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { MIN_PASSWORD_LENGTH } from '../../../util/password';
 import { BIOMETRY_TYPE } from 'react-native-keychain';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
-import { Alert, InteractionManager } from 'react-native';
+import { Alert, InteractionManager, TextInput } from 'react-native';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { QRTabSwitcherScreens } from '../QRTabSwitcher';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -1298,7 +1298,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       const confirmPasswordInput = getByTestId(
         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
       );
-      expect(confirmPasswordInput).toHaveProp('editable', false);
+      expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+        false,
+      );
 
       const passwordInput = getByTestId(
         ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
@@ -1306,7 +1308,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       fireEvent.changeText(passwordInput, 'StrongPass123!');
 
       await waitFor(() => {
-        expect(confirmPasswordInput).toHaveProp('editable', true);
+        expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+          true,
+        );
       });
     });
 
@@ -1494,7 +1498,9 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       fireEvent(passwordInput, 'submitEditing');
 
       // Verify that confirm password field is enabled and ready for input
-      expect(confirmPasswordInput).toHaveProp('editable', true);
+      expect(confirmPasswordInput.findByType(TextInput).props.editable).toBe(
+        true,
+      );
       expect(confirmPasswordInput.props.value).toBe('');
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `TextField` from DSRN package (pilot migration).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-278

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/11c9a637-7019-49a0-ac93-46b16c6be72c

### **After**

https://github.com/user-attachments/assets/ab75abad-fed4-4b9a-b562-61a1aef4a9c5

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the password inputs in the SRP import onboarding flow to a new `TextField` implementation and updates tests to match, which could affect input behavior (secure entry/disabled state) in a critical onboarding path.
> 
> **Overview**
> Updates `ImportFromSecretRecoveryPhrase` to use the design-system `TextField` instead of the legacy component-library `TextField` for the new/confirm password fields (including end-accessory visibility toggles and disabled/error states).
> 
> Adjusts the associated Jest tests to assert against the nested React Native `TextInput` inside the new `TextField` wrapper (e.g., `secureTextEntry`, `editable`, and `value`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e1618890f3ae8f04ee8dc84b075fd0f5b851aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->