### PR TITLE
fix(predict): add home_section entrypoint to Predict Feed Viewed event

### DIFF
--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -91,6 +91,7 @@ export const PredictEventValues = {
     TRENDING_SEARCH: 'trending_search',
     TRENDING: 'trending',
     BUY_PREVIEW: 'buy_preview',
+    HOME_SECTION: 'home_section',
   },
   TRANSACTION_TYPE: {
     MM_PREDICT_BUY: 'mm_predict_buy',

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -26,7 +26,8 @@ export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.MAIN_TRADE_BUTTON
   | typeof PredictEventValues.ENTRY_POINT.BACKGROUND
   | typeof PredictEventValues.ENTRY_POINT.TRENDING_SEARCH
-  | typeof PredictEventValues.ENTRY_POINT.TRENDING;
+  | typeof PredictEventValues.ENTRY_POINT.TRENDING
+  | typeof PredictEventValues.ENTRY_POINT.HOME_SECTION;
 
 /** Predict market list parameters */
 export interface PredictMarketListParams {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -223,7 +223,7 @@ describe('PredictionsSection', () => {
     expect(screen.getByText('Predictions')).toBeOnTheScreen();
   });
 
-  it('navigates to predictions market list on title press', () => {
+  it('navigates with home_section entry_point when trending markets title is pressed', () => {
     renderWithProvider(
       <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
@@ -232,6 +232,9 @@ describe('PredictionsSection', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
     });
   });
 
@@ -784,6 +787,32 @@ describe('PredictionsSection', () => {
       );
 
       expect(screen.getByText('Trending predictions')).toBeOnTheScreen();
+    });
+
+    it('navigates with home_section entry_point on title press', () => {
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: mockMarkets,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(
+        <PredictionsSection
+          sectionIndex={0}
+          totalSectionsLoaded={5}
+          mode="trending-only"
+        />,
+      );
+
+      fireEvent.press(screen.getByText('Predictions'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+        },
+      });
     });
 
     it('returns null when no markets after loading', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -233,12 +233,19 @@ const HomepagePredictPositions = ({
   </Box>
 );
 
-const usePredictNavigationHandlers = () => {
+const usePredictNavigationHandlers = (): {
+  handleViewAllPredictions: () => void;
+  handleViewAllFromPositions: () => void;
+  handlePositionPress: (position: PredictPosition) => void;
+} => {
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const handleViewAllPredictions = useCallback(() => {
     navigation.navigate(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
     });
   }, [navigation]);
 


### PR DESCRIPTION
## **Description**


The `Predict Feed Viewed` event tracks where users navigate from via an `entry_point` property. When users tapped into the Predict Feed from the homepage Predictions section (trending markets carousel, no active positions), no `entry_point` value was being passed. The property was absent from the event.

This PR adds a new `home_section` entry point value and wires it into the homepage navigation handler that leads to the Predict Feed.


## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-609

## **Manual testing steps**

```gherkin
Feature: Predict Feed Viewed entry_point from homepage

  Scenario: user navigates to Predict Feed from homepage with no positions
    Given the user has no active Predict positions
    And the user is on the Wallet homepage

    When user taps the "Predictions" section header title
    Then the Predict Feed opens
    And a "Predict Feed Viewed" event is fired with entry_point: "home_section"
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/3682b1d8-6c9a-4330-985f-8bc0e605c3dd

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small analytics/navigation parameter change scoped to the Predict homepage entry point with unit test coverage; minimal functional impact beyond event attribution.
> 
> **Overview**
> Ensures the `Predict Feed Viewed` analytics `entry_point` is populated when users enter the Predict market list from the homepage Predictions section.
> 
> This introduces a new `PredictEventValues.ENTRY_POINT.HOME_SECTION` value, extends the `PredictEntryPoint` type to include it, and updates the homepage Predictions navigation handler to pass `entryPoint: home_section` when tapping the section title (with tests updated/added to assert the new navigation params).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c366553829bd85ff9f4b4cf421c7e44501ffe17e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->