### PR TITLE
chore: add position viewed event for cash screens

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MoneyHomeView from './MoneyHomeView';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
 import { MoneyHomeViewTestIds } from './MoneyHomeView.testIds';
 import { MoneyHeaderTestIds } from '../../components/MoneyHeader/MoneyHeader.testIds';
 import { MoneyBalanceSummaryTestIds } from '../../components/MoneyBalanceSummary/MoneyBalanceSummary.testIds';
@@ -55,6 +57,15 @@ jest.mock('../../hooks/useMoneyAccountTransactions', () => ({
   useMoneyAccountTransactions: jest.fn(),
 }));
 
+jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
+  useMusdBalance: jest.fn(() => ({
+    hasMusdBalanceOnAnyChain: true,
+    tokenBalanceByChain: { '0x1': '100' },
+  })),
+}));
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics');
+
 const mockUseMoneyAccountTransactions = jest.mocked(
   useMoneyAccountTransactions,
 );
@@ -97,6 +108,7 @@ jest.mock('../../../../UI/AssetOverview/Balance/Balance', () => ({
 describe('MoneyHomeView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useAnalytics).mockReturnValue(createMockUseAnalyticsHook());
     // Activity list renders when there are at least 10 transactions; pad the
     // mock set so the activity-related assertions below find the View all button.
     const paddedTransactions = Array.from({ length: 10 }, (_, index) => ({
@@ -202,5 +214,74 @@ describe('MoneyHomeView', () => {
     fireEvent.press(getByTestId(MoneyActivityListTestIds.VIEW_ALL_BUTTON));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ACTIVITY);
+  });
+
+  describe('Position Screen Viewed analytics', () => {
+    let mockTrackEvent: jest.Mock;
+    let mockAddProperties: jest.Mock;
+
+    beforeEach(() => {
+      mockTrackEvent = jest.fn();
+      mockAddProperties = jest.fn().mockReturnThis();
+      jest.mocked(useAnalytics).mockReturnValue(
+        createMockUseAnalyticsHook({
+          trackEvent: mockTrackEvent,
+          createEventBuilder: jest.fn().mockReturnValue({
+            addProperties: mockAddProperties,
+            addSensitiveProperties: jest.fn().mockReturnThis(),
+            removeProperties: jest.fn().mockReturnThis(),
+            removeSensitiveProperties: jest.fn().mockReturnThis(),
+            setSaveDataRecording: jest.fn().mockReturnThis(),
+            build: jest.fn(),
+          }),
+        }),
+      );
+    });
+
+    it('tracks Position Screen Viewed with item_count matching chains with balance', () => {
+      jest
+        .mocked(
+          jest.requireMock('../../../Earn/hooks/useMusdBalance').useMusdBalance,
+        )
+        .mockReturnValue({
+          hasMusdBalanceOnAnyChain: true,
+          tokenBalanceByChain: { '0x1': '50', '0xe708': '25' },
+        });
+
+      renderWithProvider(<MoneyHomeView />);
+
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item_count: 2,
+          location: 'homepage',
+          is_empty: false,
+          screen_type: 'cash',
+        }),
+      );
+    });
+
+    it('tracks Position Screen Viewed with is_empty true when user has no mUSD balance', () => {
+      jest
+        .mocked(
+          jest.requireMock('../../../Earn/hooks/useMusdBalance').useMusdBalance,
+        )
+        .mockReturnValue({
+          hasMusdBalanceOnAnyChain: false,
+          tokenBalanceByChain: {},
+        });
+
+      renderWithProvider(<MoneyHomeView />);
+
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item_count: 0,
+          location: 'homepage',
+          is_empty: true,
+          screen_type: 'cash',
+        }),
+      );
+    });
   });
 });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -18,6 +18,9 @@ import MoneyWhatYouGet from '../../components/MoneyWhatYouGet';
 import MoneyActivityList from '../../components/MoneyActivityList';
 import MoneyFooter from '../../components/MoneyFooter';
 import Routes from '../../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { MoneyHomeViewTestIds } from './MoneyHomeView.testIds';
 import styleSheet from './MoneyHomeView.styles';
 import { MUSD_CONVERSION_APY } from '../../../Earn/constants/musd';
@@ -37,6 +40,29 @@ const MoneyHomeView = () => {
 
   const { tokens: conversionTokens } = useMusdConversionTokens();
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
+  const { hasMusdBalanceOnAnyChain, tokenBalanceByChain } = useMusdBalance();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const hasTrackedScreenViewRef = useRef(false);
+
+  useEffect(() => {
+    if (hasTrackedScreenViewRef.current) return;
+    hasTrackedScreenViewRef.current = true;
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.POSITION_SCREEN_VIEWED)
+        .addProperties({
+          item_count: Object.keys(tokenBalanceByChain).length,
+          location: 'homepage',
+          is_empty: Object.keys(tokenBalanceByChain).length === 0,
+          screen_type: 'cash',
+        })
+        .build(),
+    );
+  }, [
+    hasMusdBalanceOnAnyChain,
+    tokenBalanceByChain,
+    trackEvent,
+    createEventBuilder,
+  ]);
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
@@ -5,6 +5,8 @@ import CashTokensFullView from './CashTokensFullView';
 import { useMerklBonusClaim } from '../../UI/Earn/components/MerklRewards/hooks/useMerklBonusClaim';
 import { selectMoneyHubEnabledFlag } from '../../UI/Money/selectors/featureFlags';
 import { AssetType } from '../confirmations/types/token';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../util/test/analyticsMock';
 
 const mockGoBack = jest.fn();
 
@@ -15,10 +17,15 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-const mockUseMusdBalance = jest.fn(() => ({ hasMusdBalanceOnAnyChain: false }));
+const mockUseMusdBalance = jest.fn(() => ({
+  hasMusdBalanceOnAnyChain: false,
+  tokenBalanceByChain: {},
+}));
 jest.mock('../../UI/Earn/hooks/useMusdBalance', () => ({
   useMusdBalance: () => mockUseMusdBalance(),
 }));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics');
 
 // Let real CashGetMusdEmptyState render; mock its dependencies
 jest.mock('../../../core/NavigationService', () => ({
@@ -128,8 +135,12 @@ jest.mock('../../UI/Tokens', () => {
 describe('CashTokensFullView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseMusdBalance.mockReturnValue({ hasMusdBalanceOnAnyChain: false });
+    mockUseMusdBalance.mockReturnValue({
+      hasMusdBalanceOnAnyChain: false,
+      tokenBalanceByChain: {},
+    });
     mockUseMusdConversionTokens.mockReturnValue({ tokens: [] });
+    jest.mocked(useAnalytics).mockReturnValue(createMockUseAnalyticsHook());
     mockSelectMoneyHubEnabledFlag.mockReturnValue(false);
     mockUseMerklBonusClaim.mockReturnValue({
       claimableReward: null,
@@ -147,14 +158,20 @@ describe('CashTokensFullView', () => {
   });
 
   it('renders Get mUSD empty state when user has no mUSD', () => {
-    mockUseMusdBalance.mockReturnValue({ hasMusdBalanceOnAnyChain: false });
+    mockUseMusdBalance.mockReturnValue({
+      hasMusdBalanceOnAnyChain: false,
+      tokenBalanceByChain: {},
+    });
     renderWithProvider(<CashTokensFullView />);
     expect(screen.getByTestId('cash-get-musd-empty-state')).toBeOnTheScreen();
     expect(screen.getByText('Get mUSD')).toBeOnTheScreen();
   });
 
   it('renders Tokens with isFullView and showOnlyMusd when user has mUSD', () => {
-    mockUseMusdBalance.mockReturnValue({ hasMusdBalanceOnAnyChain: true });
+    mockUseMusdBalance.mockReturnValue({
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceByChain: { '0x1': '100' },
+    });
     renderWithProvider(<CashTokensFullView />);
     expect(screen.getByTestId('tokens-cash-view')).toBeOnTheScreen();
     expect(
@@ -237,5 +254,58 @@ describe('CashTokensFullView', () => {
     expect(screen.getByText('Swap')).toBeOnTheScreen();
     expect(screen.getByText('Buy')).toBeOnTheScreen();
     expect(screen.queryByText('Convert to mUSD')).not.toBeOnTheScreen();
+  });
+
+  describe('Position Screen Viewed analytics', () => {
+    let mockTrackEvent: jest.Mock;
+    let mockAddProperties: jest.Mock;
+
+    beforeEach(() => {
+      mockTrackEvent = jest.fn();
+      mockAddProperties = jest.fn().mockReturnThis();
+      jest.mocked(useAnalytics).mockReturnValue(
+        createMockUseAnalyticsHook({
+          trackEvent: mockTrackEvent,
+          createEventBuilder: jest.fn().mockReturnValue({
+            addProperties: mockAddProperties,
+            addSensitiveProperties: jest.fn().mockReturnThis(),
+            removeProperties: jest.fn().mockReturnThis(),
+            removeSensitiveProperties: jest.fn().mockReturnThis(),
+            setSaveDataRecording: jest.fn().mockReturnThis(),
+            build: jest.fn(),
+          }),
+        }),
+      );
+    });
+
+    it('tracks Position Screen Viewed with is_empty true when user has no mUSD balance', () => {
+      mockUseMusdBalance.mockReturnValue({
+        hasMusdBalanceOnAnyChain: false,
+        tokenBalanceByChain: {},
+      });
+
+      renderWithProvider(<CashTokensFullView />);
+
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item_count: 0,
+          location: 'homepage',
+          is_empty: true,
+          screen_type: 'cash',
+        }),
+      );
+    });
+
+    it('does not track Position Screen Viewed when user has mUSD balance (Tokens component handles it)', () => {
+      mockUseMusdBalance.mockReturnValue({
+        hasMusdBalanceOnAnyChain: true,
+        tokenBalanceByChain: { '0x1': '100' },
+      });
+
+      renderWithProvider(<CashTokensFullView />);
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Linking, ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -36,14 +36,41 @@ import Logger from '../../../util/Logger';
 import AppConstants from '../../../core/AppConstants';
 import { selectMoneyHubEnabledFlag } from '../../UI/Money/selectors/featureFlags';
 import { useSelector } from 'react-redux';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 
 const CashTokensFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
-  const { hasMusdBalanceOnAnyChain } = useMusdBalance();
+  const { hasMusdBalanceOnAnyChain, tokenBalanceByChain } = useMusdBalance();
   const { tokens: conversionTokens } = useMusdConversionTokens();
 
   const isMoneyHubEnabled = useSelector(selectMoneyHubEnabledFlag);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const hasTrackedScreenViewRef = useRef(false);
+
+  useEffect(() => {
+    // Only fire for the empty state — the Tokens component fires this event
+    // when isFullView=true and hasMusdBalanceOnAnyChain=true
+    if (hasMusdBalanceOnAnyChain) return;
+    if (hasTrackedScreenViewRef.current) return;
+    hasTrackedScreenViewRef.current = true;
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.POSITION_SCREEN_VIEWED)
+        .addProperties({
+          item_count: Object.keys(tokenBalanceByChain).length,
+          location: 'homepage',
+          is_empty: Object.keys(tokenBalanceByChain).length === 0,
+          screen_type: 'cash',
+        })
+        .build(),
+    );
+  }, [
+    hasMusdBalanceOnAnyChain,
+    tokenBalanceByChain,
+    trackEvent,
+    createEventBuilder,
+  ]);
 
   const hasConversionTokens = conversionTokens.length > 0;
 


### PR DESCRIPTION
## **Description**


The `Position Screen Viewed` Segment event is tracked by DeFi, Tokens, and NFTs when their full-view screens open. The Cash account ">" had no equivalent tracking.

Two screens serve as the Cash full-view destination depending on feature flags:
- `CashTokensFullView` — fires the event for the empty state (no mUSD balance); the `Tokens` component handles the non-empty case internally via `isFullView + showOnlyMusd`
- `MoneyHomeView` — fires the event on mount (the `isMoneyHomeEnabled` flag path)

Both use `tokenBalanceByChain` from `useMusdBalance` to derive `item_count`, consistent with how DeFi/Tokens count their items.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-561

## **Manual testing steps**

```gherkin
Feature: Position Screen Viewed for Cash account

  Scenario: user with no mUSD balance views Cash full-view screen
    Given the user has no mUSD balance
    And the Cash section is visible on the homepage

    When user taps the "Money" section header
    Then a "Position Screen Viewed" event fires with screen_type: "cash", is_empty: true, item_count: 0

  Scenario: user with mUSD balance views Cash full-view screen
    Given the user has mUSD balance on one or more chains
    And the Cash section is visible on the homepage

    When user taps the "Money" section header
    Then a "Position Screen Viewed" event fires with screen_type: "cash", is_empty: false, item_count equal to the number of chains with balance
```

## **Screenshots/Recordings**

Money Home Screen (Screen is WIP but event was added anyway)

https://github.com/user-attachments/assets/cb7a7e78-4cb4-40e1-972c-52fbbd9b20e8

Cash Full Screen

https://github.com/user-attachments/assets/5c535ed3-ebe6-4007-a003-4ba7ef5e8c9e

### **Before**

`~`


### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds one-time analytics events on screen mount/empty-state paths and updates tests; no changes to auth, funds, or core transaction logic.
> 
> **Overview**
> Adds Segment `MetaMetricsEvents.POSITION_SCREEN_VIEWED` tracking for the Cash full-view entry points.
> 
> `MoneyHomeView` now fires the event once on mount, using `useMusdBalance().tokenBalanceByChain` to set `item_count`, `is_empty`, `location: 'homepage'`, and `screen_type: 'cash'`. `CashTokensFullView` adds the same event *only for the empty-state path* (no mUSD balance) to avoid duplicating the existing tracking done by `Tokens` when mUSD is present.
> 
> Tests are updated to mock `useAnalytics`/`useMusdBalance` and assert the correct analytics properties (including `item_count` based on number of chains with balance) and the non-duplication behavior in `CashTokensFullView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fddf4690c647998621aa86b87be67c53362a0ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->