### PR TITLE
feat: follow-optimistic-updates

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -23,7 +23,6 @@ const mockUseTopTraders = jest.fn((_options?: unknown) => ({
   traders: mockTraders,
   isLoading: false,
   error: null,
-  followLoadingIds: new Set(),
   refresh: mockRefetch,
   toggleFollow: jest.fn(),
 }));
@@ -76,7 +75,6 @@ describe('TopTradersSection', () => {
       traders: mockTraders,
       isLoading: false,
       error: null,
-      followLoadingIds: new Set(),
       refresh: mockRefetch,
       toggleFollow: jest.fn(),
     });
@@ -87,7 +85,6 @@ describe('TopTradersSection', () => {
       traders: [],
       isLoading: false,
       error: null,
-      followLoadingIds: new Set(),
       refresh: mockRefetch,
       toggleFollow: jest.fn(),
     });
@@ -100,7 +97,6 @@ describe('TopTradersSection', () => {
       traders: [],
       isLoading: true,
       error: null,
-      followLoadingIds: new Set(),
       refresh: mockRefetch,
       toggleFollow: jest.fn(),
     });

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -52,11 +52,10 @@ const TopTradersSection = forwardRef<
   const isEnabled = useSelector(selectSocialLeaderboardEnabled);
   const title = strings('homepage.sections.top_traders');
 
-  const { traders, isLoading, refresh, toggleFollow, followLoadingIds } =
-    useTopTraders({
-      limit: HOME_TRADER_LIMIT,
-      enabled: isEnabled,
-    });
+  const { traders, isLoading, refresh, toggleFollow } = useTopTraders({
+    limit: HOME_TRADER_LIMIT,
+    enabled: isEnabled,
+  });
 
   useImperativeHandle(
     ref,
@@ -125,7 +124,6 @@ const TopTradersSection = forwardRef<
                   trader={trader}
                   onFollowPress={toggleFollow}
                   onTraderPress={handleTraderPress}
-                  isFollowDisabled={followLoadingIds.has(trader.id)}
                 />
               ))}
         </ScrollView>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -22,7 +22,6 @@ export interface TopTraderCardProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
   onTraderPress?: (traderId: string, traderName: string) => void;
-  isFollowDisabled?: boolean;
   testID?: string;
 }
 
@@ -38,7 +37,6 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
   trader,
   onFollowPress,
   onTraderPress,
-  isFollowDisabled,
   testID,
 }) => {
   const tw = useTailwind();
@@ -137,7 +135,6 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
           trader.isFollowing ? ButtonVariant.Primary : ButtonVariant.Secondary
         }
         size={ButtonSize.Sm}
-        isDisabled={isFollowDisabled}
         twClassName="self-center"
         onPress={() => onFollowPress(trader.id)}
       >

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -26,7 +26,6 @@ export interface TraderRowProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
   onTraderPress?: (traderId: string, traderName: string) => void;
-  isFollowDisabled?: boolean;
   testID?: string;
 }
 
@@ -40,7 +39,6 @@ const TraderRow: React.FC<TraderRowProps> = ({
   trader,
   onFollowPress,
   onTraderPress,
-  isFollowDisabled,
   testID,
 }) => {
   const tw = useTailwind();
@@ -151,7 +149,6 @@ const TraderRow: React.FC<TraderRowProps> = ({
           trader.isFollowing ? ButtonVariant.Primary : ButtonVariant.Secondary
         }
         size={ButtonSize.Sm}
-        isDisabled={isFollowDisabled}
         onPress={() => onFollowPress(trader.id)}
       >
         {trader.isFollowing

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -240,6 +240,67 @@ describe('useTopTraders', () => {
         },
       );
     });
+
+    it('flips isFollowing optimistically for the tapped trader', async () => {
+      let resolveCall: (value: unknown) => void = () => undefined;
+      (Engine.controllerMessenger.call as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useTopTraders());
+
+      expect(result.current.traders[0].isFollowing).toBe(false);
+
+      await act(async () => {
+        result.current.toggleFollow(mockTraders[0].profileId);
+      });
+
+      expect(result.current.traders[0].isFollowing).toBe(true);
+      expect(result.current.traders[1].isFollowing).toBe(false);
+
+      await act(async () => {
+        resolveCall({ followed: [], unfollowed: [] });
+      });
+    });
+
+    it('reverts optimistic isFollowing when the API call rejects', async () => {
+      (Engine.controllerMessenger.call as jest.Mock).mockRejectedValue(
+        new Error('boom'),
+      );
+      const { result } = renderHook(() => useTopTraders());
+
+      await act(async () => {
+        await result.current.toggleFollow(mockTraders[0].profileId);
+      });
+
+      expect(result.current.traders[0].isFollowing).toBe(false);
+    });
+
+    it('ignores concurrent toggleFollow calls for the same trader while in flight', async () => {
+      let resolveCall: (value: unknown) => void = () => undefined;
+      (Engine.controllerMessenger.call as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useTopTraders());
+
+      await act(async () => {
+        result.current.toggleFollow(mockTraders[0].profileId);
+      });
+      await act(async () => {
+        result.current.toggleFollow(mockTraders[0].profileId);
+      });
+
+      expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveCall({ followed: [], unfollowed: [] });
+      });
+    });
   });
 
   describe('refresh', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -55,7 +55,7 @@ export const useTopTraders = (
     }
 
     return data.traders.map((entry) => {
-      const reduxFollowing = followingProfileIds.includes(entry.profileId);
+      const currentFollowing = followingProfileIds.includes(entry.profileId);
       const optimistic = optimisticFollowState[entry.profileId];
       return {
         id: entry.profileId,
@@ -65,7 +65,7 @@ export const useTopTraders = (
         percentageChange: (entry.roiPercent30d ?? 0) * 100,
         pnlValue: entry.pnl30d,
         pnlPerChain: entry.pnlPerChain ?? {},
-        isFollowing: optimistic ?? reduxFollowing,
+        isFollowing: optimistic ?? currentFollowing,
       };
     });
   }, [data, followingProfileIds, optimisticFollowState]);
@@ -132,8 +132,8 @@ export const useTopTraders = (
       let changed = false;
       const next: Record<string, boolean> = {};
       for (const [id, value] of Object.entries(prev)) {
-        const reduxFollowing = followingProfileIds.includes(id);
-        if (reduxFollowing === value) {
+        const currentFollowing = followingProfileIds.includes(id);
+        if (currentFollowing === value) {
           changed = true;
           continue;
         }

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect, useState } from 'react';
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import type {
@@ -14,7 +14,6 @@ export interface UseTopTradersResult {
   traders: TopTrader[];
   isLoading: boolean;
   error: string | null;
-  followLoadingIds: Set<string>;
   refresh: () => Promise<void>;
   toggleFollow: (addressOrId: string) => void;
 }
@@ -42,26 +41,34 @@ export const useTopTraders = (
   });
 
   const followingProfileIds = useSelector(selectFollowingProfileIds);
-  const [followLoadingIds, setFollowLoadingIds] = useState<Set<string>>(
-    () => new Set(),
-  );
+
+  // Optimistic follow overrides per trader id: `true` = optimistically
+  // following, `false` = optimistically unfollowing, absent = defer to Redux.
+  const [optimisticFollowState, setOptimisticFollowState] = useState<
+    Record<string, boolean>
+  >({});
+  const inflightIdsRef = useRef<Set<string>>(new Set());
 
   const traders: TopTrader[] = useMemo(() => {
     if (!data?.traders) {
       return [];
     }
 
-    return data.traders.map((entry) => ({
-      id: entry.profileId,
-      rank: entry.rank,
-      username: entry.name,
-      avatarUri: entry.imageUrl ?? undefined,
-      percentageChange: (entry.roiPercent30d ?? 0) * 100,
-      pnlValue: entry.pnl30d,
-      pnlPerChain: entry.pnlPerChain ?? {},
-      isFollowing: followingProfileIds.includes(entry.profileId),
-    }));
-  }, [data, followingProfileIds]);
+    return data.traders.map((entry) => {
+      const reduxFollowing = followingProfileIds.includes(entry.profileId);
+      const optimistic = optimisticFollowState[entry.profileId];
+      return {
+        id: entry.profileId,
+        rank: entry.rank,
+        username: entry.name,
+        avatarUri: entry.imageUrl ?? undefined,
+        percentageChange: (entry.roiPercent30d ?? 0) * 100,
+        pnlValue: entry.pnl30d,
+        pnlPerChain: entry.pnlPerChain ?? {},
+        isFollowing: optimistic ?? reduxFollowing,
+      };
+    });
+  }, [data, followingProfileIds, optimisticFollowState]);
 
   const refresh = useCallback(async () => {
     try {
@@ -74,35 +81,67 @@ export const useTopTraders = (
 
   const toggleFollow = useCallback(
     async (addressOrId: string) => {
-      setFollowLoadingIds((prev) => new Set(prev).add(addressOrId));
+      if (inflightIdsRef.current.has(addressOrId)) {
+        return;
+      }
+      inflightIdsRef.current.add(addressOrId);
+
+      const currentOptimistic = optimisticFollowState[addressOrId];
+      const currentlyFollowing =
+        currentOptimistic ?? followingProfileIds.includes(addressOrId);
+      const nextValue = !currentlyFollowing;
+
+      setOptimisticFollowState((prev) => ({
+        ...prev,
+        [addressOrId]: nextValue,
+      }));
+
       try {
         const { profileId } =
           await Engine.context.AuthenticationController.getSessionProfile();
-        const isCurrentlyFollowing = followingProfileIds.includes(addressOrId);
         const opts = { addressOrUid: profileId, targets: [addressOrId] };
-        if (isCurrentlyFollowing) {
-          await (Engine.controllerMessenger.call as CallableFunction)(
-            'SocialController:unfollowTrader',
-            opts,
-          );
-        } else {
+        if (nextValue) {
           await (Engine.controllerMessenger.call as CallableFunction)(
             'SocialController:followTrader',
             opts,
           );
+        } else {
+          await (Engine.controllerMessenger.call as CallableFunction)(
+            'SocialController:unfollowTrader',
+            opts,
+          );
         }
       } catch (err) {
-        Logger.error(err as Error, 'useTopTraders: toggleFollow failed');
-      } finally {
-        setFollowLoadingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(addressOrId);
+        setOptimisticFollowState((prev) => {
+          const next = { ...prev };
+          delete next[addressOrId];
           return next;
         });
+        Logger.error(err as Error, 'useTopTraders: toggleFollow failed');
+      } finally {
+        inflightIdsRef.current.delete(addressOrId);
       }
     },
-    [followingProfileIds],
+    [followingProfileIds, optimisticFollowState],
   );
+
+  // Clear optimistic overrides once Redux has caught up with the intended
+  // value, to avoid stale entries lingering in local state.
+  useEffect(() => {
+    setOptimisticFollowState((prev) => {
+      let changed = false;
+      const next: Record<string, boolean> = {};
+      for (const [id, value] of Object.entries(prev)) {
+        const reduxFollowing = followingProfileIds.includes(id);
+        if (reduxFollowing === value) {
+          changed = true;
+          continue;
+        }
+        next[id] = value;
+      }
+      return changed ? next : prev;
+    });
+  }, [followingProfileIds]);
 
   useEffect(() => {
     if (error) {
@@ -115,7 +154,6 @@ export const useTopTraders = (
     isLoading,
     error:
       error instanceof Error ? error.message : error ? String(error) : null,
-    followLoadingIds,
     refresh,
     toggleFollow,
   };

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -61,7 +61,6 @@ const defaultUseTopTradersResult: UseTopTradersResult = {
   traders: fixtureTraders,
   isLoading: false,
   error: null,
-  followLoadingIds: new Set(),
   refresh: mockRefresh as () => Promise<void>,
   toggleFollow: mockToggleFollow,
 };

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -134,11 +134,10 @@ const TopTradersView = () => {
   const [selectedChain, setSelectedChain] = useState<ChainFilter>('all');
   const [refreshing, setRefreshing] = useState(false);
 
-  const { traders, isLoading, refresh, toggleFollow, followLoadingIds } =
-    useTopTraders({
-      limit: 250,
-      enabled: isEnabled,
-    });
+  const { traders, isLoading, refresh, toggleFollow } = useTopTraders({
+    limit: 250,
+    enabled: isEnabled,
+  });
 
   useEffect(() => {
     if (!isEnabled) {
@@ -264,7 +263,6 @@ const TopTradersView = () => {
               trader={item}
               onFollowPress={toggleFollow}
               onTraderPress={handleTraderPress}
-              isFollowDisabled={followLoadingIds.has(item.id)}
             />
           )}
           showsVerticalScrollIndicator={false}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -79,7 +79,6 @@ let mockProfileResult: UseTraderProfileResult = {
   isLoading: false,
   error: null,
   isFollowing: false,
-  isFollowLoading: false,
   toggleFollow: mockToggleFollow,
   refresh: mockRefresh,
 };

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -88,7 +88,6 @@ const TraderProfileView = () => {
     isLoading,
     error: profileError,
     isFollowing,
-    isFollowLoading,
     toggleFollow,
     refresh,
   } = useTraderProfile(traderId, { refetchInterval: 30_000 });
@@ -197,7 +196,6 @@ const TraderProfileView = () => {
                         : ButtonVariant.Secondary
                     }
                     isFullWidth
-                    isDisabled={isFollowLoading}
                     onPress={toggleFollow}
                     testID={TraderProfileViewSelectorsIDs.FOLLOW_BUTTON}
                   >

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
@@ -218,6 +218,66 @@ describe('useTraderProfile', () => {
         { addressOrUid: 'mock-profile-id', targets: ['trader-1'] },
       );
     });
+
+    it('flips isFollowing optimistically before the API call resolves', async () => {
+      let resolveCall: (value: unknown) => void = () => undefined;
+      (Engine.controllerMessenger.call as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useTraderProfile('trader-1'));
+
+      expect(result.current.isFollowing).toBe(false);
+
+      await act(async () => {
+        result.current.toggleFollow();
+      });
+
+      expect(result.current.isFollowing).toBe(true);
+
+      await act(async () => {
+        resolveCall({ followed: [], unfollowed: [] });
+      });
+    });
+
+    it('reverts isFollowing when the API call rejects', async () => {
+      (Engine.controllerMessenger.call as jest.Mock).mockRejectedValue(
+        new Error('boom'),
+      );
+      const { result } = renderHook(() => useTraderProfile('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(result.current.isFollowing).toBe(false);
+    });
+
+    it('ignores concurrent toggleFollow calls while one is in flight', async () => {
+      let resolveCall: (value: unknown) => void = () => undefined;
+      (Engine.controllerMessenger.call as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useTraderProfile('trader-1'));
+
+      await act(async () => {
+        result.current.toggleFollow();
+      });
+      await act(async () => {
+        result.current.toggleFollow();
+      });
+
+      expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveCall({ followed: [], unfollowed: [] });
+      });
+    });
   });
 
   describe('refresh', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import type {
@@ -18,7 +18,6 @@ export interface UseTraderProfileResult {
   isLoading: boolean;
   error: string | null;
   isFollowing: boolean;
-  isFollowLoading: boolean;
   toggleFollow: () => void;
   refresh: () => Promise<void>;
 }
@@ -41,34 +40,53 @@ export const useTraderProfile = (
   });
 
   const followingProfileIds = useSelector(selectFollowingProfileIds);
+  const reduxFollowing = followingProfileIds.includes(addressOrId);
 
-  const isFollowing = followingProfileIds.includes(addressOrId);
-  const [isFollowLoading, setIsFollowLoading] = useState(false);
+  // Optimistic follow value reflects user intent instantly; cleared once
+  // Redux catches up or if the API call fails.
+  const [optimisticFollow, setOptimisticFollow] = useState<boolean | null>(
+    null,
+  );
+  const inflightRef = useRef(false);
+
+  const isFollowing = optimisticFollow ?? reduxFollowing;
   const profile = data ?? null;
 
   const toggleFollow = useCallback(async () => {
-    setIsFollowLoading(true);
+    if (inflightRef.current) {
+      return;
+    }
+    inflightRef.current = true;
+    const nextValue = !isFollowing;
+    setOptimisticFollow(nextValue);
     try {
       const { profileId } =
         await Engine.context.AuthenticationController.getSessionProfile();
       const opts = { addressOrUid: profileId, targets: [addressOrId] };
-      if (isFollowing) {
-        await (Engine.controllerMessenger.call as CallableFunction)(
-          'SocialController:unfollowTrader',
-          opts,
-        );
-      } else {
+      if (nextValue) {
         await (Engine.controllerMessenger.call as CallableFunction)(
           'SocialController:followTrader',
           opts,
         );
+      } else {
+        await (Engine.controllerMessenger.call as CallableFunction)(
+          'SocialController:unfollowTrader',
+          opts,
+        );
       }
     } catch (err) {
+      setOptimisticFollow(null);
       Logger.error(err as Error, 'useTraderProfile: toggleFollow failed');
     } finally {
-      setIsFollowLoading(false);
+      inflightRef.current = false;
     }
   }, [isFollowing, addressOrId]);
+
+  useEffect(() => {
+    if (optimisticFollow !== null && reduxFollowing === optimisticFollow) {
+      setOptimisticFollow(null);
+    }
+  }, [optimisticFollow, reduxFollowing]);
 
   const refresh = useCallback(async () => {
     try {
@@ -91,7 +109,6 @@ export const useTraderProfile = (
     error:
       error instanceof Error ? error.message : error ? String(error) : null,
     isFollowing,
-    isFollowLoading,
     toggleFollow,
     refresh,
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces optimistic state and in-flight request guarding for follow/unfollow actions, which changes user-visible behavior and could desync UI if edge cases occur. Touches social follow flows across homepage, leaderboard, and profile screens but not security-critical auth/keys logic.
> 
> **Overview**
> **Follow/unfollow now updates optimistically** in `useTopTraders` and `useTraderProfile`, immediately flipping `isFollowing` in the UI while the follow/unfollow request is in flight.
> 
> This removes the previous per-trader/button loading-disable plumbing (`followLoadingIds` / `isFollowLoading`) from the homepage Top Traders section, Top Traders list view, and trader profile follow button, replacing it with local optimistic overrides, automatic cleanup once Redux reflects the change, and guards to ignore concurrent toggles for the same trader.
> 
> Tests were updated/added to cover optimistic flipping, revert-on-error, and concurrent-call suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56cfb684c444267bdadac2103b355617cd99a49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->