### PR TITLE
feat(rewards): show 'Entries closed' CTA when active campaign is past entry window

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -283,7 +283,7 @@ describe('OndoCampaignCTA', () => {
 
   describe('notEligibleForCampaign', () => {
     describe('not opted in + notEligibleForCampaign=true', () => {
-      it('shows the Join Campaign button', () => {
+      it('shows the Entries closed button', () => {
         const { getByTestId, getByText } = render(
           <OndoCampaignCTA
             campaign={buildCampaign()}
@@ -293,7 +293,7 @@ describe('OndoCampaignCTA', () => {
           />,
         );
         expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-        expect(getByText('Join Campaign')).toBeOnTheScreen();
+        expect(getByText('Entries closed')).toBeOnTheScreen();
       });
 
       it('fires entries-closed toast (not the opt-in sheet) when pressed', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -22,7 +22,23 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+  useTailwind: () => () => ({}),
+}));
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  }),
+}));
+
+jest.mock('../../../../../core/Analytics', () => ({
+  MetaMetricsEvents: {
+    REWARDS_PAGE_BUTTON_CLICKED: 'REWARDS_PAGE_BUTTON_CLICKED',
+  },
 }));
 
 jest.mock('./CampaignOptInSheet', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => () => ({}),
+  useTailwind: () => ({ style: (...args: unknown[]) => args }),
 }));
 
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -33,8 +33,7 @@ interface OndoCampaignCTAProps {
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
  * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, eligible)
- * - "Entries closed" button (with Lock icon + toast) when the user cannot enter — either
- *   because the campaign is complete, or because the user is not eligible for the campaign
+ * - "Entries closed" button (with Lock icon + toast) when the user cannot enter — either because the campaign is complete, or because the user is not eligible for the campaign
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -32,9 +32,9 @@ interface OndoCampaignCTAProps {
 /**
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
- * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, within deposit window)
- * - "Entries closed" button (with Lock icon + toast) when the entry window has closed — either
- *   because the campaign is complete, or because fewer than the required qualifying days remain
+ * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, eligible)
+ * - "Entries closed" button (with Lock icon + toast) when the user cannot enter — either
+ *   because the campaign is complete, or because the user is not eligible for the campaign
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */
@@ -105,9 +105,13 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   const isLoading = participantStatus.isLoading;
   const isOptedIn = participantStatus?.status?.optedIn === true;
 
-  // Show "Entries closed" for complete campaigns when user has not opted in
+  // Show "Entries closed" when the user cannot enter: campaign is complete,
+  // or campaign is active but the user is not eligible (and has not opted in).
   const isEntriesClosed =
-    !isLoading && !isOptedIn && campaignStatus === 'complete';
+    !isLoading &&
+    !isOptedIn &&
+    (campaignStatus === 'complete' ||
+      (campaignStatus === 'active' && notEligibleForCampaign));
 
   const handleEntriesClosedPress = useCallback(() => {
     showToast(
@@ -141,22 +145,6 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   }
 
   if (!isOptedIn) {
-    if (notEligibleForCampaign) {
-      return (
-        <Box twClassName="px-4 pt-2">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            startIconName={IconName.Lock}
-            onPress={handleEntriesClosedPress}
-            testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-          >
-            {strings('rewards.campaign_details.ondo.entries_closed_title')}
-          </Button>
-        </Box>
-      );
-    }
     return (
       <CampaignOptInCta
         campaign={campaign}

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -33,7 +33,8 @@ interface OndoCampaignCTAProps {
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
  * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, within deposit window)
- * - "Entries closed" button (with Lock icon + toast) when cutoff has passed and user is not opted in
+ * - "Entries closed" button (with Lock icon + toast) when the entry window has closed — either
+ *   because the campaign is complete, or because fewer than the required qualifying days remain
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */
@@ -147,10 +148,11 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
             variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             isFullWidth
+            startIconName={IconName.Lock}
             onPress={handleEntriesClosedPress}
             testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
           >
-            {strings('rewards.campaign_details.join_campaign')}
+            {strings('rewards.campaign_details.ondo.entries_closed_title')}
           </Button>
         </Box>
       );


### PR DESCRIPTION
## Summary

When a campaign is still **active** but fewer than the required qualifying days remain (\`notEligibleForCampaign=true\`), new users can no longer join and qualify. The CTA was silently showing **"Join Campaign"** — which leads nowhere useful — instead of the locked **"Entries closed"** state.

This aligns the active-but-past-entry-window state with the already-correct \`complete\` campaign state.

**Changes (2 lines):**
- \`OndoCampaignCTA.tsx\`: add \`startIconName={IconName.Lock}\` and use \`entries_closed_title\` string in the \`notEligibleForCampaign\` branch
- \`OndoCampaignCTA.test.tsx\`: update assertion from \`'Join Campaign'\` → \`'Entries closed'\`

## Figma reference

Campaigns file — *"< N days left"* section, pre-opt-in state: \`node-id=3259-56852\`

## Changelog

CHANGELOG entry: null

## Test plan

- [ ] Mock active campaign with \`endDate\` fewer than 10 days away, user not opted in → CTA shows "Entries closed" with lock icon
- [ ] Tap the button → entries-closed toast fires (not the opt-in sheet)
- [ ] Active campaign with enough days remaining, not opted in → "Join Campaign" still shows
- [ ] Complete campaign, not opted in → "Entries closed" still shows (no regression)
- [ ] Opted-in user → "Swap Ondo Assets" / "Open Position" unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only logic change to when the Ondo campaign CTA is disabled/locked, plus test updates; minimal surface area and no sensitive data/auth changes.
> 
> **Overview**
> Updates `OndoCampaignCTA` to treat *active but ineligible* (via `notEligibleForCampaign`) and *complete* campaigns the same for non-opted-in users by showing a locked **"Entries closed"** CTA that triggers the entries-closed toast, instead of delegating to the join/opt-in flow.
> 
> Adjusts the associated Jest tests to mock analytics dependencies and to assert the new "Entries closed" label/behavior in the `notEligibleForCampaign` scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ec6a10430f2047aeb63ecc9fe0fb6a0120eb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->