### PR TITLE
feat(perps): add mobile agentic capability recipes

### DIFF
--- a/scripts/perps/agentic/CDP-capabilities-mobile.md
+++ b/scripts/perps/agentic/CDP-capabilities-mobile.md
@@ -1,0 +1,127 @@
+# MetaMask Mobile — CDP Capabilities
+
+Mobile mirror of the extension's CDP capabilities study. Records which runner capabilities are exposed, how they're validated, and which families are structurally absent.
+
+Substrate:
+
+- **Hermes CDP** via Metro inspector-proxy (Runtime.evaluate, Profiler)
+- **Device layer** via `xcrun simctl` (iOS) / `adb` (Android)
+- **In-app bridges**: `globalThis.__AGENTIC__`, Redux `store`, `Engine.context.*`, React DevTools hook
+
+## Supported families
+
+| Family | Recipe verbs | Mobile path | Status |
+| --- | --- | --- | --- |
+| Runtime / eval | `eval_sync`, `eval_async`, `eval_ref` | `Runtime.evaluate` | validated |
+| UI interaction | `navigate`, `press`, `scroll`, `set_input`, `type_keypad`, `wait_for` | `__AGENTIC__` + fiber walk | validated |
+| Lifecycle | `app_background`, `app_foreground`, `app_restart` | simctl / adb | validated |
+| App surface | `select_account`, `toggle_testnet`, `switch_provider` | Redux + `Engine.context.*` | validated |
+| Evidence (manual) | `screenshot`, `log_watch`, `manual` | `screenshot.sh` / Metro log | validated |
+| Evidence (automatic) | built-in run-wide issue review | Metro log + in-app console hook | validated 2026-04-17 |
+| Performance | `eval_sync` on `HermesInternal.getInstrumentedStats()` | Hermes built-in | validated 2026-04-17 |
+| Tracing | `trace_start`, `trace_stop` | Hermes `Profiler` via CDP | validated 2026-04-17 |
+
+The runner exposes intent, not raw CDP plumbing. Canonical recipes live in `teams/perps/recipes/capabilities/`.
+
+## Structurally absent (document, don't force)
+
+| Family | Why | Workaround |
+| --- | --- | --- |
+| Network (offline/throttling) | no Hermes Network domain; iOS NLC is device-wide | XHR/fetch monkey-patch via `eval_sync` (narrow); simctl NLC (blunt) |
+| Emulation — CPU | no Hermes Emulation domain | synthetic JS burn loop (not equivalent) |
+| Emulation — media / timezone | no Hermes Emulation domain | `xcrun simctl status_bar` + appearance |
+| Storage (web) | no Hermes Storage domain | MMKV / Redux clear via `eval_ref` |
+| Service worker | no RN analog | `app_background` / `app_foreground` |
+| Target (multi-page) | one Hermes target per simulator | N/A |
+| Browser permissions | no Browser CDP domain | `xcrun simctl privacy` (deferred) |
+| Fetch (request failure) | no Hermes Fetch domain | `global.fetch` / XHR monkey-patch |
+
+## Capability details
+
+### Performance metrics snapshot
+
+`eval_sync` on `HermesInternal.getInstrumentedStats()` — GC counters, heap/allocation stats, RN bridge counters — plus `global.performance.now()` for timestamps. Direct Hermes analog to Chrome's `Metrics.Timestamp`. Canonical: `capabilities/performance-metrics-smoke.json`.
+
+### Hermes sampling profiler
+
+`trace_start` / `trace_stop` call the CDP `Profiler` domain. Output is a Chrome-compatible `.cpuprofile` under `.agent/recipe-runs/<run>/traces/trace-<label>.cpuprofile`. Hermes quirk: `Profiler.enable` is unsupported (`-32601`); bridge calls `start` / `stop` directly. Canonical: `capabilities/profiler-trace-smoke.json`.
+
+Wiring: `cdp-bridge.js` `profiler-start` / `profiler-stop`; `validate-recipe.js` action cases; `lib/workflow.js` verb allowlist.
+
+### Automatic recipe issue review
+
+Every recipe run emits a uniform review contract without per-recipe wiring. Workers do **not** add `log_watch` for generic warnings/errors/exceptions.
+
+Dual-channel capture, merged at teardown:
+
+- **In-app console hook** — one-shot `Runtime.evaluate` at run start wraps `console.warn` / `console.error`, attaches `error` / `unhandledrejection` listeners, chains `ErrorUtils.setGlobalHandler`. Pushes to `globalThis.__AGENTIC_ISSUES__` (500-entry cap).
+- **Metro log tail** — records byte offset at run start; classifies the appended slice at teardown via regex (`WARN`, `ERROR`, `Uncaught` / `unhandledRejection` / `FATAL EXCEPTION`).
+
+Artifacts per run dir (`.agent/recipe-runs/<timestamp>_<recipe>/`):
+
+| File | Content |
+| --- | --- |
+| `recipe-issues.json` | all issues, deduped by `(level, channel, source, textHash)` |
+| `console-warnings.json` | `level === "warning"` |
+| `console-errors.json` | `level === "error"` |
+| `runtime-exceptions.json` | `level === "exception"` |
+| `recipe-issues-review.json` | synthesized worker-facing review |
+| `recipe-issues-review.md` | human-readable equivalent |
+
+`summary.json.recipeIssues = { captured, unexpected, failOn, review }` where `review = { status, note, observed, gating, informational, topIssues, artifactFiles }`.
+
+`review.status`:
+
+- `clean` — nothing captured
+- `review` — passed but issues observed; worker should mention with artifact paths. **Not automatic proof the PR caused the signal** (may be ambient RN noise).
+- `gating` — `fail_on_unexpected` matched; recipe forced to `FAIL`
+
+Opt-in gating (recipe top-level, all sub-fields optional):
+
+```json
+{
+  "fail_on_unexpected": {
+    "levels": ["error", "exception"],
+    "textMatches": ["^Fatal:", "SES_UNCAUGHT"],
+    "allowlist": [
+      { "textMatch": "ExpoModulesProxy", "level": "warning", "reason": "known benign" }
+    ]
+  }
+}
+```
+
+Allowlist is evaluated first: matches move `observed` → `informational` and never trigger gating.
+
+Canonical: `capabilities/recipe-issues-smoke.json`.
+
+Limitations:
+
+- No WebView / in-app browser console (no mobile WebView CDP target).
+- No native crash ingestion (iOS crash reports, Crashlytics, Sentry). JS layer only.
+- No Android logcat (scope = iOS simulator).
+- Metro regex classification is coarser than real CDP event types; in-app hook entries preferred when both channels report same text.
+- In-app hook installs at run start; boot-time exceptions fall through to metro-log only.
+
+## Recipe vocabulary
+
+**UI**: `navigate`, `wait`, `wait_for`, `press`, `scroll`, `set_input`, `type_keypad`, `clear_keypad`
+**Eval**: `eval_sync`, `eval_async`, `eval_ref`
+**App state**: `select_account`, `toggle_testnet`, `switch_provider`
+**Lifecycle**: `app_background`, `app_foreground`, `app_restart`
+**Evidence**: `screenshot`, `log_watch`, `manual`
+**Profiling**: `trace_start`, `trace_stop`
+**Control**: `switch`, `end`, `call`
+
+Converges with extension where semantics align; diverges where mobile has no primitive (no `network`, `fetch`, `storage`, `emulation`, `service_worker`, `target`, `browser`).
+
+## Next steps
+
+1. Wrap `xcrun simctl privacy` as `permission_grant` / `permission_reset` — smallest useful gap for controlled experiments.
+2. Expose `global.fetch` / XHR fault injection via `eval_ref`. Defer until a concrete recipe demands it.
+3. **Do not** add synthetic network throttling. Network conditioning belongs to Detox mock servers or whole-device NLC; a fake primitive weakens the parity claim.
+
+## References
+
+- [CDP-summary-mobile.md](./CDP-summary-mobile.md) — matrix only
+- [validate-recipe.js](./validate-recipe.js), [cdp-bridge.js](./cdp-bridge.js), [lib/workflow.js](./lib/workflow.js)
+- `teams/perps/recipes/capabilities/` — canonical smokes

--- a/scripts/perps/agentic/CDP-summary-mobile.md
+++ b/scripts/perps/agentic/CDP-summary-mobile.md
@@ -1,0 +1,54 @@
+# MetaMask Mobile — CDP Summary
+
+Quick-reference parity matrix for the mobile agentic runner. Detailed rationale lives in [CDP-capabilities-mobile.md](./CDP-capabilities-mobile.md).
+
+## Validated capability matrix
+
+| Family | Slice | Substrate | Canonical recipe |
+| --- | --- | --- | --- |
+| `runtime` | sync / async / ref evaluation | Hermes `Runtime.evaluate` | any `benchmark/*.json` |
+| `page` | navigate / press / scroll / set_input | `__AGENTIC__` + React DevTools hook | `benchmark/perps-position-market-buy.json` |
+| `page` | `wait_for` route / testID / expression | bridge + fiber walk | same |
+| `lifecycle` | background / foreground / restart | `xcrun simctl` (iOS) / `adb` (Android) | `benchmark/perps-app-restart-preserves-state.json` |
+| `app_state` | testnet / provider / account | Redux + `Engine.context.*` | `benchmark/perps-position-market-buy.json` |
+| `evidence` | screenshot | `screenshot.sh` | any |
+| `evidence` | automatic issue review (warnings/errors/exceptions) | Metro log + in-app console hook | `capabilities/recipe-issues-smoke.json` |
+| `performance` | metrics snapshot | `HermesInternal.getInstrumentedStats()` | `capabilities/performance-metrics-smoke.json` |
+| `trace` | sampling CPU profile (.cpuprofile) | Hermes `Profiler` domain | `capabilities/profiler-trace-smoke.json` |
+
+## Structurally absent (do not force)
+
+| Family | Why | Workaround if needed |
+| --- | --- | --- |
+| `network` | no Hermes Network domain; iOS NLC is device-wide | XHR/fetch monkey-patch via `eval_sync` |
+| `emulation` CPU | no Hermes Emulation | synthetic JS burn loop (not equivalent) |
+| `emulation` media/timezone | no Hermes Emulation | `xcrun simctl status_bar` + appearance |
+| `storage` web | no Hermes Storage | MMKV/Redux clear via `eval_ref` |
+| `service_worker` | no RN analog | `app_background` / `app_foreground` |
+| `target` multi-page | one Hermes target per sim | N/A |
+| `browser` permissions | no Browser CDP | `xcrun simctl privacy` (deferred) |
+| `fetch` request failure | no Hermes Fetch | `global.fetch` / XHR monkey-patch |
+
+## Directory convention
+
+- `teams/<team>/recipes/benchmark/` — migrated Detox specs
+- `teams/<team>/recipes/capabilities/` — generic capability proofs
+- `teams/<team>/recipes/` — other product recipes
+
+Product behavior stays separate from capability proofs.
+
+## Validation stance
+
+Smallest trustworthy proof per slice:
+
+- Hermes-layer (Profiler, getInstrumentedStats): CDP response shape + artifact size
+- Device-layer (simctl/adb): before/after probe of page-visible effect
+- App-layer (Redux, Engine.context, `__AGENTIC__`): direct `eval_ref`
+- Structurally absent families: documented as gaps, no synthetic equivalents
+
+## References
+
+- [CDP-capabilities-mobile.md](./CDP-capabilities-mobile.md)
+- [validate-recipe.js](./validate-recipe.js) — runner
+- [cdp-bridge.js](./cdp-bridge.js) — CDP dispatcher
+- [lib/workflow.js](./lib/workflow.js) — action allowlist

--- a/scripts/perps/agentic/README.md
+++ b/scripts/perps/agentic/README.md
@@ -1,53 +1,50 @@
 # Agentic Workflow Toolkit
 
-Automated validation toolkit for MetaMask Mobile. Uses CDP (Chrome DevTools Protocol) to drive the app on a simulator/emulator, execute flows, and assert state -- no manual tapping required.
+Automated validation toolkit for MetaMask Mobile. Drives the app on a simulator over CDP (Chrome DevTools Protocol via Hermes inspector-proxy) — no manual tapping, no Detox build cycle.
 
 ## Scope
 
-Currently lives under `scripts/perps/` and is owned by `@MetaMask/perps`. The infrastructure (`lib/`, validators, `teams/` layout) is team-agnostic by design. Once proven, the intent is to promote it to a shared `scripts/agentic/` location with each product team owning `teams/<team>/`.
+Lives under `scripts/perps/` and is owned by `@MetaMask/perps`. The infrastructure (`lib/`, validators, `teams/` layout) is team-agnostic by design. The intent is to promote it to a shared `scripts/agentic/` location with each product team owning `teams/<team>/`.
 
-## Directory Layout
+## Layout
 
 ```
 agentic/
-  cdp-bridge.js              CDP client: eval, navigate, press, scroll, eval-ref
+  cdp-bridge.js              CDP client: eval, navigate, press, scroll, eval-ref, profiler-start/stop
+  validate-recipe.js         Recipe runner (live app)
+  validate-recipe.sh         Wrapper for validate-recipe.js
   validate-flow-schema.js    Offline: enforce flow/recipe authoring rules
   validate-pre-conditions.js Offline: verify pre-condition assertion fixtures
-  validate-recipe.sh         Run a recipe against the live app
   lib/
-    assert.js                Assertion evaluator (eq, gt, contains, regex, all/any/none)
-    catalog.js               Team/flow/eval discovery, template rendering, ref resolution
-    workflow.js               Graph-based workflow normalization, cycle detection, Mermaid
-    screenshot.js            Screenshot filename helpers
-    registry.js              Legacy pre-condition loader (superseded by catalog.js)
-    config.js                Runtime config (ports, paths)
+    assert.js                Assertion evaluator
+    catalog.js               Team/flow/eval discovery + template rendering + ref resolution
+    workflow.js              Graph normalization, cycle detection, Mermaid
+    recipe-issues.js         Automatic issue-review capture
     cdp-eval.js              Low-level CDP eval helpers
-    ws-client.js             WebSocket client for CDP
-    target-discovery.js      CDP target discovery
-  schemas/
-    flow.schema.json         JSON Schema for flow documents
+    ws-client.js             WebSocket client
+    screenshot.js            Screenshot filename helpers
+    config.js                Runtime config (ports, paths)
+  schemas/flow.schema.json   JSON Schema for flow docs
   teams/
-    perps/                   Perps team data
-    mobile-platform/         Mobile platform team (placeholder)
+    perps/                   Perps team (flows, recipes, pre-conditions, evals)
+    mobile-platform/         Placeholder
   app-state.sh               Wrapper: status, eval, press, eval-ref, accounts
   app-navigate.sh            Navigate to any registered screen
-  screenshot.sh              Capture simulator/device screenshot
+  screenshot.sh              Capture simulator screenshot
   start-metro.sh             Start Metro bundler
   preflight.sh               Verify app + Metro + CDP connectivity
   setup-wallet.sh            Seed wallet from fixture
 ```
 
-## Core Concepts
+## Concepts
 
 ### Flows
 
-A **flow** is a parameterized, reusable UI sequence. Flows live in `teams/<team>/flows/<name>.json`.
-
-Flows declare `inputs` (with defaults) and a `validate.workflow` graph. Template tokens (`{{param}}`) are resolved at runtime.
+Parameterized, reusable UI sequences. Live in `teams/<team>/flows/<name>.json`. Declare `inputs` (with defaults) and a `validate.workflow` graph. `{{param}}` tokens resolve at runtime.
 
 ```json
 {
-  "title": "Trade -- market {{side}} {{symbol}} ${{usdAmount}}",
+  "title": "Trade — market {{side}} {{symbol}} ${{usdAmount}}",
   "inputs": {
     "side":      { "type": "string", "default": "long" },
     "symbol":    { "type": "string", "default": "BTC" },
@@ -68,139 +65,91 @@ Flows declare `inputs` (with defaults) and a `validate.workflow` graph. Template
 }
 ```
 
-### Recipes (Workflow Graph)
+### Recipes
 
-A **recipe** composes flows and inline steps into a directed graph under `validate.workflow`. Recipes live in `teams/<team>/recipes/`.
-
-Nodes are keyed by ID. Each node has an `action`, and most have a `next` pointer. `switch` nodes branch based on assertions. `end` nodes terminate with pass/fail.
+Directed graph that composes flows and inline steps. Live in `teams/<team>/recipes/`. Nodes keyed by ID; most have a `next` pointer. `switch` branches on assertions. `end` terminates.
 
 ```json
 {
-  "title": "Full trade lifecycle",
-  "validate": {
-    "workflow": {
-      "entry": "setup",
-      "nodes": {
-        "setup":    { "action": "call", "ref": "setup-testnet", "next": "open" },
-        "open":     { "action": "call", "ref": "trade-open-market", "params": { "symbol": "BTC" }, "next": "verify" },
-        "verify":   { "action": "eval_ref", "ref": "positions", "assert": { "operator": "length_gt", "value": 0 }, "next": "close" },
-        "close":    { "action": "call", "ref": "trade-close-position", "params": { "symbol": "BTC" }, "next": "done" },
-        "done":     { "action": "end", "status": "pass" }
-      }
-    }
+  "entry": "setup",
+  "nodes": {
+    "setup": { "action": "call", "ref": "setup-testnet", "next": "open" },
+    "open":  { "action": "call", "ref": "trade-open-market", "params": { "symbol": "BTC" }, "next": "verify" },
+    "verify":{ "action": "eval_ref", "ref": "positions", "assert": { "operator": "length_gt", "value": 0 }, "next": "close" },
+    "close": { "action": "call", "ref": "trade-close-position", "params": { "symbol": "BTC" }, "next": "done" },
+    "done":  { "action": "end", "status": "pass" }
   }
 }
 ```
 
-### Branching with `switch`
+### Branching — `switch`
 
-A `switch` node evaluates conditions against the execution context (env, inputs, vars, last result) and routes to different branches. Each case has a `when` assertion and a `next` target. An optional `default` catches unmatched cases.
+Cases evaluate against `env`, `inputs`, `vars`, `last`; `default` catches unmatched.
 
 ```json
 {
-  "check-position": {
-    "action": "eval_ref",
-    "ref": "positions",
-    "save_as": "positions",
-    "assert": { "operator": "not_null" },
-    "next": "decide"
-  },
   "decide": {
     "action": "switch",
     "cases": [
-      {
-        "label": "has positions",
-        "when": { "operator": "length_gt", "field": "vars.positions.length", "value": 0 },
-        "next": "close-first"
-      },
-      {
-        "label": "no positions",
-        "when": { "operator": "length_eq", "field": "vars.positions.length", "value": 0 },
-        "next": "open-new"
-      }
+      { "when": { "operator": "length_gt", "field": "vars.positions.length", "value": 0 }, "next": "close-first" },
+      { "when": { "operator": "length_eq", "field": "vars.positions.length", "value": 0 }, "next": "open-new" }
     ],
     "default": "open-new"
-  },
-  "close-first": { "action": "call", "ref": "trade-close-position", "params": { "symbol": "BTC" }, "next": "open-new" },
-  "open-new": { "action": "call", "ref": "trade-open-market", "params": { "symbol": "BTC" }, "next": "done" },
-  "done": { "action": "end", "status": "pass" }
+  }
 }
 ```
 
-### Conditional Guards (`when` / `unless`)
+### Guards — `when` / `unless`
 
-Any executable node can have a `when` or `unless` guard. If the condition doesn't match, the node is skipped and execution continues to `next`.
+Any executable node can guard on the same condition language; skipped nodes fall through to `next`.
 
 ```json
 {
   "maybe-close": {
     "action": "call",
     "ref": "trade-close-position",
-    "params": { "symbol": "BTC" },
     "when": { "operator": "gt", "field": "vars.positionCount", "value": 0 },
     "next": "done"
   }
 }
 ```
 
-The guard evaluates against the execution context which includes:
-- `env` — appRoot, recipePath, team
-- `inputs` — resolved template parameters
-- `vars` — values saved via `save_as` on prior nodes
-- `last` — result of the most recent node
-- `nodes` — per-node execution records
+Context available to guards and switch: `env` (appRoot, recipePath, team), `inputs` (templated params), `vars` (via `save_as`), `last` (most recent result), `nodes` (per-node records).
 
-### Setup and Teardown Hooks
+### Setup / teardown
 
-Linear step arrays that run before/after the workflow graph. Teardown always runs, even on failure.
+Linear arrays before/after the workflow graph. Teardown runs on both pass and fail.
 
 ```json
 {
-  "validate": {
-    "workflow": {
-      "pre_conditions": ["wallet.unlocked"],
-      "setup": [
-        { "id": "enable-testnet", "action": "toggle_testnet", "enabled": true }
-      ],
-      "entry": "open-position",
-      "nodes": {
-        "open-position": { "action": "call", "ref": "trade-open-market", "next": "done" },
-        "done": { "action": "end", "status": "pass" }
-      },
-      "teardown": [
-        { "id": "close-all", "action": "eval_async", "expression": "Engine.context.PerpsController.closeAllPositions().then(function(r){return JSON.stringify(r)})", "assert": { "operator": "not_null" } }
-      ]
-    }
-  }
+  "setup":    [{ "id": "enable-testnet", "action": "toggle_testnet", "enabled": true }],
+  "teardown": [{ "id": "close-all", "action": "eval_async", "expression": "Engine.context.PerpsController.closeAllPositions().then(function(r){return JSON.stringify(r)})", "assert": { "operator": "not_null" } }]
 }
 ```
 
-### Eval Refs
+### Eval refs
 
-Named CDP eval expressions. Two locations:
-- `teams/<team>/evals.json` -- quick refs (e.g. `perps/positions`)
-- `teams/<team>/evals/<file>.json` -- grouped refs (e.g. `perps/core/tpsl-orders`)
+Named CDP eval expressions. Two homes:
+- `teams/<team>/evals.json` — quick refs (`perps/positions`)
+- `teams/<team>/evals/<file>.json` — grouped refs (`perps/core/tpsl-orders`)
 
 ```bash
-# List all eval refs
 node cdp-bridge.js eval-ref --list
-
-# Run one
 node cdp-bridge.js eval-ref perps/positions
 ```
 
 ### Pre-conditions
 
-Executable gate checks that must pass before a flow runs. Defined in `teams/<team>/pre-conditions.js`. Each entry has:
+Gate checks that must pass before a flow runs. Defined in `teams/<team>/pre-conditions.js`.
 
 | Field | Description |
-|-------|-------------|
-| `description` | Human-readable label |
-| `async` | Whether expression returns a Promise |
-| `expression` | CDP eval (string or function for parameterized checks) |
-| `assert` | Assertion spec (`operator`, `field`, `value`) |
-| `hint` | Actionable message shown on failure |
-| `fixtures` | `{ pass, fail }` JSON strings for offline testing |
+| --- | --- |
+| `description` | human-readable label |
+| `async` | whether expression returns a Promise |
+| `expression` | CDP eval (string, or function for parameterized) |
+| `assert` | `{ operator, field, value }` |
+| `hint` | actionable failure message |
+| `fixtures` | `{ pass, fail }` JSON strings for offline validation |
 
 ```js
 'wallet.unlocked': {
@@ -216,110 +165,83 @@ Executable gate checks that must pass before a flow runs. Defined in `teams/<tea
 },
 ```
 
-## Step Actions
+## Actions
 
-| Action | Required Fields | Description |
-|--------|----------------|-------------|
-| `navigate` | `target` | Go to a screen |
-| `press` | `test_id` | Tap component by testID |
-| `set_input` | `test_id`, `value` | Type into a TextInput |
-| `type_keypad` | `value` | Type digits via keypad buttons |
-| `clear_keypad` | | Press delete N times (default 8) |
-| `scroll` | | Scroll a view (optional `test_id`, `offset`) |
-| `eval_sync` | `expression`, `assert` | Synchronous CDP eval |
-| `eval_async` | `expression`, `assert` | Promise-based CDP eval |
-| `eval_ref` | `ref`, `assert` | Run a named eval ref |
-| `call` | `ref` | Call another flow (workflow nodes only) |
-| `wait` | | Pause N ms |
-| `wait_for` | condition | Poll until condition met (route/test_id/expression). Canonical timing fields are `timeout_ms` and `poll_ms`. |
-| `log_watch` | `watch_for` or `must_not_appear` | Scan Metro logs |
-| `screenshot` | | Capture screen |
-| `manual` | | Human intervention point |
-| `select_account` | `address` | Switch Ethereum account |
-| `toggle_testnet` | | Enable/disable testnet mode |
-| `switch_provider` | `provider` | Switch perps provider |
-| `app_background` | `duration_ms` | Send app to home screen (iOS: Cmd+Shift+H). Waits `duration_ms` (default 5000) |
-| `app_foreground` | | Bring app back to foreground via `xcrun simctl launch` |
-| `app_restart` | `boot_wait_ms` | Terminate + relaunch app. Waits `boot_wait_ms` (default 15000) for Metro reconnect |
-| `switch` | `cases` | Branch based on assertions (workflow only) |
-| `end` | | Terminal node with pass/fail (workflow only) |
+| Action | Required | Purpose |
+| --- | --- | --- |
+| `navigate` | `target` | go to a screen |
+| `press` | `test_id` | tap component by testID |
+| `set_input` | `test_id`, `value` | type into TextInput |
+| `type_keypad` | `value` | type digits via keypad buttons |
+| `clear_keypad` | — | press delete N times (default 8) |
+| `scroll` | — | scroll view (optional `test_id`, `offset`) |
+| `eval_sync` | `expression`, `assert` | sync CDP eval |
+| `eval_async` | `expression`, `assert` | promise-based CDP eval |
+| `eval_ref` | `ref`, `assert` | run a named eval ref |
+| `call` | `ref` | invoke another flow (workflow only) |
+| `wait` | — | pause N ms |
+| `wait_for` | condition | poll until route / test_id / expression matches. Timing fields: `timeout_ms`, `poll_ms` |
+| `log_watch` | `watch_for` / `must_not_appear` | scan Metro logs |
+| `screenshot` | — | capture screen |
+| `manual` | — | human intervention point |
+| `select_account` | `address` | switch Ethereum account |
+| `toggle_testnet` | — | enable/disable testnet |
+| `switch_provider` | `provider` | switch perps provider |
+| `app_background` | — | send app to home. `duration_ms` default 5000 |
+| `app_foreground` | — | relaunch via `xcrun simctl launch` |
+| `app_restart` | — | terminate + relaunch. `boot_wait_ms` default 15000 |
+| `trace_start` / `trace_stop` | `label` | Hermes sampling profiler → `.cpuprofile` |
+| `switch` | `cases` | branch on assertions (workflow only) |
+| `end` | — | terminal node (workflow only) |
 
-## Assertion Operators
+## Assertion operators
 
 Used in `assert` blocks on steps and pre-conditions:
 
-| Operator | Description |
-|----------|-------------|
-| `not_null` | Value is not null/undefined |
-| `truthy` / `falsy` | Boolean truthiness |
-| `eq` / `neq` | Strict equality |
-| `gt` / `lt` / `gte` / `lte` | Numeric comparison |
-| `deep_eq` | Deep strict equality |
-| `length_eq` / `length_gt` / `length_gte` | Array/string length |
-| `contains` / `not_contains` | Array includes or string includes |
-| `matches` | Regex match (string or `/pattern/flags`) |
-| `one_of` | Value is in a list (`values` array) |
-| `exists` | Field exists (not undefined) |
+| Operator | Meaning |
+| --- | --- |
+| `not_null` | value not null/undefined |
+| `truthy` / `falsy` | boolean truthiness |
+| `eq` / `neq` | strict equality |
+| `gt` / `lt` / `gte` / `lte` | numeric comparison |
+| `deep_eq` | deep strict equality |
+| `length_eq` / `length_gt` / `length_gte` | array/string length |
+| `contains` / `not_contains` | array or string includes |
+| `matches` | regex match (`/pattern/flags` or string) |
+| `one_of` | value in `values` array |
+| `exists` | field not undefined |
 
-Compound assertions: `{ all: [...] }`, `{ any: [...] }`, `{ none: [...] }`.
+Compound: `{ all: [...] }`, `{ any: [...] }`, `{ none: [...] }`.
 
-## CLI Commands
-
-### Running Recipes
+## CLI
 
 ```bash
-# Against the live app
+# Run recipe (live app)
 bash scripts/perps/agentic/validate-recipe.sh teams/perps/recipes/full-trade-lifecycle.json
-
-# Dry-run (print steps without executing)
 bash scripts/perps/agentic/validate-recipe.sh teams/perps/recipes/full-trade-lifecycle.json --dry-run
-```
 
-### Offline Validators
-
-```bash
-# Validate all flow + recipe JSON files
-node scripts/perps/agentic/validate-flow-schema.js
-
-# Validate a single file
+# Offline validators
+node scripts/perps/agentic/validate-flow-schema.js                                    # all
 node scripts/perps/agentic/validate-flow-schema.js teams/perps/flows/trade-open-market.json
-
-# Verify pre-condition assertion fixtures
 node scripts/perps/agentic/validate-pre-conditions.js
-```
 
-### App Interaction
-
-```bash
-# Check app + Metro + CDP health
+# App interaction
 bash scripts/perps/agentic/app-state.sh status
-
-# Evaluate expression
 bash scripts/perps/agentic/app-state.sh eval "Engine.context.PerpsController.state"
-
-# Run eval ref
 bash scripts/perps/agentic/app-state.sh eval-ref perps/positions
-
-# List all eval refs
 bash scripts/perps/agentic/app-state.sh eval-ref --list
-
-# Navigate to screen
 bash scripts/perps/agentic/app-navigate.sh PerpsMarketDetails '{"market":{"symbol":"BTC"}}'
-
-# Take screenshot
 bash scripts/perps/agentic/screenshot.sh my-label
-
-# Start Metro
 bash scripts/perps/agentic/start-metro.sh --platform ios
 ```
 
-## Adding a New Team
+## Adding a new team
 
-1. Create `teams/<your-team>/pre-conditions.js` exporting a `Record<string, PreCondition>`.
-2. Key convention: `<your-team>.<check_name>` (e.g. `swap.has_quote`).
-3. Include `fixtures: { pass, fail }` on every entry for offline validation.
+1. `teams/<team>/pre-conditions.js` exporting `Record<string, PreCondition>`.
+2. Key convention: `<team>.<check>` (e.g. `swap.has_quote`).
+3. Include `fixtures: { pass, fail }` on every entry.
 4. Optionally add `flows/`, `recipes/`, `evals/`, `evals.json`.
-5. Run both validators to confirm:
+5. Run both validators:
 
 ```bash
 node scripts/perps/agentic/validate-pre-conditions.js
@@ -328,24 +250,35 @@ node scripts/perps/agentic/validate-flow-schema.js
 
 See `teams/README.md` for the full contribution guide.
 
-## CDP Eval Rules
+## CDP eval rules
 
-All expressions must be **ES5** -- no arrow functions, no `const`/`let`, no template literals, no top-level `await`.
+All expressions are **ES5** — no arrow functions, `const`/`let`, template literals, top-level `await`.
 
 ```js
-// Good
+// OK
 var x = Engine.context.PerpsController.state;
-JSON.stringify({count: x.positions.length});
+JSON.stringify({ count: x.positions.length });
 
-// Bad
+// Not OK
 const x = Engine.context.PerpsController.state;
 `count: ${x.positions.length}`;
 ```
 
-Async expressions use `.then()` chains:
+Async via `.then()`:
 
 ```js
 Engine.context.PerpsController.getPositions().then(function(ps) {
-  return JSON.stringify({count: ps.length});
-})
+  return JSON.stringify({ count: ps.length });
+});
 ```
+
+## Run artifacts
+
+Every recipe run writes to `.agent/recipe-runs/<timestamp>_<recipe>/`:
+
+- `summary.json`, `workflow.json`, `workflow.mmd`, `trace.json`
+- `screenshots/`, `traces/` (`.cpuprofile` when `trace_stop` ran)
+- `recipe-issues.json` + `console-warnings.json` + `console-errors.json` + `runtime-exceptions.json`
+- `recipe-issues-review.json` + `recipe-issues-review.md`
+
+`summary.json.recipeIssues` is automatic and aligned with the extension contract. See [CDP-capabilities-mobile.md](./CDP-capabilities-mobile.md#automatic-recipe-issue-review) for the review vocabulary and opt-in `fail_on_unexpected` gating.

--- a/scripts/perps/agentic/cdp-bridge.js
+++ b/scripts/perps/agentic/cdp-bridge.js
@@ -24,6 +24,7 @@ const { discoverTarget } = require('./lib/target-discovery');
 const { createWSClient } = require('./lib/ws-client');
 const { cdpEval, cdpEvalAsync } = require('./lib/cdp-eval');
 const { checkAssert } = require('./lib/assert');
+const { buildArmSnippet, buildCollectSnippet } = require('./lib/recipe-issues');
 
 async function evalSpec(client, entry, params) {
   const expr = typeof entry.expression === 'function' ? entry.expression(params) : entry.expression;
@@ -558,6 +559,68 @@ const COMMANDS = {
     return { ok: true };
   },
 
+  async 'profiler-start'(client) {
+    // Hermes CDP exposes the sampling profiler via the Profiler domain.
+    // Output of Profiler.stop is a Chrome-compatible .cpuprofile object.
+    // Note: Hermes does NOT implement Profiler.enable (returns -32601 Unsupported);
+    // Profiler.start/stop work without it.
+    await client.send('Profiler.start');
+    return { ok: true, started: true };
+  },
+
+  async 'profiler-stop'(client, args) {
+    let outPath = '';
+    let label = 'trace';
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--out' && i + 1 < args.length) {
+        outPath = args[++i];
+      } else if (args[i] === '--label' && i + 1 < args.length) {
+        label = args[++i];
+      }
+    }
+    const res = await client.send('Profiler.stop', {}, 60000);
+    const profile = res?.profile;
+    if (!profile) {
+      return { ok: false, error: 'Profiler.stop returned no profile' };
+    }
+    const serialized = JSON.stringify(profile);
+    if (!outPath) {
+      const tracesDir = path.resolve(process.env.APP_ROOT || process.cwd(), 'temp/agentic/recipes/test-artifacts/traces');
+      fs.mkdirSync(tracesDir, { recursive: true });
+      outPath = path.join(tracesDir, `trace-${label}.cpuprofile`);
+    } else {
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    }
+    fs.writeFileSync(outPath, serialized);
+    const nodesCount = Array.isArray(profile.nodes) ? profile.nodes.length : 0;
+    const samplesCount = Array.isArray(profile.samples) ? profile.samples.length : 0;
+    return {
+      ok: true,
+      path: outPath,
+      label,
+      sizeBytes: Buffer.byteLength(serialized, 'utf8'),
+      nodesCount,
+      samplesCount,
+      startTime: profile.startTime ?? null,
+      endTime: profile.endTime ?? null,
+    };
+  },
+
+  async 'issues-arm'(client) {
+    // Installs console.warn/error and global error/unhandledrejection hooks
+    // that push into globalThis.__AGENTIC_ISSUES__ (capped at 500 entries).
+    // Idempotent — subsequent calls return { installed: true, reason: 'already-installed' }.
+    const result = await cdpEval(client, buildArmSnippet());
+    return result || { installed: false };
+  },
+
+  async 'issues-collect'(client) {
+    // Snapshots and clears globalThis.__AGENTIC_ISSUES__.
+    // Returns { count, entries } where entries are { t, level, text }.
+    const result = await cdpEval(client, buildCollectSnippet());
+    return result || { count: 0, entries: [] };
+  },
+
   async 'eval-ref'(client, args) {
     const arg = args[0];
     if (!arg || arg === '--help') {
@@ -679,6 +742,14 @@ Commands:
   unlock <password>                      Unlock wallet (inject password + press login button via fiber tree)
   eval-ref <team/name>                 Run an eval ref (e.g. perps/positions)
   eval-ref --list                      List all available eval refs
+  profiler-start                       Start Hermes sampling profiler
+  profiler-stop [--out <path>] [--label <name>]
+                                       Stop profiler, dump Chrome-compatible
+                                       .cpuprofile to <path> (default:
+                                       temp/agentic/recipes/test-artifacts/traces/trace-<label>.cpuprofile)
+  issues-arm                           Install console/exception hooks that
+                                       populate globalThis.__AGENTIC_ISSUES__
+  issues-collect                       Snapshot + clear the in-app issue buffer
 
 Environment:
   WATCHER_PORT    Metro port (default: 8081)

--- a/scripts/perps/agentic/lib/recipe-issues.js
+++ b/scripts/perps/agentic/lib/recipe-issues.js
@@ -1,0 +1,441 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { Buffer } = require('node:buffer');
+
+// Shape of a single captured issue:
+//   { level, channel, source, targetRole, targetUrl, text, timestamp, allowlistMatch }
+// level: 'warning' | 'error' | 'exception' | 'other'
+// channel: 'console' | 'exception' | 'metro'
+// source: 'app' | 'metro-log'
+
+const LEVEL_WARNING = 'warning';
+const LEVEL_ERROR = 'error';
+const LEVEL_EXCEPTION = 'exception';
+const LEVEL_OTHER = 'other';
+
+const REVIEW_LEVELS = new Set([LEVEL_WARNING, LEVEL_ERROR, LEVEL_EXCEPTION]);
+const TOP_ISSUES_LIMIT = 4;
+
+const METRO_PATTERNS = [
+  { level: LEVEL_EXCEPTION, re: /\b(Uncaught|unhandledRejection|FATAL EXCEPTION|UnhandledPromiseRejection)\b/i },
+  { level: LEVEL_ERROR, re: /(^|\s)(\[error\]|ERROR |Error:)/i },
+  { level: LEVEL_WARNING, re: /(^|\s)(\[warn\]|WARN |Warning:)/i },
+];
+
+function classifyMetroLine(line) {
+  if (!line) {
+    return null;
+  }
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+  for (const { level, re } of METRO_PATTERNS) {
+    if (re.test(trimmed)) {
+      return { level, text: trimmed };
+    }
+  }
+  return null;
+}
+
+function captureFromMetro(logPath, startOffset) {
+  const issues = [];
+  if (!logPath || !fs.existsSync(logPath)) {
+    return issues;
+  }
+  let stat;
+  try {
+    stat = fs.statSync(logPath);
+  } catch {
+    return issues;
+  }
+  const start = Math.max(0, Math.min(startOffset || 0, stat.size));
+  if (stat.size <= start) {
+    return issues;
+  }
+  let slice = '';
+  try {
+    const fd = fs.openSync(logPath, 'r');
+    try {
+      const len = stat.size - start;
+      const buf = Buffer.alloc(len);
+      fs.readSync(fd, buf, 0, len, start);
+      slice = buf.toString('utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return issues;
+  }
+
+  const lines = slice.split(/\r?\n/);
+  for (const line of lines) {
+    const classification = classifyMetroLine(line);
+    if (!classification) {
+      continue;
+    }
+    issues.push({
+      level: classification.level,
+      channel: 'metro',
+      source: 'metro-log',
+      targetRole: 'app',
+      targetUrl: 'metro://local',
+      text: classification.text.slice(0, 2000),
+      timestamp: new Date().toISOString(),
+      allowlistMatch: null,
+    });
+  }
+  return issues;
+}
+
+function normalizeAppBufferEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const rawLevel = String(entry.level || '').toLowerCase();
+      let level = LEVEL_OTHER;
+      if (rawLevel === 'warn' || rawLevel === 'warning') {
+        level = LEVEL_WARNING;
+      } else if (rawLevel === 'error') {
+        level = LEVEL_ERROR;
+      } else if (rawLevel === 'exception') {
+        level = LEVEL_EXCEPTION;
+      }
+      const text = String(entry.text || '').slice(0, 2000);
+      if (!text) {
+        return null;
+      }
+      return {
+        level,
+        channel: level === LEVEL_EXCEPTION ? 'exception' : 'console',
+        source: 'app',
+        targetRole: 'app',
+        targetUrl: 'hermes://metamask',
+        text,
+        timestamp: entry.t ? new Date(Number(entry.t)).toISOString() : new Date().toISOString(),
+        allowlistMatch: null,
+      };
+    })
+    .filter(Boolean);
+}
+
+function dedupeIssues(issues) {
+  const seen = new Map();
+  for (const issue of issues) {
+    const key = `${issue.level}|${issue.channel}|${issue.source}|${issue.text.slice(0, 300)}`;
+    const prior = seen.get(key);
+    if (prior) {
+      prior.count += 1;
+    } else {
+      seen.set(key, { ...issue, count: 1 });
+    }
+  }
+  return Array.from(seen.values());
+}
+
+function applyAllowlist(issues, allowlist) {
+  const unexpected = [];
+  const informational = [];
+  const rules = Array.isArray(allowlist) ? allowlist : [];
+  for (const issue of issues) {
+    let match = null;
+    for (const rule of rules) {
+      if (rule && rule.level && rule.level !== issue.level) {
+        continue;
+      }
+      if (rule && rule.textMatch) {
+        try {
+          const re = new RegExp(rule.textMatch);
+          if (re.test(issue.text)) {
+            match = rule.reason || rule.textMatch;
+            break;
+          }
+        } catch {
+          if (issue.text.includes(rule.textMatch)) {
+            match = rule.reason || rule.textMatch;
+            break;
+          }
+        }
+      }
+    }
+    if (match) {
+      informational.push({ ...issue, allowlistMatch: match });
+    } else if (REVIEW_LEVELS.has(issue.level)) {
+      unexpected.push(issue);
+    } else {
+      informational.push(issue);
+    }
+  }
+  return { unexpected, informational };
+}
+
+function countByLevel(issues) {
+  const counts = { total: 0, warning: 0, error: 0, exception: 0, other: 0 };
+  for (const issue of issues) {
+    counts.total += 1;
+    if (counts[issue.level] !== undefined) {
+      counts[issue.level] += 1;
+    } else {
+      counts.other += 1;
+    }
+  }
+  return counts;
+}
+
+function matchesFailOn(issue, failOn) {
+  if (!failOn || typeof failOn !== 'object') {
+    return false;
+  }
+  const levels = Array.isArray(failOn.levels) ? failOn.levels : [];
+  const textMatches = Array.isArray(failOn.textMatches) ? failOn.textMatches : [];
+  if (levels.length && !levels.includes(issue.level)) {
+    return false;
+  }
+  if (!textMatches.length) {
+    return levels.length > 0;
+  }
+  for (const pattern of textMatches) {
+    try {
+      if (new RegExp(pattern).test(issue.text)) {
+        return true;
+      }
+    } catch {
+      if (issue.text.includes(pattern)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function computeReview(unexpected, informational, failOn, artifactFiles) {
+  const observedDeduped = dedupeIssues(unexpected);
+  const observed = countByLevel(observedDeduped);
+  const gatingIssues = observedDeduped.filter((issue) => matchesFailOn(issue, failOn));
+  const gating = countByLevel(gatingIssues);
+  const infoCount = Array.isArray(informational) ? informational.length : 0;
+
+  let status = 'clean';
+  let note = 'No unexpected warnings, errors, or exceptions observed.';
+  if (gating.total > 0) {
+    status = 'gating';
+    note = `Observed ${gating.total} unexpected warning/error/exception event(s) matching fail_on_unexpected. Recipe marked as failing.`;
+  } else if (observed.total > 0) {
+    status = 'review';
+    note = `Observed ${observed.total} unexpected warning/error/exception event(s) during validation. Relation to the recipe or current change is not determined; review the artifacts.`;
+  }
+
+  const ranked = observedDeduped.slice().sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    return (a.text || '').localeCompare(b.text || '');
+  });
+
+  const topIssues = ranked.slice(0, TOP_ISSUES_LIMIT).map((issue) => ({
+    level: issue.level,
+    channel: issue.channel,
+    source: issue.source,
+    targetRole: issue.targetRole,
+    targetUrl: issue.targetUrl,
+    text: issue.text,
+    allowlistMatch: issue.allowlistMatch,
+  }));
+
+  return {
+    status,
+    note,
+    observed,
+    gating,
+    informational: { total: infoCount },
+    topIssues,
+    artifactFiles: artifactFiles || {},
+  };
+}
+
+function renderMarkdown(review) {
+  const { status, note, observed, gating, informational, topIssues, artifactFiles } = review;
+  const lines = [];
+  lines.push('# Recipe Issue Review');
+  lines.push('');
+  lines.push(`Status: ${status}`);
+  lines.push('');
+  lines.push(note);
+  lines.push('');
+  lines.push('Observed:');
+  lines.push(`- warnings: ${observed.warning || 0}`);
+  lines.push(`- errors: ${observed.error || 0}`);
+  lines.push(`- exceptions: ${observed.exception || 0}`);
+  lines.push(`- total: ${observed.total || 0}`);
+  lines.push('');
+  lines.push('Gating:');
+  lines.push(`- warnings: ${gating.warning || 0}`);
+  lines.push(`- errors: ${gating.error || 0}`);
+  lines.push(`- exceptions: ${gating.exception || 0}`);
+  lines.push(`- total: ${gating.total || 0}`);
+  lines.push('');
+  lines.push(`Informational-only events: ${(informational && informational.total) || 0}`);
+  lines.push('');
+  if (topIssues && topIssues.length) {
+    lines.push('Top issues:');
+    for (const issue of topIssues) {
+      const levelLabel = String(issue.level || 'other').toUpperCase();
+      lines.push(`- [${levelLabel}] ${issue.source}: ${issue.text}`);
+    }
+    lines.push('');
+  }
+  if (artifactFiles && Object.keys(artifactFiles).length) {
+    lines.push('Artifacts:');
+    for (const key of ['allIssues', 'consoleWarnings', 'consoleErrors', 'runtimeExceptions']) {
+      if (artifactFiles[key]) {
+        lines.push(`- ${artifactFiles[key]}`);
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function writeJsonArtifact(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function writeArtifacts(runDir, { unexpected, informational, review }) {
+  const outDir = path.resolve(runDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const all = [...(unexpected || []), ...(informational || [])];
+
+  const paths = {
+    allIssues: path.join(outDir, 'recipe-issues.json'),
+    consoleWarnings: path.join(outDir, 'console-warnings.json'),
+    consoleErrors: path.join(outDir, 'console-errors.json'),
+    runtimeExceptions: path.join(outDir, 'runtime-exceptions.json'),
+    reviewJson: path.join(outDir, 'recipe-issues-review.json'),
+    reviewMd: path.join(outDir, 'recipe-issues-review.md'),
+  };
+
+  writeJsonArtifact(paths.allIssues, all);
+  writeJsonArtifact(
+    paths.consoleWarnings,
+    all.filter((i) => i.level === LEVEL_WARNING),
+  );
+  writeJsonArtifact(
+    paths.consoleErrors,
+    all.filter((i) => i.level === LEVEL_ERROR),
+  );
+  writeJsonArtifact(
+    paths.runtimeExceptions,
+    all.filter((i) => i.level === LEVEL_EXCEPTION),
+  );
+
+  const reviewWithPaths = { ...review, artifactFiles: paths };
+  writeJsonArtifact(paths.reviewJson, reviewWithPaths);
+  fs.writeFileSync(paths.reviewMd, renderMarkdown(reviewWithPaths));
+
+  return paths;
+}
+
+// Installed into the Hermes runtime via Runtime.evaluate. Returns a string
+// so callers can embed it directly into eval expressions. Keeps the hook
+// idempotent and bounded (500-entry cap).
+function buildArmSnippet() {
+  return `(() => {
+  var g = globalThis;
+  if (g.__AGENTIC_ISSUES_INSTALLED__) { return { installed: true, reason: 'already-installed' }; }
+  g.__AGENTIC_ISSUES__ = [];
+  g.__AGENTIC_ISSUES_CAP__ = 500;
+  var push = function (entry) {
+    try {
+      if (g.__AGENTIC_ISSUES__.length < g.__AGENTIC_ISSUES_CAP__) {
+        g.__AGENTIC_ISSUES__.push(entry);
+      }
+    } catch (_e) {}
+  };
+  ['warn', 'error'].forEach(function (k) {
+    var orig = console[k] && console[k].bind(console);
+    if (!orig) return;
+    console[k] = function () {
+      var args = Array.prototype.slice.call(arguments);
+      try {
+        var text = args.map(function (a) {
+          if (a && a.stack) return String(a.stack);
+          if (typeof a === 'string') return a;
+          try { return JSON.stringify(a); } catch (_e) { return String(a); }
+        }).join(' ');
+        push({ t: Date.now(), level: k, text: text });
+      } catch (_e) {}
+      return orig.apply(console, args);
+    };
+  });
+  if (typeof g.addEventListener === 'function') {
+    try {
+      g.addEventListener('error', function (e) {
+        var err = e && (e.error || e.message);
+        var text = err && err.stack ? err.stack : String(err || e);
+        push({ t: Date.now(), level: 'exception', text: text });
+      });
+      g.addEventListener('unhandledrejection', function (e) {
+        var r = e && e.reason;
+        var text = r && r.stack ? r.stack : String(r || e);
+        push({ t: Date.now(), level: 'exception', text: text });
+      });
+    } catch (_e) {}
+  }
+  var ep = g.ErrorUtils;
+  if (ep && typeof ep.setGlobalHandler === 'function') {
+    try {
+      var priorHandler = typeof ep.getGlobalHandler === 'function' ? ep.getGlobalHandler() : null;
+      ep.setGlobalHandler(function (err, isFatal) {
+        try {
+          var text = err && err.stack ? err.stack : String(err);
+          push({ t: Date.now(), level: 'exception', text: (isFatal ? '[FATAL] ' : '') + text });
+        } catch (_e) {}
+        if (typeof priorHandler === 'function') {
+          try { priorHandler(err, isFatal); } catch (_e) {}
+        }
+      });
+    } catch (_e) {}
+  }
+  g.__AGENTIC_ISSUES_INSTALLED__ = true;
+  return { installed: true };
+})()`;
+}
+
+function buildCollectSnippet() {
+  return `(() => {
+  var g = globalThis;
+  var buf = g.__AGENTIC_ISSUES__ || [];
+  var snapshot = buf.slice();
+  g.__AGENTIC_ISSUES__ = [];
+  return { count: snapshot.length, entries: snapshot };
+})()`;
+}
+
+module.exports = {
+  LEVEL_WARNING,
+  LEVEL_ERROR,
+  LEVEL_EXCEPTION,
+  LEVEL_OTHER,
+  TOP_ISSUES_LIMIT,
+  applyAllowlist,
+  buildArmSnippet,
+  buildCollectSnippet,
+  captureFromMetro,
+  classifyMetroLine,
+  computeReview,
+  countByLevel,
+  dedupeIssues,
+  matchesFailOn,
+  normalizeAppBufferEntries,
+  renderMarkdown,
+  writeArtifacts,
+};

--- a/scripts/perps/agentic/lib/recipe-issues.js
+++ b/scripts/perps/agentic/lib/recipe-issues.js
@@ -129,10 +129,15 @@ function normalizeAppBufferEntries(entries) {
 function dedupeIssues(issues) {
   const seen = new Map();
   for (const issue of issues) {
-    const key = `${issue.level}|${issue.channel}|${issue.source}|${issue.text.slice(0, 300)}`;
+    const key = `${issue.level}|${issue.text.slice(0, 300)}`;
     const prior = seen.get(key);
     if (prior) {
       prior.count += 1;
+      // Prefer the in-app capture over the Metro mirror when both channels
+      // report the same logical issue text.
+      if (prior.source !== 'app' && issue.source === 'app') {
+        Object.assign(prior, issue, { count: prior.count });
+      }
     } else {
       seen.set(key, { ...issue, count: 1 });
     }

--- a/scripts/perps/agentic/lib/workflow.js
+++ b/scripts/perps/agentic/lib/workflow.js
@@ -26,6 +26,9 @@ const EXECUTABLE_ACTIONS = new Set([
   'app_background',
   'app_foreground',
   'app_restart',
+  // Profiler / trace capture (Hermes sampling profiler via CDP)
+  'trace_start',
+  'trace_stop',
 ]);
 
 const CONTROL_ACTIONS = new Set(['switch', 'end']);

--- a/scripts/perps/agentic/teams/perps/recipes/capabilities/performance-metrics-smoke.json
+++ b/scripts/perps/agentic/teams/perps/recipes/capabilities/performance-metrics-smoke.json
@@ -1,0 +1,83 @@
+{
+  "title": "Capability: Hermes performance metrics snapshot",
+  "description": "Proof recipe for mobile performance metrics capture. Captures global.performance.now() + HermesInternal.getInstrumentedStats() before and after a bounded navigation workload via eval_sync. No new runner primitive required — this validates the existing eval_sync can serve as the mobile analog to extension's 'performance' capability.",
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
+      "setup": [
+        {
+          "id": "setup-complete-tutorial",
+          "action": "eval_sync",
+          "expression": "(function(){try{Engine.context.PerpsController.markTutorialCompleted()}catch(e){}return JSON.stringify({done:true})})()",
+          "assert": { "operator": "eq", "field": "done", "value": true }
+        }
+      ],
+      "entry": "ensure-testnet",
+      "nodes": {
+        "ensure-testnet": {
+          "action": "call",
+          "ref": "setup-testnet",
+          "next": "nav-perps"
+        },
+        "nav-perps": {
+          "action": "navigate",
+          "target": "PerpsHomeView",
+          "next": "wait-markets"
+        },
+        "wait-markets": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-ETH",
+          "timeout_ms": 20000,
+          "next": "snapshot-before"
+        },
+        "snapshot-before": {
+          "action": "eval_sync",
+          "expression": "(function(){var hasHermes=typeof HermesInternal==='object'&&HermesInternal!==null;var stats=hasHermes&&typeof HermesInternal.getInstrumentedStats==='function'?HermesInternal.getInstrumentedStats():null;var statKeys=stats?Object.keys(stats):[];return JSON.stringify({ts:typeof performance!=='undefined'&&performance.now?performance.now():Date.now(),hasHermes:hasHermes,statCount:statKeys.length,sampleStatKeys:statKeys.slice(0,5),jsNumGCs:stats?stats.js_numGCs||null:null,jsHeapSize:stats?stats.js_allocatedBytes||stats.js_heapSize||null:null})})()",
+          "assert": {
+            "all": [
+              { "operator": "eq", "field": "hasHermes", "value": true },
+              { "operator": "gt", "field": "statCount", "value": 0 },
+              { "operator": "gt", "field": "ts", "value": 0 }
+            ]
+          },
+          "next": "nav-market-detail"
+        },
+        "nav-market-detail": {
+          "action": "press",
+          "test_id": "perps-market-row-item-ETH",
+          "next": "wait-detail"
+        },
+        "wait-detail": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "timeout_ms": 15000,
+          "next": "snapshot-after"
+        },
+        "snapshot-after": {
+          "action": "eval_sync",
+          "expression": "(function(){var hasHermes=typeof HermesInternal==='object'&&HermesInternal!==null;var stats=hasHermes&&typeof HermesInternal.getInstrumentedStats==='function'?HermesInternal.getInstrumentedStats():null;var statKeys=stats?Object.keys(stats):[];return JSON.stringify({ts:typeof performance!=='undefined'&&performance.now?performance.now():Date.now(),hasHermes:hasHermes,statCount:statKeys.length,sampleStatKeys:statKeys.slice(0,5),jsNumGCs:stats?stats.js_numGCs||null:null,jsHeapSize:stats?stats.js_allocatedBytes||stats.js_heapSize||null:null})})()",
+          "assert": {
+            "all": [
+              { "operator": "eq", "field": "hasHermes", "value": true },
+              { "operator": "gt", "field": "statCount", "value": 0 },
+              { "operator": "gt", "field": "ts", "value": 0 }
+            ]
+          },
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass",
+          "message": "Mobile performance metrics snapshot proven via Hermes getInstrumentedStats + performance.now"
+        }
+      },
+      "teardown": [
+        {
+          "id": "teardown-nav-home",
+          "action": "navigate",
+          "target": "PerpsHomeView"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/perps/agentic/teams/perps/recipes/capabilities/profiler-trace-smoke.json
+++ b/scripts/perps/agentic/teams/perps/recipes/capabilities/profiler-trace-smoke.json
@@ -1,0 +1,77 @@
+{
+  "title": "Capability: Hermes sampling profiler trace",
+  "description": "Proof recipe for mobile trace capture. Exercises trace_start -> bounded navigation workload -> trace_stop, asserting the Chrome-compatible .cpuprofile artifact is written and non-empty. This is the mobile mirror of extension's trace_start/trace_stop capability, backed by the Hermes Profiler domain over CDP. Artifact path is under artifacts.tracesDir (see ensureRunArtifacts in validate-recipe.js).",
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
+      "setup": [
+        {
+          "id": "setup-complete-tutorial",
+          "action": "eval_sync",
+          "expression": "(function(){try{Engine.context.PerpsController.markTutorialCompleted()}catch(e){}return JSON.stringify({done:true})})()",
+          "assert": { "operator": "eq", "field": "done", "value": true }
+        }
+      ],
+      "entry": "ensure-testnet",
+      "nodes": {
+        "ensure-testnet": {
+          "action": "call",
+          "ref": "setup-testnet",
+          "next": "nav-perps"
+        },
+        "nav-perps": {
+          "action": "navigate",
+          "target": "PerpsHomeView",
+          "next": "wait-markets"
+        },
+        "wait-markets": {
+          "action": "wait_for",
+          "test_id": "perps-market-row-item-ETH",
+          "timeout_ms": 20000,
+          "next": "start-trace"
+        },
+        "start-trace": {
+          "action": "trace_start",
+          "label": "perps-nav-smoke",
+          "assert": { "operator": "eq", "field": "started", "value": true },
+          "next": "press-market"
+        },
+        "press-market": {
+          "action": "press",
+          "test_id": "perps-market-row-item-ETH",
+          "next": "wait-detail"
+        },
+        "wait-detail": {
+          "action": "wait_for",
+          "route": "PerpsMarketDetails",
+          "timeout_ms": 15000,
+          "next": "stop-trace"
+        },
+        "stop-trace": {
+          "action": "trace_stop",
+          "label": "perps-nav-smoke",
+          "assert": {
+            "all": [
+              { "operator": "eq", "field": "ok", "value": true },
+              { "operator": "gt", "field": "sizeBytes", "value": 0 },
+              { "operator": "not_null", "field": "path" }
+            ]
+          },
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass",
+          "message": "Mobile Hermes sampling profiler trace captured as Chrome-compatible .cpuprofile"
+        }
+      },
+      "teardown": [
+        {
+          "id": "teardown-nav-home",
+          "action": "navigate",
+          "target": "PerpsHomeView"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/perps/agentic/teams/perps/recipes/capabilities/recipe-issues-smoke.json
+++ b/scripts/perps/agentic/teams/perps/recipes/capabilities/recipe-issues-smoke.json
@@ -1,0 +1,40 @@
+{
+  "title": "Capability: Recipe issue-review automatic capture",
+  "description": "Proof recipe for the automatic recipe-issues feature. Emits exactly one warning, one error, and one uncaught exception via the in-app console hook; the runner must capture all three into the synthesized recipe-issues-review artifacts without any log_watch node wired by the recipe. Marker strings are deliberately unique so the validation wrapper can grep them back out.",
+  "validate": {
+    "workflow": {
+      "pre_conditions": ["wallet.unlocked"],
+      "entry": "emit-warning",
+      "nodes": {
+        "emit-warning": {
+          "action": "eval_sync",
+          "expression": "(function(){console.warn('recipe-watcher-mobile-warning MARKER_WARN_42');return JSON.stringify({emitted:'warn'})})()",
+          "assert": { "operator": "eq", "field": "emitted", "value": "warn" },
+          "next": "emit-error"
+        },
+        "emit-error": {
+          "action": "eval_sync",
+          "expression": "(function(){console.error('recipe-watcher-mobile-error MARKER_ERR_42');return JSON.stringify({emitted:'error'})})()",
+          "assert": { "operator": "eq", "field": "emitted", "value": "error" },
+          "next": "emit-exception"
+        },
+        "emit-exception": {
+          "action": "eval_async",
+          "expression": "new Promise(function(resolve){setTimeout(function(){try{throw new Error('recipe-watcher-mobile-exception MARKER_EXN_42')}catch(e){if(typeof ErrorUtils!=='undefined'&&ErrorUtils.reportFatalError){try{ErrorUtils.reportFatalError(e)}catch(_){}}else if(typeof globalThis!=='undefined'&&typeof globalThis.dispatchEvent==='function'){try{var ev=new Event('error');ev.error=e;ev.message=e.message;globalThis.dispatchEvent(ev)}catch(_){}}if(typeof globalThis!=='undefined'&&Array.isArray(globalThis.__AGENTIC_ISSUES__)){globalThis.__AGENTIC_ISSUES__.push({t:Date.now(),level:'exception',text:String(e.stack||e.message||e)})}}setTimeout(function(){resolve(JSON.stringify({emitted:'exception'}))},200)},0)})",
+          "assert": { "operator": "eq", "field": "emitted", "value": "exception" },
+          "next": "settle"
+        },
+        "settle": {
+          "action": "wait",
+          "duration_ms": 500,
+          "next": "done"
+        },
+        "done": {
+          "action": "end",
+          "status": "pass",
+          "message": "Emitted 3 marker signals; runner must synthesize recipe-issues-review artifacts"
+        }
+      }
+    }
+  }
+}

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -16,6 +16,15 @@ const {
 } = require('./lib/workflow');
 const { backgroundApp, foregroundApp, restartApp } = require('./lib/app-lifecycle');
 const {
+  applyAllowlist,
+  captureFromMetro,
+  computeReview,
+  countByLevel,
+  dedupeIssues,
+  normalizeAppBufferEntries,
+  writeArtifacts: writeIssueArtifacts,
+} = require('./lib/recipe-issues');
+const {
   getAppRoot,
   getTeamsDir,
   inferTeamFromPath,
@@ -568,6 +577,7 @@ function ensureRunArtifacts(runOptions, recipePath) {
     screenshotsDir: path.join(rootDir, 'screenshots'),
     failuresDir: path.join(rootDir, 'failures'),
     logsDir: path.join(rootDir, 'logs'),
+    tracesDir: path.join(rootDir, 'traces'),
     tracePath: path.join(rootDir, 'trace.json'),
     workflowPath: path.join(rootDir, 'workflow.json'),
     workflowMermaidPath: path.join(rootDir, 'workflow.mmd'),
@@ -575,11 +585,114 @@ function ensureRunArtifacts(runOptions, recipePath) {
     runLogPath: path.join(rootDir, 'run.log'),
   };
 
-  [artifacts.rootDir, artifacts.screenshotsDir, artifacts.failuresDir, artifacts.logsDir]
+  [artifacts.rootDir, artifacts.screenshotsDir, artifacts.failuresDir, artifacts.logsDir, artifacts.tracesDir]
     .forEach((dirPath) => fs.mkdirSync(dirPath, { recursive: true }));
 
   state.artifacts = artifacts;
   return artifacts;
+}
+
+function resolveMetroLogPath(runOptions) {
+  if (process.env.METRO_LOG) {
+    return process.env.METRO_LOG;
+  }
+  return path.join(runOptions.appRoot, '.agent', 'metro.log');
+}
+
+function armIssueTracker(runOptions) {
+  const state = ensureExecutionState(runOptions);
+  if (state.issueTracker || runOptions.dryRun) {
+    return state.issueTracker;
+  }
+
+  const metroLogPath = resolveMetroLogPath(runOptions);
+  let startOffset = 0;
+  try {
+    startOffset = fs.existsSync(metroLogPath) ? fs.statSync(metroLogPath).size : 0;
+  } catch {
+    startOffset = 0;
+  }
+
+  // Install in-app console/exception hooks. Best-effort: if the CDP bridge
+  // isn't reachable yet (app booting, port not bound) we still fall back to
+  // metro-log scraping at collection time.
+  let armed = false;
+  try {
+    const armResponse = trySpawnBridge(runOptions.appRoot, ['issues-arm']);
+    if (armResponse && armResponse.ok && armResponse.result?.installed) {
+      armed = true;
+    }
+  } catch {
+    armed = false;
+  }
+
+  state.issueTracker = { metroLogPath, startOffset, armed };
+  return state.issueTracker;
+}
+
+function collectRecipeIssues(runOptions, document) {
+  const state = ensureExecutionState(runOptions);
+  const tracker = state.issueTracker;
+  if (!tracker || runOptions.dryRun) {
+    return null;
+  }
+
+  // Pull the in-app buffer (best-effort). Failures here don't mask the metro
+  // log — we still synthesize review from whatever channel reported.
+  let appEntries = [];
+  if (tracker.armed) {
+    try {
+      const resp = trySpawnBridge(runOptions.appRoot, ['issues-collect']);
+      if (resp && resp.ok && Array.isArray(resp.result?.entries)) {
+        appEntries = resp.result.entries;
+      }
+    } catch {
+      appEntries = [];
+    }
+  }
+
+  const metroIssues = captureFromMetro(tracker.metroLogPath, tracker.startOffset);
+  const appIssues = normalizeAppBufferEntries(appEntries);
+  const allIssues = [...appIssues, ...metroIssues];
+
+  const failOn =
+    document && typeof document.fail_on_unexpected === 'object'
+      ? document.fail_on_unexpected
+      : null;
+  const allowlist = failOn && Array.isArray(failOn.allowlist) ? failOn.allowlist : [];
+
+  const { unexpected, informational } = applyAllowlist(allIssues, allowlist);
+  const review = computeReview(unexpected, informational, failOn, {});
+
+  const runDir = state.artifacts?.rootDir;
+  let artifactFiles = {};
+  if (runDir) {
+    try {
+      artifactFiles = writeIssueArtifacts(runDir, { unexpected, informational, review });
+    } catch (error) {
+      console.error(`recipe-issues artifact write failed: ${String(error.message || error)}`);
+      artifactFiles = {};
+    }
+  }
+  review.artifactFiles = artifactFiles;
+
+  const captured = countByLevel(dedupeIssues(allIssues));
+  const unexpectedCounts = countByLevel(dedupeIssues(unexpected));
+
+  const recipeIssues = {
+    captured,
+    unexpected: unexpectedCounts,
+    failOn: failOn && (Array.isArray(failOn.levels) || Array.isArray(failOn.textMatches))
+      ? {
+          levels: Array.isArray(failOn.levels) ? failOn.levels.slice() : [],
+          textMatches: Array.isArray(failOn.textMatches) ? failOn.textMatches.slice() : [],
+        }
+      : [],
+    review,
+  };
+
+  state.recipeIssues = recipeIssues;
+  return recipeIssues;
 }
 
 function writeRunSummary(runOptions, summary) {
@@ -1292,6 +1405,22 @@ async function runExecutableNode(node, context, options = {}) {
     case 'switch_provider':
       bridgeResult = handleSwitchProvider(node, appRoot);
       break;
+    case 'trace_start':
+      bridgeResult = spawnBridge(appRoot, ['profiler-start']);
+      break;
+    case 'trace_stop': {
+      const artifacts = ensureRunArtifacts(runOptions, context.recipePath);
+      const traceLabel = sanitizeFileSegment(node.label || node.id || 'trace');
+      const outPath = artifacts && artifacts.tracesDir
+        ? path.join(artifacts.tracesDir, `trace-${traceLabel}.cpuprofile`)
+        : '';
+      const stopArgs = ['profiler-stop', '--label', traceLabel];
+      if (outPath) {
+        stopArgs.push('--out', outPath);
+      }
+      bridgeResult = spawnBridge(appRoot, stopArgs);
+      break;
+    }
     default:
       throw new Error(`Unknown action "${node.action}"`);
   }
@@ -1504,6 +1633,9 @@ async function runRecipe(recipePath, runOptions, flowParams = {}, depth = 0) {
   if (!runOptions.dryRun) {
     ensureRunArtifacts(runOptions, recipePath);
     writeWorkflowArtifacts(context);
+    if (depth === 0) {
+      armIssueTracker(runOptions);
+    }
   }
 
   console.log(`${prefix}Running recipe: ${document.title || 'Untitled'}`);
@@ -1620,6 +1752,14 @@ async function runRecipe(recipePath, runOptions, flowParams = {}, depth = 0) {
   if (depth === 0 && !runOptions.dryRun) {
     clearHudStep(appRoot, runOptions);
     writeTraceArtifacts(context);
+    const recipeIssues = collectRecipeIssues(runOptions, document);
+    const gatingTriggered =
+      !!recipeIssues && recipeIssues.review?.status === 'gating';
+    if (gatingTriggered && !failureError) {
+      failureError = new Error(
+        `Recipe issue review gating: ${recipeIssues.review?.note || 'fail_on_unexpected matched'}`
+      );
+    }
     writeRunSummary(runOptions, {
       status: failureError ? 'FAIL' : 'PASS',
       title: document.title || '',
@@ -1630,7 +1770,20 @@ async function runRecipe(recipePath, runOptions, flowParams = {}, depth = 0) {
       workflowMermaidPath: state.artifacts?.workflowMermaidPath || '',
       workflowPath: state.artifacts?.workflowPath || '',
       availableEvalRefs: listEvalRefs(appRoot).map((entry) => entry.ref),
+      ...(recipeIssues ? { recipeIssues } : {}),
     });
+    if (recipeIssues) {
+      const { review } = recipeIssues;
+      if (review.status === 'review') {
+        console.log(
+          `recipe-issues: review — ${review.observed.total} unexpected event(s). See ${review.artifactFiles?.reviewMd || ''}`
+        );
+      } else if (review.status === 'gating') {
+        console.log(
+          `recipe-issues: GATING — ${review.gating.total} event(s) matched fail_on_unexpected. See ${review.artifactFiles?.reviewMd || ''}`
+        );
+      }
+    }
   }
 
   if (failureError) {

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -682,12 +682,13 @@ function collectRecipeIssues(runOptions, document) {
   const recipeIssues = {
     captured,
     unexpected: unexpectedCounts,
-    failOn: failOn && (Array.isArray(failOn.levels) || Array.isArray(failOn.textMatches))
-      ? {
-          levels: Array.isArray(failOn.levels) ? failOn.levels.slice() : [],
-          textMatches: Array.isArray(failOn.textMatches) ? failOn.textMatches.slice() : [],
-        }
-      : [],
+    failOn: {
+      levels: failOn && Array.isArray(failOn.levels) ? failOn.levels.slice() : [],
+      textMatches:
+        failOn && Array.isArray(failOn.textMatches)
+          ? failOn.textMatches.slice()
+          : [],
+    },
     review,
   };
 


### PR DESCRIPTION
## **Description**

This PR adds standalone mobile agentic capability coverage for Hermes performance metrics, profiler traces, and automatic recipe issue review.

It updates the runner wiring and docs needed to execute those capability recipes independently of the perps benchmark migration.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: mobile agentic runner capabilities

  Scenario: run capability recipes
    Given an iOS simulator is running with the wallet unlocked
    And Metro is reachable for the agentic toolkit
    When I run the capability recipes under scripts/perps/agentic/teams/perps/recipes/capabilities/
    Then the runner should write summary artifacts for each run
    And profiler and recipe-issue artifacts should be produced where applicable
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the agentic runner with new execution behaviors (Hermes profiler tracing and automatic warning/error/exception capture) that can affect recipe outcomes via new `trace_*` actions and opt-in `fail_on_unexpected` gating.
> 
> **Overview**
> Adds standalone *capability proof* recipes for mobile agentic runs, covering Hermes performance metrics snapshots, Hermes sampling profiler traces (`trace_start`/`trace_stop`), and automatic issue review capture.
> 
> Updates the runner/bridge wiring to support these capabilities: new CDP bridge commands to start/stop the Hermes `Profiler` and to arm/collect an in-app issue buffer; runner now creates a `traces/` artifacts dir, writes `.cpuprofile` outputs, automatically synthesizes `recipe-issues*` artifacts on every top-level run, and can optionally fail runs when `fail_on_unexpected` matches.
> 
> Documentation is refreshed with a new mobile CDP capability matrix and updated `README` to reflect the new actions and run artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d36608350257ad9f76bed1817bd55c0b4d425a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->