### PR TITLE
fix: fix block explorer redirection cp-7.74.0

### DIFF
--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
@@ -7,6 +7,68 @@ import { strings } from '../../../../../locales/i18n';
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
+const createDefaultRouteParams = () => ({
+  address: '0x1234567890abcdef',
+  chainId: '0x1',
+  symbol: 'TEST',
+  decimals: 18,
+  name: 'Test Token',
+  isNative: false,
+  securityData: {
+    resultType: 'Verified',
+    maliciousScore: '0',
+    features: [
+      {
+        featureId: 'VERIFIED_CONTRACT',
+        type: 'Info',
+        description: 'Contract is verified',
+      },
+      {
+        featureId: 'HIGH_REPUTATION_TOKEN',
+        type: 'Benign',
+        description: 'Token has high reputation',
+      },
+    ],
+    fees: {
+      buy: 1,
+      sell: 2,
+      transfer: 0,
+      transferFeeMaxAmount: null,
+    },
+    financialStats: {
+      supply: 1000000000000000000000000,
+      holdersCount: 5000,
+      topHolders: [
+        {
+          label: 'Holder 1',
+          name: null,
+          address: '0xholder1',
+          holdingPercentage: 15,
+        },
+        {
+          label: 'Holder 2',
+          name: null,
+          address: '0xholder2',
+          holdingPercentage: 10,
+        },
+      ],
+      tradeVolume24h: 1000000,
+      lockedLiquidityPct: 80,
+      markets: [],
+    },
+    metadata: {
+      externalLinks: {
+        homepage: 'https://example.com',
+        twitterPage: 'testtoken',
+        telegramChannelId: 'testtoken',
+      },
+    },
+    created: '2023-01-01T00:00:00Z',
+  },
+});
+
+let mockRouteParams = createDefaultRouteParams();
+
 jest.mock('react-native', () => {
   const actual = jest.requireActual('react-native');
   return {
@@ -25,65 +87,7 @@ jest.mock('@react-navigation/native', () => ({
     goBack: mockGoBack,
   }),
   useRoute: () => ({
-    params: {
-      address: '0x1234567890abcdef',
-      chainId: '0x1',
-      symbol: 'TEST',
-      decimals: 18,
-      name: 'Test Token',
-      isNative: false,
-      securityData: {
-        resultType: 'Verified',
-        maliciousScore: '0',
-        features: [
-          {
-            featureId: 'VERIFIED_CONTRACT',
-            type: 'Info',
-            description: 'Contract is verified',
-          },
-          {
-            featureId: 'HIGH_REPUTATION_TOKEN',
-            type: 'Benign',
-            description: 'Token has high reputation',
-          },
-        ],
-        fees: {
-          buy: 1,
-          sell: 2,
-          transfer: 0,
-          transferFeeMaxAmount: null,
-        },
-        financialStats: {
-          supply: 1000000000000000000000000,
-          holdersCount: 5000,
-          topHolders: [
-            {
-              label: 'Holder 1',
-              name: null,
-              address: '0xholder1',
-              holdingPercentage: 15,
-            },
-            {
-              label: 'Holder 2',
-              name: null,
-              address: '0xholder2',
-              holdingPercentage: 10,
-            },
-          ],
-          tradeVolume24h: 1000000,
-          lockedLiquidityPct: 80,
-          markets: [],
-        },
-        metadata: {
-          externalLinks: {
-            homepage: 'https://example.com',
-            twitterPage: 'testtoken',
-            telegramChannelId: 'testtoken',
-          },
-        },
-        created: '2023-01-01T00:00:00Z',
-      },
-    },
+    params: mockRouteParams,
   }),
 }));
 
@@ -109,14 +113,23 @@ jest.mock('react-redux', () => ({
   }),
 }));
 
-jest.mock('../../../hooks/useBlockExplorer', () => ({
-  __esModule: true,
-  default: () => ({
-    getBlockExplorerTokenUrl: (address: string) =>
-      `https://etherscan.io/address/${address}`,
-    getBlockExplorerName: () => 'Etherscan',
-  }),
-}));
+jest.mock('../../../hooks/useBlockExplorer', () => {
+  const mockGetBlockExplorerTokenUrl = jest.fn(
+    (address: string) => `https://etherscan.io/address/${address}`,
+  );
+  return {
+    __esModule: true,
+    default: () => ({
+      getBlockExplorerTokenUrl: mockGetBlockExplorerTokenUrl,
+      getBlockExplorerName: () => 'Etherscan',
+    }),
+    mockGetBlockExplorerTokenUrl,
+  };
+});
+
+const { mockGetBlockExplorerTokenUrl } = jest.requireMock(
+  '../../../hooks/useBlockExplorer',
+) as { mockGetBlockExplorerTokenUrl: jest.Mock };
 
 jest.mock('../../TokenDetails/components/TokenDetailsStickyFooter', () => ({
   __esModule: true,
@@ -134,6 +147,7 @@ jest.mock('../../TokenDetails/hooks/useTokenActions', () => ({
 
 describe('SecurityTrustScreen', () => {
   beforeEach(() => {
+    mockRouteParams = createDefaultRouteParams();
     jest.clearAllMocks();
   });
 
@@ -256,5 +270,28 @@ describe('SecurityTrustScreen', () => {
 
     expect(getByText('Published contract')).toBeTruthy();
     expect(getByText('Established reputation')).toBeTruthy();
+  });
+
+  it('passes EVM token address unchanged to getBlockExplorerTokenUrl', () => {
+    render(<SecurityTrustScreen />);
+
+    expect(mockGetBlockExplorerTokenUrl).toHaveBeenCalledWith(
+      '0x1234567890abcdef',
+      '0x1',
+    );
+  });
+
+  it('extracts asset reference from Solana CAIP asset type for block explorer URL', () => {
+    const solanaMint = 'USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB';
+    const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    mockRouteParams.address = `${solanaChainId}/token:${solanaMint}`;
+    mockRouteParams.chainId = solanaChainId;
+
+    render(<SecurityTrustScreen />);
+
+    expect(mockGetBlockExplorerTokenUrl).toHaveBeenCalledWith(
+      solanaMint,
+      solanaChainId,
+    );
   });
 });

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -41,6 +41,7 @@ import {
 import TokenDetailsStickyFooter from '../../TokenDetails/components/TokenDetailsStickyFooter';
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useTokenActions } from '../../TokenDetails/hooks/useTokenActions';
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 
 const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
   <Text
@@ -584,8 +585,11 @@ const SecurityTrustScreen: React.FC = () => {
               )}
               {Boolean(params?.address && !params.isNative) &&
                 (() => {
+                  const tokenAddress = isCaipAssetType(params.address)
+                    ? parseCaipAssetType(params.address).assetReference
+                    : params.address;
                   const blockExplorerUrl = explorer.getBlockExplorerTokenUrl(
-                    params.address,
+                    tokenAddress,
                     params.chainId,
                   );
                   const blockExplorerName = explorer.getBlockExplorerName(


### PR DESCRIPTION


## **Description**

Fixes the block explorer URL generation for Solana SPL tokens in the Security Trust screen. The params.address contains a full CAIP asset type ID (e.g., solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB) but the block explorer URL template expects just the raw token address.

This change extracts the assetReference from the CAIP asset type before passing it to getBlockExplorerTokenUrl.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix block explorer redirection for solana.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3076?focusedCommentId=412599

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/a84d3264-4545-444f-961d-a3bf8e10a5a8


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to external link URL generation plus targeted unit tests; main risk is incorrect CAIP parsing leading to broken explorer links for some non-EVM assets.
> 
> **Overview**
> Fixes block explorer redirection from `SecurityTrustScreen` by detecting CAIP asset type addresses and passing only the parsed `assetReference` (e.g., Solana mint) into `getBlockExplorerTokenUrl` instead of the full CAIP identifier.
> 
> Updates `SecurityTrustScreen.test.tsx` to make route params configurable and adds assertions that EVM addresses are passed through unchanged while Solana CAIP addresses are correctly parsed before URL generation (with `useBlockExplorer` now mocked to verify calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5464e10f1b1f3dd45eae983eccfe9ce216ef49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->