### PR TITLE
fix: collapse Predict carousel markets to moneyline outcome when present

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -7709,6 +7709,123 @@ describe('PolymarketProvider', () => {
           ['sea', 'den'],
         );
       });
+
+      it('collapses outcomes to the moneyline outcome when present', async () => {
+        const provider = createProvider();
+        const moneylineOutcome = {
+          id: 'match-winner',
+          sportsMarketType: 'moneyline',
+          tokens: [
+            { title: 'Spirit' },
+            { title: 'MOUZ' },
+          ],
+        };
+        const overUnderOutcome = {
+          id: 'ou-2.5',
+          sportsMarketType: 'totals',
+          tokens: [{ title: 'Over' }, { title: 'Under' }],
+        };
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([{ event: {} }]);
+        mockParsePolymarketEvents.mockReturnValue([
+          {
+            id: 'cs-spirit-vs-mouz',
+            status: 'open',
+            outcomes: [overUnderOutcome, moneylineOutcome],
+          },
+        ]);
+
+        const result = await provider.getCarouselMarkets();
+
+        expect(result).toEqual([
+          {
+            id: 'cs-spirit-vs-mouz',
+            status: 'open',
+            outcomes: [moneylineOutcome],
+          },
+        ]);
+      });
+
+      it('matches moneyline regardless of sportsMarketType casing', async () => {
+        const provider = createProvider();
+        const moneylineOutcome = {
+          id: 'match-winner',
+          sportsMarketType: 'MoneyLine',
+          tokens: [{ title: 'Home' }, { title: 'Away' }],
+        };
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([{ event: {} }]);
+        mockParsePolymarketEvents.mockReturnValue([
+          {
+            id: 'm1',
+            status: 'open',
+            outcomes: [
+              { id: 'spread', sportsMarketType: 'spreads' },
+              moneylineOutcome,
+            ],
+          },
+        ]);
+
+        const result = await provider.getCarouselMarkets();
+
+        expect(result[0].outcomes).toEqual([moneylineOutcome]);
+      });
+
+      it('passes markets through unchanged when no moneyline outcome exists', async () => {
+        const provider = createProvider();
+        const marketWithoutMoneyline = {
+          id: 'binary-market',
+          status: 'open',
+          outcomes: [
+            { id: 'yes', tokens: [{ title: 'Yes' }, { title: 'No' }] },
+          ],
+        };
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([{ event: {} }]);
+        mockParsePolymarketEvents.mockReturnValue([marketWithoutMoneyline]);
+
+        const result = await provider.getCarouselMarkets();
+
+        expect(result).toEqual([marketWithoutMoneyline]);
+      });
+
+      it('preserves all home/draw/away tokens on the moneyline outcome for soccer markets', async () => {
+        const provider = createProvider();
+        const soccerMoneyline = {
+          id: 'match-winner',
+          sportsMarketType: 'moneyline',
+          tokens: [
+            { id: 'tot', title: 'Tottenham' },
+            { id: 'draw', title: 'Draw' },
+            { id: 'bri', title: 'Brighton' },
+          ],
+        };
+        const totalGoals = {
+          id: 'total-goals',
+          sportsMarketType: 'totals',
+          tokens: [{ title: 'Over' }, { title: 'Under' }],
+        };
+
+        mockFetchCarouselFromPolymarketApi.mockResolvedValue([{ event: {} }]);
+        mockParsePolymarketEvents.mockReturnValue([
+          {
+            id: 'tot-vs-bri',
+            status: 'open',
+            game: { homeTeam: { name: 'Tottenham' }, awayTeam: { name: 'Brighton' } },
+            outcomes: [soccerMoneyline, totalGoals],
+          },
+        ]);
+
+        const result = await provider.getCarouselMarkets();
+
+        expect(result[0].outcomes).toEqual([soccerMoneyline]);
+        expect(result[0].outcomes[0].tokens).toHaveLength(3);
+        expect(
+          result[0].outcomes[0].tokens.map(
+            (t: { title: string }) => t.title,
+          ),
+        ).toEqual(['Tottenham', 'Draw', 'Brighton']);
+      });
     });
 
     describe('getMarketDetails', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -7715,10 +7715,7 @@ describe('PolymarketProvider', () => {
         const moneylineOutcome = {
           id: 'match-winner',
           sportsMarketType: 'moneyline',
-          tokens: [
-            { title: 'Spirit' },
-            { title: 'MOUZ' },
-          ],
+          tokens: [{ title: 'Spirit' }, { title: 'MOUZ' }],
         };
         const overUnderOutcome = {
           id: 'ou-2.5',
@@ -7811,7 +7808,10 @@ describe('PolymarketProvider', () => {
           {
             id: 'tot-vs-bri',
             status: 'open',
-            game: { homeTeam: { name: 'Tottenham' }, awayTeam: { name: 'Brighton' } },
+            game: {
+              homeTeam: { name: 'Tottenham' },
+              awayTeam: { name: 'Brighton' },
+            },
             outcomes: [soccerMoneyline, totalGoals],
           },
         ]);
@@ -7821,9 +7821,7 @@ describe('PolymarketProvider', () => {
         expect(result[0].outcomes).toEqual([soccerMoneyline]);
         expect(result[0].outcomes[0].tokens).toHaveLength(3);
         expect(
-          result[0].outcomes[0].tokens.map(
-            (t: { title: string }) => t.title,
-          ),
+          result[0].outcomes[0].tokens.map((t: { title: string }) => t.title),
         ).toEqual(['Tottenham', 'Draw', 'Brighton']);
       });
     });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -521,9 +521,7 @@ export class PolymarketProvider implements PredictProvider {
           const moneyline = market.outcomes.find(
             (o) => o.sportsMarketType?.toLowerCase() === 'moneyline',
           );
-          return moneyline
-            ? { ...market, outcomes: [moneyline] }
-            : market;
+          return moneyline ? { ...market, outcomes: [moneyline] } : market;
         });
 
       return liveSportsEnabled

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -508,7 +508,23 @@ export class PolymarketProvider implements PredictProvider {
         sortMarketsBy: 'price',
         teamLookup,
         extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
-      }).filter((m) => m.status === 'open' && m.outcomes.length > 0);
+      })
+        .filter((m) => m.status === 'open' && m.outcomes.length > 0)
+        .map((market) => {
+          // Carousel cards only have room for a single "winning team /
+          // winning side" bet. When Polymarket returns an event with
+          // multiple markets (e.g. an e-sports match with Match Winner +
+          // O/U 2.5 Games), collapse to just the moneyline outcome so
+          // users see the primary bet instead of a random pair of
+          // secondary markets. Events without a moneyline outcome are
+          // passed through unchanged.
+          const moneyline = market.outcomes.find(
+            (o) => o.sportsMarketType?.toLowerCase() === 'moneyline',
+          );
+          return moneyline
+            ? { ...market, outcomes: [moneyline] }
+            : market;
+        });
 
       return liveSportsEnabled
         ? GameCache.getInstance().overlayOnMarkets(parsedMarkets)


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes the featured carousel showing secondary markets instead of the primary match winner on sports events.

**Problem:** Polymarket's carousel API can return a single sports event that contains multiple markets (e.g., an e-sports match with a Match Winner market plus an Over/Under 2.5 Games market). Featured carousel cards only have room for one "winning team / winning side" bet, so when multiple markets existed the card could end up displaying a random pair of secondary market outcomes (e.g., "Over" / "Under") instead of the moneyline the user actually cares about.

**Solution:** In `PolymarketProvider.getCarouselMarkets`, after parsing and filtering, map each market and — if it has an outcome with `sportsMarketType === 'moneyline'` (case-insensitive) — collapse `outcomes` down to just that single moneyline outcome. Events without a moneyline outcome are passed through unchanged, so non-sports and binary markets are unaffected. All tokens on the moneyline outcome are preserved, so soccer (home/draw/away) and other multi-token moneylines continue to render every option.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed featured carousel showing secondary markets instead of the match winner for sports events

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Featured carousel prefers moneyline outcome

  Scenario: Sports event with multiple markets collapses to moneyline
    Given a Polymarket sports event contains both a moneyline market and a totals (O/U) market
    When the featured carousel loads
    Then the carousel card for that event shows the moneyline outcome
    And the totals (Over/Under) outcome is not shown on the card

  Scenario: Soccer moneyline keeps home/draw/away
    Given a Polymarket soccer event with a moneyline market containing home, draw, and away tokens
    When the featured carousel loads
    Then the carousel card shows all three moneyline options

  Scenario: Events without a moneyline pass through unchanged
    Given a Polymarket event has no outcome with sportsMarketType "moneyline"
    When the featured carousel loads
    Then the carousel card renders with the original outcomes unchanged
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to `getCarouselMarkets` output shaping with added test coverage; no auth/security or data persistence impact.
> 
> **Overview**
> Predict’s Polymarket carousel now **collapses multi-outcome events to a single moneyline outcome** (case-insensitive) when present, leaving events without moneyline unchanged.
> 
> Adds targeted unit tests covering moneyline selection, casing, passthrough behavior, and preserving 3-way soccer moneyline tokens (home/draw/away).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bed39fdf0b68e09a033bf54c0bb95b74f873a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->