### PR TITLE
fix: exclude ended sports events from Predict featured carousel

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -7686,6 +7686,45 @@ describe('PolymarketProvider', () => {
         ]);
       });
 
+      it('excludes events with ended: true before parsing', async () => {
+        const provider = createProvider();
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([
+          { event: { id: 'event-live', ended: false } },
+          { event: { id: 'event-ended', ended: true } },
+          { event: { id: 'event-scheduled' } },
+        ]);
+        mockParsePolymarketEvents.mockReturnValue([]);
+
+        await provider.getCarouselMarkets();
+
+        expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+          [
+            { id: 'event-live', ended: false },
+            { id: 'event-scheduled' },
+          ],
+          expect.any(Object),
+        );
+      });
+
+      it('does not load teams for events with ended: true', async () => {
+        const provider = createProvider({ liveSportsLeagues: ['nfl'] });
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([
+          { event: { id: 'event-live', ended: false } },
+          { event: { id: 'event-ended', ended: true } },
+        ]);
+        mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+        mockParsePolymarketEvents.mockReturnValue([]);
+
+        await provider.getCarouselMarkets();
+
+        expect(mockExtractNeededTeamsFromEvents).toHaveBeenCalledWith(
+          [{ id: 'event-live', ended: false }],
+          ['nfl'],
+        );
+      });
+
       it('loads teams when live sports is enabled', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
         const mockEvents = [{ id: 'event-1' }];

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -7699,10 +7699,7 @@ describe('PolymarketProvider', () => {
         await provider.getCarouselMarkets();
 
         expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
-          [
-            { id: 'event-live', ended: false },
-            { id: 'event-scheduled' },
-          ],
+          [{ id: 'event-live', ended: false }, { id: 'event-scheduled' }],
           expect.any(Object),
         );
       });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -497,7 +497,13 @@ export class PolymarketProvider implements PredictProvider {
       const liveSportsEnabled = supportedLeagues.length > 0;
 
       const items = await fetchCarouselFromPolymarketApi();
-      const events = items.map((item) => item.event);
+      // Polymarket's carousel API occasionally returns sports events that have
+      // already finished (ended: true). Filter them out here so ended games
+      // never reach the carousel UI. Non-sports events have `ended` undefined
+      // and pass through unchanged.
+      const events = items
+        .map((item) => item.event)
+        .filter((event) => !event.ended);
 
       await this.#ensureTeamsLoadedForEvents(events, supportedLeagues);
 


### PR DESCRIPTION
# PR Title

fix(predict): hide ended events from featured carousel

---

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes already-finished sports games appearing in the featured carousel.

**Problem:** Polymarket's carousel API occasionally returns sports events that have already finished, flagged with `ended: true` on the event payload. These ended events were still flowing through `parsePolymarketEvents` and rendering in the featured carousel UI, showing users games that are no longer bettable.

**Solution:** In `PolymarketProvider.getCarouselMarkets`, filter items whose `event.ended` is truthy out of the event list immediately after fetching, before team loading and event parsing. Non-sports events have `ended` as `undefined` and pass through unchanged, so this only removes confirmed-finished sports events. Because the filter runs before `#ensureTeamsLoadedForEvents`, teams are no longer loaded for ended events either, which avoids unnecessary team cache lookups.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed featured carousel showing sports games that had already ended

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Featured carousel hides ended events

  Scenario: Ended sports events are filtered out of the carousel
    Given the Polymarket carousel API returns a sports event with "ended": true
    When the featured carousel loads
    Then the ended event does not appear in the carousel

  Scenario: Live and scheduled events still render
    Given the Polymarket carousel API returns events with "ended": false and "ended" undefined
    When the featured carousel loads
    Then both the live and scheduled events appear in the carousel

  Scenario: Teams are not loaded for ended events
    Given live sports is enabled
    And the Polymarket carousel API returns one live event and one ended event
    When the featured carousel loads
    Then team data is only requested for the live event
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized filter change in `getCarouselMarkets` with added unit coverage; main risk is unintentionally hiding events if `ended` is mis-set by the upstream API.
> 
> **Overview**
> Filters Polymarket carousel items at the source in `getCarouselMarkets` by dropping any event with `ended: true` *before* team loading and `parsePolymarketEvents`, preventing finished sports games from reaching the featured carousel UI.
> 
> Adds unit tests to assert ended events are excluded from parsing and do not trigger team-loading logic, while preserving behavior for non-sports events where `ended` is undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba17d28ebf8899e70ed06a06b0beba455ab39321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->