### PR TITLE
fix(predict): handle undefined team alias in sport card token matching

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
@@ -98,20 +98,26 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
   const footerTimeText = timeRemaining ?? scheduledTime;
 
   const outcome = market.outcomes[0];
+  const matchesTeam = (
+    tokenTitle: string | undefined,
+    team: { name?: string; alias?: string },
+  ) => {
+    if (!tokenTitle) return false;
+    const lower = tokenTitle.toLowerCase();
+    return (
+      lower === team.name?.toLowerCase() ||
+      (team.alias != null && lower === team.alias.toLowerCase())
+    );
+  };
+
   const homeToken =
-    outcome?.tokens?.find(
-      (t) =>
-        t.title.toLowerCase() === game.homeTeam.name.toLowerCase() ||
-        t.title.toLowerCase() === game.homeTeam.alias.toLowerCase(),
-    ) ?? outcome?.tokens?.[0];
+    outcome?.tokens?.find((t) => matchesTeam(t.title, game.homeTeam)) ??
+    outcome?.tokens?.[0];
   const awayToken =
-    outcome?.tokens?.find(
-      (t) =>
-        t.title.toLowerCase() === game.awayTeam.name.toLowerCase() ||
-        t.title.toLowerCase() === game.awayTeam.alias.toLowerCase(),
-    ) ?? outcome?.tokens?.[1];
+    outcome?.tokens?.find((t) => matchesTeam(t.title, game.awayTeam)) ??
+    outcome?.tokens?.[1];
   const drawToken = showDraw
-    ? outcome?.tokens?.find((t) => t.title.toLowerCase() === 'draw')
+    ? outcome?.tokens?.find((t) => t.title?.toLowerCase() === 'draw')
     : undefined;
 
   const handleCardPress = useCallback(() => {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -193,7 +193,7 @@ export type PredictSportTeam = {
   logo: string;
   abbreviation: string; // e.g., "SEA", "DEN"
   color: string; // Team primary color (hex)
-  alias: string; // Team alias (e.g., "Seahawks")
+  alias?: string; // Team alias (e.g., "Seahawks")
 };
 
 // Parsed score data


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `FeaturedCarouselSportCard` crashes with `TypeError: Cannot read property 'toLowerCase' of undefined` when a sport team's `alias` field is `undefined` in the API response (observed with European football teams like SC Freiburg, RC Celta de Vigo).

The fix extracts a `matchesTeam` helper that safely guards against `undefined` values on `alias`, `name`, and `title` before calling `.toLowerCase()`. The `PredictSportTeam.alias` type is also corrected to `optional` to match the actual API contract.

## **Changelog**

CHANGELOG entry: Fixed a crash in the featured carousel when sport team alias data was missing

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Featured carousel sport card stability

  Scenario: Sport card renders without crashing when team alias is undefined
    Given the featured carousel contains a sport market
    And one or more teams have an undefined alias field
    When the carousel card renders
    Then the card displays without crashing
    And the correct home/away tokens are matched by team name

  Scenario: Sport card renders normally when team alias is defined
    Given the featured carousel contains a sport market
    And all teams have a defined alias field
    When the carousel card renders
    Then tokens are matched by team name or alias
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f5b9dfeb184fd1c0aba3f05952e13bcd59138f74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->