### PR TITLE
fix(ramp): apply Verify Identity navbar options in useLayoutEffect

### DIFF
--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { Image, Linking, ScrollView } from 'react-native';
 import {
   Text,
@@ -57,11 +57,13 @@ const V2VerifyIdentity = () => {
     );
   }, [navigation, amount, currency, assetId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     navigation.setOptions(
       getDepositNavbarOptions(
         navigation,
-        { title: strings('deposit.verify_identity.navbar_title') },
+        {
+          title: ` ${strings('deposit.verify_identity.navbar_title')} fix me`,
+        },
         theme,
         () => {
           trackEvent(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Unified buy (v2) **Verify Identity** used `navigation.setOptions` inside **`useEffect`**, which runs after the first paint. During the stack push transition, the screen briefly used default header chrome while the previous route’s header was still visible, producing a “see-through” / overlapping header (same class of issue as TRAM-style ramp header bleed elsewhere).

Switching this single `setOptions` call to **`useLayoutEffect`** applies the `getDepositNavbarOptions` header before paint, consistent with [`TokenSelection.tsx`](app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed unified buy Verify Identity screen header overlapping the previous screen during navigation transitions

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Unified buy Verify Identity navigation header

  Scenario: Verify Identity header does not bleed over the previous screen during transition
    Given unified buy v2 is enabled and the user reaches Verify Identity from the prior step (e.g. Build Quote / deposit entry)

    When the Verify Identity screen is pushed onto the stack
    Then the transition completes without the previous screen’s header content showing through the Verify Identity header area
    And the Verify Identity navbar title and back control behave as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
