### PR TITLE
fix: sticky buttons should be same on market insights cp-7.74.0

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -27,23 +27,33 @@ const mockGate = jest.fn((fn: () => Promise<void>) => fn());
 const mockPerpsTrack = jest.fn();
 let mockIsEligible = true;
 
+const mockTokenETH = {
+  address: '0x123',
+  symbol: 'ETH',
+  name: 'Ethereum',
+  image: 'https://example.com/eth.png',
+  logo: 'https://example.com/eth.png',
+  balance: '1.5',
+  isETH: true,
+  isNative: true,
+  decimals: 18,
+  chainId: '0x1',
+};
+
 let mockRouteParams: {
   assetSymbol: string;
   assetIdentifier: string;
   tokenImageUrl?: string;
-  tokenAddress?: string;
-  tokenDecimals?: number;
-  tokenName?: string;
   tokenChainId?: string;
   isPerps?: boolean;
+  hasPerpsPosition?: boolean;
+  token?: Record<string, unknown>;
 } = {
   assetSymbol: 'ETH',
   assetIdentifier: 'eip155:1/erc20:0x123',
   tokenImageUrl: 'https://example.com/eth.png',
-  tokenAddress: '0x123',
-  tokenDecimals: 18,
-  tokenName: 'Ethereum',
   tokenChainId: '0x1',
+  token: mockTokenETH,
 };
 
 jest.mock('@react-navigation/native', () => {
@@ -312,10 +322,8 @@ describe('MarketInsightsView', () => {
       assetSymbol: 'ETH',
       assetIdentifier: 'eip155:1/erc20:0x123',
       tokenImageUrl: 'https://example.com/eth.png',
-      tokenAddress: '0x123',
-      tokenDecimals: 18,
-      tokenName: 'Ethereum',
       tokenChainId: '0x1',
+      token: mockTokenETH,
     };
   });
 
@@ -710,8 +718,14 @@ describe('MarketInsightsView', () => {
       ...mockRouteParams,
       assetSymbol: 'USDC',
       assetIdentifier: 'eip155:1/erc20:0x456',
-      tokenAddress: '0x456',
-      tokenName: 'USD Coin',
+      token: {
+        ...mockTokenETH,
+        address: '0x456',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        isETH: false,
+        isNative: false,
+      },
     };
 
     rerender(<MarketInsightsView />);
@@ -1208,8 +1222,14 @@ describe('MarketInsightsView', () => {
       ...mockRouteParams,
       assetSymbol: 'USDC',
       assetIdentifier: 'eip155:1/erc20:0x456',
-      tokenAddress: '0x456',
-      tokenName: 'USD Coin',
+      token: {
+        ...mockTokenETH,
+        address: '0x456',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        isETH: false,
+        isNative: false,
+      },
     };
 
     mockUseMarketInsights.mockReturnValue({
@@ -1260,7 +1280,7 @@ describe('MarketInsightsView', () => {
     );
   });
 
-  describe('token object construction for useTokenActions', () => {
+  describe('token object passed to useTokenActions', () => {
     const mockReport = {
       asset: 'eth',
       generatedAt: '2026-02-17T11:55:00.000Z',
@@ -1279,52 +1299,45 @@ describe('MarketInsightsView', () => {
       });
     });
 
-    it('passes isNative and isETH as true when tokenAddress is absent (native token)', () => {
-      mockRouteParams = {
-        assetSymbol: 'ETH',
-        assetIdentifier: 'eip155:1/slip44:60',
-        tokenImageUrl: 'https://example.com/eth.png',
-        tokenName: 'Ethereum',
-        tokenChainId: '0x1',
-        // tokenAddress intentionally omitted
-      };
-
+    it('passes the route token directly to useTokenActions (same object as Token Details)', () => {
       renderWithProvider(<MarketInsightsView />);
 
       expect(mockUseTokenActions).toHaveBeenCalledWith(
         expect.objectContaining({
-          token: expect.objectContaining({
-            address: '0x0000000000000000000000000000000000000000',
-            isNative: true,
-            isETH: true,
-            symbol: 'ETH',
-            chainId: '0x1',
-          }),
+          token: mockTokenETH,
+          sourcePage: 'MarketInsightsView',
         }),
       );
     });
 
-    it('passes isNative and isETH as false for an ERC-20 token with an explicit address', () => {
+    it('passes an ERC-20 token from route params to useTokenActions', () => {
+      const mockTokenUSDC = {
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        image: '',
+        logo: undefined,
+        balance: '500',
+        isETH: false,
+        isNative: false,
+        decimals: 6,
+        chainId: '0x1',
+      };
+
       mockRouteParams = {
         assetSymbol: 'USDC',
         assetIdentifier:
           'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        tokenDecimals: 6,
-        tokenName: 'USD Coin',
         tokenChainId: '0x1',
+        token: mockTokenUSDC,
       };
 
       renderWithProvider(<MarketInsightsView />);
 
       expect(mockUseTokenActions).toHaveBeenCalledWith(
         expect.objectContaining({
-          token: expect.objectContaining({
-            address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-            isNative: false,
-            isETH: false,
-            symbol: 'USDC',
-          }),
+          token: mockTokenUSDC,
+          sourcePage: 'MarketInsightsView',
         }),
       );
     });

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -9,8 +9,8 @@ import Routes from '../../../../../constants/navigation/Routes';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
-const mockGoToSwaps = jest.fn();
-const mockGoToBuy = jest.fn();
+const mockOnSwap = jest.fn();
+const mockOnBuy = jest.fn();
 const mockUseMarketInsights = jest.fn();
 const mockTrendSourcesBottomSheet = jest.fn();
 const mockFeedbackBottomSheet = jest.fn();
@@ -23,9 +23,6 @@ const mockCreateEventBuilder = jest.fn(
       }),
     }) as const,
 );
-const mockUseSwapBridgeNavigation = jest.fn((_options: unknown) => ({
-  goToSwaps: mockGoToSwaps,
-}));
 const mockGate = jest.fn((fn: () => Promise<void>) => fn());
 const mockPerpsTrack = jest.fn();
 let mockIsEligible = true;
@@ -75,24 +72,41 @@ jest.mock('../../hooks/useMarketInsights', () => ({
   },
 }));
 
-jest.mock('../../../Bridge/hooks/useSwapBridgeNavigation', () => ({
-  SwapBridgeNavigationLocation: {
-    TokenView: 'TokenView',
-  },
-  useSwapBridgeNavigation: (options: unknown) =>
-    mockUseSwapBridgeNavigation(options),
-}));
-
-jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
-  useRampNavigation: () => ({ goToBuy: mockGoToBuy }),
-}));
-
-jest.mock('../../../Ramp/utils/parseRampIntent', () => ({
-  __esModule: true,
-  default: ({ chainId, address }: { chainId: string; address: string }) => ({
-    assetId: `eip155:${chainId}/erc20:${address}`,
+jest.mock('../../../TokenDetails/hooks/useTokenActions', () => ({
+  useTokenActions: () => ({
+    onBuy: mockOnBuy,
+    handleStickySwapPress: mockOnSwap,
+    hasEligibleSwapTokens: true,
+    onSend: jest.fn(),
+    onReceive: jest.fn(),
+    networkModal: null,
   }),
 }));
+
+jest.mock('../../../TokenDetails/components/TokenDetailsStickyFooter', () => {
+  const {
+    View: MockView,
+    Pressable: MockPressable,
+    Text: MockText,
+  } = jest.requireActual('react-native');
+  const StickyFooter = ({
+    onSwap,
+    onBuy,
+  }: {
+    onSwap: () => void;
+    onBuy: () => void;
+  }) => (
+    <MockView>
+      <MockPressable testID="bottomsheet-swap-button" onPress={onSwap}>
+        <MockText>Swap</MockText>
+      </MockPressable>
+      <MockPressable testID="bottomsheet-buy-button" onPress={onBuy}>
+        <MockText>Buy</MockText>
+      </MockPressable>
+    </MockView>
+  );
+  return { __esModule: true, default: StickyFooter };
+});
 
 jest.mock(
   '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken',
@@ -461,30 +475,17 @@ describe('MarketInsightsView', () => {
       getByTestId(MarketInsightsSelectorsIDs.SOURCES_FOOTER),
     ).toBeOnTheScreen();
     expect(getByText('Was this helpful?')).toBeOnTheScreen();
-    expect(getByText('AI summary for information only')).toBeOnTheScreen();
 
     fireEvent.press(getByTestId(`${MarketInsightsSelectorsIDs.TWEET_CARD}-0`));
     expect(Linking.openURL).toHaveBeenCalledWith(
       'https://x.com/user/status/100',
     );
 
-    fireEvent.press(getByTestId(MarketInsightsSelectorsIDs.SWAP_BUTTON));
-    expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-    expect(mockUseSwapBridgeNavigation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcePage: 'MarketInsightsView',
-        sourceToken: expect.objectContaining({
-          address: '0x123',
-          symbol: 'ETH',
-          name: 'Ethereum',
-          decimals: 18,
-          chainId: '0x1',
-        }),
-      }),
-    );
+    fireEvent.press(getByTestId('bottomsheet-swap-button'));
+    expect(mockOnSwap).toHaveBeenCalledTimes(1);
 
-    fireEvent.press(getByTestId(MarketInsightsSelectorsIDs.BUY_BUTTON));
-    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
+    fireEvent.press(getByTestId('bottomsheet-buy-button'));
+    expect(mockOnBuy).toHaveBeenCalledTimes(1);
 
     fireEvent.press(getByTestId(`${MarketInsightsSelectorsIDs.TREND_ITEM}-0`));
     expect(
@@ -512,28 +513,6 @@ describe('MarketInsightsView', () => {
           caip19: 'eip155:1/erc20:0x123',
           asset_symbol: 'eth',
           digest_id: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
-        }),
-      }),
-    );
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        category: MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
-        properties: expect.objectContaining({
-          caip19: 'eip155:1/erc20:0x123',
-          asset_symbol: 'eth',
-          digest_id: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
-          interaction_type: 'swap',
-        }),
-      }),
-    );
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        category: MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
-        properties: expect.objectContaining({
-          caip19: 'eip155:1/erc20:0x123',
-          asset_symbol: 'eth',
-          digest_id: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
-          interaction_type: 'buy',
         }),
       }),
     );
@@ -768,8 +747,8 @@ describe('MarketInsightsView', () => {
     expect(
       getByTestId(MarketInsightsSelectorsIDs.SHORT_BUTTON),
     ).toBeOnTheScreen();
-    expect(queryByTestId(MarketInsightsSelectorsIDs.SWAP_BUTTON)).toBeNull();
-    expect(queryByTestId(MarketInsightsSelectorsIDs.BUY_BUTTON)).toBeNull();
+    expect(queryByTestId('bottomsheet-swap-button')).toBeNull();
+    expect(queryByTestId('bottomsheet-buy-button')).toBeNull();
   });
 
   it('navigates to PerpsOrderRedirect with long direction when Long button is pressed', async () => {
@@ -805,7 +784,7 @@ describe('MarketInsightsView', () => {
         params: { direction: 'long', asset: 'ETH' },
       }),
     );
-    expect(mockGoToSwaps).not.toHaveBeenCalled();
+    expect(mockOnSwap).not.toHaveBeenCalled();
   });
 
   it('navigates to PerpsOrderRedirect with short direction when Short button is pressed', async () => {
@@ -841,7 +820,7 @@ describe('MarketInsightsView', () => {
         params: { direction: 'short', asset: 'ETH' },
       }),
     );
-    expect(mockGoToSwaps).not.toHaveBeenCalled();
+    expect(mockOnSwap).not.toHaveBeenCalled();
   });
 
   it('shows geo-block modal instead of navigating when user is not eligible', async () => {
@@ -885,17 +864,18 @@ describe('MarketInsightsView', () => {
     expect(mockPerpsTrack).toHaveBeenCalled();
   });
 
-  it('navigates to swaps when swap button is pressed in token context', () => {
+  it('shows sticky footer swap/buy buttons (not perps buttons) in token context', () => {
     const { getByTestId, queryByTestId } = renderWithProvider(
       <MarketInsightsView />,
     );
 
     expect(queryByTestId(MarketInsightsSelectorsIDs.LONG_BUTTON)).toBeNull();
     expect(queryByTestId(MarketInsightsSelectorsIDs.SHORT_BUTTON)).toBeNull();
+    expect(getByTestId('bottomsheet-swap-button')).toBeOnTheScreen();
+    expect(getByTestId('bottomsheet-buy-button')).toBeOnTheScreen();
 
-    fireEvent.press(getByTestId(MarketInsightsSelectorsIDs.SWAP_BUTTON));
-
-    expect(mockGoToSwaps).toHaveBeenCalled();
+    fireEvent.press(getByTestId('bottomsheet-swap-button'));
+    expect(mockOnSwap).toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalledWith(
       Routes.PERPS.ROOT,
       expect.anything(),

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -72,15 +72,17 @@ jest.mock('../../hooks/useMarketInsights', () => ({
   },
 }));
 
+const mockUseTokenActions = jest.fn((_args: unknown) => ({
+  onBuy: mockOnBuy,
+  handleStickySwapPress: mockOnSwap,
+  hasEligibleSwapTokens: true,
+  onSend: jest.fn(),
+  onReceive: jest.fn(),
+  networkModal: null,
+}));
+
 jest.mock('../../../TokenDetails/hooks/useTokenActions', () => ({
-  useTokenActions: () => ({
-    onBuy: mockOnBuy,
-    handleStickySwapPress: mockOnSwap,
-    hasEligibleSwapTokens: true,
-    onSend: jest.fn(),
-    onReceive: jest.fn(),
-    networkModal: null,
-  }),
+  useTokenActions: (args: unknown) => mockUseTokenActions(args),
 }));
 
 jest.mock('../../../TokenDetails/components/TokenDetailsStickyFooter', () => {
@@ -298,6 +300,14 @@ describe('MarketInsightsView', () => {
     jest.clearAllMocks();
     resetFeedbackCache();
     mockIsEligible = true;
+    mockUseTokenActions.mockReturnValue({
+      onBuy: mockOnBuy,
+      handleStickySwapPress: mockOnSwap,
+      hasEligibleSwapTokens: true,
+      onSend: jest.fn(),
+      onReceive: jest.fn(),
+      networkModal: null,
+    });
     mockRouteParams = {
       assetSymbol: 'ETH',
       assetIdentifier: 'eip155:1/erc20:0x123',
@@ -1248,5 +1258,75 @@ describe('MarketInsightsView', () => {
         }),
       }),
     );
+  });
+
+  describe('token object construction for useTokenActions', () => {
+    const mockReport = {
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH extends gains',
+      summary: 'Momentum improves',
+      trends: [],
+      sources: [],
+    };
+
+    beforeEach(() => {
+      mockUseMarketInsights.mockReturnValue({
+        report: mockReport,
+        isLoading: false,
+        error: null,
+        timeAgo: '5m ago',
+      });
+    });
+
+    it('passes isNative and isETH as true when tokenAddress is absent (native token)', () => {
+      mockRouteParams = {
+        assetSymbol: 'ETH',
+        assetIdentifier: 'eip155:1/slip44:60',
+        tokenImageUrl: 'https://example.com/eth.png',
+        tokenName: 'Ethereum',
+        tokenChainId: '0x1',
+        // tokenAddress intentionally omitted
+      };
+
+      renderWithProvider(<MarketInsightsView />);
+
+      expect(mockUseTokenActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            address: '0x0000000000000000000000000000000000000000',
+            isNative: true,
+            isETH: true,
+            symbol: 'ETH',
+            chainId: '0x1',
+          }),
+        }),
+      );
+    });
+
+    it('passes isNative and isETH as false for an ERC-20 token with an explicit address', () => {
+      mockRouteParams = {
+        assetSymbol: 'USDC',
+        assetIdentifier:
+          'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        tokenDecimals: 6,
+        tokenName: 'USD Coin',
+        tokenChainId: '0x1',
+      };
+
+      renderWithProvider(<MarketInsightsView />);
+
+      expect(mockUseTokenActions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            isNative: false,
+            isETH: false,
+            symbol: 'USDC',
+          }),
+        }),
+      );
+    });
   });
 });

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -30,7 +30,7 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Hex, CaipChainId, isCaipAssetType } from '@metamask/utils';
+import { Hex, CaipChainId } from '@metamask/utils';
 import {
   Box,
   Text,
@@ -56,11 +56,6 @@ import MarketInsightsTrendSourcesBottomSheet from '../../components/MarketInsigh
 import { MarketInsightsSelectorsIDs } from '../../MarketInsights.testIds';
 import { isSafeUrl } from '../../utils/marketInsightsFormatting';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import {
-  useSwapBridgeNavigation,
-  SwapBridgeNavigationLocation,
-} from '../../../Bridge/hooks/useSwapBridgeNavigation';
-import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../../constants/bridge';
 import type {
   MarketInsightsTweet,
   MarketInsightsTrend,
@@ -82,9 +77,9 @@ import { useAppThemeFromContext } from '../../../../../util/theme';
 import MarketInsightsFeedbackBottomSheet, {
   MarketInsightsFeedbackReason,
 } from '../../components/MarketInsightsFeedbackBottomSheet';
-import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
-import parseRampIntent from '../../../Ramp/utils/parseRampIntent';
-import { getDecimalChainId } from '../../../../../util/networks';
+import { useTokenActions } from '../../../TokenDetails/hooks/useTokenActions';
+import TokenDetailsStickyFooter from '../../../TokenDetails/components/TokenDetailsStickyFooter';
+import type { TokenDetailsRouteParams } from '../../../TokenDetails/constants/constants';
 import { selectPerpsEligibility } from '../../../Perps/selectors/perpsController';
 import { useComplianceGate } from '../../../Compliance';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
@@ -266,31 +261,32 @@ const MarketInsightsView: React.FC = () => {
     null,
   );
 
-  // Build BridgeToken from route params for swap navigation
-  const sourceToken = useMemo(() => {
-    if (!tokenChainId) return undefined;
-    return {
-      address: tokenAddress ?? NATIVE_SWAPS_TOKEN_ADDRESS,
+  // Build a minimal token object from route params to drive useTokenActions
+  // and TokenDetailsStickyFooter (same shape as TokenDetailsRouteParams).
+  const token = useMemo<TokenDetailsRouteParams>(
+    () => ({
+      address: tokenAddress ?? '',
       symbol: assetSymbol,
-      name: tokenName,
-      image: tokenImageUrl,
+      name: tokenName ?? assetSymbol,
+      image: tokenImageUrl ?? '',
+      logo: tokenImageUrl,
+      balance: '',
+      isETH: false,
       decimals: tokenDecimals ?? 18,
       chainId: tokenChainId as Hex | CaipChainId,
-    };
-  }, [
-    assetSymbol,
-    tokenAddress,
-    tokenDecimals,
-    tokenName,
-    tokenImageUrl,
-    tokenChainId,
-  ]);
+    }),
+    [
+      assetSymbol,
+      tokenAddress,
+      tokenDecimals,
+      tokenName,
+      tokenImageUrl,
+      tokenChainId,
+    ],
+  );
 
-  const { goToSwaps } = useSwapBridgeNavigation({
-    location: SwapBridgeNavigationLocation.TokenView,
-    sourcePage: 'MarketInsightsView',
-    sourceToken,
-  });
+  const { onBuy, handleStickySwapPress, hasEligibleSwapTokens } =
+    useTokenActions({ token });
 
   // Sends the identifier under the right analytics property name.
   // Token flow uses caip19 (a real CAIP-19 ID); perps flow uses perps_market
@@ -309,8 +305,6 @@ const MarketInsightsView: React.FC = () => {
     () => (report?.asset ? { asset_symbol: report.asset } : {}),
     [report?.asset],
   );
-  const { goToBuy } = useRampNavigation();
-
   // Collect all tweets from all trends for the "What people are saying" section
   const allTweets: MarketInsightsTweet[] = useMemo(() => {
     if (!report) return [];
@@ -338,26 +332,6 @@ const MarketInsightsView: React.FC = () => {
       Linking.openURL(url);
     }
   }, []);
-
-  const handleSwapPress = useCallback(() => {
-    const event = createEventBuilder(
-      MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
-    )
-      .addProperties({
-        ...assetIdProperty,
-        ...assetSymbolProperty,
-        interaction_type: 'swap',
-      })
-      .build();
-    trackEvent(event);
-    goToSwaps();
-  }, [
-    goToSwaps,
-    trackEvent,
-    createEventBuilder,
-    assetIdProperty,
-    assetSymbolProperty,
-  ]);
 
   const closeEligibilityModal = useCallback(() => {
     setIsEligibilityModalVisible(false);
@@ -405,43 +379,6 @@ const MarketInsightsView: React.FC = () => {
       assetSymbol,
     ],
   );
-
-  const handleBuyPress = useCallback(() => {
-    const event = createEventBuilder(
-      MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
-    )
-      .addProperties({
-        ...assetIdProperty,
-        ...assetSymbolProperty,
-        interaction_type: 'buy',
-      })
-      .build();
-    trackEvent(event);
-
-    let assetId: string | undefined;
-    try {
-      if (tokenAddress && isCaipAssetType(tokenAddress)) {
-        assetId = tokenAddress;
-      } else if (tokenChainId && tokenAddress) {
-        assetId = parseRampIntent({
-          chainId: getDecimalChainId(tokenChainId),
-          address: tokenAddress,
-        })?.assetId;
-      }
-    } catch {
-      assetId = undefined;
-    }
-
-    goToBuy({ assetId });
-  }, [
-    goToBuy,
-    trackEvent,
-    createEventBuilder,
-    assetIdProperty,
-    assetSymbolProperty,
-    tokenAddress,
-    tokenChainId,
-  ]);
 
   const handleTrendPress = useCallback((trend: MarketInsightsTrend) => {
     const hasArticles = trend.articles.length > 0;
@@ -816,65 +753,50 @@ const MarketInsightsView: React.FC = () => {
       </ScrollView>
 
       {!(isPerps && hasPerpsPosition) && (
-        <Box
-          twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom + 8}px]`}
-        >
+        <>
           {isPerps ? (
-            <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-              <Button
-                variant={ButtonVariant.Primary}
-                size={ButtonSize.Lg}
-                twClassName="flex-1"
-                onPress={() => handlePerpsDirectionPress('long')}
-                testID={MarketInsightsSelectorsIDs.LONG_BUTTON}
-              >
-                {strings('perps.market.long')}
-              </Button>
-              <Button
-                variant={ButtonVariant.Primary}
-                size={ButtonSize.Lg}
-                twClassName="flex-1"
-                onPress={() => handlePerpsDirectionPress('short')}
-                testID={MarketInsightsSelectorsIDs.SHORT_BUTTON}
-              >
-                {strings('perps.market.short')}
-              </Button>
+            <Box
+              twClassName={`border-t border-muted bg-default px-4 pt-4 pb-[${insets.bottom + 8}px]`}
+            >
+              <Box flexDirection={BoxFlexDirection.Row} gap={3}>
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  twClassName="flex-1"
+                  onPress={() => handlePerpsDirectionPress('long')}
+                  testID={MarketInsightsSelectorsIDs.LONG_BUTTON}
+                >
+                  {strings('perps.market.long')}
+                </Button>
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  twClassName="flex-1"
+                  onPress={() => handlePerpsDirectionPress('short')}
+                  testID={MarketInsightsSelectorsIDs.SHORT_BUTTON}
+                >
+                  {strings('perps.market.short')}
+                </Button>
+              </Box>
+              <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {strings('market_insights.footer_disclaimer')}
+                </Text>
+              </Box>
             </Box>
           ) : (
-            <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-              <Box twClassName="flex-1">
-                <Button
-                  variant={ButtonVariant.Primary}
-                  size={ButtonSize.Lg}
-                  isFullWidth
-                  onPress={handleSwapPress}
-                  testID={MarketInsightsSelectorsIDs.SWAP_BUTTON}
-                >
-                  {strings('market_insights.swap_button')}
-                </Button>
-              </Box>
-              <Box twClassName="flex-1">
-                <Button
-                  variant={ButtonVariant.Primary}
-                  size={ButtonSize.Lg}
-                  isFullWidth
-                  onPress={handleBuyPress}
-                  testID={MarketInsightsSelectorsIDs.BUY_BUTTON}
-                >
-                  {strings('market_insights.buy_button')}
-                </Button>
-              </Box>
-            </Box>
+            <TokenDetailsStickyFooter
+              token={token}
+              securityData={null}
+              onBuy={onBuy}
+              onSwap={handleStickySwapPress}
+              hasEligibleSwapTokens={hasEligibleSwapTokens}
+            />
           )}
-          <Box twClassName="pt-3" alignItems={BoxAlignItems.Center}>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {strings('market_insights.footer_disclaimer')}
-            </Text>
-          </Box>
-        </Box>
+        </>
       )}
 
       {selectedTrend ? (

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -31,6 +31,8 @@ import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Hex, CaipChainId } from '@metamask/utils';
+import { isNativeAddress } from '@metamask/bridge-controller';
+import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../../constants/bridge';
 import {
   Box,
   Text,
@@ -263,27 +265,32 @@ const MarketInsightsView: React.FC = () => {
 
   // Build a minimal token object from route params to drive useTokenActions
   // and TokenDetailsStickyFooter (same shape as TokenDetailsRouteParams).
-  const token = useMemo<TokenDetailsRouteParams>(
-    () => ({
-      address: tokenAddress ?? '',
+  // When tokenAddress is absent or the zero address the asset is native, so
+  // set isNative/isETH so that useTokenBuyability can find it via the
+  // /slip44: ramp lookup (same path used by the token details page).
+  const token = useMemo<TokenDetailsRouteParams>(() => {
+    const resolvedAddress = tokenAddress ?? NATIVE_SWAPS_TOKEN_ADDRESS;
+    const native = !tokenAddress || isNativeAddress(resolvedAddress);
+    return {
+      address: resolvedAddress,
       symbol: assetSymbol,
       name: tokenName ?? assetSymbol,
       image: tokenImageUrl ?? '',
       logo: tokenImageUrl,
       balance: '',
-      isETH: false,
+      isETH: native,
+      isNative: native,
       decimals: tokenDecimals ?? 18,
       chainId: tokenChainId as Hex | CaipChainId,
-    }),
-    [
-      assetSymbol,
-      tokenAddress,
-      tokenDecimals,
-      tokenName,
-      tokenImageUrl,
-      tokenChainId,
-    ],
-  );
+    };
+  }, [
+    assetSymbol,
+    tokenAddress,
+    tokenDecimals,
+    tokenName,
+    tokenImageUrl,
+    tokenChainId,
+  ]);
 
   const { onBuy, handleStickySwapPress, hasEligibleSwapTokens } =
     useTokenActions({ token });

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -30,9 +30,6 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Hex, CaipChainId } from '@metamask/utils';
-import { isNativeAddress } from '@metamask/bridge-controller';
-import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../../constants/bridge';
 import {
   Box,
   Text,
@@ -170,6 +167,8 @@ interface MarketInsightsRouteParams {
   isPerps?: boolean;
   /** When true, the user has an existing perps position for this asset */
   hasPerpsPosition?: boolean;
+  /** Full token object from Token Details, used to drive useTokenActions with the same state as Token Details / Security Trust. */
+  token?: TokenDetailsRouteParams;
 }
 
 /**
@@ -194,12 +193,10 @@ const MarketInsightsView: React.FC = () => {
     assetSymbol,
     assetIdentifier,
     tokenImageUrl,
-    tokenAddress,
-    tokenDecimals,
-    tokenName,
     tokenChainId,
     isPerps = false,
     hasPerpsPosition = false,
+    token: routeToken,
   } = route.params;
 
   const isMarketInsightsEnabled = isPerps
@@ -263,37 +260,16 @@ const MarketInsightsView: React.FC = () => {
     null,
   );
 
-  // Build a minimal token object from route params to drive useTokenActions
-  // and TokenDetailsStickyFooter (same shape as TokenDetailsRouteParams).
-  // When tokenAddress is absent or the zero address the asset is native, so
-  // set isNative/isETH so that useTokenBuyability can find it via the
-  // /slip44: ramp lookup (same path used by the token details page).
-  const token = useMemo<TokenDetailsRouteParams>(() => {
-    const resolvedAddress = tokenAddress ?? NATIVE_SWAPS_TOKEN_ADDRESS;
-    const native = !tokenAddress || isNativeAddress(resolvedAddress);
-    return {
-      address: resolvedAddress,
-      symbol: assetSymbol,
-      name: tokenName ?? assetSymbol,
-      image: tokenImageUrl ?? '',
-      logo: tokenImageUrl,
-      balance: '',
-      isETH: native,
-      isNative: native,
-      decimals: tokenDecimals ?? 18,
-      chainId: tokenChainId as Hex | CaipChainId,
-    };
-  }, [
-    assetSymbol,
-    tokenAddress,
-    tokenDecimals,
-    tokenName,
-    tokenImageUrl,
-    tokenChainId,
-  ]);
+  // Use the full token object passed from Token Details — same object that
+  // Security Trust and the token details sticky footer receive, so
+  // useTokenActions behaves identically (source/dest token selection, balance
+  // awareness, buyability, etc.).
+  // In the perps flow routeToken is undefined (perps uses Long/Short buttons
+  // instead of TokenDetailsStickyFooter).
+  const token = (routeToken ?? {}) as TokenDetailsRouteParams;
 
   const { onBuy, handleStickySwapPress, hasEligibleSwapTokens } =
-    useTokenActions({ token });
+    useTokenActions({ token, sourcePage: 'MarketInsightsView' });
 
   // Sends the identifier under the right analytics property name.
   // Token flow uses caip19 (a real CAIP-19 ID); perps flow uses perps_market

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
@@ -369,7 +369,7 @@ describe('AssetOverviewContent', () => {
         Routes.MARKET_INSIGHTS.VIEW,
         expect.objectContaining({
           assetSymbol: 'ETH',
-          tokenAddress: '0x123',
+          assetIdentifier: 'eip155:1/erc20:0x123',
           tokenChainId: '0x1',
         }),
       );

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -545,25 +545,16 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
       assetIdentifier: marketInsightsCaip19Id,
       tokenImageUrl: token.image || token.logo,
       pricePercentChange: percentChange,
-      // Pass token data needed for swap navigation
-      tokenAddress: token.address,
-      tokenDecimals: token.decimals,
-      tokenName: token.name,
       tokenChainId: token.chainId,
+      token,
     });
   }, [
     navigation,
     trackEvent,
     createEventBuilder,
-    token.symbol,
+    token,
     marketInsightsCaip19Id,
     marketInsightsReport,
-    token.image,
-    token.logo,
-    token.address,
-    token.decimals,
-    token.name,
-    token.chainId,
     priceDiff,
     comparePrice,
   ]);

--- a/app/components/UI/TokenDetails/hooks/useTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenActions.ts
@@ -105,6 +105,8 @@ export interface UseTokenActionsParams {
   networkName?: string;
   /** Optional up-to-date token balance from Token Details balance hook */
   currentTokenBalance?: string;
+  /** Source page identifier passed to useSwapBridgeNavigation for analytics. Defaults to 'MainView'. */
+  sourcePage?: string;
 }
 
 /**
@@ -115,6 +117,7 @@ export const useTokenActions = ({
   token,
   networkName,
   currentTokenBalance,
+  sourcePage = 'MainView',
 }: UseTokenActionsParams): UseTokenActionsResult => {
   const navigation = useNavigation();
 
@@ -150,7 +153,7 @@ export const useTokenActions = ({
     'source' in token && token.source === TokenDetailsSource.Swap;
   const { goToSwaps, networkModal } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.TokenView,
-    sourcePage: 'MainView',
+    sourcePage,
     sourceToken,
     destToken,
     abTestContext: {},


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
sticky buttons should be same on market insights

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: sticky buttons should be same on market insights

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Market Insights CTA wiring to use `TokenDetailsStickyFooter`/`useTokenActions`, which affects buy/swap navigation behavior and the route params passed from Token Details. Risk is moderate due to user-facing action handling changes, but scope is localized and covered by updated tests.
> 
> **Overview**
> Market Insights’ token context footer is switched from custom Swap/Buy buttons (and direct Bridge/Ramp navigation) to `TokenDetailsStickyFooter` backed by `useTokenActions`, aiming to make the sticky CTAs behave identically to Token Details.
> 
> Navigation into Market Insights from `AssetOverviewContent` now passes the full `token` object (and `assetIdentifier` CAIP-19) instead of token address/decimals/name fields, and `useTokenActions` gains an optional `sourcePage` param so swap analytics can attribute calls to `MarketInsightsView`. Tests are updated to mock the new footer/actions and to stop asserting Market Insights interaction analytics for swap/buy presses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74b6d091aa4d0559312384cac0dc0716e011a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->