### PR TITLE
fix: gas fees sponsored full swap native in transaction display

### DIFF
--- a/app/components/UI/Bridge/_mocks_/initialState.ts
+++ b/app/components/UI/Bridge/_mocks_/initialState.ts
@@ -673,6 +673,59 @@ export const initialState = {
             startTime: Date.now(),
             estimatedProcessingTimeInSeconds: 300,
           },
+          'gas-sponsored-tx-id': {
+            txMetaId: 'gas-sponsored-tx-id',
+            account: evmAccountAddress,
+            quote: {
+              requestId: 'test-request-id',
+              srcChainId: 1329,
+              srcAsset: {
+                chainId: 1329,
+                address: '0x0000000000000000000000000000000000000000',
+                decimals: 18,
+                symbol: 'SEI',
+                name: 'Sei',
+              },
+              destChainId: 1329,
+              destAsset: {
+                chainId: 1329,
+                address: '0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392',
+                decimals: 6,
+                symbol: 'USDC',
+                name: 'USDC',
+              },
+              // srcTokenAmount has metabridge fee deducted (0.99125 SEI)
+              srcTokenAmount: '991250000000000000',
+              destTokenAmount: '55320',
+              feeData: {
+                metabridge: {
+                  amount: '8750000000000000',
+                  asset: {
+                    address: '0x0000000000000000000000000000000000000000',
+                    chainId: 1329,
+                    symbol: 'SEI',
+                    decimals: 18,
+                    name: 'Sei',
+                  },
+                },
+              },
+              gasSponsored: true,
+              gasIncluded7702: true,
+            },
+            // pricingData.amountSent is the full user amount (1.0 SEI)
+            pricingData: {
+              amountSent: '1',
+              amountSentInUsd: '0.055909',
+            },
+            status: {
+              srcChain: {
+                txHash: '0xgas123',
+              },
+              status: StatusTypes.COMPLETE,
+            },
+            startTime: Date.now(),
+            estimatedProcessingTimeInSeconds: 0,
+          },
           'solana-swap-tx': {
             quote: {
               srcChainId: 1151111081099710, // Solana Mainnet

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
@@ -248,7 +248,7 @@ describe('BridgeTransactionDetails', () => {
 
     // Should display "1.00000 SEI" (from pricingData.amountSent),
     // not "0.99125 SEI" (from srcTokenAmount)
-    expect(getByText(/1\.00000\s+SEI/)).toBeTruthy();
+    expect(getByText(/1\.00000\s+SEI/)).toBeOnTheScreen();
   });
 
   it('shows "Paid by MetaMask" when gas is sponsored and sender is not a hardware wallet', () => {

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
@@ -225,6 +225,32 @@ describe('BridgeTransactionDetails', () => {
     expect(queryByTestId('paid-by-metamask')).not.toBeOnTheScreen();
   });
 
+  it('displays full amount from pricingData.amountSent when gas is sponsored', () => {
+    mockIsHardwareAccount.mockReturnValue(false);
+
+    const gasSponsoredTx = {
+      ...mockEVMTx,
+      id: 'gas-sponsored-tx-id',
+      isGasFeeSponsored: true,
+    } as TransactionMeta;
+
+    const { getByText } = renderScreen(
+      () => (
+        <BridgeTransactionDetails
+          route={{ params: { evmTxMeta: gasSponsoredTx } }}
+        />
+      ),
+      {
+        name: Routes.BRIDGE.BRIDGE_TRANSACTION_DETAILS,
+      },
+      { state: mockState },
+    );
+
+    // Should display "1.00000 SEI" (from pricingData.amountSent),
+    // not "0.99125 SEI" (from srcTokenAmount)
+    expect(getByText(/1\.00000\s+SEI/)).toBeTruthy();
+  });
+
   it('shows "Paid by MetaMask" when gas is sponsored and sender is not a hardware wallet', () => {
     mockIsHardwareAccount.mockReturnValue(false);
 

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -234,10 +234,12 @@ export const BridgeTransactionDetails = (
     chainId: sourceChainId,
   };
 
-  const sourceTokenAmount = calcTokenAmount(
-    quote.srcTokenAmount,
-    quote.srcAsset.decimals,
-  ).toFixed(5);
+  const sourceTokenAmount =
+    quote.gasSponsored && bridgeTxHistoryItem.pricingData?.amountSent
+      ? parseFloat(bridgeTxHistoryItem.pricingData.amountSent).toFixed(5)
+      : calcTokenAmount(quote.srcTokenAmount, quote.srcAsset.decimals).toFixed(
+          5,
+        );
 
   const destinationChainId = isNonEvmChainId(quote.destChainId)
     ? formatChainIdToCaip(quote.destChainId)

--- a/app/components/UI/Bridge/utils/transaction-history.test.ts
+++ b/app/components/UI/Bridge/utils/transaction-history.test.ts
@@ -411,6 +411,100 @@ describe('decodeSwapsTx', () => {
       },
     ]);
   });
+
+  it('uses pricingData.amountSent when quote.gasSponsored is true', () => {
+    const args = {
+      tx: {
+        chainId: '0x531',
+        id: 'gas-sponsored-tx-id',
+        status: 'confirmed',
+        txParams: {
+          from: '0xc5fe6ef47965741f6f7a4734bf784bf3ae3f2452',
+          to: '0x881d40237659c251811cec9c364ef91dc08d300c',
+          gas: '0x5208',
+          value: '0x0',
+        },
+        type: 'swap',
+      },
+      txChainId: '0x531',
+      ticker: 'SEI',
+      currentCurrency: 'usd',
+      contractExchangeRates: {},
+      conversionRate: 0.055,
+      primaryCurrency: 'ETH',
+      bridgeTxHistoryData: {
+        bridgeTxHistoryItem: {
+          txMetaId: 'gas-sponsored-tx-id',
+          quote: {
+            requestId: 'test-request-id',
+            bridgeId: 'openocean',
+            srcChainId: 1329,
+            destChainId: 1329,
+            srcAsset: {
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: 1329,
+              assetId: 'eip155:1329/slip44:19000118',
+              symbol: 'SEI',
+              decimals: 18,
+              name: 'Sei',
+            },
+            // srcTokenAmount has the metabridge fee deducted (0.99125 SEI)
+            srcTokenAmount: '991250000000000000',
+            destAsset: {
+              address: '0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392',
+              chainId: 1329,
+              assetId:
+                'eip155:1329/erc20:0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392',
+              symbol: 'USDC',
+              decimals: 6,
+              name: 'USDC',
+            },
+            destTokenAmount: '55320',
+            minDestTokenAmount: '54213',
+            feeData: {
+              metabridge: {
+                amount: '8750000000000000',
+                asset: {
+                  address: '0x0000000000000000000000000000000000000000',
+                  chainId: 1329,
+                  assetId: 'eip155:1329/slip44:19000118',
+                  symbol: 'SEI',
+                  decimals: 18,
+                  name: 'Sei',
+                },
+              },
+            },
+            bridges: ['1inch'],
+            protocols: ['1inch'],
+            steps: [],
+            gasSponsored: true,
+            gasIncluded7702: true,
+          },
+          startTime: Date.now(),
+          estimatedProcessingTimeInSeconds: 0,
+          slippagePercentage: 0,
+          // amountSent is the full user amount (1.0 SEI)
+          pricingData: {
+            amountSent: '1',
+            amountSentInUsd: '0.055909',
+          },
+          account: '0xc5fe6ef47965741f6f7a4734bf784bf3ae3f2452',
+          status: {
+            status: 'PENDING',
+            srcChain: { chainId: 1329 },
+          },
+          hasApprovalTx: false,
+        },
+        isBridgeComplete: false,
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = decodeSwapsTx(args as unknown as any);
+
+    // Should display "1 SEI" (from pricingData.amountSent), not "0.99125 SEI" (from srcTokenAmount)
+    expect((res[0] as any).value).toBe('1 SEI');
+  });
 });
 
 describe('decodeBridgeTx', () => {

--- a/app/components/UI/Bridge/utils/transaction-history.ts
+++ b/app/components/UI/Bridge/utils/transaction-history.ts
@@ -140,12 +140,15 @@ export const decodeSwapsTx = (args: {
 
   const sourceTokenSymbol = quote.srcAsset?.symbol;
   const destTokenSymbol = quote.destAsset?.symbol;
-  const rawSourceAmount = parseFloat(
-    ethers.utils.formatUnits(
-      bridgeTxHistoryItem.quote.srcTokenAmount,
-      quote.srcAsset.decimals,
-    ),
-  );
+  const rawSourceAmount =
+    quote.gasSponsored && bridgeTxHistoryItem.pricingData?.amountSent
+      ? parseFloat(bridgeTxHistoryItem.pricingData.amountSent)
+      : parseFloat(
+          ethers.utils.formatUnits(
+            bridgeTxHistoryItem.quote.srcTokenAmount,
+            quote.srcAsset.decimals,
+          ),
+        );
   const sourceAmountSent = formatAmountWithThreshold(rawSourceAmount, 5);
 
   const renderTo = tx.txParams.to;


### PR DESCRIPTION
## **Description**
This pull request updates how the source token amount is displayed for gas-sponsored swap transactions, ensuring that the full amount sent by the user is shown instead of the post-fee amount. The changes affect both the transaction details UI and the transaction history decoding logic, and include new tests and mock data to cover this scenario.
The fix mirror the extension's display logic for this use case.

**Gas-sponsored transaction handling:**

* Updated `BridgeTransactionDetails` to display the full user amount (`pricingData.amountSent`) when `quote.gasSponsored` is true, instead of the fee-deducted `srcTokenAmount`. (`app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx`)
* Modified `decodeSwapsTx` to use `pricingData.amountSent` for gas-sponsored transactions, ensuring transaction history reflects the correct sent amount. (`app/components/UI/Bridge/utils/transaction-history.ts`)

**Testing and mock data:**

* Added a new test to verify that the full amount is displayed for gas-sponsored transactions in the transaction details component. (`app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx`)
* Added a new test to ensure `decodeSwapsTx` uses `pricingData.amountSent` when gas is sponsored. (`app/components/UI/Bridge/utils/transaction-history.test.ts`)
* Extended the mock bridge transaction state with a gas-sponsored transaction example, including all relevant fields for accurate testing. (`app/components/UI/Bridge/_mocks_/initialState.ts`)


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: display correct amount in swap native in transaction display for gas fees sponsored trx

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: display the full amount swapped by the user

  Scenario: user swaps native token to any tokens
    Given the network is gas fees sponsored

    When user swaps max amount SEI for USDC 
    Then the transaction history should display the full amount sent
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
Swapping 0.1 SEI for USDC on SEI gas fees sponsored network
### **Before**

<img width="250" height="550" alt="SEI native swap BEFORE" src="https://github.com/user-attachments/assets/e0fd55b1-f75d-4794-a6ea-e4aaf1b18ab0" />

------------------------

### **After**
<img width="250" height="550" alt="SEI native swap Activity trx AFTER" src="https://github.com/user-attachments/assets/d5f67be1-da6e-47e0-856d-609b86060cf2" />

<img width="250" height="550" alt="SEI native swap details AFTER" src="https://github.com/user-attachments/assets/ea7386c6-7d9b-41a6-9f17-33593cd72f56" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes that switch the source amount calculation for a specific gas-sponsored swap case; covered by new unit tests and mock state.
> 
> **Overview**
> Fixes gas-sponsored swap/bridge UI and activity decoding to show the *full user sent amount* (`pricingData.amountSent`) instead of the fee-deducted `quote.srcTokenAmount`.
> 
> Updates `BridgeTransactionDetails` and `decodeSwapsTx` to prefer `pricingData.amountSent` when `quote.gasSponsored` is true, and adds a dedicated gas-sponsored transaction fixture plus tests to prevent regressions in both the details screen and transaction history decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f57b98333f609d507f1a4d6f693130cdcba0ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->