### PR TITLE
feat(perps): add no_orders translation string

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1255,6 +1255,7 @@
       "open_orders": "Orders",
       "max": "max",
       "cancel_order": "Cancel order",
+      "no_orders": "No open orders",
       "filled": "filled",
       "reduce_only": "Reduce only",
       "yes": "Yes",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1255,7 +1255,7 @@
       "open_orders": "Orders",
       "max": "max",
       "cancel_order": "Cancel order",
-      "no_orders": "No open orders",
+      "no_orders": "You do not have any open orders",
       "filled": "filled",
       "reduce_only": "Reduce only",
       "yes": "Yes",


### PR DESCRIPTION
## **Description**

Adds the `no_orders` translation string ("You do not have any open orders") to the perps locale section. This supports displaying a user-friendly empty state message when there are no open orders in the perpetuals trading view.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2967

## **Manual testing steps**

```gherkin
Feature: Perps open orders empty state

  Scenario: User views open orders when none exist
    Given the user is on the perpetuals trading view
    And the user has no open orders

    When the user navigates to the orders tab
    Then the user sees a "You do not have any open orders" message
```

## **Screenshots/Recordings**

N/A — locale string addition only, no UI change in this PR.

### **Before**

### **After**
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-17 at 11 21 57" src="https://github.com/user-attachments/assets/49d4cb83-a1f7-4fc6-9aaf-5afec110bb62" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single i18n string with no logic or behavioral changes.
> 
> **Overview**
> Adds a new perps order locale entry, `no_orders`, with the message "You do not have any open orders" to support an open-orders empty state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a45f621e83852b050ea3bfe192879aeaa15d8ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->