### PR TITLE
feat: Implement haptic feedback improvements and new haptics rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -467,25 +467,10 @@ module.exports = {
     },
     {
       files: ['app/**/*.{ts,tsx}'],
-      excludedFiles: ['app/controllers/perps/**/*.{ts,tsx}'],
-      rules: {
-        'no-restricted-imports': [
-          'error',
-          {
-            patterns: [
-              {
-                group: ['**/controllers/perps', '**/controllers/perps/**'],
-                message:
-                  'Use @metamask/perps-controller instead of relative imports into app/controllers/perps/.',
-              },
-            ],
-          },
-        ],
-      },
-    },
-    {
-      files: ['app/**/*.{ts,tsx}'],
-      excludedFiles: ['app/util/haptics/**/*.{ts,tsx}'],
+      excludedFiles: [
+        'app/controllers/perps/**/*.{ts,tsx}',
+        'app/util/haptics/**/*.{ts,tsx}',
+      ],
       rules: {
         'no-restricted-imports': [
           'error',
@@ -498,6 +483,11 @@ module.exports = {
               },
             ],
             patterns: [
+              {
+                group: ['**/controllers/perps', '**/controllers/perps/**'],
+                message:
+                  'Use @metamask/perps-controller instead of relative imports into app/controllers/perps/.',
+              },
               {
                 group: ['expo-haptics/*'],
                 message:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -483,6 +483,31 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['app/**/*.{ts,tsx}'],
+      excludedFiles: ['app/util/haptics/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'expo-haptics',
+                message:
+                  'Import from app/util/haptics instead of expo-haptics directly.',
+              },
+            ],
+            patterns: [
+              {
+                group: ['expo-haptics/*'],
+                message:
+                  'Import from app/util/haptics instead of expo-haptics directly.',
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 
   globals: {

--- a/app/actions/settings/index.js
+++ b/app/actions/settings/index.js
@@ -94,6 +94,13 @@ export function setDeepLinkModalDisabled(deepLinkModalDisabled) {
   };
 }
 
+export function setHapticsEnabled(hapticsEnabled) {
+  return {
+    type: 'SET_HAPTICS_ENABLED',
+    hapticsEnabled,
+  };
+}
+
 export function setPerpsChartPreferredCandlePeriod(preferredCandlePeriod) {
   return {
     type: 'SET_PERPS_CHART_PREFERRED_CANDLE_PERIOD',

--- a/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
+++ b/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
@@ -5,7 +5,7 @@ import {
   PressableProps,
   useWindowDimensions,
 } from 'react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import Icon, { IconColor, IconName, IconSize } from '../../Icons/Icon';
 import { useTheme } from '../../../../util/theme';
 import Animated, {
@@ -57,7 +57,7 @@ function TradeTabBarItem({ label, ...props }: TradeTabBarItemProps) {
   }));
 
   const handleOnPress = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Medium);
+    playImpact(ImpactMoment.TabChange);
     setIsActive((active) => !active);
 
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {

--- a/app/components/UI/Compliance/contexts/AccessRestrictedContext.tsx
+++ b/app/components/UI/Compliance/contexts/AccessRestrictedContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   ReactNode,
 } from 'react';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { playWarningNotification } from '../../../../util/haptics';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
@@ -40,7 +40,7 @@ export const AccessRestrictedProvider = ({
   const { track } = usePerpsEventTracking();
 
   const showAccessRestrictedModal = useCallback(() => {
-    notificationAsync(NotificationFeedbackType.Warning);
+    playWarningNotification();
     setIsVisible(true);
     track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:

--- a/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
+++ b/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import useEarnToasts from './useEarnToasts';
 import { ToastContext } from '../../../../component-library/components/Toast';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonIconProps } from '../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon.types';
 
-jest.mock('expo-haptics');
+jest.mock('../../../../util/haptics');
 
 const mockTheme = {
   colors: {
@@ -43,7 +43,7 @@ describe('useEarnToasts', () => {
     },
   };
 
-  const mockNotificationAsync = jest.mocked(notificationAsync);
+  const mockPlayNotification = jest.mocked(playNotification);
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <ToastContext.Provider value={{ toastRef: mockToastRef }}>
@@ -87,9 +87,9 @@ describe('useEarnToasts', () => {
 
       result.current.showToast(testConfig);
 
-      expect(mockNotificationAsync).toHaveBeenCalledTimes(1);
-      expect(mockNotificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
+      expect(mockPlayNotification).toHaveBeenCalledTimes(1);
+      expect(mockPlayNotification).toHaveBeenCalledWith(
+        NotificationMoment.Success,
       );
     });
 
@@ -134,7 +134,7 @@ describe('useEarnToasts', () => {
       expect(successToast.variant).toBe(ToastVariants.Icon);
       expect(successToast.iconName).toBe(IconName.Confirmation);
       expect(successToast.iconColor).toBeDefined();
-      expect(successToast.hapticsType).toBe(NotificationFeedbackType.Success);
+      expect(successToast.hapticsType).toBe(NotificationMoment.Success);
     });
 
     it('configures inProgress toast with correct properties when called with params', () => {
@@ -147,9 +147,7 @@ describe('useEarnToasts', () => {
 
       expect(inProgressToast.variant).toBe(ToastVariants.Icon);
       expect(inProgressToast.iconName).toBe(IconName.Loading);
-      expect(inProgressToast.hapticsType).toBe(
-        NotificationFeedbackType.Warning,
-      );
+      expect(inProgressToast.hapticsType).toBe(NotificationMoment.Warning);
       expect(inProgressToast.hasNoTimeout).toBe(true);
     });
 
@@ -161,7 +159,7 @@ describe('useEarnToasts', () => {
       expect(failedToast.variant).toBe(ToastVariants.Icon);
       expect(failedToast.iconName).toBe(IconName.CircleX);
       expect(failedToast.iconColor).toBeDefined();
-      expect(failedToast.hapticsType).toBe(NotificationFeedbackType.Error);
+      expect(failedToast.hapticsType).toBe(NotificationMoment.Error);
     });
   });
 
@@ -354,8 +352,8 @@ describe('useEarnToasts', () => {
 
       result.current.showToast(inProgressToast);
 
-      expect(mockNotificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Warning,
+      expect(mockPlayNotification).toHaveBeenCalledWith(
+        NotificationMoment.Warning,
       );
     });
 
@@ -366,8 +364,8 @@ describe('useEarnToasts', () => {
 
       result.current.showToast(failedToast);
 
-      expect(mockNotificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Error,
+      expect(mockPlayNotification).toHaveBeenCalledWith(
+        NotificationMoment.Error,
       );
     });
   });
@@ -390,7 +388,7 @@ describe('useEarnToasts', () => {
 
       expect(() => result.current.showToast(testConfig)).not.toThrow();
 
-      expect(mockNotificationAsync).toHaveBeenCalled();
+      expect(mockPlayNotification).toHaveBeenCalled();
     });
 
     it('handles closeToast with null toastRef gracefully', () => {

--- a/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
+++ b/app/components/UI/Earn/hooks/useEarnToasts.test.tsx
@@ -6,7 +6,6 @@ import { ToastContext } from '../../../../component-library/components/Toast';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonIconProps } from '../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon.types';
-
 jest.mock('../../../../util/haptics');
 
 const mockTheme = {

--- a/app/components/UI/Earn/hooks/useEarnToasts.tsx
+++ b/app/components/UI/Earn/hooks/useEarnToasts.tsx
@@ -1,4 +1,8 @@
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playNotification,
+  NotificationMoment,
+  type HapticNotificationMoment,
+} from '../../../../util/haptics';
 import React, { useCallback, useContext, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { strings } from '../../../../../locales/i18n';
@@ -25,7 +29,7 @@ export type EarnToastOptions = Omit<
   Extract<ToastOptions, { variant: ToastVariants.Icon }>,
   'labelOptions'
 > & {
-  hapticsType: NotificationFeedbackType;
+  hapticsType: HapticNotificationMoment;
   // Overwriting ToastOptions.labelOptions to also support ReactNode since this works.
   labelOptions?: {
     label: string | React.ReactNode;
@@ -124,7 +128,7 @@ const useEarnToasts = (): {
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
         iconColor: theme.colors.success.default,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         startAccessory: (
           <View style={toastStyles.iconWrapper}>
             <Icon
@@ -139,7 +143,7 @@ const useEarnToasts = (): {
         ...(EARN_TOASTS_DEFAULT_OPTIONS as EarnToastOptions),
         variant: ToastVariants.Icon,
         iconName: IconName.Loading,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
         hasNoTimeout: true,
         startAccessory: (
           <View style={toastStyles.iconWrapper}>
@@ -152,7 +156,7 @@ const useEarnToasts = (): {
         variant: ToastVariants.Icon,
         iconName: IconName.CircleX,
         iconColor: theme.colors.error.default,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         startAccessory: (
           <View style={toastStyles.iconWrapper}>
             <Icon
@@ -171,7 +175,7 @@ const useEarnToasts = (): {
     (config: EarnToastOptions) => {
       const { hapticsType, ...toastOptions } = config;
       toastRef?.current?.showToast(toastOptions as ToastOptions);
-      notificationAsync(hapticsType);
+      playNotification(hapticsType);
     },
     [toastRef],
   );

--- a/app/components/UI/Earn/hooks/useMerklClaimStatus.test.ts
+++ b/app/components/UI/Earn/hooks/useMerklClaimStatus.test.ts
@@ -8,7 +8,7 @@ import { useMerklClaimStatus } from './useMerklClaimStatus';
 import useEarnToasts, { EarnToastOptionsConfig } from './useEarnToasts';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../util/haptics';
 import { MERKL_CLAIM_ORIGIN } from '../components/MerklRewards/constants';
 import Logger from '../../../../util/Logger';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -97,7 +97,7 @@ describe('useMerklClaimStatus', () => {
     iconName: IconName.Loading,
     hasNoTimeout: true,
     backgroundColor: mockTheme.colors.background.default,
-    hapticsType: NotificationFeedbackType.Warning,
+    hapticsType: NotificationMoment.Warning,
     labelOptions: [{ label: 'Claiming bonus', isBold: true }],
   };
   const mockSuccessToast = {
@@ -106,7 +106,7 @@ describe('useMerklClaimStatus', () => {
     hasNoTimeout: false,
     iconColor: mockTheme.colors.success.default,
     backgroundColor: mockTheme.colors.background.default,
-    hapticsType: NotificationFeedbackType.Success,
+    hapticsType: NotificationMoment.Success,
     labelOptions: [{ label: 'Your mUSD is here!', isBold: true }],
   };
   const mockFailedToast = {
@@ -115,7 +115,7 @@ describe('useMerklClaimStatus', () => {
     hasNoTimeout: false,
     iconColor: mockTheme.colors.error.default,
     backgroundColor: mockTheme.colors.background.default,
-    hapticsType: NotificationFeedbackType.Error,
+    hapticsType: NotificationMoment.Error,
     labelOptions: [{ label: 'Bonus claim failed', isBold: true }],
   };
   const mockEarnToastOptions: EarnToastOptionsConfig = {

--- a/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
+++ b/app/components/UI/Earn/hooks/useMusdConversionStatus.test.ts
@@ -10,7 +10,7 @@ import { useMusdConversionStatus } from './useMusdConversionStatus';
 import useEarnToasts, { EarnToastOptionsConfig } from './useEarnToasts';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../util/haptics';
 
 // Mock all external dependencies
 jest.mock('../../../../core/Engine');
@@ -115,7 +115,7 @@ describe('useMusdConversionStatus', () => {
     iconName: IconName.Loading,
     hasNoTimeout: true,
     backgroundColor: mockTheme.colors.background.default,
-    hapticsType: NotificationFeedbackType.Warning,
+    hapticsType: NotificationMoment.Warning,
     labelOptions: [{ label: 'In Progress', isBold: true }],
   };
   const mockInProgressFn = jest.fn(() => mockInProgressToast);
@@ -128,7 +128,7 @@ describe('useMusdConversionStatus', () => {
         hasNoTimeout: false,
         iconColor: mockTheme.colors.success.default,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Success', isBold: true }],
       },
       failed: {
@@ -137,7 +137,7 @@ describe('useMusdConversionStatus', () => {
         hasNoTimeout: false,
         iconColor: mockTheme.colors.error.default,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         labelOptions: [{ label: 'Failed', isBold: true }],
       },
     },
@@ -147,7 +147,7 @@ describe('useMusdConversionStatus', () => {
         iconName: IconName.Loading,
         hasNoTimeout: true,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
         labelOptions: [{ label: 'Claiming bonus', isBold: true }],
       },
       success: {
@@ -156,7 +156,7 @@ describe('useMusdConversionStatus', () => {
         hasNoTimeout: false,
         iconColor: mockTheme.colors.success.default,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Success', isBold: true }],
       },
       failed: {
@@ -165,7 +165,7 @@ describe('useMusdConversionStatus', () => {
         hasNoTimeout: false,
         iconColor: mockTheme.colors.error.default,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         labelOptions: [{ label: 'Bonus claim failed', isBold: true }],
       },
     },
@@ -176,7 +176,7 @@ describe('useMusdConversionStatus', () => {
         hasNoTimeout: false,
         iconColor: mockTheme.colors.error.default,
         backgroundColor: mockTheme.colors.background.default,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         labelOptions: [{ label: 'Withdrawal failed', isBold: true }],
       }),
     },

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { View, ActivityIndicator } from 'react-native';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../../util/haptics';
 import { strings } from '../../../../../../locales/i18n';
 import BottomSheet, {
   BottomSheetRef,
@@ -77,7 +77,7 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
         iconName: IconName.CheckBold,
         backgroundColor: theme.colors.accent03.normal,
         iconColor: theme.colors.accent03.dark,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         hasNoTimeout: false,
         labelOptions: message
           ? [
@@ -100,7 +100,7 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
         iconName: IconName.Warning,
         backgroundColor: theme.colors.accent01.light,
         iconColor: theme.colors.accent01.dark,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         hasNoTimeout: false,
         labelOptions: message
           ? [

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { View, ActivityIndicator } from 'react-native';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../../util/haptics';
 import { strings } from '../../../../../../locales/i18n';
 import BottomSheet, {
   BottomSheetRef,
@@ -103,7 +103,7 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
         iconName: IconName.CheckBold,
         backgroundColor: theme.colors.accent03.normal,
         iconColor: theme.colors.accent03.dark,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         hasNoTimeout: false,
         labelOptions: message
           ? [
@@ -126,7 +126,7 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
         iconName: IconName.Warning,
         backgroundColor: theme.colors.accent01.light,
         iconColor: theme.colors.accent01.dark,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         hasNoTimeout: false,
         labelOptions: message
           ? [

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -134,6 +134,7 @@ jest.mock('../../../../../util/haptics', () => ({
   playSelection: jest.fn(() => Promise.resolve()),
   ImpactMoment: {
     SliderTick: 'sliderTick',
+    SliderGrip: 'sliderGrip',
     TabChange: 'tabChange',
     PullToRefresh: 'pullToRefresh',
     ChartCrosshair: 'chartCrosshair',

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
 import { fireGestureHandler } from 'react-native-gesture-handler/jest-utils';
 import PerpsLeverageBottomSheet from './PerpsLeverageBottomSheet';
-
 // Mock dependencies - only what's absolutely necessary
 jest.mock('react-native-reanimated', () =>
   jest.requireActual('react-native-reanimated/mock'),
@@ -129,17 +128,7 @@ jest.mock('../../hooks/usePerpsEventTracking', () => ({
   })),
 }));
 
-jest.mock('../../../../../util/haptics', () => ({
-  playImpact: jest.fn(() => Promise.resolve()),
-  playSelection: jest.fn(() => Promise.resolve()),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    SliderGrip: 'sliderGrip',
-    TabChange: 'tabChange',
-    PullToRefresh: 'pullToRefresh',
-    ChartCrosshair: 'chartCrosshair',
-  },
-}));
+jest.mock('../../../../../util/haptics');
 
 // Mock usePerpsLivePrices hook (which uses usePerpsStream internally)
 const mockUsePerpsLivePrices = jest.fn();

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -129,13 +129,14 @@ jest.mock('../../hooks/usePerpsEventTracking', () => ({
   })),
 }));
 
-// Mock expo-haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(() => Promise.resolve()),
-  ImpactFeedbackStyle: {
-    Light: 'Light',
-    Medium: 'Medium',
-    Heavy: 'Heavy',
+jest.mock('../../../../../util/haptics', () => ({
+  playImpact: jest.fn(() => Promise.resolve()),
+  playSelection: jest.fn(() => Promise.resolve()),
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    TabChange: 'tabChange',
+    PullToRefresh: 'pullToRefresh',
+    ChartCrosshair: 'chartCrosshair',
   },
 }));
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
 import { fireGestureHandler } from 'react-native-gesture-handler/jest-utils';
 import PerpsLeverageBottomSheet from './PerpsLeverageBottomSheet';
-
 // Mock dependencies - only what's absolutely necessary
 jest.mock('react-native-gesture-handler', () => ({
   GestureHandlerRootView: 'View',
@@ -125,17 +124,7 @@ jest.mock('../../hooks/usePerpsEventTracking', () => ({
   })),
 }));
 
-jest.mock('../../../../../util/haptics', () => ({
-  playImpact: jest.fn(() => Promise.resolve()),
-  playSelection: jest.fn(() => Promise.resolve()),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    SliderGrip: 'sliderGrip',
-    TabChange: 'tabChange',
-    PullToRefresh: 'pullToRefresh',
-    ChartCrosshair: 'chartCrosshair',
-  },
-}));
+jest.mock('../../../../../util/haptics');
 
 // Mock usePerpsLivePrices hook (which uses usePerpsStream internally)
 const mockUsePerpsLivePrices = jest.fn();

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -130,6 +130,7 @@ jest.mock('../../../../../util/haptics', () => ({
   playSelection: jest.fn(() => Promise.resolve()),
   ImpactMoment: {
     SliderTick: 'sliderTick',
+    SliderGrip: 'sliderGrip',
     TabChange: 'tabChange',
     PullToRefresh: 'pullToRefresh',
     ChartCrosshair: 'chartCrosshair',

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -125,13 +125,14 @@ jest.mock('../../hooks/usePerpsEventTracking', () => ({
   })),
 }));
 
-// Mock expo-haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(() => Promise.resolve()),
-  ImpactFeedbackStyle: {
-    Light: 'Light',
-    Medium: 'Medium',
-    Heavy: 'Heavy',
+jest.mock('../../../../../util/haptics', () => ({
+  playImpact: jest.fn(() => Promise.resolve()),
+  playSelection: jest.fn(() => Promise.resolve()),
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    TabChange: 'tabChange',
+    PullToRefresh: 'pullToRefresh',
+    ChartCrosshair: 'chartCrosshair',
   },
 }));
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable @metamask/design-tokens/color-no-hex */
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import {
+  playImpact,
+  playSelection,
+  ImpactMoment,
+  type HapticImpactMoment,
+} from '../../../../../util/haptics';
 import React, {
   memo,
   useCallback,
@@ -180,13 +185,9 @@ const LeverageSlider: React.FC<{
     [onValueChange, onInteraction],
   );
 
-  // Haptic feedback callbacks
-  const triggerHapticFeedback = useCallback(
-    (impactStyle: ImpactFeedbackStyle) => {
-      impactAsync(impactStyle);
-    },
-    [],
-  );
+  const triggerHapticFeedback = useCallback((moment: HapticImpactMoment) => {
+    playImpact(moment);
+  }, []);
 
   // Check if value crosses leverage thresholds
   const checkThresholdCrossing = useCallback(
@@ -201,7 +202,7 @@ const LeverageSlider: React.FC<{
           (prevValue < threshold && newValue >= threshold) ||
           (prevValue > threshold && newValue <= threshold)
         ) {
-          runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+          runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
           break;
         }
       }
@@ -214,7 +215,7 @@ const LeverageSlider: React.FC<{
   const panGesture = Gesture.Pan()
     .onBegin(() => {
       isPressed.value = true;
-      runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Medium);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
       runOnJS(onDragStart)();
     })
     .onUpdate((event) => {
@@ -230,7 +231,7 @@ const LeverageSlider: React.FC<{
       thumbScale.value = 1; // Direct assignment, no spring
       const currentValue = positionToValue(translateX.value, sliderWidth.value);
       runOnJS(updateValue)(currentValue);
-      runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Medium);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
       runOnJS(onDragEnd)(currentValue);
     })
     .onFinalize(() => {
@@ -244,7 +245,7 @@ const LeverageSlider: React.FC<{
     const newValue = positionToValue(newPosition, sliderWidth.value);
     runOnJS(updateValue)(newValue);
     runOnJS(checkThresholdCrossing)(newValue);
-    runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+    runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
     runOnJS(onDragEnd)(newValue);
   };
 
@@ -855,7 +856,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
                 setTempLeverage(value);
                 setInputMethod('preset');
                 // Add haptic feedback for quick select buttons
-                impactAsync(ImpactFeedbackStyle.Light);
+                playSelection();
               }}
             >
               <Text

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -215,7 +215,7 @@ const LeverageSlider: React.FC<{
   const panGesture = Gesture.Pan()
     .onBegin(() => {
       isPressed.value = true;
-      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderGrip);
       runOnJS(onDragStart)();
     })
     .onUpdate((event) => {
@@ -231,7 +231,7 @@ const LeverageSlider: React.FC<{
       thumbScale.value = 1; // Direct assignment, no spring
       const currentValue = positionToValue(translateX.value, sliderWidth.value);
       runOnJS(updateValue)(currentValue);
-      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderGrip);
       runOnJS(onDragEnd)(currentValue);
     })
     .onFinalize(() => {

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import PerpsSlider from './PerpsSlider';
 import { mockTheme } from '../../../../../util/theme';
-
 // Mock dependencies - only what's absolutely necessary
 jest.mock('react-native-reanimated', () => {
   const View = jest.requireActual('react-native').View;
@@ -53,14 +52,7 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playImpact: jest.fn(),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    SliderGrip: 'sliderGrip',
-    TabChange: 'tabChange',
-  },
-}));
+jest.mock('../../../../../util/haptics');
 
 // Mock component library hooks
 jest.mock('../../../../../component-library/hooks', () => ({

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -53,10 +53,9 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-// Mock haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium' },
+jest.mock('../../../../../util/haptics', () => ({
+  playImpact: jest.fn(),
+  ImpactMoment: { SliderTick: 'sliderTick', TabChange: 'tabChange' },
 }));
 
 // Mock component library hooks
@@ -498,33 +497,33 @@ describe('PerpsSlider', () => {
     });
 
     it('triggers haptic feedback when crossing thresholds upward', () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
       // Start below thresholds
       render(<PerpsSlider {...defaultProps} value={0} />);
       // Press 50% (crosses 25 and 50)
       fireEvent.press(screen.getByText('50%'));
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
 
     it('triggers haptic feedback when crossing thresholds downward', () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
-      impactAsync.mockClear();
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
+      playImpact.mockClear();
       // Start above thresholds
       render(<PerpsSlider {...defaultProps} value={75} />);
       // Press 25% (crosses 50 & 25 downward)
       fireEvent.press(screen.getByText('25%'));
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
 
     it('triggers haptic feedback via quick value buttons threshold crossing', () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
-      impactAsync.mockClear();
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
+      playImpact.mockClear();
       render(
         <PerpsSlider {...defaultProps} value={10} quickValues={[5, 30]} />,
       );
       // 30 crosses 25 threshold
       fireEvent.press(screen.getByText('30x'));
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -55,7 +55,11 @@ jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
 jest.mock('../../../../../util/haptics', () => ({
   playImpact: jest.fn(),
-  ImpactMoment: { SliderTick: 'sliderTick', TabChange: 'tabChange' },
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    SliderGrip: 'sliderGrip',
+    TabChange: 'tabChange',
+  },
 }));
 
 // Mock component library hooks

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -28,14 +28,7 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playImpact: jest.fn(),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    SliderGrip: 'sliderGrip',
-    TabChange: 'tabChange',
-  },
-}));
+jest.mock('../../../../../util/haptics');
 
 // Mock component library hooks
 jest.mock('../../../../../component-library/hooks', () => ({

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -28,10 +28,9 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-// Mock haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium' },
+jest.mock('../../../../../util/haptics', () => ({
+  playImpact: jest.fn(),
+  ImpactMoment: { SliderTick: 'sliderTick', TabChange: 'tabChange' },
 }));
 
 // Mock component library hooks
@@ -474,31 +473,31 @@ describe('PerpsSlider', () => {
     });
 
     it('triggers haptic feedback when crossing thresholds upward', async () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
       // Start below thresholds
       render(<PerpsSlider {...defaultProps} value={0} />);
       // Press 50% (crosses 25 and 50)
       await act(async () => {
         fireEvent.press(screen.getByText('50%'));
       });
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
 
     it('triggers haptic feedback when crossing thresholds downward', async () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
-      impactAsync.mockClear();
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
+      playImpact.mockClear();
       // Start above thresholds
       render(<PerpsSlider {...defaultProps} value={75} />);
       // Press 25% (crosses 50 & 25 downward)
       await act(async () => {
         fireEvent.press(screen.getByText('25%'));
       });
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
 
     it('triggers haptic feedback via quick value buttons threshold crossing', async () => {
-      const { impactAsync } = jest.requireMock('expo-haptics');
-      impactAsync.mockClear();
+      const { playImpact } = jest.requireMock('../../../../../util/haptics');
+      playImpact.mockClear();
       render(
         <PerpsSlider {...defaultProps} value={10} quickValues={[5, 30]} />,
       );
@@ -506,7 +505,7 @@ describe('PerpsSlider', () => {
       await act(async () => {
         fireEvent.press(screen.getByText('30x'));
       });
-      expect(impactAsync).toHaveBeenCalled();
+      expect(playImpact).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -30,7 +30,11 @@ jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
 jest.mock('../../../../../util/haptics', () => ({
   playImpact: jest.fn(),
-  ImpactMoment: { SliderTick: 'sliderTick', TabChange: 'tabChange' },
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    SliderGrip: 'sliderGrip',
+    TabChange: 'tabChange',
+  },
 }));
 
 // Mock component library hooks

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -12,7 +12,11 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import {
+  playImpact,
+  ImpactMoment,
+  type HapticImpactMoment,
+} from '../../../../../util/haptics';
 import LinearGradient from 'react-native-linear-gradient';
 import Text from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
@@ -133,13 +137,9 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
     [onValueChange],
   );
 
-  // Haptic feedback callbacks
-  const triggerHapticFeedback = useCallback(
-    (impactStyle: ImpactFeedbackStyle) => {
-      impactAsync(impactStyle);
-    },
-    [],
-  );
+  const triggerHapticFeedback = useCallback((moment: HapticImpactMoment) => {
+    playImpact(moment);
+  }, []);
 
   // Check if value crosses 25/50/75 thresholds
   const checkThresholdCrossing = useCallback(
@@ -157,7 +157,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
           (prevPercentage < threshold && newPercentage >= threshold) ||
           (prevPercentage > threshold && newPercentage <= threshold)
         ) {
-          runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+          runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
           break;
         }
       }
@@ -172,7 +172,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
     .enabled(!disabled)
     .onBegin(() => {
       isPressed.value = true;
-      runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Medium);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
     })
     .onUpdate((event) => {
       const newPosition = Math.max(0, Math.min(event.x, sliderWidth.value));
@@ -187,7 +187,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
       thumbScale.value = 1; // Direct assignment, no spring
       const currentValue = positionToValue(translateX.value, sliderWidth.value);
       runOnJS(updateValue)(currentValue);
-      runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Medium);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
     })
     .onFinalize(() => {
       isPressed.value = false;

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -172,7 +172,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
     .enabled(!disabled)
     .onBegin(() => {
       isPressed.value = true;
-      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderGrip);
     })
     .onUpdate((event) => {
       const newPosition = Math.max(0, Math.min(event.x, sliderWidth.value));
@@ -187,7 +187,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
       thumbScale.value = 1; // Direct assignment, no spring
       const currentValue = positionToValue(translateX.value, sliderWidth.value);
       runOnJS(updateValue)(currentValue);
-      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+      runOnJS(triggerHapticFeedback)(ImpactMoment.SliderGrip);
     })
     .onFinalize(() => {
       isPressed.value = false;

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -17,7 +17,7 @@ import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { createTradingViewChartTemplate } from './TradingViewChartTemplate';
 import { Platform } from 'react-native';
 import { LIGHTWEIGHT_CHARTS_LIBRARY } from '../../../../../lib/lightweight-charts/LightweightChartsLib';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../../../../util/haptics';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import {
   formatPerpsFiat,
@@ -269,7 +269,7 @@ const TradingViewChart = React.forwardRef<
                   message.data.low !== ohlcData.low ||
                   message.data.close !== ohlcData.close)
               ) {
-                impactAsync(ImpactFeedbackStyle.Light);
+                playImpact(ImpactMoment.ChartCrosshair);
               }
               setOhlcData(message.data);
               break;

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -17,7 +17,7 @@ import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { createTradingViewChartTemplate } from './TradingViewChartTemplate';
 import { Platform } from 'react-native';
 import { LIGHTWEIGHT_CHARTS_LIBRARY } from '../../../../../lib/lightweight-charts/LightweightChartsLib';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../../../../util/haptics';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import {
   formatPerpsFiat,
@@ -285,7 +285,7 @@ const TradingViewChart = React.forwardRef<
                   message.data.low !== ohlcData.low ||
                   message.data.close !== ohlcData.close)
               ) {
-                impactAsync(ImpactFeedbackStyle.Light);
+                playImpact(ImpactMoment.ChartCrosshair);
               }
               setOhlcData(message.data);
               break;

--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
@@ -16,7 +16,7 @@ import {
 } from '@metamask/transaction-controller';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../util/haptics';
 import {
   USDC_ARBITRUM_MAINNET_ADDRESS,
   ARBITRUM_MAINNET_CHAIN_ID_HEX,
@@ -120,7 +120,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Deposit successful', isBold: true },
               { label: 'Your deposit has been processed' },
             ],
-            hapticsType: NotificationFeedbackType.Success,
+            hapticsType: NotificationMoment.Success,
           })),
           error: {
             variant: ToastVariants.Icon,
@@ -130,7 +130,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Deposit failed', isBold: true },
               { label: 'Your deposit could not be processed' },
             ],
-            hapticsType: NotificationFeedbackType.Error,
+            hapticsType: NotificationMoment.Error,
           } as PerpsToastOptions,
           inProgress: jest.fn(() => ({
             variant: ToastVariants.Icon,
@@ -140,7 +140,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Deposit in progress', isBold: true },
               { label: 'Processing your deposit...' },
             ],
-            hapticsType: NotificationFeedbackType.Success,
+            hapticsType: NotificationMoment.Success,
           })),
           takingLonger: {
             variant: ToastVariants.Icon,
@@ -150,7 +150,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Deposit taking longer', isBold: true },
               { label: 'Your deposit is still processing' },
             ],
-            hapticsType: NotificationFeedbackType.Warning,
+            hapticsType: NotificationMoment.Warning,
           } as PerpsToastOptions,
           tradeCanceled: {
             variant: ToastVariants.Icon,
@@ -160,7 +160,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Trade canceled', isBold: true },
               { label: 'Funds returned to account' },
             ],
-            hapticsType: NotificationFeedbackType.Warning,
+            hapticsType: NotificationMoment.Warning,
           } as PerpsToastOptions,
         },
         oneClickTrade: {
@@ -175,7 +175,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Withdrawal in progress', isBold: true },
               { label: 'Processing your withdrawal...' },
             ],
-            hapticsType: NotificationFeedbackType.Success,
+            hapticsType: NotificationMoment.Success,
           } as PerpsToastOptions,
           withdrawalSuccess: jest.fn(() => ({
             variant: ToastVariants.Icon,
@@ -185,7 +185,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Withdrawal successful', isBold: true },
               { label: 'Your withdrawal has been processed' },
             ],
-            hapticsType: NotificationFeedbackType.Success,
+            hapticsType: NotificationMoment.Success,
           })),
           withdrawalFailed: jest.fn(() => ({
             variant: ToastVariants.Icon,
@@ -195,7 +195,7 @@ describe('usePerpsDepositStatus', () => {
               { label: 'Withdrawal failed', isBold: true },
               { label: 'Your withdrawal could not be processed' },
             ],
-            hapticsType: NotificationFeedbackType.Error,
+            hapticsType: NotificationMoment.Error,
           })),
         },
       },
@@ -309,7 +309,7 @@ describe('usePerpsDepositStatus', () => {
           { label: 'Deposit in progress', isBold: true },
           { label: 'Processing your deposit...' },
         ],
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
       });
       expect(
         mockPerpsToastOptions.accountManagement.deposit.inProgress,
@@ -485,7 +485,7 @@ describe('usePerpsDepositStatus', () => {
           { label: 'Deposit successful', isBold: true },
           { label: 'Your deposit has been processed' },
         ],
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
       });
       expect(
         mockPerpsToastOptions.accountManagement.deposit.success,
@@ -589,7 +589,7 @@ describe('usePerpsDepositStatus', () => {
           { label: 'Deposit failed', isBold: true },
           { label: 'Your deposit could not be processed' },
         ],
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
       });
     });
 

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -30,9 +30,9 @@ jest.mock('../../../../component-library/components/Buttons/Button', () => ({
     Secondary: 'secondary',
   },
 }));
-jest.mock('expo-haptics', () => ({
-  notificationAsync: jest.fn(),
-  NotificationFeedbackType: {
+jest.mock('../../../../util/haptics', () => ({
+  playNotification: jest.fn(),
+  NotificationMoment: {
     Success: 'success',
     Error: 'error',
     Warning: 'warning',

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -5,7 +5,6 @@ import { usePerpsTPSLUpdate } from './usePerpsTPSLUpdate';
 import { usePerpsTrading } from './usePerpsTrading';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
-
 jest.mock('./usePerpsTrading');
 jest.mock('./usePerpsToasts');
 jest.mock('../providers/PerpsStreamManager');
@@ -30,14 +29,7 @@ jest.mock('../../../../component-library/components/Buttons/Button', () => ({
     Secondary: 'secondary',
   },
 }));
-jest.mock('../../../../util/haptics', () => ({
-  playNotification: jest.fn(),
-  NotificationMoment: {
-    Success: 'success',
-    Error: 'error',
-    Warning: 'warning',
-  },
-}));
+jest.mock('../../../../util/haptics');
 
 describe('usePerpsTPSLUpdate', () => {
   const mockUpdatePositionTPSL = jest.fn();

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -10,7 +10,6 @@ import {
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../constants/navigation/Routes';
-
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),
@@ -20,14 +19,7 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-jest.mock('../../../../util/haptics', () => ({
-  playNotification: jest.fn(),
-  NotificationMoment: {
-    Success: 'success',
-    Warning: 'warning',
-    Error: 'error',
-  },
-}));
+jest.mock('../../../../util/haptics');
 
 jest.mock('../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../util/theme');

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useContext } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import usePerpsToasts, { PerpsToastOptions } from './usePerpsToasts';
 import {
   ButtonIconVariant,
@@ -20,9 +20,9 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-jest.mock('expo-haptics', () => ({
-  notificationAsync: jest.fn(),
-  NotificationFeedbackType: {
+jest.mock('../../../../util/haptics', () => ({
+  playNotification: jest.fn(),
+  NotificationMoment: {
     Success: 'success',
     Warning: 'warning',
     Error: 'error',
@@ -102,7 +102,7 @@ describe('usePerpsToasts', () => {
       const testConfig = {
         variant: ToastVariants.Icon,
         iconName: IconName.CheckBold,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Test', isBold: true }],
         hasNoTimeout: false,
       } as unknown as PerpsToastOptions;
@@ -117,9 +117,7 @@ describe('usePerpsToasts', () => {
         labelOptions: [{ label: 'Test', isBold: true }],
         hasNoTimeout: false,
       });
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
-      );
+      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
   });
 
@@ -135,7 +133,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -156,7 +154,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
         expect(config.startAccessory).toBeTruthy();
         expect(config.closeButtonOptions).toMatchObject({
@@ -188,7 +186,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
         });
       });
     });
@@ -207,7 +205,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -273,7 +271,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -373,7 +371,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -472,7 +470,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
 
         act(() => {
@@ -500,7 +498,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -522,7 +520,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -545,7 +543,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
       });
 
@@ -567,7 +565,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
       });
 
@@ -591,7 +589,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
       });
 
@@ -609,7 +607,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
         });
       });
 
@@ -681,7 +679,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
       });
 
@@ -702,7 +700,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
         expect(config.labelOptions).toHaveLength(3);
         expect(config.labelOptions?.[0]).toMatchObject({
@@ -728,7 +726,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
         });
         expect(config.labelOptions).toEqual([
           { label: 'Failed to close position', isBold: true },
@@ -749,7 +747,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Loading,
-          hapticsType: NotificationFeedbackType.Warning,
+          hapticsType: NotificationMoment.Warning,
         });
         expect(config.labelOptions).toEqual([
           { label: 'Partially closing position', isBold: true },
@@ -776,7 +774,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
         expect(config.labelOptions).toHaveLength(3);
         expect(config.labelOptions?.[0]).toMatchObject({
@@ -802,7 +800,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
         });
         expect(config.labelOptions).toEqual([
           { label: 'Failed to partially close position', isBold: true },
@@ -823,7 +821,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
         });
         expect(config.labelOptions).toContainEqual({
           label: 'Partial close submitted',
@@ -848,7 +846,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toHaveLength(1);
@@ -868,7 +866,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toHaveLength(1);
@@ -888,7 +886,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toHaveLength(3);
@@ -909,7 +907,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toHaveLength(3);
@@ -933,7 +931,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -952,7 +950,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -970,7 +968,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -994,7 +992,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -1064,7 +1062,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.CheckBold,
-          hapticsType: NotificationFeedbackType.Success,
+          hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -1082,7 +1080,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           variant: ToastVariants.Icon,
           iconName: IconName.Warning,
-          hapticsType: NotificationFeedbackType.Error,
+          hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
         expect(config.labelOptions).toEqual([
@@ -1131,16 +1129,14 @@ describe('usePerpsToasts', () => {
       const errorToast =
         result.current.PerpsToastOptions.accountManagement.deposit.error;
 
-      expect(successToast.hapticsType).toBe(NotificationFeedbackType.Success);
-      expect(inProgressToast.hapticsType).toBe(
-        NotificationFeedbackType.Warning,
-      );
+      expect(successToast.hapticsType).toBe(NotificationMoment.Success);
+      expect(inProgressToast.hapticsType).toBe(NotificationMoment.Warning);
       expect(inProgressToast.startAccessory).toBeTruthy();
       expect(inProgressToast.closeButtonOptions).toMatchObject({
         label: 'Track',
         variant: ButtonVariants.Link,
       });
-      expect(errorToast.hapticsType).toBe(NotificationFeedbackType.Error);
+      expect(errorToast.hapticsType).toBe(NotificationMoment.Error);
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -6,7 +6,11 @@ import {
 } from '@metamask/design-system-react-native';
 import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
 import { useNavigation } from '@react-navigation/native';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playNotification,
+  NotificationMoment,
+  type HapticNotificationMoment,
+} from '../../../../util/haptics';
 import React, { useCallback, useContext, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { strings } from '../../../../../locales/i18n';
@@ -32,7 +36,7 @@ import { handlePerpsError } from '../utils/translatePerpsError';
 import { formatDurationForDisplay } from '../utils/time';
 
 export type PerpsToastOptions = Omit<ToastOptions, 'labelOptions'> & {
-  hapticsType: NotificationFeedbackType;
+  hapticsType: HapticNotificationMoment;
   // Overwriting ToastOptions.labelOptions to also support ReactNode since this works.
   labelOptions?: {
     label: string | React.ReactNode;
@@ -242,7 +246,7 @@ const usePerpsToasts = (): {
         iconName: IconName.CheckBold,
         iconColor: theme.colors.accent03.dark,
         backgroundColor: theme.colors.accent03.normal,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
       },
       // Intentional duplication for now to avoid coupling with success options.
       inProgress: {
@@ -251,7 +255,7 @@ const usePerpsToasts = (): {
         iconName: IconName.Loading,
         iconColor: theme.colors.accent04.dark,
         backgroundColor: theme.colors.accent04.normal,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
         startAccessory: (
           <View style={toastStyles.spinnerContainer}>
             <Spinner
@@ -267,7 +271,7 @@ const usePerpsToasts = (): {
         iconName: IconName.Info,
         iconColor: theme.colors.icon.default,
         backgroundColor: theme.colors.background.alternative,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
       },
       error: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
@@ -275,7 +279,7 @@ const usePerpsToasts = (): {
         iconName: IconName.Warning,
         iconColor: theme.colors.accent01.dark,
         backgroundColor: theme.colors.accent01.light,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
       },
       warning: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
@@ -283,7 +287,7 @@ const usePerpsToasts = (): {
         iconName: IconName.Warning,
         iconColor: theme.colors.warning.default,
         backgroundColor: theme.colors.warning.muted,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
       },
     }),
     [theme],
@@ -345,7 +349,7 @@ const usePerpsToasts = (): {
     (config: PerpsToastOptions) => {
       const { hapticsType, ...toastOptions } = config;
       toastRef?.current?.showToast(toastOptions as ToastOptions);
-      notificationAsync(hapticsType);
+      playNotification(hapticsType);
     },
     [toastRef],
   );
@@ -436,7 +440,7 @@ const usePerpsToasts = (): {
             iconName: IconName.Warning,
             iconColor: theme.colors.error.default,
             backgroundColor: theme.colors.error.muted,
-            hapticsType: NotificationFeedbackType.Warning,
+            hapticsType: NotificationMoment.Warning,
             labelOptions: getPerpsToastLabels(
               strings('perps.deposit.trade_canceled'),
             ),

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawStatus.test.ts
@@ -9,7 +9,7 @@ import Engine from '../../../../core/Engine';
 import type { RootState } from '../../../../reducers';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { NotificationFeedbackType } from 'expo-haptics';
+import { NotificationMoment } from '../../../../util/haptics';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -67,21 +67,21 @@ describe('usePerpsWithdrawStatus', () => {
             iconName: IconName.Loading,
             hasNoTimeout: false,
             labelOptions: [{ label: 'Withdrawal in progress', isBold: true }],
-            hapticsType: NotificationFeedbackType.Warning,
+            hapticsType: NotificationMoment.Warning,
           } as PerpsToastOptions,
           withdrawalSuccess: jest.fn(() => ({
             variant: ToastVariants.Icon,
             iconName: IconName.CheckBold,
             hasNoTimeout: false,
             labelOptions: [{ label: 'Withdrawal successful', isBold: true }],
-            hapticsType: NotificationFeedbackType.Success,
+            hapticsType: NotificationMoment.Success,
           })),
           withdrawalFailed: jest.fn(() => ({
             variant: ToastVariants.Icon,
             iconName: IconName.Warning,
             hasNoTimeout: false,
             labelOptions: [{ label: 'Withdrawal failed', isBold: true }],
-            hapticsType: NotificationFeedbackType.Error,
+            hapticsType: NotificationMoment.Error,
           })),
         },
       },

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -34,9 +34,8 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light' },
+jest.mock('../../../../../util/haptics', () => ({
+  playSelection: jest.fn(),
 }));
 
 const TEST_ID = 'line-selector';
@@ -207,8 +206,10 @@ describe('PredictSportLineSelector', () => {
   });
 
   it('fires haptic feedback on line tap', () => {
-    const { impactAsync } = jest.requireMock('expo-haptics') as {
-      impactAsync: jest.Mock;
+    const { playSelection } = jest.requireMock(
+      '../../../../../util/haptics',
+    ) as {
+      playSelection: jest.Mock;
     };
     const { getByText } = render(
       <PredictSportLineSelector {...defaultProps} />,
@@ -216,12 +217,14 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByText('4.5'));
 
-    expect(impactAsync).toHaveBeenCalledWith('light');
+    expect(playSelection).toHaveBeenCalled();
   });
 
   it('fires haptic feedback on arrow tap', () => {
-    const { impactAsync } = jest.requireMock('expo-haptics') as {
-      impactAsync: jest.Mock;
+    const { playSelection } = jest.requireMock(
+      '../../../../../util/haptics',
+    ) as {
+      playSelection: jest.Mock;
     };
     const { getByTestId } = render(
       <PredictSportLineSelector {...defaultProps} />,
@@ -229,7 +232,7 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByTestId(arrowRightId));
 
-    expect(impactAsync).toHaveBeenCalledWith('light');
+    expect(playSelection).toHaveBeenCalled();
   });
 
   it('does not call onSelectLine when selectedLine is not in lines', () => {

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import PredictSportLineSelector from './PredictSportLineSelector';
 import { PREDICT_SPORT_LINE_SELECTOR_TEST_IDS } from './PredictSportLineSelector.testIds';
-
 const mockWithTiming = jest.fn((v: number) => v);
 
 jest.mock('react-native-reanimated', () => {
@@ -34,9 +33,7 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playSelection: jest.fn(),
-}));
+jest.mock('../../../../../util/haptics');
 
 const TEST_ID = 'line-selector';
 const IDS = PREDICT_SPORT_LINE_SELECTOR_TEST_IDS;

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import PredictSportLineSelector from './PredictSportLineSelector';
 import { PREDICT_SPORT_LINE_SELECTOR_TEST_IDS } from './PredictSportLineSelector.testIds';
-
 const mockWithTiming = jest.fn((v: number) => v);
 
 jest.mock('react-native-reanimated', () => {
@@ -38,9 +37,7 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playSelection: jest.fn(),
-}));
+jest.mock('../../../../../util/haptics');
 
 const TEST_ID = 'line-selector';
 const IDS = PREDICT_SPORT_LINE_SELECTOR_TEST_IDS;

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -38,9 +38,8 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light' },
+jest.mock('../../../../../util/haptics', () => ({
+  playSelection: jest.fn(),
 }));
 
 const TEST_ID = 'line-selector';
@@ -212,8 +211,10 @@ describe('PredictSportLineSelector', () => {
   });
 
   it('fires haptic feedback on line tap', () => {
-    const { impactAsync } = jest.requireMock('expo-haptics') as {
-      impactAsync: jest.Mock;
+    const { playSelection } = jest.requireMock(
+      '../../../../../util/haptics',
+    ) as {
+      playSelection: jest.Mock;
     };
     const { getByText } = render(
       <PredictSportLineSelector {...defaultProps} />,
@@ -221,12 +222,14 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByText('4.5'));
 
-    expect(impactAsync).toHaveBeenCalledWith('light');
+    expect(playSelection).toHaveBeenCalled();
   });
 
   it('fires haptic feedback on arrow tap', () => {
-    const { impactAsync } = jest.requireMock('expo-haptics') as {
-      impactAsync: jest.Mock;
+    const { playSelection } = jest.requireMock(
+      '../../../../../util/haptics',
+    ) as {
+      playSelection: jest.Mock;
     };
     const { getByTestId } = render(
       <PredictSportLineSelector {...defaultProps} />,
@@ -234,7 +237,7 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByTestId(arrowRightId));
 
-    expect(impactAsync).toHaveBeenCalledWith('light');
+    expect(playSelection).toHaveBeenCalled();
   });
 
   it('does not call onSelectLine when selectedLine is not in lines', () => {

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { Pressable, View } from 'react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playSelection } from '../../../../../util/haptics';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -83,7 +83,7 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
 
   const selectWithHaptics = useCallback(
     (line: number) => {
-      impactAsync(ImpactFeedbackStyle.Light);
+      playSelection();
       onSelectLine(line);
     },
     [onSelectLine],

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { Pressable, View } from 'react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playSelection } from '../../../../../util/haptics';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -86,7 +86,7 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
 
   const selectWithHaptics = useCallback(
     (line: number, index: number) => {
-      impactAsync(ImpactFeedbackStyle.Light);
+      playSelection();
       onSelectLine(line, index);
     },
     [onSelectLine],

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -6,7 +6,6 @@ import PredictSportOutcomeCard, {
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
 import { PREDICT_SPORT_OUTCOME_CARD_TEST_IDS } from './PredictSportOutcomeCard.testIds';
-
 jest.mock('react-native-reanimated', () => {
   const { View } = jest.requireActual('react-native');
   return {
@@ -32,10 +31,7 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playSelection: jest.fn(),
-  playImpact: jest.fn(),
-}));
+jest.mock('../../../../../util/haptics');
 
 const createButtons = (
   overrides: Partial<PredictSportOutcomeButton>[] = [],

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -32,9 +32,9 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light' },
+jest.mock('../../../../../util/haptics', () => ({
+  playSelection: jest.fn(),
+  playImpact: jest.fn(),
 }));
 
 const createButtons = (

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -6,7 +6,6 @@ import PredictSportOutcomeCard, {
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
 import { PREDICT_SPORT_OUTCOME_CARD_TEST_IDS } from './PredictSportOutcomeCard.testIds';
-
 jest.mock('react-native-reanimated', () => {
   const { View } = jest.requireActual('react-native');
   return {
@@ -36,10 +35,7 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('../../../../../util/haptics', () => ({
-  playSelection: jest.fn(),
-  playImpact: jest.fn(),
-}));
+jest.mock('../../../../../util/haptics');
 
 const createButtons = (
   overrides: Partial<PredictSportOutcomeButton>[] = [],

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -36,9 +36,9 @@ jest.mock('@react-native-masked-view/masked-view', () =>
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: { Light: 'light' },
+jest.mock('../../../../../util/haptics', () => ({
+  playSelection: jest.fn(),
+  playImpact: jest.fn(),
 }));
 
 const createButtons = (

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.test.tsx
@@ -1,16 +1,30 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import PredictQuickAmounts from './PredictQuickAmounts';
 import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
 
-jest.mock('expo-haptics');
+const mockPlayImpact = jest.fn();
+
+jest.mock('../../../../../../../util/haptics', () => ({
+  ...jest.requireActual<typeof import('../../../../../../../util/haptics')>(
+    '../../../../../../../util/haptics',
+  ),
+  useHaptics: jest.fn(),
+}));
 
 describe('PredictQuickAmounts', () => {
   const mockOnSelectAmount = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useHaptics as jest.Mock).mockReturnValue({
+      playSuccessNotification: jest.fn(),
+      playErrorNotification: jest.fn(),
+      playWarningNotification: jest.fn(),
+      playImpact: mockPlayImpact,
+      playSelection: jest.fn(),
+    });
   });
 
   it('renders all four quick amount buttons', () => {
@@ -80,7 +94,9 @@ describe('PredictQuickAmounts', () => {
     fireEvent.press(screen.getByText('$50'));
 
     await waitFor(() => {
-      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+      expect(mockPlayImpact).toHaveBeenCalledWith(
+        ImpactMoment.QuickAmountSelection,
+      );
     });
   });
 
@@ -89,10 +105,10 @@ describe('PredictQuickAmounts', () => {
       <PredictQuickAmounts onSelectAmount={mockOnSelectAmount} disabled />,
     );
 
-    expect(screen.getByText('$20')).toBeOnTheScreen();
-    expect(screen.getByText('$250')).toBeOnTheScreen();
-
-    fireEvent.press(screen.getByText('$20'));
-    expect(mockOnSelectAmount).not.toHaveBeenCalled();
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+    buttons.forEach((button) => {
+      expect(button).toHaveProp('disabled', true);
+    });
   });
 });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.test.tsx
@@ -108,7 +108,7 @@ describe('PredictQuickAmounts', () => {
     const buttons = screen.getAllByRole('button');
     expect(buttons).toHaveLength(4);
     buttons.forEach((button) => {
-      expect(button).toHaveProp('disabled', true);
+      expect(button).toBeDisabled();
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictQuickAmounts/PredictQuickAmounts.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
 import React from 'react';
 import Button, {
   ButtonSize,
@@ -19,6 +19,7 @@ function PredictQuickAmounts({
   disabled = false,
 }: PredictQuickAmountsProps) {
   const tw = useTailwind();
+  const { playImpact } = useHaptics();
 
   return (
     <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2 py-2">
@@ -29,7 +30,7 @@ function PredictQuickAmounts({
           size={ButtonSize.Md}
           label={`$${amount}`}
           onPress={async () => {
-            await impactAsync(ImpactFeedbackStyle.Light).catch(() => undefined);
+            playImpact(ImpactMoment.QuickAmountSelection);
             onSelectAmount(amount);
           }}
           isDisabled={disabled}

--- a/app/components/UI/Rewards/hooks/useOndoOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useOndoOutcomeToast.test.ts
@@ -2,7 +2,10 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playSuccessNotification,
+  playWarningNotification,
+} from '../../../../util/haptics';
 import { useOndoOutcomeToast } from './useOndoOutcomeToast';
 import { dismissCampaignOutcomeToast } from '../../../../reducers/rewards';
 import {
@@ -39,13 +42,9 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-jest.mock('expo-haptics', () => ({
-  notificationAsync: jest.fn(),
-  NotificationFeedbackType: {
-    Success: 'success',
-    Warning: 'warning',
-    Error: 'error',
-  },
+jest.mock('../../../../util/haptics', () => ({
+  playSuccessNotification: jest.fn(),
+  playWarningNotification: jest.fn(),
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -391,9 +390,7 @@ describe('useOndoOutcomeToast', () => {
         }),
       });
       renderHook(() => useOndoOutcomeToast());
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
-      );
+      expect(playSuccessNotification).toHaveBeenCalled();
     });
 
     it('fires Warning haptic for participant_no_winner', () => {
@@ -405,9 +402,7 @@ describe('useOndoOutcomeToast', () => {
         }),
       });
       renderHook(() => useOndoOutcomeToast());
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Warning,
-      );
+      expect(playWarningNotification).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
@@ -1,7 +1,10 @@
 import { useCallback, useContext, useMemo } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playSuccessNotification,
+  playWarningNotification,
+} from '../../../../util/haptics';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
 import { ToastContext } from '../../../../component-library/components/Toast';
@@ -132,11 +135,11 @@ export function useOndoOutcomeToast(): void {
           onPress: handleDismiss,
         },
       });
-      notificationAsync(
-        isWinner
-          ? NotificationFeedbackType.Success
-          : NotificationFeedbackType.Warning,
-      );
+      if (isWinner) {
+        playSuccessNotification();
+      } else {
+        playWarningNotification();
+      }
 
       return () => {
         toastRef?.current?.closeToast();

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -79,7 +79,12 @@ describe('useRewardsToast', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(testConfig);
+      expect(mockShowToast).toHaveBeenCalledWith({
+        variant: ToastVariants.Icon,
+        iconName: IconName.Confirmation,
+        labelOptions: [{ label: 'Test', isBold: true }],
+        hasNoTimeout: false,
+      });
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
   });

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useContext } from 'react';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import { mockTheme } from '../../../../util/theme';
 import useRewardsToast, { RewardsToastOptions } from './useRewardsToast';
 import {
@@ -16,9 +16,9 @@ jest.mock('react', () => ({
   useMemo: jest.fn((fn) => fn()),
 }));
 
-jest.mock('expo-haptics', () => ({
-  notificationAsync: jest.fn(),
-  NotificationFeedbackType: {
+jest.mock('../../../../util/haptics', () => ({
+  playNotification: jest.fn(),
+  NotificationMoment: {
     Success: 'success',
     Warning: 'warning',
     Error: 'error',
@@ -69,7 +69,7 @@ describe('useRewardsToast', () => {
       const testConfig: RewardsToastOptions = {
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Test', isBold: true }],
         hasNoTimeout: false,
       };
@@ -80,9 +80,7 @@ describe('useRewardsToast', () => {
       });
 
       expect(mockShowToast).toHaveBeenCalledWith(testConfig);
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
-      );
+      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
   });
 
@@ -96,7 +94,7 @@ describe('useRewardsToast', () => {
         iconName: IconName.Confirmation,
         iconColor: mockTheme.colors.success.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         hasNoTimeout: false,
       });
       expect(config.labelOptions).toEqual([
@@ -120,7 +118,7 @@ describe('useRewardsToast', () => {
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
         iconColor: mockTheme.colors.success.default,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
       });
       expect(config.labelOptions).toEqual([
         { label: 'Test Title', isBold: true },
@@ -139,7 +137,7 @@ describe('useRewardsToast', () => {
         iconName: IconName.Danger,
         iconColor: mockTheme.colors.error.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         hasNoTimeout: false,
       });
       expect(config.labelOptions).toEqual([
@@ -163,7 +161,7 @@ describe('useRewardsToast', () => {
         variant: ToastVariants.Icon,
         iconName: IconName.Danger,
         iconColor: mockTheme.colors.error.default,
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
       });
       expect(config.labelOptions).toEqual([
         { label: 'Error Title', isBold: true },
@@ -183,7 +181,7 @@ describe('useRewardsToast', () => {
         iconName: IconName.Lock,
         iconColor: mockTheme.colors.icon.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
         hasNoTimeout: false,
       });
       expect(config.labelOptions).toEqual([
@@ -207,7 +205,7 @@ describe('useRewardsToast', () => {
         variant: ToastVariants.Icon,
         iconName: IconName.Lock,
         iconColor: mockTheme.colors.icon.default,
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
       });
       expect(config.labelOptions).toEqual([
         { label: 'Entries closed', isBold: true },
@@ -236,7 +234,7 @@ describe('useRewardsToast', () => {
       const testConfig: RewardsToastOptions = {
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Test', isBold: true }],
         hasNoTimeout: false,
       };
@@ -251,9 +249,7 @@ describe('useRewardsToast', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
-      );
+      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
 
     it('handles undefined toastRef.current gracefully in showToast', async () => {
@@ -265,7 +261,7 @@ describe('useRewardsToast', () => {
       const testConfig: RewardsToastOptions = {
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: [{ label: 'Test', isBold: true }],
         hasNoTimeout: false,
       };
@@ -280,9 +276,7 @@ describe('useRewardsToast', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(notificationAsync).toHaveBeenCalledWith(
-        NotificationFeedbackType.Success,
-      );
+      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
 
     it('handles null toastRef gracefully in close button', () => {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -8,7 +8,6 @@ import {
   ButtonIconVariant,
 } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
-
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),
@@ -16,14 +15,7 @@ jest.mock('react', () => ({
   useMemo: jest.fn((fn) => fn()),
 }));
 
-jest.mock('../../../../util/haptics', () => ({
-  playNotification: jest.fn(),
-  NotificationMoment: {
-    Success: 'success',
-    Warning: 'warning',
-    Error: 'error',
-  },
-}));
+jest.mock('../../../../util/haptics');
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -58,8 +58,9 @@ const useRewardsToast = (): {
 
   const showToast = useCallback(
     (config: RewardsToastOptions) => {
-      toastRef?.current?.showToast(config);
-      playNotification(config.hapticsType);
+      const { hapticsType, ...toastOptions } = config;
+      toastRef?.current?.showToast(toastOptions as ToastOptions);
+      playNotification(hapticsType);
     },
     [toastRef],
   );

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -9,10 +9,14 @@ import {
 } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { useAppThemeFromContext } from '../../../../util/theme';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playNotification,
+  NotificationMoment,
+  type HapticNotificationMoment,
+} from '../../../../util/haptics';
 
 export type RewardsToastOptions = ToastOptions & {
-  hapticsType: NotificationFeedbackType;
+  hapticsType: HapticNotificationMoment;
 };
 
 export interface RewardsToastConfig {
@@ -55,7 +59,7 @@ const useRewardsToast = (): {
   const showToast = useCallback(
     (config: RewardsToastOptions) => {
       toastRef?.current?.showToast(config);
-      notificationAsync(config.hapticsType);
+      playNotification(config.hapticsType);
     },
     [toastRef],
   );
@@ -68,7 +72,7 @@ const useRewardsToast = (): {
         iconName: IconName.Confirmation,
         iconColor: theme.colors.success.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Success,
+        hapticsType: NotificationMoment.Success,
         labelOptions: getRewardsToastLabels(title),
         descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
         hasNoTimeout: false,
@@ -86,7 +90,7 @@ const useRewardsToast = (): {
         iconName: IconName.Danger,
         iconColor: theme.colors.error.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Error,
+        hapticsType: NotificationMoment.Error,
         labelOptions: getRewardsToastLabels(title),
         descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
         hasNoTimeout: false,
@@ -105,7 +109,7 @@ const useRewardsToast = (): {
         iconName: IconName.Lock,
         iconColor: theme.colors.icon.default,
         backgroundColor: 'transparent',
-        hapticsType: NotificationFeedbackType.Warning,
+        hapticsType: NotificationMoment.Warning,
         labelOptions: getRewardsToastLabels(title),
         descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
         hasNoTimeout: false,

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -142,13 +142,13 @@ jest.mock('react-native-reanimated', () => ({
   },
 }));
 
-// Mock expo-haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn().mockResolvedValue(undefined),
-  ImpactFeedbackStyle: {
-    Light: 'light',
-    Medium: 'medium',
-    Heavy: 'heavy',
+jest.mock('../../../util/haptics', () => ({
+  playImpact: jest.fn().mockResolvedValue(undefined),
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    TabChange: 'tabChange',
+    PullToRefresh: 'pullToRefresh',
+    ChartCrosshair: 'chartCrosshair',
   },
 }));
 
@@ -781,15 +781,15 @@ describe('GestureWebViewWrapper', () => {
     });
 
     describe('callback invocation via runOnJS', () => {
-      it('triggerHapticFeedback invokes impactAsync', () => {
-        const { impactAsync } = jest.requireMock('expo-haptics');
+      it('triggerHapticFeedback invokes playImpact', () => {
+        const { playImpact } = jest.requireMock('../../../util/haptics');
         renderComponent({ backEnabled: true });
         const stateManager = createStateManager();
         const event = createTouchEvent(10, 200);
 
         capturedCallbacks.onTouchesDown?.(event, stateManager);
 
-        expect(impactAsync).toHaveBeenCalled();
+        expect(playImpact).toHaveBeenCalled();
       });
     });
 

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -24,7 +24,6 @@ import {
   GestureWebViewWrapper,
   type GestureWebViewWrapperProps,
 } from './GestureWebViewWrapper';
-
 // Captured gesture handler callbacks for testing
 type GestureCallback = (...args: unknown[]) => void;
 const capturedCallbacks: {
@@ -142,17 +141,7 @@ jest.mock('react-native-reanimated', () => ({
   },
 }));
 
-jest.mock('../../../util/haptics', () => ({
-  playImpact: jest.fn().mockResolvedValue(undefined),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    EdgeGestureEngage: 'edgeGestureEngage',
-    TabChange: 'tabChange',
-    PullToRefreshEngage: 'pullToRefreshEngage',
-    PullToRefresh: 'pullToRefresh',
-    ChartCrosshair: 'chartCrosshair',
-  },
-}));
+jest.mock('../../../util/haptics');
 
 // Mock useTheme
 jest.mock('../../../util/theme', () => {

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -146,6 +146,7 @@ jest.mock('../../../util/haptics', () => ({
   playImpact: jest.fn().mockResolvedValue(undefined),
   ImpactMoment: {
     SliderTick: 'sliderTick',
+    EdgeGestureEngage: 'edgeGestureEngage',
     TabChange: 'tabChange',
     PullToRefreshEngage: 'pullToRefreshEngage',
     PullToRefresh: 'pullToRefresh',
@@ -782,15 +783,17 @@ describe('GestureWebViewWrapper', () => {
     });
 
     describe('callback invocation via runOnJS', () => {
-      it('triggerHapticFeedback invokes playImpact', () => {
-        const { playImpact } = jest.requireMock('../../../util/haptics');
+      it('triggerHapticFeedback invokes playImpact with EdgeGestureEngage on left edge', () => {
+        const { playImpact, ImpactMoment } = jest.requireMock(
+          '../../../util/haptics',
+        );
         renderComponent({ backEnabled: true });
         const stateManager = createStateManager();
         const event = createTouchEvent(10, 200);
 
         capturedCallbacks.onTouchesDown?.(event, stateManager);
 
-        expect(playImpact).toHaveBeenCalled();
+        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.EdgeGestureEngage);
       });
     });
 

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -147,6 +147,7 @@ jest.mock('../../../util/haptics', () => ({
   ImpactMoment: {
     SliderTick: 'sliderTick',
     TabChange: 'tabChange',
+    PullToRefreshEngage: 'pullToRefreshEngage',
     PullToRefresh: 'pullToRefresh',
     ChartCrosshair: 'chartCrosshair',
   },

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -118,13 +118,13 @@ const mockSharedValue = <T,>(initialValue: T) => ({
   modify: jest.fn(),
 });
 
-// Mock expo-haptics
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn().mockResolvedValue(undefined),
-  ImpactFeedbackStyle: {
-    Light: 'light',
-    Medium: 'medium',
-    Heavy: 'heavy',
+jest.mock('../../../util/haptics', () => ({
+  playImpact: jest.fn().mockResolvedValue(undefined),
+  ImpactMoment: {
+    SliderTick: 'sliderTick',
+    TabChange: 'tabChange',
+    PullToRefresh: 'pullToRefresh',
+    ChartCrosshair: 'chartCrosshair',
   },
 }));
 
@@ -757,9 +757,9 @@ describe('GestureWebViewWrapper', () => {
     });
 
     describe('callback invocation via runOnJS', () => {
-      it('triggerHapticFeedback invokes impactAsync', async () => {
-        const { impactAsync, ImpactFeedbackStyle } =
-          jest.requireMock('expo-haptics');
+      it('triggerHapticFeedback invokes playImpact', async () => {
+        const { playImpact, ImpactMoment } =
+          jest.requireMock('../../../util/haptics');
         renderComponent({ backEnabled: true });
         const stateManager = createStateManager();
         const event = createTouchEvent(10, 200);
@@ -769,7 +769,7 @@ describe('GestureWebViewWrapper', () => {
         // react-native-worklets' Jest mock schedules runOnJS callbacks via queueMicrotask
         await Promise.resolve();
 
-        expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.SliderTick);
       });
     });
 

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -123,6 +123,7 @@ jest.mock('../../../util/haptics', () => ({
   ImpactMoment: {
     SliderTick: 'sliderTick',
     TabChange: 'tabChange',
+    PullToRefreshEngage: 'pullToRefreshEngage',
     PullToRefresh: 'pullToRefresh',
     ChartCrosshair: 'chartCrosshair',
   },

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -24,7 +24,6 @@ import {
   GestureWebViewWrapper,
   type GestureWebViewWrapperProps,
 } from './GestureWebViewWrapper';
-
 // Captured gesture handler callbacks for testing
 type GestureCallback = (...args: unknown[]) => void;
 const capturedCallbacks: {
@@ -118,17 +117,7 @@ const mockSharedValue = <T,>(initialValue: T) => ({
   modify: jest.fn(),
 });
 
-jest.mock('../../../util/haptics', () => ({
-  playImpact: jest.fn().mockResolvedValue(undefined),
-  ImpactMoment: {
-    SliderTick: 'sliderTick',
-    EdgeGestureEngage: 'edgeGestureEngage',
-    TabChange: 'tabChange',
-    PullToRefreshEngage: 'pullToRefreshEngage',
-    PullToRefresh: 'pullToRefresh',
-    ChartCrosshair: 'chartCrosshair',
-  },
-}));
+jest.mock('../../../util/haptics');
 
 // Mock useTheme
 jest.mock('../../../util/theme', () => {

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.test.tsx
@@ -122,6 +122,7 @@ jest.mock('../../../util/haptics', () => ({
   playImpact: jest.fn().mockResolvedValue(undefined),
   ImpactMoment: {
     SliderTick: 'sliderTick',
+    EdgeGestureEngage: 'edgeGestureEngage',
     TabChange: 'tabChange',
     PullToRefreshEngage: 'pullToRefreshEngage',
     PullToRefresh: 'pullToRefresh',
@@ -758,9 +759,10 @@ describe('GestureWebViewWrapper', () => {
     });
 
     describe('callback invocation via runOnJS', () => {
-      it('triggerHapticFeedback invokes playImpact', async () => {
-        const { playImpact, ImpactMoment } =
-          jest.requireMock('../../../util/haptics');
+      it('triggerHapticFeedback invokes playImpact with EdgeGestureEngage on left edge', async () => {
+        const { playImpact, ImpactMoment } = jest.requireMock(
+          '../../../util/haptics',
+        );
         renderComponent({ backEnabled: true });
         const stateManager = createStateManager();
         const event = createTouchEvent(10, 200);
@@ -770,7 +772,7 @@ describe('GestureWebViewWrapper', () => {
         // react-native-worklets' Jest mock schedules runOnJS callbacks via queueMicrotask
         await Promise.resolve();
 
-        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.SliderTick);
+        expect(playImpact).toHaveBeenCalledWith(ImpactMoment.EdgeGestureEngage);
       });
     });
 

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
@@ -325,7 +325,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
 
             if (!pullHapticTriggered.value && event.translationY > 10) {
               pullHapticTriggered.value = true;
-              runOnJS(triggerHapticFeedback)(ImpactMoment.PullToRefresh);
+              runOnJS(triggerHapticFeedback)(ImpactMoment.PullToRefreshEngage);
             }
 
             pullProgress.value = Math.min(

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
@@ -241,14 +241,14 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             swipeProgress.value = 0;
             swipeStartTime.current = Date.now();
             stateManager.activate();
-            runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+            runOnJS(triggerHapticFeedback)(ImpactMoment.EdgeGestureEngage);
           } else if (isRightEdge) {
             gestureType.value = 'forward';
             swipeDirection.value = 'forward';
             swipeProgress.value = 0;
             swipeStartTime.current = Date.now();
             stateManager.activate();
-            runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
+            runOnJS(triggerHapticFeedback)(ImpactMoment.EdgeGestureEngage);
           } else if (canPullToRefresh) {
             gestureType.value = 'pending_refresh';
             initialTouchY.value = y;

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
@@ -8,7 +8,11 @@ import Animated, {
   useAnimatedStyle,
   type SharedValue,
 } from 'react-native-reanimated';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import {
+  playImpact,
+  ImpactMoment,
+  type HapticImpactMoment,
+} from '../../../util/haptics';
 import { useTheme } from '../../../util/theme';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -124,11 +128,8 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
     [isTabActive, isUrlBarFocused, firstUrlLoaded],
   );
 
-  /**
-   * Trigger haptic feedback
-   */
-  const triggerHapticFeedback = useCallback((style: ImpactFeedbackStyle) => {
-    impactAsync(style);
+  const triggerHapticFeedback = useCallback((moment: HapticImpactMoment) => {
+    playImpact(moment);
   }, []);
 
   // Note: resetSwipeAnimation and resetPullAnimation are inlined directly in worklets
@@ -149,7 +150,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             })
             .build(),
         );
-        triggerHapticFeedback(ImpactFeedbackStyle.Medium);
+        triggerHapticFeedback(ImpactMoment.TabChange);
       } else if (direction === 'forward' && forwardEnabled) {
         onGoForward();
         trackEvent(
@@ -160,7 +161,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             })
             .build(),
         );
-        triggerHapticFeedback(ImpactFeedbackStyle.Medium);
+        triggerHapticFeedback(ImpactMoment.TabChange);
       }
     },
     [
@@ -182,7 +183,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
 
     isRefreshing.value = true;
     onReload();
-    impactAsync(ImpactFeedbackStyle.Medium);
+    playImpact(ImpactMoment.PullToRefresh);
 
     trackEvent(
       createEventBuilder(MetaMetricsEvents.BROWSER_PULL_REFRESH)
@@ -240,14 +241,14 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             swipeProgress.value = 0;
             swipeStartTime.current = Date.now();
             stateManager.activate();
-            runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+            runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
           } else if (isRightEdge) {
             gestureType.value = 'forward';
             swipeDirection.value = 'forward';
             swipeProgress.value = 0;
             swipeStartTime.current = Date.now();
             stateManager.activate();
-            runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+            runOnJS(triggerHapticFeedback)(ImpactMoment.SliderTick);
           } else if (canPullToRefresh) {
             gestureType.value = 'pending_refresh';
             initialTouchY.value = y;
@@ -324,7 +325,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
 
             if (!pullHapticTriggered.value && event.translationY > 10) {
               pullHapticTriggered.value = true;
-              runOnJS(triggerHapticFeedback)(ImpactFeedbackStyle.Light);
+              runOnJS(triggerHapticFeedback)(ImpactMoment.PullToRefresh);
             }
 
             pullProgress.value = Math.min(

--- a/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
+++ b/app/components/Views/BrowserTab/GestureWebViewWrapper.tsx
@@ -150,7 +150,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             })
             .build(),
         );
-        triggerHapticFeedback(ImpactMoment.TabChange);
+        triggerHapticFeedback(ImpactMoment.PageNavigation);
       } else if (direction === 'forward' && forwardEnabled) {
         onGoForward();
         trackEvent(
@@ -161,7 +161,7 @@ export const GestureWebViewWrapper: React.FC<GestureWebViewWrapperProps> = ({
             })
             .build(),
         );
-        triggerHapticFeedback(ImpactMoment.TabChange);
+        triggerHapticFeedback(ImpactMoment.PageNavigation);
       }
     },
     [

--- a/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
@@ -43,6 +43,7 @@ const CATALOG_IMPACT_MOMENTS_ORDERED: readonly HapticImpactMoment[] = [
   ImpactMoment.PageNavigation,
   ImpactMoment.SliderGrip,
   ImpactMoment.TabChange,
+  ImpactMoment.PrimaryCTA,
   ImpactMoment.PullToRefreshEngage,
   ImpactMoment.PullToRefresh,
   ImpactMoment.ChartCrosshair,
@@ -62,6 +63,8 @@ const IMPACT_MOMENT_LABEL_KEYS: Record<HapticImpactMoment, string> = {
     'app_settings.developer_options.haptics.impacts.slider_grip',
   [ImpactMoment.TabChange]:
     'app_settings.developer_options.haptics.impacts.tab_change',
+  [ImpactMoment.PrimaryCTA]:
+    'app_settings.developer_options.haptics.impacts.primary_cta',
   [ImpactMoment.PullToRefreshEngage]:
     'app_settings.developer_options.haptics.impacts.pull_to_refresh_engage',
   [ImpactMoment.PullToRefresh]:

--- a/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
@@ -1,0 +1,248 @@
+import React, { useCallback } from 'react';
+import { ImpactFeedbackStyle } from '../../../../util/haptics';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import { useTheme } from '../../../../util/theme';
+import { useStyles } from '../../../../component-library/hooks';
+import styleSheet from './DeveloperOptions.styles';
+import {
+  ImpactMoment,
+  type HapticImpactMoment,
+} from '../../../../util/haptics/catalog';
+import {
+  vendorImpact,
+  vendorImpactRaw,
+  vendorNotifyError,
+  vendorNotifySuccess,
+  vendorNotifyWarning,
+  vendorSelection,
+} from '../../../../util/haptics/vendorPlayback';
+
+async function runUngated(play: () => Promise<void>): Promise<void> {
+  try {
+    await play();
+  } catch {
+    // Mirror gatedExecution: device may not support haptics (e.g. simulator).
+  }
+}
+
+/**
+ * Ordered list of semantic impact moments from the product catalog (`catalog.ts`).
+ */
+const CATALOG_IMPACT_MOMENTS_ORDERED: readonly HapticImpactMoment[] = [
+  ImpactMoment.QuickAmountSelection,
+  ImpactMoment.SliderTick,
+  ImpactMoment.EdgeGestureEngage,
+  ImpactMoment.PageNavigation,
+  ImpactMoment.SliderGrip,
+  ImpactMoment.TabChange,
+  ImpactMoment.PullToRefreshEngage,
+  ImpactMoment.PullToRefresh,
+  ImpactMoment.ChartCrosshair,
+];
+
+const IMPACT_MOMENT_LABEL_KEYS: Record<HapticImpactMoment, string> = {
+  [ImpactMoment.QuickAmountSelection]:
+    'app_settings.developer_options.haptics.impacts.quick_amount_selection',
+  [ImpactMoment.SliderTick]:
+    'app_settings.developer_options.haptics.impacts.slider_tick',
+  [ImpactMoment.EdgeGestureEngage]:
+    'app_settings.developer_options.haptics.impacts.edge_gesture_engage',
+  [ImpactMoment.PageNavigation]:
+    'app_settings.developer_options.haptics.impacts.page_navigation',
+  [ImpactMoment.SliderGrip]:
+    'app_settings.developer_options.haptics.impacts.slider_grip',
+  [ImpactMoment.TabChange]:
+    'app_settings.developer_options.haptics.impacts.tab_change',
+  [ImpactMoment.PullToRefreshEngage]:
+    'app_settings.developer_options.haptics.impacts.pull_to_refresh_engage',
+  [ImpactMoment.PullToRefresh]:
+    'app_settings.developer_options.haptics.impacts.pull_to_refresh',
+  [ImpactMoment.ChartCrosshair]:
+    'app_settings.developer_options.haptics.impacts.chart_crosshair',
+};
+
+const RAW_IMPACT_STYLE_ORDER: readonly ImpactFeedbackStyle[] = [
+  ImpactFeedbackStyle.Light,
+  ImpactFeedbackStyle.Medium,
+  ImpactFeedbackStyle.Heavy,
+  ImpactFeedbackStyle.Rigid,
+  ImpactFeedbackStyle.Soft,
+];
+
+const RAW_IMPACT_LABEL_KEYS: Record<ImpactFeedbackStyle, string> = {
+  [ImpactFeedbackStyle.Light]:
+    'app_settings.developer_options.haptics.raw_styles.light',
+  [ImpactFeedbackStyle.Medium]:
+    'app_settings.developer_options.haptics.raw_styles.medium',
+  [ImpactFeedbackStyle.Heavy]:
+    'app_settings.developer_options.haptics.raw_styles.heavy',
+  [ImpactFeedbackStyle.Rigid]:
+    'app_settings.developer_options.haptics.raw_styles.rigid',
+  [ImpactFeedbackStyle.Soft]:
+    'app_settings.developer_options.haptics.raw_styles.soft',
+};
+
+export default function HapticsDeveloperOptionsSection() {
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+
+  const playCatalogImpact = useCallback((moment: HapticImpactMoment) => {
+    runUngated(() => vendorImpact(moment));
+  }, []);
+
+  const playRawImpact = useCallback((style: ImpactFeedbackStyle) => {
+    runUngated(() => vendorImpactRaw(style));
+  }, []);
+
+  const playSuccess = useCallback(() => {
+    runUngated(() => vendorNotifySuccess());
+  }, []);
+
+  const playError = useCallback(() => {
+    runUngated(() => vendorNotifyError());
+  }, []);
+
+  const playWarning = useCallback(() => {
+    runUngated(() => vendorNotifyWarning());
+  }, []);
+
+  const playSelectionHaptic = useCallback(() => {
+    runUngated(() => vendorSelection());
+  }, []);
+
+  return (
+    <>
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingLg}
+        style={styles.heading}
+      >
+        {strings('app_settings.developer_options.haptics.title')}
+      </Text>
+      <Text
+        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        style={styles.desc}
+      >
+        {strings('app_settings.developer_options.haptics.description')}
+      </Text>
+
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingMd}
+        style={styles.heading}
+      >
+        {strings(
+          'app_settings.developer_options.haptics.catalog_impacts_heading',
+        )}
+      </Text>
+      {CATALOG_IMPACT_MOMENTS_ORDERED.map((moment) => (
+        <Button
+          key={moment}
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onPress={() => playCatalogImpact(moment)}
+          isFullWidth
+          style={styles.accessory}
+        >
+          {strings(IMPACT_MOMENT_LABEL_KEYS[moment])}
+        </Button>
+      ))}
+
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingMd}
+        style={styles.heading}
+      >
+        {strings(
+          'app_settings.developer_options.haptics.notifications_heading',
+        )}
+      </Text>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={playSuccess}
+        isFullWidth
+        style={styles.accessory}
+      >
+        {strings(
+          'app_settings.developer_options.haptics.notification_success_button',
+        )}
+      </Button>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={playError}
+        isFullWidth
+        style={styles.accessory}
+      >
+        {strings(
+          'app_settings.developer_options.haptics.notification_error_button',
+        )}
+      </Button>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={playWarning}
+        isFullWidth
+        style={styles.accessory}
+      >
+        {strings(
+          'app_settings.developer_options.haptics.notification_warning_button',
+        )}
+      </Button>
+
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingMd}
+        style={styles.heading}
+      >
+        {strings('app_settings.developer_options.haptics.selection_heading')}
+      </Text>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={playSelectionHaptic}
+        isFullWidth
+        style={styles.accessory}
+      >
+        {strings('app_settings.developer_options.haptics.selection_button')}
+      </Button>
+
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingMd}
+        style={styles.heading}
+      >
+        {strings('app_settings.developer_options.haptics.raw_impacts_heading')}
+      </Text>
+      <Text
+        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        style={styles.desc}
+      >
+        {strings('app_settings.developer_options.haptics.raw_impacts_desc')}
+      </Text>
+      {RAW_IMPACT_STYLE_ORDER.map((style) => (
+        <Button
+          key={style}
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onPress={() => playRawImpact(style)}
+          isFullWidth
+          style={styles.accessory}
+        >
+          {strings(RAW_IMPACT_LABEL_KEYS[style])}
+        </Button>
+      ))}
+    </>
+  );
+}

--- a/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/HapticsDeveloperOptionsSection.tsx
@@ -46,6 +46,7 @@ const CATALOG_IMPACT_MOMENTS_ORDERED: readonly HapticImpactMoment[] = [
   ImpactMoment.PullToRefreshEngage,
   ImpactMoment.PullToRefresh,
   ImpactMoment.ChartCrosshair,
+  ImpactMoment.FollowToggle,
 ];
 
 const IMPACT_MOMENT_LABEL_KEYS: Record<HapticImpactMoment, string> = {
@@ -67,6 +68,8 @@ const IMPACT_MOMENT_LABEL_KEYS: Record<HapticImpactMoment, string> = {
     'app_settings.developer_options.haptics.impacts.pull_to_refresh',
   [ImpactMoment.ChartCrosshair]:
     'app_settings.developer_options.haptics.impacts.chart_crosshair',
+  [ImpactMoment.FollowToggle]:
+    'app_settings.developer_options.haptics.impacts.follow_toggle',
 };
 
 const RAW_IMPACT_STYLE_ORDER: readonly ImpactFeedbackStyle[] = [

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -9,6 +9,7 @@ import { useParams } from '../../../../util/navigation/navUtils';
 import { useStyles } from '../../../../component-library/hooks';
 import styleSheet from './DeveloperOptions.styles';
 import SentryTest from './SentryTest';
+import HapticsDeveloperOptionsSection from './HapticsDeveloperOptionsSection';
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 import SampleFeatureDevSettingsEntryPoint from '../../../../features/SampleFeature/components/views/SampleFeatureDevSettingsEntryPoint/SampleFeatureDevSettingsEntryPoint';
 ///: END:ONLY_INCLUDE_IF
@@ -63,6 +64,7 @@ const DeveloperOptions = () => {
       <ConfirmationsDeveloperOptions />
       {isMusdConversionEnabled && <MusdDeveloperOptionsSection />}
       <CardDeveloperOptionsSection />
+      <HapticsDeveloperOptionsSection />
     </ScrollView>
   );
 };

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -24,6 +24,7 @@ import {
   setPrimaryCurrency,
   setAvatarAccountType,
   setHideZeroBalanceTokens,
+  setHapticsEnabled,
 } from '../../../../actions/settings';
 import PickComponent from '../../PickComponent';
 import AvatarAccount, {
@@ -213,6 +214,14 @@ class Settings extends PureComponent {
      * Whether push notifications are currently enabled
      */
     isPushNotificationsEnabled: PropTypes.bool,
+    /**
+     * Whether haptics are currently enabled
+     */
+    hapticsEnabled: PropTypes.bool,
+    /**
+     * Called to toggle haptics
+     */
+    setHapticsEnabled: PropTypes.func,
   };
 
   state = {
@@ -252,6 +261,10 @@ class Settings extends PureComponent {
 
   toggleHideZeroBalanceTokens = (toggleHideZeroBalanceTokens) => {
     this.props.setHideZeroBalanceTokens(toggleHideZeroBalanceTokens);
+  };
+
+  toggleHapticsEnabled = (hapticsEnabled) => {
+    this.props.setHapticsEnabled(hapticsEnabled);
   };
 
   componentDidMount = () => {
@@ -317,6 +330,7 @@ class Settings extends PureComponent {
       setAvatarAccountType,
       selectedAddress,
       hideZeroBalanceTokens,
+      hapticsEnabled,
       navigation,
     } = this.props;
     const themeTokens = this.context || mockTheme;
@@ -458,6 +472,33 @@ class Settings extends PureComponent {
               </Text>
             </View>
             <View style={styles.setting}>
+              <View style={styles.titleContainer}>
+                <Text variant={TextVariant.BodyLGMedium} style={styles.title}>
+                  {strings('app_settings.haptic_feedback_title')}
+                </Text>
+                <View style={styles.toggle}>
+                  <Switch
+                    value={hapticsEnabled}
+                    onValueChange={this.toggleHapticsEnabled}
+                    trackColor={{
+                      true: colors.primary.default,
+                      false: colors.border.muted,
+                    }}
+                    thumbColor={themeTokens.brandColors.white}
+                    style={styles.switch}
+                    ios_backgroundColor={colors.border.muted}
+                  />
+                </View>
+              </View>
+              <Text
+                variant={TextVariant.BodyMD}
+                color={TextColor.Alternative}
+                style={styles.desc}
+              >
+                {strings('app_settings.haptic_feedback_desc')}
+              </Text>
+            </View>
+            <View style={styles.setting}>
               <Text variant={TextVariant.BodyLGMedium}>
                 {strings('app_settings.accounts_identicon_title')}
               </Text>
@@ -560,6 +601,7 @@ const mapStateToProps = (state) => ({
   avatarAccountType: state.settings.avatarAccountType,
   selectedAddress: selectSelectedInternalAccountFormattedAddress(state),
   hideZeroBalanceTokens: state.settings.hideZeroBalanceTokens,
+  hapticsEnabled: state.settings.hapticsEnabled !== false,
   isPushNotificationsEnabled: selectIsMetaMaskPushNotificationsEnabled(state),
   // appTheme: state.user.appTheme,
 });
@@ -572,6 +614,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setAvatarAccountType(avatarAccountType)),
   setHideZeroBalanceTokens: (hideZeroBalanceTokens) =>
     dispatch(setHideZeroBalanceTokens(hideZeroBalanceTokens)),
+  setHapticsEnabled: (hapticsEnabled) =>
+    dispatch(setHapticsEnabled(hapticsEnabled)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Settings);

--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Platform } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import {
+  ImpactFeedbackStyle,
+  ImpactMoment,
+  playImpact,
+} from '../../../../util/haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { mockTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
@@ -68,6 +72,16 @@ jest.mock('expo-haptics', () => ({
   },
 }));
 
+jest.mock('../../../../util/haptics', () => {
+  const actual = jest.requireActual<typeof import('../../../../util/haptics')>(
+    '../../../../util/haptics',
+  );
+  return {
+    ...actual,
+    playImpact: jest.fn(),
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Shared mock primitives
 // ---------------------------------------------------------------------------
@@ -82,7 +96,10 @@ const mockUseNotificationPreferences =
 const mockSelectCurrentCurrency = selectCurrentCurrency as jest.MockedFunction<
   typeof selectCurrentCurrency
 >;
-const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
+const { impactAsync: mockImpactAsync } = jest.requireMock('expo-haptics') as {
+  impactAsync: jest.Mock;
+};
+const mockPlayImpact = jest.mocked(playImpact);
 
 const makeTrader = (
   id: string,
@@ -599,9 +616,10 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
-    it('fires a light impact when changing the threshold to a new value', () => {
+    it('fires catalog impact when changing the threshold to a new value', () => {
       Platform.OS = 'ios';
       renderScreen();
 
@@ -611,8 +629,10 @@ describe('NotificationPreferencesView', () => {
         ),
       );
 
-      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
-      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
+      expect(mockPlayImpact).toHaveBeenCalledWith(
+        ImpactMoment.QuickAmountSelection,
+      );
     });
 
     it('does not fire a haptic when re-tapping the already-selected threshold', () => {
@@ -632,7 +652,7 @@ describe('NotificationPreferencesView', () => {
         ),
       );
 
-      expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
       expect(setTxAmountLimit).not.toHaveBeenCalled();
     });
 
@@ -644,6 +664,7 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
     it('does not fire a haptic when pressing a trader row to navigate to the profile', () => {
@@ -656,6 +677,7 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
     it('does not fire a haptic when toggling a per-trader switch while the master toggle is off', () => {
@@ -678,6 +700,7 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
       expect(toggleTraderNotification).not.toHaveBeenCalled();
     });
 
@@ -699,6 +722,7 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
       expect(setTxAmountLimit).not.toHaveBeenCalled();
     });
 
@@ -723,6 +747,7 @@ describe('NotificationPreferencesView', () => {
         ),
       ).toBeNull();
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
       expect(setEnabled).not.toHaveBeenCalled();
     });
   });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
@@ -10,7 +10,6 @@ import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -30,7 +29,12 @@ import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
-import { fireSwitchHaptic } from '../../../../util/haptics';
+import {
+  fireSwitchHaptic,
+  ImpactFeedbackStyle,
+  playImpact,
+  ImpactMoment,
+} from '../../../../util/haptics';
 import { NotificationPreferencesViewSelectorsIDs } from './NotificationPreferencesView.testIds';
 import {
   useNotificationPreferences,
@@ -238,7 +242,7 @@ const NotificationPreferencesView = () => {
       if (globalOff || value === preferences.txAmountLimit) {
         return Promise.resolve();
       }
-      impactAsync(ImpactFeedbackStyle.Light);
+      playImpact(ImpactMoment.QuickAmountSelection);
       return setTxAmountLimit(value);
     },
     [globalOff, preferences.txAmountLimit, setTxAmountLimit],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -317,7 +317,7 @@ describe('TraderPositionView', () => {
     );
 
     expect(mockPlayImpact).toHaveBeenCalledTimes(1);
-    expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+    expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('does not fire a haptic when the buy button is pressed without a resolved position', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import TraderPositionView from './TraderPositionView';
 import { TraderPositionViewSelectorsIDs } from './TraderPositionView.testIds';
@@ -82,16 +82,17 @@ jest.mock('@metamask/controller-utils', () => ({
   handleFetch: jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock('expo-haptics', () => ({
-  impactAsync: jest.fn(),
-  ImpactFeedbackStyle: {
-    Light: 'light',
-    Medium: 'medium',
-    Heavy: 'heavy',
-  },
-}));
+jest.mock('../../../../util/haptics', () => {
+  const actual = jest.requireActual<typeof import('../../../../util/haptics')>(
+    '../../../../util/haptics',
+  );
+  return {
+    ...actual,
+    playImpact: jest.fn(),
+  };
+});
 
-const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
+const mockPlayImpact = jest.mocked(playImpact);
 
 // New hooks added for deep-link self-sufficiency. Existing tests pass `position`
 // via route params, so these are effectively no-ops in the existing flow.
@@ -315,8 +316,8 @@ describe('TraderPositionView', () => {
       screen.getByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
     );
 
-    expect(mockImpactAsync).toHaveBeenCalledTimes(1);
-    expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    expect(mockPlayImpact).toHaveBeenCalledTimes(1);
+    expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
   });
 
   it('does not fire a haptic when the buy button is pressed without a resolved position', () => {
@@ -332,7 +333,7 @@ describe('TraderPositionView', () => {
       fireEvent.press(buyButton);
     }
 
-    expect(mockImpactAsync).not.toHaveBeenCalled();
+    expect(mockPlayImpact).not.toHaveBeenCalled();
   });
 
   it('builds the token image URL when the position chain is supported', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -9,7 +9,7 @@ import {
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import {
   Box,
   Button,
@@ -87,11 +87,11 @@ const TraderPositionView = () => {
     if (!resolvedPosition) {
       return;
     }
-    // Primary CTA opening the buy flow — Medium impact mirrors the weight
-    // used for other elevated commit-style actions (Save, master toggle).
-    // The terminal Success/Error notification haptic is fired later in
-    // useQuickBuyBottomSheet once the transaction resolves.
-    impactAsync(ImpactFeedbackStyle.Medium);
+    // Primary CTA opening the buy flow — TabChange catalog moment (Medium)
+    // mirrors other elevated commit-style actions. The terminal Success/Error
+    // notification haptic is fired later in useQuickBuyBottomSheet once the
+    // transaction resolves.
+    playImpact(ImpactMoment.TabChange);
     setIsQuickBuyVisible(true);
   }, [resolvedPosition]);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -87,11 +87,9 @@ const TraderPositionView = () => {
     if (!resolvedPosition) {
       return;
     }
-    // Primary CTA opening the buy flow — TabChange catalog moment (Medium)
-    // mirrors other elevated commit-style actions. The terminal Success/Error
-    // notification haptic is fired later in useQuickBuyBottomSheet once the
-    // transaction resolves.
-    playImpact(ImpactMoment.TabChange);
+    // Primary CTA opening the buy flow — distinct from tab-bar `TabChange`.
+    // Success/error notification haptics fire later in useQuickBuyBottomSheet.
+    playImpact(ImpactMoment.PrimaryCTA);
     setIsQuickBuyVisible(true);
   }, [resolvedPosition]);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import {
+  playSuccessNotification,
+  playErrorNotification,
+} from '../../../../../../util/haptics';
 import { TextInput } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -349,13 +352,13 @@ export function useQuickBuyBottomSheet(
         stxEnabled,
       );
       setTxPhase('success');
-      notificationAsync(NotificationFeedbackType.Success);
+      await playSuccessNotification();
       await new Promise((resolve) => setTimeout(resolve, 800));
       onClose();
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     } catch (error) {
       console.error('Error submitting QuickBuy tx', error);
-      notificationAsync(NotificationFeedbackType.Error);
+      await playErrorNotification();
     } finally {
       dispatch(setIsSubmittingTx(false));
     }

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -442,7 +442,7 @@ describe('TraderNotificationsBottomSheet', () => {
       });
 
       expect(mockPlayImpact).toHaveBeenCalledTimes(1);
-      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
     });
 
     it('fires a medium impact when pressing save even if the value did not change', () => {
@@ -463,7 +463,7 @@ describe('TraderNotificationsBottomSheet', () => {
       });
 
       expect(mockPlayImpact).toHaveBeenCalledTimes(1);
-      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
       expect(mockToggleTraderNotification).not.toHaveBeenCalled();
     });
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -1,7 +1,11 @@
 import React, { useRef, useEffect } from 'react';
 import { Platform } from 'react-native';
 import { screen, fireEvent, act } from '@testing-library/react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import {
+  ImpactFeedbackStyle,
+  ImpactMoment,
+  playImpact,
+} from '../../../../../../util/haptics';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TraderNotificationsBottomSheet, {
   type TraderNotificationsBottomSheetRef,
@@ -32,7 +36,20 @@ jest.mock('expo-haptics', () => ({
   },
 }));
 
-const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
+jest.mock('../../../../../../util/haptics', () => {
+  const actual = jest.requireActual<
+    typeof import('../../../../../../util/haptics')
+  >('../../../../../../util/haptics');
+  return {
+    ...actual,
+    playImpact: jest.fn(),
+  };
+});
+
+const { impactAsync: mockImpactAsync } = jest.requireMock('expo-haptics') as {
+  impactAsync: jest.Mock;
+};
+const mockPlayImpact = jest.mocked(playImpact);
 
 jest.mock(
   '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet',
@@ -414,6 +431,7 @@ describe('TraderNotificationsBottomSheet', () => {
         false,
       );
       mockImpactAsync.mockClear();
+      mockPlayImpact.mockClear();
 
       act(() => {
         fireEvent.press(
@@ -423,8 +441,8 @@ describe('TraderNotificationsBottomSheet', () => {
         );
       });
 
-      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
-      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
     });
 
     it('fires a medium impact when pressing save even if the value did not change', () => {
@@ -444,8 +462,8 @@ describe('TraderNotificationsBottomSheet', () => {
         );
       });
 
-      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
-      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
       expect(mockToggleTraderNotification).not.toHaveBeenCalled();
     });
 
@@ -484,6 +502,7 @@ describe('TraderNotificationsBottomSheet', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
     it('does not fire a haptic when toggling the local switch while the global toggle is off', () => {
@@ -502,6 +521,7 @@ describe('TraderNotificationsBottomSheet', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
     it('does not fire a haptic when pressing the close button', () => {
@@ -514,6 +534,7 @@ describe('TraderNotificationsBottomSheet', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
 
     it('does not fire a haptic when pressing the manage traders row', () => {
@@ -526,6 +547,7 @@ describe('TraderNotificationsBottomSheet', () => {
       );
 
       expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(mockPlayImpact).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
@@ -93,7 +93,7 @@ const TraderNotificationsBottomSheet = forwardRef<
     // Save is a deliberate primary-action commit, so always fire the haptic
     // — including when the value didn't change — to acknowledge the press.
     const handleSave = useCallback(() => {
-      playImpact(ImpactMoment.TabChange);
+      playImpact(ImpactMoment.PrimaryCTA);
       if (localEnabled !== isTraderNotificationEnabled(traderId)) {
         toggleTraderNotification(traderId);
       }

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -23,7 +22,12 @@ import HeaderCompactStandard from '../../../../../../component-library/component
 import { ButtonVariants } from '../../../../../../component-library/components/Buttons/Button/Button.types';
 import { strings } from '../../../../../../../locales/i18n';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { fireSwitchHaptic } from '../../../../../../util/haptics';
+import {
+  fireSwitchHaptic,
+  ImpactFeedbackStyle,
+  playImpact,
+  ImpactMoment,
+} from '../../../../../../util/haptics';
 import type { SocialAIPreference } from '../../../NotificationPreferencesView/hooks';
 import AllowPushNotificationsRow from '../../../NotificationPreferencesView/components/AllowPushNotificationsRow';
 import { TraderNotificationsBottomSheetSelectorsIDs } from './TraderNotificationsBottomSheet.testIds';
@@ -89,7 +93,7 @@ const TraderNotificationsBottomSheet = forwardRef<
     // Save is a deliberate primary-action commit, so always fire the haptic
     // — including when the value didn't change — to acknowledge the press.
     const handleSave = useCallback(() => {
-      impactAsync(ImpactFeedbackStyle.Medium);
+      playImpact(ImpactMoment.TabChange);
       if (localEnabled !== isTraderNotificationEnabled(traderId)) {
         toggleTraderNotification(traderId);
       }

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useSelector } from 'react-redux';
+import { playImpact, ImpactMoment } from '../../util/haptics';
 import Engine from '../../core/Engine';
 import Logger from '../../util/Logger';
 import { useFollowToggle, useFollowToggleMany } from './useFollowToggle';
@@ -25,7 +25,15 @@ jest.mock('../../core/Engine', () => ({
   },
 }));
 
+jest.mock('../../util/haptics', () => ({
+  ...jest.requireActual<typeof import('../../util/haptics')>(
+    '../../util/haptics',
+  ),
+  playImpact: jest.fn().mockResolvedValue(undefined),
+}));
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockPlayImpact = jest.mocked(playImpact);
 
 describe('useFollowToggle', () => {
   beforeEach(() => {
@@ -123,17 +131,17 @@ describe('useFollowToggle', () => {
       );
     });
 
-    it('fires a medium haptic when following a new trader', async () => {
+    it('fires follow toggle haptic when following a new trader', async () => {
       const { result } = renderHook(() => useFollowToggle('trader-1'));
 
       await act(async () => {
         await result.current.toggleFollow();
       });
 
-      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.FollowToggle);
     });
 
-    it('fires a light haptic when unfollowing a currently followed trader', async () => {
+    it('fires follow toggle haptic when unfollowing a currently followed trader', async () => {
       mockUseSelector.mockReturnValue(['trader-1']);
 
       const { result } = renderHook(() => useFollowToggle('trader-1'));
@@ -142,7 +150,7 @@ describe('useFollowToggle', () => {
         await result.current.toggleFollow();
       });
 
-      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.FollowToggle);
     });
 
     it('still fires haptic feedback when a toggle is debounced as in-flight', async () => {
@@ -164,12 +172,15 @@ describe('useFollowToggle', () => {
       });
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
-      expect(impactAsync).toHaveBeenCalledTimes(2);
-      expect(impactAsync).toHaveBeenNthCalledWith(
+      expect(mockPlayImpact).toHaveBeenCalledTimes(2);
+      expect(mockPlayImpact).toHaveBeenNthCalledWith(
         1,
-        ImpactFeedbackStyle.Medium,
+        ImpactMoment.FollowToggle,
       );
-      expect(impactAsync).toHaveBeenNthCalledWith(2, ImpactFeedbackStyle.Light);
+      expect(mockPlayImpact).toHaveBeenNthCalledWith(
+        2,
+        ImpactMoment.FollowToggle,
+      );
 
       await act(async () => {
         resolveCall({ followed: [], unfollowed: [] });

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -1,4 +1,4 @@
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { playImpact, ImpactMoment } from '../../util/haptics';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../core/Engine';
@@ -42,14 +42,10 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
         followingProfileIds.includes(addressOrId);
       const nextValue = !currentlyFollowing;
 
-      // Directional haptic: a weightier "Medium" thump rewards the
-      // constructive Follow action, while Unfollow stays on a neutral
-      // "Light" tick. Fired before the inflight guard so a quick repeat
-      // tap still produces a tactile response even when the API call is
-      // debounced.
-      impactAsync(
-        nextValue ? ImpactFeedbackStyle.Medium : ImpactFeedbackStyle.Light,
-      );
+      // Follow-toggle catalog moment (Light impact). Fired before the
+      // inflight guard so a quick repeat tap still produces tactile feedback
+      // even when the API call is debounced.
+      playImpact(ImpactMoment.FollowToggle);
 
       if (inflightIdsRef.current.has(addressOrId)) {
         return;

--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -17,6 +17,7 @@ export enum FeatureFlagNames {
   legacyIosGoogleConfigEnabled = 'legacyIosGoogleConfigEnabled',
   googleLoginIosUnsupportedBlockingEnabled = 'googleLoginIosUnsupportedBlockingEnabled',
   tronClaimUnstakedTrxButtonEnabled = 'tronClaimUnstakedTrxButtonEnabled',
+  hapticsKillSwitch = 'hapticsKillSwitch',
 }
 
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<

--- a/app/reducers/settings/index.js
+++ b/app/reducers/settings/index.js
@@ -9,6 +9,7 @@ const initialState = {
   hideZeroBalanceTokens: true,
   basicFunctionalityEnabled: true,
   deepLinkModalDisabled: false,
+  hapticsEnabled: true,
   // Perps chart preferences
   perpsChartPreferences: {
     preferredCandlePeriod: '15m', // Default to 15 minutes
@@ -66,6 +67,11 @@ const settingsReducer = (state = initialState, action) => {
       return {
         ...state,
         deepLinkModalDisabled: action.deepLinkModalDisabled,
+      };
+    case 'SET_HAPTICS_ENABLED':
+      return {
+        ...state,
+        hapticsEnabled: action.hapticsEnabled,
       };
     case 'SET_PERPS_CHART_PREFERRED_CANDLE_PERIOD':
       return {

--- a/app/selectors/featureFlagController/haptics/index.test.ts
+++ b/app/selectors/featureFlagController/haptics/index.test.ts
@@ -1,0 +1,95 @@
+import { selectHapticsKillSwitch } from './index';
+import { FeatureFlagNames } from '../../../constants/featureFlags';
+import { hasMinimumRequiredVersion } from '../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+
+jest.mock('../../../util/remoteFeatureFlag', () => ({
+  ...jest.requireActual('../../../util/remoteFeatureFlag'),
+  hasMinimumRequiredVersion: jest.fn(),
+}));
+
+describe('selectHapticsKillSwitch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(hasMinimumRequiredVersion).mockReturnValue(true);
+  });
+
+  it('returns true when remote flag is valid and enabled', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: {
+        enabled: true,
+        minimumVersion: '1.0.0',
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when remote flag is valid but disabled', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: {
+        enabled: false,
+        minimumVersion: '1.0.0',
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when version check fails', () => {
+    jest.mocked(hasMinimumRequiredVersion).mockReturnValue(false);
+
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: {
+        enabled: true,
+        minimumVersion: '99.0.0',
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when remote flag is invalid', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: {
+        enabled: 'invalid',
+        minimumVersion: 123,
+      } as unknown as { enabled: boolean; minimumVersion: string },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when remote feature flags are empty', () => {
+    const result = selectHapticsKillSwitch.resultFunc({});
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when hapticsKillSwitch property is missing', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      someOtherFlag: true,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when boolean local override is true', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: true,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when boolean local override is false', () => {
+    const result = selectHapticsKillSwitch.resultFunc({
+      [FeatureFlagNames.hapticsKillSwitch]: false,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/haptics/index.ts
+++ b/app/selectors/featureFlagController/haptics/index.ts
@@ -1,0 +1,20 @@
+import { createSelector } from 'reselect';
+import { hasProperty } from '@metamask/utils';
+import { selectRemoteFeatureFlags } from '..';
+import { FeatureFlagNames } from '../../../constants/featureFlags';
+
+/**
+ * Select whether the haptics kill switch is active.
+ * When true, all haptic playback is blocked — this is the primary
+ * rollback mechanism for haptic regressions in production.
+ * Defaults to false (haptics allowed) when the flag is absent.
+ */
+export const selectHapticsKillSwitch = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    if (!hasProperty(remoteFeatureFlags, FeatureFlagNames.hapticsKillSwitch)) {
+      return false;
+    }
+    return remoteFeatureFlags[FeatureFlagNames.hapticsKillSwitch] === true;
+  },
+);

--- a/app/selectors/featureFlagController/haptics/index.ts
+++ b/app/selectors/featureFlagController/haptics/index.ts
@@ -2,19 +2,37 @@ import { createSelector } from 'reselect';
 import { hasProperty } from '@metamask/utils';
 import { selectRemoteFeatureFlags } from '..';
 import { FeatureFlagNames } from '../../../constants/featureFlags';
+import {
+  validatedVersionGatedFeatureFlag,
+  type VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+const DEFAULT_HAPTICS_KILL_SWITCH = false;
 
 /**
  * Select whether the haptics kill switch is active.
  * When true, all haptic playback is blocked — this is the primary
  * rollback mechanism for haptic regressions in production.
- * Defaults to false (haptics allowed) when the flag is absent.
+ * Handles version-gated flag shape `{ enabled: boolean, minimumVersion: string }`
+ * (see feature-flag-registry) and boolean overrides.
+ * Defaults to false (haptics allowed) when the flag is absent or invalid.
  */
 export const selectHapticsKillSwitch = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
     if (!hasProperty(remoteFeatureFlags, FeatureFlagNames.hapticsKillSwitch)) {
-      return false;
+      return DEFAULT_HAPTICS_KILL_SWITCH;
     }
-    return remoteFeatureFlags[FeatureFlagNames.hapticsKillSwitch] === true;
+    const rawFlag = remoteFeatureFlags[FeatureFlagNames.hapticsKillSwitch];
+
+    if (typeof rawFlag === 'boolean') {
+      return rawFlag;
+    }
+
+    const remoteFlag = rawFlag as unknown as VersionGatedFeatureFlag;
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_HAPTICS_KILL_SWITCH
+    );
   },
 );

--- a/app/selectors/settings.ts
+++ b/app/selectors/settings.ts
@@ -33,6 +33,12 @@ export const selectDeepLinkModalDisabled = createSelector(
     Boolean(settingsState.deepLinkModalDisabled),
 );
 
+export const selectHapticsEnabled = createSelector(
+  selectSettings,
+  (settingsState: Record<string, unknown>) =>
+    settingsState.hapticsEnabled !== false,
+);
+
 export const selectAvatarAccountType = createSelector(
   selectSettings,
   (settingsState: Record<string, unknown>) =>

--- a/app/util/haptics/README.md
+++ b/app/util/haptics/README.md
@@ -22,6 +22,7 @@ Centralized haptic feedback module for MetaMask Mobile.
 | Warning notification | `playWarningNotification()`         | `notificationAsync(Warning)` | —      | Compliance / restriction modal    |                                                 |
 | Slider tick          | `playImpact('sliderTick')`          | `impactAsync(Light)`         | Light  | Slider step animation             |                                                 |
 | Edge gesture engage  | `playImpact('edgeGestureEngage')`   | `impactAsync(Light)`         | Light  | Browser back/forward edge swipe   | Touch-down in edge zone; not slider ticks       |
+| Page navigation      | `playImpact('pageNavigation')`      | `impactAsync(Medium)`        | Medium | Browser swipe back/forward commit | Distinct from tab bar `tabChange`               |
 | Slider grip          | `playImpact('sliderGrip')`          | `impactAsync(Medium)`        | Medium | Slider thumb press / release      | Distinct from tick / threshold crossings        |
 | Tab change           | `playImpact('tabChange')`           | `impactAsync(Medium)`        | Medium | Tab transition                    |                                                 |
 | Pull refresh engage  | `playImpact('pullToRefreshEngage')` | `impactAsync(Light)`         | Light  | Pull stretch past early threshold | Lighter than commit; pairs with `pullToRefresh` |

--- a/app/util/haptics/README.md
+++ b/app/util/haptics/README.md
@@ -15,16 +15,18 @@ Centralized haptic feedback module for MetaMask Mobile.
 
 ## Catalog
 
-| Moment               | Function                       | Underlying API               | Style  | Paired UI                      | Notes                                    |
-| -------------------- | ------------------------------ | ---------------------------- | ------ | ------------------------------ | ---------------------------------------- |
-| Success notification | `playSuccessNotification()`    | `notificationAsync(Success)` | —      | Toast / completion banner      | Non-negotiable #1                        |
-| Error notification   | `playErrorNotification()`      | `notificationAsync(Error)`   | —      | Error toast / failure banner   | Non-negotiable #2. System failures only. |
-| Warning notification | `playWarningNotification()`    | `notificationAsync(Warning)` | —      | Compliance / restriction modal |                                          |
-| Slider tick          | `playImpact('sliderTick')`     | `impactAsync(Light)`         | Light  | Slider step animation          |                                          |
-| Tab change           | `playImpact('tabChange')`      | `impactAsync(Medium)`        | Medium | Tab transition                 |                                          |
-| Pull to refresh      | `playImpact('pullToRefresh')`  | `impactAsync(Medium)`        | Medium | Pull-to-refresh trigger        |                                          |
-| Chart crosshair      | `playImpact('chartCrosshair')` | `impactAsync(Light)`         | Light  | OHLC data change               |                                          |
-| Selection            | `playSelection()`              | `selectionAsync()`           | —      | Discrete value picker          |                                          |
+| Moment               | Function                            | Underlying API               | Style  | Paired UI                         | Notes                                           |
+| -------------------- | ----------------------------------- | ---------------------------- | ------ | --------------------------------- | ----------------------------------------------- |
+| Success notification | `playSuccessNotification()`         | `notificationAsync(Success)` | —      | Toast / completion banner         | Non-negotiable #1                               |
+| Error notification   | `playErrorNotification()`           | `notificationAsync(Error)`   | —      | Error toast / failure banner      | Non-negotiable #2. System failures only.        |
+| Warning notification | `playWarningNotification()`         | `notificationAsync(Warning)` | —      | Compliance / restriction modal    |                                                 |
+| Slider tick          | `playImpact('sliderTick')`          | `impactAsync(Light)`         | Light  | Slider step animation             |                                                 |
+| Slider grip          | `playImpact('sliderGrip')`          | `impactAsync(Medium)`        | Medium | Slider thumb press / release      | Distinct from tick / threshold crossings        |
+| Tab change           | `playImpact('tabChange')`           | `impactAsync(Medium)`        | Medium | Tab transition                    |                                                 |
+| Pull refresh engage  | `playImpact('pullToRefreshEngage')` | `impactAsync(Light)`         | Light  | Pull stretch past early threshold | Lighter than commit; pairs with `pullToRefresh` |
+| Pull to refresh      | `playImpact('pullToRefresh')`       | `impactAsync(Medium)`        | Medium | Pull-to-refresh reload commit     |                                                 |
+| Chart crosshair      | `playImpact('chartCrosshair')`      | `impactAsync(Light)`         | Light  | OHLC data change                  |                                                 |
+| Selection            | `playSelection()`                   | `selectionAsync()`           | —      | Discrete value picker             |                                                 |
 
 ### Adding a new moment
 

--- a/app/util/haptics/README.md
+++ b/app/util/haptics/README.md
@@ -1,0 +1,75 @@
+# Haptics Toolkit
+
+Centralized haptic feedback module for MetaMask Mobile.
+
+**Only files under `app/util/haptics/` may import `expo-haptics` directly** (today: `vendorPlayback.ts`; `play.ts` / `useHaptics.ts` use shared gating via `gatedExecution.ts`). All feature code must import from `app/util/haptics`. ESLint `no-restricted-imports` enforces that.
+
+## Core Principles
+
+1. **Fewer moments, higher signal** — every haptic you add dilutes the ones that matter. Adding a new catalog entry requires design + platform sign-off + a QA sync note.
+2. **Sync or skip** — a haptic that fires out of sync with its animation is worse than no haptic. QA must validate sync on a real device under realistic load before shipping.
+3. **Semantic consistency** — success always feels like success; error always feels like error. Never reuse a haptic type across different meanings.
+4. **Outcome ≠ error** — `playErrorNotification` is for system failures only. User-participated negative outcomes (lost bet, liquidation) must **never** use the error haptic.
+5. **User control is mandatory** — respect OS haptics settings and the in-app "reduced haptics" toggle. The remote kill switch can disable all haptics instantly without a release.
+6. **Android is progressive enhancement** — design for iOS Taptic Engine first; treat Android as best-effort with graceful failure.
+
+## Catalog
+
+| Moment               | Function                       | Underlying API               | Style  | Paired UI                      | Notes                                    |
+| -------------------- | ------------------------------ | ---------------------------- | ------ | ------------------------------ | ---------------------------------------- |
+| Success notification | `playSuccessNotification()`    | `notificationAsync(Success)` | —      | Toast / completion banner      | Non-negotiable #1                        |
+| Error notification   | `playErrorNotification()`      | `notificationAsync(Error)`   | —      | Error toast / failure banner   | Non-negotiable #2. System failures only. |
+| Warning notification | `playWarningNotification()`    | `notificationAsync(Warning)` | —      | Compliance / restriction modal |                                          |
+| Slider tick          | `playImpact('sliderTick')`     | `impactAsync(Light)`         | Light  | Slider step animation          |                                          |
+| Tab change           | `playImpact('tabChange')`      | `impactAsync(Medium)`        | Medium | Tab transition                 |                                          |
+| Pull to refresh      | `playImpact('pullToRefresh')`  | `impactAsync(Medium)`        | Medium | Pull-to-refresh trigger        |                                          |
+| Chart crosshair      | `playImpact('chartCrosshair')` | `impactAsync(Light)`         | Light  | OHLC data change               |                                          |
+| Selection            | `playSelection()`              | `selectionAsync()`           | —      | Discrete value picker          |                                          |
+
+### Adding a new moment
+
+1. Add the value to `catalog.ts` (`ImpactMoment` or `NotificationMoment`) with JSDoc.
+2. Map the underlying style in `vendorPlayback.ts` (`IMPACT_STYLE_MAP`).
+3. Add a row to this README table.
+4. Get design + platform sign-off.
+5. QA validates sync on both iOS and Android real devices under load.
+
+## Usage
+
+### In React components
+
+```typescript
+import { useHaptics } from '../../util/haptics';
+
+function MyComponent() {
+  const { playSuccessNotification } = useHaptics();
+
+  const handleComplete = async () => {
+    await performAction();
+    await playSuccessNotification();
+  };
+}
+```
+
+### Outside React (utilities, sagas, class components)
+
+```typescript
+import { playErrorNotification } from '../../util/haptics';
+
+async function handleFailure() {
+  await playErrorNotification();
+}
+```
+
+## Gates
+
+All `play*` functions check `shouldPlayHaptic()` before calling the native API:
+
+1. **In-app preference** — "reduced haptics" toggle in Settings.
+2. **Remote kill switch** — feature flag; can disable all haptics instantly in production.
+3. **OS-level** — `expo-haptics` itself is a no-op when the user has disabled system haptics.
+4. **Try/catch** — native errors are swallowed; user flows never break.
+
+## Future: vendor swap
+
+If we migrate to Nitro Haptics or another native implementation, change `vendorPlayback.ts` (and optionally `gatedExecution.ts` if the gate contract changes). Call sites stay on `playSuccessNotification()` / `playImpact(moment)` / `useHaptics()`.

--- a/app/util/haptics/README.md
+++ b/app/util/haptics/README.md
@@ -21,6 +21,7 @@ Centralized haptic feedback module for MetaMask Mobile.
 | Error notification   | `playErrorNotification()`           | `notificationAsync(Error)`   | —      | Error toast / failure banner      | Non-negotiable #2. System failures only.        |
 | Warning notification | `playWarningNotification()`         | `notificationAsync(Warning)` | —      | Compliance / restriction modal    |                                                 |
 | Slider tick          | `playImpact('sliderTick')`          | `impactAsync(Light)`         | Light  | Slider step animation             |                                                 |
+| Edge gesture engage  | `playImpact('edgeGestureEngage')`   | `impactAsync(Light)`         | Light  | Browser back/forward edge swipe   | Touch-down in edge zone; not slider ticks       |
 | Slider grip          | `playImpact('sliderGrip')`          | `impactAsync(Medium)`        | Medium | Slider thumb press / release      | Distinct from tick / threshold crossings        |
 | Tab change           | `playImpact('tabChange')`           | `impactAsync(Medium)`        | Medium | Tab transition                    |                                                 |
 | Pull refresh engage  | `playImpact('pullToRefreshEngage')` | `impactAsync(Light)`         | Light  | Pull stretch past early threshold | Lighter than commit; pairs with `pullToRefresh` |

--- a/app/util/haptics/README.md
+++ b/app/util/haptics/README.md
@@ -25,6 +25,7 @@ Centralized haptic feedback module for MetaMask Mobile.
 | Page navigation      | `playImpact('pageNavigation')`      | `impactAsync(Medium)`        | Medium | Browser swipe back/forward commit | Distinct from tab bar `tabChange`               |
 | Slider grip          | `playImpact('sliderGrip')`          | `impactAsync(Medium)`        | Medium | Slider thumb press / release      | Distinct from tick / threshold crossings        |
 | Tab change           | `playImpact('tabChange')`           | `impactAsync(Medium)`        | Medium | Tab transition                    |                                                 |
+| Primary CTA          | `playImpact('primaryCta')`          | `impactAsync(Medium)`        | Medium | Buy / sheet Save / primary commit | Distinct from tab bar; tune independently       |
 | Pull refresh engage  | `playImpact('pullToRefreshEngage')` | `impactAsync(Light)`         | Light  | Pull stretch past early threshold | Lighter than commit; pairs with `pullToRefresh` |
 | Pull to refresh      | `playImpact('pullToRefresh')`       | `impactAsync(Medium)`        | Medium | Pull-to-refresh reload commit     |                                                 |
 | Chart crosshair      | `playImpact('chartCrosshair')`      | `impactAsync(Light)`         | Light  | OHLC data change                  |                                                 |

--- a/app/util/haptics/__mocks__/index.ts
+++ b/app/util/haptics/__mocks__/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Manual mock for `app/util/haptics` when tests call `jest.mock('…/util/haptics')`
+ * with no factory (avoids `require()` and `jest.mock` + ESM import TDZ).
+ */
+import { createHapticsJestMock } from '../testing/createHapticsJestMock';
+
+const m = createHapticsJestMock();
+
+export const playSuccessNotification = m.playSuccessNotification;
+export const playErrorNotification = m.playErrorNotification;
+export const playWarningNotification = m.playWarningNotification;
+export const playNotification = m.playNotification;
+export const playImpact = m.playImpact;
+export const playSelection = m.playSelection;
+export const useHaptics = m.useHaptics;
+export const ImpactMoment = m.ImpactMoment;
+export const NotificationMoment = m.NotificationMoment;
+
+export type {
+  HapticMoment,
+  HapticImpactMoment,
+  HapticNotificationMoment,
+  HapticsPlayer,
+} from '../catalog';

--- a/app/util/haptics/__mocks__/index.ts
+++ b/app/util/haptics/__mocks__/index.ts
@@ -6,6 +6,7 @@ import { createHapticsJestMock } from '../testing/createHapticsJestMock';
 
 const m = createHapticsJestMock();
 
+export const fireSwitchHaptic = m.fireSwitchHaptic;
 export const playSuccessNotification = m.playSuccessNotification;
 export const playErrorNotification = m.playErrorNotification;
 export const playWarningNotification = m.playWarningNotification;

--- a/app/util/haptics/__mocks__/index.ts
+++ b/app/util/haptics/__mocks__/index.ts
@@ -16,6 +16,8 @@ export const useHaptics = m.useHaptics;
 export const ImpactMoment = m.ImpactMoment;
 export const NotificationMoment = m.NotificationMoment;
 
+export { ImpactFeedbackStyle } from 'expo-haptics';
+
 export type {
   HapticMoment,
   HapticImpactMoment,

--- a/app/util/haptics/__tests__/gates.test.ts
+++ b/app/util/haptics/__tests__/gates.test.ts
@@ -1,0 +1,61 @@
+import { Platform } from 'react-native';
+import { shouldPlayHaptic, type HapticGateOptions } from '../gates';
+
+describe('shouldPlayHaptic', () => {
+  const enabledOptions: HapticGateOptions = {
+    reducedHaptics: false,
+    killSwitchActive: false,
+  };
+
+  it('returns true when all gates pass', () => {
+    expect(shouldPlayHaptic(enabledOptions)).toBe(true);
+  });
+
+  it('returns false when reducedHaptics is true', () => {
+    expect(shouldPlayHaptic({ ...enabledOptions, reducedHaptics: true })).toBe(
+      false,
+    );
+  });
+
+  it('returns false when killSwitchActive is true', () => {
+    expect(
+      shouldPlayHaptic({ ...enabledOptions, killSwitchActive: true }),
+    ).toBe(false);
+  });
+
+  it('returns false when both reducedHaptics and killSwitchActive are true', () => {
+    expect(
+      shouldPlayHaptic({ reducedHaptics: true, killSwitchActive: true }),
+    ).toBe(false);
+  });
+
+  it('returns false on web platform', () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'web' as typeof Platform.OS;
+    try {
+      expect(shouldPlayHaptic(enabledOptions)).toBe(false);
+    } finally {
+      Platform.OS = originalOS;
+    }
+  });
+
+  it('returns true on ios platform when gates pass', () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'ios';
+    try {
+      expect(shouldPlayHaptic(enabledOptions)).toBe(true);
+    } finally {
+      Platform.OS = originalOS;
+    }
+  });
+
+  it('returns true on android platform when gates pass', () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'android';
+    try {
+      expect(shouldPlayHaptic(enabledOptions)).toBe(true);
+    } finally {
+      Platform.OS = originalOS;
+    }
+  });
+});

--- a/app/util/haptics/__tests__/play.test.ts
+++ b/app/util/haptics/__tests__/play.test.ts
@@ -1,0 +1,160 @@
+import {
+  impactAsync,
+  notificationAsync,
+  selectionAsync,
+  NotificationFeedbackType,
+  ImpactFeedbackStyle,
+} from 'expo-haptics';
+import {
+  playSuccessNotification,
+  playErrorNotification,
+  playWarningNotification,
+  playImpact,
+  playSelection,
+} from '../play';
+import { ImpactMoment } from '../catalog';
+import { shouldPlayHaptic } from '../gates';
+
+jest.mock('../gates', () => ({
+  ...jest.requireActual<typeof import('../gates')>('../gates'),
+  shouldPlayHaptic: jest.fn(),
+}));
+
+jest.mock('../../../core/redux', () => ({
+  __esModule: true,
+  default: {
+    store: {
+      getState: jest.fn(() => ({
+        settings: { hapticsEnabled: true },
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {},
+              localOverrides: {},
+            },
+          },
+        },
+      })),
+    },
+  },
+}));
+
+const mockShouldPlayHaptic = shouldPlayHaptic as jest.MockedFunction<
+  typeof shouldPlayHaptic
+>;
+
+describe('play.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when gates allow playback', () => {
+    beforeEach(() => {
+      mockShouldPlayHaptic.mockReturnValue(true);
+    });
+
+    it('playSuccessNotification calls notificationAsync with Success', async () => {
+      await playSuccessNotification();
+      expect(notificationAsync).toHaveBeenCalledWith(
+        NotificationFeedbackType.Success,
+      );
+    });
+
+    it('playErrorNotification calls notificationAsync with Error', async () => {
+      await playErrorNotification();
+      expect(notificationAsync).toHaveBeenCalledWith(
+        NotificationFeedbackType.Error,
+      );
+    });
+
+    it('playWarningNotification calls notificationAsync with Warning', async () => {
+      await playWarningNotification();
+      expect(notificationAsync).toHaveBeenCalledWith(
+        NotificationFeedbackType.Warning,
+      );
+    });
+
+    it('playImpact(SliderTick) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.SliderTick);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('playImpact(TabChange) calls impactAsync with Medium', async () => {
+      await playImpact(ImpactMoment.TabChange);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('playImpact(PullToRefresh) calls impactAsync with Medium', async () => {
+      await playImpact(ImpactMoment.PullToRefresh);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('playImpact(ChartCrosshair) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.ChartCrosshair);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('playSelection calls selectionAsync', async () => {
+      await playSelection();
+      expect(selectionAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('when gates block playback', () => {
+    beforeEach(() => {
+      mockShouldPlayHaptic.mockReturnValue(false);
+    });
+
+    it('playSuccessNotification does not call vendor', async () => {
+      await playSuccessNotification();
+      expect(notificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('playErrorNotification does not call vendor', async () => {
+      await playErrorNotification();
+      expect(notificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('playWarningNotification does not call vendor', async () => {
+      await playWarningNotification();
+      expect(notificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('playImpact does not call vendor', async () => {
+      await playImpact(ImpactMoment.SliderTick);
+      expect(impactAsync).not.toHaveBeenCalled();
+    });
+
+    it('playSelection does not call vendor', async () => {
+      await playSelection();
+      expect(selectionAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error resilience', () => {
+    beforeEach(() => {
+      mockShouldPlayHaptic.mockReturnValue(true);
+    });
+
+    it('playSuccessNotification resolves when vendor throws', async () => {
+      (notificationAsync as jest.Mock).mockRejectedValueOnce(
+        new Error('native crash'),
+      );
+      await expect(playSuccessNotification()).resolves.toBeUndefined();
+    });
+
+    it('playImpact resolves when vendor throws', async () => {
+      (impactAsync as jest.Mock).mockRejectedValueOnce(
+        new Error('native crash'),
+      );
+      await expect(playImpact(ImpactMoment.TabChange)).resolves.toBeUndefined();
+    });
+
+    it('playSelection resolves when vendor throws', async () => {
+      (selectionAsync as jest.Mock).mockRejectedValueOnce(
+        new Error('native crash'),
+      );
+      await expect(playSelection()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/app/util/haptics/__tests__/play.test.ts
+++ b/app/util/haptics/__tests__/play.test.ts
@@ -79,9 +79,19 @@ describe('play.ts', () => {
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 
+    it('playImpact(SliderGrip) calls impactAsync with Medium', async () => {
+      await playImpact(ImpactMoment.SliderGrip);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
     it('playImpact(TabChange) calls impactAsync with Medium', async () => {
       await playImpact(ImpactMoment.TabChange);
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('playImpact(PullToRefreshEngage) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.PullToRefreshEngage);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 
     it('playImpact(PullToRefresh) calls impactAsync with Medium', async () => {

--- a/app/util/haptics/__tests__/useHaptics.test.ts
+++ b/app/util/haptics/__tests__/useHaptics.test.ts
@@ -1,0 +1,117 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import {
+  notificationAsync,
+  NotificationFeedbackType,
+  impactAsync,
+  ImpactFeedbackStyle,
+  selectionAsync,
+} from 'expo-haptics';
+import { useSelector } from 'react-redux';
+import { ImpactMoment } from '../catalog';
+import { useHaptics } from '../useHaptics';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe('useHaptics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setupSelectors(hapticsEnabled: boolean, killSwitchActive: boolean) {
+    const values = [hapticsEnabled, killSwitchActive];
+    mockUseSelector.mockImplementation((_selector) => {
+      // useHaptics calls useSelector twice: first for hapticsEnabled, then killSwitch.
+      // Return matching value based on call order within each render.
+      const idx = mockUseSelector.mock.calls.length - 1;
+      return values[idx % 2];
+    });
+  }
+
+  it('returns stable function references across re-renders', () => {
+    setupSelectors(true, false);
+    const { result, rerender } = renderHook(() => useHaptics());
+    const first = result.current;
+    rerender();
+    const second = result.current;
+
+    expect(first.playSuccessNotification).toBe(second.playSuccessNotification);
+    expect(first.playErrorNotification).toBe(second.playErrorNotification);
+    expect(first.playImpact).toBe(second.playImpact);
+    expect(first.playSelection).toBe(second.playSelection);
+  });
+
+  it('plays success notification when enabled', async () => {
+    setupSelectors(true, false);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playSuccessNotification();
+    });
+
+    expect(notificationAsync).toHaveBeenCalledWith(
+      NotificationFeedbackType.Success,
+    );
+  });
+
+  it('plays error notification when enabled', async () => {
+    setupSelectors(true, false);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playErrorNotification();
+    });
+
+    expect(notificationAsync).toHaveBeenCalledWith(
+      NotificationFeedbackType.Error,
+    );
+  });
+
+  it('plays impact when enabled', async () => {
+    setupSelectors(true, false);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playImpact(ImpactMoment.TabChange);
+    });
+
+    expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+  });
+
+  it('plays selection when enabled', async () => {
+    setupSelectors(true, false);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playSelection();
+    });
+
+    expect(selectionAsync).toHaveBeenCalled();
+  });
+
+  it('does not play when haptics disabled', async () => {
+    setupSelectors(false, false);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playSuccessNotification();
+    });
+
+    expect(notificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not play when kill switch is active', async () => {
+    setupSelectors(true, true);
+    const { result } = renderHook(() => useHaptics());
+
+    await act(async () => {
+      await result.current.playSuccessNotification();
+    });
+
+    expect(notificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -66,6 +66,13 @@ export const ImpactMoment = {
   EdgeGestureEngage: 'edgeGestureEngage',
 
   /**
+   * Browser WebView history navigation completed (edge swipe back / forward committed).
+   * Medium impact, paired with the in-page navigation transition. Distinct from
+   * `TabChange` (tab bar) and `EdgeGestureEngage` (edge touch-down).
+   */
+  PageNavigation: 'pageNavigation',
+
+  /**
    * Slider thumb press or release — Medium impact (grab / let go).
    * Distinct from `SliderTick` (discrete ticks / threshold crossings).
    */

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -58,10 +58,22 @@ export const ImpactMoment = {
   /** Slider step / tick — Light impact. Paired with slider animation. */
   SliderTick: 'sliderTick',
 
+  /**
+   * Slider thumb press or release — Medium impact (grab / let go).
+   * Distinct from `SliderTick` (discrete ticks / threshold crossings).
+   */
+  SliderGrip: 'sliderGrip',
+
   /** Tab bar press — Medium impact. Paired with tab transition animation. */
   TabChange: 'tabChange',
 
-  /** Pull-to-refresh trigger point — Medium impact. */
+  /**
+   * Pull-to-refresh stretch engaged — Light impact (early pull feedback).
+   * Distinct from `PullToRefresh` (Medium), which fires when the reload commits.
+   */
+  PullToRefreshEngage: 'pullToRefreshEngage',
+
+  /** Pull-to-refresh reload committed — Medium impact. */
   PullToRefresh: 'pullToRefresh',
 
   /** Chart crosshair / OHLC data point change — Light impact. */

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -1,0 +1,91 @@
+/**
+ * Haptic feedback catalog — the single source of truth for all allowed haptic moments.
+ *
+ * Adding a new entry requires design + platform sign-off, a README row update,
+ * and a QA sync note confirming animation/haptic alignment.
+ */
+
+// ────────────────────────────────────────────────────────────────────────────
+// Notification moments — map 1:1 to expo-haptics notificationAsync types
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Notification-style haptic moments.
+ *
+ * These produce a distinct "notification" pattern (Taptic Engine on iOS)
+ * and are reserved for outcome communication — never reuse across meanings.
+ */
+export const NotificationMoment = {
+  /**
+   * Task completed successfully (deposit confirmed, claim succeeded, tx mined).
+   * Fires once per completed action — never on intermediate states.
+   * Non-negotiable: every release must preserve this mapping.
+   */
+  Success: 'success',
+
+  /**
+   * **System** failure only — the app could not process a request.
+   * NEVER use for user-participated negative outcomes (lost bet, liquidation).
+   * Conflating outcome with error erodes user trust.
+   * Non-negotiable: every release must preserve this mapping.
+   */
+  Error: 'error',
+
+  /**
+   * Compliance / access restriction alert (e.g. geo-blocked).
+   * Optional moment — only when the catalog explicitly includes it.
+   */
+  Warning: 'warning',
+} as const;
+
+export type HapticNotificationMoment =
+  (typeof NotificationMoment)[keyof typeof NotificationMoment];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Impact moments — each maps to exactly one ImpactFeedbackStyle internally
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Impact-style haptic moments.
+ *
+ * Each entry maps to a single `ImpactFeedbackStyle` inside `play.ts`.
+ * The underlying style is never exposed to call sites.
+ */
+export const ImpactMoment = {
+  /** Quick amount selection — Light impact. Paired with quick amount selection animation. */
+  QuickAmountSelection: 'quickAmountSelection',
+
+  /** Slider step / tick — Light impact. Paired with slider animation. */
+  SliderTick: 'sliderTick',
+
+  /** Tab bar press — Medium impact. Paired with tab transition animation. */
+  TabChange: 'tabChange',
+
+  /** Pull-to-refresh trigger point — Medium impact. */
+  PullToRefresh: 'pullToRefresh',
+
+  /** Chart crosshair / OHLC data point change — Light impact. */
+  ChartCrosshair: 'chartCrosshair',
+} as const;
+
+export type HapticImpactMoment =
+  (typeof ImpactMoment)[keyof typeof ImpactMoment];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Union of all moments (for documentation / logging, not typically used at
+// call sites — prefer the narrower types above)
+// ────────────────────────────────────────────────────────────────────────────
+
+export type HapticMoment = HapticNotificationMoment | HapticImpactMoment;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Player interface — returned by useHaptics(), used for DI in tests
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface HapticsPlayer {
+  playSuccessNotification: () => Promise<void>;
+  playErrorNotification: () => Promise<void>;
+  playWarningNotification: () => Promise<void>;
+  playImpact: (moment: HapticImpactMoment) => Promise<void>;
+  playSelection: () => Promise<void>;
+}

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -59,6 +59,13 @@ export const ImpactMoment = {
   SliderTick: 'sliderTick',
 
   /**
+   * Browser WebView edge-swipe engaged (back / forward) — Light impact on touch-down
+   * in the edge zone. Distinct from `SliderTick`; tuning slider ticks must not change
+   * in-browser navigation gesture feedback.
+   */
+  EdgeGestureEngage: 'edgeGestureEngage',
+
+  /**
    * Slider thumb press or release — Medium impact (grab / let go).
    * Distinct from `SliderTick` (discrete ticks / threshold crossings).
    */

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -82,6 +82,13 @@ export const ImpactMoment = {
   TabChange: 'tabChange',
 
   /**
+   * Primary surface commit (Buy opening a flow, bottom-sheet Save, etc.) —
+   * Medium impact. Same underlying weight as `TabChange` by default, but a
+   * separate catalog entry so tab-bar tuning never changes unrelated CTAs.
+   */
+  PrimaryCTA: 'primaryCta',
+
+  /**
    * Pull-to-refresh stretch engaged — Light impact (early pull feedback).
    * Distinct from `PullToRefresh` (Medium), which fires when the reload commits.
    */

--- a/app/util/haptics/catalog.ts
+++ b/app/util/haptics/catalog.ts
@@ -92,6 +92,9 @@ export const ImpactMoment = {
 
   /** Chart crosshair / OHLC data point change — Light impact. */
   ChartCrosshair: 'chartCrosshair',
+
+  /** Social follow / unfollow toggle — Light impact. */
+  FollowToggle: 'followToggle',
 } as const;
 
 export type HapticImpactMoment =

--- a/app/util/haptics/gatedExecution.ts
+++ b/app/util/haptics/gatedExecution.ts
@@ -1,0 +1,17 @@
+import { shouldPlayHaptic, type HapticGateOptions } from './gates';
+
+/**
+ * Runs a vendor playback callback only when gates allow; swallows errors so
+ * user flows never break on haptic failures.
+ */
+export async function withGatedPlayback(
+  options: HapticGateOptions,
+  play: () => Promise<void>,
+): Promise<void> {
+  if (!shouldPlayHaptic(options)) return;
+  try {
+    await play();
+  } catch {
+    // no-op
+  }
+}

--- a/app/util/haptics/gates.test.ts
+++ b/app/util/haptics/gates.test.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { shouldPlayHaptic, type HapticGateOptions } from '../gates';
+import { shouldPlayHaptic, type HapticGateOptions } from './gates';
 
 describe('shouldPlayHaptic', () => {
   const enabledOptions: HapticGateOptions = {

--- a/app/util/haptics/gates.ts
+++ b/app/util/haptics/gates.ts
@@ -1,0 +1,37 @@
+import { Platform } from 'react-native';
+
+export interface HapticGateOptions {
+  /** User has toggled "Reduced haptics" ON in app settings (default: false). */
+  reducedHaptics: boolean;
+  /** Remote kill switch is active — blocks all haptic playback (default: false). */
+  killSwitchActive: boolean;
+}
+
+/**
+ * Determines whether a haptic should fire.
+ *
+ * Gate order:
+ * 1. Platform — web is never allowed (RN-only safety check).
+ * 2. In-app preference — the user toggled "reduced haptics."
+ * 3. Remote kill switch — instant production disable without a release.
+ *
+ * Note: OS-level haptics disabled state is handled by expo-haptics itself
+ * (the native API is a no-op when the user has disabled system haptics).
+ * Android is progressive enhancement — we still attempt playback and catch
+ * errors in `play.ts` / `useHaptics.ts` so flows never break.
+ */
+export function shouldPlayHaptic(options: HapticGateOptions): boolean {
+  if (Platform.OS === 'web') {
+    return false;
+  }
+
+  if (options.reducedHaptics) {
+    return false;
+  }
+
+  if (options.killSwitchActive) {
+    return false;
+  }
+
+  return true;
+}

--- a/app/util/haptics/index.ts
+++ b/app/util/haptics/index.ts
@@ -1,0 +1,16 @@
+export {
+  playSuccessNotification,
+  playErrorNotification,
+  playWarningNotification,
+  playNotification,
+  playImpact,
+  playSelection,
+} from './play';
+export { useHaptics } from './useHaptics';
+export { NotificationMoment, ImpactMoment } from './catalog';
+export type {
+  HapticMoment,
+  HapticImpactMoment,
+  HapticNotificationMoment,
+  HapticsPlayer,
+} from './catalog';

--- a/app/util/haptics/index.ts
+++ b/app/util/haptics/index.ts
@@ -1,1 +1,17 @@
 export { fireSwitchHaptic } from './switchHaptic';
+export {
+  playSuccessNotification,
+  playErrorNotification,
+  playWarningNotification,
+  playNotification,
+  playImpact,
+  playSelection,
+} from './play';
+export { useHaptics } from './useHaptics';
+export { NotificationMoment, ImpactMoment } from './catalog';
+export type {
+  HapticMoment,
+  HapticImpactMoment,
+  HapticNotificationMoment,
+  HapticsPlayer,
+} from './catalog';

--- a/app/util/haptics/index.ts
+++ b/app/util/haptics/index.ts
@@ -9,6 +9,8 @@ export {
 } from './play';
 export { useHaptics } from './useHaptics';
 export { NotificationMoment, ImpactMoment } from './catalog';
+/** Re-export for dev tooling — call sites must not import `expo-haptics` directly (eslint). */
+export { ImpactFeedbackStyle } from 'expo-haptics';
 export type {
   HapticMoment,
   HapticImpactMoment,

--- a/app/util/haptics/play.test.ts
+++ b/app/util/haptics/play.test.ts
@@ -79,6 +79,11 @@ describe('play.ts', () => {
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 
+    it('playImpact(EdgeGestureEngage) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.EdgeGestureEngage);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
     it('playImpact(QuickAmountSelection) calls impactAsync with Light', async () => {
       await playImpact(ImpactMoment.QuickAmountSelection);
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);

--- a/app/util/haptics/play.test.ts
+++ b/app/util/haptics/play.test.ts
@@ -84,6 +84,11 @@ describe('play.ts', () => {
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 
+    it('playImpact(PageNavigation) calls impactAsync with Medium', async () => {
+      await playImpact(ImpactMoment.PageNavigation);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
     it('playImpact(QuickAmountSelection) calls impactAsync with Light', async () => {
       await playImpact(ImpactMoment.QuickAmountSelection);
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);

--- a/app/util/haptics/play.test.ts
+++ b/app/util/haptics/play.test.ts
@@ -11,16 +11,16 @@ import {
   playWarningNotification,
   playImpact,
   playSelection,
-} from '../play';
-import { ImpactMoment } from '../catalog';
-import { shouldPlayHaptic } from '../gates';
+} from './play';
+import { ImpactMoment } from './catalog';
+import { shouldPlayHaptic } from './gates';
 
-jest.mock('../gates', () => ({
-  ...jest.requireActual<typeof import('../gates')>('../gates'),
+jest.mock('./gates', () => ({
+  ...jest.requireActual<typeof import('./gates')>('./gates'),
   shouldPlayHaptic: jest.fn(),
 }));
 
-jest.mock('../../../core/redux', () => ({
+jest.mock('../../core/redux', () => ({
   __esModule: true,
   default: {
     store: {
@@ -76,6 +76,11 @@ describe('play.ts', () => {
 
     it('playImpact(SliderTick) calls impactAsync with Light', async () => {
       await playImpact(ImpactMoment.SliderTick);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('playImpact(QuickAmountSelection) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.QuickAmountSelection);
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 

--- a/app/util/haptics/play.test.ts
+++ b/app/util/haptics/play.test.ts
@@ -119,6 +119,11 @@ describe('play.ts', () => {
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
     });
 
+    it('playImpact(FollowToggle) calls impactAsync with Light', async () => {
+      await playImpact(ImpactMoment.FollowToggle);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
     it('playSelection calls selectionAsync', async () => {
       await playSelection();
       expect(selectionAsync).toHaveBeenCalled();

--- a/app/util/haptics/play.test.ts
+++ b/app/util/haptics/play.test.ts
@@ -104,6 +104,11 @@ describe('play.ts', () => {
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
     });
 
+    it('playImpact(PrimaryCTA) calls impactAsync with Medium', async () => {
+      await playImpact(ImpactMoment.PrimaryCTA);
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
     it('playImpact(PullToRefreshEngage) calls impactAsync with Light', async () => {
       await playImpact(ImpactMoment.PullToRefreshEngage);
       expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);

--- a/app/util/haptics/play.ts
+++ b/app/util/haptics/play.ts
@@ -4,7 +4,7 @@
  * Vendor calls are centralized in `vendorPlayback.ts`; this file wires Redux
  * gate options and `withGatedPlayback`. App code imports from `app/util/haptics`.
  */
-import { shouldPlayHaptic, type HapticGateOptions } from './gates';
+import { type HapticGateOptions } from './gates';
 import { withGatedPlayback } from './gatedExecution';
 import {
   NotificationMoment,
@@ -21,6 +21,7 @@ import {
 import ReduxService from '../../core/redux';
 import { selectHapticsEnabled } from '../../selectors/settings';
 import { selectHapticsKillSwitch } from '../../selectors/featureFlagController/haptics';
+import Logger from '../Logger';
 
 /**
  * Reads Redux state to build gate options.
@@ -69,6 +70,13 @@ export async function playNotification(
       return playErrorNotification();
     case NotificationMoment.Warning:
       return playWarningNotification();
+    default: {
+      Logger.error(new Error('Unexpected haptic notification moment'), {
+        moment: moment as unknown,
+      });
+      const _exhaustive: never = moment;
+      return _exhaustive;
+    }
   }
 }
 

--- a/app/util/haptics/play.ts
+++ b/app/util/haptics/play.ts
@@ -1,0 +1,77 @@
+/**
+ * Haptic playback for non-React call sites (singleton Redux gates).
+ *
+ * Vendor calls are centralized in `vendorPlayback.ts`; this file wires Redux
+ * gate options and `withGatedPlayback`. App code imports from `app/util/haptics`.
+ */
+import { shouldPlayHaptic, type HapticGateOptions } from './gates';
+import { withGatedPlayback } from './gatedExecution';
+import {
+  NotificationMoment,
+  type HapticImpactMoment,
+  type HapticNotificationMoment,
+} from './catalog';
+import {
+  vendorImpact,
+  vendorNotifyError,
+  vendorNotifySuccess,
+  vendorNotifyWarning,
+  vendorSelection,
+} from './vendorPlayback';
+import ReduxService from '../../core/redux';
+import { selectHapticsEnabled } from '../../selectors/settings';
+import { selectHapticsKillSwitch } from '../../selectors/featureFlagController/haptics';
+
+/**
+ * Reads Redux state to build gate options.
+ * Safe to call outside React — uses the singleton store.
+ */
+function getGateOptions(): HapticGateOptions {
+  try {
+    const state = ReduxService.store.getState();
+    return {
+      reducedHaptics: !selectHapticsEnabled(state),
+      killSwitchActive: selectHapticsKillSwitch(state),
+    };
+  } catch {
+    // Store not initialized yet — allow playback (fail-open for startup flows).
+    return { reducedHaptics: false, killSwitchActive: false };
+  }
+}
+
+export async function playSuccessNotification(): Promise<void> {
+  await withGatedPlayback(getGateOptions(), vendorNotifySuccess);
+}
+
+export async function playErrorNotification(): Promise<void> {
+  await withGatedPlayback(getGateOptions(), vendorNotifyError);
+}
+
+export async function playWarningNotification(): Promise<void> {
+  await withGatedPlayback(getGateOptions(), vendorNotifyWarning);
+}
+
+export async function playImpact(moment: HapticImpactMoment): Promise<void> {
+  await withGatedPlayback(getGateOptions(), () => vendorImpact(moment));
+}
+
+/**
+ * Dispatch a notification haptic by moment string — useful for config-driven
+ * patterns (e.g. toast hooks that store the moment type on each config).
+ */
+export async function playNotification(
+  moment: HapticNotificationMoment,
+): Promise<void> {
+  switch (moment) {
+    case NotificationMoment.Success:
+      return playSuccessNotification();
+    case NotificationMoment.Error:
+      return playErrorNotification();
+    case NotificationMoment.Warning:
+      return playWarningNotification();
+  }
+}
+
+export async function playSelection(): Promise<void> {
+  await withGatedPlayback(getGateOptions(), vendorSelection);
+}

--- a/app/util/haptics/play.ts
+++ b/app/util/haptics/play.ts
@@ -4,13 +4,13 @@
  * Vendor calls are centralized in `vendorPlayback.ts`; this file wires Redux
  * gate options and `withGatedPlayback`. App code imports from `app/util/haptics`.
  */
-import { type HapticGateOptions } from './gates';
-import { withGatedPlayback } from './gatedExecution';
 import {
   NotificationMoment,
   type HapticImpactMoment,
   type HapticNotificationMoment,
 } from './catalog';
+import { type HapticGateOptions } from './gates';
+import { withGatedPlayback } from './gatedExecution';
 import {
   vendorImpact,
   vendorNotifyError,
@@ -27,7 +27,7 @@ import Logger from '../Logger';
  * Reads Redux state to build gate options.
  * Safe to call outside React — uses the singleton store.
  */
-function getGateOptions(): HapticGateOptions {
+export function getHapticGateOptions(): HapticGateOptions {
   try {
     const state = ReduxService.store.getState();
     return {
@@ -41,19 +41,19 @@ function getGateOptions(): HapticGateOptions {
 }
 
 export async function playSuccessNotification(): Promise<void> {
-  await withGatedPlayback(getGateOptions(), vendorNotifySuccess);
+  await withGatedPlayback(getHapticGateOptions(), vendorNotifySuccess);
 }
 
 export async function playErrorNotification(): Promise<void> {
-  await withGatedPlayback(getGateOptions(), vendorNotifyError);
+  await withGatedPlayback(getHapticGateOptions(), vendorNotifyError);
 }
 
 export async function playWarningNotification(): Promise<void> {
-  await withGatedPlayback(getGateOptions(), vendorNotifyWarning);
+  await withGatedPlayback(getHapticGateOptions(), vendorNotifyWarning);
 }
 
 export async function playImpact(moment: HapticImpactMoment): Promise<void> {
-  await withGatedPlayback(getGateOptions(), () => vendorImpact(moment));
+  await withGatedPlayback(getHapticGateOptions(), () => vendorImpact(moment));
 }
 
 /**
@@ -81,5 +81,5 @@ export async function playNotification(
 }
 
 export async function playSelection(): Promise<void> {
-  await withGatedPlayback(getGateOptions(), vendorSelection);
+  await withGatedPlayback(getHapticGateOptions(), vendorSelection);
 }

--- a/app/util/haptics/switchHaptic.test.ts
+++ b/app/util/haptics/switchHaptic.test.ts
@@ -13,6 +13,10 @@ jest.mock('expo-haptics', () => ({
 
 const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
 
+function getPlayModule() {
+  return jest.requireActual<typeof import('./play')>('./play');
+}
+
 describe('fireSwitchHaptic', () => {
   const originalPlatform = Platform.OS;
 
@@ -47,6 +51,34 @@ describe('fireSwitchHaptic', () => {
 
       expect(mockImpactAsync).toHaveBeenCalledTimes(1);
       expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('skips impactAsync when reduced haptics gate blocks playback', () => {
+      const spy = jest
+        .spyOn(getPlayModule(), 'getHapticGateOptions')
+        .mockReturnValue({
+          reducedHaptics: true,
+          killSwitchActive: false,
+        });
+
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('skips impactAsync when remote kill switch gate blocks playback', () => {
+      const spy = jest
+        .spyOn(getPlayModule(), 'getHapticGateOptions')
+        .mockReturnValue({
+          reducedHaptics: false,
+          killSwitchActive: true,
+        });
+
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      spy.mockRestore();
     });
   });
 

--- a/app/util/haptics/switchHaptic.ts
+++ b/app/util/haptics/switchHaptic.ts
@@ -1,30 +1,32 @@
 import { Platform } from 'react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import type { ImpactFeedbackStyle } from 'expo-haptics';
+import { withGatedPlayback } from './gatedExecution';
+import { getHapticGateOptions } from './play';
+import { vendorImpactRaw } from './vendorPlayback';
 
 /**
  * Fire a haptic for a `<Switch>` toggle, respecting iOS UISwitch's built-in
  * native tick.
  *
  * iOS UISwitch already emits a subtle native haptic on every toggle, so by
- * default this util only fires `impactAsync` on Android — layering our own
- * impact on top of the native iOS tick can read as a doubled feel,
- * especially at the `Light` strength. Pass `override: true` for elevated
- * controls (e.g. a master switch that should outrank subordinate toggles)
- * that are intentionally weightier than the native tick on both platforms.
+ * default this util only fires on Android — layering our own impact on top of
+ * the native iOS tick can read as a doubled feel, especially at the `Light`
+ * strength. Pass `override: true` for elevated controls (e.g. a master switch
+ * that should outrank subordinate toggles) that are intentionally weightier
+ * than the native tick on both platforms.
  *
- * Use plain `impactAsync` directly for non-Switch surfaces (buttons,
- * `TouchableOpacity` rows, sliders) — those have no native iOS haptic
- * to coexist with.
+ * Uses the same gates as `playImpact` / `playSelection` (in-app reduced haptics
+ * and the remote kill switch) before calling the vendor API.
  *
  * @param style - The `ImpactFeedbackStyle` to play (e.g. `Light`, `Medium`).
  * @param options.override - When `true`, also fire on iOS. Defaults to `false`.
  */
-export const fireSwitchHaptic = (
+export function fireSwitchHaptic(
   style: ImpactFeedbackStyle,
   options: { override?: boolean } = {},
-): void => {
+): void {
   if (Platform.OS === 'ios' && !options.override) {
     return;
   }
-  impactAsync(style);
-};
+  void withGatedPlayback(getHapticGateOptions(), () => vendorImpactRaw(style));
+}

--- a/app/util/haptics/testing/createHapticsJestMock.test.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.test.ts
@@ -1,0 +1,22 @@
+import { ImpactMoment, NotificationMoment } from '../catalog';
+import { createHapticsJestMock } from './createHapticsJestMock';
+
+describe('createHapticsJestMock', () => {
+  it('reuses catalog ImpactMoment and NotificationMoment references', () => {
+    const mock = createHapticsJestMock();
+    expect(mock.ImpactMoment).toBe(ImpactMoment);
+    expect(mock.NotificationMoment).toBe(NotificationMoment);
+  });
+
+  it('applies overrides after defaults', () => {
+    const customPlayImpact = jest.fn();
+    const mock = createHapticsJestMock({ playImpact: customPlayImpact });
+    expect(mock.playImpact).toBe(customPlayImpact);
+  });
+
+  it('exposes useHaptics returning the same play stubs', () => {
+    const mock = createHapticsJestMock();
+    const fromHook = mock.useHaptics();
+    expect(fromHook.playImpact).toBe(mock.playImpact);
+  });
+});

--- a/app/util/haptics/testing/createHapticsJestMock.test.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.test.ts
@@ -19,4 +19,19 @@ describe('createHapticsJestMock', () => {
     const fromHook = mock.useHaptics();
     expect(fromHook.playImpact).toBe(mock.playImpact);
   });
+
+  it('matches useHaptics production surface (no top-level-only playNotification)', () => {
+    const mock = createHapticsJestMock();
+    const fromHook = mock.useHaptics();
+    expect(fromHook).not.toHaveProperty('playNotification');
+    expect(Object.keys(fromHook).sort()).toEqual(
+      [
+        'playErrorNotification',
+        'playImpact',
+        'playSelection',
+        'playSuccessNotification',
+        'playWarningNotification',
+      ].sort(),
+    );
+  });
 });

--- a/app/util/haptics/testing/createHapticsJestMock.test.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.test.ts
@@ -14,6 +14,11 @@ describe('createHapticsJestMock', () => {
     expect(mock.playImpact).toBe(customPlayImpact);
   });
 
+  it('exposes fireSwitchHaptic as a jest mock', () => {
+    const mock = createHapticsJestMock();
+    expect(jest.isMockFunction(mock.fireSwitchHaptic)).toBe(true);
+  });
+
   it('exposes useHaptics returning the same play stubs', () => {
     const mock = createHapticsJestMock();
     const fromHook = mock.useHaptics();

--- a/app/util/haptics/testing/createHapticsJestMock.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.ts
@@ -1,0 +1,59 @@
+import { ImpactMoment, NotificationMoment } from '../catalog';
+
+export interface HapticsJestModuleMock {
+  playImpact: jest.Mock;
+  playNotification: jest.Mock;
+  playSelection: jest.Mock;
+  playSuccessNotification: jest.Mock;
+  playErrorNotification: jest.Mock;
+  playWarningNotification: jest.Mock;
+  useHaptics: jest.Mock;
+  ImpactMoment: typeof ImpactMoment;
+  NotificationMoment: typeof NotificationMoment;
+}
+
+/**
+ * Builds the mocked surface of `app/util/haptics` for Jest.
+ *
+ * For Jest, prefer `jest.mock('…/util/haptics')` with no factory so
+ * `app/util/haptics/__mocks__/index.ts` applies (no `require()`, no ESM hoisting TDZ).
+ * Use `createHapticsJestMock()` directly only in that manual mock or in unit tests
+ * for `createHapticsJestMock` itself.
+ *
+ * Reuses real `ImpactMoment` / `NotificationMoment` from the catalog; only `play*`
+ * and `useHaptics` are stubbed.
+ *
+ * @param overrides - Replace fields (e.g. `{ useHaptics: jest.fn() }` for custom hook tests).
+ */
+export function createHapticsJestMock(
+  overrides: Partial<HapticsJestModuleMock> = {},
+): HapticsJestModuleMock {
+  const playImpact = jest.fn().mockResolvedValue(undefined);
+  const playNotification = jest.fn().mockResolvedValue(undefined);
+  const playSelection = jest.fn().mockResolvedValue(undefined);
+  const playSuccessNotification = jest.fn().mockResolvedValue(undefined);
+  const playErrorNotification = jest.fn().mockResolvedValue(undefined);
+  const playWarningNotification = jest.fn().mockResolvedValue(undefined);
+
+  const useHaptics = jest.fn(() => ({
+    playSuccessNotification,
+    playErrorNotification,
+    playWarningNotification,
+    playImpact,
+    playNotification,
+    playSelection,
+  }));
+
+  return {
+    playImpact,
+    playNotification,
+    playSelection,
+    playSuccessNotification,
+    playErrorNotification,
+    playWarningNotification,
+    useHaptics,
+    ImpactMoment,
+    NotificationMoment,
+    ...overrides,
+  };
+}

--- a/app/util/haptics/testing/createHapticsJestMock.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.ts
@@ -40,7 +40,6 @@ export function createHapticsJestMock(
     playErrorNotification,
     playWarningNotification,
     playImpact,
-    playNotification,
     playSelection,
   }));
 

--- a/app/util/haptics/testing/createHapticsJestMock.ts
+++ b/app/util/haptics/testing/createHapticsJestMock.ts
@@ -1,6 +1,7 @@
 import { ImpactMoment, NotificationMoment } from '../catalog';
 
 export interface HapticsJestModuleMock {
+  fireSwitchHaptic: jest.Mock;
   playImpact: jest.Mock;
   playNotification: jest.Mock;
   playSelection: jest.Mock;
@@ -20,14 +21,15 @@ export interface HapticsJestModuleMock {
  * Use `createHapticsJestMock()` directly only in that manual mock or in unit tests
  * for `createHapticsJestMock` itself.
  *
- * Reuses real `ImpactMoment` / `NotificationMoment` from the catalog; only `play*`
- * and `useHaptics` are stubbed.
+ * Reuses real `ImpactMoment` / `NotificationMoment` from the catalog; only `play*`,
+ * `fireSwitchHaptic`, and `useHaptics` are stubbed.
  *
  * @param overrides - Replace fields (e.g. `{ useHaptics: jest.fn() }` for custom hook tests).
  */
 export function createHapticsJestMock(
   overrides: Partial<HapticsJestModuleMock> = {},
 ): HapticsJestModuleMock {
+  const fireSwitchHaptic = jest.fn();
   const playImpact = jest.fn().mockResolvedValue(undefined);
   const playNotification = jest.fn().mockResolvedValue(undefined);
   const playSelection = jest.fn().mockResolvedValue(undefined);
@@ -44,6 +46,7 @@ export function createHapticsJestMock(
   }));
 
   return {
+    fireSwitchHaptic,
     playImpact,
     playNotification,
     playSelection,

--- a/app/util/haptics/testing/index.ts
+++ b/app/util/haptics/testing/index.ts
@@ -1,0 +1,1 @@
+export { createHapticsJestMock } from './createHapticsJestMock';

--- a/app/util/haptics/useHaptics.test.ts
+++ b/app/util/haptics/useHaptics.test.ts
@@ -7,8 +7,8 @@ import {
   selectionAsync,
 } from 'expo-haptics';
 import { useSelector } from 'react-redux';
-import { ImpactMoment } from '../catalog';
-import { useHaptics } from '../useHaptics';
+import { ImpactMoment } from './catalog';
+import { useHaptics } from './useHaptics';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),

--- a/app/util/haptics/useHaptics.ts
+++ b/app/util/haptics/useHaptics.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { shouldPlayHaptic } from './gates';
 import { withGatedPlayback } from './gatedExecution';
 import { type HapticImpactMoment, type HapticsPlayer } from './catalog';
 import {

--- a/app/util/haptics/useHaptics.ts
+++ b/app/util/haptics/useHaptics.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { shouldPlayHaptic } from './gates';
+import { withGatedPlayback } from './gatedExecution';
+import { type HapticImpactMoment, type HapticsPlayer } from './catalog';
+import {
+  vendorImpact,
+  vendorNotifyError,
+  vendorNotifySuccess,
+  vendorNotifyWarning,
+  vendorSelection,
+} from './vendorPlayback';
+import { selectHapticsEnabled } from '../../selectors/settings';
+import { selectHapticsKillSwitch } from '../../selectors/featureFlagController/haptics';
+
+/**
+ * React hook that returns a stable bundle of semantic haptic functions.
+ *
+ * Reads reactive state (user preference + remote kill switch) from Redux so
+ * toggling "reduced haptics" applies immediately without app restart.
+ * Playback matches `play.ts`: gates, then try/catch with `// no-op` on failure.
+ *
+ * For non-React contexts (sagas, utilities, class components), import the
+ * plain functions from `app/util/haptics` instead.
+ */
+export function useHaptics(): HapticsPlayer {
+  const hapticsEnabled = useSelector(selectHapticsEnabled);
+  const killSwitchActive = useSelector(selectHapticsKillSwitch);
+
+  const gateOptions = useMemo(
+    () => ({
+      reducedHaptics: !hapticsEnabled,
+      killSwitchActive,
+    }),
+    [hapticsEnabled, killSwitchActive],
+  );
+
+  const playSuccessNotification = useCallback(async () => {
+    await withGatedPlayback(gateOptions, vendorNotifySuccess);
+  }, [gateOptions]);
+
+  const playErrorNotification = useCallback(async () => {
+    await withGatedPlayback(gateOptions, vendorNotifyError);
+  }, [gateOptions]);
+
+  const playWarningNotification = useCallback(async () => {
+    await withGatedPlayback(gateOptions, vendorNotifyWarning);
+  }, [gateOptions]);
+
+  const playImpact = useCallback(
+    async (moment: HapticImpactMoment) => {
+      await withGatedPlayback(gateOptions, () => vendorImpact(moment));
+    },
+    [gateOptions],
+  );
+
+  const playSelectionFn = useCallback(async () => {
+    await withGatedPlayback(gateOptions, vendorSelection);
+  }, [gateOptions]);
+
+  return useMemo(
+    () => ({
+      playSuccessNotification,
+      playErrorNotification,
+      playWarningNotification,
+      playImpact,
+      playSelection: playSelectionFn,
+    }),
+    [
+      playSuccessNotification,
+      playErrorNotification,
+      playWarningNotification,
+      playImpact,
+      playSelectionFn,
+    ],
+  );
+}

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -17,6 +17,7 @@ export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
   {
     [ImpactMoment.QuickAmountSelection]: ImpactFeedbackStyle.Light,
     [ImpactMoment.SliderTick]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.EdgeGestureEngage]: ImpactFeedbackStyle.Light,
     [ImpactMoment.SliderGrip]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.TabChange]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.PullToRefreshEngage]: ImpactFeedbackStyle.Light,

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -17,7 +17,9 @@ export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
   {
     [ImpactMoment.QuickAmountSelection]: ImpactFeedbackStyle.Light,
     [ImpactMoment.SliderTick]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.SliderGrip]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.TabChange]: ImpactFeedbackStyle.Medium,
+    [ImpactMoment.PullToRefreshEngage]: ImpactFeedbackStyle.Light,
     [ImpactMoment.PullToRefresh]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.ChartCrosshair]: ImpactFeedbackStyle.Light,
   };

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -1,0 +1,43 @@
+/**
+ * Raw expo-haptics calls — no gates, no try/catch.
+ * All `expo-haptics` imports for the haptics toolkit live here alongside `play.ts`
+ * barrel usage; `play.ts` / `useHaptics.ts` add gating and error swallowing.
+ */
+import {
+  impactAsync,
+  ImpactFeedbackStyle,
+  notificationAsync,
+  NotificationFeedbackType,
+  selectionAsync,
+} from 'expo-haptics';
+import { ImpactMoment, type HapticImpactMoment } from './catalog';
+
+/** Maps each catalog impact moment to exactly one Expo impact style. */
+export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
+  {
+    [ImpactMoment.QuickAmountSelection]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.SliderTick]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.TabChange]: ImpactFeedbackStyle.Medium,
+    [ImpactMoment.PullToRefresh]: ImpactFeedbackStyle.Medium,
+    [ImpactMoment.ChartCrosshair]: ImpactFeedbackStyle.Light,
+  };
+
+export async function vendorNotifySuccess(): Promise<void> {
+  await notificationAsync(NotificationFeedbackType.Success);
+}
+
+export async function vendorNotifyError(): Promise<void> {
+  await notificationAsync(NotificationFeedbackType.Error);
+}
+
+export async function vendorNotifyWarning(): Promise<void> {
+  await notificationAsync(NotificationFeedbackType.Warning);
+}
+
+export async function vendorImpact(moment: HapticImpactMoment): Promise<void> {
+  await impactAsync(IMPACT_STYLE_MAP[moment]);
+}
+
+export async function vendorSelection(): Promise<void> {
+  await selectionAsync();
+}

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -18,6 +18,7 @@ export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
     [ImpactMoment.QuickAmountSelection]: ImpactFeedbackStyle.Light,
     [ImpactMoment.SliderTick]: ImpactFeedbackStyle.Light,
     [ImpactMoment.EdgeGestureEngage]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.PageNavigation]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.SliderGrip]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.TabChange]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.PullToRefreshEngage]: ImpactFeedbackStyle.Light,

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -21,6 +21,7 @@ export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
     [ImpactMoment.PageNavigation]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.SliderGrip]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.TabChange]: ImpactFeedbackStyle.Medium,
+    [ImpactMoment.PrimaryCTA]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.PullToRefreshEngage]: ImpactFeedbackStyle.Light,
     [ImpactMoment.PullToRefresh]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.ChartCrosshair]: ImpactFeedbackStyle.Light,

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -24,6 +24,7 @@ export const IMPACT_STYLE_MAP: Record<HapticImpactMoment, ImpactFeedbackStyle> =
     [ImpactMoment.PullToRefreshEngage]: ImpactFeedbackStyle.Light,
     [ImpactMoment.PullToRefresh]: ImpactFeedbackStyle.Medium,
     [ImpactMoment.ChartCrosshair]: ImpactFeedbackStyle.Light,
+    [ImpactMoment.FollowToggle]: ImpactFeedbackStyle.Light,
   };
 
 export async function vendorNotifySuccess(): Promise<void> {

--- a/app/util/haptics/vendorPlayback.ts
+++ b/app/util/haptics/vendorPlayback.ts
@@ -42,6 +42,13 @@ export async function vendorImpact(moment: HapticImpactMoment): Promise<void> {
   await impactAsync(IMPACT_STYLE_MAP[moment]);
 }
 
+/** Direct Expo impact style — for dev preview / tooling only (not gated at call site). */
+export async function vendorImpactRaw(
+  style: ImpactFeedbackStyle,
+): Promise<void> {
+  await impactAsync(style);
+}
+
 export async function vendorSelection(): Promise<void> {
   await selectionAsync();
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6302,7 +6302,7 @@
     "your_stablecoins": "Your stablecoins"
   },
   "money": {
-    "title": "Money 2",
+    "title": "Money",
     "apy_label": "{{percentage}}% APY",
     "apy_info_label": "APY info",
     "onboarding": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3275,6 +3275,8 @@
     "invalid_number_range": "Invalid number. Enter a number between 1 and %{maxSafeChainId}",
     "hide_zero_balance_tokens_title": "Hide tokens without balance",
     "hide_zero_balance_tokens_desc": "Prevents tokens with no balance from displaying in your token listing.",
+    "haptic_feedback_title": "Haptic feedback",
+    "haptic_feedback_desc": "Feel subtle vibrations for confirmations, errors, and interactions. Disable to reduce haptic stimuli.",
     "token_detection_title": "Autodetect tokens",
     "token_detection_description": "We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to pull data from those services.",
     "theme_button_text": "Change theme",
@@ -6300,7 +6302,7 @@
     "your_stablecoins": "Your stablecoins"
   },
   "money": {
-    "title": "Money",
+    "title": "Money 2",
     "apy_label": "{{percentage}}% APY",
     "apy_info_label": "APY info",
     "onboarding": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3596,7 +3596,8 @@
           "tab_change": "Impact — Tab change",
           "pull_to_refresh_engage": "Impact — Pull to refresh (engage)",
           "pull_to_refresh": "Impact — Pull to refresh (release)",
-          "chart_crosshair": "Impact — Chart crosshair"
+          "chart_crosshair": "Impact — Chart crosshair",
+          "follow_toggle": "Impact — Follow toggle"
         },
         "raw_styles": {
           "light": "Raw impact — Light",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3594,6 +3594,7 @@
           "page_navigation": "Impact — Page navigation",
           "slider_grip": "Impact — Slider grip",
           "tab_change": "Impact — Tab change",
+          "primary_cta": "Impact — Primary CTA",
           "pull_to_refresh_engage": "Impact — Pull to refresh (engage)",
           "pull_to_refresh": "Impact — Pull to refresh (release)",
           "chart_crosshair": "Impact — Chart crosshair",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3574,6 +3574,37 @@
         "title": "Card",
         "reset_onboarding_description": "Reset Card onboarding state to start the onboarding flow from the beginning.",
         "reset_onboarding_button": "Reset Onboarding State"
+      },
+      "haptics": {
+        "title": "Haptics",
+        "description": "Preview haptic feedback on a physical device. This bypasses in-app reduced-haptics and the remote kill switch so you can evaluate each pattern. Simulators often do not play haptics.",
+        "catalog_impacts_heading": "Catalog impact moments",
+        "notifications_heading": "Notification patterns",
+        "selection_heading": "Selection",
+        "notification_success_button": "Notification — Success",
+        "notification_error_button": "Notification — Error",
+        "notification_warning_button": "Notification — Warning",
+        "selection_button": "Selection",
+        "raw_impacts_heading": "Raw Expo impact styles",
+        "raw_impacts_desc": "Direct expo-haptics impact styles for comparison with the mapped catalog moments above.",
+        "impacts": {
+          "quick_amount_selection": "Impact — Quick amount selection",
+          "slider_tick": "Impact — Slider tick",
+          "edge_gesture_engage": "Impact — Edge gesture engage",
+          "page_navigation": "Impact — Page navigation",
+          "slider_grip": "Impact — Slider grip",
+          "tab_change": "Impact — Tab change",
+          "pull_to_refresh_engage": "Impact — Pull to refresh (engage)",
+          "pull_to_refresh": "Impact — Pull to refresh (release)",
+          "chart_crosshair": "Impact — Chart crosshair"
+        },
+        "raw_styles": {
+          "light": "Raw impact — Light",
+          "medium": "Raw impact — Medium",
+          "heavy": "Raw impact — Heavy",
+          "rigid": "Raw impact — Rigid",
+          "soft": "Raw impact — Soft"
+        }
       }
     },
     "feature_flag_override": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6478,7 +6478,7 @@
     "your_stablecoins": "Your stablecoins"
   },
   "money": {
-    "title": "Money 2",
+    "title": "Money",
     "apy_label": "{{percentage}}% APY",
     "apy_info_label": "APY info",
     "onboarding": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3314,6 +3314,8 @@
     "invalid_number_range": "Invalid number. Enter a number between 1 and %{maxSafeChainId}",
     "hide_zero_balance_tokens_title": "Hide tokens without balance",
     "hide_zero_balance_tokens_desc": "Prevents tokens with no balance from displaying in your token listing.",
+    "haptic_feedback_title": "Haptic feedback",
+    "haptic_feedback_desc": "Feel subtle vibrations for confirmations, errors, and interactions. Disable to reduce haptic stimuli.",
     "token_detection_title": "Autodetect tokens",
     "token_detection_description": "We use third-party APIs to detect and display new tokens sent to your wallet. Turn off if you don’t want the app to pull data from those services.",
     "theme_button_text": "Change theme",
@@ -6476,7 +6478,7 @@
     "your_stablecoins": "Your stablecoins"
   },
   "money": {
-    "title": "Money",
+    "title": "Money 2",
     "apy_label": "{{percentage}}% APY",
     "apy_info_label": "APY info",
     "onboarding": {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -62,7 +62,7 @@ export interface FeatureFlagRegistryEntry {
  * Remote flag values are stored in the exact format returned by the production
  * client-config API, so they can be served directly by the E2E mock server.
  *
- * Production defaults last synced: 2026-04-07
+ * Production defaults last synced: 2026-04-20
  * Source: https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=prod
  */
 export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
@@ -769,6 +769,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       enabled: false,
+      minimumVersion: '7.70.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -793,6 +794,303 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      contracts: {
+        '0x19': [
+          {
+            signature:
+              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos',
+          },
+        ],
+        '0xa4ba': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Nova',
+            signature:
+              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
+          },
+        ],
+        '0x8f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad',
+            signature:
+              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
+          },
+        ],
+        '0x1079': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo',
+            signature:
+              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
+          },
+        ],
+        '0x1012': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea',
+            signature:
+              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
+          },
+        ],
+        '0x18c6': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'MegaEth Testnet',
+            signature:
+              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
+          },
+        ],
+        '0xe708': [
+          {
+            signature:
+              '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Linea',
+          },
+        ],
+        '0x61': [
+          {
+            signature:
+              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB Testnet',
+          },
+        ],
+        '0x82': [
+          {
+            signature:
+              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Mainnet',
+          },
+        ],
+        '0xaa36a7': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sepolia - Official',
+            signature:
+              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
+          },
+          {
+            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
+            name: 'Sepolia - Testing',
+            signature:
+              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
+          },
+        ],
+        '0x13882': [
+          {
+            signature:
+              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon Amoy Testnet',
+          },
+        ],
+        '0x2105': [
+          {
+            name: 'Base',
+            signature:
+              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x38': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB',
+            signature:
+              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
+          },
+        ],
+        '0xa5bf': [
+          {
+            name: 'Tempo Testnet',
+            signature:
+              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa4ec': [
+          {
+            signature:
+              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Mainnet',
+          },
+        ],
+        '0x89': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon',
+            signature:
+              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
+          },
+        ],
+        '0x3909': [
+          {
+            signature:
+              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Testnet',
+          },
+        ],
+        '0x14a34': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base Sepolia',
+            signature:
+              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
+          },
+        ],
+        '0x515': [
+          {
+            signature:
+              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Sepolia',
+          },
+        ],
+        '0x66eee': [
+          {
+            name: 'Arbitrum Sepolia',
+            signature:
+              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138c5': [
+          {
+            name: 'Berachain Testnet',
+            signature:
+              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xaa37dc': [
+          {
+            name: 'Optimism Sepolia',
+            signature:
+              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x531': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Mainnet',
+            signature:
+              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
+          },
+        ],
+        '0xaa044c': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Sepolia',
+            signature:
+              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
+          },
+        ],
+        '0x88bb0': [
+          {
+            signature:
+              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Hoodi Testnet',
+          },
+        ],
+        '0x13fb': [
+          {
+            signature:
+              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea Testnet',
+          },
+        ],
+        '0x530': [
+          {
+            name: 'Sei Testnet',
+            signature:
+              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x1': [
+          {
+            name: 'Mainnet',
+            signature:
+              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x152': [
+          {
+            name: 'Cronos Testnet',
+            signature:
+              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138de': [
+          {
+            name: 'Berachain',
+            signature:
+              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Optimism',
+            signature:
+              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
+          },
+        ],
+        '0x64': [
+          {
+            name: 'Gnosis',
+            signature:
+              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x279f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad Testnet',
+            signature:
+              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
+          },
+        ],
+        '0x27d8': [
+          {
+            signature:
+              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Chiado',
+          },
+        ],
+        '0xa4b1': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum One',
+            signature:
+              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
+          },
+        ],
+        '0x92': [
+          {
+            name: 'Sonic Mainnet',
+            signature:
+              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+      },
+      name: 'main',
       supportedChains: [
         '0x1',
         '0x1012',
@@ -829,296 +1127,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0xaa044c',
         '0xaa36a7',
         '0xaa37dc',
+        '0xe708',
       ],
-      contracts: {
-        '0x152': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos Testnet',
-            signature:
-              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
-          },
-        ],
-        '0x13fb': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea Testnet',
-            signature:
-              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
-          },
-        ],
-        '0xa4ec': [
-          {
-            name: 'Celo Mainnet',
-            signature:
-              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x138c5': [
-          {
-            signature:
-              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain Testnet',
-          },
-        ],
-        '0x88bb0': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Hoodi Testnet',
-            signature:
-              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
-          },
-        ],
-        '0x13882': [
-          {
-            name: 'Polygon Amoy Testnet',
-            signature:
-              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa37dc': [
-          {
-            name: 'Optimism Sepolia',
-            signature:
-              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x61': [
-          {
-            name: 'BNB Testnet',
-            signature:
-              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x8f': [
-          {
-            name: 'Monad',
-            signature:
-              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x515': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Sepolia',
-            signature:
-              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
-          },
-        ],
-        '0x531': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sei Mainnet',
-            signature:
-              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
-          },
-        ],
-        '0x279f': [
-          {
-            name: 'Monad Testnet',
-            signature:
-              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x27d8': [
-          {
-            name: 'Chiado',
-            signature:
-              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x18c6': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'MegaEth Testnet',
-            signature:
-              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
-          },
-        ],
-        '0xa4ba': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum Nova',
-            signature:
-              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
-          },
-        ],
-        '0x66eee': [
-          {
-            name: 'Arbitrum Sepolia',
-            signature:
-              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x19': [
-          {
-            signature:
-              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos',
-          },
-        ],
-        '0x1079': [
-          {
-            name: 'Tempo',
-            signature:
-              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x89': [
-          {
-            signature:
-              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon',
-          },
-        ],
-        '0xaa36a7': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sepolia - Official',
-            signature:
-              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
-          },
-          {
-            name: 'Sepolia - Testing',
-            signature:
-              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
-            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
-          },
-        ],
-        '0x92': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Mainnet',
-            signature:
-              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
-          },
-        ],
-        '0x3909': [
-          {
-            signature:
-              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Testnet',
-          },
-        ],
-        '0x530': [
-          {
-            name: 'Sei Testnet',
-            signature:
-              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x38': [
-          {
-            name: 'BNB',
-            signature:
-              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa044c': [
-          {
-            signature:
-              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Celo Sepolia',
-          },
-        ],
-        '0x2105': [
-          {
-            signature:
-              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base',
-          },
-        ],
-        '0xa': [
-          {
-            signature:
-              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Optimism',
-          },
-        ],
-        '0x138de': [
-          {
-            signature:
-              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain',
-          },
-        ],
-        '0x82': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Mainnet',
-            signature:
-              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
-          },
-        ],
-        '0xa5bf': [
-          {
-            signature:
-              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Tempo Testnet',
-          },
-        ],
-        '0x1': [
-          {
-            signature:
-              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Mainnet',
-          },
-        ],
-        '0x64': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Gnosis',
-            signature:
-              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
-          },
-        ],
-        '0x1012': [
-          {
-            name: 'Citrea',
-            signature:
-              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x14a34': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base Sepolia',
-            signature:
-              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
-          },
-        ],
-        '0xa4b1': [
-          {
-            name: 'Arbitrum One',
-            signature:
-              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-      },
-      name: 'main',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1434,7 +1444,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      enabled: false,
+      useBackendWebSocketService: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1444,7 +1454,65 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      relayDisabledGasStationChains: [],
+      bufferStep: 0.015,
+      bufferSubsequent: 0.05,
+      stxDisabled: false,
+      perpsWithdrawAnyToken: false,
+      relayFallbackGas: {
+        max: '1500001',
+        estimate: '900001',
+      },
+      slippageTokens: {
+        '0xa4b1': {
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
+          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
+          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
+        },
+        '0xe708': {
+          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
+          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+        },
+        '0x1': {
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x2105': {
+          '0x4200000000000000000000000000000000000006': 0.005,
+          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
+          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x38': {
+          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
+          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
+          '0x55d398326f99059fF775485246999027B3197955': 0.005,
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x89': {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
+          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
+          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
+          '0x0000000000000000000000000000000000001010': 0.005,
+          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
+        },
+      },
+      slippage: 0.02,
+      bufferInitial: 0.015,
       allowedPredictWithdrawTokens: {
+        '0x38': [
+          '0x0000000000000000000000000000000000000000',
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+        ],
         '0x89': [
           '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
           '0x0000000000000000000000000000000000000000',
@@ -1454,67 +1522,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           '0x0000000000000000000000000000000000000000',
           '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         ],
-        '0x38': [
-          '0x0000000000000000000000000000000000000000',
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-        ],
       },
       relayQuoteUrl: 'https://bridge.api.cx.metamask.io/relay/quote/v2',
-      bufferInitial: 0.015,
-      relayDisabledGasStationChains: [],
-      predictWithdrawAnyToken: true,
-      slippage: 0.02,
-      relayFallbackGas: {
-        estimate: '900001',
-        max: '1500001',
-      },
-      bufferSubsequent: 0.05,
       attemptsMax: 4,
-      slippageTokens: {
-        '0xe708': {
-          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
-          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x1': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
-        },
-        '0x2105': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x4200000000000000000000000000000000000006': 0.005,
-          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
-          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
-        },
-        '0x38': {
-          '0x55d398326f99059fF775485246999027B3197955': 0.005,
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
-          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
-        },
-        '0x89': {
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
-          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
-          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
-          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
-          '0x0000000000000000000000000000000000001010': 0.005,
-        },
-        '0xa4b1': {
-          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
-          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
-          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-      },
-      bufferStep: 0.015,
-      perpsWithdrawAnyToken: false,
+      predictWithdrawAnyToken: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1574,45 +1585,72 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedTokens: {
-        default: {
-          tokens: [
-            {
-              chainId: '0x1',
-              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-            },
-          ],
-          chainIds: [],
-        },
-        overrides: {
-          perpsDeposit: {
-            chainIds: [],
-            tokens: [
-              {
-                chainId: '0x38',
-                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
-              },
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-            ],
-          },
-          predictDeposit: {
-            chainIds: [],
-            tokens: [
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-            ],
-          },
-        },
-      },
       minimumRequiredTokenBalance: 10,
       preferredTokens: {
         default: [],
         overrides: {
+          predictDeposit: [
+            {
+              successRate: 88.47,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x1',
+              name: 'ETH',
+            },
+            {
+              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+              chainId: '0x89',
+              name: 'USDC',
+              successRate: 87.55,
+            },
+            {
+              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+              chainId: '0x89',
+              name: 'USDC.e',
+              successRate: 90.04,
+            },
+            {
+              successRate: 88.36,
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
+              chainId: '0x1',
+              name: 'USDC',
+            },
+            {
+              name: 'BNB',
+              successRate: 92.22,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x38',
+            },
+            {
+              chainId: '0x1',
+              name: 'USDT',
+              successRate: 88.5,
+              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+            },
+            {
+              chainId: '0x89',
+              name: 'POL',
+              successRate: 94.08,
+              address: '0x0000000000000000000000000000000000000000',
+            },
+            {
+              name: 'USDT',
+              successRate: 89.34,
+              address: '0x55d398326f99059fF775485246999027B3197955',
+              chainId: '0x38',
+            },
+            {
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
+              chainId: '0x1',
+              name: 'MUSD',
+              successRate: 93.61,
+            },
+            {
+              successRate: 90,
+              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+              chainId: '0x89',
+              name: 'WETH',
+            },
+          ],
           predictWithdraw: [
             {
               address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
@@ -1622,22 +1660,22 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           ],
           perpsDeposit: [
             {
-              name: 'ETH',
-              successRate: 93.89,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x1',
+              name: 'ETH',
+              successRate: 93.89,
             },
             {
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
               chainId: '0x1',
               name: 'USDC',
               successRate: 93.17,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
             },
             {
-              chainId: '0xa4b1',
-              name: 'USDC',
               successRate: 90.73,
               address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+              chainId: '0xa4b1',
+              name: 'USDC',
             },
             {
               address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -1646,40 +1684,40 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 90.4,
             },
             {
-              address: '0x55d398326f99059fF775485246999027B3197955',
               chainId: '0x38',
               name: 'USDT',
               successRate: 91.4,
+              address: '0x55d398326f99059fF775485246999027B3197955',
             },
             {
-              successRate: 96.55,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0xa4b1',
               name: 'ETH',
+              successRate: 96.55,
             },
             {
-              name: 'ETH',
-              successRate: 91.15,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x2105',
+              name: 'ETH',
+              successRate: 91.15,
             },
             {
-              successRate: 97.5,
               address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
               chainId: '0xa4b1',
               name: 'USDT',
+              successRate: 97.5,
             },
             {
-              chainId: '0x38',
-              name: 'USDC',
               successRate: 96.38,
               address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+              chainId: '0x38',
+              name: 'USDC',
             },
             {
-              chainId: '0x38',
               name: 'BNB',
               successRate: 89.94,
               address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x38',
             },
             {
               name: 'POL',
@@ -1688,74 +1726,66 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               chainId: '0x89',
             },
             {
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
               chainId: '0x1',
               name: 'MUSD',
               successRate: 96.66,
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
             },
           ],
-          predictDeposit: [
+          perpsWithdraw: [
             {
-              address: '0x0000000000000000000000000000000000000000',
+              address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
               chainId: '0x1',
-              name: 'ETH',
-              successRate: 88.47,
+              name: 'mUSD',
             },
+          ],
+        },
+      },
+      blockedTokens: {
+        default: {
+          tokens: [
             {
-              name: 'USDC',
-              successRate: 87.55,
-              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-              chainId: '0x89',
-            },
-            {
-              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-              chainId: '0x89',
-              name: 'USDC.e',
-              successRate: 90.04,
-            },
-            {
-              name: 'USDC',
-              successRate: 88.36,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
+              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
               chainId: '0x1',
             },
             {
               chainId: '0x38',
-              name: 'BNB',
-              successRate: 92.22,
-              address: '0x0000000000000000000000000000000000000000',
-            },
-            {
-              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-              chainId: '0x1',
-              name: 'USDT',
-              successRate: 88.5,
-            },
-            {
-              successRate: 94.08,
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x89',
-              name: 'POL',
-            },
-            {
-              successRate: 89.34,
-              address: '0x55d398326f99059fF775485246999027B3197955',
-              chainId: '0x38',
-              name: 'USDT',
-            },
-            {
-              chainId: '0x1',
-              name: 'MUSD',
-              successRate: 93.61,
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
-            },
-            {
-              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
-              chainId: '0x89',
-              name: 'WETH',
-              successRate: 90,
+              address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
             },
           ],
+          chainIds: [],
+        },
+        overrides: {
+          predictDeposit: {
+            chainIds: [],
+            tokens: [
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+              {
+                chainId: '0x38',
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              },
+            ],
+          },
+          perpsDeposit: {
+            tokens: [
+              {
+                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
+                chainId: '0x38',
+              },
+              {
+                chainId: '0x1',
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+              },
+              {
+                chainId: '0x38',
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              },
+            ],
+            chainIds: [],
+          },
         },
       },
     },
@@ -2773,7 +2803,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   earnMoneyHubEnabled: {
     name: 'earnMoneyHubEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '0.0.0',
@@ -2889,8 +2919,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '0.0.0',
-      enabled: false,
+      minimumVersion: '7.72.0',
+      enabled: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2908,7 +2938,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      chainIds: [],
+      chainIds: ['0x1', '0xe708'],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3032,9 +3062,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      '0x38': false,
-      '0x531': false,
       '0x8f': true,
+      '0x38': false,
+      '0x531': true,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  hapticsKillSwitch: {
+    name: 'hapticsKillSwitch',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3123,7 +3164,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   moneyActivityMockDataEnabled: {
     name: 'moneyActivityMockDataEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
@@ -3338,7 +3379,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedRegions: ['BE', 'US', 'CA-ON', 'GB'],
+      blockedRegions: ['BE', 'US', 'CA-ON', 'GB', 'CU', 'IR', 'KP', 'SY'],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3925,7 +3966,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'tronClaimUnstakedTrxButtonEnabled',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: false,
+    productionDefault: true,
     status: FeatureFlagStatus.Active,
   },
 
@@ -4049,17 +4090,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  moneyEnableMoneyTab: {
-    name: 'moneyEnableMoneyTab',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      minimumVersion: '0.0.0',
-      enabled: false,
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   perpsDefaultPayTokenWhenNoBalanceEnabled: {
     name: 'perpsDefaultPayTokenWhenNoBalanceEnabled',
     type: FeatureFlagType.Remote,
@@ -4129,6 +4159,213 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: {
       allowedEvents: [],
       allowedTraits: [],
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+  extensionUxPna25: {
+    name: 'extensionUxPna25',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: true,
+    status: FeatureFlagStatus.Active,
+  },
+
+  homepageRedesignV1: {
+    name: 'homepageRedesignV1',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: true,
+      minimumVersion: '7.59',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  moneyAccountVaultConfig: {
+    name: 'moneyAccountVaultConfig',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      accountantAddress: '0x800ebc3B74F67EaC27C9CCE4E4FF28b17CdCA173',
+      boringVault: '0xB5F07d769dD60fE54c97dd53101181073DDf21b2',
+      chainId: '0x',
+      lensAddress: '0x846a7832022350434B5cC006d07cc9c782469660',
+      tellerAddress: '0x86821F179eaD9F0b3C79b2f8deF0227eEBFDc9f9',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  predictClobV2: {
+    name: 'predictClobV2',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  predictExtendedSportsMarkets: {
+    name: 'predictExtendedSportsMarkets',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      leagues: [],
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  stickyButtonsAbTest: {
+    name: 'stickyButtonsAbTest',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationBatchStatus: {
+    name: 'stxMigrationBatchStatus',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+        value: true,
+      },
+      {
+        name: 'sentinel off',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationCancel: {
+    name: 'stxMigrationCancel',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'sentinel on',
+        scope: {
+          value: 0,
+          type: 'threshold',
+        },
+        value: true,
+      },
+      {
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+        name: 'sentinel off',
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationGetFees: {
+    name: 'stxMigrationGetFees',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: true,
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+      },
+      {
+        value: false,
+        name: 'sentinel off',
+        scope: {
+          value: 1,
+          type: 'threshold',
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationSubmitTransactions: {
+    name: 'stxMigrationSubmitTransactions',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: true,
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+      },
+      {
+        name: 'sentinel off',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  tokenDetailsV2AbTest: {
+    name: 'tokenDetailsV2AbTest',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: {
+          minimumVersion: '7.69.0',
+          variant: 'control',
+        },
+        name: 'Control is ON',
+        scope: {
+          value: 0,
+          type: 'threshold',
+        },
+      },
+      {
+        name: 'Control is OFF',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: {
+          minimumVersion: '7.69.0',
+          variant: 'treatment',
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  walletHomeOnboardingSteps: {
+    name: 'walletHomeOnboardingSteps',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -62,7 +62,7 @@ export interface FeatureFlagRegistryEntry {
  * Remote flag values are stored in the exact format returned by the production
  * client-config API, so they can be served directly by the E2E mock server.
  *
- * Production defaults last synced: 2026-04-07
+ * Production defaults last synced: 2026-04-20
  * Source: https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=prod
  */
 export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
@@ -769,6 +769,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       enabled: false,
+      minimumVersion: '7.70.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -793,6 +794,303 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      contracts: {
+        '0x19': [
+          {
+            signature:
+              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos',
+          },
+        ],
+        '0xa4ba': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Nova',
+            signature:
+              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
+          },
+        ],
+        '0x8f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad',
+            signature:
+              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
+          },
+        ],
+        '0x1079': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo',
+            signature:
+              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
+          },
+        ],
+        '0x1012': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea',
+            signature:
+              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
+          },
+        ],
+        '0x18c6': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'MegaEth Testnet',
+            signature:
+              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
+          },
+        ],
+        '0xe708': [
+          {
+            signature:
+              '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Linea',
+          },
+        ],
+        '0x61': [
+          {
+            signature:
+              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB Testnet',
+          },
+        ],
+        '0x82': [
+          {
+            signature:
+              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Mainnet',
+          },
+        ],
+        '0xaa36a7': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sepolia - Official',
+            signature:
+              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
+          },
+          {
+            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
+            name: 'Sepolia - Testing',
+            signature:
+              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
+          },
+        ],
+        '0x13882': [
+          {
+            signature:
+              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon Amoy Testnet',
+          },
+        ],
+        '0x2105': [
+          {
+            name: 'Base',
+            signature:
+              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x38': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB',
+            signature:
+              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
+          },
+        ],
+        '0xa5bf': [
+          {
+            name: 'Tempo Testnet',
+            signature:
+              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa4ec': [
+          {
+            signature:
+              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Mainnet',
+          },
+        ],
+        '0x89': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon',
+            signature:
+              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
+          },
+        ],
+        '0x3909': [
+          {
+            signature:
+              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Testnet',
+          },
+        ],
+        '0x14a34': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base Sepolia',
+            signature:
+              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
+          },
+        ],
+        '0x515': [
+          {
+            signature:
+              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Sepolia',
+          },
+        ],
+        '0x66eee': [
+          {
+            name: 'Arbitrum Sepolia',
+            signature:
+              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138c5': [
+          {
+            name: 'Berachain Testnet',
+            signature:
+              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xaa37dc': [
+          {
+            name: 'Optimism Sepolia',
+            signature:
+              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x531': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Mainnet',
+            signature:
+              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
+          },
+        ],
+        '0xaa044c': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Sepolia',
+            signature:
+              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
+          },
+        ],
+        '0x88bb0': [
+          {
+            signature:
+              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Hoodi Testnet',
+          },
+        ],
+        '0x13fb': [
+          {
+            signature:
+              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea Testnet',
+          },
+        ],
+        '0x530': [
+          {
+            name: 'Sei Testnet',
+            signature:
+              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x1': [
+          {
+            name: 'Mainnet',
+            signature:
+              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x152': [
+          {
+            name: 'Cronos Testnet',
+            signature:
+              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138de': [
+          {
+            name: 'Berachain',
+            signature:
+              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Optimism',
+            signature:
+              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
+          },
+        ],
+        '0x64': [
+          {
+            name: 'Gnosis',
+            signature:
+              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x279f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad Testnet',
+            signature:
+              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
+          },
+        ],
+        '0x27d8': [
+          {
+            signature:
+              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Chiado',
+          },
+        ],
+        '0xa4b1': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum One',
+            signature:
+              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
+          },
+        ],
+        '0x92': [
+          {
+            name: 'Sonic Mainnet',
+            signature:
+              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+      },
+      name: 'main',
       supportedChains: [
         '0x1',
         '0x1012',
@@ -829,296 +1127,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0xaa044c',
         '0xaa36a7',
         '0xaa37dc',
+        '0xe708',
       ],
-      contracts: {
-        '0x152': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos Testnet',
-            signature:
-              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
-          },
-        ],
-        '0x13fb': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea Testnet',
-            signature:
-              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
-          },
-        ],
-        '0xa4ec': [
-          {
-            name: 'Celo Mainnet',
-            signature:
-              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x138c5': [
-          {
-            signature:
-              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain Testnet',
-          },
-        ],
-        '0x88bb0': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Hoodi Testnet',
-            signature:
-              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
-          },
-        ],
-        '0x13882': [
-          {
-            name: 'Polygon Amoy Testnet',
-            signature:
-              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa37dc': [
-          {
-            name: 'Optimism Sepolia',
-            signature:
-              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x61': [
-          {
-            name: 'BNB Testnet',
-            signature:
-              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x8f': [
-          {
-            name: 'Monad',
-            signature:
-              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x515': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Sepolia',
-            signature:
-              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
-          },
-        ],
-        '0x531': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sei Mainnet',
-            signature:
-              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
-          },
-        ],
-        '0x279f': [
-          {
-            name: 'Monad Testnet',
-            signature:
-              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x27d8': [
-          {
-            name: 'Chiado',
-            signature:
-              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x18c6': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'MegaEth Testnet',
-            signature:
-              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
-          },
-        ],
-        '0xa4ba': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum Nova',
-            signature:
-              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
-          },
-        ],
-        '0x66eee': [
-          {
-            name: 'Arbitrum Sepolia',
-            signature:
-              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x19': [
-          {
-            signature:
-              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos',
-          },
-        ],
-        '0x1079': [
-          {
-            name: 'Tempo',
-            signature:
-              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x89': [
-          {
-            signature:
-              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon',
-          },
-        ],
-        '0xaa36a7': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sepolia - Official',
-            signature:
-              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
-          },
-          {
-            name: 'Sepolia - Testing',
-            signature:
-              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
-            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
-          },
-        ],
-        '0x92': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Mainnet',
-            signature:
-              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
-          },
-        ],
-        '0x3909': [
-          {
-            signature:
-              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Testnet',
-          },
-        ],
-        '0x530': [
-          {
-            name: 'Sei Testnet',
-            signature:
-              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x38': [
-          {
-            name: 'BNB',
-            signature:
-              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa044c': [
-          {
-            signature:
-              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Celo Sepolia',
-          },
-        ],
-        '0x2105': [
-          {
-            signature:
-              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base',
-          },
-        ],
-        '0xa': [
-          {
-            signature:
-              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Optimism',
-          },
-        ],
-        '0x138de': [
-          {
-            signature:
-              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain',
-          },
-        ],
-        '0x82': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Mainnet',
-            signature:
-              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
-          },
-        ],
-        '0xa5bf': [
-          {
-            signature:
-              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Tempo Testnet',
-          },
-        ],
-        '0x1': [
-          {
-            signature:
-              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Mainnet',
-          },
-        ],
-        '0x64': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Gnosis',
-            signature:
-              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
-          },
-        ],
-        '0x1012': [
-          {
-            name: 'Citrea',
-            signature:
-              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x14a34': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base Sepolia',
-            signature:
-              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
-          },
-        ],
-        '0xa4b1': [
-          {
-            name: 'Arbitrum One',
-            signature:
-              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-      },
-      name: 'main',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1434,7 +1444,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      enabled: false,
+      useBackendWebSocketService: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1444,7 +1454,65 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      relayDisabledGasStationChains: [],
+      bufferStep: 0.015,
+      bufferSubsequent: 0.05,
+      stxDisabled: false,
+      perpsWithdrawAnyToken: false,
+      relayFallbackGas: {
+        max: '1500001',
+        estimate: '900001',
+      },
+      slippageTokens: {
+        '0xa4b1': {
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
+          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
+          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
+        },
+        '0xe708': {
+          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
+          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+        },
+        '0x1': {
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x2105': {
+          '0x4200000000000000000000000000000000000006': 0.005,
+          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
+          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x38': {
+          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
+          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
+          '0x55d398326f99059fF775485246999027B3197955': 0.005,
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x89': {
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
+          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
+          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
+          '0x0000000000000000000000000000000000001010': 0.005,
+          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
+        },
+      },
+      slippage: 0.02,
+      bufferInitial: 0.015,
       allowedPredictWithdrawTokens: {
+        '0x38': [
+          '0x0000000000000000000000000000000000000000',
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+        ],
         '0x89': [
           '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
           '0x0000000000000000000000000000000000000000',
@@ -1454,67 +1522,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           '0x0000000000000000000000000000000000000000',
           '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         ],
-        '0x38': [
-          '0x0000000000000000000000000000000000000000',
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-        ],
       },
       relayQuoteUrl: 'https://bridge.api.cx.metamask.io/relay/quote/v2',
-      bufferInitial: 0.015,
-      relayDisabledGasStationChains: [],
-      predictWithdrawAnyToken: true,
-      slippage: 0.02,
-      relayFallbackGas: {
-        estimate: '900001',
-        max: '1500001',
-      },
-      bufferSubsequent: 0.05,
       attemptsMax: 4,
-      slippageTokens: {
-        '0xe708': {
-          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
-          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x1': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
-        },
-        '0x2105': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x4200000000000000000000000000000000000006': 0.005,
-          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
-          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
-        },
-        '0x38': {
-          '0x55d398326f99059fF775485246999027B3197955': 0.005,
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
-          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
-        },
-        '0x89': {
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
-          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
-          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
-          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
-          '0x0000000000000000000000000000000000001010': 0.005,
-        },
-        '0xa4b1': {
-          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
-          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
-          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-      },
-      bufferStep: 0.015,
-      perpsWithdrawAnyToken: false,
+      predictWithdrawAnyToken: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1574,45 +1585,72 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedTokens: {
-        default: {
-          tokens: [
-            {
-              chainId: '0x1',
-              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-            },
-          ],
-          chainIds: [],
-        },
-        overrides: {
-          perpsDeposit: {
-            chainIds: [],
-            tokens: [
-              {
-                chainId: '0x38',
-                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
-              },
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-            ],
-          },
-          predictDeposit: {
-            chainIds: [],
-            tokens: [
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-            ],
-          },
-        },
-      },
       minimumRequiredTokenBalance: 10,
       preferredTokens: {
         default: [],
         overrides: {
+          predictDeposit: [
+            {
+              successRate: 88.47,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x1',
+              name: 'ETH',
+            },
+            {
+              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+              chainId: '0x89',
+              name: 'USDC',
+              successRate: 87.55,
+            },
+            {
+              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+              chainId: '0x89',
+              name: 'USDC.e',
+              successRate: 90.04,
+            },
+            {
+              successRate: 88.36,
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
+              chainId: '0x1',
+              name: 'USDC',
+            },
+            {
+              name: 'BNB',
+              successRate: 92.22,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x38',
+            },
+            {
+              chainId: '0x1',
+              name: 'USDT',
+              successRate: 88.5,
+              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+            },
+            {
+              chainId: '0x89',
+              name: 'POL',
+              successRate: 94.08,
+              address: '0x0000000000000000000000000000000000000000',
+            },
+            {
+              name: 'USDT',
+              successRate: 89.34,
+              address: '0x55d398326f99059fF775485246999027B3197955',
+              chainId: '0x38',
+            },
+            {
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
+              chainId: '0x1',
+              name: 'MUSD',
+              successRate: 93.61,
+            },
+            {
+              successRate: 90,
+              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+              chainId: '0x89',
+              name: 'WETH',
+            },
+          ],
           predictWithdraw: [
             {
               address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
@@ -1622,22 +1660,22 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           ],
           perpsDeposit: [
             {
-              name: 'ETH',
-              successRate: 93.89,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x1',
+              name: 'ETH',
+              successRate: 93.89,
             },
             {
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
               chainId: '0x1',
               name: 'USDC',
               successRate: 93.17,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
             },
             {
-              chainId: '0xa4b1',
-              name: 'USDC',
               successRate: 90.73,
               address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+              chainId: '0xa4b1',
+              name: 'USDC',
             },
             {
               address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -1646,40 +1684,40 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 90.4,
             },
             {
-              address: '0x55d398326f99059fF775485246999027B3197955',
               chainId: '0x38',
               name: 'USDT',
               successRate: 91.4,
+              address: '0x55d398326f99059fF775485246999027B3197955',
             },
             {
-              successRate: 96.55,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0xa4b1',
               name: 'ETH',
+              successRate: 96.55,
             },
             {
-              name: 'ETH',
-              successRate: 91.15,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0x2105',
+              name: 'ETH',
+              successRate: 91.15,
             },
             {
-              successRate: 97.5,
               address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
               chainId: '0xa4b1',
               name: 'USDT',
+              successRate: 97.5,
             },
             {
-              chainId: '0x38',
-              name: 'USDC',
               successRate: 96.38,
               address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+              chainId: '0x38',
+              name: 'USDC',
             },
             {
-              chainId: '0x38',
               name: 'BNB',
               successRate: 89.94,
               address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x38',
             },
             {
               name: 'POL',
@@ -1688,74 +1726,66 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               chainId: '0x89',
             },
             {
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
               chainId: '0x1',
               name: 'MUSD',
               successRate: 96.66,
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
             },
           ],
-          predictDeposit: [
+          perpsWithdraw: [
             {
-              address: '0x0000000000000000000000000000000000000000',
+              address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
               chainId: '0x1',
-              name: 'ETH',
-              successRate: 88.47,
+              name: 'mUSD',
             },
+          ],
+        },
+      },
+      blockedTokens: {
+        default: {
+          tokens: [
             {
-              name: 'USDC',
-              successRate: 87.55,
-              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-              chainId: '0x89',
-            },
-            {
-              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-              chainId: '0x89',
-              name: 'USDC.e',
-              successRate: 90.04,
-            },
-            {
-              name: 'USDC',
-              successRate: 88.36,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
+              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
               chainId: '0x1',
             },
             {
               chainId: '0x38',
-              name: 'BNB',
-              successRate: 92.22,
-              address: '0x0000000000000000000000000000000000000000',
-            },
-            {
-              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-              chainId: '0x1',
-              name: 'USDT',
-              successRate: 88.5,
-            },
-            {
-              successRate: 94.08,
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x89',
-              name: 'POL',
-            },
-            {
-              successRate: 89.34,
-              address: '0x55d398326f99059fF775485246999027B3197955',
-              chainId: '0x38',
-              name: 'USDT',
-            },
-            {
-              chainId: '0x1',
-              name: 'MUSD',
-              successRate: 93.61,
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
-            },
-            {
-              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
-              chainId: '0x89',
-              name: 'WETH',
-              successRate: 90,
+              address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
             },
           ],
+          chainIds: [],
+        },
+        overrides: {
+          predictDeposit: {
+            chainIds: [],
+            tokens: [
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+              {
+                chainId: '0x38',
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              },
+            ],
+          },
+          perpsDeposit: {
+            tokens: [
+              {
+                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
+                chainId: '0x38',
+              },
+              {
+                chainId: '0x1',
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+              },
+              {
+                chainId: '0x38',
+                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              },
+            ],
+            chainIds: [],
+          },
         },
       },
     },
@@ -2773,7 +2803,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   earnMoneyHubEnabled: {
     name: 'earnMoneyHubEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: {
       enabled: false,
       minimumVersion: '0.0.0',
@@ -2889,8 +2919,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '0.0.0',
-      enabled: false,
+      minimumVersion: '7.72.0',
+      enabled: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2908,7 +2938,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      chainIds: [],
+      chainIds: ['0x1', '0xe708'],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3032,9 +3062,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      '0x38': false,
-      '0x531': false,
       '0x8f': true,
+      '0x38': false,
+      '0x531': true,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  hapticsKillSwitch: {
+    name: 'hapticsKillSwitch',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3137,7 +3178,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   moneyActivityMockDataEnabled: {
     name: 'moneyActivityMockDataEnabled',
     type: FeatureFlagType.Remote,
-    inProd: false,
+    inProd: true,
     productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
@@ -3352,7 +3393,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedRegions: ['BE', 'US', 'CA-ON', 'GB'],
+      blockedRegions: ['BE', 'US', 'CA-ON', 'GB', 'CU', 'IR', 'KP', 'SY'],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3939,7 +3980,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'tronClaimUnstakedTrxButtonEnabled',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: false,
+    productionDefault: true,
     status: FeatureFlagStatus.Active,
   },
 
@@ -4063,17 +4104,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  moneyEnableMoneyTab: {
-    name: 'moneyEnableMoneyTab',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      minimumVersion: '0.0.0',
-      enabled: false,
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   perpsDefaultPayTokenWhenNoBalanceEnabled: {
     name: 'perpsDefaultPayTokenWhenNoBalanceEnabled',
     type: FeatureFlagType.Remote,
@@ -4143,6 +4173,213 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: {
       allowedEvents: [],
       allowedTraits: [],
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+  extensionUxPna25: {
+    name: 'extensionUxPna25',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: true,
+    status: FeatureFlagStatus.Active,
+  },
+
+  homepageRedesignV1: {
+    name: 'homepageRedesignV1',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: true,
+      minimumVersion: '7.59',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  moneyAccountVaultConfig: {
+    name: 'moneyAccountVaultConfig',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      accountantAddress: '0x800ebc3B74F67EaC27C9CCE4E4FF28b17CdCA173',
+      boringVault: '0xB5F07d769dD60fE54c97dd53101181073DDf21b2',
+      chainId: '0x',
+      lensAddress: '0x846a7832022350434B5cC006d07cc9c782469660',
+      tellerAddress: '0x86821F179eaD9F0b3C79b2f8deF0227eEBFDc9f9',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  predictClobV2: {
+    name: 'predictClobV2',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  predictExtendedSportsMarkets: {
+    name: 'predictExtendedSportsMarkets',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      leagues: [],
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  stickyButtonsAbTest: {
+    name: 'stickyButtonsAbTest',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationBatchStatus: {
+    name: 'stxMigrationBatchStatus',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+        value: true,
+      },
+      {
+        name: 'sentinel off',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationCancel: {
+    name: 'stxMigrationCancel',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'sentinel on',
+        scope: {
+          value: 0,
+          type: 'threshold',
+        },
+        value: true,
+      },
+      {
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+        name: 'sentinel off',
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationGetFees: {
+    name: 'stxMigrationGetFees',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: true,
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+      },
+      {
+        value: false,
+        name: 'sentinel off',
+        scope: {
+          value: 1,
+          type: 'threshold',
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  stxMigrationSubmitTransactions: {
+    name: 'stxMigrationSubmitTransactions',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: true,
+        name: 'sentinel on',
+        scope: {
+          type: 'threshold',
+          value: 0,
+        },
+      },
+      {
+        name: 'sentinel off',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: false,
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  tokenDetailsV2AbTest: {
+    name: 'tokenDetailsV2AbTest',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        value: {
+          minimumVersion: '7.69.0',
+          variant: 'control',
+        },
+        name: 'Control is ON',
+        scope: {
+          value: 0,
+          type: 'threshold',
+        },
+      },
+      {
+        name: 'Control is OFF',
+        scope: {
+          type: 'threshold',
+          value: 1,
+        },
+        value: {
+          minimumVersion: '7.69.0',
+          variant: 'treatment',
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
+  walletHomeOnboardingSteps: {
+    name: 'walletHomeOnboardingSteps',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4196,20 +4196,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  moneyAccountVaultConfig: {
-    name: 'moneyAccountVaultConfig',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      accountantAddress: '0x800ebc3B74F67EaC27C9CCE4E4FF28b17CdCA173',
-      boringVault: '0xB5F07d769dD60fE54c97dd53101181073DDf21b2',
-      chainId: '0x',
-      lensAddress: '0x846a7832022350434B5cC006d07cc9c782469660',
-      tellerAddress: '0x86821F179eaD9F0b3C79b2f8deF0227eEBFDc9f9',
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   predictClobV2: {
     name: 'predictClobV2',
     type: FeatureFlagType.Remote,

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -62,7 +62,7 @@ export interface FeatureFlagRegistryEntry {
  * Remote flag values are stored in the exact format returned by the production
  * client-config API, so they can be served directly by the E2E mock server.
  *
- * Production defaults last synced: 2026-04-20
+ * Production defaults last synced: 2026-04-07
  * Source: https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=main&environment=prod
  */
 export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
@@ -769,7 +769,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       enabled: false,
-      minimumVersion: '7.70.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -794,303 +793,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      contracts: {
-        '0x19': [
-          {
-            signature:
-              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos',
-          },
-        ],
-        '0xa4ba': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum Nova',
-            signature:
-              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
-          },
-        ],
-        '0x8f': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad',
-            signature:
-              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
-          },
-        ],
-        '0x1079': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Tempo',
-            signature:
-              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
-          },
-        ],
-        '0x1012': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea',
-            signature:
-              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
-          },
-        ],
-        '0x18c6': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'MegaEth Testnet',
-            signature:
-              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
-          },
-        ],
-        '0xe708': [
-          {
-            signature:
-              '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Linea',
-          },
-        ],
-        '0x61': [
-          {
-            signature:
-              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'BNB Testnet',
-          },
-        ],
-        '0x82': [
-          {
-            signature:
-              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Mainnet',
-          },
-        ],
-        '0xaa36a7': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sepolia - Official',
-            signature:
-              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
-          },
-          {
-            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
-            name: 'Sepolia - Testing',
-            signature:
-              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
-          },
-        ],
-        '0x13882': [
-          {
-            signature:
-              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon Amoy Testnet',
-          },
-        ],
-        '0x2105': [
-          {
-            name: 'Base',
-            signature:
-              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x38': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'BNB',
-            signature:
-              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
-          },
-        ],
-        '0xa5bf': [
-          {
-            name: 'Tempo Testnet',
-            signature:
-              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xa4ec': [
-          {
-            signature:
-              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Celo Mainnet',
-          },
-        ],
-        '0x89': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon',
-            signature:
-              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
-          },
-        ],
-        '0x3909': [
-          {
-            signature:
-              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Testnet',
-          },
-        ],
-        '0x14a34': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Base Sepolia',
-            signature:
-              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
-          },
-        ],
-        '0x515': [
-          {
-            signature:
-              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Sepolia',
-          },
-        ],
-        '0x66eee': [
-          {
-            name: 'Arbitrum Sepolia',
-            signature:
-              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x138c5': [
-          {
-            name: 'Berachain Testnet',
-            signature:
-              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa37dc': [
-          {
-            name: 'Optimism Sepolia',
-            signature:
-              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x531': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sei Mainnet',
-            signature:
-              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
-          },
-        ],
-        '0xaa044c': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Celo Sepolia',
-            signature:
-              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
-          },
-        ],
-        '0x88bb0': [
-          {
-            signature:
-              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Hoodi Testnet',
-          },
-        ],
-        '0x13fb': [
-          {
-            signature:
-              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea Testnet',
-          },
-        ],
-        '0x530': [
-          {
-            name: 'Sei Testnet',
-            signature:
-              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x1': [
-          {
-            name: 'Mainnet',
-            signature:
-              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x152': [
-          {
-            name: 'Cronos Testnet',
-            signature:
-              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x138de': [
-          {
-            name: 'Berachain',
-            signature:
-              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xa': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Optimism',
-            signature:
-              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
-          },
-        ],
-        '0x64': [
-          {
-            name: 'Gnosis',
-            signature:
-              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x279f': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad Testnet',
-            signature:
-              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
-          },
-        ],
-        '0x27d8': [
-          {
-            signature:
-              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Chiado',
-          },
-        ],
-        '0xa4b1': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum One',
-            signature:
-              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
-          },
-        ],
-        '0x92': [
-          {
-            name: 'Sonic Mainnet',
-            signature:
-              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-      },
-      name: 'main',
       supportedChains: [
         '0x1',
         '0x1012',
@@ -1127,8 +829,296 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0xaa044c',
         '0xaa36a7',
         '0xaa37dc',
-        '0xe708',
       ],
+      contracts: {
+        '0x152': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos Testnet',
+            signature:
+              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
+          },
+        ],
+        '0x13fb': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Citrea Testnet',
+            signature:
+              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
+          },
+        ],
+        '0xa4ec': [
+          {
+            name: 'Celo Mainnet',
+            signature:
+              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138c5': [
+          {
+            signature:
+              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Berachain Testnet',
+          },
+        ],
+        '0x88bb0': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Hoodi Testnet',
+            signature:
+              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
+          },
+        ],
+        '0x13882': [
+          {
+            name: 'Polygon Amoy Testnet',
+            signature:
+              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xaa37dc': [
+          {
+            name: 'Optimism Sepolia',
+            signature:
+              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x61': [
+          {
+            name: 'BNB Testnet',
+            signature:
+              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x8f': [
+          {
+            name: 'Monad',
+            signature:
+              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x515': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Sepolia',
+            signature:
+              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
+          },
+        ],
+        '0x531': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Mainnet',
+            signature:
+              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
+          },
+        ],
+        '0x279f': [
+          {
+            name: 'Monad Testnet',
+            signature:
+              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x27d8': [
+          {
+            name: 'Chiado',
+            signature:
+              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x18c6': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'MegaEth Testnet',
+            signature:
+              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
+          },
+        ],
+        '0xa4ba': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Nova',
+            signature:
+              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
+          },
+        ],
+        '0x66eee': [
+          {
+            name: 'Arbitrum Sepolia',
+            signature:
+              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x19': [
+          {
+            signature:
+              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos',
+          },
+        ],
+        '0x1079': [
+          {
+            name: 'Tempo',
+            signature:
+              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x89': [
+          {
+            signature:
+              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon',
+          },
+        ],
+        '0xaa36a7': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sepolia - Official',
+            signature:
+              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
+          },
+          {
+            name: 'Sepolia - Testing',
+            signature:
+              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
+            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
+          },
+        ],
+        '0x92': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Mainnet',
+            signature:
+              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
+          },
+        ],
+        '0x3909': [
+          {
+            signature:
+              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sonic Testnet',
+          },
+        ],
+        '0x530': [
+          {
+            name: 'Sei Testnet',
+            signature:
+              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x38': [
+          {
+            name: 'BNB',
+            signature:
+              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xaa044c': [
+          {
+            signature:
+              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Celo Sepolia',
+          },
+        ],
+        '0x2105': [
+          {
+            signature:
+              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base',
+          },
+        ],
+        '0xa': [
+          {
+            signature:
+              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Optimism',
+          },
+        ],
+        '0x138de': [
+          {
+            signature:
+              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Berachain',
+          },
+        ],
+        '0x82': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Mainnet',
+            signature:
+              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
+          },
+        ],
+        '0xa5bf': [
+          {
+            signature:
+              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo Testnet',
+          },
+        ],
+        '0x1': [
+          {
+            signature:
+              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Mainnet',
+          },
+        ],
+        '0x64': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Gnosis',
+            signature:
+              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
+          },
+        ],
+        '0x1012': [
+          {
+            name: 'Citrea',
+            signature:
+              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x14a34': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base Sepolia',
+            signature:
+              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
+          },
+        ],
+        '0xa4b1': [
+          {
+            name: 'Arbitrum One',
+            signature:
+              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+      },
+      name: 'main',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1444,7 +1434,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      useBackendWebSocketService: true,
+      enabled: false,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1454,65 +1444,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      relayDisabledGasStationChains: [],
-      bufferStep: 0.015,
-      bufferSubsequent: 0.05,
-      stxDisabled: false,
-      perpsWithdrawAnyToken: false,
-      relayFallbackGas: {
-        max: '1500001',
-        estimate: '900001',
-      },
-      slippageTokens: {
-        '0xa4b1': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
-          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
-          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
-        },
-        '0xe708': {
-          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
-          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-        },
-        '0x1': {
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x2105': {
-          '0x4200000000000000000000000000000000000006': 0.005,
-          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
-          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x38': {
-          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
-          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
-          '0x55d398326f99059fF775485246999027B3197955': 0.005,
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x89': {
-          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
-          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
-          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
-          '0x0000000000000000000000000000000000001010': 0.005,
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
-        },
-      },
-      slippage: 0.02,
-      bufferInitial: 0.015,
       allowedPredictWithdrawTokens: {
-        '0x38': [
-          '0x0000000000000000000000000000000000000000',
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-        ],
         '0x89': [
           '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
           '0x0000000000000000000000000000000000000000',
@@ -1522,10 +1454,67 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           '0x0000000000000000000000000000000000000000',
           '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         ],
+        '0x38': [
+          '0x0000000000000000000000000000000000000000',
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+        ],
       },
       relayQuoteUrl: 'https://bridge.api.cx.metamask.io/relay/quote/v2',
-      attemptsMax: 4,
+      bufferInitial: 0.015,
+      relayDisabledGasStationChains: [],
       predictWithdrawAnyToken: true,
+      slippage: 0.02,
+      relayFallbackGas: {
+        estimate: '900001',
+        max: '1500001',
+      },
+      bufferSubsequent: 0.05,
+      attemptsMax: 4,
+      slippageTokens: {
+        '0xe708': {
+          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
+          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+        '0x1': {
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
+          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
+          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
+        },
+        '0x2105': {
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x4200000000000000000000000000000000000006': 0.005,
+          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
+          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
+        },
+        '0x38': {
+          '0x55d398326f99059fF775485246999027B3197955': 0.005,
+          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
+          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
+        },
+        '0x89': {
+          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
+          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
+          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
+          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
+          '0x0000000000000000000000000000000000001010': 0.005,
+        },
+        '0xa4b1': {
+          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
+          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
+          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
+          '0x0000000000000000000000000000000000000000': 0.005,
+        },
+      },
+      bufferStep: 0.015,
+      perpsWithdrawAnyToken: false,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1585,72 +1574,45 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      blockedTokens: {
+        default: {
+          tokens: [
+            {
+              chainId: '0x1',
+              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+            },
+          ],
+          chainIds: [],
+        },
+        overrides: {
+          perpsDeposit: {
+            chainIds: [],
+            tokens: [
+              {
+                chainId: '0x38',
+                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
+              },
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+            ],
+          },
+          predictDeposit: {
+            chainIds: [],
+            tokens: [
+              {
+                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+                chainId: '0x1',
+              },
+            ],
+          },
+        },
+      },
       minimumRequiredTokenBalance: 10,
       preferredTokens: {
         default: [],
         overrides: {
-          predictDeposit: [
-            {
-              successRate: 88.47,
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x1',
-              name: 'ETH',
-            },
-            {
-              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-              chainId: '0x89',
-              name: 'USDC',
-              successRate: 87.55,
-            },
-            {
-              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-              chainId: '0x89',
-              name: 'USDC.e',
-              successRate: 90.04,
-            },
-            {
-              successRate: 88.36,
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
-              chainId: '0x1',
-              name: 'USDC',
-            },
-            {
-              name: 'BNB',
-              successRate: 92.22,
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x38',
-            },
-            {
-              chainId: '0x1',
-              name: 'USDT',
-              successRate: 88.5,
-              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-            },
-            {
-              chainId: '0x89',
-              name: 'POL',
-              successRate: 94.08,
-              address: '0x0000000000000000000000000000000000000000',
-            },
-            {
-              name: 'USDT',
-              successRate: 89.34,
-              address: '0x55d398326f99059fF775485246999027B3197955',
-              chainId: '0x38',
-            },
-            {
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
-              chainId: '0x1',
-              name: 'MUSD',
-              successRate: 93.61,
-            },
-            {
-              successRate: 90,
-              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
-              chainId: '0x89',
-              name: 'WETH',
-            },
-          ],
           predictWithdraw: [
             {
               address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
@@ -1660,22 +1622,22 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
           ],
           perpsDeposit: [
             {
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x1',
               name: 'ETH',
               successRate: 93.89,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x1',
             },
             {
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
               chainId: '0x1',
               name: 'USDC',
               successRate: 93.17,
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
             },
             {
-              successRate: 90.73,
-              address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
               chainId: '0xa4b1',
               name: 'USDC',
+              successRate: 90.73,
+              address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
             },
             {
               address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
@@ -1684,40 +1646,40 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               successRate: 90.4,
             },
             {
+              address: '0x55d398326f99059fF775485246999027B3197955',
               chainId: '0x38',
               name: 'USDT',
               successRate: 91.4,
-              address: '0x55d398326f99059fF775485246999027B3197955',
             },
             {
+              successRate: 96.55,
               address: '0x0000000000000000000000000000000000000000',
               chainId: '0xa4b1',
               name: 'ETH',
-              successRate: 96.55,
             },
             {
-              address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x2105',
               name: 'ETH',
               successRate: 91.15,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x2105',
             },
             {
+              successRate: 97.5,
               address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
               chainId: '0xa4b1',
               name: 'USDT',
-              successRate: 97.5,
             },
             {
-              successRate: 96.38,
-              address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
               chainId: '0x38',
               name: 'USDC',
+              successRate: 96.38,
+              address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
             },
             {
+              chainId: '0x38',
               name: 'BNB',
               successRate: 89.94,
               address: '0x0000000000000000000000000000000000000000',
-              chainId: '0x38',
             },
             {
               name: 'POL',
@@ -1726,66 +1688,74 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
               chainId: '0x89',
             },
             {
-              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
               chainId: '0x1',
               name: 'MUSD',
               successRate: 96.66,
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
             },
           ],
-          perpsWithdraw: [
+          predictDeposit: [
             {
-              address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+              address: '0x0000000000000000000000000000000000000000',
               chainId: '0x1',
-              name: 'mUSD',
+              name: 'ETH',
+              successRate: 88.47,
             },
-          ],
-        },
-      },
-      blockedTokens: {
-        default: {
-          tokens: [
             {
-              address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+              name: 'USDC',
+              successRate: 87.55,
+              address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+              chainId: '0x89',
+            },
+            {
+              address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+              chainId: '0x89',
+              name: 'USDC.e',
+              successRate: 90.04,
+            },
+            {
+              name: 'USDC',
+              successRate: 88.36,
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eb48',
               chainId: '0x1',
             },
             {
               chainId: '0x38',
-              address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
+              name: 'BNB',
+              successRate: 92.22,
+              address: '0x0000000000000000000000000000000000000000',
+            },
+            {
+              address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+              chainId: '0x1',
+              name: 'USDT',
+              successRate: 88.5,
+            },
+            {
+              successRate: 94.08,
+              address: '0x0000000000000000000000000000000000000000',
+              chainId: '0x89',
+              name: 'POL',
+            },
+            {
+              successRate: 89.34,
+              address: '0x55d398326f99059fF775485246999027B3197955',
+              chainId: '0x38',
+              name: 'USDT',
+            },
+            {
+              chainId: '0x1',
+              name: 'MUSD',
+              successRate: 93.61,
+              address: '0xe2fceAc20813592220b8C56999000d08C7844E6c',
+            },
+            {
+              address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+              chainId: '0x89',
+              name: 'WETH',
+              successRate: 90,
             },
           ],
-          chainIds: [],
-        },
-        overrides: {
-          predictDeposit: {
-            chainIds: [],
-            tokens: [
-              {
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-                chainId: '0x1',
-              },
-              {
-                chainId: '0x38',
-                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-              },
-            ],
-          },
-          perpsDeposit: {
-            tokens: [
-              {
-                address: '0x33A3d962955A3862C8093D1273344719f03cA17C',
-                chainId: '0x38',
-              },
-              {
-                chainId: '0x1',
-                address: '0x66a3c2fa3e467aa586e90912f977e648589cabaf',
-              },
-              {
-                chainId: '0x38',
-                address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-              },
-            ],
-            chainIds: [],
-          },
         },
       },
     },
@@ -2803,7 +2773,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   earnMoneyHubEnabled: {
     name: 'earnMoneyHubEnabled',
     type: FeatureFlagType.Remote,
-    inProd: true,
+    inProd: false,
     productionDefault: {
       enabled: false,
       minimumVersion: '0.0.0',
@@ -2919,8 +2889,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '7.72.0',
-      enabled: true,
+      minimumVersion: '0.0.0',
+      enabled: false,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2938,7 +2908,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      chainIds: ['0x1', '0xe708'],
+      chainIds: [],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3062,9 +3032,9 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      '0x8f': true,
       '0x38': false,
-      '0x531': true,
+      '0x531': false,
+      '0x8f': true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3178,7 +3148,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
   moneyActivityMockDataEnabled: {
     name: 'moneyActivityMockDataEnabled',
     type: FeatureFlagType.Remote,
-    inProd: true,
+    inProd: false,
     productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
@@ -3393,7 +3363,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedRegions: ['BE', 'US', 'CA-ON', 'GB', 'CU', 'IR', 'KP', 'SY'],
+      blockedRegions: ['BE', 'US', 'CA-ON', 'GB'],
     },
     status: FeatureFlagStatus.Active,
   },
@@ -3980,7 +3950,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'tronClaimUnstakedTrxButtonEnabled',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: true,
+    productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
 
@@ -4104,6 +4074,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  moneyEnableMoneyTab: {
+    name: 'moneyEnableMoneyTab',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      minimumVersion: '0.0.0',
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   perpsDefaultPayTokenWhenNoBalanceEnabled: {
     name: 'perpsDefaultPayTokenWhenNoBalanceEnabled',
     type: FeatureFlagType.Remote,
@@ -4173,199 +4154,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: {
       allowedEvents: [],
       allowedTraits: [],
-      enabled: false,
-    },
-    status: FeatureFlagStatus.Active,
-  },
-  extensionUxPna25: {
-    name: 'extensionUxPna25',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: true,
-    status: FeatureFlagStatus.Active,
-  },
-
-  homepageRedesignV1: {
-    name: 'homepageRedesignV1',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      enabled: true,
-      minimumVersion: '7.59',
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
-  predictClobV2: {
-    name: 'predictClobV2',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      enabled: false,
-      minimumVersion: '0.0.0',
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
-  predictExtendedSportsMarkets: {
-    name: 'predictExtendedSportsMarkets',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      enabled: false,
-      leagues: [],
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
-  stickyButtonsAbTest: {
-    name: 'stickyButtonsAbTest',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      enabled: false,
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
-  stxMigrationBatchStatus: {
-    name: 'stxMigrationBatchStatus',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: [
-      {
-        name: 'sentinel on',
-        scope: {
-          type: 'threshold',
-          value: 0,
-        },
-        value: true,
-      },
-      {
-        name: 'sentinel off',
-        scope: {
-          type: 'threshold',
-          value: 1,
-        },
-        value: false,
-      },
-    ],
-    status: FeatureFlagStatus.Active,
-  },
-
-  stxMigrationCancel: {
-    name: 'stxMigrationCancel',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: [
-      {
-        name: 'sentinel on',
-        scope: {
-          value: 0,
-          type: 'threshold',
-        },
-        value: true,
-      },
-      {
-        scope: {
-          type: 'threshold',
-          value: 1,
-        },
-        value: false,
-        name: 'sentinel off',
-      },
-    ],
-    status: FeatureFlagStatus.Active,
-  },
-
-  stxMigrationGetFees: {
-    name: 'stxMigrationGetFees',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: [
-      {
-        value: true,
-        name: 'sentinel on',
-        scope: {
-          type: 'threshold',
-          value: 0,
-        },
-      },
-      {
-        value: false,
-        name: 'sentinel off',
-        scope: {
-          value: 1,
-          type: 'threshold',
-        },
-      },
-    ],
-    status: FeatureFlagStatus.Active,
-  },
-
-  stxMigrationSubmitTransactions: {
-    name: 'stxMigrationSubmitTransactions',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: [
-      {
-        value: true,
-        name: 'sentinel on',
-        scope: {
-          type: 'threshold',
-          value: 0,
-        },
-      },
-      {
-        name: 'sentinel off',
-        scope: {
-          type: 'threshold',
-          value: 1,
-        },
-        value: false,
-      },
-    ],
-    status: FeatureFlagStatus.Active,
-  },
-
-  tokenDetailsV2AbTest: {
-    name: 'tokenDetailsV2AbTest',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: [
-      {
-        value: {
-          minimumVersion: '7.69.0',
-          variant: 'control',
-        },
-        name: 'Control is ON',
-        scope: {
-          value: 0,
-          type: 'threshold',
-        },
-      },
-      {
-        name: 'Control is OFF',
-        scope: {
-          type: 'threshold',
-          value: 1,
-        },
-        value: {
-          minimumVersion: '7.69.0',
-          variant: 'treatment',
-        },
-      },
-    ],
-    status: FeatureFlagStatus.Active,
-  },
-
-  walletHomeOnboardingSteps: {
-    name: 'walletHomeOnboardingSteps',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      enabled: false,
-      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Reason:** Haptic feedback was invoked via scattered `expo-haptics` imports, with no shared semantics, no user or remote kill switch, and no single place to swap implementations (e.g. future Nitro path).

**Solution:** Introduced `app/util/haptics/` as the only package allowed to call `expo-haptics` (via `vendorPlayback.ts`), with:

- **Semantic API:** `playSuccessNotification`, `playErrorNotification`, `playWarningNotification`, `playNotification(moment)`, `playImpact(moment)`, `playSelection`, plus `useHaptics()` for reactive Redux-driven playback.
- **Gates:** `gates.ts` + `gatedExecution.ts` — web blocked, in-app preference (`hapticsEnabled` in settings), remote `hapticsKillSwitch` feature flag; vendor calls wrapped so failures never break flows.
- **Catalog:** Typed notification/impact moments in `catalog.ts` with JSDoc; README documents principles and how to add moments.
- **Settings:** General Settings toggle + `en.json` strings for haptic feedback on/off.
- **Lint:** `no-restricted-imports` blocks `expo-haptics` outside `app/util/haptics/**`.
- **Tests:** Unit tests for gates, play paths, and `useHaptics`; existing toast/feature tests updated to mock `app/util/haptics` / `NotificationMoment`.

**Call sites migrated:** Earn / Perps / Rewards toasts, Compliance access restricted, Perps close/cancel flows, Trade tab bar, browser gesture wrapper, Perps slider & leverage sheet, TradingView chart, Predict line selector (and associated tests).

**i18n:** New strings are in `locales/languages/en.json` only in this branch; mirror `app_settings.haptic_feedback_*` into other locale files if your release process requires parity before merge.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a General Settings toggle for haptic feedback and centralized in-app haptics behind a single module, with an optional remote kill switch.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Haptics toolkit and settings

  Scenario: User disables haptic feedback in settings
    Given the user is on General Settings
    When the user turns off "Haptic feedback"
    Then subsequent actions that previously triggered haptics (e.g. Perps toast success, tab trade button) should not vibrate

  Scenario: User enables haptic feedback and sees a success toast
    Given haptic feedback is enabled in General Settings
    And the remote haptics kill switch flag is not forcing playback off
    When the user completes a flow that shows a success toast with haptics (e.g. Earn / Perps / Rewards)
    Then the toast appears and a success-style haptic plays (device and OS settings permitting)

  Scenario: Compliance access restricted uses warning-style haptic
    Given haptic feedback is enabled
    When the user triggers the access restricted experience that shows the compliance modal
    Then a warning-style haptic may play aligned with the modal (OS permitting)

  Scenario: Remote kill switch disables all haptics
    Given haptic feedback is enabled in app settings
    And remote feature flag `hapticsKillSwitch` is true (e.g. via feature flag overrides in dev)
    When the user performs actions that would normally trigger haptics
    Then no haptic playback occurs

  Scenario: Impact moments on trading and browser surfaces
    Given haptic feedback is enabled
    When the user uses the Perps slider, leverage quick-select, trade tab bar, browser pull-to-refresh / edge gestures, chart crosshair updates, or Predict line selector
    Then corresponding light/medium/selection haptics fire without crashing the app if native haptics fail
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many user-interaction surfaces and introduces new gating/feature-flag logic that could unintentionally suppress or change haptic behavior across the app. Fail-safe error swallowing reduces crash risk, but behavior regressions are plausible without broad device testing.
> 
> **Overview**
> **Centralizes all haptic feedback behind a new `app/util/haptics` toolkit** with a typed catalog (`ImpactMoment`/`NotificationMoment`), gated playback (app setting + remote kill switch + platform check), and a single vendor layer; adds ESLint restrictions to prevent direct `expo-haptics` imports outside this module.
> 
> Adds a General Settings toggle (`hapticsEnabled`) and a version-gated remote feature flag (`hapticsKillSwitch`) to disable haptics globally, plus a Developer Options section to manually trigger catalog/raw haptics.
> 
> Migrates multiple call sites (Perps/Earn/Rewards toasts, browser gestures, sliders/leverage, TradingView chart, Predict, compliance modal, social trading UI) and updates tests to mock the new haptics module and assert semantic moments rather than `expo-haptics` APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934c4d8a2fc843a720d0f8b6d451d46647f0fa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->