### PR TITLE
chore(perps): harden agentic preflight logging

### DIFF
--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -126,7 +126,7 @@ stage_log() { echo -e "  ${DIM}Log: $1${NC}"; }
 # corepack wrapper, not the deep child (yarn → corepack → yarn.cjs → node
 # expo/cli) that actually binds $PORT. Killing just the wrapper leaves the
 # child alive and still holding the port. Scoped strictly to descendants of
-# the given PID — safe for parallel worktrees / farmslot slots.
+# the given PID — safe for parallel worktrees.
 collect_tree() {
   local parent=$1
   local children
@@ -149,6 +149,74 @@ kill_tree() {
     t=$((t + 1))
   done
   for p in $pids; do kill -KILL "$p" 2>/dev/null || true; done
+}
+
+# Live tail: refresh the last N lines of a log file in-place while a PID is
+# running. TTY-gated so piped runs / CI see no ANSI escapes. Called as a
+# background job; kill it once the watched process has exited.
+#
+# Frame invariant: always owns exactly N terminal rows. Reserves the frame
+# up-front, then every tick does the same symmetric cursor-up-N → redraw.
+# Truncates each line strictly below terminal width to prevent wrap (a
+# wrapped row would break the cursor-up anchor and cause accumulating scroll).
+watch_log() {
+  local log="$1" watcher_of="$2" N="${3:-3}"
+  [ -t 1 ] || return 0
+  local cols width i
+  cols=$(tput cols 2>/dev/null || echo 120)
+  width=$((cols - 6))
+  [ "$width" -lt 20 ] && width=20
+
+  # Reserve N rows once; every subsequent tick starts with cursor-up N.
+  i=0
+  while [ $i -lt $N ]; do printf '\n'; i=$((i + 1)); done
+  # Hide cursor during tail to avoid blink/drift artifacts.
+  tput civis 2>/dev/null || true
+  trap 'tput cnorm 2>/dev/null || true' RETURN
+
+  while kill -0 "$watcher_of" 2>/dev/null; do
+    # Move cursor up N rows and clear from cursor to end of screen.
+    printf '\033[%dA\033[J' "$N"
+    if [ -f "$log" ]; then
+      local lines padded
+      lines=$(tail -n "$N" "$log" 2>/dev/null \
+        | tr -d '\r' \
+        | sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g; s/\t/  /g' \
+        | awk -v w="$width" '{ if (length($0) > w) print substr($0, 1, w); else print }')
+      i=0
+      if [ -n "$lines" ]; then
+        while IFS= read -r l; do
+          printf '    \033[2m%s\033[0m\n' "$l"
+          i=$((i + 1))
+        done <<< "$lines"
+      fi
+      # Pad to exactly N rows so the frame size never shrinks.
+      while [ $i -lt $N ]; do printf '\n'; i=$((i + 1)); done
+    else
+      i=0
+      while [ $i -lt $N ]; do printf '\n'; i=$((i + 1)); done
+    fi
+    sleep 0.75
+  done
+
+  # Final clear: leave N blank rows behind so the caller can print its status.
+  printf '\033[%dA\033[J' "$N"
+  tput cnorm 2>/dev/null || true
+}
+
+# Run a command in the background while tailing its log file live. Returns
+# the command's exit status. Usage: run_with_live_log "$LOG" "$CMD_STRING"
+run_with_live_log() {
+  local log="$1" cmd="$2"
+  bash -c "$cmd" >>"$log" 2>&1 &
+  local cmd_pid=$!
+  watch_log "$log" "$cmd_pid" 3 &
+  local watch_pid=$!
+  local rc=0
+  wait "$cmd_pid" || rc=$?
+  kill "$watch_pid" 2>/dev/null || true
+  wait "$watch_pid" 2>/dev/null || true
+  return $rc
 }
 
 # ── Early fixture validation (fail fast before long pipeline) ────────
@@ -288,7 +356,7 @@ if $DO_CLEAN; then
   fi
   stage_log "$DEPS_LOG"
   printf '$ yarn setup\n' > "$DEPS_LOG"
-  if ! yarn setup >>"$DEPS_LOG" 2>&1; then
+  if ! run_with_live_log "$DEPS_LOG" "yarn setup"; then
     echo ""
     echo -e "  ${RED}Dependencies failed — see $DEPS_LOG${NC}"
     tail -20 "$DEPS_LOG" | sed 's/^/    /'
@@ -338,7 +406,7 @@ if [ "$PLAT" = "ios" ]; then
     echo "  Running pod install via bundler..."
     stage_log "$POD_INSTALL_LOG"
     printf '$ (cd ios && bundle exec pod install --repo-update --ansi)\n' > "$POD_INSTALL_LOG"
-    if (cd ios && bundle exec pod install --repo-update --ansi >>"$POD_INSTALL_LOG" 2>&1); then
+    if run_with_live_log "$POD_INSTALL_LOG" "cd ios && bundle exec pod install --repo-update --ansi"; then
       ok "pod install complete"
     else
       warn "pod install had issues — see $POD_INSTALL_LOG"
@@ -369,12 +437,16 @@ if [ "$PLAT" = "ios" ]; then
     eval "$EXPO_CMD" >"$BUILD_LOG" 2>&1 &
     EXPO_PID=$!
 
+    watch_log "$BUILD_LOG" "$EXPO_PID" 3 &
+    WATCH_PID=$!
+
     APP_PATH=""
     BUILD_TIMEOUT=900
     while :; do
       NOW=$(date +%s)
       ELAPSED=$((NOW - BUILD_START))
       if [ $ELAPSED -ge $BUILD_TIMEOUT ]; then
+        kill "$WATCH_PID" 2>/dev/null || true; wait "$WATCH_PID" 2>/dev/null || true
         kill_tree "$EXPO_PID"
         wait $EXPO_PID 2>/dev/null || true
         echo ""
@@ -400,6 +472,7 @@ if [ "$PLAT" = "ios" ]; then
           fi
         done < <(find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/MetaMask-*/Build/Products/Debug-iphonesimulator/MetaMask.app" -maxdepth 5 -prune 2>/dev/null)
         if [ -n "$APP_PATH" ]; then
+          kill "$WATCH_PID" 2>/dev/null || true; wait "$WATCH_PID" 2>/dev/null || true
           echo -e "  ${GREEN}→${NC} Build Succeeded (${ELAPSED}s)"
           kill_tree "$EXPO_PID"
           wait $EXPO_PID 2>/dev/null || true
@@ -409,6 +482,7 @@ if [ "$PLAT" = "ios" ]; then
 
       # Surface fatal CLI errors only after confirming build hasn't succeeded.
       if grep -qE 'CommandError:|BUILD FAILED' "$BUILD_LOG" 2>/dev/null; then
+        kill "$WATCH_PID" 2>/dev/null || true; wait "$WATCH_PID" 2>/dev/null || true
         kill_tree "$EXPO_PID"
         wait $EXPO_PID 2>/dev/null || true
         echo ""
@@ -419,6 +493,7 @@ if [ "$PLAT" = "ios" ]; then
 
       # If expo exited on its own before we found a fresh .app, treat as failure.
       if ! kill -0 $EXPO_PID 2>/dev/null; then
+        kill "$WATCH_PID" 2>/dev/null || true; wait "$WATCH_PID" 2>/dev/null || true
         echo ""
         echo -e "  ${RED}expo run:ios exited without producing a fresh .app${NC}"
         echo -e "  ${RED}Build log tail:${NC}"
@@ -433,11 +508,19 @@ if [ "$PLAT" = "ios" ]; then
     # Wait for expo's Metro on $PORT to actually release the socket — kill_tree
     # already SIGKILLed any stragglers, but the kernel takes a moment to free the
     # port. start-metro.sh probes /status and would race an orphaned bundler.
-    for _ in $(seq 1 10); do
+    #
+    # Exception: zombie sweep may have preserved a reused Metro on $PORT (healthy
+    # /status). In that case the port is expected to stay bound and we accept it.
+    for _ in $(seq 1 20); do
       lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1 || break
+      if curl -sf --max-time 1 "http://localhost:$PORT/status" >/dev/null 2>&1; then
+        ok "Port $PORT held by healthy Metro (reused) — continuing"
+        break
+      fi
       sleep 1
     done
-    if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1 \
+       && ! curl -sf --max-time 1 "http://localhost:$PORT/status" >/dev/null 2>&1; then
       HOLDER=$(lsof -iTCP:"$PORT" -sTCP:LISTEN -Fc 2>/dev/null | grep '^c' | head -1)
       fail "Port $PORT still held after expo teardown ($HOLDER) — aborting to avoid CDP misrouting"
     fi
@@ -534,16 +617,19 @@ else
 
     BUILD_LOG="$(resolve_path '.agent/android-build.log')"
     stage_log "$BUILD_LOG"
+    : > "$BUILD_LOG"
     set +e
-    (cd android && SENTRY_DISABLE_AUTO_UPLOAD=true ./gradlew app:assembleProdDebug -PreactNativeArchitectures=arm64-v8a) 2>&1 | tee "$BUILD_LOG" | while IFS= read -r line; do
-      case "$line" in
-        *"BUILD SUCCESSFUL"*) echo -e "  ${GREEN}→${NC} $line" ;;
-        *"BUILD FAILED"*)     echo -e "  ${RED}→${NC} $line" ;;
-        *"error:"*)           echo -e "  ${RED}→${NC} $line" ;;
-        *"FAILURE"*)          echo -e "  ${RED}→${NC} $line" ;;
-      esac
-    done
+    run_with_live_log "$BUILD_LOG" "cd android && SENTRY_DISABLE_AUTO_UPLOAD=true ./gradlew app:assembleProdDebug -PreactNativeArchitectures=arm64-v8a"
+    GRADLE_RC=$?
     set -e
+    if grep -q 'BUILD SUCCESSFUL' "$BUILD_LOG" 2>/dev/null; then
+      echo -e "  ${GREEN}→${NC} BUILD SUCCESSFUL"
+    elif [ "$GRADLE_RC" -ne 0 ] || grep -qE 'BUILD FAILED|FAILURE|error:' "$BUILD_LOG" 2>/dev/null; then
+      echo ""
+      echo -e "  ${RED}Build log tail:${NC}"
+      tail -30 "$BUILD_LOG" | sed 's/^/    /'
+      fail "Gradle build failed — see $BUILD_LOG"
+    fi
 
     # Find the APK and install via adb
     APK_PATH=$(find android/app/build/outputs/apk -name "*.apk" -path "*/debug/*" 2>/dev/null | head -1)

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -162,17 +162,25 @@ kill_tree() {
 watch_log() {
   local log="$1" watcher_of="$2" N="${3:-3}"
   [ -t 1 ] || return 0
-  local cols width i
+  local cols width i cleanup_done=0
   cols=$(tput cols 2>/dev/null || echo 120)
   width=$((cols - 6))
   [ "$width" -lt 20 ] && width=20
+
+  watch_log_cleanup() {
+    [ "$cleanup_done" -eq 1 ] && return
+    cleanup_done=1
+    printf '\033[%dA\033[J' "$N" 2>/dev/null || true
+    tput cnorm 2>/dev/null || true
+  }
 
   # Reserve N rows once; every subsequent tick starts with cursor-up N.
   i=0
   while [ $i -lt $N ]; do printf '\n'; i=$((i + 1)); done
   # Hide cursor during tail to avoid blink/drift artifacts.
   tput civis 2>/dev/null || true
-  trap 'tput cnorm 2>/dev/null || true' RETURN
+  trap 'watch_log_cleanup' EXIT
+  trap 'watch_log_cleanup; exit 0' TERM INT
 
   while kill -0 "$watcher_of" 2>/dev/null; do
     # Move cursor up N rows and clear from cursor to end of screen.
@@ -200,8 +208,8 @@ watch_log() {
   done
 
   # Final clear: leave N blank rows behind so the caller can print its status.
-  printf '\033[%dA\033[J' "$N"
-  tput cnorm 2>/dev/null || true
+  watch_log_cleanup
+  trap - EXIT TERM INT
 }
 
 # Run a command in the background while tailing its log file live. Returns


### PR DESCRIPTION
## **Description**

This PR hardens `scripts/perps/agentic/preflight.sh`.

It adds live log tailing for long-running setup steps and improves Metro teardown and reuse handling during agentic setup flows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: agentic preflight shell flow

  Scenario: stream logs during preflight
    Given an iOS development environment is available for the agentic toolkit
    When I run bash scripts/perps/agentic/preflight.sh
    Then long-running steps should tail recent log lines live in place
    And the script should continue cleanly when a healthy Metro instance is reused on the expected port
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify how long-running build/setup commands are executed and how processes/ports are managed, which could cause preflight runs to hang, misreport failures, or leave orphaned processes if the new watcher/teardown logic misbehaves. Impact is limited to local developer tooling (no production runtime).
> 
> **Overview**
> Adds a TTY-only live log tailer (`watch_log`) and a `run_with_live_log` helper so long-running preflight steps stream the last few log lines in-place while still writing full logs to disk.
> 
> Updates `preflight.sh` to use live tailing for `yarn setup`, iOS `pod install`, iOS `expo run:ios` build, and Android Gradle builds, and adjusts Android failure detection to rely on log scanning + exit code (with tail-on-fail).
> 
> Hardens iOS Metro/port teardown by tolerating a still-bound port when a healthy Metro `/status` responds (reuse case) and extends the wait window before failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245c9cfb1c74ad37c00aca17b5a3b03f26565383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->