### PR TITLE
chore: align legacy and advanced charts loading overlay layout

### DIFF
--- a/app/components/UI/AssetOverview/ChartNavigationButton/ChartNavigationButton.styles.tsx
+++ b/app/components/UI/AssetOverview/ChartNavigationButton/ChartNavigationButton.styles.tsx
@@ -12,21 +12,22 @@ const styleSheet = (params: {
     vars: { selected },
   } = params;
   const { colors } = theme;
+  const finalBackgroundColor = selected
+    ? colors.background.muted
+    : 'transparent';
+  /** Matches {@link TimeRangeSelector} segment Pressables: `py-1`, `px-4`, `rounded-lg`, `flex-1`, `bg-muted` when selected. */
   return StyleSheet.create({
     button: {
-      backgroundColor: selected
-        ? colors.background.pressed
-        : colors.background.default,
-      borderRadius: 40,
-      paddingVertical: 2,
-      paddingHorizontal: 8,
-      // compensates for letter spacing
-      paddingLeft: 10,
+      flex: 1,
+      minWidth: 0,
       alignItems: 'center',
       justifyContent: 'center',
+      backgroundColor: finalBackgroundColor,
+      borderRadius: 8,
+      paddingVertical: 4,
+      paddingHorizontal: 16,
     },
     label: {
-      letterSpacing: 3,
       textAlign: 'center',
     } as TextStyle,
   });

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -364,7 +364,7 @@ const PriceAdvanced = ({
           ) : null}
         </Text>
       </View>
-      <Box twClassName="mt-3">
+      <Box twClassName="mt-3 w-full overflow-hidden">
         {crosshairData && chartType === ChartType.Candles && (
           <OHLCVBar data={crosshairData} currency={currentCurrency} />
         )}

--- a/app/components/UI/AssetOverview/Price/Price.legacy.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.legacy.tsx
@@ -173,7 +173,7 @@ const PriceLegacy = ({
           )}
         </Text>
       </View>
-      <Box twClassName={'mt-3'}>
+      <Box twClassName="mt-3 w-full overflow-hidden">
         <PriceChart
           prices={distributedPriceData}
           priceDiff={priceDiff}
@@ -182,17 +182,21 @@ const PriceLegacy = ({
         />
       </Box>
       {chartNavigationButtons.length > 0 && onTimePeriodChange && (
-        <View style={styles.chartNavigationWrapper}>
-          {chartNavigationButtons.map((label) => (
-            <ChartNavigationButton
-              key={label}
-              label={strings(
-                `asset_overview.chart_time_period_navigation.${label}`,
-              )}
-              onPress={() => onTimePeriodChange(label)}
-              selected={timePeriod === label}
-            />
-          ))}
+        <View style={styles.timeRangeContainer}>
+          <Box twClassName="w-full px-4">
+            <View style={styles.chartNavigationWrapper}>
+              {chartNavigationButtons.map((label) => (
+                <ChartNavigationButton
+                  key={label}
+                  label={strings(
+                    `asset_overview.chart_time_period_navigation.${label}`,
+                  )}
+                  onPress={() => onTimePeriodChange(label)}
+                  selected={timePeriod === label}
+                />
+              ))}
+            </View>
+          </Box>
         </View>
       )}
     </>

--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -1,9 +1,9 @@
 import type { Theme } from '@metamask/design-tokens';
 import { StyleSheet, ViewStyle } from 'react-native';
+import { TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT } from './tokenOverviewChart.constants';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
-  return StyleSheet.create({
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
     wrapper: {
       width: '100%',
       paddingHorizontal: 16,
@@ -49,15 +49,19 @@ const styleSheet = (params: { theme: Theme }) => {
       alignItems: 'center',
       zIndex: 2,
     } as ViewStyle,
+    /**
+     * Segment row for legacy chart periods; matches {@link TimeRangeSelector} segment padding (`py-1` / `px-4`).
+     * Vertical spacing chart→selector and selector→actions comes from the parent `timeRangeContainer`
+     * (same as `Price.advanced`).
+     */
     chartNavigationWrapper: {
       display: 'flex',
       flexDirection: 'row',
-      justifyContent: 'space-around',
-      paddingHorizontal: 10,
-      paddingTop: 20,
-      marginBottom: 16,
+      alignItems: 'center',
+      width: '100%',
+      borderRadius: 8,
+      minHeight: TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT,
     } as ViewStyle,
   });
-};
 
 export default styleSheet;

--- a/app/components/UI/AssetOverview/Price/tokenOverviewChart.constants.ts
+++ b/app/components/UI/AssetOverview/Price/tokenOverviewChart.constants.ts
@@ -9,3 +9,10 @@ export const TOKEN_OVERVIEW_CHART_HEIGHT =
 
 /** Minimum distributed price points to draw the legacy line chart (matches advanced fallback). */
 export const CHART_DATA_THRESHOLD = 5;
+
+/**
+ * Min height for the token overview time-range row (advanced selector + legacy period nav).
+ * Matches TimeRangeSelector skeleton height so swapping loading/loaded does not shift content
+ * below (e.g. Receive/More).
+ */
+export const TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT = 34;

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -33,11 +33,9 @@ const styleSheet = (params: {
       ...StyleSheet.absoluteFillObject,
       justifyContent: 'center',
       alignItems: 'center',
-      zIndex: 10,
     },
     noDataOverlayContainer: {
       ...StyleSheet.absoluteFillObject,
-      zIndex: 5,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -20,8 +20,24 @@ const styleSheet = (params: {
       alignSelf: 'stretch',
       overflow: 'visible',
     },
+    /** Touch + overlay host; `AreaChart` stays full-size while overlays are absolutely positioned. */
+    chartAreaWrapper: {
+      flex: 1,
+      position: 'relative',
+    },
     chartArea: {
       flex: 1,
+    },
+    /** Same pattern as AdvancedChart: overlay does not participate in flex layout with AreaChart. */
+    loadingOverlayContainer: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'center',
+      alignItems: 'center',
+      zIndex: 10,
+    },
+    noDataOverlayContainer: {
+      ...StyleSheet.absoluteFillObject,
+      zIndex: 5,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
@@ -363,7 +363,7 @@ const PriceChart = ({
       }}
     >
       <View
-        style={styles.chartArea}
+        style={styles.chartAreaWrapper}
         testID={chartHasData ? 'price-chart-area' : undefined}
         {...panResponder.current.panHandlers}
       >
@@ -386,12 +386,12 @@ const PriceChart = ({
           {chartHasData && !isLoading ? <EndDot /> : null}
         </AreaChart>
         {isLoading && (
-          <View>
+          <View style={styles.loadingOverlayContainer}>
             <LoadingOverlay />
           </View>
         )}
         {!isLoading && !chartHasData && (
-          <View>
+          <View style={styles.noDataOverlayContainer} pointerEvents="box-none">
             <NoDataOverlay
               chartHeight={chartHeight}
               chartPlaceholderFill={theme.colors.border.muted}

--- a/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
+++ b/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
@@ -13,6 +13,7 @@ import {
 import { IconSize } from '../../../../component-library/components/Icons/Icon';
 import { useTheme } from '../../../../util/theme';
 import { ChartType } from './AdvancedChart.types';
+import { TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT } from '../../AssetOverview/Price/tokenOverviewChart.constants';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 const CandlestickIcon = ({
@@ -71,8 +72,8 @@ const TIME_RANGES: TimeRange[] = ['1H', '1D', '1W', '1M', '1Y'];
 const SEGMENT_BUTTON_BASE =
   'min-w-0 flex-1 flex-row items-center justify-center gap-1 rounded-lg px-4 py-1 rounded-xl';
 
-/** Matches row of segment controls + chart type toggle; Item needs explicit width to render. */
-const TIME_RANGE_SKELETON_HEIGHT = 44;
+/** @see TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT */
+const TIME_RANGE_SKELETON_HEIGHT = TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT;
 /** Root `Box` uses `px-4` (16px each side). */
 const HORIZONTAL_INSET_PX = 32;
 
@@ -105,25 +106,37 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
     [],
   );
 
+  const showChartLoadingSkeleton = isChartLoading;
+
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       twClassName="w-full px-4"
+      style={{ minHeight: TIME_RANGE_SKELETON_HEIGHT }}
     >
-      {isChartLoading ? (
-        <SkeletonPlaceholder
-          backgroundColor={colors.background.section}
-          highlightColor={colors.background.subsection}
+      {showChartLoadingSkeleton ? (
+        <Box
+          style={{ height: TIME_RANGE_SKELETON_HEIGHT }}
+          twClassName="w-full flex-1 overflow-hidden rounded-lg"
         >
-          <SkeletonPlaceholder.Item
-            width={skeletonBarWidth}
-            height={TIME_RANGE_SKELETON_HEIGHT}
-            borderRadius={8}
-          />
-        </SkeletonPlaceholder>
+          <SkeletonPlaceholder
+            backgroundColor={colors.background.section}
+            highlightColor={colors.background.subsection}
+          >
+            <SkeletonPlaceholder.Item
+              width={skeletonBarWidth}
+              height={TIME_RANGE_SKELETON_HEIGHT}
+              borderRadius={8}
+            />
+          </SkeletonPlaceholder>
+        </Box>
       ) : (
-        <>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="w-full flex-1 rounded-lg"
+        >
           {ranges.map((range) => {
             const isSelected = selected === range;
             return (
@@ -176,7 +189,7 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
               )}
             </Pressable>
           ) : null}
-        </>
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Token details legacy and advanced chart areas had inconsistent vertical spacing, and Receive/More could move slightly when loading finished. 


**Solution**

- Legacy vs advanced: Legacy period controls use the same timeRangeContainer padding as advanced (12 / 24) so chart → time range → actions spacing matches.
- Time range row: Added TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT (34) in tokenOverviewChart.constants.ts. TimeRangeSelector uses minHeight on the root so swapping skeleton ↔ segments does not change row height; legacy chartNavigationWrapper uses the same minHeight.
- Legacy PriceChart: Loading and empty-state overlays are absolutely positioned over the chart (aligned with AdvancedChart) so the loader is not a second flex sibling of AreaChart and does not shift layout when it unmounts.
- Cleanup: Removed __DEV__ chart borders, removed the dev-only TimeRangeSelector loading hook, and dropped primary test borders from earlier iteration.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update CSS layout spacing for legacy and advanced charts

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/b2fde652-c404-474d-a5c3-3aab8a543e92


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f15d48d3-f032-4c70-a8d1-504967414b58


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout/styling-only changes to chart and selector containers; risk is limited to potential UI regressions in spacing/overlay rendering across platforms.
> 
> **Overview**
> Unifies token overview chart layout between advanced and legacy modes to prevent content below the chart (e.g. actions) from shifting when loading finishes.
> 
> This standardizes the time-range row sizing via new `TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT`, updates `TimeRangeSelector` to keep a fixed min height between skeleton and loaded segments, and refactors legacy period navigation (`ChartNavigationButton` + wrapper) to match the advanced selector padding/segmented-control styling.
> 
> Legacy `PriceChart` loading/empty overlays are now absolutely positioned over the chart (instead of participating in flex layout), and chart containers are tightened with `w-full overflow-hidden` to ensure consistent clipping/alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8c2b387f0e5e9d91ce6f003c0e03f64997209c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->