### PR TITLE
fix(e2e): improve Detox local debug build support

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -81,9 +81,9 @@ module.exports = {
   devices: {
     'ios.simulator': {
       type: 'ios.simulator',
-      device: {
-        type: 'iPhone 16 Pro',
-      },
+      device: process.env.IOS_SIMULATOR
+        ? { name: process.env.IOS_SIMULATOR }
+        : { type: 'iPhone 16 Pro' },
     },
     'android.emulator': {
       type: 'android.emulator',

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -15,7 +15,7 @@ const logger = createLogger({
  * These screens are expected to appear when running locally.
  */
 export const dismissDevScreens = async (): Promise<void> => {
-  const port = process.env.METRO_PORT_E2E || '8081';
+  const port = process.env.METRO_PORT_E2E || process.env.WATCHER_PORT || '8081';
   const host = process.env.METRO_HOST_E2E || 'localhost';
   const serverUrl = `http://${host}:${port}`;
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -394,7 +394,13 @@ export default class TestHelpers {
   static async launchApp(launchOptions) {
     const config = await resolveConfig();
     const platform = device.getPlatform();
-    if (!config.configurationName.endsWith('.ci')) {
+    // Use debug launch for configs explicitly named 'debug' (original behavior)
+    // AND for any non-CI config (e.g. ios.sim.main which uses ios.debug app locally).
+    // CI configs (*.ci) use release apps and the normal recovery-based launch.
+    if (
+      config.configurationName.endsWith('debug') ||
+      !config.configurationName.endsWith('.ci')
+    ) {
       return this.launchAppForDebugBuild(platform, launchOptions);
     }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -394,7 +394,7 @@ export default class TestHelpers {
   static async launchApp(launchOptions) {
     const config = await resolveConfig();
     const platform = device.getPlatform();
-    if (config.configurationName.endsWith('debug')) {
+    if (!config.configurationName.endsWith('.ci')) {
       return this.launchAppForDebugBuild(platform, launchOptions);
     }
 
@@ -555,6 +555,8 @@ export default class TestHelpers {
   }
 
   static getDevLauncherPackagerUrl(platform) {
-    return `http://localhost:8081/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
+    const port =
+      process.env.METRO_PORT_E2E || process.env.WATCHER_PORT || '8081';
+    return `http://localhost:${port}/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
   }
 }

--- a/tests/jest.e2e.detox.config.js
+++ b/tests/jest.e2e.detox.config.js
@@ -1,8 +1,7 @@
 /* eslint-disable import-x/no-commonjs */
-// Load .js.env for shared infra vars (WATCHER_PORT, IOS_SIMULATOR, etc.) used by
-// helpers.js and general.flow.ts. dotenv never overrides existing vars, so the
-// first file to set a key wins. In practice .js.env and .e2e.env don't share
-// keys — .js.env owns port/device config, .e2e.env owns test accounts/flags.
+// Load .js.env for WATCHER_PORT used by helpers.js and general.flow.ts at
+// test runtime. dotenv never overrides existing vars, so .e2e.env keys win
+// when both files define the same key (in practice they don't overlap).
 require('dotenv').config({ path: '.js.env' });
 require('dotenv').config({ path: '.e2e.env' });
 

--- a/tests/jest.e2e.detox.config.js
+++ b/tests/jest.e2e.detox.config.js
@@ -1,4 +1,9 @@
 /* eslint-disable import-x/no-commonjs */
+// Load .js.env for shared infra vars (WATCHER_PORT, IOS_SIMULATOR, etc.) used by
+// helpers.js and general.flow.ts. dotenv never overrides existing vars, so the
+// first file to set a key wins. In practice .js.env and .e2e.env don't share
+// keys — .js.env owns port/device config, .e2e.env owns test accounts/flags.
+require('dotenv').config({ path: '.js.env' });
 require('dotenv').config({ path: '.e2e.env' });
 
 // Due the emulator resource constraints, is much better to run the tests in band (1 worker)

--- a/tests/jest.e2e.detox.config.js
+++ b/tests/jest.e2e.detox.config.js
@@ -1,9 +1,9 @@
 /* eslint-disable import-x/no-commonjs */
-// Load .js.env for WATCHER_PORT used by helpers.js and general.flow.ts at
-// test runtime. dotenv never overrides existing vars, so .e2e.env keys win
-// when both files define the same key (in practice they don't overlap).
-require('dotenv').config({ path: '.js.env' });
+// dotenv never overrides existing vars — first file loaded wins on collisions.
+// Load .e2e.env first so test accounts/flags take precedence, then .js.env
+// for WATCHER_PORT used by helpers.js and general.flow.ts at test runtime.
 require('dotenv').config({ path: '.e2e.env' });
+require('dotenv').config({ path: '.js.env' });
 
 // Due the emulator resource constraints, is much better to run the tests in band (1 worker)
 // Multiple workers will cause the tests to fail due to resource constraints.


### PR DESCRIPTION
## **Description**

Fixes several issues that prevent Detox e2e specs from running correctly in local debug builds:

1. **`.detoxrc.js`** — Allow `IOS_SIMULATOR` env var to override the hardcoded `iPhone 16 Pro` device type. Falls back to the default when unset, so CI is unaffected.

2. **`tests/helpers.js` — launch detection** — The original `endsWith('debug')` check never matched any Detox configuration name (`ios.sim.main`, `ios.sim.flask`, `ios.sim.apiSpecs`), so `launchAppForDebugBuild` was never called locally. This PR keeps the original `endsWith('debug')` check for backwards compatibility and adds `!endsWith('.ci')` as a fallback, so all non-CI configs (which use debug apps like `ios.debug`) correctly route through `launchAppForDebugBuild`. CI configs (`ios.sim.main.ci`, `ios.sim.flask.ci`) are unaffected — they still use `launchAppWithRecovery` with release apps.

3. **`tests/helpers.js` — packager URL** — Use `METRO_PORT_E2E` / `WATCHER_PORT` for the packager URL instead of hardcoded `8081`. `METRO_PORT_E2E` remains the primary source, `WATCHER_PORT` is a fallback for local `.js.env` config.

4. **`tests/flows/general.flow.ts`** — Add `WATCHER_PORT` as fallback after `METRO_PORT_E2E` in `dismissDevScreens`, so local `.js.env` port config is respected.

5. **`tests/jest.e2e.detox.config.js`** — Load `.js.env` via dotenv for shared infra vars (`WATCHER_PORT`, `IOS_SIMULATOR`) alongside `.e2e.env`. dotenv never overrides existing vars, so `.e2e.env` keys are unaffected.

### Backwards compatibility
- `METRO_PORT_E2E` remains the primary port source everywhere
- CI configurations (`*.ci`) are unaffected — they still use release apps and recovery-based launch
- `IOS_SIMULATOR` falls back to `iPhone 16 Pro` when unset

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2942

## **Manual testing steps**

```gherkin
Feature: Detox local debug builds

  Scenario: Run Detox spec on custom simulator and port
    Given .js.env has WATCHER_PORT=8062 and IOS_SIMULATOR=mm-2
    And a debug build is installed on the mm-2 simulator

    When user runs yarn test:e2e:ios:debug:run tests/smoke/perps/perps-position.spec.ts
    Then Detox launches on mm-2 simulator (not iPhone 16 Pro)
    And Metro deep link uses port 8062 (not 8081)
    And dismissDevScreens connects to localhost:8062

  Scenario: CI behavior unchanged
    Given CI sets METRO_PORT_E2E and uses ios.sim.main.ci config

    When CI runs Detox specs
    Then launchAppWithRecovery is used (not launchAppForDebugBuild)
    And METRO_PORT_E2E is used for port (WATCHER_PORT ignored)
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — test infrastructure, no UI changes -->

### **After**

<!-- N/A — test infrastructure, no UI changes -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Detox/Jest e2e test configuration, but they do alter app launch routing and Metro port selection which could affect local/CI test stability if misconfigured.
> 
> **Overview**
> Improves Detox local debug e2e runs by making the iOS simulator and Metro packager port configurable via env vars.
> 
> Detox now (1) allows `IOS_SIMULATOR` to override the default iOS device, (2) routes all non-`*.ci` configurations through the debug-build launch path in `tests/helpers.js`, and (3) uses `METRO_PORT_E2E` with `WATCHER_PORT` fallback for both deep-link packager URLs and `dismissDevScreens`.
> 
> Jest e2e config now loads `.js.env` after `.e2e.env` so shared infra vars like `WATCHER_PORT` are available at runtime without overriding test-specific env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8523269f8dfa0e800de2acbf7795104f336b79f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->