### PR TITLE
fix(rewards): fix Ondo campaign tour carousel exit animation direction

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -144,7 +144,7 @@ import RewardOptInAccountGroupModal from '../../UI/Rewards/components/Settings/R
 import EndOfSeasonClaimBottomSheet from '../../UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet';
 import RewardsSelectSheet from '../../UI/Rewards/components/RewardsSelectSheet';
 import OndoPendingSheet from '../../UI/Rewards/components/Campaigns/OndoPendingSheet';
-import CampaignTourStepView from '../../UI/Rewards/Views/CampaignTourStepView';
+
 import SitesFullView from '../../Views/SitesFullView/SitesFullView';
 import { TokenDetails } from '../../UI/TokenDetails/Views/TokenDetails';
 import BenefitFullView from '../../UI/Rewards/Views/BenefitFullView';
@@ -1391,11 +1391,6 @@ const MainNavigator = () => {
         ///: END:ONLY_INCLUDE_IF
       }
       <Stack.Screen name={Routes.CARD.ROOT} component={CardRoutes} />
-      <Stack.Screen
-        name={Routes.REWARDS_CAMPAIGN_TOUR_STEP}
-        component={CampaignTourStepView}
-        options={{ headerShown: false }}
-      />
       <Stack.Screen
         name={Routes.RAMP.MODALS.PROCESSING_INFO}
         component={ProcessingInfoModal}

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -421,15 +421,6 @@ exports[`MainNavigator Tab Bar Visibility hides tab bar when browser is active 1
   />
   <Screen
     component={[Function]}
-    name="RewardsCampaignTourStep"
-    options={
-      {
-        "headerShown": false,
-      }
-    }
-  />
-  <Screen
-    component={[Function]}
     name="RampProcessingInfoModal"
     options={
       {
@@ -867,15 +858,6 @@ exports[`MainNavigator Tab Bar Visibility shows tab bar when not in browser 1`] 
   />
   <Screen
     component={[Function]}
-    name="RewardsCampaignTourStep"
-    options={
-      {
-        "headerShown": false,
-      }
-    }
-  />
-  <Screen
-    component={[Function]}
     name="RampProcessingInfoModal"
     options={
       {
@@ -1310,15 +1292,6 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   <Screen
     component={[Function]}
     name="CardScreens"
-  />
-  <Screen
-    component={[Function]}
-    name="RewardsCampaignTourStep"
-    options={
-      {
-        "headerShown": false,
-      }
-    }
   />
   <Screen
     component={[Function]}

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -69,6 +69,18 @@ jest.mock('./Views/RewardsSettingsView', () => {
   };
 });
 
+jest.mock('./Views/CampaignTourStepView', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return function MockCampaignTourStepView() {
+    return ReactActual.createElement(
+      View,
+      { testID: 'campaign-tour-step-view' },
+      ReactActual.createElement(Text, null, 'Campaign Tour Step View'),
+    );
+  };
+});
+
 jest.mock('./Views/OndoCampaignDetailsView', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');
@@ -512,6 +524,19 @@ describe('RewardsNavigator', () => {
       mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
 
       // Rendering should not throw with the new screen registered
+      const { getByTestId } = renderWithNavigation(<RewardsNavigator />);
+
+      await waitFor(() => {
+        expect(getByTestId('rewards-dashboard-view')).toBeOnTheScreen();
+      });
+    });
+
+    it('registers REWARDS_CAMPAIGN_TOUR_STEP route when subscription exists', async () => {
+      // The campaign tour screen is registered inside the subscriptionId-guarded block
+      // so that navigate() from the tour to campaign details is a push (not a pop),
+      // keeping the slide-left direction consistent with the carousel animation.
+      mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
+
       const { getByTestId } = renderWithNavigation(<RewardsNavigator />);
 
       await waitFor(() => {

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -14,6 +14,7 @@ import OndoLeaderboardView from './Views/OndoLeaderboardView';
 import OndoCampaignRwaSelectorView from './Views/OndoCampaignRwaSelectorView';
 import OndoCampaignPortfolioView from './Views/OndoCampaignPortfolioView';
 import OndoCampaignStatsView from './Views/OndoCampaignStatsView';
+import CampaignTourStepView from './Views/CampaignTourStepView';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { selectIsRewardsVersionBlocked } from '../../../reducers/rewards/selectors';
@@ -103,6 +104,11 @@ const RewardsNavigator: React.FC = () => {
           <Stack.Screen
             name={Routes.REWARDS_CAMPAIGNS_VIEW}
             component={CampaignsView}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={Routes.REWARDS_CAMPAIGN_TOUR_STEP}
+            component={CampaignTourStepView}
             options={{ headerShown: false }}
           />
           <Stack.Screen

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { StackActions } from '@react-navigation/native';
 import CampaignTourStepView from './CampaignTourStepView';
 import Routes from '../../../../constants/navigation/Routes';
 import { CAMPAIGN_TOUR_STEP_TEST_IDS } from '../components/Campaigns/tour/CampaignTourStep';
@@ -8,18 +9,20 @@ import {
   CampaignType,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 
-const mockNavigate = jest.fn();
-const mockGoBack = jest.fn();
+const mockDispatch = jest.fn();
 
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({
-    navigate: mockNavigate,
-    goBack: mockGoBack,
-  }),
-  useRoute: () => ({
-    params: { campaignId: 'campaign-1' },
-  }),
-}));
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      dispatch: mockDispatch,
+    }),
+    useRoute: () => ({
+      params: { campaignId: 'campaign-1' },
+    }),
+  };
+});
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -212,9 +215,10 @@ describe('CampaignTourStepView', () => {
     fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
     fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
-      { campaignId: 'campaign-1' },
+    expect(mockDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+        campaignId: 'campaign-1',
+      }),
     );
   });
 
@@ -223,9 +227,10 @@ describe('CampaignTourStepView', () => {
 
     fireEvent.press(getByTestId(CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
-      { campaignId: 'campaign-1' },
+    expect(mockDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+        campaignId: 'campaign-1',
+      }),
     );
   });
 
@@ -234,9 +239,10 @@ describe('CampaignTourStepView', () => {
 
     render(<CampaignTourStepView />);
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
-      { campaignId: 'campaign-1' },
+    expect(mockDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+        campaignId: 'campaign-1',
+      }),
     );
   });
 

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
@@ -8,6 +8,7 @@ import React, {
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
+  StackActions,
   useNavigation,
   useRoute,
   type RouteProp,
@@ -60,9 +61,11 @@ const CampaignTourStepView: React.FC = () => {
   >(null);
 
   const navigateToDetails = useCallback(() => {
-    navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
-      campaignId,
-    });
+    navigation.dispatch(
+      StackActions.replace(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+        campaignId,
+      }),
+    );
   }, [navigation, campaignId]);
 
   const currentStep = tour?.[currentTab];

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
@@ -46,7 +46,7 @@ const CampaignOptInCta: React.FC<CampaignOptInCtaProps> = ({
 
   return (
     <>
-      <Box twClassName="px-4 pt-2">
+      <Box twClassName="p-4 mb-2">
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -148,7 +148,7 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
 
   return (
     <>
-      <Box twClassName="px-4 pt-2">
+      <Box twClassName="p-4 mb-2">
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
@@ -306,7 +306,7 @@ const OnboardingMainStep: React.FC = () => {
         />
       )}
 
-      <Box twClassName="w-full gap-4">
+      <Box twClassName="w-full gap-2">
         <Text variant={TextVariant.HeadingLg} twClassName="text-center">
           {strings('rewards.onboarding.title')}
         </Text>
@@ -321,59 +321,63 @@ const OnboardingMainStep: React.FC = () => {
     </Box>
   );
 
-  const renderReferralSection = () => (
-    <Box twClassName="w-full items-center gap-2 mt-2">
-      {!showReferralInput && (
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="text-text-alternative my-2"
-          onPress={() => setShowReferralInput(true)}
-          testID="referral-prompt"
-        >
-          {strings('rewards.onboarding.referral_prompt')}
-        </Text>
-      )}
-
-      {showReferralInput && (
-        <Box twClassName="w-full gap-2">
-          <Box twClassName="gap-1">
-            <TextField
-              placeholder={strings('rewards.onboarding.referral_placeholder')}
-              value={referralCode}
-              autoCapitalize="characters"
-              maxLength={6}
-              onChangeText={handleReferralCodeChange}
-              isDisabled={optinLoading}
-              endAccessory={renderReferralIcon()}
-              testID="referral-input"
-              isError={
-                referralCode.length >= 6 &&
-                !referralCodeIsValid &&
-                !isValidatingReferralCode &&
-                !isUnknownErrorReferralCode
-              }
-            />
-            {referralCode.length >= 6 &&
+  const renderAboveCTA = () =>
+    showReferralInput ? (
+      <Box twClassName="w-full gap-2">
+        <Box twClassName="gap-1">
+          <TextField
+            placeholder={strings('rewards.onboarding.referral_placeholder')}
+            value={referralCode}
+            autoCapitalize="characters"
+            maxLength={6}
+            onChangeText={handleReferralCodeChange}
+            isDisabled={optinLoading}
+            endAccessory={renderReferralIcon()}
+            testID="referral-input"
+            isError={
+              referralCode.length >= 6 &&
               !referralCodeIsValid &&
               !isValidatingReferralCode &&
-              !isUnknownErrorReferralCode && (
-                <Text twClassName="text-error-default">
-                  {strings('rewards.onboarding.step4_referral_input_error')}
-                </Text>
-              )}
-          </Box>
-
-          {isUnknownErrorReferralCode && (
-            <RewardsErrorBanner
-              title={strings('rewards.referral_validation_unknown_error.title')}
-              description={strings(
-                'rewards.referral_validation_unknown_error.description',
-              )}
-            />
-          )}
+              !isUnknownErrorReferralCode
+            }
+          />
+          {referralCode.length >= 6 &&
+            !referralCodeIsValid &&
+            !isValidatingReferralCode &&
+            !isUnknownErrorReferralCode && (
+              <Text twClassName="text-error-default">
+                {strings('rewards.onboarding.step4_referral_input_error')}
+              </Text>
+            )}
         </Box>
-      )}
-    </Box>
+
+        {isUnknownErrorReferralCode && (
+          <RewardsErrorBanner
+            title={strings('rewards.referral_validation_unknown_error.title')}
+            description={strings(
+              'rewards.referral_validation_unknown_error.description',
+            )}
+          />
+        )}
+      </Box>
+    ) : null;
+
+  const renderBelowCTA = () => (
+    <Text
+      variant={TextVariant.BodyMd}
+      twClassName="text-text-alternative"
+      onPress={() => {
+        if (showReferralInput) {
+          handleReferralCodeChange('');
+        }
+        setShowReferralInput(!showReferralInput);
+      }}
+      testID="referral-prompt"
+    >
+      {showReferralInput
+        ? strings('rewards.onboarding.referral_hide')
+        : strings('rewards.onboarding.referral_prompt')}
+    </Text>
   );
 
   const renderLegalDisclaimer = () => (
@@ -419,7 +423,8 @@ const OnboardingMainStep: React.FC = () => {
       nextButtonText={strings('rewards.onboarding.sign_up')}
       renderStepImage={renderStepImage}
       renderStepInfo={renderStepInfo}
-      renderReferralSection={renderReferralSection}
+      renderAboveCTA={renderAboveCTA}
+      renderBelowCTA={renderBelowCTA}
       renderLegalDisclaimer={renderLegalDisclaimer}
       disableSwipe
       showProgressIndicator={false}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
@@ -41,7 +41,8 @@ interface OnboardingStepProps {
 
   // Button props
   nextButtonText?: string;
-  renderReferralSection?: () => ReactNode;
+  renderAboveCTA?: () => ReactNode;
+  renderBelowCTA?: () => ReactNode;
   renderLegalDisclaimer?: () => ReactNode;
 
   // Render props for customizable content
@@ -62,7 +63,8 @@ const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
   onNextLoadingText,
   onNextDisabled,
   nextButtonText,
-  renderReferralSection,
+  renderAboveCTA,
+  renderBelowCTA,
   renderLegalDisclaimer,
   renderStepImage,
   renderStepInfo,
@@ -141,6 +143,8 @@ const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
         </Box>
 
         <Box twClassName="w-full flex-col gap-4 items-center">
+          {renderAboveCTA?.()}
+
           <Button
             variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
@@ -154,7 +158,7 @@ const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
             {nextButtonText || strings('rewards.onboarding.step_confirm')}
           </Button>
 
-          {renderReferralSection?.()}
+          {renderBelowCTA?.()}
 
           {onSkip && (
             <Button

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
@@ -319,7 +319,8 @@ jest.mock('../OnboardingStep', () => {
     default: ({
       renderStepInfo,
       renderStepImage,
-      renderReferralSection,
+      renderAboveCTA,
+      renderBelowCTA,
       renderLegalDisclaimer,
       onNext,
       onNextDisabled,
@@ -330,7 +331,8 @@ jest.mock('../OnboardingStep', () => {
     }: {
       renderStepInfo: () => React.ReactElement;
       renderStepImage?: () => React.ReactElement;
-      renderReferralSection?: () => React.ReactElement;
+      renderAboveCTA?: () => React.ReactElement | null;
+      renderBelowCTA?: () => React.ReactElement;
       renderLegalDisclaimer?: () => React.ReactElement;
       onNext: () => void;
       onNextDisabled?: boolean;
@@ -347,7 +349,7 @@ jest.mock('../OnboardingStep', () => {
         },
         renderStepInfo?.(),
         renderStepImage?.(),
-        renderReferralSection?.(),
+        renderAboveCTA?.(),
         renderLegalDisclaimer?.(),
         ReactActual.createElement(
           View,
@@ -358,6 +360,7 @@ jest.mock('../OnboardingStep', () => {
           },
           nextButtonText || 'Next',
         ),
+        renderBelowCTA?.(),
         onNextLoadingText &&
           ReactActual.createElement(
             View,
@@ -571,21 +574,22 @@ describe('OnboardingMainStep', () => {
     it('shows referral input when prompt is pressed', () => {
       renderWithProviders(<OnboardingMainStep />);
 
-      const prompts = screen.getAllByTestId('referral-prompt');
-      const pressable = prompts[0];
-      fireEvent.press(pressable);
+      fireEvent.press(screen.getAllByTestId('referral-prompt')[0]);
 
       expect(screen.getByTestId('referral-input')).toBeDefined();
     });
 
-    it('hides prompt text when referral input is shown', () => {
+    it('shows hide code text when referral input is visible', () => {
       renderWithProviders(<OnboardingMainStep />);
 
-      const prompts = screen.getAllByTestId('referral-prompt');
-      const pressable = prompts[0];
-      fireEvent.press(pressable);
+      fireEvent.press(screen.getAllByTestId('referral-prompt')[0]);
 
-      expect(screen.queryByTestId('referral-prompt')).toBeNull();
+      expect(screen.getAllByTestId('referral-prompt').length).toBeGreaterThan(
+        0,
+      );
+      expect(
+        screen.getByText('mocked_rewards.onboarding.referral_hide'),
+      ).toBeDefined();
       expect(screen.getByTestId('referral-input')).toBeDefined();
     });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7910,7 +7910,8 @@
       "legal_disclaimer_3": ". All accounts on this device will be opted in.",
       "legal_disclaimer_4": "Learn more",
       "referral_prompt": "Have a referral code?",
-      "referral_placeholder": "Optional referral code",
+      "referral_hide": "Hide code",
+      "referral_placeholder": "Referral code (optional)",
       "referral_label": "Referral code"
     },
     "settings": {


### PR DESCRIPTION
## **Description**

At the end of the Ondo onboarding carousel (step 3), pressing "Next" triggered a reverse animation: the tour screen slid to the **right** while the campaign details screen came from the **left**. This is the opposite of the carousel's internal paging direction (which always slides left), making the transition feel jarring.

**Root cause:** `CampaignTourStepView` (`REWARDS_CAMPAIGN_TOUR_STEP`) was registered in `MainNavigator` (the root stack), while `REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW` lives inside the nested `RewardsNavigator`. When the last tour step called `navigation.navigate(REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW)`, React Navigation resolved this as a **pop** back to the parent navigator instead of a **push** — triggering the reverse (back) animation.

**Fix:** Move `REWARDS_CAMPAIGN_TOUR_STEP`'s screen registration from `MainNavigator.js` into `RewardsNavigator.tsx` (inside the `subscriptionId`-gated block). Both screens are now siblings in the same stack, so the navigate call becomes a **push**: tour exits left, details enters from the right — consistent with the carousel.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ondo campaign tour animation

  Scenario: user completes the onboarding carousel
    Given user is on the Rewards Campaigns screen with an Ondo campaign tile that has a tour
    When user taps the campaign tile to launch the tour
    Then the tour screen slides in from the right

    When user presses "Next" on step 1 or step 2
    Then the carousel slides left to the next step

    When user presses "Next" on step 3 (last step)
    Then the tour screen slides left (not right)
    And the campaign details screen slides in from the right
    And the direction is consistent with the carousel's previous paging direction

  Scenario: user skips the tour
    Given user is on any step of the tour
    When user presses "Skip"
    Then the tour screen slides left to the campaign details screen
```

## **Screenshots/Recordings**

### **Before**

Step 3 exits to the **right** (reverse animation) while campaign details slides in from the left.

### **After**

Step 3 exits to the **left** (forward animation) consistent with the carousel slide direction.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Rewards navigation stack structure and tour-to-details transition behavior, which could affect routing/back-stack semantics for enrolled users. Also adjusts onboarding referral UI rendering, with low data/security impact but some UX regression risk.
> 
> **Overview**
> Fixes the Ondo campaign tour exit transition by moving `Routes.REWARDS_CAMPAIGN_TOUR_STEP` registration from `MainNavigator` into the subscription-gated `RewardsNavigator`, making the tour and campaign details siblings in the same stack.
> 
> Updates `CampaignTourStepView` to `dispatch(StackActions.replace(...))` when leaving the tour (Next/Skip/no-tour), and updates related navigator tests/snapshots accordingly.
> 
> Includes small Rewards UI tweaks: adjusts bottom CTA padding/margins, and refactors onboarding referral code UI to render *above* the main CTA with a toggleable "Hide code" prompt rendered *below* the CTA (plus updated copy in `en.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdef2960390a9323ac843bddcaf21b52d656a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->