### PR TITLE
feat: add native token send in transaction activity for gas fees spon…

### DIFF
--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -647,6 +647,10 @@ export async function getTransactionActionKey(transaction, chainId) {
     return SMART_CONTRACT_INTERACTION_ACTION_KEY;
   }
 
+  if (type === TransactionType.simpleSend) {
+    return SEND_ETHER_ACTION_KEY;
+  }
+
   const toSmartContract =
     transaction.toSmartContract !== undefined
       ? transaction.toSmartContract
@@ -667,10 +671,6 @@ export async function getTransactionActionKey(transaction, chainId) {
 
   if (isUpgrade) {
     return UPGRADE_SMART_ACCOUNT_ACTION_KEY;
-  }
-
-  if (type === TransactionType.simpleSend) {
-    return SEND_ETHER_ACTION_KEY;
   }
 
   if (toSmartContract) {

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -669,6 +669,10 @@ export async function getTransactionActionKey(transaction, chainId) {
     return UPGRADE_SMART_ACCOUNT_ACTION_KEY;
   }
 
+  if (type === TransactionType.simpleSend) {
+    return SEND_ETHER_ACTION_KEY;
+  }
+
   if (toSmartContract) {
     return SMART_CONTRACT_INTERACTION_ACTION_KEY;
   }

--- a/app/util/transactions/index.test.ts
+++ b/app/util/transactions/index.test.ts
@@ -49,6 +49,8 @@ import {
   getTransactionById,
   UPGRADE_SMART_ACCOUNT_ACTION_KEY,
   DOWNGRADE_SMART_ACCOUNT_ACTION_KEY,
+  SEND_ETHER_ACTION_KEY,
+  SMART_CONTRACT_INTERACTION_ACTION_KEY,
   isLegacyTransaction,
   getTokenAddressParam,
   getTokenValueParamAsHex,
@@ -1741,6 +1743,48 @@ describe('Transactions utils :: getTransactionActionKey', () => {
 
       expect(actionKey).toBe(TOKEN_METHOD_MINT);
     }
+  });
+
+  describe('simpleSend type bypasses smart contract check (gas-sponsored native sends)', () => {
+    it('returns SEND_ETHER_ACTION_KEY for simpleSend even when to is a smart contract', async () => {
+      const transaction = {
+        type: TransactionType.simpleSend,
+        toSmartContract: true,
+        txParams: {
+          to: '0xSmartContractAddress',
+        },
+      };
+
+      const actionKey = await getTransactionActionKey(transaction, '0x1');
+
+      expect(actionKey).toBe(SEND_ETHER_ACTION_KEY);
+    });
+
+    it('returns SEND_ETHER_ACTION_KEY for simpleSend without toSmartContract flag', async () => {
+      const transaction = {
+        type: TransactionType.simpleSend,
+        txParams: {
+          to: '0x0000000000000000000000000000000000000001',
+        },
+      };
+
+      const actionKey = await getTransactionActionKey(transaction, '0x1');
+
+      expect(actionKey).toBe(SEND_ETHER_ACTION_KEY);
+    });
+
+    it('returns SMART_CONTRACT_INTERACTION_ACTION_KEY when type is not simpleSend and to is a smart contract', async () => {
+      const transaction = {
+        toSmartContract: true,
+        txParams: {
+          to: '0xSmartContractAddress',
+        },
+      };
+
+      const actionKey = await getTransactionActionKey(transaction, '0x1');
+
+      expect(actionKey).toBe(SMART_CONTRACT_INTERACTION_ACTION_KEY);
+    });
   });
 });
 


### PR DESCRIPTION
## **Description**

This pull request updates the logic for determining transaction action keys and adds comprehensive tests to ensure correct behavior, especially for native ETH send transactions (`simpleSend`) in gas fees sponsored scenario (EIP-7702). The changes ensure that `simpleSend` transactions are always classified as ETH sends, even if the recipient is a smart contract.

**Transaction Action Key Logic Updates:**

* Updated `getTransactionActionKey` in `app/util/transactions/index.js` so that transactions of type `simpleSend` always return `SEND_ETHER_ACTION_KEY`, bypassing the smart contract recipient check.

**Testing Enhancements:**

* Added tests in `app/util/transactions/index.test.ts` to verify that `simpleSend` transactions return `SEND_ETHER_ACTION_KEY` regardless of the recipient, and that other transaction types interacting with smart contracts return `SMART_CONTRACT_INTERACTION_ACTION_KEY`.
* Updated imports in `app/util/transactions/index.test.ts` to include `SEND_ETHER_ACTION_KEY` and `SMART_CONTRACT_INTERACTION_ACTION_KEY` for use in the new tests.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add native token send in transaction activity for gas fees sponsored

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="250" height="500" alt="MON sent native mobile" src="https://github.com/user-attachments/assets/07b12358-9dab-4be1-9dd4-463be77c1290" />


### **After**

<img width="250" height="500" alt="MON sent native mobile2" src="https://github.com/user-attachments/assets/553e340e-ee16-4e55-9947-0850ca5cf95e" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction action-key classification used for activity/review labeling, which may affect how some native transfers are displayed. Scope is small and covered by targeted unit tests.
> 
> **Overview**
> Updates `getTransactionActionKey` so `TransactionType.simpleSend` **always** returns `SEND_ETHER_ACTION_KEY`, bypassing the `toSmartContract` / on-chain contract-code check that would otherwise label it as `smartContractInteraction`.
> 
> Adds unit tests covering `simpleSend` to smart-contract recipients, `simpleSend` without a `toSmartContract` flag, and the unchanged behavior for non-`simpleSend` transactions that target smart contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44381f6a618ff95b30185dc5e8abf1fee11ff2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->