### PR TITLE
fix: add asset_symbol to Ramps Button Clicked event for token buy actions

### DIFF
--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -10,6 +10,7 @@ interface RampsButtonClicked {
   is_authenticated?: boolean;
   preferred_provider?: string;
   order_count?: number;
+  asset_symbol?: string;
 }
 
 interface RampsDepositCashButtonClicked {

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.test.ts
@@ -316,6 +316,27 @@ describe('useTokenActions', () => {
 
       expect(mockTrackEvent).toHaveBeenCalledTimes(2);
     });
+
+    it('includes asset_symbol in RAMPS_BUTTON_CLICKED event', () => {
+      const { result } = renderHook(() =>
+        useTokenActions({
+          token: defaultToken,
+          networkName: 'Ethereum Mainnet',
+        }),
+      );
+
+      result.current.onBuy();
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.RAMPS_BUTTON_CLICKED,
+      );
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: 'TokenDetails',
+          asset_symbol: 'DAI',
+        }),
+      );
+    });
   });
 
   describe('onSend', () => {

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.ts
@@ -308,6 +308,7 @@ export const useTokenActions = ({
           is_authenticated: rampsButtonClickData.is_authenticated,
           preferred_provider: rampsButtonClickData.preferred_provider,
           order_count: rampsButtonClickData.order_count,
+          asset_symbol: token.symbol,
         })
         .build(),
     );
@@ -322,6 +323,7 @@ export const useTokenActions = ({
     rampGeodetectedRegion,
     rampsButtonClickData,
     goToBuy,
+    token.symbol,
   ]);
 
   // Convert current token to BridgeToken format (used as dest for Buy, source for Sell)

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.test.tsx
@@ -285,6 +285,16 @@ describe('PopularTokenRow', () => {
 
       expect(mockTrackBuyButtonClicked).toHaveBeenCalledTimes(1);
     });
+
+    it('passes the token symbol to the analytics event when Buy is pressed', () => {
+      const token = createMockToken({ symbol: 'USDC' });
+
+      renderWithProvider(<PopularTokenRow token={token} />);
+
+      fireEvent.press(screen.getByText('Buy'));
+
+      expect(mockTrackBuyButtonClicked).toHaveBeenCalledWith('USDC');
+    });
   });
 
   describe('edge cases', () => {

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokenRow.tsx
@@ -167,9 +167,9 @@ const PopularTokenRow: React.FC<PopularTokenRowProps> = ({ token }) => {
   }, [navigation, token.assetId, token.symbol]);
 
   const handleBuy = useCallback(() => {
-    trackBuyButtonClicked();
+    trackBuyButtonClicked(token.symbol);
     goToBuy({ assetId: token.assetId }, { buyFlowOrigin: 'homeTokenList' });
-  }, [trackBuyButtonClicked, goToBuy, token.assetId]);
+  }, [trackBuyButtonClicked, goToBuy, token.assetId, token.symbol]);
 
   const priceDisplay = useMemo(() => {
     if (token.price === undefined) {

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.test.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.test.ts
@@ -78,8 +78,33 @@ describe('useRampsButtonClickedEvent', () => {
       is_authenticated: false,
       preferred_provider: undefined,
       order_count: 0,
+      asset_symbol: undefined,
     });
     expect(mockTrackEvent).toHaveBeenCalledWith({ event: 'built' });
+  });
+
+  it('includes asset_symbol when provided', () => {
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked('ETH');
+    });
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ asset_symbol: 'ETH' }),
+    );
+  });
+
+  it('omits asset_symbol when not provided', () => {
+    const { result } = renderHook(() => useRampsButtonClickedEvent());
+
+    act(() => {
+      result.current.trackBuyButtonClicked();
+    });
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ asset_symbol: undefined }),
+    );
   });
 
   it('fires with ramp_type UNIFIED_BUY when V1 is enabled', () => {

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/useRampsButtonClickedEvent.ts
@@ -20,35 +20,39 @@ export const useRampsButtonClickedEvent = () => {
   const isV2UnifiedEnabled = useRampsUnifiedV2Enabled();
   const region = useSelector(getDetectedGeolocation);
 
-  const trackBuyButtonClicked = useCallback(() => {
-    const rampType = isV2UnifiedEnabled
-      ? 'UNIFIED_BUY_2'
-      : rampUnifiedV1Enabled
-        ? 'UNIFIED_BUY'
-        : 'BUY';
+  const trackBuyButtonClicked = useCallback(
+    (assetSymbol?: string) => {
+      const rampType = isV2UnifiedEnabled
+        ? 'UNIFIED_BUY_2'
+        : rampUnifiedV1Enabled
+          ? 'UNIFIED_BUY'
+          : 'BUY';
 
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)
-        .addProperties({
-          button_text: 'Buy',
-          location: 'TokensSection',
-          ramp_type: rampType,
-          region,
-          ramp_routing: buttonClickData.ramp_routing,
-          is_authenticated: buttonClickData.is_authenticated,
-          preferred_provider: buttonClickData.preferred_provider,
-          order_count: buttonClickData.order_count,
-        })
-        .build(),
-    );
-  }, [
-    trackEvent,
-    createEventBuilder,
-    isV2UnifiedEnabled,
-    rampUnifiedV1Enabled,
-    region,
-    buttonClickData,
-  ]);
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)
+          .addProperties({
+            button_text: 'Buy',
+            location: 'TokensSection',
+            ramp_type: rampType,
+            region,
+            ramp_routing: buttonClickData.ramp_routing,
+            is_authenticated: buttonClickData.is_authenticated,
+            preferred_provider: buttonClickData.preferred_provider,
+            order_count: buttonClickData.order_count,
+            asset_symbol: assetSymbol,
+          })
+          .build(),
+      );
+    },
+    [
+      trackEvent,
+      createEventBuilder,
+      isV2UnifiedEnabled,
+      rampUnifiedV1Enabled,
+      region,
+      buttonClickData,
+    ],
+  );
 
   return { trackBuyButtonClicked };
 };


### PR DESCRIPTION
## **Description**

The `Ramps Button Clicked` analytics event was missing the `asset_symbol` property when fired from the token section on the home screen and from the token details page. This meant we had no visibility into which asset a user intended to buy.

- Added `asset_symbol?: string` to the `RampsButtonClicked` analytics type
- Updated `useRampsButtonClickedEvent` hook to accept and forward `asset_symbol` to the event
- Passed `token.symbol` from `PopularTokenRow` (home screen zero-balance state) into the hook
- Passed `token.symbol` from `useTokenActions` (token details Buy button) directly into the event

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-607

## **Manual testing steps**

```gherkin
Feature: Ramps Button Clicked event includes asset symbol

  Scenario: user taps Buy on a popular token from the home screen
    Given the user has an account with zero token balance
    And the user is on the home screen

    When user taps the "Buy" button next to any popular token (e.g. ETH)
    Then the "Ramps Button Clicked" analytics event fires with asset_symbol set to that token's symbol (e.g. "ETH")

  Scenario: user taps Buy from the token details page
    Given the user has navigated to a token details page (e.g. DAI)

    When user taps the "Buy" button in the action bar
    Then the "Ramps Button Clicked" analytics event fires with asset_symbol set to "DAI"
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/a95fb018-0775-47ee-a57a-444667eb2dbe

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ x I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive analytics-only changes (new optional property and parameter) with no impact on transaction flow or security-sensitive logic.
> 
> **Overview**
> Adds `asset_symbol` to the `RAMPS_BUTTON_CLICKED` analytics payload so token buy intent is captured from both the home Tokens section and Token Details.
> 
> Updates `useRampsButtonClickedEvent` to accept an optional symbol and wires `token.symbol` through `PopularTokenRow` and `useTokenActions`, with new/updated tests asserting the property is present (or `undefined` when omitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40b0f4bbbe67a6dfaea57b932b3e9bdadc7057e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->