### PR TITLE
feat(agentic): set missing post-onboarding flags in setupWallet

### DIFF
--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -67,7 +67,7 @@ jest.mock('../../actions/user', () => ({
   seedphraseBackedUp: () => ({ type: 'SEED_PHRASE_BACKED_UP' }),
   setMultichainAccountsIntroModalSeen: (seen: boolean) => ({
     type: 'SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN',
-    seen,
+    payload: { seen },
   }),
 }));
 jest.mock('../../actions/onboarding', () => ({
@@ -866,7 +866,7 @@ describe('AgenticService.install', () => {
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN',
-          seen: true,
+          payload: { seen: true },
         }),
       );
     });

--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -65,6 +65,10 @@ jest.mock('../../actions/user', () => ({
   setExistingUser: () => ({ type: 'SET_EXISTING_USER' }),
   logIn: () => ({ type: 'LOG_IN' }),
   seedphraseBackedUp: () => ({ type: 'SEED_PHRASE_BACKED_UP' }),
+  setMultichainAccountsIntroModalSeen: (seen: boolean) => ({
+    type: 'SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN',
+    seen,
+  }),
 }));
 jest.mock('../../actions/onboarding', () => ({
   setCompletedOnboarding: () => ({ type: 'SET_COMPLETED_ONBOARDING' }),
@@ -88,6 +92,7 @@ jest.mock('../../store/storage-wrapper', () => ({
   setItem: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../../constants/storage', () => ({
+  OPTIN_META_METRICS_UI_SEEN: 'optin_meta_metrics_ui_seen',
   PERPS_GTM_MODAL_SHOWN: 'perps_gtm',
   PREDICT_GTM_MODAL_SHOWN: 'predict_gtm',
   REWARDS_GTM_MODAL_SHOWN: 'rewards_gtm',
@@ -822,6 +827,47 @@ describe('AgenticService.install', () => {
       });
       expect(mockDispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: 'SET_OS_AUTH_ENABLED' }),
+      );
+    });
+
+    it('sets OPTIN_META_METRICS_UI_SEEN when metametrics is defined', async () => {
+      const StorageWrapper = jest.requireMock('../../store/storage-wrapper');
+      StorageWrapper.setItem.mockClear();
+      await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+        settings: { metametrics: true },
+      });
+      expect(StorageWrapper.setItem).toHaveBeenCalledWith(
+        'optin_meta_metrics_ui_seen',
+        'true',
+      );
+    });
+
+    it('does not set OPTIN_META_METRICS_UI_SEEN when metametrics is undefined', async () => {
+      const StorageWrapper = jest.requireMock('../../store/storage-wrapper');
+      StorageWrapper.setItem.mockClear();
+      await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+      });
+      expect(StorageWrapper.setItem).not.toHaveBeenCalledWith(
+        'optin_meta_metrics_ui_seen',
+        'true',
+      );
+    });
+
+    it('always dispatches setMultichainAccountsIntroModalSeen', async () => {
+      mockDispatch.mockClear();
+      await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+      });
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'SET_MULTICHAIN_ACCOUNTS_INTRO_MODAL_SEEN',
+          seen: true,
+        }),
       );
     });
   });

--- a/app/core/AgenticService/AgenticService.ts
+++ b/app/core/AgenticService/AgenticService.ts
@@ -21,12 +21,14 @@ import {
   setExistingUser,
   logIn,
   seedphraseBackedUp,
+  setMultichainAccountsIntroModalSeen,
 } from '../../actions/user';
 import { setCompletedOnboarding } from '../../actions/onboarding';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
 import { AccountImportStrategy } from '@metamask/keyring-controller';
 import StorageWrapper from '../../store/storage-wrapper';
 import {
+  OPTIN_META_METRICS_UI_SEEN,
   PERPS_GTM_MODAL_SHOWN,
   PREDICT_GTM_MODAL_SHOWN,
   REWARDS_GTM_MODAL_SHOWN,
@@ -488,6 +490,15 @@ const AgenticService = {
             // Suppress ExperienceEnhancer (marketing consent) modal
             store.dispatch(setDataCollectionForMarketing(false));
           }
+
+          // 5b. Set metrics UI as seen (prevents Authentication.unlockWallet
+          // from navigating to OptinMetrics after setupWallet resets to Wallet)
+          if (settings.metametrics !== undefined) {
+            await StorageWrapper.setItem(OPTIN_META_METRICS_UI_SEEN, 'true');
+          }
+
+          // 5c. Mark multichain accounts intro modal as seen
+          store.dispatch(setMultichainAccountsIntroModalSeen(true));
 
           // 6. Skip perps tutorial onboarding if requested
           if (settings.skipPerpsTutorial === true) {


### PR DESCRIPTION
## **Description**

`setupWallet()` in `AgenticService.ts` creates the wallet and sets `skipGtmModals` flags, but was missing two critical flags that cause post-setup onboarding modals to appear unexpectedly:

1. **`OPTIN_META_METRICS_UI_SEEN`** (StorageWrapper) — without this, `Authentication.unlockWallet` checks `isOptinMetaMetricsUISeen` and navigates to the `OptinMetrics` screen, even though metrics were already opted in via `analytics.optIn()`.
2. **`multichainAccountsIntroModalSeen`** (Redux) — without this, the `MultichainAccountsIntroModal` appears after wallet setup.

### Changes
- Set `OPTIN_META_METRICS_UI_SEEN` in StorageWrapper when `metametrics` setting is defined
- Dispatch `setMultichainAccountsIntroModalSeen(true)` unconditionally (always desired after programmatic wallet setup)
- Added 3 unit tests verifying the new flags

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2942

## **Manual testing steps**

```gherkin
Feature: Agentic wallet setup skips onboarding modals

  Scenario: setupWallet lands on Wallet screen
    Given a fresh app with no wallet

    When agent calls setupWallet with metametrics: true and skipGtmModals: true
    Then app navigates to Wallet screen (not OptinMetrics or MultichainAccountsIntro)
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — dev-only agentic tooling, no UI changes -->

### **After**

<!-- N/A — dev-only agentic tooling, no UI changes -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.