### PR TITLE
chore(release): Bump main version to 7.75.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,7 +187,7 @@ android {
         applicationId "io.metamask"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName "7.74.0"
+        versionName "7.75.0"
         versionCode 4138
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3555,13 +3555,13 @@ app:
       PROJECT_LOCATION_IOS: ios
     - opts:
         is_expand: false
-      VERSION_NAME: 7.74.0
+      VERSION_NAME: 7.75.0
     - opts:
         is_expand: false
       VERSION_NUMBER: 4138
     - opts:
         is_expand: false
-      FLASK_VERSION_NAME: 7.74.0
+      FLASK_VERSION_NAME: 7.75.0
     - opts:
         is_expand: false
       FLASK_VERSION_NUMBER: 4138

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1319,7 +1319,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1385,7 +1385,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1454,7 +1454,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1518,7 +1518,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1684,7 +1684,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1751,7 +1751,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.74.0;
+				MARKETING_VERSION = 7.75.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask",
-  "version": "7.74.0",
+  "version": "7.75.0",
   "private": true,
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 7.74.0 to 7.75.0 after cutting the release branch.

CHANGELOG entry: null

### Why this is needed:

- **Nightly builds**: Each nightly build needs to be one minor version ahead of the current release candidate
- **Version conflicts**: Prevents conflicts between nightlies and release candidates
- **Platform alignment**: Maintains version alignment between MetaMask mobile and extension
- **Update systems**: Ensures nightlies are accepted by app stores and browser update systems

### What changed:

- Version bumped from `7.74.0` to `7.75.0`
- Platform: `mobile`
- Files updated by `set-semvar-version.sh` script

### Next steps:

This PR should be **manually reviewed and merged by the release manager** to maintain proper version flow.

### Related:

- Release version: 7.74.0
- Release branch: release/7.74.0
- Platform: mobile
- Test mode: false

---

_This PR mirrors the process used in #28357 (`chore(release): Bump main version to 7.74.0`)._

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a623ae010cdc7ff8549edb9b4df8ce0f9996888f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->