### PR TITLE
fix: notifications text overlap [GE-192] cp-7.74.0

### DIFF
--- a/app/components/Views/Notifications/Details/styles.ts
+++ b/app/components/Views/Notifications/Details/styles.ts
@@ -136,6 +136,7 @@ export const createStyles = ({ colors, typography }: Theme) =>
     },
     modalContainer: {
       flex: 1,
+      backgroundColor: colors.background.default,
     },
     navContainer: {
       flexDirection: 'row',

--- a/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
@@ -5,9 +5,11 @@ import { Theme } from '../../../../util/theme/models';
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
     container: {
+      flex: 1,
       paddingLeft: 16,
       paddingRight: 16,
       paddingBottom: 48,
+      backgroundColor: params.theme.colors.background.default,
     },
     line: {
       borderTopWidth: 1,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The modalContainer wrapping the details screen had only `flex: 1` with no `backgroundColor`. During the slide-in animation, the details screen was transparent, so the notifications list text underneath was visible through it, causing a text overlap.

Every other similar modalContainer in the codebase already uses `backgroundColor: theme.colors.background.default`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-192

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only changes that set background colors and layout flex; low chance of behavioral regressions beyond potential minor UI spacing differences.
> 
> **Overview**
> Fixes visual bleed-through during notification detail modal transitions by giving `modalContainer` an explicit `backgroundColor` (`colors.background.default`).
> 
> Also updates the Notifications Settings screen container to use full-height layout (`flex: 1`) and apply the theme default background color, aligning it with other modal/screen containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2f7bdee11e719ba8e2d2608b39173e0a0e7d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->