### PR TITLE
fix(predict): filter ended games from carousel and move carousel into list scroll

### DIFF
--- a/app/components/UI/Predict/hooks/useFeaturedCarouselData.test.ts
+++ b/app/components/UI/Predict/hooks/useFeaturedCarouselData.test.ts
@@ -214,4 +214,79 @@ describe('useFeaturedCarouselData', () => {
 
     expect(result.current.markets).toHaveLength(2);
   });
+
+  it('filters out sports markets with ended games', async () => {
+    mockUpDownEnabled = true;
+    const { Wrapper } = createWrapper();
+    const mockMarkets = [
+      createMockMarket({ id: 'active-market' }),
+      createMockMarket({
+        id: 'ended-game-market',
+        game: {
+          id: 'game-1',
+          startTime: '2026-04-10T18:00:00Z',
+          status: 'ended',
+          league: 'epl',
+          elapsed: null,
+          period: null,
+          score: null,
+          homeTeam: {
+            id: '1',
+            name: 'Team A',
+            logo: '',
+            abbreviation: 'TA',
+            color: 'rgb(0,0,0)',
+          },
+          awayTeam: {
+            id: '2',
+            name: 'Team B',
+            logo: '',
+            abbreviation: 'TB',
+            color: 'rgb(255,255,255)',
+          },
+        },
+      }),
+      createMockMarket({
+        id: 'live-game-market',
+        game: {
+          id: 'game-2',
+          startTime: '2026-04-15T18:00:00Z',
+          status: 'ongoing',
+          league: 'epl',
+          elapsed: '45',
+          period: '1H',
+          score: { away: 0, home: 1, raw: '0-1' },
+          homeTeam: {
+            id: '3',
+            name: 'Team C',
+            logo: '',
+            abbreviation: 'TC',
+            color: 'rgb(0,0,0)',
+          },
+          awayTeam: {
+            id: '4',
+            name: 'Team D',
+            logo: '',
+            abbreviation: 'TD',
+            color: 'rgb(255,255,255)',
+          },
+        },
+      }),
+    ];
+    mockGetCarouselMarkets.mockResolvedValue(mockMarkets);
+
+    const { result } = renderHook(() => useFeaturedCarouselData(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.markets).toHaveLength(2);
+    expect(result.current.markets.map((m) => m.id)).toEqual([
+      'active-market',
+      'live-game-market',
+    ]);
+  });
 });

--- a/app/components/UI/Predict/hooks/useFeaturedCarouselData.ts
+++ b/app/components/UI/Predict/hooks/useFeaturedCarouselData.ts
@@ -41,10 +41,11 @@ export const useFeaturedCarouselData = (): UseFeaturedCarouselDataResult => {
 
   const markets = useMemo(() => {
     const data = query.data ?? [];
-    if (upDownEnabled) {
-      return data;
-    }
-    return data.filter((market) => !isCryptoUpDown(market));
+    return data.filter((market) => {
+      if (market.game?.status === 'ended') return false;
+      if (!upDownEnabled && isCryptoUpDown(market)) return false;
+      return true;
+    });
   }, [query.data, upDownEnabled]);
 
   return {

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -161,10 +161,6 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
-  const isFeaturedCarouselEnabled = useSelector(
-    selectPredictFeaturedCarouselEnabledFlag,
-  );
-
   const animatedContainerStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: headerTranslateY.value }],
   }));
@@ -195,11 +191,6 @@ const AnimatedHeader: React.FC<AnimatedHeaderProps> = ({
         onLayout={onHeaderLayout}
       >
         <PredictFeedHeader />
-        {isFeaturedCarouselEnabled && (
-          <Box twClassName="pb-3">
-            <FeaturedCarousel />
-          </Box>
-        )}
       </Animated.View>
       <View ref={tabBarRef} onLayout={onTabBarLayout}>
         <PredictFeedTabBar
@@ -232,6 +223,7 @@ interface PredictTabContentProps {
   tabBarHeight: number;
   headerHidden: boolean;
   customQueryParams?: string;
+  showCarousel?: boolean;
 }
 
 const PredictTabContent: React.FC<PredictTabContentProps> = ({
@@ -242,6 +234,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
   tabBarHeight,
   headerHidden,
   customQueryParams,
+  showCarousel,
 }) => {
   const tw = useTailwind();
   const listRef = useRef<PredictFlashListRef>(null);
@@ -346,6 +339,16 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     [tw, contentInsetTop, headerHidden, tabBarHeight],
   );
 
+  const renderListHeader = useCallback(
+    () =>
+      showCarousel ? (
+        <Box twClassName="pb-3 pt-2 -mx-4">
+          <FeaturedCarousel />
+        </Box>
+      ) : null,
+    [showCarousel],
+  );
+
   if (!hasEverBeenActive || (isFetching && !isRefreshing && !isFetchingMore)) {
     return (
       <Box twClassName="flex-1 px-4" style={{ paddingTop: currentPaddingTop }}>
@@ -396,6 +399,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
       keyExtractor={keyExtractor}
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.7}
+      ListHeaderComponent={renderListHeader}
       ListFooterComponent={renderFooter}
       scrollEventThrottle={50}
       onScroll={isActive ? (scrollHandler as never) : undefined}
@@ -426,6 +430,7 @@ interface PredictFeedTabsProps {
   headerHidden: boolean;
   hotTabQueryParams?: string;
   initialPage: number;
+  showCarousel?: boolean;
 }
 
 const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
@@ -438,6 +443,7 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
   headerHidden,
   hotTabQueryParams,
   initialPage,
+  showCarousel,
 }) => {
   const tw = useTailwind();
   const pagerRef = useRef<PagerView>(null);
@@ -478,6 +484,7 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
             customQueryParams={
               tab.key === 'hot' ? hotTabQueryParams : undefined
             }
+            showCarousel={index === 0 && showCarousel}
           />
         </View>
       ))}
@@ -637,6 +644,10 @@ const PredictFeed: React.FC = () => {
     hotTabQueryParams,
   } = usePredictTabs();
 
+  const isFeaturedCarouselEnabled = useSelector(
+    selectPredictFeaturedCarouselEnabledFlag,
+  );
+
   const tw = useTailwind();
   const { colors } = useTheme();
   const navigation = useNavigation();
@@ -784,6 +795,7 @@ const PredictFeed: React.FC = () => {
               headerHidden={headerHidden}
               hotTabQueryParams={hotTabQueryParams}
               initialPage={activeIndex}
+              showCarousel={isFeaturedCarouselEnabled}
             />
           )}
         </Box>


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Two fixes for the featured carousel:

1. **Ended games appearing in carousel**: Sports markets with `game.status === 'ended'` were still showing in the featured carousel. Added filtering in `useFeaturedCarouselData` to exclude them.

2. **Vertical scroll blocked by carousel**: The carousel was inside an absolutely-positioned header (`z-10`) which captured all touch events, preventing vertical scrolling on the feed unless the user touched below the header. Moved the carousel from the header into the list's `ListHeaderComponent` so it scrolls naturally with the feed content. The carousel now appears below the tab bar and scrolls away with the content. The collapsible header (balance/add funds) and sticky tab bar remain unchanged.

## **Changelog**

CHANGELOG entry: Fixed featured carousel blocking feed scroll and filtering out ended sports games

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Featured carousel scroll and filtering

  Scenario: Vertical scroll works with carousel enabled
    Given the featured carousel is enabled and visible
    When the user swipes vertically on the carousel area
    Then the feed scrolls normally
    And the carousel scrolls away with the content

  Scenario: Ended games are not shown in carousel
    Given a sports market has game status "ended"
    When the featured carousel loads
    Then the ended game does not appear in the carousel

  Scenario: Feed works normally with carousel disabled
    Given the featured carousel feature flag is disabled
    When the user opens the Predict feed
    Then the feed renders and scrolls identically to before this change
```


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="404" height="848" alt="Screenshot 2026-04-16 at 6 03 27 PM" src="https://github.com/user-attachments/assets/c96c359d-b270-494a-96c1-7a013313efad" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict feed layout/scroll behavior and carousel market filtering; risk is mainly UI regressions (header offsets, list rendering) rather than data/security concerns.
> 
> **Overview**
> Fixes featured carousel content and interaction issues in Predict.
> 
> `useFeaturedCarouselData` now filters out markets whose `game.status` is `ended` (in addition to the existing up/down crypto filtering), with a new unit test covering the ended-game case. The feed UI moves `FeaturedCarousel` out of the absolutely-positioned header and into the first tab’s `FlashList` `ListHeaderComponent` (gated by the existing feature flag) so vertical scrolling isn’t blocked by the header overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21623a22757726b1fc7fda0c41d32b043cae34f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->