### PR TITLE
feat(perps): add decimal parity recipe coverage

### DIFF
--- a/scripts/perps/agentic/teams/perps/recipes/mobile-decimal-matrix.json
+++ b/scripts/perps/agentic/teams/perps/recipes/mobile-decimal-matrix.json
@@ -1,0 +1,197 @@
+{
+  "title": "Mobile perps decimal matrix",
+  "validate": {
+    "workflow": {
+      "pre_conditions": [
+        "wallet.unlocked",
+        "perps.feature_enabled"
+      ],
+      "entry": "btc-nav-market",
+      "nodes": {
+        "btc-nav-market": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "BTC",
+              "name": "BTC",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "btc-wait-market"
+        },
+        "btc-wait-market": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "next": "btc-market-data"
+        },
+        "btc-market-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-market-header')); return JSON.stringify({symbol:'BTC',screen:'market_detail',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "btc_market",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "btc-open-order"
+        },
+        "btc-open-order": {
+          "action": "press",
+          "test_id": "perps-market-details-long-button",
+          "next": "btc-wait-order"
+        },
+        "btc-wait-order": {
+          "action": "wait_for",
+          "route": "RedesignedConfirmations",
+          "next": "btc-order-data"
+        },
+        "btc-order-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-order-header')); return JSON.stringify({symbol:'BTC',screen:'order_entry',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "btc_order",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "eth-nav-market"
+        },
+
+        "eth-nav-market": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "ETH",
+              "name": "ETH",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "eth-wait-market"
+        },
+        "eth-wait-market": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "next": "eth-market-data"
+        },
+        "eth-market-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-market-header')); return JSON.stringify({symbol:'ETH',screen:'market_detail',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "eth_market",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "eth-open-order"
+        },
+        "eth-open-order": {
+          "action": "press",
+          "test_id": "perps-market-details-long-button",
+          "next": "eth-wait-order"
+        },
+        "eth-wait-order": {
+          "action": "wait_for",
+          "route": "RedesignedConfirmations",
+          "next": "eth-order-data"
+        },
+        "eth-order-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-order-header')); return JSON.stringify({symbol:'ETH',screen:'order_entry',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "eth_order",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "sol-nav-market"
+        },
+
+        "sol-nav-market": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "SOL",
+              "name": "SOL",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "sol-wait-market"
+        },
+        "sol-wait-market": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "next": "sol-market-data"
+        },
+        "sol-market-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-market-header')); return JSON.stringify({symbol:'SOL',screen:'market_detail',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "sol_market",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "fartcoin-nav-market"
+        },
+
+        "fartcoin-nav-market": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "FARTCOIN",
+              "name": "FARTCOIN",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "fartcoin-wait-market"
+        },
+        "fartcoin-wait-market": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "next": "fartcoin-market-data"
+        },
+        "fartcoin-market-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-market-header')); return JSON.stringify({symbol:'FARTCOIN',screen:'market_detail',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "fartcoin_market",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "pump-nav-market"
+        },
+
+        "pump-nav-market": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "PUMP",
+              "name": "PUMP",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "pump-wait-market"
+        },
+        "pump-wait-market": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "next": "pump-market-data"
+        },
+        "pump-market-data": {
+          "action": "eval_sync",
+          "expression": "(function(){ function flat(v,out){ if(v===null||v===undefined)return; if(typeof v==='string'||typeof v==='number'){ var s=String(v).trim(); if(s) out.push(s); return; } if(Array.isArray(v)){ for(var i=0;i<v.length;i++) flat(v[i],out); return; } if(v&&v.props&&v.props.children!==undefined){ flat(v.props.children,out); } } function find(testId){ var hook=globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; if(!hook||!hook.renderers||!hook.getFiberRoots)return null; var found=null; function walk(f){ if(!f||found)return; var p=f.memoizedProps; if(p&&p.testID===testId){ found=f; return; } walk(f.child); walk(f.sibling); } var it=hook.renderers.entries(); var step=it.next(); while(!step.done){ var roots=hook.getFiberRoots(step.value[0]); if(roots){ roots.forEach(function(r){ if(!found&&r.current) walk(r.current); }); } if(found) break; step=it.next(); } return found; } function collect(root){ var out=[]; function walk(f){ if(!f)return; var p=f.memoizedProps; if(p&&p.children!==undefined) flat(p.children,out); walk(f.child); walk(f.sibling); } walk(root); return out; } function firstMatch(arr,re){ for(var i=0;i<arr.length;i++){ if(re.test(arr[i])) return arr[i]; } return null; } var header=collect(find('perps-market-header')); return JSON.stringify({symbol:'PUMP',screen:'market_detail',title:header[0]||null,price:firstMatch(header,/^\\$/),change:firstMatch(header,/%$/),header:header.slice(0,12)}); })()",
+          "save_as": "pump_market",
+          "assert": { "operator": "not_null", "field": "price" },
+          "next": "done"
+        },
+
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/scripts/perps/agentic/teams/perps/recipes/mobile-decimal-parity.json
+++ b/scripts/perps/agentic/teams/perps/recipes/mobile-decimal-parity.json
@@ -1,0 +1,213 @@
+{
+  "title": "Mobile perps decimal parity reference",
+  "validate": {
+    "workflow": {
+      "pre_conditions": [
+        "wallet.unlocked",
+        "perps.feature_enabled"
+      ],
+      "setup": [
+        {
+          "id": "setup-account",
+          "action": "call",
+          "ref": "perps/select-account",
+          "params": {
+            "address": "0x8dc623e964475d4d669da601fd15ea9125469003"
+          }
+        },
+        {
+          "id": "setup-testnet",
+          "action": "call",
+          "ref": "perps/setup-testnet"
+        },
+        {
+          "id": "setup-clear-eth",
+          "action": "eval_async",
+          "expression": "Engine.context.PerpsController.getPositions().then(function(ps){var p=ps.find(function(x){return x.symbol==='ETH'});if(!p){return JSON.stringify({cleared:true});}return Engine.context.PerpsController.closePosition({symbol:'ETH'}).then(function(){return JSON.stringify({cleared:true});});})",
+          "assert": {
+            "operator": "eq",
+            "field": "cleared",
+            "value": true
+          }
+        },
+        {
+          "id": "setup-wait-no-eth",
+          "action": "wait_for",
+          "expression": "Engine.context.PerpsController.getPositions().then(function(ps){var p=ps.find(function(x){return x.symbol==='ETH'});return JSON.stringify({found:!!p});})",
+          "assert": {
+            "operator": "eq",
+            "field": "found",
+            "value": false
+          },
+          "timeout_ms": 10000
+        }
+      ],
+      "entry": "ac1-home",
+      "nodes": {
+        "ac1-home": {
+          "action": "navigate",
+          "target": "PerpsHomeView",
+          "next": "ac1-home-wait"
+        },
+        "ac1-home-wait": {
+          "action": "wait_for",
+          "route": "PerpsMarketListView",
+          "next": "ac1-home-shot"
+        },
+        "ac1-home-shot": {
+          "action": "screenshot",
+          "filename": "mobile-01-home.png",
+          "next": "ac2-market"
+        },
+        "ac2-market": {
+          "action": "call",
+          "ref": "perps/market-discovery",
+          "params": {
+            "symbol": "ETH"
+          },
+          "next": "ac2-market-shot"
+        },
+        "ac2-market-shot": {
+          "action": "screenshot",
+          "filename": "mobile-02-market-detail.png",
+          "next": "ac3-order-press"
+        },
+        "ac3-order-press": {
+          "action": "press",
+          "test_id": "perps-market-details-long-button",
+          "next": "ac3-order-wait"
+        },
+        "ac3-order-wait": {
+          "action": "wait_for",
+          "route": "RedesignedConfirmations",
+          "next": "ac3-order-shot"
+        },
+        "ac3-order-shot": {
+          "action": "screenshot",
+          "filename": "mobile-03-order-entry.png",
+          "next": "ac3-open-eth"
+        },
+        "ac3-open-eth": {
+          "action": "call",
+          "ref": "perps/trade-open-market",
+          "params": {
+            "symbol": "ETH",
+            "side": "long",
+            "usdAmount": "11",
+            "leverage": "2"
+          },
+          "next": "ac3-wait-eth"
+        },
+        "ac3-wait-eth": {
+          "action": "wait_for",
+          "expression": "Engine.context.PerpsController.getPositions().then(function(ps){var p=ps.find(function(x){return x.symbol==='ETH'});return JSON.stringify({found:!!p});})",
+          "assert": {
+            "operator": "eq",
+            "field": "found",
+            "value": true
+          },
+          "timeout_ms": 10000,
+          "next": "ac4-market-reset"
+        },
+        "ac4-market-reset": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "ETH",
+              "name": "ETH",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "ac4-margin-wait"
+        },
+        "ac4-margin-wait": {
+          "action": "wait_for",
+          "test_id": "position-card-margin-chevron",
+          "next": "ac4-margin-press"
+        },
+        "ac4-margin-press": {
+          "action": "press",
+          "test_id": "position-card-margin-chevron",
+          "next": "ac4-reduce-wait"
+        },
+        "ac4-reduce-wait": {
+          "action": "wait_for",
+          "test_id": "perps-adjust-margin-reduce-btn",
+          "next": "ac4-reduce-press"
+        },
+        "ac4-reduce-press": {
+          "action": "press",
+          "test_id": "perps-adjust-margin-reduce-btn",
+          "next": "ac4-adjust-wait"
+        },
+        "ac4-adjust-wait": {
+          "action": "wait_for",
+          "route": "PerpsAdjustMargin",
+          "next": "ac4-adjust-shot"
+        },
+        "ac4-adjust-shot": {
+          "action": "screenshot",
+          "filename": "mobile-04-adjust-margin.png",
+          "next": "ac5-market-reset"
+        },
+        "ac5-market-reset": {
+          "action": "navigate",
+          "target": "PerpsMarketDetails",
+          "params": {
+            "market": {
+              "symbol": "ETH",
+              "name": "ETH",
+              "price": "0",
+              "change24h": "0",
+              "change24hPercent": "0",
+              "volume": "0",
+              "maxLeverage": "100"
+            }
+          },
+          "next": "ac5-close-wait"
+        },
+        "ac5-close-wait": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-close-button",
+          "next": "ac5-close-press"
+        },
+        "ac5-close-press": {
+          "action": "press",
+          "test_id": "perps-market-details-close-button",
+          "next": "ac5-close-route"
+        },
+        "ac5-close-route": {
+          "action": "wait_for",
+          "route": "PerpsClosePosition",
+          "next": "ac5-close-shot"
+        },
+        "ac5-close-shot": {
+          "action": "screenshot",
+          "filename": "mobile-05-close-view.png",
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      },
+      "teardown": [
+        {
+          "id": "teardown-close-eth",
+          "action": "eval_async",
+          "expression": "Engine.context.PerpsController.getPositions().then(function(ps){var p=ps.find(function(x){return x.symbol==='ETH'});if(!p){return JSON.stringify({cleared:true});}return Engine.context.PerpsController.closePosition({symbol:'ETH'}).then(function(){return JSON.stringify({cleared:true});});})",
+          "assert": {
+            "operator": "eq",
+            "field": "cleared",
+            "value": true
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## **Description**

This adds a dedicated perps decimal recipe branch so recipe/evidence work stays separate from controller sync work. It includes both the original mobile parity screenshot recipe and a new multi-symbol decimal matrix recipe that captures structured price output across representative perps markets.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
- Related to MetaMask/metamask-extension#41558
- Related to MetaMask/metamask-mobile#28871

## **Manual testing steps**

```gherkin
Feature: reusable mobile perps decimal recipes

  Scenario: run the parity screenshot recipe
    Given the mobile app is running with the shared test fixture account
    When I run `bash scripts/perps/agentic/validate-recipe.sh scripts/perps/agentic/teams/perps/recipes/mobile-decimal-parity.json --skip-manual --artifacts-dir <artifacts-dir>`
    Then the recipe captures the intended perps parity surfaces for review

  Scenario: run the structured decimal matrix recipe
    Given the mobile app is running with the shared test fixture account
    When I run `bash scripts/perps/agentic/validate-recipe.sh scripts/perps/agentic/teams/perps/recipes/mobile-decimal-matrix.json --skip-manual --artifacts-dir <artifacts-dir>`
    Then the recipe emits structured market-detail and order-entry values for representative symbols
```

## **Screenshots/Recordings**

### **Before**

N/A - recipe/tooling change.

### **After**

Recipe paths:
- `scripts/perps/agentic/teams/perps/recipes/mobile-decimal-parity.json`
- `scripts/perps/agentic/teams/perps/recipes/mobile-decimal-matrix.json`

Symbol coverage in the matrix recipe:
- BTC
- ETH
- SOL
- FARTCOIN
- PUMP

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new JSON-based validation recipes only; no production app logic is modified, with risk limited to recipe flakiness or brittle UI selectors.
> 
> **Overview**
> Adds new Perps *agentic* recipe coverage for mobile decimal/price validation.
> 
> Introduces `mobile-decimal-parity.json`, a workflow that sets up a fixture account on testnet, walks through key ETH perps surfaces (home, market detail, order entry, adjust margin, close) and captures screenshots, with setup/teardown ensuring an ETH position is cleared.
> 
> Introduces `mobile-decimal-matrix.json`, a multi-symbol workflow that navigates through several markets (BTC/ETH/SOL/FARTCOIN/PUMP), captures structured header values from market detail and order entry via `eval_sync`, and asserts extracted prices are non-null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8b33599c5ffa298d273d7418fd45a08e2e07bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->