### PR TITLE
chore: bump @metamask/smart-transactions-controller to ^24.0.0

### DIFF
--- a/app/core/Engine/controllers/smart-transactions-controller-init.test.ts
+++ b/app/core/Engine/controllers/smart-transactions-controller-init.test.ts
@@ -11,8 +11,10 @@ import {
   SmartTransactionsControllerMessenger,
 } from '@metamask/smart-transactions-controller';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { setSentinelApiAuth } from '../../../util/transactions/sentinel-api';
 
 jest.mock('@metamask/smart-transactions-controller');
+jest.mock('../../../util/transactions/sentinel-api');
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<
@@ -51,28 +53,32 @@ describe('SmartTransactionsControllerInit', () => {
       clientId: 'mobile',
       getMetaMetricsProps: expect.any(Function),
       trackMetaMetricsEvent: expect.any(Function),
-      getBearerToken: expect.any(Function),
       trace: expect.any(Function),
     });
   });
 
-  describe('getBearerToken', () => {
-    it('passes getter that returns token when AuthenticationController returns one', async () => {
+  describe('sentinel API auth', () => {
+    const mockSetSentinelApiAuth = jest.mocked(setSentinelApiAuth);
+
+    beforeEach(() => {
+      mockSetSentinelApiAuth.mockClear();
+    });
+
+    it('configures sentinel API auth that returns token when AuthenticationController returns one', async () => {
       const bearerToken = 'test-bearer-token';
       const request = getInitRequestMock();
       const mockCall = jest.fn().mockResolvedValue(bearerToken);
-      jest.spyOn(request.initMessenger, 'call').mockImplementation(mockCall);
+      jest
+        .spyOn(request.controllerMessenger, 'call')
+        .mockImplementation(mockCall);
 
       smartTransactionsControllerInit(request);
 
-      const controllerMock = jest.mocked(SmartTransactionsController);
-      const constructorCall =
-        controllerMock.mock.calls[controllerMock.mock.calls.length - 1][0];
-      const getBearerToken = constructorCall.getBearerToken as () => Promise<
-        string | undefined
-      >;
-
-      const result = await getBearerToken();
+      expect(mockSetSentinelApiAuth).toHaveBeenCalledWith(expect.any(Function));
+      const sentinelGetter = mockSetSentinelApiAuth.mock.calls[0][0] as (
+        ...args: unknown[]
+      ) => Promise<string | undefined>;
+      const result = await sentinelGetter();
 
       expect(result).toBe(bearerToken);
       expect(mockCall).toHaveBeenCalledWith(
@@ -80,40 +86,36 @@ describe('SmartTransactionsControllerInit', () => {
       );
     });
 
-    it('passes getter that returns undefined when AuthenticationController returns undefined', async () => {
+    it('configures sentinel API auth that returns undefined when AuthenticationController returns undefined', async () => {
       const request = getInitRequestMock();
       const mockCall = jest.fn().mockResolvedValue(undefined);
-      jest.spyOn(request.initMessenger, 'call').mockImplementation(mockCall);
+      jest
+        .spyOn(request.controllerMessenger, 'call')
+        .mockImplementation(mockCall);
 
       smartTransactionsControllerInit(request);
 
-      const controllerMock = jest.mocked(SmartTransactionsController);
-      const constructorCall =
-        controllerMock.mock.calls[controllerMock.mock.calls.length - 1][0];
-      const getBearerToken = constructorCall.getBearerToken as () => Promise<
-        string | undefined
-      >;
-
-      const result = await getBearerToken();
+      const sentinelGetter = mockSetSentinelApiAuth.mock.calls[0][0] as (
+        ...args: unknown[]
+      ) => Promise<string | undefined>;
+      const result = await sentinelGetter();
 
       expect(result).toBeUndefined();
     });
 
-    it('passes getter that returns undefined when AuthenticationController throws', async () => {
+    it('configures sentinel API auth that returns undefined when AuthenticationController throws', async () => {
       const request = getInitRequestMock();
       const mockCall = jest.fn().mockRejectedValue(new Error('auth error'));
-      jest.spyOn(request.initMessenger, 'call').mockImplementation(mockCall);
+      jest
+        .spyOn(request.controllerMessenger, 'call')
+        .mockImplementation(mockCall);
 
       smartTransactionsControllerInit(request);
 
-      const controllerMock = jest.mocked(SmartTransactionsController);
-      const constructorCall =
-        controllerMock.mock.calls[controllerMock.mock.calls.length - 1][0];
-      const getBearerToken = constructorCall.getBearerToken as () => Promise<
-        string | undefined
-      >;
-
-      const result = await getBearerToken();
+      const sentinelGetter = mockSetSentinelApiAuth.mock.calls[0][0] as (
+        ...args: unknown[]
+      ) => Promise<string | undefined>;
+      const result = await sentinelGetter();
 
       expect(result).toBeUndefined();
     });

--- a/app/core/Engine/controllers/smart-transactions-controller-init.ts
+++ b/app/core/Engine/controllers/smart-transactions-controller-init.ts
@@ -55,7 +55,7 @@ export const smartTransactionsControllerInit: MessengerClientInitFunction<
   const getBearerToken = async (): Promise<string | undefined> => {
     try {
       return await Promise.resolve(
-        initMessenger.call('AuthenticationController:getBearerToken'),
+        controllerMessenger.call('AuthenticationController:getBearerToken'),
       );
     } catch {
       return undefined;
@@ -74,7 +74,6 @@ export const smartTransactionsControllerInit: MessengerClientInitFunction<
     // transactions.
     getMetaMetricsProps: () => Promise.resolve({}),
     trackMetaMetricsEvent,
-    getBearerToken,
 
     // @ts-expect-error: Type of `TraceRequest` is different.
     trace,

--- a/app/core/Engine/messengers/smart-transactions-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/smart-transactions-controller-messenger.test.ts
@@ -37,6 +37,7 @@ describe('getSmartTransactionsControllerMessenger', () => {
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         actions: expect.arrayContaining([
+          'AuthenticationController:getBearerToken',
           'NetworkController:getNetworkClientById',
           'NetworkController:getState',
           'RemoteFeatureFlagController:getState',

--- a/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
+++ b/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
@@ -6,7 +6,6 @@ import {
 import { RootMessenger } from '../types';
 import { SmartTransactionsControllerMessenger } from '@metamask/smart-transactions-controller';
 import { AnalyticsControllerActions } from '@metamask/analytics-controller';
-import { AuthenticationController } from '@metamask/profile-sync-controller';
 
 /**
  * Get the messenger for the smart transactions controller. This is scoped to the
@@ -29,6 +28,7 @@ export function getSmartTransactionsControllerMessenger(
   });
   rootMessenger.delegate({
     actions: [
+      'AuthenticationController:getBearerToken',
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',
       'RemoteFeatureFlagController:getState',
@@ -46,8 +46,7 @@ export function getSmartTransactionsControllerMessenger(
 }
 
 type SmartTransactionsControllerInitMessengerActions =
-  | AnalyticsControllerActions
-  | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
+  AnalyticsControllerActions;
 
 /**
  * Get the SmartTransactionsControllerInitMessenger for the SmartTransactionsController.
@@ -79,10 +78,7 @@ export function getSmartTransactionsControllerInitMessenger(
   });
 
   rootMessenger.delegate({
-    actions: [
-      'AnalyticsController:trackEvent',
-      'AuthenticationController:getBearerToken',
-    ],
+    actions: ['AnalyticsController:trackEvent'],
     events: [],
     messenger,
   });

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/signature-controller": "^39.1.2",
     "@metamask/slip44": "^4.2.0",
-    "@metamask/smart-transactions-controller": "^23.0.0",
+    "@metamask/smart-transactions-controller": "^24.0.0",
     "@metamask/snaps-controllers": "^20.0.1",
     "@metamask/snaps-execution-environments": "^11.0.2",
     "@metamask/snaps-rpc-methods": "^15.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9865,9 +9865,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^23.0.0":
-  version: 23.0.0
-  resolution: "@metamask/smart-transactions-controller@npm:23.0.0"
+"@metamask/smart-transactions-controller@npm:^24.0.0":
+  version: 24.0.0
+  resolution: "@metamask/smart-transactions-controller@npm:24.0.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -9879,9 +9879,10 @@ __metadata:
     "@metamask/controller-utils": "npm:^11.0.0"
     "@metamask/eth-json-rpc-provider": "npm:^4.1.6"
     "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/messenger": "npm:^1.1.0"
     "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/polling-controller": "npm:^16.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/transaction-controller": "npm:^63.0.0"
@@ -9899,7 +9900,7 @@ __metadata:
       optional: true
     "@metamask/gas-fee-controller":
       optional: true
-  checksum: 10/5dc6e3fdc8ad93967da8e1a8ec9334b3fd82444793074689981ac56a38159a8c7f651d86ac2282463af424519ca5630d46f09d0833da149928974761f8fac7fe
+  checksum: 10/9dad9c49e6c2ce84377b5f1ba13184a6c131763f2d001ef33ac7ec82329303ae8f5c1b5be36bc98e86dfbdcef91f9d63a67050a93ce070d6a2d17836ee632e64
   languageName: node
   linkType: hard
 
@@ -35926,7 +35927,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/signature-controller": "npm:^39.1.2"
     "@metamask/slip44": "npm:^4.2.0"
-    "@metamask/smart-transactions-controller": "npm:^23.0.0"
+    "@metamask/smart-transactions-controller": "npm:^24.0.0"
     "@metamask/snaps-controllers": "npm:^20.0.1"
     "@metamask/snaps-execution-environments": "npm:^11.0.2"
     "@metamask/snaps-rpc-methods": "npm:^15.1.1"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/smart-transactions-controller` from `^23.0.0` to `^24.0.0` and handles the v24 breaking change.

**Breaking change in v24:** The `getBearerToken` constructor parameter was removed. The controller now calls `AuthenticationController:getBearerToken` directly through its own runtime messenger.

Changes made:
- `AuthenticationController:getBearerToken` moved from the init messenger to the controller's runtime messenger (`getSmartTransactionsControllerMessenger`)
- Removed the `getBearerToken` wrapper closure from `smart-transactions-controller-init.ts`
- Mobile-specific: `setSentinelApiAuth` still needs the bearer token and now calls `controllerMessenger.call('AuthenticationController:getBearerToken')` directly
- Updated unit tests to match the new constructor signature

No behavior change — the bearer token is still fetched and sent with authenticated requests.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: STX-503

## **Manual testing steps**

```gherkin
Feature: smart transactions controller bump

  Scenario: no behavior change
    Given the app is open
    When smart transactions are used
    Then they behave identically to before the bump
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — no runtime behavior change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth token plumbing and messenger delegation for Smart Transactions/Sentinel requests; incorrect wiring could silently drop authenticated headers or break controller calls, though the change is narrowly scoped and covered by updated tests.
> 
> **Overview**
> Updates `@metamask/smart-transactions-controller` to `^24.0.0` and adjusts the engine integration for the v24 breaking change that removes the controller constructor’s `getBearerToken` option.
> 
> `AuthenticationController:getBearerToken` delegation is moved to the Smart Transactions *runtime* messenger, and init-time delegation is removed; `smart-transactions-controller-init` now configures Sentinel auth via `setSentinelApiAuth` using a token getter that calls `controllerMessenger.call('AuthenticationController:getBearerToken')`. Unit tests are updated to assert the new constructor signature and to validate Sentinel auth setup/token retrieval behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e1eb3bd9ab5ce28d6883b4783a31cb2cbf309f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->