### PR TITLE
fix: format updated fixture with Prettier in E2E workflow

### DIFF
--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -298,6 +298,10 @@ jobs:
             echo "HAS_CHANGES=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Format updated fixture with prettier
+        if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
+        run: npx --yes prettier@^3.6.2 --write tests/framework/fixtures/json/default-fixture.json
+
       # Note: Commits pushed with the default GITHUB_TOKEN do not trigger
       # downstream CI workflows (GitHub anti-loop protection). This is
       # intentional — a follow-up push or manual CI re-run will validate

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -298,9 +298,17 @@ jobs:
             echo "HAS_CHANGES=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Node.js for prettier
+        if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
       - name: Format updated fixture with prettier
         if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
-        run: npx --yes prettier@^3.6.2 --write tests/framework/fixtures/json/default-fixture.json
+        run: |
+          npm install --no-save --ignore-scripts prettier@^3.6.2
+          ./node_modules/.bin/prettier --write tests/framework/fixtures/json/default-fixture.json
 
       # Note: Commits pushed with the default GITHUB_TOKEN do not trigger
       # downstream CI workflows (GitHub anti-loop protection). This is


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

 - Adds a `prettier` formatting step to the `commit-updated-fixtures` job in the `update-e2e-fixtures` workflow
  - Runs `npx --yes prettier@^3.6.2 --write` on the fixture file before committing, so the committed file is already formatted
  - Eliminates the need for devs to run prettier locally after the bot commits, which was causing an unnecessary extra push and CI
  re-run

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; the main impact is added Node/Prettier installation in the `commit-updated-fixtures` job, which could fail due to npm/network issues but doesn’t affect app runtime logic.
> 
> **Overview**
> Ensures the `update-e2e-fixtures` workflow commits a consistently formatted `tests/framework/fixtures/json/default-fixture.json` by adding a conditional Node setup and a Prettier `--write` step before the bot commit.
> 
> The formatting only runs when the fixture diff detects changes, using the repo’s `.nvmrc` Node version and installing `prettier@^3.6.2` on the fly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3d9b0de9c8d41bb33f47117b18803bfe91eb5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->