### PR TITLE
feat: migration reset native balance to 0 on tempo chains

### DIFF
--- a/app/store/migrations/132.test.ts
+++ b/app/store/migrations/132.test.ts
@@ -1,0 +1,231 @@
+import { zeroAddress } from 'ethereumjs-util';
+import { cloneDeep } from 'lodash';
+
+import migrate from './132';
+import { ensureValidState, ValidState } from './util';
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const ZERO_ADDRESS = zeroAddress();
+
+describe('migration 132', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(ensureValidState).mockReturnValue(true);
+  });
+
+  it('does not modify the state if `ensureValidState` returns `false`', () => {
+    const state = { some: 'state' };
+    jest.mocked(ensureValidState).mockReturnValueOnce(false);
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+  });
+
+  it('migrate balances to 0x0 ONLY for native, ONLY for Tempo chains and FOR ALL accounts', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          TokenBalancesController: {
+            tokenBalances: {
+              '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+                '0x1': {
+                  [ZERO_ADDRESS]: '0x42',
+                },
+                '0x1079': {
+                  [ZERO_ADDRESS]: '0x0',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+                '0xa5bf': {
+                  [ZERO_ADDRESS]: '0x0',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+              },
+              '0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8': {
+                '0x1': {
+                  [ZERO_ADDRESS]: '0x42',
+                },
+                '0x1079': {
+                  [ZERO_ADDRESS]:
+                    '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+                '0xa5bf': {
+                  [ZERO_ADDRESS]: '0x0',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+              },
+              '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': {
+                '0x1': {
+                  [ZERO_ADDRESS]: '0x42',
+                },
+                '0x1079': {
+                  [ZERO_ADDRESS]:
+                    '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+                '0xa5bf': {
+                  [ZERO_ADDRESS]:
+                    '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = migrate(state) as ValidState;
+
+    expect(result.engine.backgroundState.TokenBalancesController).toStrictEqual(
+      {
+        tokenBalances: {
+          '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+            '0x1': {
+              [ZERO_ADDRESS]: '0x42',
+            },
+            '0x1079': {
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+            '0xa5bf': {
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+          },
+          '0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8': {
+            '0x1': {
+              [ZERO_ADDRESS]: '0x42',
+            },
+            '0x1079': {
+              // Migrated
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+            '0xa5bf': {
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+          },
+          '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': {
+            '0x1': {
+              [ZERO_ADDRESS]: '0x42',
+            },
+            '0x1079': {
+              // Migrated
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+            '0xa5bf': {
+              // Migrated
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+          },
+        },
+      },
+    );
+  });
+
+  it('does not mark the controller as migrated if no change happened', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          TokenBalancesController: {
+            tokenBalances: {
+              '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+                '0x1': {
+                  [ZERO_ADDRESS]: '0x42',
+                },
+                '0x1079': {
+                  [ZERO_ADDRESS]: '0x0',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+                '0xa5bf': {
+                  [ZERO_ADDRESS]: '0x0',
+                  '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // const versionedData = cloneDeep(oldStorage);
+    // const changedControllers = new Set<string>();
+
+    const result = migrate(state) as ValidState;
+
+    expect(result.engine.backgroundState.TokenBalancesController).toStrictEqual(
+      {
+        tokenBalances: {
+          '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+            '0x1': {
+              [ZERO_ADDRESS]: '0x42',
+            },
+            '0x1079': {
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+            '0xa5bf': {
+              [ZERO_ADDRESS]: '0x0',
+              '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+            },
+          },
+        },
+      },
+    );
+  });
+
+  it('does nothing when TokenBalancesController is missing', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          SomeOtherController: {},
+        },
+      },
+    };
+
+    const oldState = cloneDeep(state);
+    const result = migrate(state);
+
+    expect(result).toStrictEqual(oldState);
+  });
+
+  it('does nothing when TokenBalancesController is of incorrect type', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          TokenBalancesController: 'I am not an object',
+        },
+      },
+    };
+
+    const oldState = cloneDeep(state);
+    const result = migrate(state);
+
+    expect(result).toStrictEqual(oldState);
+  });
+
+  it('does nothing when tokenBalances object is missing', async () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          TokenBalancesController: {
+            iamNotTheTokenBalanceObject: {},
+          },
+        },
+      },
+    };
+
+    const oldState = cloneDeep(state);
+    const result = migrate(state);
+
+    expect(result).toStrictEqual(oldState);
+  });
+});

--- a/app/store/migrations/132.ts
+++ b/app/store/migrations/132.ts
@@ -1,0 +1,83 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { zeroAddress } from 'ethereumjs-util';
+import { ensureValidState } from './util';
+
+const CHAINS_TO_MIGRATE_NATIVE_BALANCE_TO_ZERO = [
+  '0x1079', // Tempo Mainnet
+  '0xa5bf', // Tempo Testnet Moderato
+];
+
+const ZERO_ADDRESS = zeroAddress();
+const ZERO_BALANCE = '0x0';
+
+/**
+ * Migration 132:
+ *
+ * On Tempo, there is no native token.
+ * However Tempo's RPC returns '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2'
+ * as balance to `getbalance` causing a huge number to be displayed in MetaMask.
+ *
+ * The newest version of MetaMask hide this "non-existing native token" from everywhere in the UI.
+ * It also prevents that huge balance to be stored in the state.
+ * HOWEVER, if a user used Tempo before the latest version, their Tempo native balance may remain
+ * "cached" in `TokenBalancesController.tokenBalances`, causing the "total USD amount" (aggregated)
+ * to still show that huge number forever - since the native balance of the user will never change,
+ * it would never refresh.
+ *
+ * This one-time migration resets the native balance to 0 (`0x0`) on Tempo chains.
+ * Since the "hidding native" behavior is already in this version of MetaMask, the
+ * migration should only need to run once for those users that already used Tempo before.
+ *
+ */
+const migration = (state: unknown): unknown => {
+  const migrationVersion = 132;
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  if (
+    !hasProperty(state.engine.backgroundState, 'TokenBalancesController') ||
+    !isObject(state.engine.backgroundState.TokenBalancesController)
+  ) {
+    return state;
+  }
+
+  const { TokenBalancesController } = state.engine.backgroundState;
+
+  if (
+    !hasProperty(TokenBalancesController, 'tokenBalances') ||
+    !isObject(TokenBalancesController.tokenBalances)
+  ) {
+    return state;
+  }
+
+  const { tokenBalances } = TokenBalancesController;
+
+  Object.values(tokenBalances).forEach((balancesPerChain) => {
+    if (!isObject(balancesPerChain)) {
+      return;
+    }
+    CHAINS_TO_MIGRATE_NATIVE_BALANCE_TO_ZERO.forEach((chainId) => {
+      if (
+        !hasProperty(balancesPerChain, chainId) ||
+        !isObject(balancesPerChain[chainId])
+      ) {
+        return;
+      }
+      const balancesForThisTempoChain = balancesPerChain[chainId] as Object;
+      if (
+        !hasProperty(balancesForThisTempoChain, ZERO_ADDRESS) ||
+        balancesForThisTempoChain[ZERO_ADDRESS] === ZERO_BALANCE
+      ) {
+        return;
+      }
+      // Assigns '0x0' (zero balance) if entry exists. We want balance to always be zero for those chains.
+      balancesForThisTempoChain[ZERO_ADDRESS] = ZERO_BALANCE;
+    });
+  });
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -132,6 +132,7 @@ import migration128 from './128';
 import migration129 from './129';
 import migration130 from './130';
 import migration131 from './131';
+import migration132 from './132';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -283,6 +284,7 @@ export const migrationList: MigrationsList = {
   129: migration129,
   130: migration130,
   131: migration131,
+  132: migration132,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On Tempo, there is no native token.

However Tempo's RPC returns '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2'
as balance to `getbalance` causing a huge number to be displayed in MetaMask.

The newest version of MetaMask hide this "non-existing native token" from everywhere in the UI.
It also prevents that huge balance to be stored in the state.
HOWEVER, if a user used Tempo before the latest version, their Tempo native balance may remain
"cached" in `TokenBalancesController.tokenBalances`, causing the "total USD amount" (aggregated)
to still show that huge number forever - since the native balance of the user will never change,
it would never refresh.

This one-time migration resets the native balance to 0 (`0x0`) on Tempo chains.
Since the "hidding native" behavior is already in this version of MetaMask, the
migration should only need to run once for those users that already used Tempo before.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migration to reset native balance to 0 on tempo chains

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-957?atlOrigin=eyJpIjoiMGE5Y2RiYmY3YWI3NGY1OTkzMzY3YWI0NWFlMGRiYTciLCJwIjoiaiJ9

## **Manual testing steps**

1. Use version prior to v7-73-0.
2. Add Tempo chain, observe huge "total aggregated balance" at the top + presence of the `USD` token with huge balance.
3. Use latest version v7-74-0.
4. Observe that glitched `USD` is gone, but "total aggregated balance" still shows with a huge value at the top.
5. Use THIS PR version.
6. Observe that the "total aggregated balance" now shows a correct value.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ac82a331-68a4-4d17-9c69-35cd839ea060" />
<!-- [screenshots/recordings] -->

### **After**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9e1a7507-4e5a-4b2b-a6e1-6a63b558a9e1" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted `TokenBalancesController.tokenBalances` via a new state migration, so mistakes could corrupt cached balances for Tempo users. Scope is narrow (two chain IDs and only the native `0x0` token entry) with defensive type checks and unit tests.
> 
> **Overview**
> Adds migration `132` to **reset cached native-token balances to `0x0`** for Tempo networks (`0x1079`, `0xa5bf`) inside `TokenBalancesController.tokenBalances`, preventing previously cached bogus native balances from skewing aggregated portfolio totals.
> 
> Registers the migration in the global migrations manifest and includes Jest coverage for the Tempo-only/native-only behavior plus no-op/invalid-state guard cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4e716522018e4b7bc0fcc97413554516de5200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->