### PR TITLE
fix(predict): show predict claim button and carousel when claimable positions

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -578,6 +578,136 @@ describe('PredictionsSection', () => {
     });
   });
 
+  describe('claimable-only (no active positions)', () => {
+    const setupClaimableOnly = () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+          positions: claimable ? mockClaimablePositions : [],
+          isLoading: false,
+          error: null,
+          totalClaimableValue: claimable ? 200 : 0,
+          refetch: jest.fn(),
+        }),
+      );
+    };
+
+    it('renders claim button when only claimable positions exist', async () => {
+      setupClaimableOnly();
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      });
+    });
+
+    it('renders trending carousel above claim button when no active positions', async () => {
+      setupClaimableOnly();
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: mockMarkets,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+        expect(screen.getByText('Will BTC reach 100k?')).toBeOnTheScreen();
+      });
+    });
+
+    it('renders only claim button when no active positions and no markets', async () => {
+      setupClaimableOnly();
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: [],
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      });
+      expect(screen.queryByText('Will BTC reach 100k?')).not.toBeOnTheScreen();
+    });
+
+    it('does not render active position rows in claimable-only state', async () => {
+      setupClaimableOnly();
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      });
+      expect(screen.queryByText('Test Position 1')).not.toBeOnTheScreen();
+      expect(screen.queryByText('Test Position 2')).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('positions-only mode with claimable-only', () => {
+    it('renders claim button when only claimable positions exist', async () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        ({
+          claimable = false,
+        }: { maxPositions?: number; claimable?: boolean } = {}) => ({
+          positions: claimable ? mockClaimablePositions : [],
+          isLoading: false,
+          error: null,
+          totalClaimableValue: claimable ? 200 : 0,
+          refetch: jest.fn(),
+        }),
+      );
+
+      renderWithProvider(
+        <PredictionsSection
+          sectionIndex={0}
+          totalSectionsLoaded={5}
+          mode="positions-only"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
+      });
+    });
+
+    it('returns null when no active and no claimable positions', () => {
+      mockUsePredictPositionsForHomepage.mockImplementation(
+        (_options: { maxPositions?: number; claimable?: boolean } = {}) => ({
+          positions: [],
+          isLoading: false,
+          error: null,
+          totalClaimableValue: 0,
+          refetch: jest.fn(),
+        }),
+      );
+
+      const { toJSON } = renderWithProvider(
+        <PredictionsSection
+          sectionIndex={0}
+          totalSectionsLoaded={5}
+          mode="positions-only"
+        />,
+      );
+
+      expect(toJSON()).toBeNull();
+    });
+  });
+
   describe('privacy mode', () => {
     beforeEach(() => {
       mockSelectPrivacyMode.mockReturnValue(true);

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -70,11 +70,13 @@ interface HomepagePredictTrendingMarketsProps {
   isLoadingMarkets: boolean;
   markets: PredictMarket[];
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
+  /** When false the section header is omitted (e.g. carousel shown below positions). */
+  showHeader?: boolean;
 }
 
 /**
  * Shared header + horizontal markets carousel for homepage predictions
- * (default “trending when empty” and dedicated trending-only section).
+ * (default "trending when empty" and dedicated trending-only section).
  */
 const HomepagePredictTrendingMarkets = ({
   title,
@@ -83,15 +85,20 @@ const HomepagePredictTrendingMarkets = ({
   isLoadingMarkets,
   markets,
   transactionActiveAbTests,
+  showHeader = true,
 }: HomepagePredictTrendingMarketsProps) => {
   const tw = useTailwind();
   return (
     <Box gap={3}>
-      <SectionHeader
-        title={title}
-        onPress={onViewAll}
-        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(headerTestIdKey)}
-      />
+      {showHeader && (
+        <SectionHeader
+          title={title}
+          onPress={onViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+            headerTestIdKey,
+          )}
+        />
+      )}
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -180,6 +187,7 @@ interface HomepagePredictPositionsProps {
   predictHomepageUnrealizedPnl: PredictHomepageUnrealizedPnlRowState;
   onClaim: () => Promise<void>;
   onPositionPress: (position: PredictPosition) => void;
+  showHeader?: boolean;
 }
 
 const HomepagePredictPositions = ({
@@ -193,24 +201,27 @@ const HomepagePredictPositions = ({
   predictHomepageUnrealizedPnl,
   onClaim,
   onPositionPress,
+  showHeader = true,
 }: HomepagePredictPositionsProps) => (
   <Box gap={3}>
-    <Box gap={1}>
-      <SectionHeader
-        title={title}
-        onPress={onViewAll}
-        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('predictions')}
-      />
-      {predictHomepageUnrealizedPnl.show && (
-        <HomepageSectionUnrealizedPnlRow
-          isLoading={predictHomepageUnrealizedPnl.isLoading}
-          valueText={predictHomepageUnrealizedPnl.valueText}
-          tone={predictHomepageUnrealizedPnl.tone}
-          label={strings('predict.unrealized_pnl_label')}
-          testID="homepage-predict-unrealized-pnl"
+    {showHeader && (
+      <Box gap={1}>
+        <SectionHeader
+          title={title}
+          onPress={onViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('predictions')}
         />
-      )}
-    </Box>
+        {predictHomepageUnrealizedPnl.show && (
+          <HomepageSectionUnrealizedPnlRow
+            isLoading={predictHomepageUnrealizedPnl.isLoading}
+            valueText={predictHomepageUnrealizedPnl.valueText}
+            tone={predictHomepageUnrealizedPnl.tone}
+            label={strings('predict.unrealized_pnl_label')}
+            testID="homepage-predict-unrealized-pnl"
+          />
+        )}
+      </Box>
+    )}
     <Box>
       {isLoadingPositions ? (
         <>
@@ -355,6 +366,7 @@ const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
   }, [claim]);
 
   const hasPositions = positions.length > 0;
+  const hasClaimablePositions = !isLoadingClaimable && totalClaimableValue > 0;
   const {
     data: predictUnrealizedPnL,
     isLoading: isPredictUnrealizedPnLLoading,
@@ -388,6 +400,7 @@ const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
     isLoadingClaimable,
     handleClaim,
     hasPositions,
+    hasClaimablePositions,
     predictHomepageUnrealizedPnl,
   };
 };
@@ -428,6 +441,7 @@ const PredictionsSectionDefault = forwardRef<
       isLoadingClaimable,
       handleClaim,
       hasPositions,
+      hasClaimablePositions,
       predictHomepageUnrealizedPnl,
     } = usePredictPositionsSectionData(isPredictEnabled);
     const {
@@ -439,17 +453,19 @@ const PredictionsSectionDefault = forwardRef<
       enabled: isPredictEnabled,
     });
 
-    const isLoading = isLoadingPositions || isLoadingMarkets;
+    const hasAnyPositions = hasPositions || hasClaimablePositions;
+    const isLoading =
+      isLoadingPositions || isLoadingMarkets || isLoadingClaimable;
     const hasError =
       !isLoadingPositions &&
       !isLoadingMarkets &&
-      !hasPositions &&
+      !hasAnyPositions &&
       markets.length === 0 &&
       (positionsError || marketsError);
     const isEmpty =
-      !isLoading && !hasPositions && markets.length === 0 && !hasError;
+      !isLoading && !hasAnyPositions && markets.length === 0 && !hasError;
     const willRender = isPredictEnabled && !isLoading && !isEmpty && !hasError;
-    const itemCount = hasPositions ? positions.length : markets.length;
+    const itemCount = hasAnyPositions ? positions.length : markets.length;
 
     const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
@@ -484,11 +500,28 @@ const PredictionsSectionDefault = forwardRef<
       return null;
     }
 
-    if (hasPositions || isLoadingPositions) {
+    if (hasAnyPositions || isLoadingPositions || isLoadingClaimable) {
+      const showTrendingAbove =
+        !hasPositions &&
+        !isLoadingPositions &&
+        (isLoadingMarkets || markets.length > 0);
+
       return (
         <View ref={sectionViewRef} onLayout={onLayout}>
+          {showTrendingAbove && (
+            <Box paddingBottom={3}>
+              <HomepagePredictTrendingMarkets
+                title={title}
+                onViewAll={handleViewAllPredictions}
+                headerTestIdKey="predictions"
+                isLoadingMarkets={isLoadingMarkets}
+                markets={markets}
+              />
+            </Box>
+          )}
           <HomepagePredictPositions
             title={title}
+            showHeader={!showTrendingAbove}
             onViewAll={handleViewAllFromPositions}
             privacyMode={privacyMode}
             isLoadingPositions={isLoadingPositions}
@@ -555,19 +588,22 @@ const PredictionsSectionPositionsOnly = forwardRef<
       isLoadingClaimable,
       handleClaim,
       hasPositions,
+      hasClaimablePositions,
       predictHomepageUnrealizedPnl,
     } = usePredictPositionsSectionData(isPredictEnabled);
 
-    const willRender = isPredictEnabled && !isLoadingPositions && hasPositions;
-    const itemCount = positions.length;
+    const hasAnyPositions = hasPositions || hasClaimablePositions;
+    const isLoading = isLoadingPositions || isLoadingClaimable;
+    const willRender = isPredictEnabled && !isLoading && hasAnyPositions;
+    const itemCount = hasAnyPositions ? positions.length : 0;
 
     const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
-      isLoading: isLoadingPositions,
+      isLoading,
       sectionName: analyticsName,
       sectionIndex,
       totalSectionsLoaded,
-      isEmpty: !isLoadingPositions && !hasPositions,
+      isEmpty: !isLoading && !hasAnyPositions,
       itemCount,
     });
 
@@ -578,7 +614,7 @@ const PredictionsSectionPositionsOnly = forwardRef<
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
-    if (!isPredictEnabled || (!isLoadingPositions && !hasPositions)) {
+    if (!isPredictEnabled || (!isLoading && !hasAnyPositions)) {
       return null;
     }
 

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -459,13 +459,18 @@ const PredictionsSectionDefault = forwardRef<
     const hasError =
       !isLoadingPositions &&
       !isLoadingMarkets &&
+      !isLoadingClaimable &&
       !hasAnyPositions &&
       markets.length === 0 &&
       (positionsError || marketsError);
     const isEmpty =
       !isLoading && !hasAnyPositions && markets.length === 0 && !hasError;
     const willRender = isPredictEnabled && !isLoading && !isEmpty && !hasError;
-    const itemCount = hasAnyPositions ? positions.length : markets.length;
+    const itemCount = hasPositions
+      ? positions.length
+      : hasClaimablePositions
+        ? markets.length || 1
+        : markets.length;
 
     const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,
@@ -595,7 +600,11 @@ const PredictionsSectionPositionsOnly = forwardRef<
     const hasAnyPositions = hasPositions || hasClaimablePositions;
     const isLoading = isLoadingPositions || isLoadingClaimable;
     const willRender = isPredictEnabled && !isLoading && hasAnyPositions;
-    const itemCount = hasAnyPositions ? positions.length : 0;
+    const itemCount = hasPositions
+      ? positions.length
+      : hasClaimablePositions
+        ? 1
+        : 0;
 
     const { onLayout } = useHomeViewedEvent({
       sectionRef: willRender ? sectionViewRef : null,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Claim button on the homepage Predictions section was invisible when the user had only resolved/claimable positions and no active (open) positions. The render gate in `PredictionsSectionDefault` only checked for active positions (`hasPositions`), so when all positions were settled the section fell through to the trending markets carousel — which has no claim button.

**Root cause**: `usePredictPositionsForHomepage()` (called without options) defaults to `claimable: false` and returns only active positions. The gate `if (hasPositions || isLoadingPositions)` therefore evaluated to `false` when only claimable positions existed, skipping the entire positions view (which contains the claim button).

**Fix**:
- Introduced `hasClaimablePositions` derived from `totalClaimableValue > 0` after loading completes.
- Updated the render gate in both `PredictionsSectionDefault` and `PredictionsSectionPositionsOnly` to consider claimable positions alongside active ones.
- When only claimable positions exist (no active), the featured markets carousel now renders **above** the claim button with a 16px gap, giving users both discovery and a clear claim affordance.
- Added `showHeader` prop to `HomepagePredictTrendingMarkets` and `HomepagePredictPositions` to avoid duplicate "Predictions >" section headers in the combined view.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-825](https://consensyssoftware.atlassian.net/browse/PRED-825) 

## **Manual testing steps**

```gherkin
Feature: Predict claim button visibility on homepage

  Scenario: user sees claim button with only claimable positions
    Given the user has resolved/claimable prediction positions
    And the user has no active (open) prediction positions

    When user navigates to the homepage
    Then the Predictions section displays the featured markets carousel
    And the Claim button with the total claimable amount is visible below the carousel

  Scenario: user sees claim button alongside active positions
    Given the user has both active and claimable prediction positions

    When user navigates to the homepage
    Then the Predictions section displays the active position rows
    And the Claim button with the total claimable amount is visible below the positions
    And the featured markets carousel is not shown

  Scenario: user sees only trending carousel when no positions at all
    Given the user has no prediction positions (neither active nor claimable)

    When user navigates to the homepage
    Then the Predictions section displays only the featured markets carousel
    And no Claim button is visible
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/f711e92c-aec3-410e-b82c-72c7aea66eaf

### **Before**

<img width="446" height="969" alt="Screenshot 2026-04-16 at 11 39 42" src="https://github.com/user-attachments/assets/e1d66ffa-fe92-486e-aa2c-80947ac43c4b" />

<!-- User with only claimable positions sees featured carousel with no Claim button -->

### **After**

<img width="444" height="969" alt="Screenshot 2026-04-16 at 11 39 31" src="https://github.com/user-attachments/assets/3fa9878b-6d26-4d75-92c6-13d66360d254" />


<!-- User with only claimable positions sees featured carousel above the Claim button -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[PRED-825]: https://consensyssoftware.atlassian.net/browse/PRED-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/render-logic change limited to the homepage Predictions section; main risk is unintended empty/loading gating or duplicated headers affecting what renders and analytics counts.
> 
> **Overview**
> Fixes the homepage Predictions section so it **renders when users only have claimable (settled) positions**, ensuring the `Claim` button is visible even with no active positions.
> 
> When in this claimable-only state, the section can now show the trending markets carousel **above** the claim button/positions container while avoiding duplicate headers via a new `showHeader` option on the shared header components, and it updates loading/empty/error gating + `itemCount` calculations accordingly (including `mode="positions-only"`).
> 
> Adds tests covering claimable-only rendering (claim button shown, optional carousel presence, no active rows) and the positions-only null/claimable behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5487ef5d9f7f1c0caa76020b7613270799db0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->