### PR TITLE
fix: dynamic chart compare prices

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -30,6 +30,7 @@ import {
   type ChartInteractedPayload,
   type CrosshairData,
   type IndicatorType,
+  type VisibleRangeChangedPayload,
 } from '../../Charts/AdvancedChart/AdvancedChart.types';
 import TimeRangeSelector, {
   TIME_RANGE_CONFIGS,
@@ -99,10 +100,20 @@ const PriceAdvanced = ({
   const [crosshairData, setCrosshairData] = useState<CrosshairData | null>(
     null,
   );
+  const [actualVisibleFromMs, setActualVisibleFromMs] = useState<
+    number | undefined
+  >(undefined);
   const { setIsChartBeingTouched } = usePriceChart();
 
   const handleCrosshairMove = useCallback(
     (data: CrosshairData | null) => setCrosshairData(data),
+    [],
+  );
+
+  const handleVisibleRangeChanged = useCallback(
+    (payload: VisibleRangeChangedPayload) => {
+      setActualVisibleFromMs(payload.visibleFromMs);
+    },
     [],
   );
 
@@ -159,6 +170,9 @@ const PriceAdvanced = ({
       if (range === timeRange) {
         return;
       }
+      // Clear crosshair and reset visible range when changing timeframes
+      setCrosshairData(null);
+      setActualVisibleFromMs(undefined);
       trackEvent(
         createEventBuilder(MetaMetricsEvents.CHART_INTERACTED)
           .addProperties({
@@ -240,12 +254,15 @@ const PriceAdvanced = ({
   const dateLabel = strings(TIME_RANGE_LABELS[timeRange]);
 
   // Calculate the current compare price from OHLCV data
+  // Use actual visible range from chart if available, otherwise fall back to static calculation
   const currentComparePrice = useMemo(() => {
-    if (ohlcvData.length === 0 || visibleFromMs == null) return null;
+    if (ohlcvData.length === 0) return null;
+    const compareFromMs = actualVisibleFromMs ?? visibleFromMs;
+    if (compareFromMs == null) return null;
     const firstVisible =
-      ohlcvData.find((c) => c.time >= visibleFromMs) ?? ohlcvData[0];
+      ohlcvData.find((c) => c.time >= compareFromMs) ?? ohlcvData[0];
     return firstVisible.close;
-  }, [ohlcvData, visibleFromMs]);
+  }, [ohlcvData, actualVisibleFromMs, visibleFromMs]);
 
   // Store last good compare price to show during loading
   const stableComparePriceRef = useRef<number | null>(null);
@@ -403,6 +420,7 @@ const PriceAdvanced = ({
             visibleToMs={visibleToMs}
             onCrosshairMove={handleCrosshairMove}
             onChartInteracted={handleChartInteracted}
+            onVisibleRangeChanged={handleVisibleRangeChanged}
             onChartTradingViewClicked={handleChartTradingViewClicked}
           />
         </View>

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -88,6 +88,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       onError,
       onCrosshairMove,
       onChartInteracted,
+      onVisibleRangeChanged,
       onChartTradingViewClicked,
       isLoading = false,
       lineChrome,
@@ -330,6 +331,10 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             onChartInteracted?.(message.payload);
             break;
 
+          case 'VISIBLE_RANGE_CHANGED':
+            onVisibleRangeChanged?.(message.payload);
+            break;
+
           case 'CHART_TRADINGVIEW_CLICKED': {
             const bridgeUrl = message.payload?.url;
             if (typeof bridgeUrl === 'string' && bridgeUrl.length > 0) {
@@ -364,6 +369,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         onError,
         onCrosshairMove,
         onChartInteracted,
+        onVisibleRangeChanged,
         handleTradingViewOpen,
       ],
     );

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -183,6 +183,8 @@ export type WebViewToRNMessageType =
   | 'INDICATOR_ADDED'
   | 'INDICATOR_REMOVED'
   | 'CROSSHAIR_MOVE'
+  | 'CHART_INTERACTED'
+  | 'VISIBLE_RANGE_CHANGED'
   | 'ERROR'
   | 'DEBUG';
 
@@ -271,6 +273,13 @@ export interface ChartInteractedPayload {
   interaction_type: ChartInteractionType;
 }
 
+export interface VisibleRangeChangedPayload {
+  /** Unix timestamp in milliseconds for the leftmost visible bar */
+  visibleFromMs: number;
+  /** Unix timestamp in milliseconds for the rightmost visible bar */
+  visibleToMs: number;
+}
+
 export interface ErrorPayload {
   message: string;
   code?: string;
@@ -283,6 +292,7 @@ export type WebViewToRNMessage =
   | { type: 'INDICATOR_REMOVED'; payload: IndicatorRemovedPayload }
   | { type: 'CROSSHAIR_MOVE'; payload: CrosshairMovePayload }
   | { type: 'CHART_INTERACTED'; payload: ChartInteractedPayload }
+  | { type: 'VISIBLE_RANGE_CHANGED'; payload: VisibleRangeChangedPayload }
   | { type: 'CHART_TRADINGVIEW_CLICKED'; payload?: { url?: string } }
   | { type: 'ERROR'; payload: ErrorPayload }
   | { type: 'DEBUG'; payload: { message: string } };
@@ -357,6 +367,21 @@ export function parseWebViewMessage(raw: unknown): WebViewToRNMessage | null {
           type,
           payload: {
             interaction_type: obj.interaction_type,
+          },
+        };
+      }
+      return null;
+
+    case 'VISIBLE_RANGE_CHANGED':
+      if (
+        typeof obj.visibleFromMs === 'number' &&
+        typeof obj.visibleToMs === 'number'
+      ) {
+        return {
+          type,
+          payload: {
+            visibleFromMs: obj.visibleFromMs,
+            visibleToMs: obj.visibleToMs,
           },
         };
       }
@@ -459,6 +484,11 @@ export interface AdvancedChartProps {
    * crosshair tooltip (first OHLC payload per crosshair session). Suppressed during data reloads.
    */
   onChartInteracted?: (payload: ChartInteractedPayload) => void;
+  /**
+   * Callback when the visible time range changes due to user panning/scrolling.
+   * Used to update the compare price reference based on actual visible leftmost bar.
+   */
+  onVisibleRangeChanged?: (payload: VisibleRangeChangedPayload) => void;
   /**
    * WebView is about to navigate to tradingview.com (e.g. user tapped attribution logo).
    * Native layer opens the URL in the system browser and cancels in-WebView navigation.

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -1370,6 +1370,49 @@ function clearLineEndDotVisibleRangeDebounce() {
   }
 }
 
+/**
+ * Debounced visible range notification to React Native. Posts VISIBLE_RANGE_CHANGED message
+ * when user pans/scrolls the chart, allowing RN to update compare price based on actual visible bars.
+ */
+var visibleRangeChangeDebounce = null;
+var VISIBLE_RANGE_DEBOUNCE_MS = 300;
+
+function postVisibleRangeToRN(chart) {
+  if (!chart) return;
+
+  try {
+    var vr = chart.getVisibleRange();
+    if (!vr || !vr.from || !vr.to) return;
+
+    // Convert from seconds to milliseconds
+    var visibleFromMs = Math.round(vr.from * 1000);
+    var visibleToMs = Math.round(vr.to * 1000);
+
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        type: 'VISIBLE_RANGE_CHANGED',
+        payload: {
+          visibleFromMs: visibleFromMs,
+          visibleToMs: visibleToMs,
+        },
+      }),
+    );
+  } catch (err) {
+    console.error('Failed to post visible range:', err);
+  }
+}
+
+function scheduleVisibleRangeUpdate(chart) {
+  if (visibleRangeChangeDebounce) {
+    clearTimeout(visibleRangeChangeDebounce);
+  }
+
+  visibleRangeChangeDebounce = setTimeout(function () {
+    visibleRangeChangeDebounce = null;
+    postVisibleRangeToRN(chart);
+  }, VISIBLE_RANGE_DEBOUNCE_MS);
+}
+
 function scheduleLineEndDotAfterVisibleRangeChange() {
   if (window.currentChartType !== 2) {
     return;
@@ -1441,6 +1484,7 @@ function subscribeLastCloseLabelUpdates() {
         if (getLineChrome().useCustomLineEndMarker) {
           scheduleLineEndDotAfterVisibleRangeChange();
         }
+        scheduleVisibleRangeUpdate(window.chartWidget.activeChart());
       });
   } catch (e) {}
 }
@@ -3789,6 +3833,7 @@ function initChart() {
           .onVisibleRangeChanged()
           .subscribe(null, function () {
             scheduleChartInteractPan();
+            scheduleVisibleRangeUpdate(window.chartWidget.activeChart());
           });
       } catch (e) {}
 

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1379,6 +1379,49 @@ function clearLineEndDotVisibleRangeDebounce() {
   }
 }
 
+/**
+ * Debounced visible range notification to React Native. Posts VISIBLE_RANGE_CHANGED message
+ * when user pans/scrolls the chart, allowing RN to update compare price based on actual visible bars.
+ */
+var visibleRangeChangeDebounce = null;
+var VISIBLE_RANGE_DEBOUNCE_MS = 300;
+
+function postVisibleRangeToRN(chart) {
+  if (!chart) return;
+  
+  try {
+    var vr = chart.getVisibleRange();
+    if (!vr || !vr.from || !vr.to) return;
+    
+    // Convert from seconds to milliseconds
+    var visibleFromMs = Math.round(vr.from * 1000);
+    var visibleToMs = Math.round(vr.to * 1000);
+    
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        type: 'VISIBLE_RANGE_CHANGED',
+        payload: {
+          visibleFromMs: visibleFromMs,
+          visibleToMs: visibleToMs,
+        },
+      })
+    );
+  } catch (err) {
+    console.error('Failed to post visible range:', err);
+  }
+}
+
+function scheduleVisibleRangeUpdate(chart) {
+  if (visibleRangeChangeDebounce) {
+    clearTimeout(visibleRangeChangeDebounce);
+  }
+  
+  visibleRangeChangeDebounce = setTimeout(function () {
+    visibleRangeChangeDebounce = null;
+    postVisibleRangeToRN(chart);
+  }, VISIBLE_RANGE_DEBOUNCE_MS);
+}
+
 function scheduleLineEndDotAfterVisibleRangeChange() {
   if (window.currentChartType !== 2) {
     return;
@@ -1450,6 +1493,7 @@ function subscribeLastCloseLabelUpdates() {
         if (getLineChrome().useCustomLineEndMarker) {
           scheduleLineEndDotAfterVisibleRangeChange();
         }
+        scheduleVisibleRangeUpdate(window.chartWidget.activeChart());
       });
   } catch (e) {}
 }
@@ -3798,6 +3842,7 @@ function initChart() {
           .onVisibleRangeChanged()
           .subscribe(null, function () {
             scheduleChartInteractPan();
+            scheduleVisibleRangeUpdate(window.chartWidget.activeChart());
           });
       } catch (e) {}
 


### PR DESCRIPTION


## **Description**

Implemented a solution to make the chart compare price dynamic based on the actual visible range when users pan/scroll the chart. Previously, the percentage calculation was anchored to a static point (24h before the most recent bar)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
