### PR TITLE
fix(rewards): match carousel design from perps

### DIFF
--- a/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.test.tsx
@@ -49,6 +49,7 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
       'rewards.onboarding.step_confirm': 'Next',
+      'rewards.onboarding.step_finish': "Let's go",
       'rewards.onboarding.step_skip': 'Skip',
     };
     return map[key] ?? key;
@@ -220,6 +221,17 @@ describe('CampaignTourStepView', () => {
         campaignId: 'campaign-1',
       }),
     );
+  });
+
+  it("shows the Let's go label on the last step", () => {
+    const { getByText, queryByText } = render(<CampaignTourStepView />);
+
+    // Advance to last step
+    fireEvent.press(getByText('Next'));
+    fireEvent.press(getByText('Next'));
+
+    expect(getByText("Let's go")).toBeOnTheScreen();
+    expect(queryByText('Next')).toBeNull();
   });
 
   it('navigates to campaign details when Skip is pressed', () => {

--- a/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignTourStepView.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   StackActions,
@@ -20,7 +20,10 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
+  FontWeight,
   Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { selectCampaignById } from '../../../../reducers/rewards/selectors';
@@ -88,6 +91,14 @@ const CampaignTourStepView: React.FC = () => {
 
   const renderTabBar = useCallback(() => <View />, []);
 
+  const nextButtonLabel = useMemo(
+    () =>
+      isLastStep
+        ? strings('rewards.onboarding.step_finish')
+        : strings('rewards.onboarding.step_confirm'),
+    [isLastStep],
+  );
+
   useEffect(() => {
     if (!tour?.length) {
       navigateToDetails();
@@ -103,7 +114,8 @@ const CampaignTourStepView: React.FC = () => {
       twClassName="flex-1 bg-default"
       style={{ paddingTop: safeAreaInsets.top }}
     >
-      <Box twClassName="items-center pt-4 pb-2">
+      {/* Progress Dots */}
+      <Box twClassName="flex-row justify-center items-center py-6 px-4">
         <ProgressIndicator
           totalSteps={tour.length}
           currentStep={currentTab + 1}
@@ -111,6 +123,7 @@ const CampaignTourStepView: React.FC = () => {
         />
       </Box>
 
+      {/* Tutorial Content */}
       <Box twClassName="flex-1">
         <ScrollableTabView
           ref={scrollableTabViewRef}
@@ -126,34 +139,39 @@ const CampaignTourStepView: React.FC = () => {
         </ScrollableTabView>
       </Box>
 
-      <Box
-        twClassName="px-4 gap-2 pb-2"
-        style={{ paddingBottom: safeAreaInsets.bottom }}
-      >
-        {showNext && (
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            onPress={handleNext}
-            twClassName="w-full"
-            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON}
+      {/* Footer */}
+      <Box twClassName="px-4" style={{ paddingBottom: safeAreaInsets.bottom }}>
+        <Box twClassName="mb-4 gap-4">
+          {showNext && (
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              onPress={handleNext}
+              twClassName="w-full"
+              testID={CAMPAIGN_TOUR_STEP_TEST_IDS.NEXT_BUTTON}
+            >
+              {nextButtonLabel}
+            </Button>
+          )}
+          <Box
+            twClassName="self-center px-4"
+            style={tw.style(!showSkip && 'opacity-0')}
           >
-            {strings('rewards.onboarding.step_confirm')}
-          </Button>
-        )}
-        {showSkip && (
-          <Button
-            variant={ButtonVariant.Tertiary}
-            size={ButtonSize.Lg}
-            onPress={navigateToDetails}
-            twClassName="w-full bg-gray-500 border-gray-500"
-            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON}
-          >
-            <Text twClassName="text-text-default">
-              {strings('rewards.onboarding.step_skip')}
-            </Text>
-          </Button>
-        )}
+            <TouchableOpacity
+              onPress={navigateToDetails}
+              disabled={!showSkip}
+              testID={CAMPAIGN_TOUR_STEP_TEST_IDS.SKIP_BUTTON}
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+                fontWeight={FontWeight.Medium}
+              >
+                {strings('rewards.onboarding.step_skip')}
+              </Text>
+            </TouchableOpacity>
+          </Box>
+        </Box>
       </Box>
     </Box>
   );

--- a/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
@@ -4,7 +4,6 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Text,
   Box,
-  BoxAlignItems,
   BoxJustifyContent,
   TextColor,
   TextVariant,
@@ -56,9 +55,8 @@ const CampaignTourStep: React.FC<CampaignTourStepProps> = ({ step }) => {
 
         {step.image && (
           <Box
-            twClassName="flex-1"
+            twClassName="flex-1 w-full"
             justifyContent={BoxJustifyContent.Center}
-            alignItems={BoxAlignItems.Center}
           >
             <RewardsThemeImageComponent
               themeImage={step.image}

--- a/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/tour/CampaignTourStep.tsx
@@ -6,7 +6,7 @@ import {
   Box,
   BoxAlignItems,
   BoxJustifyContent,
-  BoxFlexDirection,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import RewardsThemeImageComponent from '../../ThemeImageComponent/RewardsThemeImageComponent';
@@ -30,38 +30,42 @@ const CampaignTourStep: React.FC<CampaignTourStepProps> = ({ step }) => {
 
   return (
     <ScrollView
-      contentContainerStyle={tw.style('flex-grow px-4 justify-center')}
+      style={tw.style('flex-1')}
+      contentContainerStyle={tw.style('flex-grow')}
       showsVerticalScrollIndicator={false}
     >
-      {step.image && (
-        <Box
-          justifyContent={BoxJustifyContent.Center}
-          alignItems={BoxAlignItems.Center}
-          flexDirection={BoxFlexDirection.Column}
-          twClassName="mb-6"
-        >
-          <RewardsThemeImageComponent
-            themeImage={step.image}
-            style={tw.style('w-64 h-64')}
-          />
+      <Box twClassName="flex-1 px-6 pt-3">
+        <Box>
+          <Text
+            variant={TextVariant.HeadingLg}
+            color={TextColor.TextDefault}
+            twClassName="text-left mb-1.5"
+            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.TITLE}
+          >
+            {documentToPlainText(step.title)}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            twClassName="text-left mb-4"
+            testID={CAMPAIGN_TOUR_STEP_TEST_IDS.DESCRIPTION}
+          >
+            {documentToPlainText(step.description)}
+          </Text>
         </Box>
-      )}
 
-      <Box twClassName="w-full">
-        <Text
-          variant={TextVariant.HeadingLg}
-          twClassName="text-center"
-          testID={CAMPAIGN_TOUR_STEP_TEST_IDS.TITLE}
-        >
-          {documentToPlainText(step.title)}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="mt-2 text-center text-text-alternative"
-          testID={CAMPAIGN_TOUR_STEP_TEST_IDS.DESCRIPTION}
-        >
-          {documentToPlainText(step.description)}
-        </Text>
+        {step.image && (
+          <Box
+            twClassName="flex-1"
+            justifyContent={BoxJustifyContent.Center}
+            alignItems={BoxAlignItems.Center}
+          >
+            <RewardsThemeImageComponent
+              themeImage={step.image}
+              style={tw.style('w-full h-[400px] max-h-[400px]')}
+            />
+          </Box>
+        )}
       </Box>
     </ScrollView>
   );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7902,6 +7902,7 @@
       "geo_check_fail_description": "We cannot determine if your region allows enrolling into the rewards program. Please check your connection and try again.",
       "intro_confirm_geo_loading": "Checking region...",
       "step_confirm": "Next",
+      "step_finish": "Let's go",
       "step_skip": "Skip",
       "step4_title_referral_validating": "Validating referral code...",
       "step4_referral_input_error": "Invalid referral code",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This makes the Rewards carousel match the Perps carousel.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/a2021070-1b01-41b5-9d20-22ec5909d7cd

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/layout tweaks and copy changes to the Rewards tour carousel, with a small test addition; low likelihood of impacting core app flows beyond the onboarding screen.
> 
> **Overview**
> Aligns the Rewards campaign tour carousel UI with the Perps carousel by adjusting spacing/layout, left-aligning step text, resizing/repositioning the optional image, and restyling the footer (notably changing *Skip* from a secondary button to a centered text link).
> 
> Updates the primary CTA to show **"Let’s go"** on the last step (new `rewards.onboarding.step_finish` i18n string), and adds a test to assert the final-step label swap from `Next` to `Let’s go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f0ba85bbace00be71f6478a874a416ab4ca53a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->