### PR TITLE
feat(tooling): add TOOL_USAGE_COLLECTION_DB_PATH env var to override SQLite DB path

### DIFF
--- a/scripts/tooling/README.md
+++ b/scripts/tooling/README.md
@@ -1,0 +1,78 @@
+# scripts/tooling
+
+Developer tooling usage collection — writes events to a local SQLite database so tool adoption can be understood without automatic or silent data sharing.
+
+## How it works
+
+Every tool that participates writes a `start` event when it begins and an `end` event when it finishes. Events land in a local SQLite file on the developer's machine. Nothing is sent anywhere automatically. A separate `yarn tooling:report` command (Phase 3) lets developers review their history and choose what to share.
+
+## Database location
+
+| Scenario | Path |
+|---|---|
+| Default | `~/.tool-usage-collection/events.db` |
+| Custom | Set `TOOL_USAGE_COLLECTION_DB_PATH` to any absolute path |
+
+To redirect the database — for example to keep per-project histories separate, or to point multiple machines at the same location — set `TOOL_USAGE_COLLECTION_DB_PATH` in your shell profile:
+
+```bash
+# ~/.zshrc or ~/.bashrc
+# Use $HOME (not ~) — double quotes suppress tilde expansion but not $HOME
+export TOOL_USAGE_COLLECTION_DB_PATH="$HOME/.tool-usage-collection/events.db"
+```
+
+This applies to all projects on the machine. The directory is created automatically if it does not exist.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `db.ts` | Opens / creates the SQLite database and initialises the schema |
+| `events.ts` | `trackEvent()` — shared write function used by all collection paths |
+| `tool-usage-collection.ts` | Thin CLI wrapper invoked by yarn hooks and agent skill hooks |
+
+## CLI usage
+
+The CLI is invoked internally by hooks. You can also call it directly for debugging:
+
+```bash
+yarn tsx scripts/tooling/tool-usage-collection.ts \
+  --tool my-tool \
+  --type skill \
+  --event start \
+  [--session <uuid>] \
+  [--agent cursor|claude|codex] \
+  [--success true|false] \
+  [--duration <ms>] \
+  [--verbose]
+```
+
+`--tool`, `--type`, and `--event` are required. All other flags are optional.
+
+## Collection paths
+
+Three automated paths feed events into the shared database:
+
+**Yarn Berry plugin** — `.yarn/plugins/plugin-usage-tracking.cjs` hooks into `wrapScriptExecution` and fires `start`, `end`, and `interrupted` events for every `yarn <script>` run. Zero changes to `package.json` scripts are needed.
+
+**Claude Code skills** — a `PreToolUse` frontmatter hook (`once: true`, `async: true`) fires automatically on the first tool call after a skill is loaded. Zero tokens consumed.
+
+**Cursor skills** — `.cursor/hooks.json` defines a `beforeReadFile` hook that fires when Cursor reads any `SKILL.md` file. The hook calls the CLI via `scripts/tooling/cursor-hook-skill-tracking.ts`.
+
+## Schema
+
+```sql
+CREATE TABLE events (
+  event_id     TEXT PRIMARY KEY,
+  session_id   TEXT,
+  tool_name    TEXT NOT NULL,
+  tool_type    TEXT NOT NULL,   -- 'skill' | 'yarn_script' | 'cli_command'
+  event_type   TEXT NOT NULL CHECK(event_type IN ('start', 'end')),
+  repo         TEXT,
+  agent_vendor TEXT,
+  success      INTEGER,         -- 0 or 1; NULL on 'start' events
+  duration_ms  INTEGER,         -- NULL on 'start' events
+  metadata     TEXT,            -- JSON blob
+  created_at   TEXT NOT NULL
+);
+```

--- a/scripts/tooling/db.test.ts
+++ b/scripts/tooling/db.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { openDb, DEFAULT_DB_PATH, DEFAULT_DB_DIR } from './db';
+import { openDb } from './db';
 
 // mockDb is used for all non-:memory: openDb calls to avoid real fs side effects
 const mockDb = {
@@ -25,11 +25,38 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('DEFAULT_DB_PATH', () => {
-  it('points inside the home directory', () => {
-    expect(DEFAULT_DB_PATH).toContain(os.homedir());
-    expect(DEFAULT_DB_PATH).toContain('events.db');
-    expect(DEFAULT_DB_DIR).toContain('.tool-usage-collection');
+describe('openDb default path', () => {
+  // The jest.fn() inside the jest.mock factory is not tracked by jest.clearAllMocks(),
+  // so we clear it explicitly before each test.
+  const DatabaseCtor = jest.requireMock<jest.Mock>('better-sqlite3');
+
+  beforeEach(() => {
+    DatabaseCtor.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.TOOL_USAGE_COLLECTION_DB_PATH;
+  });
+
+  it('defaults to ~/.tool-usage-collection/events.db when env var is not set', () => {
+    delete process.env.TOOL_USAGE_COLLECTION_DB_PATH;
+    jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+
+    openDb();
+
+    const calledPath = DatabaseCtor.mock.calls[0][0] as string;
+    expect(calledPath).toContain(os.homedir());
+    expect(calledPath).toContain(path.join('.tool-usage-collection', 'events.db'));
+  });
+
+  it('uses TOOL_USAGE_COLLECTION_DB_PATH when the env var is set', () => {
+    const customPath = '/custom/path/mydb.db';
+    process.env.TOOL_USAGE_COLLECTION_DB_PATH = customPath;
+    jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+
+    openDb();
+
+    expect(DatabaseCtor.mock.calls[0][0]).toBe(customPath);
   });
 });
 

--- a/scripts/tooling/db.ts
+++ b/scripts/tooling/db.ts
@@ -9,7 +9,7 @@ import path from 'path';
 const getDbPath = (): string => {
   const env: Record<string, string | undefined> = process.env;
   return (
-    env.TOOL_USAGE_COLLECTION_DB_PATH ??
+    env.TOOL_USAGE_COLLECTION_DB_PATH ||
     path.join(os.homedir(), '.tool-usage-collection', 'events.db')
   );
 };

--- a/scripts/tooling/db.ts
+++ b/scripts/tooling/db.ts
@@ -3,8 +3,16 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-export const DEFAULT_DB_DIR = path.join(os.homedir(), '.tool-usage-collection');
-export const DEFAULT_DB_PATH = path.join(DEFAULT_DB_DIR, 'events.db');
+// babel-plugin-transform-inline-environment-variables statically replaces
+// process.env.VAR_NAME at compile time. Routing through a dynamic key
+// (`env[key]`) prevents inlining and preserves runtime override behaviour.
+const getDbPath = (): string => {
+  const env: Record<string, string | undefined> = process.env;
+  return (
+    env.TOOL_USAGE_COLLECTION_DB_PATH ??
+    path.join(os.homedir(), '.tool-usage-collection', 'events.db')
+  );
+};
 
 /**
  * Opens (or creates) the tool-usage SQLite database, initialises the schema,
@@ -12,7 +20,7 @@ export const DEFAULT_DB_PATH = path.join(DEFAULT_DB_DIR, 'events.db');
  *
  * Pass ':memory:' during tests to avoid touching the filesystem.
  */
-export function openDb(dbPath = DEFAULT_DB_PATH): Database.Database {
+export function openDb(dbPath = getDbPath()): Database.Database {
   // WAL journal mode requires a real file; skip dir creation and pragma for memory DBs
   const isMemory = dbPath === ':memory:';
 


### PR DESCRIPTION
## **Description**

The SQLite database path in `scripts/tooling/db.ts` was hardcoded to `~/.tool-usage-collection/events.db`, making it impossible to redirect the database without modifying source code.

This PR introduces the `TOOL_USAGE_COLLECTION_DB_PATH` environment variable as an optional override. When set, `openDb()` uses that path; when absent, it falls back to the existing default.

A `scripts/tooling/README.md` is also added documenting the database location, the env var, the CLI, and the three collection paths.

Part of [MCWP-448](https://consensyssoftware.atlassian.net/browse/MCWP-448) — sub-task [MCWP-539](https://consensyssoftware.atlassian.net/browse/MCWP-539).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-539

## **Manual testing steps**

```gherkin
Feature: TOOL_USAGE_COLLECTION_DB_PATH env var overrides the SQLite database path

  Background:
    Given I have the metamask-mobile repository checked out
    And I have run yarn setup

  Scenario: default database path is used when env var is not set
    Given TOOL_USAGE_COLLECTION_DB_PATH is not set in my shell environment

    When I run a yarn script that triggers tool-usage collection
    Then the events database is created at ~/.tool-usage-collection/events.db

  Scenario: custom database path is used when env var is set to a valid path
    Given I export TOOL_USAGE_COLLECTION_DB_PATH="/tmp/test-tooling/mydb.db"

    When I run a yarn script that triggers tool-usage collection
    Then the events database is created at /tmp/test-tooling/mydb.db
    And the directory /tmp/test-tooling is created automatically if it does not exist
    And no file is written to ~/.tool-usage-collection/events.db
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

[MCWP-448]: https://consensyssoftware.atlassian.net/browse/MCWP-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MCWP-539]: https://consensyssoftware.atlassian.net/browse/MCWP-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ