### PR TITLE
feat(ramp): TRAM-3451 inline headers for unified buy v2

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -285,6 +285,7 @@ const TransactionsHome = () => {
       <Stack.Screen
         name={Routes.RAMP.RAMPS_ORDER_DETAILS}
         component={RampsOrderDetails}
+        options={{ headerShown: false }}
       />
       <Stack.Screen
         name={Routes.DEPOSIT.ORDER_DETAILS}
@@ -615,7 +616,7 @@ const SettingsFlow = () => {
       <Stack.Screen
         name={Routes.SETTINGS.REGION_SELECTOR}
         component={RegionSelector}
-        options={RegionSelector.navigationOptions}
+        options={{ headerShown: false }}
       />
       {
         ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -55,34 +55,6 @@ jest.mock('../../utils/v2OrderToast', () => ({
   showV2OrderToast: jest.fn(),
 }));
 
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: jest.fn().mockReturnValue({
-    colors: {
-      background: { default: '#FFFFFF' },
-      text: { default: '#000000' },
-    },
-    themeAppearance: 'light',
-    typography: {},
-    shadows: {},
-    brandColors: {},
-  }),
-}));
-
-let capturedDepositNavbarOnClose: (() => void) | undefined;
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(
-    (
-      _navigation: unknown,
-      _params: unknown,
-      _theme: unknown,
-      onClose?: () => void,
-    ) => {
-      capturedDepositNavbarOnClose = onClose;
-      return { header: () => null };
-    },
-  ),
-}));
-
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
   log: jest.fn(),
@@ -207,10 +179,6 @@ jest.mock('@metamask/react-native-webview', () => {
   };
 });
 
-jest.mock('../../../../../util/device', () => ({
-  isAndroid: jest.fn(() => false),
-}));
-
 const mockUseParams = jest.requireMock(
   '../../../../../util/navigation/navUtils',
 ).useParams as jest.Mock;
@@ -246,7 +214,6 @@ describe('Checkout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    capturedDepositNavbarOnClose = undefined;
     mockUseParams.mockReturnValue({
       url: 'https://provider.example.com/checkout',
       providerName: 'Test Provider',
@@ -498,27 +465,6 @@ describe('Checkout', () => {
       expect(Logger.log).toHaveBeenCalledWith(
         expect.stringContaining('Checkout: HTTP error 404'),
       );
-    });
-  });
-
-  describe('deposit navbar back analytics', () => {
-    it('tracks RAMPS_BACK_BUTTON_CLICKED when deposit navbar onClose runs', () => {
-      mockUseParams.mockReturnValue({
-        url: 'https://provider.example.com/checkout',
-        providerName: 'RampCo',
-      });
-
-      renderWithProvider(<Checkout />, {}, true, false);
-
-      expect(capturedDepositNavbarOnClose).toEqual(expect.any(Function));
-      act(() => {
-        capturedDepositNavbarOnClose?.();
-      });
-
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED,
-      );
-      expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -5,8 +5,6 @@ import { WebView, WebViewNavigation } from '@metamask/react-native-webview';
 import { useNavigation } from '@react-navigation/native';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { useTheme } from '../../../../../util/theme';
-import { getDepositNavbarOptions } from '../../../Navbar';
 import { callbackBaseUrl } from '../../Aggregator/sdk';
 import { getRampRoutingDecision } from '../../../../../reducers/fiatOrders';
 import { normalizeProviderCode } from '@metamask/ramps-controller';
@@ -73,7 +71,6 @@ const Checkout = () => {
   const [key, setKey] = useState(0);
   const navigation = useNavigation();
   const params = useParams<CheckoutParams>();
-  const theme = useTheme();
   const { styles } = useStyles(styleSheet, {});
   const { addOrder, addPrecreatedOrder, getOrderFromCallback } =
     useRampsOrders();
@@ -84,7 +81,6 @@ const Checkout = () => {
   const {
     url: uri,
     providerCode,
-    providerName,
     orderId: orderIdParam,
     customOrderId,
     walletAddress,
@@ -97,34 +93,6 @@ const Checkout = () => {
   const initialUriRef = useRef(uri);
   const registeredOrderIdsRef = useRef<Set<string>>(new Set());
   const hasCallbackFlow = Boolean(providerCode && walletAddress);
-
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: providerName ?? '' },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'Checkout',
-                ramp_type: 'UNIFIED_BUY_2',
-                ramp_routing: rampRoutingDecision ?? undefined,
-              })
-              .build(),
-          );
-        },
-      ),
-    );
-  }, [
-    navigation,
-    theme,
-    providerName,
-    createEventBuilder,
-    trackEvent,
-    rampRoutingDecision,
-  ]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {

--- a/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
@@ -4,23 +4,19 @@ import V2AdditionalVerification from './AdditionalVerification';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 const mockNavigateToKycWebview = jest.fn();
@@ -74,11 +70,13 @@ describe('V2AdditionalVerification', () => {
   });
 
   it('renders the title and paragraphs', () => {
-    const { getByText } = renderWithTheme(<V2AdditionalVerification />);
+    const { getByText, getAllByText } = renderWithTheme(
+      <V2AdditionalVerification />,
+    );
 
-    expect(
-      getByText('deposit.additional_verification.title'),
-    ).toBeOnTheScreen();
+    expect(getAllByText('deposit.additional_verification.title')).toHaveLength(
+      2,
+    );
     expect(
       getByText('deposit.additional_verification.paragraph_1'),
     ).toBeOnTheScreen();

--- a/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.test.tsx
@@ -69,6 +69,14 @@ describe('V2AdditionalVerification', () => {
     });
   });
 
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2AdditionalVerification />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
   it('renders the title and paragraphs', () => {
     const { getByText, getAllByText } = renderWithTheme(
       <V2AdditionalVerification />,

--- a/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/AdditionalVerification.tsx
@@ -10,7 +10,7 @@ import {
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from '../../Deposit/Views/AdditionalVerification/AdditionalVerification.styles';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useNavigation } from '@react-navigation/native';
 import PoweredByTransak from '../../Deposit/components/PoweredByTransak';
 import additionalVerificationImage from '../../Deposit/assets/additional-verification.png';
@@ -35,21 +35,15 @@ const V2AdditionalVerification = () => {
     amount: userEnteredAmount,
   } = useParams<V2AdditionalVerificationParams>();
 
-  const { styles, theme } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {});
 
   const { navigateToKycWebview } = useTransakRouting({
     screenLocation: 'V2 AdditionalVerification Screen',
   });
 
-  React.useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.additional_verification.title') },
-        theme,
-      ),
-    );
-  }, [navigation, theme]);
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const handleContinuePress = useCallback(() => {
     navigateToKycWebview({
@@ -63,6 +57,12 @@ const V2AdditionalVerification = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.additional_verification.title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScreenLayout.Content grow>
           <Image
             source={additionalVerificationImage}

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.test.tsx
@@ -340,6 +340,23 @@ describe('V2BankDetails', () => {
     ).toBeOnTheScreen();
   });
 
+  it('calls navigation.goBack when header back is pressed', async () => {
+    mockGetOrderById.mockReturnValue(createMockV2Order());
+    mockGetOrder.mockResolvedValue(createMockDepositOrder());
+
+    const { getByTestId } = renderWithTheme(<V2BankDetails />);
+
+    await waitFor(() => {
+      expect(getByTestId('deposit-back-navbar-button')).toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('deposit-back-navbar-button'));
+    });
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
   it('toggles bank info when show/hide button is pressed', async () => {
     mockGetOrderById.mockReturnValue(
       createMockV2Order({

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.test.tsx
@@ -6,7 +6,7 @@ import type { RampsOrder } from '@metamask/ramps-controller';
 
 const mockNavigate = jest.fn();
 const mockReplace = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 const mockDispatch = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
@@ -14,7 +14,7 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
     replace: mockReplace,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
     dispatch: mockDispatch,
   }),
   StackActions: {
@@ -32,10 +32,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
     return key;
   },
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 let mockShouldUpdate = true;

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, TouchableOpacity, RefreshControl } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import styleSheet from '../../Deposit/Views/BankDetails/BankDetails.styles';
@@ -7,7 +7,7 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useStyles } from '../../../../hooks/useStyles';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../locales/i18n';
 import {
   Text,
@@ -201,19 +201,17 @@ const V2BankDetails = () => {
     order?.paymentMethod?.shortName ??
     '';
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        {
-          title: strings('deposit.bank_details.navbar_title', {
-            paymentMethod: paymentMethodShortName,
-          }),
-        },
-        theme,
-      ),
-    );
-  }, [navigation, theme, paymentMethodShortName]);
+  const headerTitle = useMemo(
+    () =>
+      strings('deposit.bank_details.navbar_title', {
+        paymentMethod: paymentMethodShortName,
+      }),
+    [paymentMethodShortName],
+  );
+
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const handleBankTransferSent = useCallback(async () => {
     setCancelOrderError(null);
@@ -313,18 +311,24 @@ const V2BankDetails = () => {
 
   return (
     <ScreenLayout>
-      <ScrollView
-        testID={BANK_DETAILS_TEST_IDS.REFRESH_CONTROL_SCROLLVIEW}
-        refreshControl={
-          <RefreshControl
-            colors={[colors.primary.default]}
-            tintColor={colors.icon.default}
-            refreshing={isRefreshing}
-            onRefresh={handleOnRefresh}
-          />
-        }
-      >
-        <ScreenLayout.Body>
+      <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={headerTitle}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
+        <ScrollView
+          testID={BANK_DETAILS_TEST_IDS.REFRESH_CONTROL_SCROLLVIEW}
+          refreshControl={
+            <RefreshControl
+              colors={[colors.primary.default]}
+              tintColor={colors.icon.default}
+              refreshing={isRefreshing}
+              onRefresh={handleOnRefresh}
+            />
+          }
+        >
           <ScreenLayout.Content style={styles.content}>
             <View style={styles.mainSection}>
               <Text variant={TextVariant.HeadingMd}>
@@ -445,8 +449,8 @@ const V2BankDetails = () => {
               <Loader size="large" color={theme.colors.primary.default} />
             )}
           </ScreenLayout.Content>
-        </ScreenLayout.Body>
-      </ScrollView>
+        </ScrollView>
+      </ScreenLayout.Body>
 
       <ScreenLayout.Footer>
         <ScreenLayout.Content>

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
@@ -5,23 +5,19 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 const mockUseParamsReturn = {

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
@@ -161,6 +161,14 @@ describe('V2BasicInfo', () => {
     };
   });
 
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2BasicInfo />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
   it('renders the form fields', () => {
     const { getByTestId } = renderWithTheme(<V2BasicInfo />);
 

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
@@ -14,7 +14,7 @@ import {
   ButtonSize,
 } from '@metamask/design-system-react-native';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from '../../Deposit/Views/BasicInfo/BasicInfo.styles';
 import { useParams } from '../../../../../util/navigation/navUtils';
@@ -57,7 +57,7 @@ interface V2BasicInfoParams {
 
 const V2BasicInfo = (): JSX.Element => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {});
   const trackEvent = useAnalytics();
   const { quote, previousFormData } = useParams<V2BasicInfoParams>();
   const { logoutFromProvider, patchUser, submitSsnDetails } =
@@ -143,15 +143,9 @@ const V2BasicInfo = (): JSX.Element => {
     [handleChange],
   );
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.basic_info.navbar_title') },
-        theme,
-      ),
-    );
-  }, [navigation, theme]);
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   useEffect(() => {
     handleFormDataChange('ssn')('');
@@ -310,6 +304,12 @@ const V2BasicInfo = (): JSX.Element => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.basic_info.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <KeyboardAwareScrollView
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
@@ -4,23 +4,19 @@ import V2EnterAddress from './EnterAddress';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
@@ -198,6 +198,14 @@ describe('V2EnterAddress', () => {
     });
   });
 
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2EnterAddress />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
   it('tracks analytics event on form submission', async () => {
     mockPatchUser.mockResolvedValue({});
     mockRouteAfterAuthentication.mockResolvedValue(undefined);

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { View, TextInput, Keyboard } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
@@ -10,7 +10,7 @@ import {
   ButtonSize,
 } from '@metamask/design-system-react-native';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from '../../Deposit/Views/EnterAddress/EnterAddress.styles';
 import { useParams } from '../../../../../util/navigation/navUtils';
@@ -50,7 +50,7 @@ interface V2EnterAddressParams {
 
 const V2EnterAddress = (): JSX.Element => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {});
   const { quote, previousFormData } = useParams<V2EnterAddressParams>();
   const { patchUser } = useTransakController();
   const { userRegion } = useRampsUserRegion();
@@ -180,15 +180,9 @@ const V2EnterAddress = (): JSX.Element => {
     [formData, handleFormDataChange],
   );
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.enter_address.navbar_title') },
-        theme,
-      ),
-    );
-  }, [navigation, theme]);
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const handleOnPressContinue = useCallback(async () => {
     if (!validateFormData()) return;
@@ -236,6 +230,12 @@ const V2EnterAddress = (): JSX.Element => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.enter_address.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <KeyboardAwareScrollView
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.test.tsx
@@ -4,23 +4,19 @@ import V2EnterEmail from './EnterEmail';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 const mockSendUserOtp = jest.fn();

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.test.tsx
@@ -42,6 +42,16 @@ jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: (props: object) => ({ build: () => ({ ...props }) }),
+    }),
+  }),
+}));
+
 jest.mock('../../Deposit/utils', () => ({
   ...jest.requireActual('../../Deposit/utils'),
   validateEmail: (email: string) => /\S+@\S+\.\S+/.test(email),
@@ -124,6 +134,15 @@ describe('V2EnterEmail', () => {
       queryByText('deposit.enter_email.validation_error'),
     ).toBeOnTheScreen();
     expect(mockSendUserOtp).not.toHaveBeenCalled();
+  });
+
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2EnterEmail />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
   });
 
   it('shows error message when sendUserOtp fails', async () => {

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
@@ -18,7 +18,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import TextField from '../../../../../component-library/components/Form/TextField';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { createV2OtpCodeNavDetails } from './OtpCode';
 import { validateEmail } from '../../Deposit/utils';
 import DepositProgressBar from '../../Deposit/components/DepositProgressBar/DepositProgressBar';
@@ -51,25 +51,17 @@ const V2EnterEmail = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { sendUserOtp } = useTransakController();
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.enter_email.navbar_title') },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'Enter Email',
-                ramp_type: 'UNIFIED_BUY_2',
-              })
-              .build(),
-          );
-        },
-      ),
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
+        .addProperties({
+          location: 'Enter Email',
+          ramp_type: 'UNIFIED_BUY_2',
+        })
+        .build(),
     );
-  }, [navigation, theme, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -138,6 +130,12 @@ const V2EnterEmail = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.enter_email.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScreenLayout.Content grow>
           <DepositProgressBar steps={4} currentStep={0} />
           <View style={styles.contentContainer}>

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
@@ -94,6 +94,9 @@ describe('V2KycProcessing', () => {
     expect(getByText('deposit.kyc_processing.heading')).toBeOnTheScreen();
     expect(getByText('deposit.kyc_processing.description')).toBeOnTheScreen();
 
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+    expect(mockGoBack).toHaveBeenCalled();
+
     await act(async () => {
       await Promise.resolve();
     });

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
@@ -4,13 +4,13 @@ import V2KycProcessing from './KycProcessing';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
   useFocusEffect: (cb: () => void) => {
     const { useEffect } = jest.requireActual('react');
@@ -21,10 +21,6 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 const mockGetAdditionalRequirements = jest.fn();

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
@@ -5,7 +5,7 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import DepositProgressBar from '../../Deposit/components/DepositProgressBar';
 import { useStyles } from '../../../../hooks/useStyles';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../locales/i18n';
 import {
   Text,
@@ -54,15 +54,9 @@ const V2KycProcessing = () => {
   const [isContinueLoading, setIsContinueLoading] = useState(false);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.kyc_processing.navbar_title') },
-        theme,
-      ),
-    );
-  }, [navigation, theme]);
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const quoteId = quote?.quoteId;
 
@@ -177,6 +171,12 @@ const V2KycProcessing = () => {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('deposit.kyc_processing.navbar_title')}
+            onBack={handleHeaderBack}
+            backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+            includesTopInset
+          />
           <ScreenLayout.Content grow>
             <DepositProgressBar steps={4} currentStep={3} />
             <View style={styles.container}>
@@ -216,6 +216,12 @@ const V2KycProcessing = () => {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('deposit.kyc_processing.navbar_title')}
+            onBack={handleHeaderBack}
+            backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+            includesTopInset
+          />
           <ScreenLayout.Content grow>
             <DepositProgressBar steps={4} currentStep={3} />
             <View style={styles.container}>
@@ -260,6 +266,12 @@ const V2KycProcessing = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.kyc_processing.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScreenLayout.Content grow>
           <DepositProgressBar steps={4} currentStep={3} />
           <View style={styles.container}>

--- a/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.test.tsx
@@ -6,23 +6,19 @@ import { Linking } from 'react-native';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({

--- a/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.test.tsx
@@ -84,6 +84,28 @@ describe('V2OrderProcessing', () => {
     expect(getByTestId('loader')).toBeOnTheScreen();
   });
 
+  it('calls navigation.goBack when header back is pressed while order is loading', () => {
+    mockOrder = null;
+    const { getByTestId } = renderWithTheme(<V2OrderProcessing />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('calls navigation.goBack when header back is pressed for pending order', () => {
+    mockOrder = {
+      id: 'test-order-id',
+      state: FIAT_ORDER_STATES.PENDING,
+      data: {},
+    };
+    const { getByTestId } = renderWithTheme(<V2OrderProcessing />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
   it('renders main action button when order is pending', () => {
     mockOrder = {
       id: 'test-order-id',

--- a/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OrderProcessing.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Linking, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import styleSheet from '../../Deposit/Views/OrderProcessing/OrderProcessing.styles';
@@ -7,7 +7,7 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useStyles } from '../../../../hooks/useStyles';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { getOrderById } from '../../../../../reducers/fiatOrders';
 import { RootState } from '../../../../../reducers';
 import { strings } from '../../../../../../locales/i18n';
@@ -47,19 +47,25 @@ const V2OrderProcessing = () => {
     Linking.openURL(TRANSAK_SUPPORT_URL);
   }, []);
 
-  useEffect(() => {
-    const title =
-      order?.state === FIAT_ORDER_STATES.COMPLETED
-        ? strings('deposit.order_processing.success_title')
-        : order?.state === FIAT_ORDER_STATES.CANCELLED ||
-            order?.state === FIAT_ORDER_STATES.FAILED
-          ? strings('deposit.order_processing.error_title')
-          : strings('deposit.order_processing.title');
+  const headerTitle = useMemo(() => {
+    if (!order) {
+      return strings('deposit.order_processing.title');
+    }
+    if (order.state === FIAT_ORDER_STATES.COMPLETED) {
+      return strings('deposit.order_processing.success_title');
+    }
+    if (
+      order.state === FIAT_ORDER_STATES.CANCELLED ||
+      order.state === FIAT_ORDER_STATES.FAILED
+    ) {
+      return strings('deposit.order_processing.error_title');
+    }
+    return strings('deposit.order_processing.title');
+  }, [order]);
 
-    navigation.setOptions(
-      getDepositNavbarOptions(navigation, { title }, theme),
-    );
-  }, [navigation, theme, order?.state]);
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   useEffect(() => {
     if (order?.state === FIAT_ORDER_STATES.CANCELLED) {
@@ -70,7 +76,15 @@ const V2OrderProcessing = () => {
   if (!order) {
     return (
       <ScreenLayout>
-        <Loader size="large" color={theme.colors.primary.default} />
+        <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={headerTitle}
+            onBack={handleHeaderBack}
+            backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+            includesTopInset
+          />
+          <Loader size="large" color={theme.colors.primary.default} />
+        </ScreenLayout.Body>
       </ScreenLayout>
     );
   }
@@ -78,6 +92,12 @@ const V2OrderProcessing = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={headerTitle}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScreenLayout.Content style={styles.content}>
           <DepositOrderContent order={order} />
         </ScreenLayout.Content>

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
@@ -4,13 +4,13 @@ import V2OtpCode, { type V2OtpCodeParams } from './OtpCode';
 import { ThemeContext, mockTheme } from '../../../../../util/theme';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
 }));
 
@@ -20,10 +20,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
     return key;
   },
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 const mockVerifyUserOtp = jest.fn();

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
@@ -79,6 +79,16 @@ jest.mock('../../../../../util/trace', () => ({
   TraceName: { DepositInputOtp: 'DepositInputOtp' },
 }));
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: (props: object) => ({ build: () => ({ ...props }) }),
+    }),
+  }),
+}));
+
 jest.mock('@react-native-clipboard/clipboard', () => ({
   getString: jest.fn().mockResolvedValue(''),
 }));
@@ -150,6 +160,15 @@ describe('V2OtpCode', () => {
 
     expect(getByTestId('otp-code-input')).toBeOnTheScreen();
     expect(getByTestId('otp-code-submit-button')).toBeOnTheScreen();
+  });
+
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2OtpCode />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
   });
 
   it('renders the submit button', () => {

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
@@ -27,7 +27,7 @@ import {
   useBlurOnFulfill,
   useClearByFocusCell,
 } from 'react-native-confirmation-code-field';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import DepositProgressBar from '../../Deposit/components/DepositProgressBar';
 import Row from '../../Aggregator/components/Row';
 import { TRANSAK_SUPPORT_URL } from '../../Deposit/constants';
@@ -76,7 +76,7 @@ const ResendButton: FC<{
 
 const V2OtpCode = () => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {});
   const { email, stateToken, amount, currency, assetId } =
     useParams<V2OtpCodeParams>();
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -106,25 +106,17 @@ const V2OtpCode = () => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const [resetAttemptCount, setResetAttemptCount] = useState(0);
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.otp_code.navbar_title') },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'OTP Code',
-                ramp_type: 'UNIFIED_BUY_2',
-              })
-              .build(),
-          );
-        },
-      ),
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
+        .addProperties({
+          location: 'OTP Code',
+          ramp_type: 'UNIFIED_BUY_2',
+        })
+        .build(),
     );
-  }, [navigation, theme, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -335,6 +327,12 @@ const V2OtpCode = () => {
   return (
     <ScreenLayout testID={OtpCodeSelectorsIDs.OTP_CODE_SCREEN}>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.otp_code.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScreenLayout.Content grow>
           <DepositProgressBar steps={4} currentStep={1} />
           <Text variant={TextVariant.HeadingLg} style={styles.title}>

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.test.tsx
@@ -48,6 +48,16 @@ jest.mock(
   () => 'mock-image',
 );
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: (props: object) => ({ build: () => ({ ...props }) }),
+    }),
+  }),
+}));
+
 const renderWithTheme = (component: React.ReactElement) =>
   render(
     <ThemeContext.Provider value={mockTheme}>
@@ -58,6 +68,15 @@ const renderWithTheme = (component: React.ReactElement) =>
 describe('V2VerifyIdentity', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('calls navigation.goBack when header back is pressed', () => {
+    const { getByTestId } = renderWithTheme(<V2VerifyIdentity />);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
   });
 
   it('navigates to enter email when submit button is pressed', async () => {

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.test.tsx
@@ -5,13 +5,13 @@ import { ThemeContext, mockTheme } from '../../../../../util/theme';
 import { Linking } from 'react-native';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
+    goBack: mockGoBack,
   }),
   useRoute: () => ({
     params: {},
@@ -25,10 +25,6 @@ jest.mock('./EnterEmail', () => ({
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
   I18nEvents: { addListener: jest.fn() },
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getDepositNavbarOptions: jest.fn(() => ({})),
 }));
 
 jest.mock('../../hooks/useRampsUserRegion', () => ({

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
@@ -13,7 +13,7 @@ import styleSheet from '../../Deposit/Views/VerifyIdentity/VerifyIdentity.styles
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
-import { getDepositNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import { strings } from '../../../../../../locales/i18n';
 import VerifyIdentityImage from '../../Deposit/assets/verifyIdentityIllustration.png';
 import PoweredByTransak from '../../Deposit/components/PoweredByTransak';
@@ -44,7 +44,7 @@ export const createV2VerifyIdentityNavDetails =
 
 const V2VerifyIdentity = () => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {});
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { userRegion } = useRampsUserRegion();
   const { amount, currency, assetId } = useParams<V2VerifyIdentityParams>();
@@ -57,25 +57,17 @@ const V2VerifyIdentity = () => {
     );
   }, [navigation, amount, currency, assetId]);
 
-  useEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        { title: strings('deposit.verify_identity.navbar_title') },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'Verify Identity',
-                ramp_type: 'UNIFIED_BUY_2',
-              })
-              .build(),
-          );
-        },
-      ),
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
+        .addProperties({
+          location: 'Verify Identity',
+          ramp_type: 'UNIFIED_BUY_2',
+        })
+        .build(),
     );
-  }, [navigation, theme, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -168,6 +160,12 @@ const V2VerifyIdentity = () => {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.verify_identity.navbar_title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <ScrollView contentContainerStyle={styles.scrollContainer}>
           <ScreenLayout.Content grow>
             <Image

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -193,6 +193,19 @@ describe('OrderDetails', () => {
     expect(result[0]).toBe(Routes.RAMP.RAMPS_ORDER_DETAILS);
   });
 
+  it('calls navigation.goBack when header back is pressed with loaded order', async () => {
+    const { getByTestId } = render();
+
+    await waitFor(() => {
+      expect(getByTestId('order-content')).toBeOnTheScreen();
+    });
+
+    fireEvent.press(getByTestId('ramps-order-details-back-navbar-button'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
   it('shows error state with retry when initial callback fetch fails', async () => {
     mockUseParams.mockReturnValue({
       callbackUrl: 'metamask://on-ramp/providers/paypal?orderId=abc',

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -9,16 +9,15 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 import { RampsOrderStatus } from '@metamask/ramps-controller';
 
-const mockSetOptions = jest.fn();
+const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockSetParams = jest.fn();
 const mockReset = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
-    setOptions: mockSetOptions,
     navigate: mockNavigate,
-    goBack: jest.fn(),
+    goBack: mockGoBack,
     setParams: mockSetParams,
     reset: mockReset,
   }),
@@ -35,12 +34,6 @@ jest.mock('../../hooks/useRampsOrders', () => ({
     getOrderFromCallback: mockGetOrderFromCallback,
     addOrder: mockAddOrder,
   }),
-}));
-
-jest.mock('../../../Navbar', () => ({
-  getRampsOrderDetailsNavbarOptions: jest.fn((_nav, _opts, _theme, onBack) => ({
-    headerLeft: onBack ? () => null : undefined,
-  })),
 }));
 
 jest.mock('../../../../../util/theme', () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../utils/rampsNavigation';
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
 import { strings } from '../../../../../../locales/i18n';
-import { getRampsOrderDetailsNavbarOptions } from '../../../Navbar';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import Routes from '../../../../../constants/navigation/Routes';
 import {
   createNavigationDetails,
@@ -134,6 +134,18 @@ const OrderDetails = () => {
     [getOrderFromCallback, addOrder, navigation],
   );
 
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
+        .addProperties({
+          location: 'Order Details',
+          ramp_type: 'UNIFIED_BUY_2',
+        })
+        .build(),
+    );
+  }, [navigation, trackEvent, createEventBuilder]);
+
   const handleRetryCallbackFetch = useCallback(async () => {
     if (!params.callbackUrl || !params.providerCode || !params.walletAddress) {
       return;
@@ -151,26 +163,6 @@ const OrderDetails = () => {
     params.walletAddress,
     executeCallbackFetch,
   ]);
-
-  useEffect(() => {
-    navigation.setOptions(
-      getRampsOrderDetailsNavbarOptions(
-        navigation,
-        { title: strings('ramps_order_details.title') },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'Order Details',
-                ramp_type: 'UNIFIED_BUY_2',
-              })
-              .build(),
-          );
-        },
-      ),
-    );
-  }, [theme, navigation, createEventBuilder, trackEvent]);
 
   const hasTrackedScreenView = useRef(false);
   useEffect(() => {
@@ -253,6 +245,14 @@ const OrderDetails = () => {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('ramps_order_details.title')}
+            onBack={handleHeaderBack}
+            backButtonProps={{
+              testID: 'ramps-order-details-back-navbar-button',
+            }}
+            includesTopInset
+          />
           <ScreenLayout.Content>
             <ActivityIndicator />
           </ScreenLayout.Content>
@@ -268,6 +268,14 @@ const OrderDetails = () => {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('ramps_order_details.title')}
+            onBack={handleHeaderBack}
+            backButtonProps={{
+              testID: 'ramps-order-details-back-navbar-button',
+            }}
+            includesTopInset
+          />
           <Box twClassName="flex-1 items-center justify-center px-16 py-16">
             <Icon
               name={IconName.Danger}
@@ -302,31 +310,52 @@ const OrderDetails = () => {
   }
 
   if (!order) {
-    return <ScreenLayout />;
+    return (
+      <ScreenLayout>
+        <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('ramps_order_details.title')}
+            onBack={handleHeaderBack}
+            backButtonProps={{
+              testID: 'ramps-order-details-back-navbar-button',
+            }}
+            includesTopInset
+          />
+        </ScreenLayout.Body>
+      </ScreenLayout>
+    );
   }
 
   return (
     <ScreenLayout testID={RampsOrderDetailsSelectorsIDs.CONTAINER}>
-      <ScrollView
-        contentContainerStyle={styles.scrollContentContainer}
-        refreshControl={
-          <RefreshControl
-            colors={[colors.primary.default]}
-            tintColor={colors.icon.default}
-            refreshing={isRefreshing}
-            onRefresh={handleOnRefresh}
-          />
-        }
-      >
-        <ScreenLayout.Body>
+      <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('ramps_order_details.title')}
+          onBack={handleHeaderBack}
+          backButtonProps={{
+            testID: 'ramps-order-details-back-navbar-button',
+          }}
+          includesTopInset
+        />
+        <ScrollView
+          contentContainerStyle={styles.scrollContentContainer}
+          refreshControl={
+            <RefreshControl
+              colors={[colors.primary.default]}
+              tintColor={colors.icon.default}
+              refreshing={isRefreshing}
+              onRefresh={handleOnRefresh}
+            />
+          }
+        >
           <ScreenLayout.Content style={styles.contentContainer}>
             <OrderContent
               order={order}
               showCloseButton={params.showCloseButton}
             />
           </ScreenLayout.Content>
-        </ScreenLayout.Body>
-      </ScrollView>
+        </ScrollView>
+      </ScreenLayout.Body>
     </ScreenLayout>
   );
 };

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
@@ -6,10 +6,10 @@ import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { Country, State, UserRegion } from '@metamask/ramps-controller';
+import { REGION_SELECTOR_TEST_IDS } from './RegionSelector.testIds';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
-const mockSetOptions = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -18,7 +18,6 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
       goBack: mockGoBack,
-      setOptions: mockSetOptions,
     }),
   };
 });
@@ -237,7 +236,9 @@ describe('RegionSelector', () => {
     render(RegionSelector);
     const countryItem = screen.getByText('United States');
     fireEvent.press(countryItem);
-    expect(mockSetOptions).toHaveBeenCalled();
+    expect(
+      screen.getByTestId(REGION_SELECTOR_TEST_IDS.BACK_BUTTON),
+    ).toBeOnTheScreen();
     expect(screen.getByText('California')).toBeOnTheScreen();
   });
 
@@ -303,7 +304,9 @@ describe('RegionSelector', () => {
     render(RegionSelector);
     const countryItem = screen.getByText('United States');
     fireEvent.press(countryItem);
-    expect(mockSetOptions).toHaveBeenCalled();
+    expect(
+      screen.getByTestId(REGION_SELECTOR_TEST_IDS.BACK_BUTTON),
+    ).toBeOnTheScreen();
   });
 
   it('renders search placeholder for states view', () => {
@@ -431,7 +434,9 @@ describe('RegionSelector', () => {
     render(RegionSelector);
     const countryItem = screen.getByText('United States');
     fireEvent.press(countryItem);
-    expect(mockSetOptions).toHaveBeenCalled();
+    expect(
+      screen.getByTestId(REGION_SELECTOR_TEST_IDS.BACK_BUTTON),
+    ).toBeOnTheScreen();
     expect(screen.getByText('California')).toBeOnTheScreen();
   });
 
@@ -530,7 +535,9 @@ describe('RegionSelector', () => {
     render(RegionSelector);
     const countryItem = screen.getByText('United States');
     fireEvent.press(countryItem);
-    expect(mockSetOptions).toHaveBeenCalled();
+    expect(
+      screen.getByTestId(REGION_SELECTOR_TEST_IDS.BACK_BUTTON),
+    ).toBeOnTheScreen();
   });
 
   it('resets search when navigating to state view', () => {

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.test.tsx
@@ -7,6 +7,7 @@ import { backgroundState } from '../../../../../../util/test/initial-root-state'
 import Routes from '../../../../../../constants/navigation/Routes';
 import { Country, State, UserRegion } from '@metamask/ramps-controller';
 import { REGION_SELECTOR_TEST_IDS } from './RegionSelector.testIds';
+import { CommonSelectorsIDs } from '../../../../../../util/Common.testIds';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -215,6 +216,14 @@ describe('RegionSelector', () => {
 
     expect(searchInput.props.value).toBe('');
     expect(screen.getByText('United States')).toBeOnTheScreen();
+  });
+
+  it('calls navigation.goBack when header back is pressed on country list', () => {
+    render(RegionSelector);
+
+    fireEvent.press(screen.getByTestId(CommonSelectorsIDs.BACK_ARROW_BUTTON));
+
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
   it('navigates to states view when country with states is selected', () => {

--- a/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
+++ b/app/components/UI/Ramp/Views/Settings/RegionSelector/RegionSelector.tsx
@@ -12,11 +12,7 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
-import {
-  useNavigation,
-  NavigationProp,
-  ParamListBase,
-} from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import Fuse from 'fuse.js';
 
 import ListItemSelect from '../../../../../../component-library/components/List/ListItemSelect';
@@ -32,15 +28,12 @@ import {
   FontWeight,
   Icon,
   IconName,
-  ButtonIcon,
-  ButtonIconSize,
 } from '@metamask/design-system-react-native';
 
-import styleSheet, {
-  styles as navigationOptionsStyles,
-} from './RegionSelector.styles';
+import styleSheet from './RegionSelector.styles';
 import { useStyles } from '../../../../../hooks/useStyles';
-import { getNavigationOptionsTitle } from '../../../../Navbar';
+import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
+import { CommonSelectorsIDs } from '../../../../../../util/Common.testIds';
 import { strings } from '../../../../../../../locales/i18n';
 import { useAppTheme } from '../../../../../../util/theme';
 import { Country, State } from '@metamask/ramps-controller';
@@ -88,23 +81,6 @@ function isRegionSupported(supported: unknown): boolean {
   );
 }
 
-interface HeaderBackButtonProps {
-  onPress: () => void;
-  testID?: string;
-}
-
-function HeaderBackButton({ onPress, testID }: HeaderBackButtonProps) {
-  return (
-    <ButtonIcon
-      size={ButtonIconSize.Md}
-      iconName={IconName.ArrowLeft}
-      onPress={onPress}
-      style={navigationOptionsStyles.headerLeft}
-      testID={testID}
-    />
-  );
-}
-
 function RegionSelector() {
   const navigation = useNavigation();
   const { colors } = useAppTheme();
@@ -122,20 +98,6 @@ function RegionSelector() {
   const [currentData, setCurrentData] = useState<RegionItem[]>(countries);
   const [regionInTransit, setRegionInTransit] = useState<Country | null>(null);
   const { styles } = useStyles(styleSheet, {});
-
-  useEffect(() => {
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        activeView === RegionViewType.COUNTRY
-          ? strings('fiat_on_ramp_aggregator.region.title')
-          : regionInTransit?.name ||
-              strings('fiat_on_ramp_aggregator.region.title'),
-        navigation,
-        false,
-        colors,
-      ),
-    );
-  }, [colors, navigation, activeView, regionInTransit]);
 
   useEffect(() => {
     if (countries.length > 0 && activeView === RegionViewType.COUNTRY) {
@@ -638,38 +600,42 @@ function RegionSelector() {
     navigation.goBack();
   }, [navigation]);
 
-  const stateHeaderLeft = useCallback(
-    () => (
-      <HeaderBackButton
-        onPress={handleRegionBackButton}
-        testID={REGION_SELECTOR_TEST_IDS.BACK_BUTTON}
-      />
-    ),
-    [handleRegionBackButton],
+  const headerTitle = useMemo(
+    () =>
+      activeView === RegionViewType.COUNTRY
+        ? strings('fiat_on_ramp_aggregator.region.title')
+        : regionInTransit?.name ||
+          strings('fiat_on_ramp_aggregator.region.title'),
+    [activeView, regionInTransit],
   );
 
-  const defaultHeaderLeft = useCallback(
-    () => <HeaderBackButton onPress={handleGoBack} />,
-    [handleGoBack],
+  const headerBackTestId = useMemo(
+    () =>
+      activeView === RegionViewType.STATE
+        ? REGION_SELECTOR_TEST_IDS.BACK_BUTTON
+        : CommonSelectorsIDs.BACK_ARROW_BUTTON,
+    [activeView],
   );
 
-  useEffect(() => {
+  const handleHeaderBack = useCallback(() => {
     if (activeView === RegionViewType.STATE) {
-      navigation.setOptions({
-        headerLeft: stateHeaderLeft,
-      });
+      handleRegionBackButton();
     } else {
-      navigation.setOptions({
-        headerLeft: defaultHeaderLeft,
-      });
+      handleGoBack();
     }
-  }, [activeView, navigation, stateHeaderLeft, defaultHeaderLeft]);
+  }, [activeView, handleRegionBackButton, handleGoBack]);
 
   return (
     <KeyboardAvoidingView
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
+      <HeaderCompactStandard
+        title={headerTitle}
+        onBack={handleHeaderBack}
+        backButtonProps={{ testID: headerBackTestId }}
+        includesTopInset
+      />
       <View style={styles.searchContainer}>
         {activeView === RegionViewType.COUNTRY && (
           <Text
@@ -724,20 +690,5 @@ function RegionSelector() {
     </KeyboardAvoidingView>
   );
 }
-
-RegionSelector.navigationOptions = ({
-  navigation,
-}: {
-  navigation: NavigationProp<ParamListBase>;
-}) => ({
-  headerLeft: () => (
-    <ButtonIcon
-      size={ButtonIconSize.Md}
-      iconName={IconName.ArrowLeft}
-      onPress={() => navigation.goBack()}
-      style={navigationOptionsStyles.headerLeft}
-    />
-  ),
-});
 
 export default RegionSelector;

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
@@ -12,15 +12,13 @@ import { useRampsController } from '../../hooks/useRampsController';
 import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
-const mockSetOptions = jest.fn();
-const mockGoBack = jest.fn();
+const mockHeaderGoBack = jest.fn();
 const mockParentGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
-    setOptions: mockSetOptions,
-    goBack: mockGoBack,
+    goBack: mockHeaderGoBack,
     getParent: () => ({
       goBack: mockParentGoBack,
     }),

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
@@ -25,6 +25,16 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: () => ({
+      addProperties: () => ({ build: () => ({}) }),
+    }),
+  }),
+}));
+
 interface CustomTestState {
   fiatOrders?: {
     rampRoutingDecision?: UnifiedRampRoutingType;
@@ -204,6 +214,60 @@ describe('TokenSelection Component', () => {
     expect(
       getByPlaceholderText('Search token by name or address'),
     ).toBeOnTheScreen();
+  });
+
+  it('calls navigation.goBack when header back is pressed (V2 loaded list)', () => {
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+    const { getByTestId } = renderWithProvider(TokenSelection);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockHeaderGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('calls navigation.goBack when header back is pressed while tokens are loading (V2)', () => {
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+    mockUseRampsController.mockReturnValue({
+      tokens: null,
+      selectedToken: null,
+      setSelectedToken: jest.fn(),
+      tokensLoading: true,
+      tokensError: null,
+      userRegion: null,
+      setUserRegion: jest.fn(),
+      selectedProvider: null,
+      setSelectedProvider: jest.fn(),
+      providers: [],
+      providersLoading: false,
+      providersError: null,
+      countries: [],
+      countriesLoading: false,
+      countriesError: null,
+      paymentMethods: [],
+      selectedPaymentMethod: null,
+      setSelectedPaymentMethod: jest.fn(),
+      paymentMethodsLoading: false,
+      paymentMethodsError: null,
+      paymentMethodsFetching: false,
+      paymentMethodsStatus: 'idle' as const,
+      getQuotes: jest.fn(),
+      getBuyWidgetData: jest.fn(),
+      orders: [],
+      getOrderById: jest.fn(),
+      addOrder: jest.fn(),
+      addPrecreatedOrder: jest.fn(),
+      removeOrder: jest.fn(),
+      refreshOrder: jest.fn(),
+      getOrderFromCallback: jest.fn(),
+    });
+
+    const { getByTestId } = renderWithProvider(TokenSelection);
+
+    fireEvent.press(getByTestId('deposit-back-navbar-button'));
+
+    expect(mockHeaderGoBack).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
   });
 
   it('displays empty state when no tokens match search', async () => {

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
@@ -1,7 +1,6 @@
 import React, {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -13,6 +12,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 
 import ScreenLayout from '../../Aggregator/components/ScreenLayout';
+import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import TokenNetworkFilterBar from '../../components/TokenNetworkFilterBar';
 import TokenListItem from '../../components/TokenListItem';
 import { createUnsupportedTokenModalNavigationDetails } from '../Modals/UnsupportedTokenModal/UnsupportedTokenModal';
@@ -33,7 +33,6 @@ import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
 import { useRampsController } from '../../hooks/useRampsController';
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../locales/i18n';
-import { getDepositNavbarOptions } from '../../../Navbar';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import { useRampNavigation } from '../../hooks/useRampNavigation';
@@ -322,33 +321,28 @@ function TokenSelection() {
     return Array.from(uniqueNetworksSet);
   }, [supportedTokens]);
 
-  useLayoutEffect(() => {
-    navigation.setOptions(
-      getDepositNavbarOptions(
-        navigation,
-        {
-          title: strings('deposit.token_modal.select_token'),
-          showBack: false,
-        },
-        theme,
-        () => {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
-              .addProperties({
-                location: 'Token Selection',
-                ramp_type: rampType,
-              })
-              .build(),
-          );
-        },
-      ),
+  const handleHeaderBack = useCallback(() => {
+    navigation.goBack();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
+        .addProperties({
+          location: 'Token Selection',
+          ramp_type: rampType,
+        })
+        .build(),
     );
-  }, [navigation, theme, createEventBuilder, trackEvent, rampType]);
+  }, [navigation, trackEvent, createEventBuilder, rampType]);
 
   if (isLoading) {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('deposit.token_modal.select_token')}
+            onBack={handleHeaderBack}
+            backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+            includesTopInset
+          />
           <Box twClassName="flex-1 items-center justify-center">
             <ActivityIndicator
               size="large"
@@ -365,6 +359,12 @@ function TokenSelection() {
     return (
       <ScreenLayout>
         <ScreenLayout.Body>
+          <HeaderCompactStandard
+            title={strings('deposit.token_modal.select_token')}
+            onBack={handleHeaderBack}
+            backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+            includesTopInset
+          />
           <Box twClassName="flex-1 items-center justify-center px-4">
             <Box twClassName="text-center">
               <Text variant={TextVariant.BodyMd}>
@@ -386,6 +386,12 @@ function TokenSelection() {
   return (
     <ScreenLayout>
       <ScreenLayout.Body>
+        <HeaderCompactStandard
+          title={strings('deposit.token_modal.select_token')}
+          onBack={handleHeaderBack}
+          backButtonProps={{ testID: 'deposit-back-navbar-button' }}
+          includesTopInset
+        />
         <Box twClassName="px-4 pb-3">
           <TextFieldSearch
             testID={selectTokenSelectors.TOKEN_SELECT_MODAL_SEARCH_INPUT}

--- a/app/components/UI/Ramp/routes.tsx
+++ b/app/components/UI/Ramp/routes.tsx
@@ -35,7 +35,10 @@ const Stack = createStackNavigator();
 const ModalsStack = createStackNavigator();
 
 const MainRoutes = () => (
-  <Stack.Navigator initialRouteName={Routes.RAMP.TOKEN_SELECTION}>
+  <Stack.Navigator
+    initialRouteName={Routes.RAMP.TOKEN_SELECTION}
+    screenOptions={{ headerShown: false }}
+  >
     <Stack.Screen
       name={Routes.RAMP.TOKEN_SELECTION}
       component={TokenSelection}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Reason

Unified Buy v2 (ramp) screens were still partially coupled to React Navigation’s stack header via `navigation.setOptions`, `navigationOptions`, or implicit defaults. That produced **inconsistent UX** with other migrated flows: duplicate titles/back affordances, route-name titles (for example when the same screen was mounted from Activity), and harder-to-reason layout when combined with fullscreen `BottomSheet` (for example Checkout).

Internal ticket: **TRAM-3451** (inline headers for ramp views).

### What changed

1. **Ramp inner stack (`app/components/UI/Ramp/routes.tsx`)**  
   Set `screenOptions={{ headerShown: false }}` on the inner `Stack.Navigator` so Buy v2 routes **do not** render the default stack header by default. Each screen owns its chrome via `HeaderCompactStandard` (or equivalent) where needed.

2. **Activity / wallet path for order details (`app/components/UI/Nav/Main/MainNavigator.js`)**  
   `Routes.RAMP.RAMPS_ORDER_DETAILS` is registered on the transactions stack as well as inside the ramp flow. That stack still used the default header, which caused a **double header** with the migrated `OrderDetails` view. Added `options={{ headerShown: false }}` for that screen so only the in-view header shows.

3. **Native KYC / onboarding-style ramp views**  
   Migrated to inline `HeaderCompactStandard` + explicit back handling (using `navigation.goBack()` where appropriate for the typed navigation API), preserving existing MetaMetrics events where the old navbar helpers did. Touched: `EnterEmail`, `OtpCode`, `AdditionalVerification`, `OrderProcessing`, `EnterAddress`, `BasicInfo`, `VerifyIdentity`, `KycProcessing` (including branch-specific layouts), `BankDetails`.

4. **Checkout (`Checkout.tsx`)**  
   Removed stack-header coupling and simplified the top chrome to match the fullscreen WebView sheet (close-only header pattern as agreed for this flow). Tests were updated accordingly (including removal of obsolete header-back expectations).

5. **Token selection**  
   Removed `useLayoutEffect` / `setOptions` usage; header is provided inline for loading, error, and main states.

6. **Region selector**  
   Removed `setOptions` / static `navigationOptions`; added inline header with dynamic title/back `testID`s. `MainNavigator` sets `headerShown: false` for `Routes.SETTINGS.REGION_SELECTOR` instead of delegating to removed `RegionSelector.navigationOptions`.

7. **Order details**  
   Inline header with back/close behavior aligned with params; tests updated for navigation mocks (`goBack` vs `pop` where relevant).

8. **Tests**  
   Unit tests for the above screens were updated: mocks for `setOptions` / `pop` where removed, assertions adjusted for duplicate title text where header + body share copy, and Checkout close/back coverage aligned with the new UI.

### Risk / scope notes

- **Navigation**: Back is now explicit per screen; behavior should match prior flows, with `goBack()` used consistently with the app’s typed `useNavigation` surface.
- **Analytics**: Screen-level events that previously fired from navbar helpers should still fire from the new handlers where we preserved them; Checkout header back analytics were dropped with the back affordance.
- **No engine / controller API changes** in this PR—UI and navigation wiring only.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved unified buy and ramp order screens so headers are shown once and match the rest of the in-app flow.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TRAM-3451 ramp inline headers (unified buy v2)

  Scenario: Build quote to Checkout (in-app WebView)
    Given the user is on Unified Buy v2 Build quote with a provider that opens in-app Checkout
    When the user continues into Checkout
    Then the screen shows a single top chrome (no duplicate React Navigation stack header above the sheet)
    And the user can dismiss Checkout with the close control and returns to the prior flow as before

  Scenario: Native ramp steps show one header
    Given the user enters a native KYC or onboarding step (for example Enter email, OTP, Verify identity, Bank details)
    When the screen finishes loading
    Then only the compact inline header is visible (no second stack header with route title)
    And the back control navigates back to the previous step

  Scenario: Order details from Activity
    Given the user opens Activity and taps a ramp order that opens RAMPS_ORDER_DETAILS on the transactions stack
    When the order details screen is shown
    Then there is no duplicate native header titled with the route component name
    And the in-screen header shows the expected title and actions

  Scenario: Region selector from settings
    Given the user opens Region selector from settings entry that uses MainNavigator
    When the region list is displayed
    Then the stack does not render a duplicate default header above the region selector content
    And back from the inline header returns to the previous settings context

  Scenario: Token selection states
    Given the user is on ramp token selection in loading, error, or loaded state
    Then the header is provided by the screen (no reliance on stack setOptions for title or actions)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — Not applicable for this PR (no before/after screenshots attached).

### **After**


https://github.com/user-attachments/assets/c7fdad3d-a81e-46b1-bd54-e6224835d968



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates navigation/header behavior across multiple Ramp Unified Buy v2 and settings screens, which can change back navigation and analytics triggering if any edge paths were missed. No controller/engine or data-layer changes, but UI flow regressions are possible due to header ownership moving into screens.
> 
> **Overview**
> **Unifies Ramp Unified Buy v2 header behavior by removing reliance on React Navigation stack headers.** The inner Ramp stack now defaults to `headerShown: false`, and `MainNavigator` also disables the stack header for `Routes.RAMP.RAMPS_ORDER_DETAILS` (Activity path) and `Routes.SETTINGS.REGION_SELECTOR` to prevent double headers.
> 
> Ramp V2 screens (Checkout, token selection, native KYC/onboarding steps, order details, and region selector) were migrated from `navigation.setOptions`/`navigationOptions` + navbar helpers to inline `HeaderCompactStandard` with explicit back/close handlers, keeping existing back/close MetaMetrics tracking where applicable. Tests were updated to drop `setOptions` mocks/assertions and to validate the new inline header/back button behavior (including the removal of Checkout back-navbar analytics coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f50108b6bafb2fc2aa20efd91e2fbf67096131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->