### PR TITLE
feat(rewards): network filter + sanitize token names in RWA selector

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -38,13 +38,8 @@ jest.mock('../../../../selectors/tokenBalancesController', () => ({
 }));
 
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ goBack: mockGoBack, navigate: jest.fn() }),
+  useNavigation: () => ({ goBack: mockGoBack }),
   useRoute: () => ({ params: mockRouteParams }),
-  StackActions: { push: jest.fn() },
-}));
-
-jest.mock('@react-navigation/stack', () => ({
-  ...jest.requireActual('@react-navigation/stack'),
 }));
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
@@ -65,17 +60,15 @@ jest.mock(
       default: ({
         title,
         onBack,
-        onClose,
       }: {
         title: React.ReactNode;
-        onBack?: () => void;
-        onClose?: () => void;
+        onBack: () => void;
       }) =>
         ReactActual.createElement(
           View,
           { testID: 'header' },
           ReactActual.createElement(Pressable, {
-            onPress: onBack ?? onClose,
+            onPress: onBack,
             testID: 'header-back-button',
           }),
           typeof title === 'string'
@@ -183,16 +176,70 @@ jest.mock(
             onPress: () => onPress(token),
           },
           ReactActual.createElement(Text, null, token.symbol),
+          ReactActual.createElement(Text, null, token.name),
         ),
     };
   },
 );
 
-jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
-  getTrendingTokenImageUrl: jest.fn(
-    (assetId: string) => `https://mock.image/${assetId}`,
-  ),
-}));
+jest.mock(
+  '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet',
+  () => ({
+    TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
+  }),
+);
+
+const mockOnNetworkSelect = jest.fn();
+
+jest.mock('../../Trending/components/TrendingTokensBottomSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    TrendingTokenNetworkBottomSheet: ({
+      isVisible,
+      onNetworkSelect,
+    }: {
+      isVisible: boolean;
+      onNetworkSelect: (chainIds: string[] | null) => void;
+      onClose: () => void;
+    }) => {
+      if (!isVisible) return null;
+      mockOnNetworkSelect.mockImplementation(onNetworkSelect);
+      return ReactActual.createElement(
+        View,
+        { testID: 'network-bottom-sheet' },
+        ReactActual.createElement(TouchableOpacity, {
+          testID: 'select-bnb-network',
+          onPress: () => onNetworkSelect(['eip155:56']),
+        }),
+      );
+    },
+    NetworkOption: { AllNetworks: 'all' },
+  };
+});
+
+jest.mock('../../Trending/components/FilterBar/FilterBar', () => {
+  const ReactActual = jest.requireActual('react');
+  const { TouchableOpacity, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    FilterButton: ({
+      testID,
+      label,
+      onPress,
+    }: {
+      testID: string;
+      label: string;
+      onPress: () => void;
+    }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { testID, onPress },
+        ReactActual.createElement(Text, null, label),
+      ),
+  };
+});
 
 jest.mock('../../Trending/utils/trendingNetworksList', () => ({
   RWA_NETWORKS_LIST: [
@@ -202,16 +249,14 @@ jest.mock('../../Trending/utils/trendingNetworksList', () => ({
 }));
 
 jest.mock('../../Trending/hooks/useNetworkName/useNetworkName', () => ({
-  useNetworkName: () => 'All networks',
+  useNetworkName: jest.fn(() => 'Ethereum'),
 }));
 
-jest.mock('../../Trending/services/TrendingFeedSessionManager', () => ({
-  __esModule: true,
-  default: {
-    getInstance: () => ({
-      trackFilterChange: jest.fn(),
-    }),
-  },
+// Silence utility mocks
+jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
+  getTrendingTokenImageUrl: jest.fn(
+    (assetId: string) => `https://mock.image/${assetId}`,
+  ),
 }));
 
 jest.mock('../../../../util/theme', () => ({
@@ -221,7 +266,6 @@ jest.mock('../../../../util/theme', () => ({
       border: { muted: 'muted-border' },
     },
   }),
-  useAppThemeFromContext: () => ({}),
 }));
 
 jest.mock('../../AssetOverview/Balance/Balance', () => ({
@@ -244,112 +288,6 @@ jest.mock('@metamask/utils', () => ({
   ...jest.requireActual('@metamask/utils'),
 }));
 
-jest.mock('react-native-safe-area-context', () => ({
-  SafeAreaView: jest.requireActual('react-native').View,
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
-
-// Mock the shared ListHeaderWithSearch used by TrendingListHeader
-jest.mock('../../shared/ListHeaderWithSearch', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Text, Pressable, TextInput } =
-    jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({
-      title,
-      isSearchVisible,
-      searchQuery,
-      onSearchQueryChange,
-      onBack,
-      onSearchToggle,
-      searchPlaceholder,
-      testID,
-    }: {
-      title: React.ReactNode;
-      isSearchVisible: boolean;
-      searchQuery: string;
-      onSearchQueryChange: (q: string) => void;
-      onBack: () => void;
-      onSearchToggle: () => void;
-      searchPlaceholder?: string;
-      cancelText?: string;
-      testID?: string;
-    }) =>
-      ReactActual.createElement(
-        View,
-        { testID: testID ?? 'header' },
-        ReactActual.createElement(Pressable, {
-          onPress: onBack,
-          testID: 'header-back-button',
-        }),
-        typeof title === 'string'
-          ? ReactActual.createElement(Text, { testID: 'header-title' }, title)
-          : title,
-        ReactActual.createElement(Pressable, {
-          onPress: onSearchToggle,
-          testID: 'search-toggle',
-        }),
-        isSearchVisible
-          ? ReactActual.createElement(TextInput, {
-              testID: 'search-input',
-              placeholder: searchPlaceholder,
-              value: searchQuery,
-              onChangeText: onSearchQueryChange,
-            })
-          : null,
-      ),
-  };
-});
-
-// Mock FilterBar
-jest.mock('../../Trending/components/FilterBar/FilterBar', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Pressable, Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({
-      networkName,
-      onNetworkPress,
-      priceChangeButtonText,
-      onPriceChangePress,
-    }: {
-      networkName: string;
-      onNetworkPress: () => void;
-      priceChangeButtonText: string;
-      onPriceChangePress: () => void;
-      isPriceChangeDisabled?: boolean;
-    }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'filter-bar' },
-        ReactActual.createElement(
-          Pressable,
-          { testID: 'all-networks-button', onPress: onNetworkPress },
-          ReactActual.createElement(Text, null, networkName),
-        ),
-        ReactActual.createElement(
-          Pressable,
-          { testID: 'price-change-button', onPress: onPriceChangePress },
-          ReactActual.createElement(Text, null, priceChangeButtonText),
-        ),
-      ),
-  };
-});
-
-// Mock bottom sheets as no-ops for rendering
-jest.mock('../../Trending/components/TrendingTokensBottomSheet', () => ({
-  PriceChangeOption: {
-    PriceChange: 'price_change',
-    Volume: 'volume',
-    MarketCap: 'market_cap',
-  },
-  TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
-  SortDirection: { Ascending: 'asc', Descending: 'desc' },
-  TrendingTokenNetworkBottomSheet: () => null,
-  TrendingTokenPriceChangeBottomSheet: () => null,
-}));
-
 const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
   ({
     symbol,
@@ -359,6 +297,7 @@ const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
     rwaData: null,
   }) as unknown as TrendingAsset;
 
+// Default mock values: no active group accounts, no balances
 let mockActiveGroupAccounts: { address: string }[] = [];
 let mockAllTokenBalances: Record<
   string,
@@ -389,12 +328,13 @@ describe('OndoCampaignRwaSelectorView', () => {
 
   it('renders without crashing', () => {
     const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-    expect(getByTestId('ondo-rwa-selector-header')).toBeDefined();
+    expect(getByTestId('header')).toBeDefined();
   });
 
   it('renders skeleton when loading', () => {
     mockUseRwaTokens.mockReturnValue({ data: [], isLoading: true });
     const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+    // When loading, FlatList is replaced by skeleton boxes — no token rows rendered
     expect(queryByTestId('token-row-AAPL')).toBeNull();
   });
 
@@ -416,6 +356,14 @@ describe('OndoCampaignRwaSelectorView', () => {
     expect(getByTestId('token-row-MSFT')).toBeDefined();
   });
 
+  it('in open_position mode, shows plain title string', () => {
+    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+    const { getByText } = render(<OndoCampaignRwaSelectorView />);
+    expect(
+      getByText('rewards.ondo_rwa_asset_selector.title_open_position'),
+    ).toBeDefined();
+  });
+
   it('calls goToSwaps when a token item is pressed', () => {
     const token = buildToken('AAPL');
     mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
@@ -428,37 +376,6 @@ describe('OndoCampaignRwaSelectorView', () => {
     const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
     fireEvent.press(getByTestId('header-back-button'));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
-  });
-
-  describe('filter bar', () => {
-    it('shows filter bar with network and price-change buttons in open_position mode', () => {
-      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      expect(getByTestId('filter-bar')).toBeDefined();
-      expect(getByTestId('all-networks-button')).toBeDefined();
-      expect(getByTestId('price-change-button')).toBeDefined();
-    });
-
-    it('shows filter bar in swap mode', () => {
-      mockRouteParams = {
-        mode: 'swap',
-        campaignId: 'campaign-1',
-        srcTokenAsset: 'eip155:1/erc20:0xabc',
-        srcTokenSymbol: 'USDC',
-        srcTokenDecimals: 6,
-      };
-      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      expect(getByTestId('filter-bar')).toBeDefined();
-    });
-
-    it('defaults to Ethereum chainId in open_position mode', () => {
-      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
-      render(<OndoCampaignRwaSelectorView />);
-      const lastCall =
-        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
-      expect(lastCall.chainIds).toEqual(['eip155:1']);
-    });
   });
 
   describe('swap mode', () => {
@@ -486,41 +403,101 @@ describe('OndoCampaignRwaSelectorView', () => {
         queryByText('rewards.ondo_rwa_asset_selector.title_open_position'),
       ).toBeNull();
     });
+  });
 
-    it('uppercases the source symbol in the title', () => {
-      mockRouteParams = {
-        ...mockRouteParams,
-        srcTokenSymbol: 'NIOon',
-      };
-      const { getByText } = render(<OndoCampaignRwaSelectorView />);
-      expect(getByText('NIOON')).toBeDefined();
+  describe('after-hours sheet', () => {
+    const token = buildToken('AAPL');
+
+    beforeEach(() => {
+      mockIsTokenTradingOpen = jest.fn(() => false);
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
     });
 
-    it('excludes the source token from the destination list by CAIP-19 assetId', () => {
-      const srcAssetId = 'eip155:1/erc20:0xabc';
-      mockRouteParams = {
-        mode: 'swap',
-        campaignId: 'campaign-1',
-        srcTokenAsset: srcAssetId,
-        srcTokenSymbol: 'NIOon',
-        srcTokenDecimals: 18,
-      };
-      mockUseRwaTokens.mockReturnValue({
-        data: [
-          buildToken('NIOon', srcAssetId),
-          buildToken('AAPL', 'eip155:1/erc20:0xdef'),
-        ],
-        isLoading: false,
-      });
-      const { queryByTestId, getByTestId } = render(
+    it('shows the after-hours sheet when token trading is closed', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
+    });
+
+    it('closes the after-hours sheet without navigating when onClose is called', () => {
+      const { getByTestId, queryByTestId } = render(
         <OndoCampaignRwaSelectorView />,
       );
-      expect(queryByTestId('token-row-NIOon')).toBeNull();
-      expect(getByTestId('token-row-AAPL')).toBeDefined();
+
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
+
+      fireEvent.press(getByTestId('after-hours-close'));
+
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+      expect(mockGoToSwaps).not.toHaveBeenCalled();
+    });
+
+    it('tracks REWARDS_PAGE_BUTTON_CLICKED and calls goToSwaps when onConfirm is called', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      act(() => {
+        fireEvent.press(getByTestId('after-hours-confirm'));
+      });
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+      const buttonClickIndex = mockCreateEventBuilder.mock.calls.findIndex(
+        (call: unknown[]) =>
+          call[0] === MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+      const builder =
+        mockCreateEventBuilder.mock.results[buttonClickIndex]?.value;
+      expect(builder?.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          button_type: 'ondo_campaign_swap_aapl',
+        }),
+      );
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('search interactions', () => {
+    it('shows the clear button when search query is not empty and clears it on press', () => {
+      const { getByPlaceholderText, getByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      const input = getByPlaceholderText(
+        'rewards.ondo_rwa_asset_selector.search_placeholder',
+      );
+      fireEvent.changeText(input, 'AAPL');
+      expect(getByTestId('clear-search-button')).toBeDefined();
+      fireEvent.press(getByTestId('clear-search-button'));
+      // After pressing clear, the button should disappear
+      expect(() => getByTestId('clear-search-button')).toThrow();
+    });
+
+    it('displays skeleton after search query changes (isFiltering)', () => {
+      mockUseRwaTokens.mockReturnValue({
+        data: [buildToken('AAPL'), buildToken('MSFT')],
+        isLoading: false,
+      });
+      const { getByPlaceholderText, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      const input = getByPlaceholderText(
+        'rewards.ondo_rwa_asset_selector.search_placeholder',
+      );
+      // After changing text, isFiltering becomes true → skeleton shown
+      fireEvent.changeText(input, 'AAPL');
+      // Skeleton replaces the token list
+      expect(queryByTestId('token-row-MSFT')).toBeNull();
     });
   });
 
   describe('open_position mode — USDY source preselection', () => {
+    // parseCaip19 mock always returns assetReference '0xabc', so the balance
+    // lookup key matches that address regardless of the USDY_CAIP19 constant.
     const USDY_HEX_ADDRESS = '0xabc';
     const ACCOUNT_ADDRESS = '0xaccount1';
 
@@ -529,6 +506,8 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
 
     it('passes USDY as source token when user holds a non-zero USDY balance', () => {
+      // rwaTokens intentionally does NOT contain USDY — preset comes from the
+      // hardcoded constant, not from the token list.
       mockUseRwaTokens.mockReturnValue({
         data: [buildToken('AAPL')],
         isLoading: false,
@@ -546,6 +525,24 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(srcArg).toBeDefined();
       expect(srcArg?.symbol).toBe('USDY');
       expect(destArg?.symbol).toBe('AAPL');
+    });
+
+    it('preset survives search — applies even when rwaTokens is filtered to non-USDY results', () => {
+      // Simulate the user having searched for "AAPL": rwaTokens contains only AAPL.
+      mockUseRwaTokens.mockReturnValue({
+        data: [buildToken('AAPL')],
+        isLoading: false,
+      });
+      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
+      mockAllTokenBalances = {
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+      };
+
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      const [srcArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg?.symbol).toBe('USDY');
     });
 
     it('passes undefined as source token when active group accounts are empty', () => {
@@ -604,6 +601,70 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
       const [srcArg] = mockGoToSwaps.mock.calls[0];
       expect(srcArg).toBeUndefined();
+    });
+  });
+
+  describe('network filter (open_position mode)', () => {
+    it('shows the network filter button in open_position mode', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByTestId('network-filter-button')).toBeDefined();
+    });
+
+    it('does not show the network filter button in swap mode', () => {
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: 'eip155:1/erc20:0xabc',
+        srcTokenSymbol: 'USDC',
+        srcTokenDecimals: 6,
+      };
+      const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(queryByTestId('network-filter-button')).toBeNull();
+    });
+
+    it('opens the network bottom sheet when the filter button is pressed', () => {
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      expect(queryByTestId('network-bottom-sheet')).toBeNull();
+      fireEvent.press(getByTestId('network-filter-button'));
+      expect(getByTestId('network-bottom-sheet')).toBeDefined();
+    });
+
+    it('calls useRwaTokens with Ethereum chainId by default', () => {
+      render(<OndoCampaignRwaSelectorView />);
+      const lastCall =
+        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
+      expect(lastCall.chainIds).toEqual(['eip155:1']);
+    });
+
+    it('updates chainIds when a different network is selected', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('network-filter-button'));
+      fireEvent.press(getByTestId('select-bnb-network'));
+      const lastCall =
+        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
+      expect(lastCall.chainIds).toEqual(['eip155:56']);
+    });
+  });
+
+  describe('token name sanitization', () => {
+    it('strips "Ondo Tokenized " prefix from token names in list rows', () => {
+      const token = {
+        ...buildToken('AAPL'),
+        name: 'Ondo Tokenized Apple',
+      };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByText, queryByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByText('Apple')).toBeDefined();
+      expect(queryByText('Ondo Tokenized Apple')).toBeNull();
+    });
+
+    it('leaves unrelated token names unchanged', () => {
+      const token = { ...buildToken('USDY'), name: 'Ondo USD Yield' };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByText('Ondo USD Yield')).toBeDefined();
     });
   });
 

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -690,7 +690,7 @@ describe('OndoCampaignRwaSelectorView', () => {
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
       expect(mockGoToSwaps).toHaveBeenCalledWith(
-        expect.anything(),
+        undefined,
         expect.objectContaining({ name: 'Ondo Tokenized Apple' }),
       );
     });

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -683,6 +683,17 @@ describe('OndoCampaignRwaSelectorView', () => {
       const { getByText } = render(<OndoCampaignRwaSelectorView />);
       expect(getByText('Ondo USD Yield')).toBeDefined();
     });
+
+    it('passes original unsanitized name to goToSwaps when token has Ondo prefix', () => {
+      const token = { ...buildToken('AAPL'), name: 'Ondo Tokenized Apple' };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      expect(mockGoToSwaps).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: 'Ondo Tokenized Apple' }),
+      );
+    });
   });
 
   describe('page view tracking', () => {

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -38,9 +38,38 @@ jest.mock('../../../../selectors/tokenBalancesController', () => ({
 }));
 
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: jest.fn() }),
   useRoute: () => ({ params: mockRouteParams }),
+  StackActions: { push: jest.fn() },
 }));
+
+jest.mock('@react-navigation/stack', () => ({
+  ...jest.requireActual('@react-navigation/stack'),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  const stub = () => ReactActual.createElement(View, null);
+  return {
+    BadgeWrapper: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(View, null, children),
+    BadgeWrapperPosition: { BottomRight: 'bottom-right' },
+    Box: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, children),
+    BoxAlignItems: { Center: 'center' },
+    BoxFlexDirection: { Row: 'row' },
+    Icon: stub,
+    IconColor: { IconAlternative: 'alternative' },
+    IconName: { Search: 'search', Close: 'close' },
+    IconSize: { Sm: 'sm' },
+    Skeleton: stub,
+    Text: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(Text, null, children),
+    TextColor: { TextAlternative: 'alternative' },
+    TextVariant: { BodyMd: 'body-md', HeadingSm: 'heading-sm' },
+  };
+});
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => {
@@ -60,15 +89,17 @@ jest.mock(
       default: ({
         title,
         onBack,
+        onClose,
       }: {
         title: React.ReactNode;
-        onBack: () => void;
+        onBack?: () => void;
+        onClose?: () => void;
       }) =>
         ReactActual.createElement(
           View,
           { testID: 'header' },
           ReactActual.createElement(Pressable, {
-            onPress: onBack,
+            onPress: onBack ?? onClose,
             testID: 'header-back-button',
           }),
           typeof title === 'string'
@@ -145,6 +176,13 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));
 
+jest.mock('../../../../core/Analytics', () => ({
+  MetaMetricsEvents: {
+    REWARDS_PAGE_BUTTON_CLICKED: 'REWARDS_PAGE_BUTTON_CLICKED',
+    REWARDS_PAGE_VIEWED: 'REWARDS_PAGE_VIEWED',
+  },
+}));
+
 jest.mock('../utils/formatUtils', () => ({
   ...jest.requireActual('../utils/formatUtils'),
   parseCaip19: jest.fn(() => ({
@@ -182,64 +220,11 @@ jest.mock(
   },
 );
 
-jest.mock(
-  '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet',
-  () => ({
-    TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
-  }),
-);
-
-const mockOnNetworkSelect = jest.fn();
-
-jest.mock('../../Trending/components/TrendingTokensBottomSheet', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, TouchableOpacity } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    TrendingTokenNetworkBottomSheet: ({
-      isVisible,
-      onNetworkSelect,
-    }: {
-      isVisible: boolean;
-      onNetworkSelect: (chainIds: string[] | null) => void;
-      onClose: () => void;
-    }) => {
-      if (!isVisible) return null;
-      mockOnNetworkSelect.mockImplementation(onNetworkSelect);
-      return ReactActual.createElement(
-        View,
-        { testID: 'network-bottom-sheet' },
-        ReactActual.createElement(TouchableOpacity, {
-          testID: 'select-bnb-network',
-          onPress: () => onNetworkSelect(['eip155:56']),
-        }),
-      );
-    },
-    NetworkOption: { AllNetworks: 'all' },
-  };
-});
-
-jest.mock('../../Trending/components/FilterBar/FilterBar', () => {
-  const ReactActual = jest.requireActual('react');
-  const { TouchableOpacity, Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    FilterButton: ({
-      testID,
-      label,
-      onPress,
-    }: {
-      testID: string;
-      label: string;
-      onPress: () => void;
-    }) =>
-      ReactActual.createElement(
-        TouchableOpacity,
-        { testID, onPress },
-        ReactActual.createElement(Text, null, label),
-      ),
-  };
-});
+jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
+  getTrendingTokenImageUrl: jest.fn(
+    (assetId: string) => `https://mock.image/${assetId}`,
+  ),
+}));
 
 jest.mock('../../Trending/utils/trendingNetworksList', () => ({
   RWA_NETWORKS_LIST: [
@@ -249,14 +234,16 @@ jest.mock('../../Trending/utils/trendingNetworksList', () => ({
 }));
 
 jest.mock('../../Trending/hooks/useNetworkName/useNetworkName', () => ({
-  useNetworkName: jest.fn(() => 'Ethereum'),
+  useNetworkName: () => 'All networks',
 }));
 
-// Silence utility mocks
-jest.mock('../../Trending/utils/getTrendingTokenImageUrl', () => ({
-  getTrendingTokenImageUrl: jest.fn(
-    (assetId: string) => `https://mock.image/${assetId}`,
-  ),
+jest.mock('../../Trending/services/TrendingFeedSessionManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      trackFilterChange: jest.fn(),
+    }),
+  },
 }));
 
 jest.mock('../../../../util/theme', () => ({
@@ -266,11 +253,26 @@ jest.mock('../../../../util/theme', () => ({
       border: { muted: 'muted-border' },
     },
   }),
+  useAppThemeFromContext: () => ({}),
 }));
 
 jest.mock('../../AssetOverview/Balance/Balance', () => ({
   NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
 }));
+
+jest.mock('../../../../component-library/components/Avatars/Avatar', () => ({
+  AvatarSize: { Xs: 'xs', Sm: 'sm', Md: 'md', Lg: 'lg', Xl: 'xl' },
+}));
+
+jest.mock('../../../../component-library/components/Badges/Badge', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () => ReactActual.createElement(View, null),
+    BadgeVariant: { Network: 'Network' },
+  };
+});
 
 jest.mock('../../Trending/components/TrendingTokenLogo', () => {
   const ReactActual = jest.requireActual('react');
@@ -288,6 +290,112 @@ jest.mock('@metamask/utils', () => ({
   ...jest.requireActual('@metamask/utils'),
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: jest.requireActual('react-native').View,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Mock the shared ListHeaderWithSearch used by TrendingListHeader
+jest.mock('../../shared/ListHeaderWithSearch', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text, Pressable, TextInput } =
+    jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      title,
+      isSearchVisible,
+      searchQuery,
+      onSearchQueryChange,
+      onBack,
+      onSearchToggle,
+      searchPlaceholder,
+      testID,
+    }: {
+      title: React.ReactNode;
+      isSearchVisible: boolean;
+      searchQuery: string;
+      onSearchQueryChange: (q: string) => void;
+      onBack: () => void;
+      onSearchToggle: () => void;
+      searchPlaceholder?: string;
+      cancelText?: string;
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: testID ?? 'header' },
+        ReactActual.createElement(Pressable, {
+          onPress: onBack,
+          testID: 'header-back-button',
+        }),
+        typeof title === 'string'
+          ? ReactActual.createElement(Text, { testID: 'header-title' }, title)
+          : title,
+        ReactActual.createElement(Pressable, {
+          onPress: onSearchToggle,
+          testID: 'search-toggle',
+        }),
+        isSearchVisible
+          ? ReactActual.createElement(TextInput, {
+              testID: 'search-input',
+              placeholder: searchPlaceholder,
+              value: searchQuery,
+              onChangeText: onSearchQueryChange,
+            })
+          : null,
+      ),
+  };
+});
+
+// Mock FilterBar
+jest.mock('../../Trending/components/FilterBar/FilterBar', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Pressable, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      networkName,
+      onNetworkPress,
+      priceChangeButtonText,
+      onPriceChangePress,
+    }: {
+      networkName: string;
+      onNetworkPress: () => void;
+      priceChangeButtonText: string;
+      onPriceChangePress: () => void;
+      isPriceChangeDisabled?: boolean;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'filter-bar' },
+        ReactActual.createElement(
+          Pressable,
+          { testID: 'all-networks-button', onPress: onNetworkPress },
+          ReactActual.createElement(Text, null, networkName),
+        ),
+        ReactActual.createElement(
+          Pressable,
+          { testID: 'price-change-button', onPress: onPriceChangePress },
+          ReactActual.createElement(Text, null, priceChangeButtonText),
+        ),
+      ),
+  };
+});
+
+// Mock bottom sheets as no-ops for rendering
+jest.mock('../../Trending/components/TrendingTokensBottomSheet', () => ({
+  PriceChangeOption: {
+    PriceChange: 'price_change',
+    Volume: 'volume',
+    MarketCap: 'market_cap',
+  },
+  TimeOption: { TwentyFourHours: '24H', OneWeek: '1W', OneMonth: '1M' },
+  SortDirection: { Ascending: 'asc', Descending: 'desc' },
+  TrendingTokenNetworkBottomSheet: () => null,
+  TrendingTokenPriceChangeBottomSheet: () => null,
+}));
+
 const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
   ({
     symbol,
@@ -297,7 +405,6 @@ const buildToken = (symbol: string, assetId?: string): TrendingAsset =>
     rwaData: null,
   }) as unknown as TrendingAsset;
 
-// Default mock values: no active group accounts, no balances
 let mockActiveGroupAccounts: { address: string }[] = [];
 let mockAllTokenBalances: Record<
   string,
@@ -328,13 +435,12 @@ describe('OndoCampaignRwaSelectorView', () => {
 
   it('renders without crashing', () => {
     const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-    expect(getByTestId('header')).toBeDefined();
+    expect(getByTestId('ondo-rwa-selector-header')).toBeDefined();
   });
 
   it('renders skeleton when loading', () => {
     mockUseRwaTokens.mockReturnValue({ data: [], isLoading: true });
     const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
-    // When loading, FlatList is replaced by skeleton boxes — no token rows rendered
     expect(queryByTestId('token-row-AAPL')).toBeNull();
   });
 
@@ -356,14 +462,6 @@ describe('OndoCampaignRwaSelectorView', () => {
     expect(getByTestId('token-row-MSFT')).toBeDefined();
   });
 
-  it('in open_position mode, shows plain title string', () => {
-    mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
-    const { getByText } = render(<OndoCampaignRwaSelectorView />);
-    expect(
-      getByText('rewards.ondo_rwa_asset_selector.title_open_position'),
-    ).toBeDefined();
-  });
-
   it('calls goToSwaps when a token item is pressed', () => {
     const token = buildToken('AAPL');
     mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
@@ -376,6 +474,37 @@ describe('OndoCampaignRwaSelectorView', () => {
     const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
     fireEvent.press(getByTestId('header-back-button'));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  describe('filter bar', () => {
+    it('shows filter bar with network and price-change buttons in open_position mode', () => {
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByTestId('filter-bar')).toBeDefined();
+      expect(getByTestId('all-networks-button')).toBeDefined();
+      expect(getByTestId('price-change-button')).toBeDefined();
+    });
+
+    it('shows filter bar in swap mode', () => {
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: 'eip155:1/erc20:0xabc',
+        srcTokenSymbol: 'USDC',
+        srcTokenDecimals: 6,
+      };
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByTestId('filter-bar')).toBeDefined();
+    });
+
+    it('defaults to Ethereum chainId in open_position mode', () => {
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      render(<OndoCampaignRwaSelectorView />);
+      const lastCall =
+        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
+      expect(lastCall.chainIds).toEqual(['eip155:1']);
+    });
   });
 
   describe('swap mode', () => {
@@ -403,101 +532,41 @@ describe('OndoCampaignRwaSelectorView', () => {
         queryByText('rewards.ondo_rwa_asset_selector.title_open_position'),
       ).toBeNull();
     });
-  });
 
-  describe('after-hours sheet', () => {
-    const token = buildToken('AAPL');
-
-    beforeEach(() => {
-      mockIsTokenTradingOpen = jest.fn(() => false);
-      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+    it('uppercases the source symbol in the title', () => {
+      mockRouteParams = {
+        ...mockRouteParams,
+        srcTokenSymbol: 'NIOon',
+      };
+      const { getByText } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByText('NIOON')).toBeDefined();
     });
 
-    it('shows the after-hours sheet when token trading is closed', () => {
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-
-      fireEvent.press(getByTestId('token-row-AAPL'));
-
-      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
-    });
-
-    it('closes the after-hours sheet without navigating when onClose is called', () => {
-      const { getByTestId, queryByTestId } = render(
-        <OndoCampaignRwaSelectorView />,
-      );
-
-      fireEvent.press(getByTestId('token-row-AAPL'));
-      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
-
-      fireEvent.press(getByTestId('after-hours-close'));
-
-      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
-      expect(mockGoToSwaps).not.toHaveBeenCalled();
-    });
-
-    it('tracks REWARDS_PAGE_BUTTON_CLICKED and calls goToSwaps when onConfirm is called', () => {
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-
-      fireEvent.press(getByTestId('token-row-AAPL'));
-
-      act(() => {
-        fireEvent.press(getByTestId('after-hours-confirm'));
-      });
-
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
-      );
-      const buttonClickIndex = mockCreateEventBuilder.mock.calls.findIndex(
-        (call: unknown[]) =>
-          call[0] === MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
-      );
-      const builder =
-        mockCreateEventBuilder.mock.results[buttonClickIndex]?.value;
-      expect(builder?.addProperties).toHaveBeenCalledWith(
-        expect.objectContaining({
-          button_type: 'ondo_campaign_swap_aapl',
-        }),
-      );
-      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('search interactions', () => {
-    it('shows the clear button when search query is not empty and clears it on press', () => {
-      const { getByPlaceholderText, getByTestId } = render(
-        <OndoCampaignRwaSelectorView />,
-      );
-      const input = getByPlaceholderText(
-        'rewards.ondo_rwa_asset_selector.search_placeholder',
-      );
-      fireEvent.changeText(input, 'AAPL');
-      expect(getByTestId('clear-search-button')).toBeDefined();
-      fireEvent.press(getByTestId('clear-search-button'));
-      // After pressing clear, the button should disappear
-      expect(() => getByTestId('clear-search-button')).toThrow();
-    });
-
-    it('displays skeleton after search query changes (isFiltering)', () => {
+    it('excludes the source token from the destination list by CAIP-19 assetId', () => {
+      const srcAssetId = 'eip155:1/erc20:0xabc';
+      mockRouteParams = {
+        mode: 'swap',
+        campaignId: 'campaign-1',
+        srcTokenAsset: srcAssetId,
+        srcTokenSymbol: 'NIOon',
+        srcTokenDecimals: 18,
+      };
       mockUseRwaTokens.mockReturnValue({
-        data: [buildToken('AAPL'), buildToken('MSFT')],
+        data: [
+          buildToken('NIOon', srcAssetId),
+          buildToken('AAPL', 'eip155:1/erc20:0xdef'),
+        ],
         isLoading: false,
       });
-      const { getByPlaceholderText, queryByTestId } = render(
+      const { queryByTestId, getByTestId } = render(
         <OndoCampaignRwaSelectorView />,
       );
-      const input = getByPlaceholderText(
-        'rewards.ondo_rwa_asset_selector.search_placeholder',
-      );
-      // After changing text, isFiltering becomes true → skeleton shown
-      fireEvent.changeText(input, 'AAPL');
-      // Skeleton replaces the token list
-      expect(queryByTestId('token-row-MSFT')).toBeNull();
+      expect(queryByTestId('token-row-NIOon')).toBeNull();
+      expect(getByTestId('token-row-AAPL')).toBeDefined();
     });
   });
 
   describe('open_position mode — USDY source preselection', () => {
-    // parseCaip19 mock always returns assetReference '0xabc', so the balance
-    // lookup key matches that address regardless of the USDY_CAIP19 constant.
     const USDY_HEX_ADDRESS = '0xabc';
     const ACCOUNT_ADDRESS = '0xaccount1';
 
@@ -506,8 +575,6 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
 
     it('passes USDY as source token when user holds a non-zero USDY balance', () => {
-      // rwaTokens intentionally does NOT contain USDY — preset comes from the
-      // hardcoded constant, not from the token list.
       mockUseRwaTokens.mockReturnValue({
         data: [buildToken('AAPL')],
         isLoading: false,
@@ -525,24 +592,6 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(srcArg).toBeDefined();
       expect(srcArg?.symbol).toBe('USDY');
       expect(destArg?.symbol).toBe('AAPL');
-    });
-
-    it('preset survives search — applies even when rwaTokens is filtered to non-USDY results', () => {
-      // Simulate the user having searched for "AAPL": rwaTokens contains only AAPL.
-      mockUseRwaTokens.mockReturnValue({
-        data: [buildToken('AAPL')],
-        isLoading: false,
-      });
-      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
-      mockAllTokenBalances = {
-        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
-      };
-
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      fireEvent.press(getByTestId('token-row-AAPL'));
-
-      const [srcArg] = mockGoToSwaps.mock.calls[0];
-      expect(srcArg?.symbol).toBe('USDY');
     });
 
     it('passes undefined as source token when active group accounts are empty', () => {
@@ -604,60 +653,28 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
   });
 
-  describe('network filter (open_position mode)', () => {
-    it('shows the network filter button in open_position mode', () => {
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      expect(getByTestId('network-filter-button')).toBeDefined();
-    });
-
-    it('does not show the network filter button in swap mode', () => {
-      mockRouteParams = {
-        mode: 'swap',
-        campaignId: 'campaign-1',
-        srcTokenAsset: 'eip155:1/erc20:0xabc',
-        srcTokenSymbol: 'USDC',
-        srcTokenDecimals: 6,
-      };
-      const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
-      expect(queryByTestId('network-filter-button')).toBeNull();
-    });
-
-    it('opens the network bottom sheet when the filter button is pressed', () => {
-      const { getByTestId, queryByTestId } = render(
-        <OndoCampaignRwaSelectorView />,
-      );
-      expect(queryByTestId('network-bottom-sheet')).toBeNull();
-      fireEvent.press(getByTestId('network-filter-button'));
-      expect(getByTestId('network-bottom-sheet')).toBeDefined();
-    });
-
-    it('calls useRwaTokens with Ethereum chainId by default', () => {
-      render(<OndoCampaignRwaSelectorView />);
-      const lastCall =
-        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
-      expect(lastCall.chainIds).toEqual(['eip155:1']);
-    });
-
-    it('updates chainIds when a different network is selected', () => {
-      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
-      fireEvent.press(getByTestId('network-filter-button'));
-      fireEvent.press(getByTestId('select-bnb-network'));
-      const lastCall =
-        mockUseRwaTokens.mock.calls[mockUseRwaTokens.mock.calls.length - 1][0];
-      expect(lastCall.chainIds).toEqual(['eip155:56']);
-    });
-  });
-
   describe('token name sanitization', () => {
     it('strips "Ondo Tokenized " prefix from token names in list rows', () => {
-      const token = {
-        ...buildToken('AAPL'),
-        name: 'Ondo Tokenized Apple',
-      };
+      const token = { ...buildToken('AAPL'), name: 'Ondo Tokenized Apple' };
       mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
-      const { getByText, queryByText } = render(<OndoCampaignRwaSelectorView />);
+      const { getByText, queryByText } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
       expect(getByText('Apple')).toBeDefined();
       expect(queryByText('Ondo Tokenized Apple')).toBeNull();
+    });
+
+    it('strips "(Ondo Tokenized)" suffix from token names in list rows', () => {
+      const token = {
+        ...buildToken('AAPL'),
+        name: 'Apple (Ondo Tokenized)',
+      };
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByText, queryByText } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      expect(getByText('Apple')).toBeDefined();
+      expect(queryByText('Apple (Ondo Tokenized)')).toBeNull();
     });
 
     it('leaves unrelated token names unchanged', () => {
@@ -691,4 +708,106 @@ describe('OndoCampaignRwaSelectorView', () => {
       );
     });
   });
+
+  describe('analytics — button clicked', () => {
+    it('tracks button_clicked with token symbol when token is selected', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      // createEventBuilder is called twice: once for page view, once for button click
+      const clickBuilder = mockCreateEventBuilder.mock.results[1].value;
+      expect(clickBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          button_type: 'ondo_campaign_swap_aapl',
+        }),
+      );
+    });
+  });
+
+  describe('after hours sheet', () => {
+    beforeEach(() => {
+      mockIsTokenTradingOpen = jest.fn(() => false);
+    });
+
+    it('shows after hours sheet when token trading is closed', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      expect(getByTestId('after-hours-sheet')).toBeDefined();
+    });
+
+    it('does not navigate to swaps when after hours sheet is shown', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      expect(mockGoToSwaps).not.toHaveBeenCalled();
+    });
+
+    it('closes sheet and does not navigate when close button is pressed', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      fireEvent.press(getByTestId('after-hours-close'));
+      expect(queryByTestId('after-hours-sheet')).toBeNull();
+      expect(mockGoToSwaps).not.toHaveBeenCalled();
+    });
+
+    it('navigates to swaps and closes sheet when confirm is pressed', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      fireEvent.press(getByTestId('after-hours-confirm'));
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      expect(queryByTestId('after-hours-sheet')).toBeNull();
+    });
+
+    it('tracks button_clicked event when after hours confirm is pressed', () => {
+      const token = buildToken('AAPL');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      fireEvent.press(getByTestId('after-hours-confirm'));
+
+      // createEventBuilder: [0] = page view, [1] = button click on confirm
+      const confirmBuilder = mockCreateEventBuilder.mock.results[1].value;
+      expect(confirmBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          button_type: 'ondo_campaign_swap_aapl',
+        }),
+      );
+    });
+  });
+
+  describe('search', () => {
+    it('hides filter bar when search is visible', () => {
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      expect(getByTestId('filter-bar')).toBeDefined();
+      fireEvent.press(getByTestId('search-toggle'));
+      expect(queryByTestId('filter-bar')).toBeNull();
+    });
+
+    it('shows filter bar again when search is dismissed', () => {
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('search-toggle'));
+      fireEvent.press(getByTestId('search-toggle'));
+      expect(getByTestId('filter-bar')).toBeDefined();
+    });
+  });
 });
+
+// keep the act import used in other test files from triggering "unused import" lint
+void act;

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -5,19 +5,26 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import {
+  FlatList,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   BadgeWrapper,
   BadgeWrapperPosition,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Skeleton,
   Text,
   TextColor,
@@ -26,6 +33,7 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Hex, type CaipChainId } from '@metamask/utils';
 import type { TrendingAsset } from '@metamask/assets-controllers';
+import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import TrendingTokenLogo from '../../Trending/components/TrendingTokenLogo';
 import Badge, {
   BadgeVariant,
@@ -36,31 +44,27 @@ import ErrorBoundary from '../../../Views/ErrorBoundary';
 import { useRwaTokens } from '../../Trending/hooks/useRwaTokens/useRwaTokens';
 import TrendingTokenRowItem from '../../Trending/components/TrendingTokenRowItem/TrendingTokenRowItem';
 import { getTrendingTokenImageUrl } from '../../Trending/utils/getTrendingTokenImageUrl';
-import { parseCaip19, caipChainIdToHex } from '../utils/formatUtils';
+import {
+  parseCaip19,
+  caipChainIdToHex,
+  sanitizeOndoTokenName,
+} from '../utils/formatUtils';
 import { RWA_NETWORKS_LIST } from '../../Trending/utils/trendingNetworksList';
+import { TrendingTokenNetworkBottomSheet } from '../../Trending/components/TrendingTokensBottomSheet';
+import { FilterButton } from '../../Trending/components/FilterBar/FilterBar';
+import { useNetworkName } from '../../Trending/hooks/useNetworkName/useNetworkName';
 import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
 } from '../../Bridge/hooks/useSwapBridgeNavigation';
 import type { BridgeToken } from '../../Bridge/types';
 import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
-import {
-  PriceChangeOption,
-  TimeOption,
-  TrendingTokenNetworkBottomSheet,
-  TrendingTokenPriceChangeBottomSheet,
-} from '../../Trending/components/TrendingTokensBottomSheet';
-import { TrendingListHeader } from '../../Trending/components/TrendingListHeader';
-import FilterBar from '../../Trending/components/FilterBar/FilterBar';
-import { useTokenListFilters } from '../../Trending/hooks/useTokenListFilters/useTokenListFilters';
+import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet';
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
-import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../core/Analytics';
-import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 
 // USDY (Ondo USD Yield) on Ethereum mainnet — used to preset the source token
 // for open_position mode. This is the only network where USDY is supported in
@@ -68,6 +72,9 @@ import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 const USDY_CAIP19 =
   'eip155:1/erc20:0x96f6ef951840721adbf46ac996b59e0235cb985c' as const;
 const USDY_DECIMALS = 18;
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -94,9 +101,7 @@ const styles = StyleSheet.create({
 const OndoCampaignRwaSelectorView: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
   const navigation = useNavigation();
-  const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<
       RouteProp<OndoCampaignRwaSelectorRouteParams, 'OndoCampaignRwaSelector'>
@@ -110,30 +115,11 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     campaignId,
   } = route.params;
 
-  const filters = useTokenListFilters({
-    timeOption: TimeOption.TwentyFourHours,
-  });
-
-  // Set the default network filter based on mode:
-  // - swap: pre-select the source asset's chain
-  // - open_position: pre-select Ethereum
-  const hasSetInitialNetwork = useRef(false);
-  useEffect(() => {
-    if (hasSetInitialNetwork.current) return;
-    hasSetInitialNetwork.current = true;
-
-    if (mode === 'swap' && srcTokenAsset) {
-      const parsed = parseCaip19(srcTokenAsset);
-      if (parsed) {
-        filters.handleNetworkSelect([
-          `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
-        ]);
-        return;
-      }
-    }
-    filters.handleNetworkSelect([RWA_NETWORKS_LIST[0].caipChainId]);
-  }, [mode, srcTokenAsset, filters]);
-
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedChainId, setSelectedChainId] = useState<CaipChainId>(
+    RWA_NETWORKS_LIST[0].caipChainId,
+  );
+  const [showNetworkSheet, setShowNetworkSheet] = useState(false);
   const [isAfterHoursSheetOpen, setIsAfterHoursSheetOpen] = useState(false);
   const [afterHoursNextOpen, setAfterHoursNextOpen] = useState<Date | null>(
     null,
@@ -141,35 +127,20 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   const [afterHoursPendingToken, setAfterHoursPendingToken] =
     useState<BridgeToken | null>(null);
 
-  // Uppercase the source symbol — on-chain BSC symbols use mixed case
-  // (e.g. "NIOon") but the convention on this screen is always uppercase.
-  const srcTokenSymbolDisplay = srcTokenSymbol?.toUpperCase();
-
-  // Build the source BridgeToken from route params (swap mode only).
-  // chainId must be hex for EVM chains so useLatestBalance can fetch the
-  // on-chain balance (it skips CAIP-formatted EVM chain IDs).
+  // Build the source BridgeToken from route params (swap mode only)
   const srcBridgeToken = useMemo((): BridgeToken | undefined => {
-    if (mode !== 'swap' || !srcTokenAsset || !srcTokenSymbolDisplay)
-      return undefined;
+    if (mode !== 'swap' || !srcTokenAsset || !srcTokenSymbol) return undefined;
     const parsed = parseCaip19(srcTokenAsset);
-    if (!parsed || parsed.namespace !== 'eip155') return undefined;
+    if (!parsed) return undefined;
     return {
       address: parsed.assetReference,
-      symbol: srcTokenSymbolDisplay,
-      name: srcTokenName ?? srcTokenSymbolDisplay,
+      symbol: srcTokenSymbol,
+      name: srcTokenName ?? srcTokenSymbol,
       decimals: srcTokenDecimals ?? 18,
-      chainId: caipChainIdToHex(
-        `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
-      ),
+      chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
       image: getTrendingTokenImageUrl(srcTokenAsset),
     };
-  }, [
-    mode,
-    srcTokenAsset,
-    srcTokenSymbolDisplay,
-    srcTokenName,
-    srcTokenDecimals,
-  ]);
+  }, [mode, srcTokenAsset, srcTokenSymbol, srcTokenName, srcTokenDecimals]);
 
   const srcChainHex = useMemo(() => {
     if (!srcTokenAsset) return undefined;
@@ -180,32 +151,21 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     );
   }, [srcTokenAsset]);
 
-  // In swap mode, restrict the network picker to the source asset's chain.
-  // In open_position mode, show all RWA networks.
-  const allowedNetworks = useMemo(() => {
+  // open_position: show one chain at a time (user-selected, defaults to Ethereum).
+  // swap: lock to the src asset's chain.
+  const chainIds = useMemo((): CaipChainId[] => {
     if (mode === 'swap' && srcTokenAsset) {
       const parsed = parseCaip19(srcTokenAsset);
       if (parsed) {
-        const srcCaipChainId =
-          `${parsed.namespace}:${parsed.chainId}` as CaipChainId;
-        return RWA_NETWORKS_LIST.filter(
-          (n) => n.caipChainId === srcCaipChainId,
-        );
+        return [`${parsed.namespace}:${parsed.chainId}` as CaipChainId];
       }
     }
-    return RWA_NETWORKS_LIST;
-  }, [mode, srcTokenAsset]);
-
-  const chainIds = filters.selectedNetwork;
+    return [selectedChainId];
+  }, [mode, srcTokenAsset, selectedChainId]);
 
   const { data: rwaTokens, isLoading } = useRwaTokens({
-    searchQuery: filters.searchQuery || undefined,
+    searchQuery,
     chainIds,
-    sortTrendingTokensOptions: {
-      option:
-        filters.selectedPriceChangeOption ?? PriceChangeOption.PriceChange,
-      direction: filters.priceChangeSortDirection,
-    },
   });
 
   const activeGroupAccounts = useSelector(
@@ -244,6 +204,32 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     };
   }, [mode, activeGroupAccounts, allTokenBalances]);
 
+  // Show skeleton while client-side filters are being applied.
+  // useRwaTokens applies search/sort synchronously but via useStableReference,
+  // which delays opts by one render cycle — so rwaTokens lags behind the inputs
+  // by exactly one render. isFiltering bridges that gap.
+  const [isFiltering, setIsFiltering] = useState(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setIsFiltering(true);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    setIsFiltering(false);
+  }, [rwaTokens]);
+
+  const showSkeleton = isLoading || isFiltering;
+
+  const selectedNetworkName = useNetworkName(
+    mode === 'open_position' ? [selectedChainId] : null,
+  );
+
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { isTokenTradingOpen } = useRWAToken();
 
   useTrackRewardsPageView({
@@ -259,17 +245,15 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   });
 
   // Deduplicate by symbol so the same stock on multiple chains appears once.
-  // Use CAIP-19 assetId (not symbol) to exclude the source token in swap mode —
-  // symbol comparison is fragile when casing differs between chains.
   const tokens = useMemo((): TrendingAsset[] => {
     const seen = new Set<string>();
     return rwaTokens.filter((token) => {
-      if (srcTokenAsset && token.assetId === srcTokenAsset) return false;
+      if (srcTokenSymbol && token.symbol === srcTokenSymbol) return false;
       if (seen.has(token.symbol)) return false;
       seen.add(token.symbol);
       return true;
     });
-  }, [rwaTokens, srcTokenAsset]);
+  }, [rwaTokens, srcTokenSymbol]);
 
   const handleAssetSelect = useCallback(
     (asset: TrendingAsset) => {
@@ -314,10 +298,8 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     ],
   );
 
-  const swapTitle = useMemo(() => {
-    if (mode !== 'swap' || !srcTokenSymbolDisplay || !srcTokenAsset)
-      return undefined;
-    return (
+  const title =
+    mode === 'swap' && srcTokenSymbol && srcTokenAsset ? (
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -341,23 +323,21 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
         >
           <TrendingTokenLogo
             assetId={srcTokenAsset}
-            symbol={srcTokenSymbolDisplay}
+            symbol={srcTokenSymbol}
             size={28}
           />
         </BadgeWrapper>
-        <Text variant={TextVariant.HeadingSm}>{srcTokenSymbolDisplay}</Text>
+        <Text variant={TextVariant.HeadingSm}>{srcTokenSymbol}</Text>
       </Box>
+    ) : (
+      strings('rewards.ondo_rwa_asset_selector.title_open_position')
     );
-  }, [mode, srcTokenSymbolDisplay, srcTokenAsset, srcChainHex]);
-
-  const headerTitle =
-    swapTitle ?? strings('rewards.ondo_rwa_asset_selector.title_open_position');
 
   const renderItem = ({ item }: { item: TrendingAsset }) => (
     <View style={styles.row}>
       <TrendingTokenRowItem
-        token={item}
-        selectedTimeOption={filters.selectedTimeOption}
+        token={{ ...item, name: sanitizeOndoTokenName(item.name) }}
+        selectedTimeOption={TimeOption.TwentyFourHours}
         onPress={handleAssetSelect}
       />
     </View>
@@ -382,36 +362,70 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="OndoCampaignRwaSelectorView">
       <SafeAreaView
+        edges={{ bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
-        edges={['left', 'right']}
       >
-        <View style={tw.style('bg-default', { paddingTop: insets.top })}>
-          <TrendingListHeader
-            title={headerTitle}
-            isSearchVisible={filters.isSearchVisible}
-            searchQuery={filters.searchQuery}
-            onSearchQueryChange={filters.handleSearchQueryChange}
-            onBack={() => navigation.goBack()}
-            onSearchToggle={filters.handleSearchToggle}
-            testID="ondo-rwa-selector-header"
-          />
+        <HeaderCompactStandard
+          title={title}
+          onBack={() => navigation.goBack()}
+          includesTopInset
+        />
+
+        {/* Sticky search bar */}
+        <View style={tw.style('px-4 py-2 bg-default')}>
+          <View
+            style={tw.style(
+              'flex-row items-center bg-muted rounded-xl px-3 py-2 gap-2',
+            )}
+          >
+            <Icon
+              name={IconName.Search}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+            <TextInput
+              style={tw.style('flex-1 text-default body-md')}
+              placeholder={strings(
+                'rewards.ondo_rwa_asset_selector.search_placeholder',
+              )}
+              placeholderTextColor={colors.text.muted}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+            />
+            {searchQuery.length > 0 && (
+              <TouchableOpacity
+                testID="clear-search-button"
+                onPress={() => setSearchQuery('')}
+              >
+                <Icon
+                  name={IconName.Close}
+                  size={IconSize.Sm}
+                  color={IconColor.IconAlternative}
+                />
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
 
-        {!filters.isSearchVisible ? (
-          <FilterBar
-            priceChangeButtonText={filters.priceChangeButtonText}
-            onPriceChangePress={filters.handlePriceChangePress}
-            isPriceChangeDisabled={rwaTokens.length === 0}
-            networkName={filters.selectedNetworkName}
-            onNetworkPress={filters.handleAllNetworksPress}
-          />
-        ) : null}
+        {/* Network filter — only in open_position mode */}
+        {mode === 'open_position' && (
+          <View style={tw.style('px-4 pb-2')}>
+            <FilterButton
+              testID="network-filter-button"
+              label={selectedNetworkName}
+              onPress={() => setShowNetworkSheet(true)}
+            />
+          </View>
+        )}
 
         <View
           style={[styles.divider, { backgroundColor: colors.border.muted }]}
         />
 
-        {isLoading ? (
+        {showSkeleton ? (
           renderSkeleton()
         ) : (
           <FlatList<TrendingAsset>
@@ -423,22 +437,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
             ListEmptyComponent={renderEmpty}
           />
         )}
-
         <TrendingTokenNetworkBottomSheet
-          isVisible={filters.showNetworkBottomSheet}
-          onClose={() => filters.setShowNetworkBottomSheet(false)}
-          onNetworkSelect={filters.handleNetworkSelect}
-          selectedNetwork={filters.selectedNetwork}
-          networks={allowedNetworks}
+          isVisible={mode === 'open_position' && showNetworkSheet}
+          onClose={() => setShowNetworkSheet(false)}
+          onNetworkSelect={(chainIds) => {
+            if (chainIds?.[0]) setSelectedChainId(chainIds[0]);
+            setShowNetworkSheet(false);
+          }}
+          selectedNetwork={[selectedChainId]}
+          networks={RWA_NETWORKS_LIST}
+          hideAllNetworks
         />
-        <TrendingTokenPriceChangeBottomSheet
-          isVisible={filters.showPriceChangeBottomSheet}
-          onClose={() => filters.setShowPriceChangeBottomSheet(false)}
-          onPriceChangeSelect={filters.handlePriceChangeSelect}
-          selectedOption={filters.selectedPriceChangeOption}
-          sortDirection={filters.priceChangeSortDirection}
-        />
-
         {isAfterHoursSheetOpen && (
           <OndoAfterHoursSheet
             onClose={() => {

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -283,10 +283,11 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     (asset: TrendingAsset) => {
       const parsed = parseCaip19(asset.assetId);
       if (!parsed) return;
+      const rawToken = rwaTokens.find((t) => t.assetId === asset.assetId);
       const destToken: BridgeToken = {
         address: parsed.assetReference,
         symbol: asset.symbol,
-        name: asset.name,
+        name: rawToken?.name ?? asset.name,
         decimals: asset.decimals,
         chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
         image: getTrendingTokenImageUrl(asset.assetId),
@@ -319,6 +320,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
       trackEvent,
       createEventBuilder,
       ondoUsdSrcToken,
+      rwaTokens,
     ],
   );
 

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -262,18 +262,16 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     sourceToken: srcBridgeToken,
   });
 
-  // Deduplicate by symbol so the same stock on multiple chains appears once.
-  // Use CAIP-19 assetId (not symbol) to exclude the source token in swap mode —
-  // symbol comparison is fragile when casing differs between chains.
-  // Names are sanitized here so renderItem can pass token directly without
-  // creating a new object on every render call.
+  // Deduplicate by assetId and sanitize display names.
+  // Use CAIP-19 assetId (not symbol) for deduplication — symbol comparison
+  // is fragile when casing differs between chains.
   const tokens = useMemo((): TrendingAsset[] => {
     const seen = new Set<string>();
     return rwaTokens
       .filter((token) => {
         if (srcTokenAsset && token.assetId === srcTokenAsset) return false;
-        if (seen.has(token.symbol)) return false;
-        seen.add(token.symbol);
+        if (seen.has(token.assetId)) return false;
+        seen.add(token.assetId);
         return true;
       })
       .map((token) => ({ ...token, name: sanitizeOndoTokenName(token.name) }));

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -265,14 +265,18 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   // Deduplicate by symbol so the same stock on multiple chains appears once.
   // Use CAIP-19 assetId (not symbol) to exclude the source token in swap mode —
   // symbol comparison is fragile when casing differs between chains.
+  // Names are sanitized here so renderItem can pass token directly without
+  // creating a new object on every render call.
   const tokens = useMemo((): TrendingAsset[] => {
     const seen = new Set<string>();
-    return rwaTokens.filter((token) => {
-      if (srcTokenAsset && token.assetId === srcTokenAsset) return false;
-      if (seen.has(token.symbol)) return false;
-      seen.add(token.symbol);
-      return true;
-    });
+    return rwaTokens
+      .filter((token) => {
+        if (srcTokenAsset && token.assetId === srcTokenAsset) return false;
+        if (seen.has(token.symbol)) return false;
+        seen.add(token.symbol);
+        return true;
+      })
+      .map((token) => ({ ...token, name: sanitizeOndoTokenName(token.name) }));
   }, [rwaTokens, srcTokenAsset]);
 
   const handleAssetSelect = useCallback(
@@ -357,14 +361,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   const headerTitle =
     swapTitle ?? strings('rewards.ondo_rwa_asset_selector.title_open_position');
 
-  const renderItem = ({ item }: { item: TrendingAsset }) => (
-    <View style={styles.row}>
-      <TrendingTokenRowItem
-        token={{ ...item, name: sanitizeOndoTokenName(item.name) }}
-        selectedTimeOption={filters.selectedTimeOption}
-        onPress={handleAssetSelect}
-      />
-    </View>
+  const renderItem = useCallback(
+    ({ item }: { item: TrendingAsset }) => (
+      <View style={styles.row}>
+        <TrendingTokenRowItem
+          token={item}
+          selectedTimeOption={filters.selectedTimeOption}
+          onPress={handleAssetSelect}
+        />
+      </View>
+    ),
+    [filters.selectedTimeOption, handleAssetSelect],
   );
 
   const renderSkeleton = () => (

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -5,26 +5,19 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  FlatList,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import {
   BadgeWrapper,
   BadgeWrapperPosition,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
   Skeleton,
   Text,
   TextColor,
@@ -33,7 +26,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Hex, type CaipChainId } from '@metamask/utils';
 import type { TrendingAsset } from '@metamask/assets-controllers';
-import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import TrendingTokenLogo from '../../Trending/components/TrendingTokenLogo';
 import Badge, {
   BadgeVariant,
@@ -50,21 +42,29 @@ import {
   sanitizeOndoTokenName,
 } from '../utils/formatUtils';
 import { RWA_NETWORKS_LIST } from '../../Trending/utils/trendingNetworksList';
-import { TrendingTokenNetworkBottomSheet } from '../../Trending/components/TrendingTokensBottomSheet';
-import { FilterButton } from '../../Trending/components/FilterBar/FilterBar';
-import { useNetworkName } from '../../Trending/hooks/useNetworkName/useNetworkName';
 import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
 } from '../../Bridge/hooks/useSwapBridgeNavigation';
 import type { BridgeToken } from '../../Bridge/types';
 import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
-import { TimeOption } from '../../Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet';
+import {
+  PriceChangeOption,
+  TimeOption,
+  TrendingTokenNetworkBottomSheet,
+  TrendingTokenPriceChangeBottomSheet,
+} from '../../Trending/components/TrendingTokensBottomSheet';
+import { TrendingListHeader } from '../../Trending/components/TrendingListHeader';
+import FilterBar from '../../Trending/components/FilterBar/FilterBar';
+import { useTokenListFilters } from '../../Trending/hooks/useTokenListFilters/useTokenListFilters';
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import OndoAfterHoursSheet from '../components/Campaigns/OndoAfterHoursSheet';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesController';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 
 // USDY (Ondo USD Yield) on Ethereum mainnet — used to preset the source token
 // for open_position mode. This is the only network where USDY is supported in
@@ -72,9 +72,6 @@ import { selectAllTokenBalances } from '../../../../selectors/tokenBalancesContr
 const USDY_CAIP19 =
   'eip155:1/erc20:0x96f6ef951840721adbf46ac996b59e0235cb985c' as const;
 const USDY_DECIMALS = 18;
-import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../core/Analytics';
-import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -101,7 +98,9 @@ const styles = StyleSheet.create({
 const OndoCampaignRwaSelectorView: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<
       RouteProp<OndoCampaignRwaSelectorRouteParams, 'OndoCampaignRwaSelector'>
@@ -115,11 +114,30 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     campaignId,
   } = route.params;
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedChainId, setSelectedChainId] = useState<CaipChainId>(
-    RWA_NETWORKS_LIST[0].caipChainId,
-  );
-  const [showNetworkSheet, setShowNetworkSheet] = useState(false);
+  const filters = useTokenListFilters({
+    timeOption: TimeOption.TwentyFourHours,
+  });
+
+  // Set the default network filter based on mode:
+  // - swap: pre-select the source asset's chain
+  // - open_position: pre-select Ethereum
+  const hasSetInitialNetwork = useRef(false);
+  useEffect(() => {
+    if (hasSetInitialNetwork.current) return;
+    hasSetInitialNetwork.current = true;
+
+    if (mode === 'swap' && srcTokenAsset) {
+      const parsed = parseCaip19(srcTokenAsset);
+      if (parsed) {
+        filters.handleNetworkSelect([
+          `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+        ]);
+        return;
+      }
+    }
+    filters.handleNetworkSelect([RWA_NETWORKS_LIST[0].caipChainId]);
+  }, [mode, srcTokenAsset, filters]);
+
   const [isAfterHoursSheetOpen, setIsAfterHoursSheetOpen] = useState(false);
   const [afterHoursNextOpen, setAfterHoursNextOpen] = useState<Date | null>(
     null,
@@ -127,20 +145,35 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   const [afterHoursPendingToken, setAfterHoursPendingToken] =
     useState<BridgeToken | null>(null);
 
-  // Build the source BridgeToken from route params (swap mode only)
+  // Uppercase the source symbol — on-chain BSC symbols use mixed case
+  // (e.g. "NIOon") but the convention on this screen is always uppercase.
+  const srcTokenSymbolDisplay = srcTokenSymbol?.toUpperCase();
+
+  // Build the source BridgeToken from route params (swap mode only).
+  // chainId must be hex for EVM chains so useLatestBalance can fetch the
+  // on-chain balance (it skips CAIP-formatted EVM chain IDs).
   const srcBridgeToken = useMemo((): BridgeToken | undefined => {
-    if (mode !== 'swap' || !srcTokenAsset || !srcTokenSymbol) return undefined;
+    if (mode !== 'swap' || !srcTokenAsset || !srcTokenSymbolDisplay)
+      return undefined;
     const parsed = parseCaip19(srcTokenAsset);
-    if (!parsed) return undefined;
+    if (!parsed || parsed.namespace !== 'eip155') return undefined;
     return {
       address: parsed.assetReference,
-      symbol: srcTokenSymbol,
-      name: srcTokenName ?? srcTokenSymbol,
+      symbol: srcTokenSymbolDisplay,
+      name: srcTokenName ?? srcTokenSymbolDisplay,
       decimals: srcTokenDecimals ?? 18,
-      chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      chainId: caipChainIdToHex(
+        `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+      ),
       image: getTrendingTokenImageUrl(srcTokenAsset),
     };
-  }, [mode, srcTokenAsset, srcTokenSymbol, srcTokenName, srcTokenDecimals]);
+  }, [
+    mode,
+    srcTokenAsset,
+    srcTokenSymbolDisplay,
+    srcTokenName,
+    srcTokenDecimals,
+  ]);
 
   const srcChainHex = useMemo(() => {
     if (!srcTokenAsset) return undefined;
@@ -151,21 +184,32 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     );
   }, [srcTokenAsset]);
 
-  // open_position: show one chain at a time (user-selected, defaults to Ethereum).
-  // swap: lock to the src asset's chain.
-  const chainIds = useMemo((): CaipChainId[] => {
+  // In swap mode, restrict the network picker to the source asset's chain.
+  // In open_position mode, show all RWA networks.
+  const allowedNetworks = useMemo(() => {
     if (mode === 'swap' && srcTokenAsset) {
       const parsed = parseCaip19(srcTokenAsset);
       if (parsed) {
-        return [`${parsed.namespace}:${parsed.chainId}` as CaipChainId];
+        const srcCaipChainId =
+          `${parsed.namespace}:${parsed.chainId}` as CaipChainId;
+        return RWA_NETWORKS_LIST.filter(
+          (n) => n.caipChainId === srcCaipChainId,
+        );
       }
     }
-    return [selectedChainId];
-  }, [mode, srcTokenAsset, selectedChainId]);
+    return RWA_NETWORKS_LIST;
+  }, [mode, srcTokenAsset]);
+
+  const chainIds = filters.selectedNetwork;
 
   const { data: rwaTokens, isLoading } = useRwaTokens({
-    searchQuery,
+    searchQuery: filters.searchQuery || undefined,
     chainIds,
+    sortTrendingTokensOptions: {
+      option:
+        filters.selectedPriceChangeOption ?? PriceChangeOption.PriceChange,
+      direction: filters.priceChangeSortDirection,
+    },
   });
 
   const activeGroupAccounts = useSelector(
@@ -204,32 +248,6 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     };
   }, [mode, activeGroupAccounts, allTokenBalances]);
 
-  // Show skeleton while client-side filters are being applied.
-  // useRwaTokens applies search/sort synchronously but via useStableReference,
-  // which delays opts by one render cycle — so rwaTokens lags behind the inputs
-  // by exactly one render. isFiltering bridges that gap.
-  const [isFiltering, setIsFiltering] = useState(false);
-  const isFirstRender = useRef(true);
-
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-    setIsFiltering(true);
-  }, [searchQuery]);
-
-  useEffect(() => {
-    setIsFiltering(false);
-  }, [rwaTokens]);
-
-  const showSkeleton = isLoading || isFiltering;
-
-  const selectedNetworkName = useNetworkName(
-    mode === 'open_position' ? [selectedChainId] : null,
-  );
-
-  const { trackEvent, createEventBuilder } = useAnalytics();
   const { isTokenTradingOpen } = useRWAToken();
 
   useTrackRewardsPageView({
@@ -245,15 +263,17 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   });
 
   // Deduplicate by symbol so the same stock on multiple chains appears once.
+  // Use CAIP-19 assetId (not symbol) to exclude the source token in swap mode —
+  // symbol comparison is fragile when casing differs between chains.
   const tokens = useMemo((): TrendingAsset[] => {
     const seen = new Set<string>();
     return rwaTokens.filter((token) => {
-      if (srcTokenSymbol && token.symbol === srcTokenSymbol) return false;
+      if (srcTokenAsset && token.assetId === srcTokenAsset) return false;
       if (seen.has(token.symbol)) return false;
       seen.add(token.symbol);
       return true;
     });
-  }, [rwaTokens, srcTokenSymbol]);
+  }, [rwaTokens, srcTokenAsset]);
 
   const handleAssetSelect = useCallback(
     (asset: TrendingAsset) => {
@@ -298,8 +318,10 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     ],
   );
 
-  const title =
-    mode === 'swap' && srcTokenSymbol && srcTokenAsset ? (
+  const swapTitle = useMemo(() => {
+    if (mode !== 'swap' || !srcTokenSymbolDisplay || !srcTokenAsset)
+      return undefined;
+    return (
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -323,21 +345,23 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
         >
           <TrendingTokenLogo
             assetId={srcTokenAsset}
-            symbol={srcTokenSymbol}
+            symbol={srcTokenSymbolDisplay}
             size={28}
           />
         </BadgeWrapper>
-        <Text variant={TextVariant.HeadingSm}>{srcTokenSymbol}</Text>
+        <Text variant={TextVariant.HeadingSm}>{srcTokenSymbolDisplay}</Text>
       </Box>
-    ) : (
-      strings('rewards.ondo_rwa_asset_selector.title_open_position')
     );
+  }, [mode, srcTokenSymbolDisplay, srcTokenAsset, srcChainHex]);
+
+  const headerTitle =
+    swapTitle ?? strings('rewards.ondo_rwa_asset_selector.title_open_position');
 
   const renderItem = ({ item }: { item: TrendingAsset }) => (
     <View style={styles.row}>
       <TrendingTokenRowItem
         token={{ ...item, name: sanitizeOndoTokenName(item.name) }}
-        selectedTimeOption={TimeOption.TwentyFourHours}
+        selectedTimeOption={filters.selectedTimeOption}
         onPress={handleAssetSelect}
       />
     </View>
@@ -362,70 +386,36 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="OndoCampaignRwaSelectorView">
       <SafeAreaView
-        edges={{ bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
+        edges={['left', 'right']}
       >
-        <HeaderCompactStandard
-          title={title}
-          onBack={() => navigation.goBack()}
-          includesTopInset
-        />
-
-        {/* Sticky search bar */}
-        <View style={tw.style('px-4 py-2 bg-default')}>
-          <View
-            style={tw.style(
-              'flex-row items-center bg-muted rounded-xl px-3 py-2 gap-2',
-            )}
-          >
-            <Icon
-              name={IconName.Search}
-              size={IconSize.Sm}
-              color={IconColor.IconAlternative}
-            />
-            <TextInput
-              style={tw.style('flex-1 text-default body-md')}
-              placeholder={strings(
-                'rewards.ondo_rwa_asset_selector.search_placeholder',
-              )}
-              placeholderTextColor={colors.text.muted}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-              autoCorrect={false}
-              autoCapitalize="none"
-              returnKeyType="search"
-            />
-            {searchQuery.length > 0 && (
-              <TouchableOpacity
-                testID="clear-search-button"
-                onPress={() => setSearchQuery('')}
-              >
-                <Icon
-                  name={IconName.Close}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                />
-              </TouchableOpacity>
-            )}
-          </View>
+        <View style={tw.style('bg-default', { paddingTop: insets.top })}>
+          <TrendingListHeader
+            title={headerTitle}
+            isSearchVisible={filters.isSearchVisible}
+            searchQuery={filters.searchQuery}
+            onSearchQueryChange={filters.handleSearchQueryChange}
+            onBack={() => navigation.goBack()}
+            onSearchToggle={filters.handleSearchToggle}
+            testID="ondo-rwa-selector-header"
+          />
         </View>
 
-        {/* Network filter — only in open_position mode */}
-        {mode === 'open_position' && (
-          <View style={tw.style('px-4 pb-2')}>
-            <FilterButton
-              testID="network-filter-button"
-              label={selectedNetworkName}
-              onPress={() => setShowNetworkSheet(true)}
-            />
-          </View>
-        )}
+        {!filters.isSearchVisible ? (
+          <FilterBar
+            priceChangeButtonText={filters.priceChangeButtonText}
+            onPriceChangePress={filters.handlePriceChangePress}
+            isPriceChangeDisabled={rwaTokens.length === 0}
+            networkName={filters.selectedNetworkName}
+            onNetworkPress={filters.handleAllNetworksPress}
+          />
+        ) : null}
 
         <View
           style={[styles.divider, { backgroundColor: colors.border.muted }]}
         />
 
-        {showSkeleton ? (
+        {isLoading ? (
           renderSkeleton()
         ) : (
           <FlatList<TrendingAsset>
@@ -437,17 +427,23 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
             ListEmptyComponent={renderEmpty}
           />
         )}
+
         <TrendingTokenNetworkBottomSheet
-          isVisible={mode === 'open_position' && showNetworkSheet}
-          onClose={() => setShowNetworkSheet(false)}
-          onNetworkSelect={(chainIds) => {
-            if (chainIds?.[0]) setSelectedChainId(chainIds[0]);
-            setShowNetworkSheet(false);
-          }}
-          selectedNetwork={[selectedChainId]}
-          networks={RWA_NETWORKS_LIST}
+          isVisible={filters.showNetworkBottomSheet}
+          onClose={() => filters.setShowNetworkBottomSheet(false)}
+          onNetworkSelect={filters.handleNetworkSelect}
+          selectedNetwork={filters.selectedNetwork}
+          networks={allowedNetworks}
           hideAllNetworks
         />
+        <TrendingTokenPriceChangeBottomSheet
+          isVisible={filters.showPriceChangeBottomSheet}
+          onClose={() => filters.setShowPriceChangeBottomSheet(false)}
+          onPriceChangeSelect={filters.handlePriceChangeSelect}
+          selectedOption={filters.selectedPriceChangeOption}
+          sortDirection={filters.priceChangeSortDirection}
+        />
+
         {isAfterHoursSheetOpen && (
           <OndoAfterHoursSheet
             onClose={() => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -48,7 +48,7 @@ import {
   groupPortfolioPositionsByAsset,
   formatPnlPercent,
   isPnlNonNegative,
-  sanitizeTokenName,
+  sanitizeOndoTokenName,
 } from './OndoPortfolio.utils';
 import { formatComputedAt } from './OndoLeaderboard.utils';
 import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
@@ -463,7 +463,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {sanitizeTokenName(row.tokenName)}
+                      {sanitizeOndoTokenName(row.tokenName)}
                     </Text>
                     <Text
                       variant={TextVariant.BodyMd}

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
@@ -114,10 +114,14 @@ describe('isPnlNonNegative', () => {
 });
 
 describe('sanitizeOndoTokenName', () => {
-  it('strips "(Ondo Tokenized)" and trims', () => {
+  it('strips "(Ondo Tokenized)" suffix and trims', () => {
     expect(sanitizeOndoTokenName('US Dollar (Ondo Tokenized)')).toBe(
       'US Dollar',
     );
+  });
+
+  it('strips "Ondo Tokenized " prefix (trending token API format)', () => {
+    expect(sanitizeOndoTokenName('Ondo Tokenized Apple')).toBe('Apple');
   });
 
   it('is case-insensitive', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.test.ts
@@ -2,7 +2,7 @@ import {
   groupPortfolioPositionsByAsset,
   formatPnlPercent,
   isPnlNonNegative,
-  sanitizeTokenName,
+  sanitizeOndoTokenName,
 } from './OndoPortfolio.utils';
 
 describe('groupPortfolioPositionsByAsset', () => {
@@ -113,38 +113,40 @@ describe('isPnlNonNegative', () => {
   });
 });
 
-describe('sanitizeTokenName', () => {
+describe('sanitizeOndoTokenName', () => {
   it('strips "(Ondo Tokenized)" and trims', () => {
-    expect(sanitizeTokenName('US Dollar (Ondo Tokenized)')).toBe('US Dollar');
+    expect(sanitizeOndoTokenName('US Dollar (Ondo Tokenized)')).toBe(
+      'US Dollar',
+    );
   });
 
   it('is case-insensitive', () => {
-    expect(sanitizeTokenName('Token (ondo tokenized)')).toBe('Token');
+    expect(sanitizeOndoTokenName('Token (ondo tokenized)')).toBe('Token');
   });
 
   it('truncates to 28 characters with ellipsis', () => {
-    expect(sanitizeTokenName('A Very Long Token Name That Exceeds')).toBe(
+    expect(sanitizeOndoTokenName('A Very Long Token Name That Exceeds')).toBe(
       'A Very Long Token Name That...',
     );
   });
 
   it('strips then truncates with ellipsis', () => {
     const long = 'Extremely Long Name Here That Keeps Going (Ondo Tokenized)';
-    const result = sanitizeTokenName(long);
+    const result = sanitizeOndoTokenName(long);
     expect(result).toBe('Extremely Long Name Here Tha...');
   });
 
   it('does not add ellipsis when exactly 28 characters', () => {
-    expect(sanitizeTokenName('1234567890123456789012345678')).toBe(
+    expect(sanitizeOndoTokenName('1234567890123456789012345678')).toBe(
       '1234567890123456789012345678',
     );
   });
 
   it('returns the name unchanged when no stripping or truncation is needed', () => {
-    expect(sanitizeTokenName('OUSG')).toBe('OUSG');
+    expect(sanitizeOndoTokenName('OUSG')).toBe('OUSG');
   });
 
   it('handles empty string', () => {
-    expect(sanitizeTokenName('')).toBe('');
+    expect(sanitizeOndoTokenName('')).toBe('');
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.ts
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.utils.ts
@@ -8,6 +8,7 @@ export {
   getChainHex,
   shortenAddress,
   getAssetReference,
+  sanitizeOndoTokenName,
 } from '../../utils/formatUtils';
 
 /**
@@ -60,12 +61,4 @@ export function groupPortfolioPositionsByAsset(
   }
 
   return Array.from(map.values());
-}
-
-const MAX_TOKEN_NAME_LENGTH = 28;
-
-export function sanitizeTokenName(raw: string): string {
-  const cleaned = raw.replace(/\(Ondo Tokenized\)/gi, '').trim();
-  if (cleaned.length <= MAX_TOKEN_NAME_LENGTH) return cleaned;
-  return `${cleaned.slice(0, MAX_TOKEN_NAME_LENGTH).trim()}...`;
 }

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -26,6 +26,7 @@ import {
   formatUsd,
   formatSignedUsd,
   formatCompactUsd,
+  sanitizeOndoTokenName,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -1595,6 +1596,34 @@ describe('formatUtils', () => {
 
     it('formats negative thousands', () => {
       expect(formatCompactUsd(-75_000)).toBe('-$75K');
+    });
+  });
+
+  describe('sanitizeOndoTokenName', () => {
+    it('strips "Ondo Tokenized " prefix (exact casing)', () => {
+      expect(sanitizeOndoTokenName('Ondo Tokenized Apple')).toBe('Apple');
+    });
+
+    it('strips prefix case-insensitively', () => {
+      expect(sanitizeOndoTokenName('ondo tokenized google')).toBe('google');
+      expect(sanitizeOndoTokenName('ONDO TOKENIZED TSLA')).toBe('TSLA');
+    });
+
+    it('handles multiple spaces between words', () => {
+      expect(sanitizeOndoTokenName('Ondo  Tokenized  Apple')).toBe('Apple');
+    });
+
+    it('leaves unrelated names unchanged', () => {
+      expect(sanitizeOndoTokenName('Apple Inc')).toBe('Apple Inc');
+      expect(sanitizeOndoTokenName('USDY')).toBe('USDY');
+    });
+
+    it('returns empty string for an empty input', () => {
+      expect(sanitizeOndoTokenName('')).toBe('');
+    });
+
+    it('trims surrounding whitespace after stripping', () => {
+      expect(sanitizeOndoTokenName('Ondo Tokenized  Apple  ')).toBe('Apple');
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -1606,8 +1606,16 @@ describe('formatUtils', () => {
       );
     });
 
-    it('is case-insensitive', () => {
+    it('strips "Ondo Tokenized " prefix (trending token API format)', () => {
+      expect(sanitizeOndoTokenName('Ondo Tokenized Apple')).toBe('Apple');
+    });
+
+    it('is case-insensitive for suffix form', () => {
       expect(sanitizeOndoTokenName('Token (ondo tokenized)')).toBe('Token');
+    });
+
+    it('is case-insensitive for prefix form', () => {
+      expect(sanitizeOndoTokenName('ONDO TOKENIZED Apple')).toBe('Apple');
     });
 
     it('truncates to 28 characters with ellipsis', () => {
@@ -1616,11 +1624,19 @@ describe('formatUtils', () => {
       );
     });
 
-    it('strips then truncates with ellipsis', () => {
+    it('strips suffix then truncates with ellipsis', () => {
       const long = 'Extremely Long Name Here That Keeps Going (Ondo Tokenized)';
       expect(sanitizeOndoTokenName(long)).toBe(
         'Extremely Long Name Here Tha...',
       );
+    });
+
+    it('strips prefix then truncates with ellipsis', () => {
+      expect(
+        sanitizeOndoTokenName(
+          'Ondo Tokenized Extremely Long Name That Exceeds',
+        ),
+      ).toBe('Extremely Long Name That Exc...');
     });
 
     it('does not add ellipsis when exactly 28 characters', () => {

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -1600,30 +1600,41 @@ describe('formatUtils', () => {
   });
 
   describe('sanitizeOndoTokenName', () => {
-    it('strips "Ondo Tokenized " prefix (exact casing)', () => {
-      expect(sanitizeOndoTokenName('Ondo Tokenized Apple')).toBe('Apple');
+    it('strips "(Ondo Tokenized)" suffix and trims', () => {
+      expect(sanitizeOndoTokenName('US Dollar (Ondo Tokenized)')).toBe(
+        'US Dollar',
+      );
     });
 
-    it('strips prefix case-insensitively', () => {
-      expect(sanitizeOndoTokenName('ondo tokenized google')).toBe('google');
-      expect(sanitizeOndoTokenName('ONDO TOKENIZED TSLA')).toBe('TSLA');
+    it('is case-insensitive', () => {
+      expect(sanitizeOndoTokenName('Token (ondo tokenized)')).toBe('Token');
     });
 
-    it('handles multiple spaces between words', () => {
-      expect(sanitizeOndoTokenName('Ondo  Tokenized  Apple')).toBe('Apple');
+    it('truncates to 28 characters with ellipsis', () => {
+      expect(sanitizeOndoTokenName('A Very Long Token Name That Exceeds')).toBe(
+        'A Very Long Token Name That...',
+      );
+    });
+
+    it('strips then truncates with ellipsis', () => {
+      const long = 'Extremely Long Name Here That Keeps Going (Ondo Tokenized)';
+      expect(sanitizeOndoTokenName(long)).toBe(
+        'Extremely Long Name Here Tha...',
+      );
+    });
+
+    it('does not add ellipsis when exactly 28 characters', () => {
+      expect(sanitizeOndoTokenName('1234567890123456789012345678')).toBe(
+        '1234567890123456789012345678',
+      );
     });
 
     it('leaves unrelated names unchanged', () => {
-      expect(sanitizeOndoTokenName('Apple Inc')).toBe('Apple Inc');
-      expect(sanitizeOndoTokenName('USDY')).toBe('USDY');
+      expect(sanitizeOndoTokenName('OUSG')).toBe('OUSG');
     });
 
     it('returns empty string for an empty input', () => {
       expect(sanitizeOndoTokenName('')).toBe('');
-    });
-
-    it('trims surrounding whitespace after stripping', () => {
-      expect(sanitizeOndoTokenName('Ondo Tokenized  Apple  ')).toBe('Apple');
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -483,9 +483,14 @@ export const shortenAddress = (address: string): string => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
+const MAX_ONDO_TOKEN_NAME_LENGTH = 28;
+
 /**
- * Strips the "Ondo Tokenized " prefix from a token name returned by the
- * search API, so list rows show just the underlying asset name (e.g. "Apple").
+ * Strips the "(Ondo Tokenized)" suffix from a token name and truncates to
+ * MAX_ONDO_TOKEN_NAME_LENGTH characters with an ellipsis if needed.
  */
-export const sanitizeOndoTokenName = (name: string): string =>
-  name.replace(/^ondo\s+tokenized\s+/i, '').trim();
+export function sanitizeOndoTokenName(raw: string): string {
+  const cleaned = raw.replace(/\(Ondo Tokenized\)/gi, '').trim();
+  if (cleaned.length <= MAX_ONDO_TOKEN_NAME_LENGTH) return cleaned;
+  return `${cleaned.slice(0, MAX_ONDO_TOKEN_NAME_LENGTH).trim()}...`;
+}

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -489,9 +489,8 @@ const MAX_ONDO_TOKEN_NAME_LENGTH = 28;
  * Strips Ondo branding from a token name and truncates to
  * MAX_ONDO_TOKEN_NAME_LENGTH characters with an ellipsis if needed.
  *
- * Handles two forms returned by Ondo APIs:
- *  - Prefix (trending tokens):  "Ondo Tokenized Apple"  → "Apple"
- *  - Suffix (portfolio):        "US Dollar (Ondo Tokenized)" → "US Dollar"
+ * Handles two forms: prefix ("Ondo Tokenized Apple" → "Apple") and
+ * suffix ("US Dollar (Ondo Tokenized)" → "US Dollar").
  */
 export function sanitizeOndoTokenName(raw: string): string {
   const cleaned = raw

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -495,8 +495,7 @@ const MAX_ONDO_TOKEN_NAME_LENGTH = 28;
  */
 export function sanitizeOndoTokenName(raw: string): string {
   const cleaned = raw
-    .replace(/^ondo\s+tokenized\s+/i, '')
-    .replace(/\s*\(ondo\s+tokenized\)/gi, '')
+    .replace(/(?:^ondo\s+tokenized\s+|\s*\(ondo\s+tokenized\))/gi, '')
     .trim();
   if (cleaned.length <= MAX_ONDO_TOKEN_NAME_LENGTH) return cleaned;
   return `${cleaned.slice(0, MAX_ONDO_TOKEN_NAME_LENGTH).trim()}...`;

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -486,11 +486,18 @@ export const shortenAddress = (address: string): string => {
 const MAX_ONDO_TOKEN_NAME_LENGTH = 28;
 
 /**
- * Strips the "(Ondo Tokenized)" suffix from a token name and truncates to
+ * Strips Ondo branding from a token name and truncates to
  * MAX_ONDO_TOKEN_NAME_LENGTH characters with an ellipsis if needed.
+ *
+ * Handles two forms returned by Ondo APIs:
+ *  - Prefix (trending tokens):  "Ondo Tokenized Apple"  → "Apple"
+ *  - Suffix (portfolio):        "US Dollar (Ondo Tokenized)" → "US Dollar"
  */
 export function sanitizeOndoTokenName(raw: string): string {
-  const cleaned = raw.replace(/\(Ondo Tokenized\)/gi, '').trim();
+  const cleaned = raw
+    .replace(/^ondo\s+tokenized\s+/i, '')
+    .replace(/\s*\(ondo\s+tokenized\)/gi, '')
+    .trim();
   if (cleaned.length <= MAX_ONDO_TOKEN_NAME_LENGTH) return cleaned;
   return `${cleaned.slice(0, MAX_ONDO_TOKEN_NAME_LENGTH).trim()}...`;
 }

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -482,3 +482,10 @@ export const shortenAddress = (address: string): string => {
   if (address.length <= 10) return address;
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
+
+/**
+ * Strips the "Ondo Tokenized " prefix from a token name returned by the
+ * search API, so list rows show just the underlying asset name (e.g. "Apple").
+ */
+export const sanitizeOndoTokenName = (name: string): string =>
+  name.replace(/^ondo\s+tokenized\s+/i, '').trim();

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx
@@ -510,4 +510,37 @@ describe('TrendingTokenNetworkBottomSheet', () => {
 
     expect(queryByTestId('bottom-sheet')).toBeOnTheScreen();
   });
+
+  it('hides the "All networks" option when hideAllNetworks is true', () => {
+    const { queryByText } = renderWithProvider(
+      <TrendingTokenNetworkBottomSheet
+        isVisible
+        onClose={mockOnClose}
+        networks={mockNetworks}
+        selectedNetwork={['eip155:1' as CaipChainId]}
+        hideAllNetworks
+      />,
+      { state: mockState },
+      false,
+    );
+
+    expect(queryByText('All networks')).toBeNull();
+  });
+
+  it('still renders network options when hideAllNetworks is true', () => {
+    const { getByText } = renderWithProvider(
+      <TrendingTokenNetworkBottomSheet
+        isVisible
+        onClose={mockOnClose}
+        networks={mockNetworks}
+        selectedNetwork={['eip155:1' as CaipChainId]}
+        hideAllNetworks
+      />,
+      { state: mockState },
+      false,
+    );
+
+    expect(getByText('Ethereum Mainnet')).toBeOnTheScreen();
+    expect(getByText('Polygon')).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.tsx
@@ -30,6 +30,8 @@ export interface TrendingTokenNetworkBottomSheetProps {
   selectedNetwork?: CaipChainId[] | null;
   /** Networks to display in the bottom sheet */
   networks: ProcessedNetwork[];
+  /** When true, the "All networks" option is hidden */
+  hideAllNetworks?: boolean;
 }
 
 const TrendingTokenNetworkBottomSheet: React.FC<
@@ -40,6 +42,7 @@ const TrendingTokenNetworkBottomSheet: React.FC<
   onNetworkSelect,
   selectedNetwork: initialSelectedNetwork,
   networks,
+  hideAllNetworks = false,
 }) => {
   const sheetRef = useRef<BottomSheetRef>(null);
 
@@ -118,21 +121,23 @@ const TrendingTokenNetworkBottomSheet: React.FC<
         closeButtonProps={{ testID: 'close-button' }}
       />
       <ScrollView style={optionStyles.optionsList}>
-        <Cell
-          variant={CellVariant.Select}
-          title={strings('trending.all_networks')}
-          isSelected={isAllNetworksSelected}
-          onPress={() => onNetworkOptionPress(NetworkOption.AllNetworks)}
-          avatarProps={{
-            variant: AvatarVariant.Icon,
-            name: IconName.Global,
-            size: AvatarSize.Sm,
-          }}
-        >
-          {isAllNetworksSelected && (
-            <Icon name={IconName.Check} size={IconSize.Md} />
-          )}
-        </Cell>
+        {!hideAllNetworks && (
+          <Cell
+            variant={CellVariant.Select}
+            title={strings('trending.all_networks')}
+            isSelected={isAllNetworksSelected}
+            onPress={() => onNetworkOptionPress(NetworkOption.AllNetworks)}
+            avatarProps={{
+              variant: AvatarVariant.Icon,
+              name: IconName.Global,
+              size: AvatarSize.Sm,
+            }}
+          >
+            {isAllNetworksSelected && (
+              <Icon name={IconName.Check} size={IconSize.Md} />
+            )}
+          </Cell>
+        )}
         {networks.map((network) => {
           const isSelected = isNetworkSelected(network);
           return (


### PR DESCRIPTION
## Summary

- **Network filter (open_position only):** replaces loading all RWA chains simultaneously with a single-chain filter button backed by `TrendingTokenNetworkBottomSheet`. Defaults to Ethereum; user can switch to BNB Chain. The \"All Networks\" option is suppressed via a new `hideAllNetworks` prop. Swap mode is unchanged — chain stays locked to the source asset.
- **Name sanitization:** strips the \"Ondo Tokenized \" prefix from token names before rendering list rows (e.g. \"Ondo Tokenized Apple\" → \"Apple\") using a new `sanitizeOndoTokenName` util.

## Files changed

- `TrendingTokenNetworkBottomSheet.tsx` — add `hideAllNetworks?: boolean` prop
- `OndoCampaignRwaSelectorView.tsx` — chain filter button + bottom sheet + name sanitize in `renderItem`
- `formatUtils.ts` — `sanitizeOndoTokenName` util
- All three test files updated / extended

## Changelog

CHANGELOG entry: null

## Screenshots

Network selector not showing all, it'll be either network of src asset or both mainnet or bnb for open position

<img width="496" height="993" alt="image" src="https://github.com/user-attachments/assets/23da3e8a-a02d-4120-a0f3-9d5372b6b5af" />

<img width="485" height="981" alt="image" src="https://github.com/user-attachments/assets/4b70efef-5c67-41ba-b585-3ca6e792b277" />


Sanitized names in rwa page & ondo details page

<img width="496" height="993" alt="image" src="https://github.com/user-attachments/assets/6344b39e-4947-4b0d-9c21-8fc28f2cd30b" />

<img width="469" height="167" alt="image" src="https://github.com/user-attachments/assets/9d4612bf-fd60-4f8c-997b-c36e9e52f7ec" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the RWA selector’s token-list and selection logic (deduping, name rewriting, and swap destination construction) and changes network filtering UI behavior, which could affect what assets users can select and how swaps are initiated.
> 
> **Overview**
> Improves the Ondo RWA asset selector by **adding a constrained network picker** (via `TrendingTokenNetworkBottomSheet`) that can hide the *All networks* option and defaults the initial network based on mode (source chain for `swap`, Ethereum for `open_position`).
> 
> Introduces `sanitizeOndoTokenName` in `formatUtils` and applies it to **clean up displayed token names** (handling both `"Ondo Tokenized ..."` prefix and `(Ondo Tokenized)` suffix) while still passing the original unsanitized name through to swaps; token list deduplication is also changed to key off `assetId`.
> 
> Updates tests to cover the new sanitization behavior, the `hideAllNetworks` prop, and additional selector behaviors (search/filter bar visibility, after-hours sheet flow, and button-click analytics properties).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 331063bac027df41b5d0838d8ee4e8f88f6f6379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->