### PR TITLE
chore: fix fetch history from webview on advanced charts

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -330,7 +330,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             if (__DEV__) {
               // WebView console is not the Metro / Xcode log; chartLogic mirrors here via DEBUG.
               // eslint-disable-next-line no-console -- intentional dev bridge from WebView
-              console.log(message.payload.message);
+              console.log('[AdvancedChart]', message.payload);
             }
             break;
 

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChartTemplate.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChartTemplate.ts
@@ -102,7 +102,7 @@ export const createAdvancedChartTemplate = (
     <meta charset="UTF-8">
     <title>TradingView Advanced Chart</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${CHARTING_LIBRARY_BASE_URL}; script-src 'unsafe-inline' ${CHARTING_LIBRARY_BASE_URL}; style-src 'unsafe-inline' ${CHARTING_LIBRARY_BASE_URL}; img-src 'self' data: ${CHARTING_LIBRARY_BASE_URL}; font-src ${CHARTING_LIBRARY_BASE_URL}; worker-src blob:; frame-src 'self' blob: ${CHARTING_LIBRARY_ORIGIN}; connect-src 'none'; object-src 'none'; base-uri 'none'; frame-ancestors 'none';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' ${CHARTING_LIBRARY_BASE_URL}; script-src 'unsafe-inline' ${CHARTING_LIBRARY_BASE_URL}; style-src 'unsafe-inline' ${CHARTING_LIBRARY_BASE_URL}; img-src 'self' data: ${CHARTING_LIBRARY_BASE_URL}; font-src ${CHARTING_LIBRARY_BASE_URL}; worker-src blob:; frame-src 'self' blob: ${CHARTING_LIBRARY_ORIGIN}; connect-src https://price.api.cx.metamask.io; object-src 'none'; base-uri 'none'; frame-ancestors 'none';">
     <style>
         /*
          * Page root: fill the WebView, no scrolling. TradingView draws inside this area.

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -3007,6 +3007,7 @@ var OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv-chart';
  */
 function fetchOlderBars(pending) {
   var pag = window.ohlcvPagination;
+
   if (!pag.nextCursor || !pag.hasMore || !pag.assetId) {
     pending.onResult([], { noData: true });
     if (window.__mmLayoutSettlePending) {
@@ -3016,15 +3017,15 @@ function fetchOlderBars(pending) {
   }
 
   var gen = window.ohlcvGeneration;
-  var url =
-    OHLCV_BASE_URL +
-    '/' +
-    encodeURIComponent(pag.assetId) +
-    '?nextCursor=' +
-    encodeURIComponent(pag.nextCursor);
+  // Build URL using the same approach as RN: construct then add query params
+  // AssetId contains "/" which should be preserved in the path
+  var url = OHLCV_BASE_URL + '/' + pag.assetId;
+  var queryParams = [];
+  queryParams.push('nextCursor=' + encodeURIComponent(pag.nextCursor));
   if (pag.vsCurrency) {
-    url += '&vsCurrency=' + encodeURIComponent(pag.vsCurrency);
+    queryParams.push('vsCurrency=' + encodeURIComponent(pag.vsCurrency));
   }
+  url = url + '?' + queryParams.join('&');
 
   fetch(url)
     .then(function (response) {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -3016,6 +3016,7 @@ var OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv-chart';
  */
 function fetchOlderBars(pending) {
   var pag = window.ohlcvPagination;
+  
   if (!pag.nextCursor || !pag.hasMore || !pag.assetId) {
     pending.onResult([], { noData: true });
     if (window.__mmLayoutSettlePending) {
@@ -3025,15 +3026,15 @@ function fetchOlderBars(pending) {
   }
 
   var gen = window.ohlcvGeneration;
-  var url =
-    OHLCV_BASE_URL +
-    '/' +
-    encodeURIComponent(pag.assetId) +
-    '?nextCursor=' +
-    encodeURIComponent(pag.nextCursor);
+  // Build URL using the same approach as RN: construct then add query params
+  // AssetId contains "/" which should be preserved in the path
+  var url = OHLCV_BASE_URL + '/' + pag.assetId;
+  var queryParams = [];
+  queryParams.push('nextCursor=' + encodeURIComponent(pag.nextCursor));
   if (pag.vsCurrency) {
-    url += '&vsCurrency=' + encodeURIComponent(pag.vsCurrency);
+    queryParams.push('vsCurrency=' + encodeURIComponent(pag.vsCurrency));
   }
+  url = url + '?' + queryParams.join('&');
 
   fetch(url)
     .then(function (response) {


### PR DESCRIPTION


## **Description**

Fixes advanced chart pagination that prevented loading older historical data when scrolling left on the chart.
## Problem
After the WebView-based pagination PR was merged, chart scroll-back pagination stopped working. When users scrolled left to view older historical data, no additional API requests were made, preventing access to historical candles beyond the initial load.
Investigation revealed two issues:
1. **CSP blocking**: The Content Security Policy had `connect-src 'none'` which blocked all fetch requests from the WebView
2. **Incorrect URL encoding**: The assetId path component (e.g., `eip155:8453/slip44:60`) was being URL-encoded with `encodeURIComponent()`, which encoded the forward slash to `%2F`, causing the API to return 404
## Solution
1. Updated CSP `connect-src` directive to allow `https://price.api.cx.metamask.io`
2. Fixed URL construction in `fetchOlderBars` to preserve the forward slash in the assetId path:
   - Changed from: `encodeURIComponent(pag.assetId)` 
   - To: Direct concatenation without encoding the path component
   - Query parameters (nextCursor, vsCurrency) remain properly encoded

## Test Locally (Optional Debug Logs)
To add temporary debug logs for testing, add the following in `chartLogic.js` inside `fetchOlderBars`:
**Before the fetch (line ~3030):**
```javascript
// Log fetch request
sendToReactNative('DEBUG', {
  message: '[Pagination] Fetching: ' + url,
});
```
After successful response (line ~3059):
```javascript
// Log successful response
window.ohlcvPagination.hasMore = !!result.hasNext;
sendToReactNative('DEBUG', {
  message: '[Pagination] Success: received ' + newBars.length + ' bars, hasNext=' + result.hasNext,
});
```
Update error log (line ~3086):
```javascript
sendToReactNative('DEBUG', {
  message: '[Pagination] Error: ' + (err.message || String(err)),
});
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/2d0f019b-f04d-443c-8a1d-d276b7bdb561


### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/9fc49c9e-8120-4572-9ef2-1b98ecb8011e



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it loosens the WebView CSP and changes how historical price data is fetched/constructed, which could impact chart loading behavior or network access if misconfigured.
> 
> **Overview**
> Fixes AdvancedChart historical scroll-back pagination by enabling WebView-side OHLCV fetches to the Price API (CSP `connect-src` now allows `https://price.api.cx.metamask.io`).
> 
> Corrects `fetchOlderBars` URL construction so `assetId` remains a path segment (preserving `/`) while keeping query params (`nextCursor`, `vsCurrency`) encoded, preventing 404s when requesting older candles. Also tweaks WebView `DEBUG` logging to include an `[AdvancedChart]` prefix and log the full payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03104adde28034b53300c4624fdc0975b0c88be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->