### PR TITLE
feat(rewards): add Ondo after-hours trading sheet

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -55,6 +55,19 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   },
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    ...actual,
+    // Skeleton is not exported in the installed version of the design-system
+    // package — stub it so the loading skeleton test doesn't throw.
+    Skeleton: ({ style }: { style?: unknown }) =>
+      ReactActual.createElement(View, { testID: 'skeleton', style }),
+  };
+});
+
 jest.mock(
   '../../../../component-library/components-temp/HeaderCompactStandard',
   () => {
@@ -119,6 +132,16 @@ jest.mock('../../Bridge/hooks/useRWAToken', () => ({
 }));
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
+
+// Mock core/Analytics to avoid the deep import chain:
+// Analytics → store → Engine → assets-controller-init → @metamask/assets-controller
+jest.mock('../../../../core/Analytics', () => ({
+  MetaMetricsEvents: {
+    REWARDS_PAGE_BUTTON_CLICKED: 'REWARDS_PAGE_BUTTON_CLICKED',
+    REWARDS_PAGE_VIEWED: 'REWARDS_PAGE_VIEWED',
+    REWARDS_CAMPAIGN_PAGE_VIEWED: 'REWARDS_CAMPAIGN_PAGE_VIEWED',
+  },
+}));
 
 jest.mock('../components/Campaigns/OndoAfterHoursSheet', () => {
   const ReactActual = jest.requireActual('react');
@@ -226,6 +249,32 @@ jest.mock('../../../../util/theme', () => ({
 
 jest.mock('../../AssetOverview/Balance/Balance', () => ({
   NetworkBadgeSource: jest.fn(() => ({ uri: 'https://mock.icon' })),
+}));
+
+// Mock Badge and Avatar to avoid deep import chain via component-library
+// that pulls in @metamask/assets-controller through Engine
+jest.mock('../../../../component-library/components/Badges/Badge', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, children),
+    BadgeVariant: { Network: 'Network', Status: 'Status', Count: 'Count' },
+  };
+});
+
+jest.mock('../../../../component-library/components/Avatars/Avatar', () => ({
+  __esModule: true,
+  default: () => null,
+  AvatarSize: {
+    Xs: 'xs',
+    Sm: 'sm',
+    Md: 'md',
+    Lg: 'lg',
+    Xl: 'xl',
+  },
+  AvatarVariant: { Account: 'account', Favicon: 'favicon', Network: 'network' },
 }));
 
 jest.mock('../../Trending/components/TrendingTokenLogo', () => {
@@ -517,6 +566,90 @@ describe('OndoCampaignRwaSelectorView', () => {
       );
       expect(queryByTestId('token-row-NIOon')).toBeNull();
       expect(getByTestId('token-row-AAPL')).toBeDefined();
+    });
+  });
+
+  describe('after-hours sheet', () => {
+    const token = buildToken('AAPL');
+
+    beforeEach(() => {
+      mockIsTokenTradingOpen = jest.fn(() => false);
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+    });
+
+    it('shows the after-hours sheet proactively on load when first token market is closed', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
+    });
+
+    it('does not show after-hours sheet proactively when tokens list is empty', () => {
+      mockUseRwaTokens.mockReturnValue({ data: [], isLoading: false });
+      const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+    });
+
+    it('does not show after-hours sheet proactively when market is open', () => {
+      mockIsTokenTradingOpen = jest.fn(() => true);
+      const { queryByTestId } = render(<OndoCampaignRwaSelectorView />);
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+    });
+
+    it('only shows proactive sheet once — does not re-open on token list update', () => {
+      const { rerender, getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+      // Sheet is shown on first load
+      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
+      // Close the sheet
+      fireEvent.press(getByTestId('after-hours-close'));
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+      // Even if rwaTokens changes (e.g. search update), sheet must not re-open
+      mockUseRwaTokens.mockReturnValue({
+        data: [buildToken('MSFT')],
+        isLoading: false,
+      });
+      rerender(<OndoCampaignRwaSelectorView />);
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+    });
+
+    it('closes the after-hours sheet without navigating when onClose is called', () => {
+      const { getByTestId, queryByTestId } = render(
+        <OndoCampaignRwaSelectorView />,
+      );
+
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      expect(getByTestId('after-hours-sheet')).toBeOnTheScreen();
+
+      fireEvent.press(getByTestId('after-hours-close'));
+
+      expect(queryByTestId('after-hours-sheet')).not.toBeOnTheScreen();
+      expect(mockGoToSwaps).not.toHaveBeenCalled();
+    });
+
+    it('tracks REWARDS_PAGE_BUTTON_CLICKED and calls goToSwaps when onConfirm is called', () => {
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+
+      fireEvent.press(getByTestId('token-row-AAPL'));
+
+      act(() => {
+        fireEvent.press(getByTestId('after-hours-confirm'));
+      });
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+      const buttonClickIndex = mockCreateEventBuilder.mock.calls.findIndex(
+        (call: unknown[]) =>
+          call[0] === MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+      const builder =
+        mockCreateEventBuilder.mock.results[buttonClickIndex]?.value;
+      expect(builder?.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          button_type: 'ondo_campaign_swap_aapl',
+        }),
+      );
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -246,6 +246,28 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
 
   const { isTokenTradingOpen } = useRWAToken();
 
+  // Proactive first-token check: if the first RWA token's market is closed
+  // when the list loads, immediately surface the after-hours sheet so the
+  // user is informed before they tap anything.
+  const hasShownAfterHoursRef = useRef(false);
+  useEffect(() => {
+    if (hasShownAfterHoursRef.current || !rwaTokens.length) return;
+    const firstToken: BridgeToken = {
+      ...rwaTokens[0],
+      rwaData: rwaTokens[0].rwaData as BridgeToken['rwaData'],
+    };
+    if (!isTokenTradingOpen(firstToken)) {
+      const rawNextOpen = firstToken.rwaData?.market?.nextOpen;
+      const nextOpenDate = rawNextOpen ? new Date(String(rawNextOpen)) : null;
+      setAfterHoursNextOpen(
+        nextOpenDate && !isNaN(nextOpenDate.getTime()) ? nextOpenDate : null,
+      );
+      setAfterHoursPendingToken(firstToken);
+      setIsAfterHoursSheetOpen(true);
+      hasShownAfterHoursRef.current = true;
+    }
+  }, [rwaTokens, isTokenTradingOpen]);
+
   useTrackRewardsPageView({
     page_type:
       mode === 'swap' ? 'ondo_campaign_swap' : 'ondo_campaign_open_position',

--- a/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.test.tsx
@@ -5,7 +5,8 @@ import OndoAfterHoursSheet from './OndoAfterHoursSheet';
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   const ReactActual = jest.requireActual('react');
-  const { View, Pressable } = jest.requireActual('react-native');
+  const { View, Pressable, Text, TouchableOpacity } =
+    jest.requireActual('react-native');
   return {
     ...actual,
     BottomSheet: ({
@@ -24,11 +25,49 @@ jest.mock('@metamask/design-system-react-native', () => {
           onPress: onClose,
         }),
       ),
+    // Icon uses SVGs which are unavailable in the test environment
+    Icon: ({ name }: { name?: string }) =>
+      ReactActual.createElement(View, { testID: `icon-${name ?? 'unknown'}` }),
+    ButtonIcon: ({
+      onPress,
+      testID,
+    }: {
+      onPress?: () => void;
+      testID?: string;
+    }) => ReactActual.createElement(TouchableOpacity, { onPress, testID }),
+    // Text/Box pass-throughs so i18n strings are visible
+    Text: ({
+      children,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+    }) => ReactActual.createElement(Text, { testID }, children),
+    Box: ({ children }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(View, null, children),
+    Button: ({
+      children,
+      onPress,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { onPress, testID },
+        ReactActual.createElement(Text, null, children),
+      ),
   };
 });
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({ style: (...args: unknown[]) => args }),
+  useTailwind: () => {
+    const tw = () => ({});
+    tw.style = (..._args: unknown[]) => ({});
+    return tw;
+  },
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8239,7 +8239,7 @@
     "ondo_campaign_after_hours_trading": {
       "title": "After-hours trading",
       "reopens_in_label": "Reopens in",
-      "content": "You're trading outside of regular market hours (9:30 am to 4 pm EST). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates.",
+      "content": "You're trading outside of regular market hours (9:30 am to 4 pm ET). When markets are closed, there's risk for wider spreads, price moves, and higher funding rates.",
       "got_it_button": "Got it"
     },
     "ondo_campaign_not_eligible": {


### PR DESCRIPTION
## **Description**

Adds an after-hours trading warning sheet to the Ondo RWA selector page. When the NY market (9:30 am–4 pm ET) is closed, users are proactively informed before interacting with any RWA token.

- On page load: if `rwaTokens[0]` reports market closed via `isTokenTradingOpen()`, the sheet opens automatically (one-shot, `hasShownAfterHoursRef` guard)
- On token tap: existing guard in `handleAssetSelect` fires as a fallback
- "Got it" → proceeds to the swap flow (`goToSwaps`)
- "X" → closes the sheet, user stays on the selector

Also fixes the `ondo_campaign_after_hours_trading.content` i18n string: **EST → ET** (Eastern Time is correct year-round; EST is winter-only).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

\`\`\`gherkin
Feature: Ondo after-hours trading sheet

  Scenario: user opens RWA selector when market is closed
    Given the Ondo RWA selector page is loading
    And the NY market is currently closed

    When the token list resolves
    Then the after-hours sheet opens automatically
    And the sheet shows the market reopen countdown (if available)

  Scenario: user taps a token when market is closed
    Given the after-hours sheet has already been dismissed
    And the NY market is still closed

    When user taps any RWA token
    Then the after-hours sheet opens again

  Scenario: user confirms after-hours sheet
    Given the after-hours sheet is open

    When user presses "Got it"
    Then the sheet closes
    And the swap flow opens for the selected token

  Scenario: user dismisses after-hours sheet with X
    Given the after-hours sheet is open

    When user presses the X button
    Then the sheet closes
    And the user remains on the RWA selector
\`\`\`

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.