### PR TITLE
feat: display realized PnL and sold value for closed positions

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -14,6 +14,14 @@ jest.mock('../../utils/chainMapping', () => ({
   ),
 }));
 
+jest.mock('../../../../UI/Perps/utils/formatUtils', () => {
+  const actual = jest.requireActual('../../../../UI/Perps/utils/formatUtils');
+  return {
+    ...actual,
+    formatOrderCardDate: jest.fn().mockReturnValue('Apr 15 at 2:00 PM'),
+  };
+});
+
 const basePosition: Position = {
   tokenSymbol: 'STARKBOT',
   tokenName: 'Starkbot',
@@ -29,6 +37,16 @@ const basePosition: Position = {
   currentValueUSD: 2259.96,
   pnlValueUsd: 1059.96,
   pnlPercent: 182,
+};
+
+const closedPosition: Position = {
+  ...basePosition,
+  positionAmount: 0,
+  soldUsd: 1500,
+  realizedPnl: 300,
+  boughtUsd: 1200,
+  currentValueUSD: 0,
+  pnlPercent: null,
 };
 
 describe('PositionRow', () => {
@@ -161,5 +179,51 @@ describe('PositionRow', () => {
     renderWithProvider(<PositionRow position={position} />);
 
     expect(screen.getByTestId('position-row-PEPE')).toBeOnTheScreen();
+  });
+
+  describe('closed position', () => {
+    it('renders soldUsd as the value', () => {
+      renderWithProvider(<PositionRow position={closedPosition} />);
+
+      expect(screen.getByText('$1,500.00')).toBeOnTheScreen();
+    });
+
+    it('renders formatted closed date as subtitle instead of token amount', () => {
+      renderWithProvider(<PositionRow position={closedPosition} />);
+
+      expect(screen.getByText('Apr 15 at 2:00 PM')).toBeOnTheScreen();
+    });
+
+    it('renders realized PnL percent', () => {
+      renderWithProvider(<PositionRow position={closedPosition} />);
+
+      // realizedPnl (300) / boughtUsd (1200) * 100 = 25%
+      expect(screen.getByText('+25%')).toBeOnTheScreen();
+    });
+
+    it('renders dash for PnL when boughtUsd is zero', () => {
+      const position = { ...closedPosition, boughtUsd: 0 };
+
+      renderWithProvider(<PositionRow position={position} />);
+
+      expect(screen.getByText('\u2014')).toBeOnTheScreen();
+    });
+
+    it('renders soldUsd as value even when currentValueUSD is zero', () => {
+      const position = { ...closedPosition, currentValueUSD: 0 };
+
+      renderWithProvider(<PositionRow position={position} />);
+
+      expect(screen.getByText('$1,500.00')).toBeOnTheScreen();
+    });
+
+    it('renders negative realized PnL percent', () => {
+      const position = { ...closedPosition, realizedPnl: -300 };
+
+      renderWithProvider(<PositionRow position={position} />);
+
+      // -300 / 1200 * 100 = -25%
+      expect(screen.getByText('-25%')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -225,5 +225,13 @@ describe('PositionRow', () => {
       // -300 / 1200 * 100 = -25%
       expect(screen.getByText('-25%')).toBeOnTheScreen();
     });
+
+    it('uses realized PnL percent even when pnlPercent is 0', () => {
+      const position = { ...closedPosition, pnlPercent: 0 };
+
+      renderWithProvider(<PositionRow position={position} />);
+
+      expect(screen.getByText('+25%')).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -58,7 +58,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
       ? (position.realizedPnl / position.boughtUsd) * 100
       : null;
 
-  const displayPnlPercent = position.pnlPercent ?? closedPnlPercent;
+  const displayPnlPercent = isClosed ? closedPnlPercent : position.pnlPercent;
   const hasPnl = displayPnlPercent != null;
   const isPnlPositive = hasPnl && (displayPnlPercent ?? 0) >= 0;
   const testID = `position-row-${position.tokenSymbol}`;

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -12,7 +12,6 @@ import {
   AvatarToken,
   AvatarTokenSize,
 } from '@metamask/design-system-react-native';
-import { DateTime } from 'luxon';
 import type { Position } from '@metamask/social-controllers';
 import { getAssetImageUrl } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import { chainNameToId } from '../../utils/chainMapping';
@@ -20,6 +19,7 @@ import { addThousandsSeparator } from '../../utils/numberFormatting';
 import {
   formatPerpsFiat,
   formatPercentage,
+  formatOrderCardDate,
 } from '../../../../UI/Perps/utils/formatUtils';
 
 export interface PositionRowProps {
@@ -46,17 +46,10 @@ function formatPercent(value: number | null | undefined): string {
   return formatPercentage(value, 0);
 }
 
-function formatClosedDate(timestamp: number): string {
-  const dt = DateTime.fromSeconds(timestamp);
-  const time = dt.toFormat('h:mma').toLowerCase();
-  return `${dt.toFormat('MMMM d')} at ${time}`;
-}
-
 const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
   const isClosed = position.positionAmount === 0 && position.soldUsd > 0;
 
-  const displayValue =
-    position.currentValueUSD ?? (isClosed ? position.soldUsd : null);
+  const displayValue = isClosed ? position.soldUsd : position.currentValueUSD ?? null;
 
   const closedPnlPercent =
     isClosed && position.boughtUsd > 0
@@ -109,7 +102,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
             numberOfLines={1}
           >
             {isClosed
-              ? formatClosedDate(position.lastTradeAt)
+              ? formatOrderCardDate(position.lastTradeAt)
               : `${formatTokenAmount(position.positionAmount)} ${position.tokenSymbol}`}
           </Text>
         </Box>

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -46,8 +46,19 @@ function formatPercent(value: number | null | undefined): string {
 }
 
 const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
-  const hasPnl = position.pnlPercent != null;
-  const isPnlPositive = hasPnl && (position.pnlPercent ?? 0) >= 0;
+  const isClosed = position.positionAmount === 0 && position.soldUsd > 0;
+
+  const displayValue =
+    position.currentValueUSD ?? (isClosed ? position.soldUsd : null);
+
+  const closedPnlPercent =
+    isClosed && position.boughtUsd > 0
+      ? (position.realizedPnl / position.boughtUsd) * 100
+      : null;
+
+  const displayPnlPercent = position.pnlPercent ?? closedPnlPercent;
+  const hasPnl = displayPnlPercent != null;
+  const isPnlPositive = hasPnl && (displayPnlPercent ?? 0) >= 0;
   const testID = `position-row-${position.tokenSymbol}`;
 
   const tokenImageUrl = useMemo(() => {
@@ -90,7 +101,9 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
             color={TextColor.TextAlternative}
             numberOfLines={1}
           >
-            {`${formatTokenAmount(position.positionAmount)} ${position.tokenSymbol}`}
+            {isClosed
+              ? `${formatUsd(position.boughtUsd)} invested`
+              : `${formatTokenAmount(position.positionAmount)} ${position.tokenSymbol}`}
           </Text>
         </Box>
       </Box>
@@ -101,7 +114,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
           fontWeight={FontWeight.Medium}
           color={TextColor.TextDefault}
         >
-          {formatUsd(position.currentValueUSD)}
+          {formatUsd(displayValue)}
         </Text>
         <Text
           variant={TextVariant.BodySm}
@@ -114,7 +127,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
               : undefined
           }
         >
-          {formatPercent(position.pnlPercent)}
+          {formatPercent(displayPnlPercent)}
         </Text>
       </Box>
     </Box>

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -49,7 +49,9 @@ function formatPercent(value: number | null | undefined): string {
 const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
   const isClosed = position.positionAmount === 0 && position.soldUsd > 0;
 
-  const displayValue = isClosed ? position.soldUsd : position.currentValueUSD ?? null;
+  const displayValue = isClosed
+    ? position.soldUsd
+    : (position.currentValueUSD ?? null);
 
   const closedPnlPercent =
     isClosed && position.boughtUsd > 0

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -47,7 +47,9 @@ function formatPercent(value: number | null | undefined): string {
 }
 
 function formatClosedDate(timestamp: number): string {
-  return DateTime.fromSeconds(timestamp).toFormat('M/d/yy, h:mm a');
+  const dt = DateTime.fromSeconds(timestamp);
+  const time = dt.toFormat('h:mma').toLowerCase();
+  return `${dt.toFormat('MMMM d')} at ${time}`;
 }
 
 const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -12,6 +12,7 @@ import {
   AvatarToken,
   AvatarTokenSize,
 } from '@metamask/design-system-react-native';
+import { DateTime } from 'luxon';
 import type { Position } from '@metamask/social-controllers';
 import { getAssetImageUrl } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import { chainNameToId } from '../../utils/chainMapping';
@@ -43,6 +44,10 @@ function formatTokenAmount(value: number): string {
 function formatPercent(value: number | null | undefined): string {
   if (value == null) return '\u2014';
   return formatPercentage(value, 0);
+}
+
+function formatClosedDate(timestamp: number): string {
+  return DateTime.fromSeconds(timestamp).toFormat('M/d/yy, h:mm a');
 }
 
 const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
@@ -102,7 +107,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
             numberOfLines={1}
           >
             {isClosed
-              ? `${formatUsd(position.boughtUsd)} invested`
+              ? formatClosedDate(position.lastTradeAt)
               : `${formatTokenAmount(position.positionAmount)} ${position.tokenSymbol}`}
           </Text>
         </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Closed positions now show soldUsd as the value and realizedPnl/boughtUsd as PnL%, with "$X invested" as the subtitle. Previously these showed dashes since the v1 endpoint doesn't include price enrichment fields.

[TSA-409](https://consensyssoftware.atlassian.net/browse/TSA-409)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: closed positions now show realized PnL %

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TSA-409]: https://consensyssoftware.atlassian.net/browse/TSA-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic changes with added unit tests; risk is mainly around edge-case classification of what counts as a “closed” position and potential date/number formatting regressions.
> 
> **Overview**
> Updates `PositionRow` to detect *closed* positions (`positionAmount === 0` and `soldUsd > 0`) and switch displayed fields accordingly: the row value now uses `soldUsd` instead of `currentValueUSD`, and PnL% is derived from `realizedPnl / boughtUsd` (falling back to a dash when `boughtUsd` is zero).
> 
> For closed positions, the subtitle now shows a formatted close date via `formatOrderCardDate(lastTradeAt)` instead of the token amount. Test coverage is expanded to validate sold value, date subtitle, realized PnL% (positive/negative), and edge cases like `pnlPercent` being `0` or null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ba9eaec307eeaaff5dd67506b44ac912859558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->