### PR TITLE
fix(charts): handle fast timeframe reloads in advanced chart cp-7.74.0

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -184,7 +184,10 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       setWebViewLoaded(false);
       setLayoutSettling(false);
       clearLayoutSettleTimeout();
-      ohlcvSeriesStaleSnapshotRef.current = null;
+      ohlcvSeriesStaleSnapshotRef.current =
+        prevOhlcvSeriesKeyRef.current !== undefined
+          ? prevOhlcvDataRef.current
+          : null;
       activeIndicatorsRef.current.clear();
       prevPositionLinesRef.current = undefined;
       prevChartTypeRef.current = undefined;
@@ -431,13 +434,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         ohlcvSeriesKey !== undefined &&
         ohlcvSeriesKey !== prevOhlcvSeriesKeyRef.current
       ) {
-        if (prevOhlcvSeriesKeyRef.current !== undefined) {
-          beginFullOhlcvLayoutSettle();
-          ohlcvSeriesStaleSnapshotRef.current = ohlcvData;
-          prevOhlcvSeriesKeyRef.current = ohlcvSeriesKey;
-          prevOhlcvDataRef.current = [];
-          return;
-        }
         beginFullOhlcvLayoutSettle();
         sendOHLCVData(ohlcvData);
         prevOhlcvDataRef.current = ohlcvData;

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -250,6 +250,45 @@ describe('AdvancedChart', () => {
     expect(realtimeCalls).toHaveLength(0);
   });
 
+  it('sends fresh data after a series change when the new array arrives before WebView load end', () => {
+    const staleBars: OHLCVBar[] = [
+      { time: 1000000, open: 10, high: 12, low: 9, close: 11, volume: 100 },
+      { time: 1000300, open: 11, high: 13, low: 10, close: 12, volume: 200 },
+    ];
+    const freshBars: OHLCVBar[] = [
+      { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
+      { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
+    ];
+
+    const { getByTestId, rerender } = render(
+      <AdvancedChart ohlcvData={staleBars} ohlcvSeriesKey="range-a" />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+
+    mockPostMessage.mockClear();
+
+    rerender(<AdvancedChart ohlcvData={staleBars} ohlcvSeriesKey="range-b" />);
+    rerender(<AdvancedChart ohlcvData={freshBars} ohlcvSeriesKey="range-b" />);
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+
+    const webViewAfterKeyChange = getByTestId('mock-webview');
+    act(() => {
+      webViewAfterKeyChange.props.onLoadEnd();
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'SET_OHLCV_DATA',
+        payload: { data: freshBars },
+      }),
+    );
+  });
+
   it('reset() clears stale series snapshot so OHLCV sync runs after reload with the same data ref', () => {
     const staleBars: OHLCVBar[] = [
       { time: 1000000, open: 10, high: 12, low: 9, close: 11, volume: 100 },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a post-merge regression in the advanced chart timeframe switch flow. After the recent remount based fix, there was still a race where a new OHLCV response could arrive before the remounted WebView finished loading. In that case, the stale snapshot guard could misclassify the already fresh candle array as stale and never send SET_OHLCV_DATA, leaving the new chart instance without data.

The fix narrows the stale snapshot logic so it captures only the previously synced OHLCV array at the moment the series key changes, instead of marking again whatever data happens to be in props later. This preserves the original protection against sending the previous range into the new WebView, while also allowing fast new range responses to sync correctly as soon as the remounted WebView finishes loading.

The PR also adds a focused regression test covering the fast-response / delayed-WebView-load case.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Covered fast response / delayed WebView load case in stale snapshot guard

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a8ede52e-3699-4c9d-9dc3-c3051dfd0cf7



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chart data synchronization and remount timing logic, which can impact whether users see up-to-date candles during timeframe switches. Changes are localized and backed by a targeted regression test.
> 
> **Overview**
> Fixes a timeframe-switch race in `AdvancedChart` where a fast new `ohlcvData` response could be incorrectly treated as “stale” during a WebView remount, preventing `SET_OHLCV_DATA` from ever being sent.
> 
> The stale-snapshot guard is tightened to snapshot the *previously synced* OHLCV array at the moment `ohlcvSeriesKey` changes (instead of whatever happens to be in props later), and the extra early-return path on series-key change is removed so fresh data can sync once the new WebView finishes loading. Adds a regression test covering “fresh data arrives before `onLoadEnd` after series change.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5303f8258d9e5e988b88e56093ca39b5e89599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->