### PR TITLE
fix(predict): show both Yes/No buttons for binary markets in featured carousel

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselCard.test.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselCard.test.tsx
@@ -353,4 +353,110 @@ describe('FeaturedCarouselCard', () => {
     ).toBeOnTheScreen();
     expect(queryByTestId('market-image')).not.toBeOnTheScreen();
   });
+
+  describe('binary market (single outcome with multiple tokens)', () => {
+    const createBinaryMarket = (
+      overrides: Partial<PredictMarket> = {},
+    ): PredictMarket =>
+      createMockMarket({
+        outcomes: [
+          createMockOutcome({
+            id: 'outcome-binary',
+            title: 'Binary Outcome',
+            groupItemTitle: 'Binary Outcome',
+            tokens: [
+              { id: 'token-yes', title: 'Yes', price: 0.65 },
+              { id: 'token-no', title: 'No', price: 0.35 },
+            ],
+          }),
+        ],
+        ...overrides,
+      });
+
+    it('renders two token-based buttons for a binary market', () => {
+      const market = createBinaryMarket();
+
+      const { getByTestId } = renderWithProvider(
+        <FeaturedCarouselCard market={market} index={0} />,
+        { state: initialState },
+      );
+
+      expect(
+        getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 0)),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 1)),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(0, 0)),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(0, 1)),
+      ).toBeOnTheScreen();
+    });
+
+    it('passes correct outcome and token when buying in a binary market', () => {
+      const market = createBinaryMarket();
+
+      const { getByTestId } = renderWithProvider(
+        <FeaturedCarouselCard market={market} index={0} />,
+        { state: initialState },
+      );
+
+      fireEvent.press(
+        getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(0, 1)),
+      );
+
+      expect(mockNavigateToBuyPreview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          market,
+          outcome: market.outcomes[0],
+          outcomeToken: market.outcomes[0].tokens[1],
+        }),
+        { throughRoot: true },
+      );
+    });
+
+    it('reports zero remaining options for a binary market', () => {
+      const market = createBinaryMarket();
+
+      const { queryByTestId } = renderWithProvider(
+        <FeaturedCarouselCard market={market} index={0} />,
+        { state: initialState },
+      );
+
+      expect(
+        queryByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 2)),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('skips outcomes with no tokens in multi-outcome markets', () => {
+    const market = createMockMarket({
+      outcomes: [
+        createMockOutcome({
+          id: 'o-with-token',
+          groupItemTitle: 'Has Token',
+          tokens: [{ id: 't1', title: 'Yes', price: 0.7 }],
+        }),
+        createMockOutcome({
+          id: 'o-no-token',
+          groupItemTitle: 'No Token',
+          tokens: [],
+        }),
+      ],
+    });
+
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <FeaturedCarouselCard market={market} index={0} />,
+      { state: initialState },
+    );
+
+    expect(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 0)),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 1)),
+    ).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselCard.tsx
@@ -93,8 +93,39 @@ const FeaturedCarouselCard: React.FC<FeaturedCarouselCardProps> = ({
     );
   }
 
-  const displayOutcomes = market.outcomes.slice(0, 2);
-  const remainingOptions = Math.max(0, market.outcomes.length - 2);
+  const isBinaryMarket =
+    market.outcomes.length === 1 && market.outcomes[0].tokens.length >= 2;
+
+  interface DisplayItem {
+    key: string;
+    label: string;
+    outcome: PredictOutcome;
+    token: PredictOutcomeToken;
+  }
+
+  const displayItems: DisplayItem[] = isBinaryMarket
+    ? market.outcomes[0].tokens.slice(0, 2).map((token) => ({
+        key: token.id,
+        label: token.title,
+        outcome: market.outcomes[0],
+        token,
+      }))
+    : market.outcomes.slice(0, 2).reduce<DisplayItem[]>((acc, outcome) => {
+        const token = outcome.tokens[0];
+        if (token) {
+          acc.push({
+            key: outcome.id,
+            label: outcome.groupItemTitle || outcome.title,
+            outcome,
+            token,
+          });
+        }
+        return acc;
+      }, []);
+
+  const remainingOptions = isBinaryMarket
+    ? 0
+    : Math.max(0, market.outcomes.length - 2);
   const totalVolume = calculateTotalVolume(market.outcomes);
 
   const formattedEndDate = market.endDate
@@ -140,17 +171,15 @@ const FeaturedCarouselCard: React.FC<FeaturedCarouselCardProps> = ({
             justifyContent={BoxJustifyContent.Center}
             twClassName="gap-6"
           >
-            {displayOutcomes.map((outcome, outcomeIdx) => {
-              const token = outcome.tokens[0];
-              if (!token) return null;
-              const percentage = Math.round(token.price * 100);
+            {displayItems.map((item, itemIdx) => {
+              const percentage = Math.round(item.token.price * 100);
 
               return (
                 <Box
-                  key={outcome.id}
+                  key={item.key}
                   testID={FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(
                     index,
-                    outcomeIdx,
+                    itemIdx,
                   )}
                   alignItems={BoxAlignItems.Center}
                   twClassName="flex-1"
@@ -161,18 +190,18 @@ const FeaturedCarouselCard: React.FC<FeaturedCarouselCardProps> = ({
                     color={TextColor.TextDefault}
                     numberOfLines={1}
                   >
-                    {outcome.groupItemTitle || outcome.title}
+                    {item.label}
                   </Text>
 
-                  <FeaturedCarouselPayoutRow price={token.price} />
+                  <FeaturedCarouselPayoutRow price={item.token.price} />
 
                   <Box twClassName="w-full mt-2">
                     <Button
                       testID={FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(
                         index,
-                        outcomeIdx,
+                        itemIdx,
                       )}
-                      onPress={() => handleBuy(outcome, token)}
+                      onPress={() => handleBuy(item.outcome, item.token)}
                       twClassName="bg-success-muted"
                       isFullWidth
                       size={ButtonBaseSize.Lg}


### PR DESCRIPTION
## **Description**

Fixes the featured carousel rendering only one button for binary Yes/No markets (e.g. "Strait of Hormuz traffic returns to normal by end of April?").

The card component iterated `market.outcomes` and took `tokens[0]` from each, but binary markets have a single outcome with two tokens inside it (Yes and No). This resulted in only one button showing. The fix detects binary markets (1 outcome, 2+ tokens) and flattens both tokens into separate buttons. Multi-outcome markets (e.g. Champions League winner) render unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Featured carousel binary market buttons

  Scenario: Binary Yes/No market shows both buttons
    Given the featured carousel contains a binary Yes/No market
    When the carousel card renders
    Then both Yes and No buttons are visible with correct percentages
    And tapping either button navigates to the buy preview for that outcome

  Scenario: Multi-outcome market renders unchanged
    Given the featured carousel contains a multi-outcome market (e.g. Champions League)
    When the carousel card renders
    Then the first two outcomes are displayed as buttons
    And a "+N more" label shows the remaining outcome count
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes UI rendering and buy-navigation inputs for a common user flow; mistakes could route users to the wrong token or hide options, but the behavior is covered by new unit tests.
> 
> **Overview**
> Featured carousel cards now detect *binary* prediction markets (single outcome with multiple tokens) and render two CTAs based on the first two tokens, ensuring both Yes/No options appear and pass the correct `outcomeToken` into `navigateToBuyPreview`.
> 
> For non-binary markets, the card now builds display items from the first two outcomes while skipping outcomes with no tokens, and keeps the footer’s “+N more” count disabled for binary markets. Tests are expanded to cover binary rendering/buy behavior and skipping tokenless outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb1e97228307fee16518197676918ac3968a1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->