### PR TITLE
feat(perps): Fix candlestick chart 429 rate limiting on rapid asset navigation

### DIFF
--- a/app/controllers/perps/services/HyperLiquidClientService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidClientService.test.ts
@@ -521,7 +521,7 @@ describe('HyperLiquidClientService', () => {
         { t: 1700003600000, o: 50500, h: 51500, l: 50000, c: 51000, v: 150 },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockResponse);
 
@@ -555,7 +555,7 @@ describe('HyperLiquidClientService', () => {
           },
         ],
       });
-      expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalledWith(
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalledWith(
         {
           coin: 'BTC', // SDK uses 'coin' terminology
           interval: '1h',
@@ -568,7 +568,7 @@ describe('HyperLiquidClientService', () => {
 
     it('uses the default limit and forwards an explicit abort signal', async () => {
       const abortController = new AbortController();
-      mockInfoClientWs.candleSnapshot = jest.fn().mockResolvedValue([]);
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
 
       await service.fetchHistoricalCandles({
         symbol: 'BTC',
@@ -576,7 +576,7 @@ describe('HyperLiquidClientService', () => {
         signal: abortController.signal,
       });
 
-      expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalledWith(
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalledWith(
         {
           coin: 'BTC',
           interval: '1h',
@@ -586,7 +586,7 @@ describe('HyperLiquidClientService', () => {
         abortController.signal,
       );
 
-      const request = mockInfoClientWs.candleSnapshot.mock.calls[0][0];
+      const request = mockInfoClientHttp.candleSnapshot.mock.calls[0][0];
       expect(request.endTime - request.startTime).toBe(100 * 60 * 60 * 1000);
     });
 
@@ -594,7 +594,7 @@ describe('HyperLiquidClientService', () => {
       // Arrange
       const mockResponse: any[] = [];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockResponse);
 
@@ -616,7 +616,7 @@ describe('HyperLiquidClientService', () => {
     it('handles API errors gracefully', async () => {
       // Arrange
       const errorMessage = 'API request failed';
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockRejectedValue(new Error(errorMessage));
 
@@ -638,7 +638,7 @@ describe('HyperLiquidClientService', () => {
         candles: [],
       };
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockResponse);
 
@@ -650,7 +650,7 @@ describe('HyperLiquidClientService', () => {
       });
 
       // Assert
-      expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalledWith(
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalledWith(
         {
           coin: 'ETH', // SDK uses 'coin' terminology
           interval: '5m',
@@ -661,7 +661,7 @@ describe('HyperLiquidClientService', () => {
       );
 
       // Verify time range calculation
-      const callArgs = mockInfoClientWs.candleSnapshot.mock.calls[0][0];
+      const callArgs = mockInfoClientHttp.candleSnapshot.mock.calls[0][0];
       const timeDiff = callArgs.endTime - callArgs.startTime;
       const expectedTimeDiff = 50 * 5 * 60 * 1000; // 50 intervals * 5 minutes * 60 seconds * 1000ms
       expect(timeDiff).toBe(expectedTimeDiff);
@@ -680,7 +680,7 @@ describe('HyperLiquidClientService', () => {
 
         // Reset mock before each iteration
         jest.clearAllMocks();
-        mockInfoClientWs.candleSnapshot = jest
+        mockInfoClientHttp.candleSnapshot = jest
           .fn()
           .mockResolvedValue(mockResponse);
 
@@ -692,7 +692,7 @@ describe('HyperLiquidClientService', () => {
         });
 
         // Assert
-        const callArgs = mockInfoClientWs.candleSnapshot.mock.calls[0][0];
+        const callArgs = mockInfoClientHttp.candleSnapshot.mock.calls[0][0];
         const timeDiff = callArgs.endTime - callArgs.startTime;
         expect(timeDiff).toBe(10 * expected);
       }
@@ -707,7 +707,7 @@ describe('HyperLiquidClientService', () => {
 
       const mockResponse: any[] = [];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockResponse);
 
@@ -719,7 +719,7 @@ describe('HyperLiquidClientService', () => {
       });
 
       // Assert
-      expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalled();
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalled();
       // The testnet configuration is handled in the service initialization
     });
 
@@ -735,6 +735,32 @@ describe('HyperLiquidClientService', () => {
           limit: 100,
         }),
       ).rejects.toThrow('CLIENT_NOT_INITIALIZED');
+    });
+
+    it('uses HTTP transport instead of WebSocket for historical fetches (TAT-2954)', async () => {
+      // Arrange
+      const mockResponse = [
+        { t: 1700000000000, o: 50000, h: 51000, l: 49000, c: 50500, v: 100 },
+      ];
+      mockInfoClientHttp.candleSnapshot = jest
+        .fn()
+        .mockResolvedValue(mockResponse);
+
+      // Spy on getInfoClient to verify useHttp option
+      const getInfoClientSpy = jest.spyOn(service, 'getInfoClient');
+
+      // Act
+      await service.fetchHistoricalCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        limit: 100,
+      });
+
+      // Assert — HTTP transport used, not WebSocket
+      expect(getInfoClientSpy).toHaveBeenCalledWith({ useHttp: true });
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalled();
+
+      getInfoClientSpy.mockRestore();
     });
   });
 
@@ -798,7 +824,7 @@ describe('HyperLiquidClientService', () => {
         },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockHistoricalData);
 
@@ -823,7 +849,7 @@ describe('HyperLiquidClientService', () => {
       await jest.advanceTimersByTimeAsync(100);
 
       // Assert - should have fetched historical data (SDK uses 'coin' terminology)
-      expect(mockInfoClientWs.candleSnapshot).toHaveBeenCalledWith(
+      expect(mockInfoClientHttp.candleSnapshot).toHaveBeenCalledWith(
         expect.objectContaining({
           coin: 'BTC',
           interval: '1h',
@@ -869,7 +895,7 @@ describe('HyperLiquidClientService', () => {
         },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockHistoricalData);
 
@@ -918,7 +944,7 @@ describe('HyperLiquidClientService', () => {
         },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockHistoricalData);
 
@@ -986,7 +1012,7 @@ describe('HyperLiquidClientService', () => {
         },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockHistoricalData);
 
@@ -1062,7 +1088,7 @@ describe('HyperLiquidClientService', () => {
         },
       ];
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockResolvedValue(mockHistoricalData);
 
@@ -1105,7 +1131,7 @@ describe('HyperLiquidClientService', () => {
 
     it('handles empty historical data', async () => {
       // Arrange
-      mockInfoClientWs.candleSnapshot = jest.fn().mockResolvedValue([]);
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
 
       (mockSubscriptionClient as any).candle = jest
         .fn()
@@ -1132,7 +1158,7 @@ describe('HyperLiquidClientService', () => {
 
     it('invokes unsubscribe when cleanup function called', async () => {
       // Arrange
-      mockInfoClientWs.candleSnapshot = jest.fn().mockResolvedValue([]);
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
 
       const mockWsUnsubscribe = jest.fn();
       (mockSubscriptionClient as any).candle = jest
@@ -1167,7 +1193,7 @@ describe('HyperLiquidClientService', () => {
         resolveSnapshot = resolve;
       });
 
-      mockInfoClientWs.candleSnapshot = jest
+      mockInfoClientHttp.candleSnapshot = jest
         .fn()
         .mockReturnValue(delayedPromise);
 
@@ -1202,7 +1228,9 @@ describe('HyperLiquidClientService', () => {
       // Arrange - make snapshot reject with abort error
       const abortError = new Error('AbortError');
       abortError.name = 'AbortError';
-      mockInfoClientWs.candleSnapshot = jest.fn().mockRejectedValue(abortError);
+      mockInfoClientHttp.candleSnapshot = jest
+        .fn()
+        .mockRejectedValue(abortError);
 
       const onError = jest.fn();
       const callback = jest.fn();
@@ -1227,7 +1255,7 @@ describe('HyperLiquidClientService', () => {
 
     it('cleans up WebSocket when unsubscribed during subscription establishment', async () => {
       // Arrange - fast snapshot, slow WebSocket subscription
-      mockInfoClientWs.candleSnapshot = jest.fn().mockResolvedValue([]);
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
 
       let resolveWsSubscription: (value: any) => void = () => {
         /* noop */

--- a/app/controllers/perps/services/HyperLiquidClientService.ts
+++ b/app/controllers/perps/services/HyperLiquidClientService.ts
@@ -490,9 +490,10 @@ export class HyperLiquidClientService {
       const intervalMs = this.#getIntervalMilliseconds(interval);
       const startTime = now - limit * intervalMs;
 
-      // Use the SDK's InfoClient to fetch candle data
-      // HyperLiquid SDK uses 'coin' terminology
-      const infoClient = this.getInfoClient();
+      // Use HTTP transport for historical candle snapshots (request/response).
+      // This avoids the WebSocket abort race condition that causes 429s
+      // during rapid market switching on extension (#TAT-2954).
+      const infoClient = this.getInfoClient({ useHttp: true });
       const data = await infoClient.candleSnapshot(
         {
           coin: symbol, // Map to HyperLiquid SDK's 'coin' parameter


### PR DESCRIPTION
## **Description**

Historical candlestick chart data (`candleSnapshot`) was being fetched through the WebSocket-backed `InfoClient`. On extension, rapid market navigation causes an abort race condition — the UI unmount message arrives too late to cancel in-flight WebSocket requests, leading to bursty candleSnapshot traffic and 429 rate limit errors from Hyperliquid.

This PR switches `fetchHistoricalCandles()` to use the HTTP `InfoClient` instead. Live candle streaming remains on WebSocket. This is the source-of-truth fix in the controller/client-service layer, so both mobile and extension benefit.

Transport split after this change:
- Initial chart history load → **HTTP**
- Load-more historical candles → **HTTP**
- Live candle updates → **WebSocket** (unchanged)

## **Changelog**

CHANGELOG entry: Fixed candlestick chart 429 rate limiting during rapid market navigation by routing historical candle fetches over HTTP

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2954

## **Manual testing steps**

```gherkin
Feature: Candlestick chart loads during rapid market switching

  Scenario: User rapidly switches between 5+ market detail pages
    Given the user is on the Perps trending markets list

    When user taps BTC, then back, then ETH, then back, then SOL, then back, then HYPE, then back, then BTC again, then back, then ETH again
    Then each market detail page loads successfully with chart visible
    And no candleSnapshot errors appear in Metro logs
```

## **Screenshots/Recordings**

### Video
_Uploaded artifact links below; replace with manual GitHub video attachments if you want inline playback._
- After video: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/features/28865/after.mp4)

## **Validation Recipe**

<details><summary>recipe.json (27 nodes — rapid market switching validation)</summary>

```json
{
  "title": "Validate candlestick chart loads correctly during rapid market switching (TAT-2954)",
  "initial_conditions": { "testnet": false },
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "setup-nav-perps",
      "nodes": {
        "setup-nav-perps": {
          "action": "navigate",
          "target": "PerpsTrendingView",
          "next": "setup-wait-list"
        },
        "setup-wait-list": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-BTC",
          "timeout": 10000,
          "next": "ac1-open-btc"
        },
        "ac1-open-btc": {
          "action": "press",
          "test_id": "perps-market-row-item-BTC",
          "next": "ac1-wait-detail-btc"
        },
        "ac1-wait-detail-btc": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-back-1"
        },
        "ac1-back-1": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac1-wait-list-1"
        },
        "ac1-wait-list-1": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-ETH",
          "timeout": 5000,
          "next": "ac1-open-eth"
        },
        "ac1-open-eth": {
          "action": "press",
          "test_id": "perps-market-row-item-ETH",
          "next": "ac1-wait-detail-eth"
        },
        "ac1-wait-detail-eth": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-back-2"
        },
        "ac1-back-2": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac1-wait-list-2"
        },
        "ac1-wait-list-2": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-SOL",
          "timeout": 5000,
          "next": "ac1-open-sol"
        },
        "ac1-open-sol": {
          "action": "press",
          "test_id": "perps-market-row-item-SOL",
          "next": "ac1-wait-detail-sol"
        },
        "ac1-wait-detail-sol": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-back-3"
        },
        "ac1-back-3": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac1-wait-list-3"
        },
        "ac1-wait-list-3": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-HYPE",
          "timeout": 5000,
          "next": "ac1-open-hype"
        },
        "ac1-open-hype": {
          "action": "press",
          "test_id": "perps-market-row-item-HYPE",
          "next": "ac1-wait-detail-hype"
        },
        "ac1-wait-detail-hype": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-back-4"
        },
        "ac1-back-4": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac1-wait-list-4"
        },
        "ac1-wait-list-4": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-BTC",
          "timeout": 5000,
          "next": "ac1-open-btc2"
        },
        "ac1-open-btc2": {
          "action": "press",
          "test_id": "perps-market-row-item-BTC",
          "next": "ac1-wait-detail-btc2"
        },
        "ac1-wait-detail-btc2": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-back-5"
        },
        "ac1-back-5": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac1-wait-list-5"
        },
        "ac1-wait-list-5": {
          "action": "wait_for",
          "test_id": "perps-market-row-item-ETH",
          "timeout": 5000,
          "next": "ac1-open-eth2"
        },
        "ac1-open-eth2": {
          "action": "press",
          "test_id": "perps-market-row-item-ETH",
          "next": "ac1-wait-detail-eth2"
        },
        "ac1-wait-detail-eth2": {
          "action": "wait_for",
          "test_id": "perps-market-details-view",
          "timeout": 8000,
          "next": "ac1-screenshot-final"
        },
        "ac1-screenshot-final": {
          "action": "screenshot",
          "filename": "evidence-rapid-switch-chart-loaded.png",
          "next": "ac1-back-6"
        },
        "ac1-back-6": {
          "action": "press",
          "test_id": "perps-market-header-back-button",
          "next": "ac2-check-no-rate-limit"
        },
        "ac2-check-no-rate-limit": {
          "action": "log_watch",
          "window_seconds": 45,
          "must_not_appear": ["candleSnapshot error", "historical_candles_api", "candle_subscription_async", "initial_candles_fetch"],
          "watch_for": ["candleSnapshot", "fetchHistoricalCandles", "historical_candles"],
          "next": "ac2-done"
        },
        "ac2-done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Validation Logs**

Command:
```bash
bash scripts/perps/agentic/validate-recipe.sh .task/feat/tat-2954-0415-2218/artifacts/ --skip-manual
```

<details><summary>Full output (27/27 passed)</summary>

```
Running recipe: Validate candlestick chart loads correctly during rapid market switching (TAT-2954)
Pre-conditions: wallet.unlocked, perps.feature_enabled
Workflow nodes: 28

Pre-conditions: PASS

[setup-nav-perps] navigate to PerpsTrendingView — PASS
[setup-wait-list] wait for perps-market-row-item-BTC — PASS
[ac1-open-btc] press perps-market-row-item-BTC — PASS
[ac1-wait-detail-btc] wait for perps-market-details-view — PASS
[ac1-back-1] press perps-market-header-back-button — PASS
[ac1-wait-list-1] wait for perps-market-row-item-ETH — PASS
[ac1-open-eth] press perps-market-row-item-ETH — PASS
[ac1-wait-detail-eth] wait for perps-market-details-view — PASS
[ac1-back-2] press perps-market-header-back-button — PASS
[ac1-wait-list-2] wait for perps-market-row-item-SOL — PASS
[ac1-open-sol] press perps-market-row-item-SOL — PASS
[ac1-wait-detail-sol] wait for perps-market-details-view — PASS
[ac1-back-3] press perps-market-header-back-button — PASS
[ac1-wait-list-3] wait for perps-market-row-item-HYPE — PASS
[ac1-open-hype] press perps-market-row-item-HYPE — PASS
[ac1-wait-detail-hype] wait for perps-market-details-view — PASS
[ac1-back-4] press perps-market-header-back-button — PASS
[ac1-wait-list-4] wait for perps-market-row-item-BTC — PASS
[ac1-open-btc2] press perps-market-row-item-BTC — PASS
[ac1-wait-detail-btc2] wait for perps-market-details-view — PASS
[ac1-back-5] press perps-market-header-back-button — PASS
[ac1-wait-list-5] wait for perps-market-row-item-ETH — PASS
[ac1-open-eth2] press perps-market-row-item-ETH — PASS
[ac1-wait-detail-eth2] wait for perps-market-details-view — PASS
[ac1-screenshot-final] capture screenshot — PASS
[ac1-back-6] press perps-market-header-back-button — PASS
[ac2-check-no-rate-limit] scan metro log — PASS

Results: 27/27 passed
Recipe: PASS
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit de043e117d2c44f4aec9b8db7522ba349499417c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

