### PR TITLE
fix: resolve networkClientId mismatch in delegation transaction

### DIFF
--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -13,6 +13,9 @@ const mockIsAtomicBatchSupported: jest.MockedFn<
   TransactionController['isAtomicBatchSupported']
 > = jest.fn();
 
+const mockGetNetworkClientById = jest.fn();
+const mockFindNetworkClientIdByChainId = jest.fn();
+
 jest.spyOn(Math, 'random').mockReturnValue(0);
 
 jest.mock('../../core/Engine', () => ({
@@ -21,6 +24,12 @@ jest.mock('../../core/Engine', () => ({
       getNonceLock: () => mockGetNonceLock(),
       isAtomicBatchSupported: (request: IsAtomicBatchSupportedRequest) =>
         mockIsAtomicBatchSupported(request),
+    },
+    NetworkController: {
+      getNetworkClientById: (...args: unknown[]) =>
+        mockGetNetworkClientById(...args),
+      findNetworkClientIdByChainId: (...args: unknown[]) =>
+        mockFindNetworkClientIdByChainId(...args),
     },
   },
 }));
@@ -32,8 +41,11 @@ const NONCE_MOCK = 123;
 const AUTHORIZATION_SIGNATURE_MOCK =
   '0xf85c827a6994663f3ad617193148711d28f5334ee4ed070166028080a040e292da533253143f134643a03405f1af1de1d305526f44ed27e62061368d4ea051cfb0af34e491aa4d6796dececf95569088322e116c4b2f312bb23f20699269';
 
+const NETWORK_CLIENT_ID_MOCK = 'mainnet';
+
 const TRANSACTION_META_MOCK = {
   chainId: '0x1' as Hex,
+  networkClientId: NETWORK_CLIENT_ID_MOCK,
   nestedTransactions: [
     {
       data: '0x123456781234' as Hex,
@@ -81,6 +93,10 @@ describe('Transaction Delegation Utils', () => {
     mockGetNonceLock.mockResolvedValue({
       nextNonce: NONCE_MOCK,
       releaseLock: jest.fn(),
+    });
+
+    mockGetNetworkClientById.mockReturnValue({
+      configuration: { chainId: TRANSACTION_META_MOCK.chainId },
     });
   });
 
@@ -170,6 +186,40 @@ describe('Transaction Delegation Utils', () => {
       await expect(
         getDelegationTransaction(messengerMock, TRANSACTION_META_MOCK),
       ).rejects.toThrow('Upgrade contract address not found');
+    });
+
+    it('resolves networkClientId when it does not match chainId', async () => {
+      const wrongNetworkClientId = 'arbitrum';
+      const correctNetworkClientId = 'mainnet-resolved';
+
+      mockGetNetworkClientById.mockReturnValue({
+        configuration: { chainId: '0xa4b1' },
+      });
+
+      mockFindNetworkClientIdByChainId.mockReturnValue(correctNetworkClientId);
+
+      await getDelegationTransaction(messengerMock, {
+        ...TRANSACTION_META_MOCK,
+        networkClientId: wrongNetworkClientId,
+      });
+
+      expect(mockGetNetworkClientById).toHaveBeenCalledWith(
+        wrongNetworkClientId,
+      );
+
+      expect(mockFindNetworkClientIdByChainId).toHaveBeenCalledWith(
+        TRANSACTION_META_MOCK.chainId,
+      );
+    });
+
+    it('uses original networkClientId when it matches chainId', async () => {
+      await getDelegationTransaction(messengerMock, TRANSACTION_META_MOCK);
+
+      expect(mockGetNetworkClientById).toHaveBeenCalledWith(
+        NETWORK_CLIENT_ID_MOCK,
+      );
+
+      expect(mockFindNetworkClientIdByChainId).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -51,7 +51,14 @@ export async function getDelegationTransaction<
   messenger: MessengerType,
   transaction: TransactionMeta,
 ): Promise<DelegationTransaction> {
-  const { chainId } = transaction;
+  const resolvedNetworkClientId = resolveNetworkClientId(transaction);
+
+  const resolvedTransaction = {
+    ...transaction,
+    networkClientId: resolvedNetworkClientId,
+  };
+
+  const { chainId } = resolvedTransaction;
   const delegationEnvironment = getDeleGatorEnvironment(parseInt(chainId, 16));
 
   const delegationManagerAddress =
@@ -59,11 +66,11 @@ export async function getDelegationTransaction<
 
   const delegations = await buildDelegation(
     delegationEnvironment,
-    transaction,
+    resolvedTransaction,
     messenger,
   );
 
-  const executions = buildExecutions(transaction);
+  const executions = buildExecutions(resolvedTransaction);
 
   const modes: ExecutionMode[] = [
     executions[0].length > 1 ? BATCH_DEFAULT_MODE : SINGLE_DEFAULT_MODE,
@@ -78,7 +85,7 @@ export async function getDelegationTransaction<
   });
 
   const authorizationList = await buildAuthorizationList(
-    transaction,
+    resolvedTransaction,
     messenger,
   );
 
@@ -95,7 +102,7 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
   messenger: MessengerType,
 ): Promise<AuthorizationList | undefined> {
   const { TransactionController } = Engine.context;
-  const { chainId, networkClientId, txParams } = transactionMeta;
+  const { chainId, txParams } = transactionMeta;
   const { from } = txParams;
 
   const atomicBatchResult = await TransactionController.isAtomicBatchSupported({
@@ -135,7 +142,7 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
 
   const nonceLock = await TransactionController.getNonceLock(
     from,
-    networkClientId,
+    transactionMeta.networkClientId,
   );
 
   const nonce = nonceLock.nextNonce;
@@ -270,6 +277,39 @@ function buildCaveats(
   caveatBuilder.addCaveat(limitedCalls, 1);
 
   return caveatBuilder.build();
+}
+
+// The transaction meta may carry a networkClientId for the target chain
+// rather than the source chain. Verify it matches the expected chainId.
+function resolveNetworkClientId(transactionMeta: TransactionMeta): string {
+  const { NetworkController } = Engine.context;
+  const { chainId, networkClientId } = transactionMeta;
+
+  log('Resolving networkClientId', { chainId, networkClientId });
+
+  const networkClientChainId =
+    NetworkController.getNetworkClientById(networkClientId).configuration
+      .chainId;
+
+  log('Network client chain lookup', { networkClientId, networkClientChainId });
+
+  if (networkClientChainId.toLowerCase() === chainId.toLowerCase()) {
+    log('networkClientId matches chainId, no resolution needed');
+    return networkClientId;
+  }
+
+  const resolved = NetworkController.findNetworkClientIdByChainId(
+    chainId as Hex,
+  );
+
+  log('networkClientId chain mismatch, resolved to correct client', {
+    chainId,
+    networkClientChainId,
+    original: networkClientId,
+    resolved,
+  });
+
+  return resolved;
 }
 
 function decodeAuthorizationSignature(signature: Hex) {


### PR DESCRIPTION
## **Description**

During cross-chain pay flows, the `TransactionMeta` may carry a `networkClientId` for the **target chain** rather than the **source chain**. This causes `getNonceLock` to query the wrong chain, producing an incorrect nonce in the EIP-7702 authorization list.

Adds a `resolveNetworkClientId` helper at the top of `getDelegationTransaction` that:
1. Looks up the chain ID for the provided `networkClientId` via `NetworkController.getNetworkClientById`
2. Compares it to the transaction's `chainId`
3. Falls back to `NetworkController.findNetworkClientIdByChainId` when there's a mismatch

The resolved `networkClientId` then flows through to all downstream functions (`buildDelegation`, `buildExecutions`, `buildAuthorizationList`).

## **Changelog**

CHANGELOG entry: Fixed incorrect nonce in EIP-7702 authorization during cross-chain pay transactions

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: Cross-chain MetaMask Pay with EIP-7702 delegation

  Scenario: User sends a cross-chain pay transaction requiring 7702 authorization
    Given the user has an EOA that is not yet EIP-7702 upgraded
    And the user initiates a cross-chain pay transaction (e.g. Ethereum → Arbitrum)

    When the delegation transaction is built
    Then the networkClientId should match the source chain
    And the nonce in the authorization list should be the account nonce on the source chain
```

## **Screenshots/Recordings**

N/A — logic-only change with no UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.