### PR TITLE
fix: srp word truncation cp-7.73.0

### DIFF
--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -419,8 +419,9 @@ const ManualBackupStep1 = () => {
                       variant={TextVariant.BodyMd}
                       color={TextColor.TextDefault}
                       key={index}
-                      ellipsizeMode="tail"
                       numberOfLines={1}
+                      adjustsFontSizeToFit
+                      minimumFontScale={0.7}
                       style={tw.style('flex-1')}
                       testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
                       maxFontSizeMultiplier={1}

--- a/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
+++ b/app/components/Views/RevealPrivateCredential/components/SeedPhraseDisplay.tsx
@@ -60,8 +60,9 @@ const SeedPhraseDisplay = ({
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}
               key={index}
-              ellipsizeMode="tail"
               numberOfLines={1}
+              adjustsFontSizeToFit
+              minimumFontScale={0.7}
               maxFontSizeMultiplier={1}
               twClassName="flex-1"
               testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Some BIP39 words in the Secret Recovery Phrase grid were being truncated with an ellipsis (e.g. coun..., cult...)

* This PR automatically shrinks the font size until the full word fits on a single line, with no layout changes
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed truncated words in the Secret Recovery Phrase grid so all words are fully visible

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-695

## **Manual testing steps**

```gherkin
Feature: Secret Recovery Phrase word visibility

  Scenario: user views SRP during wallet backup
    Given the user has created a new wallet
    And the user has been prompted to back up their Secret Recovery Phrase

    When the user taps "Start" on the backup screen
    Then all 12 SRP words are fully visible in the grid
    And no word is truncated with "..."
    And long words like "country", "culture", display completely

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="310" height="675" alt="Screenshot 2026-04-16 at 4 11 38 PM" src="https://github.com/user-attachments/assets/448059da-11fb-4642-b52d-604f0674cf9a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="302" height="674" alt="Screenshot 2026-04-16 at 1 39 22 PM" src="https://github.com/user-attachments/assets/a6994748-ef79-48bb-aa38-38d5a12fa675" />
<img width="285" height="606" alt="Screenshot 2026-04-16 at 1 47 44 PM" src="https://github.com/user-attachments/assets/e4ea3f87-4599-4390-8120-68b26d5bb533" />
<img width="302" height="674" alt="Screenshot 2026-04-16 at 12 40 08 PM" src="https://github.com/user-attachments/assets/3ff0c3ab-03a0-4798-9f86-686b8999d12a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-only change to text rendering properties; minimal risk beyond potential platform-specific font scaling quirks.
> 
> **Overview**
> Fixes Secret Recovery Phrase word display in the 3-column grids during manual backup (`ManualBackupStep1`) and seed phrase reveal (`SeedPhraseDisplay`) so long BIP39 words no longer show `...`.
> 
> Replaces `ellipsizeMode="tail"` with `adjustsFontSizeToFit` and sets `minimumFontScale={0.7}` while keeping `numberOfLines={1}`, allowing words to auto-shrink to fit on one line without changing layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5407634d7fdd64ed061ca7c469badeca9a0c2c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->