### PR TITLE
fix(perps): historical-candle cancellation handling 

### DIFF
--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -12,6 +12,7 @@ const mockGetIsInitialized = jest.fn().mockReturnValue(true);
 
 jest.mock('../../../../../core/Engine');
 jest.mock('../../../../../core/SDKConnect/utils/DevLogger');
+jest.mock('../../../../../util/Logger');
 
 const mockEngine = Engine as jest.Mocked<typeof Engine>;
 
@@ -986,6 +987,39 @@ describe('CandleStreamChannel', () => {
           TimeDuration.OneDay,
         ),
       ).rejects.toThrow('Network error');
+    });
+
+    it('skips Sentry logging for abort errors', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger').default;
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation(({ callback }) => {
+        capturedCallback = callback;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneDay,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+
+      capturedCallback?.(mockCandleData);
+
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetchHistoricalCandles.mockRejectedValue(abortError);
+
+      await expect(
+        channel.fetchHistoricalCandles(
+          'BTC',
+          CandlePeriod.OneHour,
+          TimeDuration.OneDay,
+        ),
+      ).rejects.toThrow();
+
+      expect(Logger.error).not.toHaveBeenCalled();
     });
 
     it('returns early when no additional candles available', async () => {

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -5,6 +5,7 @@ import {
   calculateCandleCount,
   PERPS_CONSTANTS,
   PERFORMANCE_CONFIG,
+  isAbortError,
   type CandleData,
 } from '@metamask/perps-controller';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -528,6 +529,11 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
         },
       );
     } catch (error) {
+      // Expected cancellation — skip Sentry to avoid noisy abort reports
+      if (isAbortError(error)) {
+        throw error;
+      }
+
       const errorInstance = ensureError(
         error,
         'CandleStreamChannel.fetchHistoricalCandles',

--- a/app/controllers/perps/index.ts
+++ b/app/controllers/perps/index.ts
@@ -431,7 +431,7 @@ export {
   aggregateAccountStates,
 } from './utils';
 export type { ReturnOnEquityInput } from './utils';
-export { ensureError } from './utils';
+export { ensureError, isAbortError } from './utils';
 export type {
   OrderBookCacheEntry,
   ProcessL2BookDataParams,

--- a/app/controllers/perps/services/HyperLiquidClientService.ts
+++ b/app/controllers/perps/services/HyperLiquidClientService.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types';
 import type { HyperLiquidNetwork } from '../types/config';
 import type { CandleData } from '../types/perps-types';
-import { ensureError } from '../utils/errorUtils';
+import { ensureError, isAbortError } from '../utils/errorUtils';
 import { getPerpsConnectionAttemptContext } from '../utils/perpsConnectionAttemptContext';
 
 /**
@@ -533,10 +533,11 @@ export class HyperLiquidClientService {
         'HyperLiquidClientService.fetchHistoricalCandles',
       );
 
-      this.#deps.debugLogger.log(
-        '[PR-28953] BUG_MARKER: abort error logged to Sentry in fetchHistoricalCandles',
-        { errorName: errorInstance.name, errorMessage: errorInstance.message },
-      );
+      // Expected cancellation — skip Sentry to avoid noisy abort reports
+      if (isAbortError(error)) {
+        throw error;
+      }
+
       // Log to Sentry: prevents initial chart data load
       this.#deps.logger.error(errorInstance, {
         tags: {

--- a/app/controllers/perps/services/HyperLiquidClientService.ts
+++ b/app/controllers/perps/services/HyperLiquidClientService.ts
@@ -533,6 +533,10 @@ export class HyperLiquidClientService {
         'HyperLiquidClientService.fetchHistoricalCandles',
       );
 
+      this.#deps.debugLogger.log(
+        '[PR-28953] BUG_MARKER: abort error logged to Sentry in fetchHistoricalCandles',
+        { errorName: errorInstance.name, errorMessage: errorInstance.message },
+      );
       // Log to Sentry: prevents initial chart data load
       this.#deps.logger.error(errorInstance, {
         tags: {

--- a/app/controllers/perps/services/MarketDataService.test.ts
+++ b/app/controllers/perps/services/MarketDataService.test.ts
@@ -943,5 +943,43 @@ describe('MarketDataService', () => {
 
       expect(mockContext.stateManager?.update).toHaveBeenCalled();
     });
+
+    it('skips Sentry logging for abort errors', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockProvider.fetchHistoricalCandles = jest
+        .fn()
+        .mockRejectedValue(abortError);
+
+      await expect(
+        marketDataService.fetchHistoricalCandles({
+          provider: mockProvider,
+          symbol: 'BTC',
+          interval: '1h' as CandlePeriod,
+          context: mockContext,
+        }),
+      ).rejects.toThrow();
+
+      expect(mockDeps.logger.error).not.toHaveBeenCalled();
+      expect(mockContext.stateManager?.update).not.toHaveBeenCalled();
+    });
+
+    it('logs to Sentry for real fetch failures', async () => {
+      const networkError = new Error('Network timeout');
+      mockProvider.fetchHistoricalCandles = jest
+        .fn()
+        .mockRejectedValue(networkError);
+
+      await expect(
+        marketDataService.fetchHistoricalCandles({
+          provider: mockProvider,
+          symbol: 'BTC',
+          interval: '1h' as CandlePeriod,
+          context: mockContext,
+        }),
+      ).rejects.toThrow('Network timeout');
+
+      expect(mockDeps.logger.error).toHaveBeenCalled();
+    });
   });
 });

--- a/app/controllers/perps/services/MarketDataService.ts
+++ b/app/controllers/perps/services/MarketDataService.ts
@@ -33,7 +33,7 @@ import type {
   PerpsPlatformDependencies,
 } from '../types';
 import type { CandleData } from '../types/perps-types';
-import { ensureError } from '../utils/errorUtils';
+import { ensureError, isAbortError } from '../utils/errorUtils';
 
 /**
  * MarketDataService
@@ -779,33 +779,36 @@ export class MarketDataService {
           ? error.message
           : 'Failed to fetch historical candles';
 
-      this.#deps.logger.error(
-        ensureError(error, 'MarketDataService.fetchHistoricalCandles'),
-        {
-          tags: {
-            feature: PERPS_CONSTANTS.FeatureName,
-            provider: context.tracingContext.provider,
-            network: context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
-          },
-          context: {
-            name: context.errorContext.controller,
-            data: {
-              method: context.errorContext.method,
-              symbol,
-              interval,
-              limit,
-              endTime,
+      // Expected cancellation — skip Sentry and state updates
+      if (!isAbortError(error)) {
+        this.#deps.logger.error(
+          ensureError(error, 'MarketDataService.fetchHistoricalCandles'),
+          {
+            tags: {
+              feature: PERPS_CONSTANTS.FeatureName,
+              provider: context.tracingContext.provider,
+              network: context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
+            },
+            context: {
+              name: context.errorContext.controller,
+              data: {
+                method: context.errorContext.method,
+                symbol,
+                interval,
+                limit,
+                endTime,
+              },
             },
           },
-        },
-      );
+        );
 
-      // Update error state (if stateManager is provided)
-      if (context.stateManager) {
-        context.stateManager.update((state) => {
-          state.lastError = errorMessage;
-          state.lastUpdateTimestamp = Date.now();
-        });
+        // Update error state (if stateManager is provided)
+        if (context.stateManager) {
+          context.stateManager.update((state) => {
+            state.lastError = errorMessage;
+            state.lastUpdateTimestamp = Date.now();
+          });
+        }
       }
 
       traceData = {

--- a/app/controllers/perps/utils/errorUtils.test.ts
+++ b/app/controllers/perps/utils/errorUtils.test.ts
@@ -1,0 +1,74 @@
+import { isAbortError, ensureError } from './errorUtils';
+
+describe('errorUtils', () => {
+  describe('isAbortError', () => {
+    it('returns true for Error with name AbortError', () => {
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+
+      expect(isAbortError(error)).toBe(true);
+    });
+
+    it('returns true for Error with "signal is aborted" message', () => {
+      const error = new Error('AbortError: signal is aborted without reason');
+
+      expect(isAbortError(error)).toBe(true);
+    });
+
+    it('returns true for Error with "The operation was aborted" message', () => {
+      const error = new Error('The operation was aborted');
+
+      expect(isAbortError(error)).toBe(true);
+    });
+
+    it('returns false for regular Error', () => {
+      const error = new Error('Network timeout');
+
+      expect(isAbortError(error)).toBe(false);
+    });
+
+    it('returns false for non-Error values', () => {
+      expect(isAbortError('some string')).toBe(false);
+      expect(isAbortError(null)).toBe(false);
+      expect(isAbortError(undefined)).toBe(false);
+      expect(isAbortError(42)).toBe(false);
+    });
+
+    it('returns false for DOMException with non-abort name', () => {
+      const error = new Error('Something failed');
+      error.name = 'TypeError';
+
+      expect(isAbortError(error)).toBe(false);
+    });
+  });
+
+  describe('ensureError', () => {
+    it('returns Error instance unchanged', () => {
+      const error = new Error('test');
+
+      expect(ensureError(error)).toBe(error);
+    });
+
+    it('wraps string in Error', () => {
+      const result = ensureError('string error');
+
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('string error');
+    });
+
+    it('wraps undefined with context', () => {
+      const result = ensureError(undefined, 'TestContext');
+
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain('Unknown error');
+      expect(result.message).toContain('TestContext');
+    });
+
+    it('wraps null with context', () => {
+      const result = ensureError(null, 'TestContext');
+
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain('Unknown error');
+    });
+  });
+});

--- a/app/controllers/perps/utils/errorUtils.ts
+++ b/app/controllers/perps/utils/errorUtils.ts
@@ -5,6 +5,25 @@
 import { hasProperty } from '@metamask/utils';
 
 /**
+ * Detects expected cancellation/abort errors that should not be reported to Sentry.
+ * These occur during normal navigation or view teardown when in-flight fetch requests
+ * are cancelled via AbortController.
+ *
+ * @param error - The error to check.
+ * @returns True if the error is an expected abort/cancellation.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return (
+      error.name === 'AbortError' ||
+      error.message.includes('signal is aborted') ||
+      error.message.includes('The operation was aborted')
+    );
+  }
+  return false;
+}
+
+/**
  * Ensures we have a proper Error object for logging.
  * Converts unknown/string errors to proper Error instances.
  * Handles undefined/null specially for better Sentry context.

--- a/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
+++ b/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
@@ -1,0 +1,170 @@
+{
+  "title": "Rapid market switching — validates candles load and no rate-limit/abort errors across BTC→ETH→SOL→HYPE→BTC→ETH",
+  "inputs": {},
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
+      "entry": "nav-list",
+      "nodes": {
+        "nav-list": {
+          "action": "navigate",
+          "target": "PerpsTrendingView",
+          "next": "wait-list"
+        },
+        "wait-list": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-BTC",
+          "timeout_ms": 10000,
+          "next": "open-btc-1"
+        },
+        "open-btc-1": {
+          "action": "press",
+          "test_id": "perps-market-row-item-BTC",
+          "next": "wait-detail-btc-1"
+        },
+        "wait-detail-btc-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back-1"
+        },
+        "back-1": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "wait-eth-1"
+        },
+        "wait-eth-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-ETH",
+          "timeout_ms": 5000,
+          "next": "open-eth-1"
+        },
+        "open-eth-1": {
+          "action": "press",
+          "test_id": "perps-market-row-item-ETH",
+          "next": "wait-detail-eth-1"
+        },
+        "wait-detail-eth-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back-2"
+        },
+        "back-2": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "wait-sol-1"
+        },
+        "wait-sol-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-SOL",
+          "timeout_ms": 5000,
+          "next": "open-sol-1"
+        },
+        "open-sol-1": {
+          "action": "press",
+          "test_id": "perps-market-row-item-SOL",
+          "next": "wait-detail-sol-1"
+        },
+        "wait-detail-sol-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back-3"
+        },
+        "back-3": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "wait-hype-1"
+        },
+        "wait-hype-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-HYPE",
+          "timeout_ms": 5000,
+          "next": "open-hype-1"
+        },
+        "open-hype-1": {
+          "action": "press",
+          "test_id": "perps-market-row-item-HYPE",
+          "next": "wait-detail-hype-1"
+        },
+        "wait-detail-hype-1": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back-4"
+        },
+        "back-4": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "wait-btc-2"
+        },
+        "wait-btc-2": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-BTC",
+          "timeout_ms": 5000,
+          "next": "open-btc-2"
+        },
+        "open-btc-2": {
+          "action": "press",
+          "test_id": "perps-market-row-item-BTC",
+          "next": "wait-detail-btc-2"
+        },
+        "wait-detail-btc-2": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back-5"
+        },
+        "back-5": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "wait-eth-2"
+        },
+        "wait-eth-2": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-ETH",
+          "timeout_ms": 5000,
+          "next": "open-eth-2"
+        },
+        "open-eth-2": {
+          "action": "press",
+          "test_id": "perps-market-row-item-ETH",
+          "next": "wait-detail-eth-2"
+        },
+        "wait-detail-eth-2": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "screenshot-chart"
+        },
+        "screenshot-chart": {
+          "action": "screenshot",
+          "filename": "evidence-rapid-switch-chart-loaded.png",
+          "next": "back-6"
+        },
+        "back-6": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "check-no-errors"
+        },
+        "check-no-errors": {
+          "action": "log_watch",
+          "window_seconds": 45,
+          "must_not_appear": [
+            "candleSnapshot error",
+            "historical_candles_api",
+            "candle_subscription_async",
+            "initial_candles_fetch"
+          ],
+          "watch_for": ["candleSnapshot", "fetchHistoricalCandles", "historical_candles"],
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}

--- a/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
+++ b/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
@@ -1,6 +1,12 @@
 {
   "title": "Rapid market switching — validates candles load and no rate-limit/abort errors across BTC→ETH→SOL→HYPE→BTC→ETH",
-  "inputs": {},
+  "inputs": {
+    "screenshot_filename": {
+      "type": "string",
+      "default": "",
+      "description": "If non-empty, capture a screenshot of the final market detail screen with this filename. Pass e.g. 'evidence-ac3-rapid-switch.png' from a recipe that needs visual proof."
+    }
+  },
   "validate": {
     "workflow": {
       "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
@@ -136,11 +142,24 @@
           "action": "wait_for",
           "test_id": "perps-market-details-view",
           "timeout_ms": 8000,
-          "next": "screenshot-chart"
+          "next": "gate-screenshot-check"
+        },
+        "gate-screenshot-check": {
+          "action": "eval_sync",
+          "expression": "JSON.stringify({take: '{{screenshot_filename}}' !== ''})",
+          "assert": { "operator": "not_null" },
+          "next": "gate-screenshot-route"
+        },
+        "gate-screenshot-route": {
+          "action": "switch",
+          "cases": [
+            { "when": { "operator": "eq", "field": "take", "value": true }, "next": "screenshot-chart" }
+          ],
+          "default": "back-6"
         },
         "screenshot-chart": {
           "action": "screenshot",
-          "filename": "evidence-rapid-switch-chart-loaded.png",
+          "filename": "{{screenshot_filename}}",
           "next": "back-6"
         },
         "back-6": {

--- a/scripts/perps/agentic/teams/perps/flows/market-visit.json
+++ b/scripts/perps/agentic/teams/perps/flows/market-visit.json
@@ -1,0 +1,44 @@
+{
+  "title": "Market Visit — open {{symbol}} detail, wait for candles to load, go back",
+  "inputs": {
+    "symbol": {
+      "type": "string",
+      "default": "BTC",
+      "description": "Market symbol to visit (must be visible in the current market list)"
+    }
+  },
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
+      "entry": "wait-row",
+      "nodes": {
+        "wait-row": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-{{symbol}}",
+          "timeout_ms": 8000,
+          "next": "open-market"
+        },
+        "open-market": {
+          "action": "press",
+          "test_id": "perps-market-row-item-{{symbol}}",
+          "next": "wait-detail"
+        },
+        "wait-detail": {
+          "action": "wait_for",
+          "test_id": "perps-market-details-view",
+          "timeout_ms": 8000,
+          "next": "back"
+        },
+        "back": {
+          "action": "press",
+          "test_id": "perps-market-header-back-button",
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## **Description**

AbortErrors from candle fetch cancellations during normal navigation/view teardown were treated as real errors and logged to Sentry at 3 service layers. Added `isAbortError()` utility and abort guards at all 3 catch blocks (`HyperLiquidClientService`, `MarketDataService`, `CandleStreamChannel`) to suppress expected cancellation noise while preserving real error reporting.

Also adds two reusable agentic flows:
- `perps/candle-rapid-switch` — cycles through BTC→ETH→SOL→HYPE→BTC→ETH and asserts no candle rate-limit or abort errors appear in logs. Reusable regression check for any PR touching the candle fetch path.
- `perps/market-visit` — single-market atom (open detail → wait → back). Building block for composing multi-market navigation sequences.

## **Changelog**

CHANGELOG entry: Fixed noisy Sentry error reports from expected candle fetch cancellations during navigation

## **Related issues**

Fixes: [TAT-2971](https://consensyssoftware.atlassian.net/browse/TAT-2971)

## **Manual testing steps**

```gherkin
Feature: Candle fetch cancellation handling

  Scenario: user navigates away from market detail during candle load
    Given the user is on the Perps BTC market detail screen
    And candle data is loading via WebSocket

    When user navigates away from the market detail screen
    Then no AbortError is logged to Sentry
    And candle data loaded successfully before navigation

  Scenario: rapid market switching does not trigger rate-limit errors
    Given the user is on the Perps market list
    When user rapidly opens and closes BTC, ETH, SOL, HYPE, BTC, ETH in sequence
    Then all candle charts load successfully
    And no candleSnapshot or rate-limit errors appear in logs

  Scenario: real candle fetch failure still reports
    Given the user is on the Perps BTC market detail screen
    When a real network error occurs during candle fetch
    Then the error is logged to Sentry normally
```

## **Screenshots/Recordings**

### **Before**

<!-- before.mp4 — recipe run on pre-fix code -->

### **After**

<!-- after-rapid-switch-validation.mp4 — full recipe run including rapid switching across 6 markets -->

https://github.com/user-attachments/assets/e5dc38ca-0aed-4d0e-a29f-1a2ce18fb9e2


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "pr": "28953",
  "title": "Verify candle abort errors are not logged to Sentry",
  "jira": "TAT-2971",
  "acceptance_criteria": [
    "Expected candle-request cancellations (AbortError) are not reported as errors to Sentry/Logger",
    "Real candle fetch failures still log/report normally to Sentry/Logger",
    "No new TypeScript errors introduced"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "setup-nav-market",
      "nodes": {
        "setup-nav-market": {
          "action": "call",
          "ref": "perps/market-discovery",
          "params": { "symbol": "BTC" },
          "next": "ac2-wait-candles"
        },
        "ac2-wait-candles": {
          "action": "wait_for",
          "expression": "Engine.context.PerpsController.getMarketDataWithPrices().then(function(ms){var m=ms.find(function(x){return x.symbol==='BTC'});return JSON.stringify({found:!!m,price:m?m.price:'0'})})",
          "assert": { "operator": "not_null", "field": "price" },
          "timeout_ms": 15000,
          "next": "ac2-screenshot-candles"
        },
        "ac2-screenshot-candles": {
          "action": "screenshot",
          "filename": "evidence-ac2-candles-loaded.png",
          "next": "setup-nav-away"
        },
        "setup-nav-away": {
          "action": "navigate",
          "target": "Wallet",
          "next": "setup-wait-teardown"
        },
        "setup-wait-teardown": {
          "action": "wait",
          "ms": 500,
          "next": "ac1-log-check"
        },
        "ac1-log-check": {
          "action": "log_watch",
          "window_seconds": 10,
          "must_not_appear": ["BUG_MARKER: abort error logged to Sentry"],
          "watch_for": ["CandleStreamChannel"],
          "next": "ac1-screenshot-clean-logs"
        },
        "ac1-screenshot-clean-logs": {
          "action": "screenshot",
          "filename": "evidence-ac1-no-abort-noise.png",
          "next": "ac3-rapid-switch"
        },
        "ac3-rapid-switch": {
          "action": "call",
          "ref": "perps/candle-rapid-switch",
          "params": { "screenshot_filename": "evidence-ac3-rapid-switch-chart.png" },
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow graph</summary>

```mermaid
graph TD
    setup-nav-market["setup-nav-market<br/>call: perps/market-discovery"] --> ac2-wait-candles
    ac2-wait-candles["ac2-wait-candles<br/>wait_for: BTC price"] --> ac2-screenshot-candles
    ac2-screenshot-candles["ac2-screenshot-candles<br/>screenshot"] --> setup-nav-away
    setup-nav-away["setup-nav-away<br/>navigate: Wallet"] --> setup-wait-teardown
    setup-wait-teardown["setup-wait-teardown<br/>wait 500ms"] --> ac1-log-check
    ac1-log-check["ac1-log-check<br/>log_watch: no abort noise"] --> ac1-screenshot-clean-logs
    ac1-screenshot-clean-logs["ac1-screenshot-clean-logs<br/>screenshot"] --> ac3-rapid-switch
    ac3-rapid-switch["ac3-rapid-switch<br/>call: perps/candle-rapid-switch<br/>BTC→ETH→SOL→HYPE→BTC→ETH"] --> done
    done["done<br/>end: pass"]
```

</details>


[TAT-2971]: https://consensyssoftware.atlassian.net/browse/TAT-2971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ