### PR TITLE
refactor: handle universal links from Braze notif deeplinks [GE-188]

### DIFF
--- a/app/core/Braze/BrazeDeeplinks.test.ts
+++ b/app/core/Braze/BrazeDeeplinks.test.ts
@@ -1,5 +1,4 @@
 import Braze from '@braze/react-native-sdk';
-import { Platform } from 'react-native';
 import {
   getBrazeInitialDeeplink,
   subscribeToBrazePushDeeplinks,
@@ -88,14 +87,7 @@ describe('BrazeDeeplinks', () => {
   });
 
   describe('subscribeToBrazePushDeeplinks', () => {
-    const originalPlatform = Platform.OS;
-
-    afterEach(() => {
-      Object.defineProperty(Platform, 'OS', { value: originalPlatform });
-    });
-
-    it('subscribes to push events on Android and invokes callback with URL', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
+    it('subscribes to push events and invokes callback with URL', () => {
       const callback = jest.fn();
 
       subscribeToBrazePushDeeplinks(callback);
@@ -116,18 +108,7 @@ describe('BrazeDeeplinks', () => {
       expect(callback).toHaveBeenCalledWith('https://link.metamask.io/rewards');
     });
 
-    it('returns null on iOS without subscribing', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'ios' });
-      const callback = jest.fn();
-
-      const result = subscribeToBrazePushDeeplinks(callback);
-
-      expect(result).toBeNull();
-      expect(Braze.addListener).not.toHaveBeenCalled();
-    });
-
     it('ignores push_received events (foreground notifications)', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
       const callback = jest.fn();
 
       subscribeToBrazePushDeeplinks(callback);
@@ -144,7 +125,6 @@ describe('BrazeDeeplinks', () => {
     });
 
     it('ignores silent push notifications', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
       const callback = jest.fn();
 
       subscribeToBrazePushDeeplinks(callback);
@@ -161,7 +141,6 @@ describe('BrazeDeeplinks', () => {
     });
 
     it('ignores Braze internal push notifications', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
       const callback = jest.fn();
 
       subscribeToBrazePushDeeplinks(callback);
@@ -178,7 +157,6 @@ describe('BrazeDeeplinks', () => {
     });
 
     it('does not invoke callback when push event has no URL', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
       const callback = jest.fn();
 
       subscribeToBrazePushDeeplinks(callback);
@@ -194,8 +172,7 @@ describe('BrazeDeeplinks', () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
-    it('returns the EmitterSubscription on Android', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
+    it('returns the EmitterSubscription', () => {
       const callback = jest.fn();
 
       const result = subscribeToBrazePushDeeplinks(callback);
@@ -204,7 +181,6 @@ describe('BrazeDeeplinks', () => {
     });
 
     it('returns null when addListener throws', () => {
-      Object.defineProperty(Platform, 'OS', { value: 'android' });
       (Braze.addListener as jest.Mock).mockImplementation(() => {
         throw new Error('Listener error');
       });

--- a/app/core/Braze/BrazeDeeplinks.ts
+++ b/app/core/Braze/BrazeDeeplinks.ts
@@ -1,5 +1,5 @@
 import Braze, { type PushNotificationEvent } from '@braze/react-native-sdk';
-import { Platform, type EmitterSubscription } from 'react-native';
+import { type EmitterSubscription } from 'react-native';
 import Logger from '../../util/Logger';
 
 /**
@@ -36,23 +36,22 @@ export function getBrazeInitialDeeplink(): Promise<string | null> {
  * Subscribe to Braze push notification tap events and invoke `callback` with
  * the deep link URL when one is present.
  *
- * Android-only — on iOS, warm/suspended push deep links flow through the
- * system URL handlers (Linking / Branch) which are already wired up.
+ * On iOS, the native `BrazeDelegate.shouldOpenURL` routes universal links
+ * (Branch domains) through Branch for proper resolution, and suppresses all
+ * other URLs. Non-universal-link URLs are handled exclusively through this JS
+ * listener, tagged with ORIGIN_BRAZE. Universal links are resolved by Branch
+ * and delivered through the Branch flow with ORIGIN_DEEPLINK (unless further
+ * tagged).
  *
- * @returns An unsubscribe function, or null on iOS / on error.
+ * @returns An EmitterSubscription, or null on error.
  */
 export function subscribeToBrazePushDeeplinks(
   callback: (deeplink: string) => void,
 ): EmitterSubscription | null {
-  if (Platform.OS !== 'android') {
-    return null;
-  }
-
   try {
     return Braze.addListener(
       Braze.Events.PUSH_NOTIFICATION_EVENT,
       (event: PushNotificationEvent) => {
-        // Only handle user-tapped notifications, not foreground-received ones
         if (event.payload_type !== 'push_opened') {
           return;
         }

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -1388,14 +1388,24 @@ describe('handleUniversalLink', () => {
     });
 
     describe('in-app link sources', () => {
-      const inAppSources = [
+      // Sources that are trusted and skip the interstitial
+      const trustedInAppSources = [
         AppConstants.DEEPLINKS.ORIGIN_CAROUSEL,
         AppConstants.DEEPLINKS.ORIGIN_NOTIFICATION,
-        AppConstants.DEEPLINKS.ORIGIN_IN_APP_BROWSER,
-        AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
         AppConstants.DEEPLINKS.ORIGIN_PUSH_NOTIFICATION,
         AppConstants.DEEPLINKS.ORIGIN_BRAZE,
       ];
+
+      // All in-app sources except the trusted ones (excluding ORIGIN_DEEPLINK which is external)
+      const untrustedInAppSources = Object.values(
+        AppConstants.DEEPLINKS,
+      ).filter(
+        (source) =>
+          source !== AppConstants.DEEPLINKS.ORIGIN_DEEPLINK &&
+          !trustedInAppSources.includes(
+            source as (typeof trustedInAppSources)[number],
+          ),
+      );
 
       const validSignature = Buffer.from(new Array(64).fill(0)).toString(
         'base64',
@@ -1405,7 +1415,7 @@ describe('handleUniversalLink', () => {
         mockSubtle.verify.mockResolvedValue(true);
       });
 
-      it.each(inAppSources)(
+      it.each(trustedInAppSources)(
         'skips modal when source is "%s" with signed (PRIVATE) link',
         async (testSource) => {
           const signedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.SWAP}?sig=${validSignature}`;
@@ -1430,8 +1440,63 @@ describe('handleUniversalLink', () => {
         },
       );
 
-      it.each(inAppSources)(
-        'displays "Proceed with caution" modal when source is "%s" with unsigned (PUBLIC) link',
+      it.each(trustedInAppSources)(
+        'skips modal when source is "%s" with unsigned (PUBLIC) link',
+        async (testSource) => {
+          const unsignedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.SWAP}`;
+          const testUrlObj = {
+            ...urlObj,
+            hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+            href: unsignedUrl,
+            pathname: `/${ACTIONS.SWAP}`,
+          };
+
+          await handleUniversalLink({
+            instance,
+            handled,
+            urlObj: testUrlObj,
+            browserCallBack: mockBrowserCallBack,
+            url: unsignedUrl,
+            source: testSource,
+          });
+
+          expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
+          expect(handled).toHaveBeenCalled();
+        },
+      );
+
+      it.each(untrustedInAppSources)(
+        'shows modal when source is "%s" with signed (PRIVATE) link',
+        async (testSource) => {
+          const signedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.SWAP}?sig=${validSignature}`;
+          const testUrlObj = {
+            ...urlObj,
+            hostname: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+            href: signedUrl,
+            pathname: `/${ACTIONS.SWAP}`,
+          };
+
+          await handleUniversalLink({
+            instance,
+            handled,
+            urlObj: testUrlObj,
+            browserCallBack: mockBrowserCallBack,
+            url: signedUrl,
+            source: testSource,
+          });
+
+          expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
+            linkType: 'private',
+            onContinue: expect.any(Function),
+            onBack: expect.any(Function),
+            pageTitle: 'Swap',
+          });
+          expect(handled).toHaveBeenCalled();
+        },
+      );
+
+      it.each(untrustedInAppSources)(
+        'shows modal when source is "%s" with unsigned (PUBLIC) link',
         async (testSource) => {
           const unsignedUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.SWAP}`;
           const testUrlObj = {
@@ -1451,10 +1516,10 @@ describe('handleUniversalLink', () => {
           });
 
           expect(mockHandleDeepLinkModalDisplay).toHaveBeenCalledWith({
-            linkType: DeepLinkModalLinkType.PUBLIC,
-            pageTitle: 'Swap',
+            linkType: 'public',
             onContinue: expect.any(Function),
             onBack: expect.any(Function),
+            pageTitle: 'Swap',
           });
           expect(handled).toHaveBeenCalled();
         },

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -125,12 +125,10 @@ const METAMASK_SDK_ACTIONS: SUPPORTED_ACTIONS[] = [
 
 const interstitialWhitelistUrls = [] as const;
 
-// This is used when links originate from within the app itself
-const inAppLinkSources = [
+// Deeplinks from these sources are sent by MetaMask and won't show the interstitial modal
+const trustedInAppSources = [
   AppConstants.DEEPLINKS.ORIGIN_CAROUSEL,
   AppConstants.DEEPLINKS.ORIGIN_NOTIFICATION,
-  AppConstants.DEEPLINKS.ORIGIN_QR_CODE,
-  AppConstants.DEEPLINKS.ORIGIN_IN_APP_BROWSER,
   AppConstants.DEEPLINKS.ORIGIN_PUSH_NOTIFICATION,
   AppConstants.DEEPLINKS.ORIGIN_BRAZE,
 ] as string[];
@@ -384,9 +382,10 @@ async function handleUniversalLink({
         validatedUrlString.startsWith(u),
       );
       const linkInstanceType = linkType();
-      const isInAppSourceWithPrivateLink =
-        inAppLinkSources.includes(source) &&
-        linkInstanceType === DeepLinkModalLinkType.PRIVATE;
+      const isTrustedInAppSource =
+        trustedInAppSources.includes(source) &&
+        (linkInstanceType === DeepLinkModalLinkType.PRIVATE ||
+          linkInstanceType === DeepLinkModalLinkType.PUBLIC);
 
       // Build analytics context - interstitialShown starts as false, set to true when modal is actually shown
       // interstitialAction will be set when user takes action
@@ -401,8 +400,8 @@ async function handleUniversalLink({
         // interstitialAction is undefined initially, set when user takes action
       };
 
-      // Track analytics for skipped cases (whitelisted URLs or in-app sources with private links)
-      if (isWhitelistedUrl || isInAppSourceWithPrivateLink) {
+      // Track analytics for skipped cases (whitelisted URLs or trusted in-app sources)
+      if (isWhitelistedUrl || isTrustedInAppSource) {
         analyticsContext.interstitialAction = InterstitialState.ACCEPTED;
         // Track analytics asynchronously without blocking
         trackDeepLinkAnalytics(analyticsContext);

--- a/ios/MetaMask/AppDelegate.h
+++ b/ios/MetaMask/AppDelegate.h
@@ -2,10 +2,9 @@
 #import <Expo/Expo.h>
 #import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
+#import <BrazeKit/BrazeKit-Swift.h>
 
-@class Braze;
-
-@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate>
+@interface AppDelegate : EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate, BrazeDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 @property (class, strong, nonatomic) Braze *braze;

--- a/ios/MetaMask/AppDelegate.m
+++ b/ios/MetaMask/AppDelegate.m
@@ -54,7 +54,9 @@ static Braze *_braze = nil;
     // requestAuthorizationAtLaunch is NO so the existing permission flow (Firebase/Notifee) is preserved.
     configuration.push.automation = [[BRZConfigurationPushAutomation alloc] initEnablingAllAutomations:YES];
     configuration.push.automation.requestAuthorizationAtLaunch = NO;
+    configuration.forwardUniversalLinks = YES;
     Braze *braze = [BrazeReactBridge initBraze:configuration];
+    braze.delegate = self;
     AppDelegate.braze = braze;
     [[BrazeReactUtils sharedInstance] populateInitialPayloadFromLaunchOptions:launchOptions];
   }
@@ -108,6 +110,28 @@ static Braze *_braze = nil;
 {
 
   return [super application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
+#pragma mark - BrazeDelegate
+
+// Route Braze deep link URLs ourselves instead of letting BrazeKit open them
+// via UIApplication.open (which would cause a duplicate delivery — once from
+// the Braze RN bridge JS event and once from the system URL handler).
+//
+// Universal links (Branch domains) are forwarded to Branch for proper routing.
+// All other URLs are suppressed here; they are handled exclusively through
+// the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE.
+- (BOOL)braze:(Braze *)braze shouldOpenURL:(BRZURLContext *)context {
+  NSString *host = context.url.host;
+  if (host &&
+      ([host containsString:@"app.link"] ||
+       [host containsString:@"test-app.link"] ||
+       [host containsString:@"link.metamask.io"] ||
+       [host containsString:@"link-test.metamask.io"])) {
+    [[Branch getInstance] handleDeepLink:context.url];
+    return NO;
+  }
+  return NO;
 }
 
 @end


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR adds support for universal links from Braze push notification deeplinks. It also removes the interstitial from this source, alongside all trusted sources (carousels, push notifications, Braze push notifications and in-app notifications).

Relevant documentation:
https://www.braze.com/docs/developer_guide/push_notifications/deep_linking?tab=objective-c&sdktab=swift
https://www.braze.com/docs/partners/message_orchestration/deeplinking/branch_for_deeplinking/?tab=objective-c

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-188

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```
Cold & Hot Start: Deeplink Flow Requirements
1. Open deeplinks without interstitial

Send test notifications with deeplinks from Braze and NaaP

→ Expect: Direct open, no interstitial

2. Open deeplinks with interstitial

Open deeplinks from your notes
Open a deeplink from a QR code (e.g., [generated here](https://fr.qr-code-generator.com/)) pointing to: https://link.metamask.io/trending

→ Expect: Interstitial displayed before opening

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deep-link routing and interstitial behavior for several in-app origins, plus adds iOS-native Braze URL interception, which could affect notification/universal-link navigation and analytics flows if misrouted.
> 
> **Overview**
> Enables Braze push-notification deep links on iOS to correctly resolve **universal links** by forwarding Branch domains from `BrazeDelegate.shouldOpenURL` to Branch, while suppressing Braze’s default URL opening to avoid duplicate deliveries.
> 
> Updates deep-link interstitial logic in `handleUniversalLink` so a defined set of **trusted in-app sources** (carousel, in-app notification, push notification, Braze) skip the interstitial for both *public and private* links; other in-app sources now show the modal. The Braze JS listener is no longer Android-gated, and corresponding tests are updated.
> 
> Bumps mobile build numbers (`versionCode`/`CURRENT_PROJECT_VERSION`/Bitrise version numbers) to `4543`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0c232dc037dd79a272bd7e43070b27bbe68f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->