### PR TITLE
refactor(ramp): show Ramp settings logout toasts via ToastService

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
@@ -6,7 +6,7 @@ import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { ToastContext } from '../../../../../../component-library/components/Toast';
+import ToastService from '../../../../../../core/ToastService';
 import {
   getProviderToken,
   resetProviderToken,
@@ -84,14 +84,6 @@ const mockResetProviderToken = resetProviderToken as jest.MockedFunction<
   typeof resetProviderToken
 >;
 
-const mockShowToast = jest.fn();
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: jest.fn(),
-  },
-};
-
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockSetNavigationOptions = jest.fn();
@@ -128,31 +120,21 @@ jest.mock('../../../hooks/useRampsProviders', () => ({
   }),
 }));
 
-jest.mock('../../../../../../component-library/components/Toast', () => {
-  const actualToast = jest.requireActual(
-    '../../../../../../component-library/components/Toast',
-  );
+jest.mock('../../../../../../core/ToastService', () => ({
+  __esModule: true,
+  default: {
+    showToast: jest.fn(),
+    closeToast: jest.fn(),
+  },
+}));
 
-  return {
-    ...actualToast,
-    ToastVariants: {
-      Icon: 'Icon',
-    },
-  };
-});
+const mockToastServiceShowToast = ToastService.showToast as jest.MockedFunction<
+  typeof ToastService.showToast
+>;
 
 function renderWithProvider(component: React.ComponentType) {
-  const WrappedComponent = () => {
-    const Component = component;
-    return (
-      <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-        <Component />
-      </ToastContext.Provider>
-    );
-  };
-
   return renderScreen(
-    WrappedComponent,
+    component,
     {
       name: 'SettingsModal',
     },
@@ -282,7 +264,7 @@ describe('SettingsModal', () => {
       });
 
       expect(mockSetSelectedProvider).toHaveBeenCalledWith(null);
-      expect(mockShowToast).toHaveBeenCalledWith({
+      expect(mockToastServiceShowToast).toHaveBeenCalledWith({
         variant: 'Icon',
         labelOptions: [{ label: 'Successfully logged out' }],
         iconName: 'CheckBold',
@@ -306,7 +288,7 @@ describe('SettingsModal', () => {
         expect(mockResetProviderToken).toHaveBeenCalled();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith({
+      expect(mockToastServiceShowToast).toHaveBeenCalledWith({
         variant: 'Icon',
         labelOptions: [{ label: 'Error logging out' }],
         iconName: 'CircleX',

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useRef,
-  useContext,
-  useState,
-  useEffect,
-} from 'react';
+import React, { useCallback, useRef, useState, useEffect } from 'react';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {
   BottomSheet,
@@ -19,10 +13,8 @@ import { createNavigationDetails } from '../../../../../../util/navigation/navUt
 import Routes from '../../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../../locales/i18n';
 import { useNavigation } from '@react-navigation/native';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../../component-library/components/Toast';
+import { ToastVariants } from '../../../../../../component-library/components/Toast/Toast.types';
+import ToastService from '../../../../../../core/ToastService';
 import Logger from '../../../../../../util/Logger';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
 import MenuItem from '../../../components/MenuItem';
@@ -53,7 +45,6 @@ function SettingsModal() {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
-  const { toastRef } = useContext(ToastContext);
   const { selectedProvider, setSelectedProvider } = useRampsProviders();
 
   const [isAuthenticatedWithProvider, setIsAuthenticatedWithProvider] =
@@ -159,7 +150,7 @@ function SettingsModal() {
       setSelectedProvider(null);
 
       sheetRef.current?.onCloseBottomSheet();
-      toastRef?.current?.showToast({
+      ToastService.showToast({
         variant: ToastVariants.Icon,
         labelOptions: [
           {
@@ -175,7 +166,7 @@ function SettingsModal() {
       });
     } catch (error) {
       Logger.error(error as Error, 'Error logging out from provider:');
-      toastRef?.current?.showToast({
+      ToastService.showToast({
         variant: ToastVariants.Icon,
         labelOptions: [
           {
@@ -189,7 +180,7 @@ function SettingsModal() {
         hasNoTimeout: false,
       });
     }
-  }, [setSelectedProvider, toastRef, trackEvent, createEventBuilder]);
+  }, [setSelectedProvider, trackEvent, createEventBuilder]);
 
   const handleClosePress = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ramp design-system migration **phase 3 (toast)** for in-scope `Views`: `SettingsModal` no longer reads `ToastContext` from the component library. Logout success and error notifications now call `ToastService.showToast`, which uses the same toast ref registered by Root’s `ToastContextWrapper` (same path as `v2OrderToast`).

Toast payloads still use the **legacy** component-library `ToastVariants` and icon options because the mounted app toast remains the legacy implementation; this change removes context coupling from the modal and aligns tests with `ToastService` mocks.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp Transak settings — logout toast

  Scenario: Successful logout shows success toast
    Given the user is on the Ramp flow with Transak as provider and is authenticated
    When the user opens Ramp settings and taps Log out
    Then a success toast is shown with the logged-out message

  Scenario: Failed logout shows error toast
    Given the same authenticated Transak context and logout will fail (e.g. forced error in dev)
    When the user taps Log out from Ramp settings
    Then an error toast is shown with the logout error message
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

