### PR TITLE
fix: remove notification account setting modal that was causing flickering [GE-50]

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -179,7 +179,7 @@ describe('useNotificationAccountListProps', () => {
   it('returns correct loading state', async () => {
     const addresses = ['0x123', '0x456'];
     const { hook } = arrange(addresses);
-    expect(hook.result.current.isAnyAccountLoading).toBe(false);
+    expect(hook.result.current.shouldDisableSwitches).toBe(false);
   });
 
   it('returns correct account loading state', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -15,7 +15,8 @@ export function useNotificationAccountListProps() {
   const { update, initialLoading, accountsBeingUpdated, data } =
     useFetchAccountNotifications(accountAddresses);
 
-  const isAnyAccountLoading = initialLoading || accountsBeingUpdated.length > 0;
+  // Only disable switches during initial data loading, not when individual accounts are updating
+  const shouldDisableSwitches = initialLoading;
 
   const refetchAccountSettings = useCallback(async () => {
     await update(accountAddresses);
@@ -74,7 +75,7 @@ export function useNotificationAccountListProps() {
   );
 
   return {
-    isAnyAccountLoading,
+    shouldDisableSwitches,
     refetchAccountSettings,
     isAccountLoading,
     isAccountEnabled,

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -140,7 +140,7 @@ describe('AccountList', () => {
 
     const mockRefetchAccountSettings = jest.fn();
     const createUseNotificationAccountListProps = () => ({
-      isAnyAccountLoading: false,
+      shouldDisableSwitches: false,
       refetchAccountSettings: mockRefetchAccountSettings,
       isAccountLoading: jest
         .fn()
@@ -203,11 +203,11 @@ describe('AccountList', () => {
     expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch).props.value).toBe(false); // The switch is set to false
   });
 
-  it('disable switches when any account is loading', () => {
+  it('disables switches during initial data loading', () => {
     const mocks = arrangeMocks();
     mocks.mockUseNotificationAccountListProps.mockReturnValue({
       ...mocks.createUseNotificationAccountListProps(),
-      isAnyAccountLoading: true,
+      shouldDisableSwitches: true,
       isAccountLoading: () => false,
     });
 
@@ -215,7 +215,7 @@ describe('AccountList', () => {
       state: initialRootState,
     });
 
-    // Assert switches are disabled since we are loading
+    // Assert switches are disabled during initial loading
     expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch).props.disabled).toBe(true);
     expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch).props.disabled).toBe(true);
   });
@@ -224,7 +224,7 @@ describe('AccountList', () => {
     const mocks = arrangeMocks();
     mocks.mockUseNotificationAccountListProps.mockReturnValue({
       ...mocks.createUseNotificationAccountListProps(),
-      isAnyAccountLoading: false,
+      shouldDisableSwitches: false,
       isAccountLoading: () => false,
     });
 

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -17,7 +17,7 @@ export const AccountsList = () => {
 
   const { accountAvatarType, firstHDWalletGroups } = useAccountProps();
   const {
-    isAnyAccountLoading,
+    shouldDisableSwitches,
     isAccountLoading,
     isAccountEnabled,
     refetchAccountSettings,
@@ -43,7 +43,7 @@ export const AccountsList = () => {
             item={item}
             evmAddress={getEvmAddress(item.accounts)}
             icon={accountAvatarType}
-            disabledSwitch={isAnyAccountLoading}
+            disabledSwitch={shouldDisableSwitches}
             isLoading={isAccountLoading(item.accounts)}
             isEnabled={isAccountEnabled(item.accounts)}
             refetchNotificationAccounts={refetchAccountSettings}

--- a/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
@@ -31,6 +31,9 @@ const styleSheet = (params: { theme: Theme }) =>
       marginTop: 16,
       marginLeft: -16,
     },
+    accountCellContainer: {
+      paddingHorizontal: 16,
+    },
     clearHistoryConfirm: {
       marginTop: 18,
     },

--- a/app/util/notifications/hooks/useSwitchNotifications.test.tsx
+++ b/app/util/notifications/hooks/useSwitchNotifications.test.tsx
@@ -458,15 +458,14 @@ describe('useSwitchNotifications - useSwitchNotificationLoadingText()', () => {
     );
   });
 
-  it('returns updating account settings text when accounts are being updated', () => {
+  it('returns undefined when accounts are being updated (no modal for account updates)', () => {
     const { hook } = arrangeAct((m) => {
       m.mockSelectIsUpdatingMetamaskNotificationsAccount.mockReturnValue([
         '0xAddr1',
       ]);
     });
-    expect(hook.result.current).toBe(
-      strings('app_settings.updating_account_settings'),
-    );
+    // Account loading is now handled inline per-toggle, not in a modal
+    expect(hook.result.current).toBeUndefined();
   });
 
   it('returns undefined when no loading state is active', () => {

--- a/app/util/notifications/hooks/useSwitchNotifications.ts
+++ b/app/util/notifications/hooks/useSwitchNotifications.ts
@@ -176,18 +176,10 @@ export function useSwitchNotificationLoadingText(): string | undefined {
     selectIsMetaMaskPushNotificationsLoading,
   );
 
-  const accountsLoading = useSelector(
-    selectIsUpdatingMetamaskNotificationsAccount,
-  );
-
   const loading = useContiguousLoading(
     notificationsLoading,
     pushNotificationsLoading,
   );
-
-  if (accountsLoading.length > 0) {
-    return strings('app_settings.updating_account_settings');
-  }
 
   if (notificationsLoading || pushNotificationsLoading || loading) {
     return strings('app_settings.updating_notifications');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR removes the modal that was displayed when toggling individual accounts in notification settings. It was supposed to display some text, but isn't displayed long enough to be readable, making it look buggy.

There are still some other state issues with this list, but as it'll be refactored soon.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-50

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/UX-only loading-state changes in notification settings with updated tests; risk is limited to potential regressions in when toggles are disabled or loading indicators appear.
> 
> **Overview**
> Removes the global “updating account settings” loading modal during per-account notification toggles by updating `useSwitchNotificationLoadingText` to ignore `selectIsUpdatingMetamaskNotificationsAccount`, so account updates are now indicated inline instead.
> 
> Adjusts the accounts list hooks/component API from `isAnyAccountLoading` to `shouldDisableSwitches`, disabling all switches only during initial settings fetch while allowing interaction when individual accounts are updating; updates associated tests and adds a small style entry (`accountCellContainer`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9744b02bc3241bbc1fda290dbc29996655ec8563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->