### PR TITLE
feat(rewards): network filter + sanitize token names in RWA selector

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -176,6 +176,7 @@ jest.mock(
             onPress: () => onPress(token),
           },
           ReactActual.createElement(Text, null, token.symbol),
+          ReactActual.createElement(Text, null, token.name),
         ),
     };
   },
@@ -187,6 +188,69 @@ jest.mock(
     TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
   }),
 );
+
+const mockOnNetworkSelect = jest.fn();
+
+jest.mock('../../Trending/components/TrendingTokensBottomSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    TrendingTokenNetworkBottomSheet: ({
+      isVisible,
+      onNetworkSelect,
+    }: {
+      isVisible: boolean;
+      onNetworkSelect: (chainIds: string[] | null) => void;
+      onClose: () => void;
+    }) => {
+      if (!isVisible) return null;
+      mockOnNetworkSelect.mockImplementation(onNetworkSelect);
+      return ReactActual.createElement(
+        View,
+        { testID: 'network-bottom-sheet' },
+        ReactActual.createElement(TouchableOpacity, {
+          testID: 'select-bnb-network',
+          onPress: () => onNetworkSelect(['eip155:56']),
+        }),
+      );
+    },
+    NetworkOption: { AllNetworks: 'all' },
+  };
+});
+
+jest.mock('../../Trending/components/FilterBar/FilterBar', () => {
+  const ReactActual = jest.requireActual('react');
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    FilterButton: ({
+      testID,
+      label,
+      onPress,
+    }: {
+      testID: string;
+      label: string;
+      onPress: () => void;
+    }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { testID, onPress },
+        ReactActual.createElement(Text, null, label),
+      ),
+  };
+});
+
+jest.mock('../../Trending/utils/trendingNetworksList', () => ({
+  RWA_NETWORKS_LIST: [
+    { caipChainId: 'eip155:1', name: 'Ethereum' },
+    { caipChainId: 'eip155:56', name: 'BNB Chain' },
+  ],
+}));
+
+jest.mock('../../Trending/hooks/useNetworkName/useNetworkName', () => ({
+  useNetworkName: jest.fn(() => 'Ethereum'),
+}));
 
 // Silence utility mocks
 jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
@@ -537,6 +601,70 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
       const [srcArg] = mockGoToSwaps.mock.calls[0];
       expect(srcArg).toBeUndefined();
+    });
+  });
+
+  describe('network filter (open_position mode)', () => {
+    it('shows the network filter button in open_position mode', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByTestId('network-filter-button')).toBeDefined();
+    });
+
+    it('does not show the network filter button in swap mode', () => {
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: 'eip155:1/erc20:0xabc',
+        srcTokenSymbol: 'USDC',
+        srcTokenDecimals: 6,
+      };
+      const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(queryByTestId('network-filter-button')).toBeNull();
+    });
+
+    it('opens the network bottom sheet when the filter button is pressed', () => {
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      expect(queryByTestId('network-bottom-sheet')).toBeNull();
+      fireEvent.press(getByTestId('network-filter-button'));
+      expect(getByTestId('network-bottom-sheet')).toBeDefined();
+    });
+
+    it('calls useRwaTokens with Ethereum chainId by default', () => {
+      render(<OndoCampaignRwaSelectorView />);
+      const lastCall =
+        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
+      expect(lastCall.chainIds).toEqual(['eip155:1']);
+    });
+
+    it('updates chainIds when a different network is selected', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('network-filter-button'));
+      fireEvent.press(getByTestId('select-bnb-network'));
+      const lastCall =
+        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
+      expect(lastCall.chainIds).toEqual(['eip155:56']);
+    });
+  });
+
+  describe('token name sanitization', () => {
+    it('strips "Ondo Tokenized " prefix from token names in list rows', () => {
+      const token = {
+        ...buildToken('AAPL'),
+        name: 'Ondo Tokenized Apple',
+      };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByText, queryByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByText('Apple')).toBeDefined();
+      expect(queryByText('Ondo Tokenized Apple')).toBeNull();
+    });
+
+    it('leaves unrelated token names unchanged', () => {
+      const token = { ...buildToken('USDY'), name: 'Ondo USD Yield' };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByText('Ondo USD Yield')).toBeDefined();
     });
   });
 

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -44,7 +44,15 @@ import ErrorBoundary from '../../../Views/ErrorBoundary';
 import { useRwaTokens } from '../../Trending/hooks/useRwaTokens/useRwaTokens';
 import TrendingTokenRowItem from '../../Trending/components/TrendingTokenRowItem/TrendingTokenRowItem';
 import { getTrendingTokenImageUrl } from '../../Trending/utils/getTrendingTokenImageUrl';
-import { parseCaip19, caipChainIdToHex } from '../utils/formatUtils';
+import {
+  parseCaip19,
+  caipChainIdToHex,
+  sanitizeOndoTokenName,
+} from '../utils/formatUtils';
+import { RWA_NETWORKS_LIST } from '../../Trending/utils/trendingNetworksList';
+import { TrendingTokenNetworkBottomSheet } from '../../Trending/components/TrendingTokensBottomSheet';
+import { FilterButton } from '../../Trending/components/FilterBar/FilterBar';
+import { useNetworkName } from '../../Trending/hooks/useNetworkName/useNetworkName';
 import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
@@ -108,6 +116,10 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   } = route.params;
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [selectedChainId, setSelectedChainId] = useState<CaipChainId>(
+    RWA_NETWORKS_LIST[0].caipChainId,
+  );
+  const [showNetworkSheet, setShowNetworkSheet] = useState(false);
   const [isAfterHoursSheetOpen, setIsAfterHoursSheetOpen] = useState(false);
   const [afterHoursNextOpen, setAfterHoursNextOpen] = useState<Date | null>(
     null,
@@ -139,13 +151,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     );
   }, [srcTokenAsset]);
 
-  // In swap mode, filter to same chain as src asset
-  const chainIds = useMemo((): CaipChainId[] | undefined => {
-    if (mode !== 'swap' || !srcTokenAsset) return undefined;
-    const parsed = parseCaip19(srcTokenAsset);
-    if (!parsed) return undefined;
-    return [`${parsed.namespace}:${parsed.chainId}` as CaipChainId];
-  }, [mode, srcTokenAsset]);
+  // open_position: show one chain at a time (user-selected, defaults to Ethereum).
+  // swap: lock to the src asset's chain.
+  const chainIds = useMemo((): CaipChainId[] => {
+    if (mode === 'swap' && srcTokenAsset) {
+      const parsed = parseCaip19(srcTokenAsset);
+      if (parsed) {
+        return [`${parsed.namespace}:${parsed.chainId}` as CaipChainId];
+      }
+    }
+    return [selectedChainId];
+  }, [mode, srcTokenAsset, selectedChainId]);
 
   const { data: rwaTokens, isLoading } = useRwaTokens({
     searchQuery,
@@ -208,6 +224,10 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   }, [rwaTokens]);
 
   const showSkeleton = isLoading || isFiltering;
+
+  const selectedNetworkName = useNetworkName(
+    mode === 'open_position' ? [selectedChainId] : null,
+  );
 
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { isTokenTradingOpen } = useRWAToken();
@@ -316,7 +336,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   const renderItem = ({ item }: { item: TrendingAsset }) => (
     <View style={styles.row}>
       <TrendingTokenRowItem
-        token={item}
+        token={{ ...item, name: sanitizeOndoTokenName(item.name) }}
         selectedTimeOption={TimeOption.TwentyFourHours}
         onPress={handleAssetSelect}
       />
@@ -390,6 +410,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
           </View>
         </View>
 
+        {/* Network filter — only in open_position mode */}
+        {mode === 'open_position' && (
+          <View style={tw.style('px-4 pb-2')}>
+            <FilterButton
+              testID="network-filter-button"
+              label={selectedNetworkName}
+              onPress={() => setShowNetworkSheet(true)}
+            />
+          </View>
+        )}
+
         <View
           style={[styles.divider, { backgroundColor: colors.border.muted }]}
         />
@@ -406,6 +437,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
             ListEmptyComponent={renderEmpty}
           />
         )}
+        <TrendingTokenNetworkBottomSheet
+          isVisible={mode === 'open_position' && showNetworkSheet}
+          onClose={() => setShowNetworkSheet(false)}
+          onNetworkSelect={(chainIds) => {
+            if (chainIds?.[0]) setSelectedChainId(chainIds[0]);
+            setShowNetworkSheet(false);
+          }}
+          selectedNetwork={[selectedChainId]}
+          networks={RWA_NETWORKS_LIST}
+          hideAllNetworks
+        />
         {isAfterHoursSheetOpen && (
           <OndoAfterHoursSheet
             onClose={() => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -283,7 +283,7 @@ describe('OndoCampaignCTA', () => {
 
   describe('notEligibleForCampaign', () => {
     describe('not opted in + notEligibleForCampaign=true', () => {
-      it('shows the Join Campaign button', () => {
+      it('shows the Entries closed button', () => {
         const { getByTestId, getByText } = render(
           <OndoCampaignCTA
             campaign={buildCampaign()}
@@ -293,7 +293,7 @@ describe('OndoCampaignCTA', () => {
           />,
         );
         expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-        expect(getByText('Join Campaign')).toBeOnTheScreen();
+        expect(getByText('Entries closed')).toBeOnTheScreen();
       });
 
       it('fires entries-closed toast (not the opt-in sheet) when pressed', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -22,7 +22,23 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+  useTailwind: () => () => ({}),
+}));
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({}),
+    })),
+  }),
+}));
+
+jest.mock('../../../../../core/Analytics', () => ({
+  MetaMetricsEvents: {
+    REWARDS_PAGE_BUTTON_CLICKED: 'REWARDS_PAGE_BUTTON_CLICKED',
+  },
 }));
 
 jest.mock('./CampaignOptInSheet', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -32,9 +32,9 @@ interface OndoCampaignCTAProps {
 /**
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
- * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, within deposit window)
- * - "Entries closed" button (with Lock icon + toast) when the entry window has closed — either
- *   because the campaign is complete, or because fewer than the required qualifying days remain
+ * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, eligible)
+ * - "Entries closed" button (with Lock icon + toast) when the user cannot enter — either
+ *   because the campaign is complete, or because the user is not eligible for the campaign
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */
@@ -105,9 +105,13 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   const isLoading = participantStatus.isLoading;
   const isOptedIn = participantStatus?.status?.optedIn === true;
 
-  // Show "Entries closed" for complete campaigns when user has not opted in
+  // Show "Entries closed" when the user cannot enter: campaign is complete,
+  // or campaign is active but the user is not eligible (and has not opted in).
   const isEntriesClosed =
-    !isLoading && !isOptedIn && campaignStatus === 'complete';
+    !isLoading &&
+    !isOptedIn &&
+    (campaignStatus === 'complete' ||
+      (campaignStatus === 'active' && notEligibleForCampaign));
 
   const handleEntriesClosedPress = useCallback(() => {
     showToast(
@@ -141,22 +145,6 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
   }
 
   if (!isOptedIn) {
-    if (notEligibleForCampaign) {
-      return (
-        <Box twClassName="px-4 pt-2">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            startIconName={IconName.Lock}
-            onPress={handleEntriesClosedPress}
-            testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-          >
-            {strings('rewards.campaign_details.ondo.entries_closed_title')}
-          </Button>
-        </Box>
-      );
-    }
     return (
       <CampaignOptInCta
         campaign={campaign}

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -33,7 +33,8 @@ interface OndoCampaignCTAProps {
  * Bottom CTA for the Ondo campaign details page.
  * Renders one of four states depending on campaign/participant status:
  * - Delegates to CampaignCTA for the opt-in flow (active, not opted in, within deposit window)
- * - "Entries closed" button (with Lock icon + toast) when cutoff has passed and user is not opted in
+ * - "Entries closed" button (with Lock icon + toast) when the entry window has closed — either
+ *   because the campaign is complete, or because fewer than the required qualifying days remain
  * - "Open Position" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */
@@ -147,10 +148,11 @@ const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({
             variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             isFullWidth
+            startIconName={IconName.Lock}
             onPress={handleEntriesClosedPress}
             testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
           >
-            {strings('rewards.campaign_details.join_campaign')}
+            {strings('rewards.campaign_details.ondo.entries_closed_title')}
           </Button>
         </Box>
       );

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -26,6 +26,7 @@ import {
   formatUsd,
   formatSignedUsd,
   formatCompactUsd,
+  sanitizeOndoTokenName,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -1595,6 +1596,34 @@ describe('formatUtils', () => {
 
     it('formats negative thousands', () => {
       expect(formatCompactUsd(-75_000)).toBe('-$75K');
+    });
+  });
+
+  describe('sanitizeOndoTokenName', () => {
+    it('strips "Ondo Tokenized " prefix (exact casing)', () => {
+      expect(sanitizeOndoTokenName('Ondo Tokenized Apple')).toBe('Apple');
+    });
+
+    it('strips prefix case-insensitively', () => {
+      expect(sanitizeOndoTokenName('ondo tokenized google')).toBe('google');
+      expect(sanitizeOndoTokenName('ONDO TOKENIZED TSLA')).toBe('TSLA');
+    });
+
+    it('handles multiple spaces between words', () => {
+      expect(sanitizeOndoTokenName('Ondo  Tokenized  Apple')).toBe('Apple');
+    });
+
+    it('leaves unrelated names unchanged', () => {
+      expect(sanitizeOndoTokenName('Apple Inc')).toBe('Apple Inc');
+      expect(sanitizeOndoTokenName('USDY')).toBe('USDY');
+    });
+
+    it('returns empty string for an empty input', () => {
+      expect(sanitizeOndoTokenName('')).toBe('');
+    });
+
+    it('trims surrounding whitespace after stripping', () => {
+      expect(sanitizeOndoTokenName('Ondo Tokenized  Apple  ')).toBe('Apple');
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -482,3 +482,10 @@ export const shortenAddress = (address: string): string => {
   if (address.length <= 10) return address;
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
+
+/**
+ * Strips the "Ondo Tokenized " prefix from a token name returned by the
+ * search API, so list rows show just the underlying asset name (e.g. "Apple").
+ */
+export const sanitizeOndoTokenName = (name: string): string =>
+  name.replace(/^ondo\s+tokenized\s+/i, '').trim();

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
@@ -510,4 +510,37 @@ describe('TrendingTokenNetworkBottomSheet', () => {
 
     expect(queryByTestId('bottom-sheet')).toBeOnTheScreen();
   });
+
+  it('hides the "All networks" option when hideAllNetworks is true', () => {
+    const { queryByText } = renderWithProvider(
+      <TrendingTokenNetworkBottomSheet
+        isVisible
+        onClose={mockOnClose}
+        networks={mockNetworks}
+        selectedNetwork={['eip155:1' as CaipChainId]}
+        hideAllNetworks
+      />,
+      { state: mockState },
+      false,
+    );
+
+    expect(queryByText('All networks')).toBeNull();
+  });
+
+  it('still renders network options when hideAllNetworks is true', () => {
+    const { getByText } = renderWithProvider(
+      <TrendingTokenNetworkBottomSheet
+        isVisible
+        onClose={mockOnClose}
+        networks={mockNetworks}
+        selectedNetwork={['eip155:1' as CaipChainId]}
+        hideAllNetworks
+      />,
+      { state: mockState },
+      false,
+    );
+
+    expect(getByText('Ethereum Mainnet')).toBeOnTheScreen();
+    expect(getByText('Polygon')).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
@@ -30,6 +30,8 @@ export interface TrendingTokenNetworkBottomSheetProps {
   selectedNetwork?: CaipChainId[] | null;
   /** Networks to display in the bottom sheet */
   networks: ProcessedNetwork[];
+  /** When true, the "All networks" option is hidden */
+  hideAllNetworks?: boolean;
 }
 
 const TrendingTokenNetworkBottomSheet: React.FC<
@@ -40,6 +42,7 @@ const TrendingTokenNetworkBottomSheet: React.FC<
   onNetworkSelect,
   selectedNetwork: initialSelectedNetwork,
   networks,
+  hideAllNetworks = false,
 }) => {
   const sheetRef = useRef<BottomSheetRef>(null);
 
@@ -118,21 +121,23 @@ const TrendingTokenNetworkBottomSheet: React.FC<
         closeButtonProps={{ testID: 'close-button' }}
       />
       <ScrollView style={optionStyles.optionsList}>
-        <Cell
-          variant={CellVariant.Select}
-          title={strings('trending.all_networks')}
-          isSelected={isAllNetworksSelected}
-          onPress={() => onNetworkOptionPress(NetworkOption.AllNetworks)}
-          avatarProps={{
-            variant: AvatarVariant.Icon,
-            name: IconName.Global,
-            size: AvatarSize.Sm,
-          }}
-        >
-          {isAllNetworksSelected && (
-            <Icon name={IconName.Check} size={IconSize.Md} />
-          )}
-        </Cell>
+        {!hideAllNetworks && (
+          <Cell
+            variant={CellVariant.Select}
+            title={strings('trending.all_networks')}
+            isSelected={isAllNetworksSelected}
+            onPress={() => onNetworkOptionPress(NetworkOption.AllNetworks)}
+            avatarProps={{
+              variant: AvatarVariant.Icon,
+              name: IconName.Global,
+              size: AvatarSize.Sm,
+            }}
+          >
+            {isAllNetworksSelected && (
+              <Icon name={IconName.Check} size={IconSize.Md} />
+            )}
+          </Cell>
+        )}
         {networks.map((network) => {
           const isSelected = isNetworkSelected(network);
           return (


### PR DESCRIPTION
## Summary

- **Network filter (open_position only):** replaces loading all RWA chains simultaneously with a single-chain filter button backed by `TrendingTokenNetworkBottomSheet`. Defaults to Ethereum; user can switch to BNB Chain. The \"All Networks\" option is suppressed via a new `hideAllNetworks` prop. Swap mode is unchanged — chain stays locked to the source asset.
- **Name sanitization:** strips the \"Ondo Tokenized \" prefix from token names before rendering list rows (e.g. \"Ondo Tokenized Apple\" → \"Apple\") using a new `sanitizeOndoTokenName` util.

## Files changed

- `TrendingTokenNetworkBottomSheet.tsx` — add `hideAllNetworks?: boolean` prop
- `OndoCampaignRwaSelectorView.tsx` — chain filter button + bottom sheet + name sanitize in `renderItem`
- `formatUtils.ts` — `sanitizeOndoTokenName` util
- All three test files updated / extended

## Test plan

- [ ] `yarn jest app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx`
- [ ] `yarn jest app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx`
- [ ] `yarn jest app/components/UI/Rewards/utils/formatUtils.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing flows (Money home layout, Ramp deposit navigation headers, and Predict data fetching) and adds new external API calls/CSP allowances, which could impact navigation behavior and data rendering if assumptions differ across platforms or providers.
> 
> **Overview**
> Updates the Money home screen to a new section layout (onboarding card, earnings summary, explicit mUSD row, updated “What you get” section), enhances `MoneyBalanceSummary` with loading/balance props and an APY info action, and reworks `MoneyPotentialEarnings` to filter/limit tokens, prioritize stablecoins, and compute/display projected earnings.
> 
> Adds a new Predict “crypto target price” pipeline end-to-end: provider fetch via a new Polymarket endpoint, controller method with trace + fallback to `groupItemThreshold`, React Query `queries`/`useCryptoTargetPrice` hook, and associated typings/tests.
> 
> Simplifies Ramp native flow headers by removing `navigation.setOptions` deposit navbar usage in favor of `HeaderCompactStandard` (with explicit back handling and tests), and adjusts a few navigation/header behaviors (e.g., hide header on `RampsOrderDetails`, remove `OndoPendingSheet` route, tweak chart WebView CSP and OHLCV URL construction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e59ae2779abe02c9fd25a9c6553d6099281400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->