### PR TITLE
chore: bump chart margin on token details cp-7.74.0

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -793,7 +793,7 @@ function applyChartScaleLayout(type) {
       'paneProperties.separatorColor': theme.backgroundColor,
       'paneProperties.topMargin': 8,
       // Same margin in both modes so scale padding (and logo anchor) does not shift on toggle.
-      'paneProperties.bottomMargin': 8,
+      'paneProperties.bottomMargin': 9,
     });
   } catch (e) {}
 

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -802,7 +802,7 @@ function applyChartScaleLayout(type) {
       'paneProperties.separatorColor': theme.backgroundColor,
       'paneProperties.topMargin': 8,
       // Same margin in both modes so scale padding (and logo anchor) does not shift on toggle.
-      'paneProperties.bottomMargin': 8,
+      'paneProperties.bottomMargin': 9,
     });
   } catch (e) {}
 
@@ -2649,7 +2649,10 @@ function isCustomLineEndMarkerVisibleInPlot(chart, lastBarTimeSec) {
     if (tNorm === null) {
       return null;
     }
-    const xCut = Math.max(0, Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1));
+    const xCut = Math.max(
+      0,
+      Math.floor(plotW - LINE_END_ICON_TIME_INSET_PX - 1),
+    );
     const maxX = Math.max(0, Math.floor(plotW - 1));
 
     const tMax = timeScaleCoordinateToTimeSec(ts, maxX);
@@ -3290,7 +3293,7 @@ var OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv-chart';
  */
 function fetchOlderBars(pending) {
   var pag = window.ohlcvPagination;
-  
+
   if (!pag.nextCursor || !pag.hasMore || !pag.assetId) {
     pending.onResult([], { noData: true });
     if (window.__mmLayoutSettlePending) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates the margin bottom of advanced chart in token details page to avoid price scale tick being clipped.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="529" height="546" alt="Screenshot 2026-04-17 at 01 58 23" src="https://github.com/user-attachments/assets/2571fe52-d1b1-4ed6-bef7-1f89eaac6d02" />

### **After**

<!-- [screenshots/recordings] -->
<img width="424" height="511" alt="Screenshot 2026-04-17 at 01 58 35" src="https://github.com/user-attachments/assets/050994a8-abc1-49e6-91d1-a8e1ad562fba" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/layout tweak to chart overrides plus formatting-only changes; no business logic, data handling, or security-sensitive code is affected.
> 
> **Overview**
> Adjusts TradingView override layout by increasing `paneProperties.bottomMargin` from `8` to `9` in both the runtime WebView script (`chartLogic.js`) and its injected string source (`chartLogicString.ts`) to prevent right price-scale tick labels from being clipped.
> 
> Includes a couple of no-op formatting/whitespace-only edits in `chartLogicString.ts` (line wrapping and blank line normalization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588ef8455575e974b4fc9a4589c0c64c8079e379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->