### PR TITLE
feat(analytics): split request_source to distinguish SDK v1 from MetaMask Connect (MWP)

### DIFF
--- a/app/components/hooks/useAnalytics/useAnalytics.types.ts
+++ b/app/components/hooks/useAnalytics/useAnalytics.types.ts
@@ -18,7 +18,7 @@ type AnalyticsEventBuilderType = ReturnType<
 >;
 
 /**
- * Source type constants for analytics tracking
+ * Source type constants for analytics tracking (used on Connect Request events).
  */
 export const SourceType = {
   SDK: 'sdk',
@@ -27,6 +27,16 @@ export const SourceType = {
   IN_APP_BROWSER: 'in-app browser',
   PERMISSION_SYSTEM: 'permission system',
   DAPP_DEEPLINK_URL: 'dapp-deeplink-url',
+} as const;
+
+/**
+ * Transport type constants — identifies the underlying connection transport.
+ * Values align with the segment-schema transport_type enum.
+ */
+export const TransportType = {
+  SOCKET_RELAY: 'socket_relay',
+  MWP: 'mwp',
+  WALLETCONNECT: 'walletconnect',
 } as const;
 
 export interface UseAnalyticsHook {

--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -268,6 +268,7 @@ export default {
   ADD_CUSTOM_NETWORK_CUSTOM_TAB_ID: 'custom-tab',
   REQUEST_SOURCES: {
     SDK_REMOTE_CONN: 'MetaMask-SDK-Remote-Conn',
+    MM_CONNECT: 'MetaMask-Connect',
     WC: 'WalletConnect',
     WC2: 'WalletConnectV2',
     IN_APP_BROWSER: 'In-App-Browser',

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -27,6 +27,7 @@ import { store } from '../../store';
 import { v1 as random } from 'uuid';
 import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants';
+import { TransportType } from '../../components/hooks/useAnalytics/useAnalytics.types';
 import PPOMUtil from '../../lib/ppom/ppom-util';
 import { setEventStageError, setEventStage } from '../../actions/rpcEvents';
 import { isWhitelistedRPC, RPCStageTypes } from '../../reducers/rpcEvents';
@@ -415,7 +416,7 @@ export const getRpcMethodMiddleware = ({
 
   const getSource = () => {
     if (analytics?.isRemoteConn) {
-      return analytics?.transport === 'mwp'
+      return analytics?.transport === TransportType.MWP
         ? AppConstants.REQUEST_SOURCES.MM_CONNECT
         : AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
     }

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -414,8 +414,11 @@ export const getRpcMethodMiddleware = ({
   const origin = channelId ?? hostname;
 
   const getSource = () => {
-    if (analytics?.isRemoteConn)
-      return AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
+    if (analytics?.isRemoteConn) {
+      return analytics?.transport === 'mwp'
+        ? AppConstants.REQUEST_SOURCES.MM_CONNECT
+        : AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
+    }
     if (isWalletConnect) return AppConstants.REQUEST_SOURCES.WC;
     return AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
   };

--- a/app/core/SDKConnect/getDefaultBridgeParams.ts
+++ b/app/core/SDKConnect/getDefaultBridgeParams.ts
@@ -38,6 +38,7 @@ const getDefaultBridgeParams = (clientInfo: DappClient) => ({
       isWalletConnect: false,
       analytics: {
         isRemoteConn: true,
+        transport: 'socket_relay',
         platform:
           clientInfo.originatorInfo.platform ??
           AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnect/getDefaultBridgeParams.ts
+++ b/app/core/SDKConnect/getDefaultBridgeParams.ts
@@ -1,6 +1,7 @@
 import { ImageSourcePropType } from 'react-native';
 import AppConstants from '../AppConstants';
 import getRpcMethodMiddleware from '../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../components/hooks/useAnalytics/useAnalytics.types';
 import { DappClient } from './dapp-sdk-types';
 
 const getDefaultBridgeParams = (clientInfo: DappClient) => ({
@@ -38,7 +39,7 @@ const getDefaultBridgeParams = (clientInfo: DappClient) => ({
       isWalletConnect: false,
       analytics: {
         isRemoteConn: true,
-        transport: 'socket_relay',
+        transport: TransportType.SOCKET_RELAY,
         platform:
           clientInfo.originatorInfo.platform ??
           AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -96,6 +96,7 @@ export const setupBridge = ({
         isWalletConnect: false,
         analytics: {
           isRemoteConn: true,
+          transport: 'socket_relay',
           platform:
             originatorInfo?.platform ?? AppConstants.MM_SDK.UNKNOWN_PARAM,
         },

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -3,6 +3,7 @@ import BackgroundBridge from '../../BackgroundBridge/BackgroundBridge';
 import getRpcMethodMiddleware, {
   RPCMethodsMiddleParameters,
 } from '../../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
 
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -96,7 +97,7 @@ export const setupBridge = ({
         isWalletConnect: false,
         analytics: {
           isRemoteConn: true,
-          transport: 'socket_relay',
+          transport: TransportType.SOCKET_RELAY,
           platform:
             originatorInfo?.platform ?? AppConstants.MM_SDK.UNKNOWN_PARAM,
         },

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -4,6 +4,7 @@ import { IRPCBridgeAdapter } from '../types/rpc-bridge-adapter';
 import Engine, { RootExtendedMessenger } from '../../Engine';
 import AppConstants from '../../AppConstants';
 import getRpcMethodMiddleware from '../../RPCMethods/RPCMethodMiddleware';
+import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
 import { ImageSourcePropType } from 'react-native';
 import { ConnectionInfo } from '../types/connection-info';
 import { whenEngineReady } from '../utils/when-engine-ready';
@@ -153,7 +154,7 @@ export class RPCBridgeAdapter
           isWalletConnect: false,
           analytics: {
             isRemoteConn: true,
-            transport: 'mwp',
+            transport: TransportType.MWP,
             platform:
               this.connInfo.metadata.sdk.platform ??
               AppConstants.MM_SDK.UNKNOWN_PARAM,

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -153,6 +153,7 @@ export class RPCBridgeAdapter
           isWalletConnect: false,
           analytics: {
             isRemoteConn: true,
+            transport: 'mwp',
             platform:
               this.connInfo.metadata.sdk.platform ??
               AppConstants.MM_SDK.UNKNOWN_PARAM,


### PR DESCRIPTION
## Summary

Splits the `request_source` value on RPC pipeline events (`Transaction Added`, `Signature Requested`, `Signature Approved`, etc.) so that legacy MetaMask SDK v1 (socket relay) connections and MetaMask Connect / MWP / SDK v2 connections are distinguishable. Previously both emitted `'MetaMask-SDK-Remote-Conn'` and were indistinguishable in analytics.

Paired with [Consensys/segment-schema#534](https://github.com/Consensys/segment-schema/pull/534), which adds the matching schema change.

Relates to **WAPI-1398**.

## The problem

`getSource()` in `RPCMethodMiddleware.ts` branched only on `isRemoteConn` / `isWalletConnect`:

\`\`\`ts
const getSource = () => {
  if (analytics?.isRemoteConn) return AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
  if (isWalletConnect) return AppConstants.REQUEST_SOURCES.WC;
  return AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
};
\`\`\`

Both SDK v1 (via `setupBridge.ts` / `getDefaultBridgeParams.ts`) and MWP (via `rpc-bridge-adapter.ts`) pass `analytics: { isRemoteConn: true }` to the `BackgroundBridge`, so both transports collapsed to `'MetaMask-SDK-Remote-Conn'` downstream.

Using `BackgroundBridge.sdkVersion` as the discriminator was considered and rejected — it's a feature flag for multichain gating and was never threaded into the `analytics` object that feeds the middleware. `originatorInfo.apiVersion` is a semver string and also unrelated.

## Changes

### 1. New `transport` field on the analytics param

Added an optional `transport` field on the `analytics` object passed to `getRpcMethodMiddleware`, carrying values from a new `TransportType` vocabulary (`socket_relay` / `mwp`).

### 2. `getSource()` branches on transport

\`\`\`ts
const getSource = () => {
  if (analytics?.isRemoteConn) {
    return analytics?.transport === TransportType.MWP
      ? AppConstants.REQUEST_SOURCES.MM_CONNECT      // 'MetaMask-Connect' (new)
      : AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN; // 'MetaMask-SDK-Remote-Conn' (unchanged)
  }
  if (isWalletConnect) return AppConstants.REQUEST_SOURCES.WC;
  return AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
};
\`\`\`

### 3. New `MM_CONNECT` constant

`AppConstants.REQUEST_SOURCES.MM_CONNECT = 'MetaMask-Connect'`.

### 4. Each transport declares itself

| File | Added |
|------|-------|
| `app/core/SDKConnect/handlers/setupBridge.ts` | `transport: TransportType.SOCKET_RELAY` |
| `app/core/SDKConnect/getDefaultBridgeParams.ts` | `transport: TransportType.SOCKET_RELAY` |
| `app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts` | `transport: TransportType.MWP` |

### 5. `TransportType` constant

Added alongside `SourceType` in `app/components/hooks/useAnalytics/useAnalytics.types.ts` to centralize the vocabulary and avoid scattered magic strings.

\`\`\`ts
export const TransportType = {
  SOCKET_RELAY: 'socket_relay',
  MWP: 'mwp',
  WALLETCONNECT: 'walletconnect',
} as const;
\`\`\`

## Decision: `'MetaMask-Connect'` as the new value

Option A from the design doc — minimize blast radius:

| Transport | `request_source` value |
|-----------|-------------------------|
| SDK v1 (socket relay) | `MetaMask-SDK-Remote-Conn` *(unchanged — preserves historic Mixpanel continuity)* |
| **MWP / SDK v2** | **`MetaMask-Connect`** *(new)* |
| WalletConnect | `WalletConnect` *(unchanged)* |
| In-App Browser | `In-App-Browser` *(unchanged)* |

Full alignment to the `source` property vocabulary (`sdk` / `mm_connect` / `walletconnect` / `in-app browser` used on Connect Request events) was considered as Option B but deferred — it would break all four existing values, and the historical dashboards we're aware of don't query `request_source`, so the upside isn't worth the break right now.

## Impact

- MWP / SDK v2 connections on pipeline events will start emitting `request_source: 'MetaMask-Connect'` once this + [#534](https://github.com/Consensys/segment-schema/pull/534) land and the next tracking-plan sync runs.
- SDK v1 socket relay keeps emitting `'MetaMask-SDK-Remote-Conn'` — no discontinuity.
- Nothing else changes: WC, in-app browser, and all downstream emitters (`useSignatureMetrics`, `eth_sendTransaction` → `metrics.ts`, `ethereum-chain-utils`, etc.) spread the analytics bag through untouched.

## Verification

- Lints clean on all modified files.
- Existing `setupBridge.test.ts` passes unchanged — it uses `expect.objectContaining` on the `BackgroundBridge` args and tolerates the additive `transport` key inside the nested `analytics` object.
- Branch contains two commits: initial feat + follow-up refactor centralizing the transport values in `TransportType`.

## Ordering for deploy

1. Merge [#534](https://github.com/Consensys/segment-schema/pull/534) (schema-side change).
2. Wait for the schema-build workflow to sync the mobile tracking plan.
3. Merge this PR (starts emitting `'MetaMask-Connect'`).

Landing this PR first would cause Protocols to strip the new value until the schema syncs.

## Related

- Consensys/segment-schema#534 — schema side for `request_source`
- Consensys/segment-schema#532 — consolidate mobile signature schemas
- Consensys/segment-schema#533 — `remote_request_platform` on sig/txn
- MetaMask/metamask-mobile#28995 — `remote_request_platform` emitter side
- WAPI-1398 — parent ticket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central RPC middleware used to populate analytics metadata for many request flows; mis-tagging or missing `transport` could skew metrics, though runtime behavior beyond analytics labeling should be unchanged.
> 
> **Overview**
> RPC pipeline analytics now **splits `request_source` for remote connections** by introducing a `transport` field on the `analytics` bag and branching in `RPCMethodMiddleware.getSource()`.
> 
> A new `TransportType` enum centralizes transport vocabulary, SDK v1 bridge setup (`setupBridge`, `getDefaultBridgeParams`) tags connections as `socket_relay`, SDK v2/MWP (`rpc-bridge-adapter`) tags as `mwp`, and `AppConstants.REQUEST_SOURCES` gains a new `MM_CONNECT` value (`MetaMask-Connect`) used when `transport === mwp` (otherwise preserving the existing `MetaMask-SDK-Remote-Conn`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27ae07cbd99fb6f0f4633f22ae6c0303565c0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->