### PR TITLE
chore: fix time range change race condition cp-7.74.0

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -185,6 +185,9 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       setLayoutSettling(false);
       clearLayoutSettleTimeout();
       ohlcvSeriesStaleSnapshotRef.current = null;
+      activeIndicatorsRef.current.clear();
+      prevPositionLinesRef.current = undefined;
+      prevChartTypeRef.current = undefined;
     }, [ohlcvSeriesKey, clearLayoutSettleTimeout]);
 
     useEffect(

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -400,6 +400,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
           prevChartTypeRef.current = undefined;
           prevOhlcvDataRef.current = [];
           prevOhlcvSeriesKeyRef.current = undefined;
+          ohlcvSeriesStaleSnapshotRef.current = null;
           webViewRef.current?.reload();
         },
       }),

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -120,6 +120,8 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const prevChartTypeRef = useRef(chartType);
     const prevOhlcvDataRef = useRef<OHLCVBar[]>([]);
     const prevOhlcvSeriesKeyRef = useRef<string | undefined>(undefined);
+    /** When non-null, `ohlcvData` is still the previous series' array; skip sync until the hook replaces it. */
+    const ohlcvSeriesStaleSnapshotRef = useRef<OHLCVBar[] | null>(null);
     const tradingViewOpenInterceptRef = useRef(0);
 
     const htmlContent = useMemo(
@@ -141,6 +143,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       prevChartTypeRef.current = undefined;
       prevOhlcvDataRef.current = [];
       prevOhlcvSeriesKeyRef.current = undefined;
+      ohlcvSeriesStaleSnapshotRef.current = null;
     }, [htmlContent]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // ---- Helpers ----
@@ -170,6 +173,19 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         setLayoutSettling(false);
       }, LAYOUT_SETTLE_FALLBACK_MS);
     }, [isChartReady, clearLayoutSettleTimeout]);
+
+    // WebView remounts when `key` changes; parent state would otherwise still look "ready".
+    // `CHART_READY` clears indicator/position/chart-type refs once the new instance loads.
+    useEffect(() => {
+      if (ohlcvSeriesKey === undefined) {
+        return;
+      }
+      setChartReadyCount(0);
+      setWebViewLoaded(false);
+      setLayoutSettling(false);
+      clearLayoutSettleTimeout();
+      ohlcvSeriesStaleSnapshotRef.current = null;
+    }, [ohlcvSeriesKey, clearLayoutSettleTimeout]);
 
     useEffect(
       () => () => {
@@ -397,6 +413,14 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     useEffect(() => {
       if (ohlcvData.length === 0 || !webViewLoaded) return;
 
+      if (ohlcvSeriesStaleSnapshotRef.current !== null) {
+        if (ohlcvData !== ohlcvSeriesStaleSnapshotRef.current) {
+          ohlcvSeriesStaleSnapshotRef.current = null;
+        } else {
+          return;
+        }
+      }
+
       const prevData = prevOhlcvDataRef.current;
 
       if (
@@ -404,12 +428,8 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         ohlcvSeriesKey !== prevOhlcvSeriesKeyRef.current
       ) {
         if (prevOhlcvSeriesKeyRef.current !== undefined) {
-          // Time range switch: ohlcvData is still stale from the previous
-          // period (fetch is in progress). Show skeleton, mark the key, and
-          // clear prevData so the fresh data triggers the length-diff branch
-          // on arrival — avoiding sending stale data to the WebView which
-          // causes a resolution race condition in TradingView.
           beginFullOhlcvLayoutSettle();
+          ohlcvSeriesStaleSnapshotRef.current = ohlcvData;
           prevOhlcvSeriesKeyRef.current = ohlcvSeriesKey;
           prevOhlcvDataRef.current = [];
           return;
@@ -561,6 +581,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       <View style={styles.container}>
         <View style={styles.chartSurface}>
           <WebView
+            key={`advanced-chart-${ohlcvSeriesKey ?? ''}`}
             ref={webViewRef}
             source={{ html: htmlContent, baseUrl: CHARTING_LIBRARY_BASE_URL }}
             style={styles.webview}

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -115,8 +115,20 @@ describe('AdvancedChart', () => {
 
     expect(getByTestId('advanced-chart-skeleton')).toBeOnTheScreen();
 
+    const webViewAfterRerender = getByTestId('mock-webview');
     act(() => {
-      webView.props.onMessage({
+      webViewAfterRerender.props.onLoadEnd();
+    });
+    act(() => {
+      webViewAfterRerender.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    act(() => {
+      webViewAfterRerender.props.onMessage({
         nativeEvent: {
           data: JSON.stringify({ type: 'CHART_LAYOUT_SETTLED', payload: {} }),
         },
@@ -200,6 +212,22 @@ describe('AdvancedChart', () => {
       },
     );
     expect(setOhlcvCallsAfterKeyChange).toHaveLength(0);
+
+    // Series key remounts the WebView; load must finish before sync runs. Stale wait still applies.
+    const webViewAfterKeyChange = getByTestId('mock-webview');
+    act(() => {
+      webViewAfterKeyChange.props.onLoadEnd();
+    });
+
+    expect(
+      mockPostMessage.mock.calls.filter((call) => {
+        try {
+          return JSON.parse(call[0] as string).type === 'SET_OHLCV_DATA';
+        } catch {
+          return false;
+        }
+      }),
+    ).toHaveLength(0);
 
     // Fresh data arrives (same key, different bars) — NOW it should send
     mockPostMessage.mockClear();

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -250,6 +250,59 @@ describe('AdvancedChart', () => {
     expect(realtimeCalls).toHaveLength(0);
   });
 
+  it('reset() clears stale series snapshot so OHLCV sync runs after reload with the same data ref', () => {
+    const staleBars: OHLCVBar[] = [
+      { time: 1000000, open: 10, high: 12, low: 9, close: 11, volume: 100 },
+    ];
+    const ref = React.createRef<AdvancedChartRef>();
+    const { getByTestId, rerender } = render(
+      <AdvancedChart
+        ref={ref}
+        ohlcvData={staleBars}
+        ohlcvSeriesKey="range-a"
+      />,
+    );
+
+    const webViewInitial = getByTestId('mock-webview');
+    act(() => {
+      webViewInitial.props.onLoadEnd();
+    });
+
+    rerender(
+      <AdvancedChart
+        ref={ref}
+        ohlcvData={staleBars}
+        ohlcvSeriesKey="range-b"
+      />,
+    );
+
+    const webViewAfterKeyChange = getByTestId('mock-webview');
+    act(() => {
+      webViewAfterKeyChange.props.onLoadEnd();
+    });
+
+    mockPostMessage.mockClear();
+
+    act(() => {
+      ref.current?.reset();
+    });
+
+    const webViewAfterReset = getByTestId('mock-webview');
+    act(() => {
+      webViewAfterReset.props.onLoadEnd();
+    });
+
+    expect(
+      mockPostMessage.mock.calls.some((call) => {
+        try {
+          return JSON.parse(call[0] as string).type === 'SET_OHLCV_DATA';
+        } catch {
+          return false;
+        }
+      }),
+    ).toBe(true);
+  });
+
   it('exposes addIndicator via ref', () => {
     const ref = React.createRef<AdvancedChartRef>();
     render(<AdvancedChart ref={ref} ohlcvData={MOCK_BARS} />);


### PR DESCRIPTION

## **Description**

Fixes the token advanced chart staying scrolled back in time when users pan and then change the time range quickly. Also avoids sending previous range OHLCV into the WebView while the new fetch is still in flight

**Problem**
Viewport / scroll — TradingView keeps pan/scroll state inside the WebView. Changing range without a full new surface could reuse that state, so the chart looked wrong after a fast time-range change.

Stale data — useOHLCVChart keeps the last ohlcvData until the new request completes. Right after a range change, props can show the new ohlcvSeriesKey but the old candle array (same reference). Sending that as SET_OHLCV_DATA for the new range causes bad data / races.


**Solution**
WebView key — Tie key to ohlcvSeriesKey (with ?? '' when the prop is omitted) so each series change remounts the WebView and drops inherited TradingView scroll state.

ohlcvSeriesStaleSnapshotRef + guard — When the series key changes but ohlcvData is still the previous array reference, don’t sync full OHLCV; wait until the hook returns a new array reference, then send.

useEffect on ohlcvSeriesKey — Reset loading / ready state (chartReadyCount, webViewLoaded, layout settle timers) and clear ohlcvSeriesStaleSnapshotRef. Reset activeIndicatorsRef, prevPositionLinesRef, and prevChartTypeRef so the new WebView gets indicators, position lines, and chart type (line vs candles) applied correctly without a default-candles flash.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes race condition on timeRange switch

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Uploading Screen Recording 2026-04-16 at 23.39.54.mov…


### **After**

<!-- [screenshots/recordings] -->


Uploading Screen Recording 2026-04-17 at 00.10.19.mov…



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chart lifecycle/sync logic and WebView remount behavior, which could regress loading/skeleton timing or data updates across range switches if edge cases weren’t covered.
> 
> **Overview**
> Fixes a race on time-range changes in `AdvancedChart` by **remounting the WebView** when `ohlcvSeriesKey` changes (via a `key`) and resetting “ready/loading/layout settle” state so the new instance re-applies indicators, position lines, and chart type deterministically.
> 
> Adds a **stale-series guard** (`ohlcvSeriesStaleSnapshotRef`) that suppresses `SET_OHLCV_DATA` syncing when the series key updates but `ohlcvData` is still the previous array reference, resuming only once fresh data arrives; updates tests to reflect the WebView remount/load sequence and stale-data wait behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a52c7a839681ababa09f92c982883d5e40705c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->