### PR TITLE
feat(agentic): clear Babel transpilation cache before Metro start

### DIFF
--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -163,7 +163,7 @@ fi
 # babel-plugin-transform-inline-environment-variables caches compiled values in
 # $TMPDIR/metro-cache. Without clearing, switching METAMASK_ENVIRONMENT between
 # 'e2e' and 'dev' may serve bundles with stale inlined values.
-rm -rf "${TMPDIR}/metro-cache" "${TMPDIR}/haste-map-"* 2>/dev/null || true
+rm -rf "${TMPDIR:-/tmp}/metro-cache" "${TMPDIR:-/tmp}/haste-map-"* 2>/dev/null || true
 
 echo "Starting Metro on port $PORT..."
 EXPO_NO_TYPESCRIPT_SETUP=1 yarn expo start --port "$PORT" >> "$LOGFILE" 2>&1 &

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -159,6 +159,12 @@ fi
 # --- No Metro detected — start fresh ---
 > "$LOGFILE"
 
+# Clear Metro + Babel transpilation caches to ensure env vars are freshly inlined.
+# babel-plugin-transform-inline-environment-variables caches compiled values in
+# $TMPDIR/metro-cache. Without clearing, switching METAMASK_ENVIRONMENT between
+# 'e2e' and 'dev' may serve bundles with stale inlined values.
+rm -rf "${TMPDIR}/metro-cache" "${TMPDIR}/haste-map-"* 2>/dev/null || true
+
 echo "Starting Metro on port $PORT..."
 EXPO_NO_TYPESCRIPT_SETUP=1 yarn expo start --port "$PORT" >> "$LOGFILE" 2>&1 &
 METRO_PID=$!


### PR DESCRIPTION
## **Description**

`babel-plugin-transform-inline-environment-variables` inlines `process.env.*` values at compile time. Metro's `--clear` flag clears the bundle cache but NOT the Babel transpilation cache in `$TMPDIR/metro-cache`. When switching between `METAMASK_ENVIRONMENT=e2e` and `dev` (e.g. during benchmark runs), stale inlined values persist and the app receives the wrong environment flags.

### Changes
- Clear `$TMPDIR/metro-cache` and `$TMPDIR/haste-map-*` before starting Metro in `start-metro.sh`
- Use `${TMPDIR:-/tmp}` fallback to avoid unbound variable crash under `set -u`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2942

## **Manual testing steps**

```gherkin
Feature: Metro cache cleared on start

  Scenario: Switching from e2e to dev environment
    Given Metro was previously running with METAMASK_ENVIRONMENT=e2e
    And Metro was stopped

    When start-metro.sh is run with METAMASK_ENVIRONMENT=dev
    Then the bundle contains dev-inlined env vars (not stale e2e values)
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — build tooling script, no UI changes -->

### **After**

<!-- N/A — build tooling script, no UI changes -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.