### PR TITLE
feat: Accounts Metrics

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -622,7 +622,7 @@ const Wallet = ({
   );
 
   const { toastRef } = useContext(ToastContext);
-  const { trackEvent, createEventBuilder, addTraitsToUser } = useAnalytics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { colors } = theme;
   const dispatch = useDispatch();

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -148,8 +148,6 @@ import { TokenI } from '../../UI/Tokens/types';
 import NetworkConnectionBanner from '../../UI/NetworkConnectionBanner';
 
 import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
-import { selectHDKeyrings } from '../../../selectors/keyringController';
-import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import {
   SwapBridgeNavigationLocation,
   useSwapBridgeNavigation,
@@ -770,8 +768,6 @@ const Wallet = ({
 
   const currentToast = toastRef?.current;
 
-  const hdKeyrings = useSelector(selectHDKeyrings);
-
   const accountName = useAccountName();
   const accountGroupName = useAccountGroupName();
 
@@ -865,12 +861,6 @@ const Wallet = ({
     isPredictGTMModalEnabled,
     checkAndNavigateToPredictGTM,
   ]);
-
-  useEffect(() => {
-    addTraitsToUser({
-      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: hdKeyrings.length,
-    });
-  }, [addTraitsToUser, hdKeyrings.length]);
 
   const isConnectionRemoved = useSelector(selectIsConnectionRemoved);
 

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
@@ -4,7 +4,10 @@ import {
   AnalyticsControllerMessenger,
 } from '@metamask/analytics-controller';
 import { MessengerClientInitRequest } from '../../types';
-import { AnalyticsControllerInitMessenger , getAnalyticsControllerMessenger } from '../../messengers/analytics-controller-messenger';
+import {
+  AnalyticsControllerInitMessenger,
+  getAnalyticsControllerMessenger,
+} from '../../messengers/analytics-controller-messenger';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
@@ -239,9 +242,9 @@ describe('analyticsControllerInit', () => {
       const mockFlags = {
         remoteFeatureFlags: { brazeSegmentForwarding: { allowedEvents: [] } },
       };
-      const result = (selector as (state: typeof mockFlags) => unknown)(
-        mockFlags,
-      );
+      const result = (
+        selector as unknown as (state: typeof mockFlags) => unknown
+      )(mockFlags);
       expect(result).toBe(mockFlags.remoteFeatureFlags.brazeSegmentForwarding);
     });
   });
@@ -289,9 +292,9 @@ describe('analyticsControllerInit', () => {
       const mockState = {
         internalAccounts: { accounts: buildMockAccounts() },
       };
-      const result = (selector as (state: typeof mockState) => unknown)(
-        mockState,
-      );
+      const result = (
+        selector as unknown as (state: typeof mockState) => unknown
+      )(mockState);
       expect(result).toBe(mockState.internalAccounts.accounts);
     });
 

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
@@ -1,0 +1,510 @@
+import { analyticsControllerInit } from './analytics-controller-init';
+import {
+  AnalyticsController,
+  AnalyticsControllerMessenger,
+} from '@metamask/analytics-controller';
+import { MessengerClientInitRequest } from '../../types';
+import { AnalyticsControllerInitMessenger , getAnalyticsControllerMessenger } from '../../messengers/analytics-controller-messenger';
+import { ExtendedMessenger } from '../../../ExtendedMessenger';
+import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
+import { analytics } from '../../../../util/analytics/analytics';
+import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
+import Logger from '../../../../util/Logger';
+import type { AccountsControllerState } from '@metamask/accounts-controller';
+
+type InternalAccounts = AccountsControllerState['internalAccounts']['accounts'];
+
+jest.mock('@metamask/analytics-controller', () => ({
+  ...jest.requireActual('@metamask/analytics-controller'),
+  AnalyticsController: jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+  })),
+}));
+
+jest.mock('./platform-adapter', () => ({
+  createPlatformAdapter: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('./platform-adapter-e2e', () => ({
+  createPlatformAdapter: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../../../util/test/utils', () => ({
+  isE2E: false,
+}));
+
+jest.mock('../../../Braze', () => ({
+  getBrazePlugin: jest.fn().mockReturnValue({}),
+  syncBrazeAllowlists: jest.fn(),
+}));
+
+jest.mock('../../../../util/analytics/analytics', () => ({
+  analytics: {
+    identify: jest.fn(),
+  },
+}));
+
+jest.mock(
+  '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData',
+  () => ({
+    getAccountCompositionTraits: jest.fn().mockReturnValue({ trait: 'value' }),
+  }),
+);
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+const mockSyncBrazeAllowlists = jest.requireMock('../../../Braze')
+  .syncBrazeAllowlists as jest.Mock;
+const mockAnalyticsIdentify = jest.mocked(analytics.identify);
+const mockGetAccountCompositionTraits = jest.mocked(
+  getAccountCompositionTraits,
+);
+const mockLoggerError = jest.mocked(Logger.error);
+
+const MOCK_BRAZE_SEGMENT_FORWARDING = { allowedEvents: ['event1'] };
+
+function buildInitMessengerMock(): jest.Mocked<AnalyticsControllerInitMessenger> {
+  return {
+    subscribe: jest.fn(),
+    call: jest.fn().mockReturnValue({
+      remoteFeatureFlags: {
+        brazeSegmentForwarding: MOCK_BRAZE_SEGMENT_FORWARDING,
+      },
+    }),
+  } as unknown as jest.Mocked<AnalyticsControllerInitMessenger>;
+}
+
+function getInitRequestMock(
+  overrides: Partial<{
+    analyticsId: string;
+    persistedState: Record<string, unknown>;
+    initMessenger: jest.Mocked<AnalyticsControllerInitMessenger>;
+  }> = {},
+): jest.Mocked<
+  MessengerClientInitRequest<
+    AnalyticsControllerMessenger,
+    AnalyticsControllerInitMessenger
+  >
+> {
+  const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+  return {
+    ...buildMessengerClientInitRequestMock(baseMessenger),
+    controllerMessenger: getAnalyticsControllerMessenger(
+      baseMessenger as never,
+    ),
+    initMessenger: overrides.initMessenger ?? buildInitMessengerMock(),
+    analyticsId: overrides.analyticsId ?? 'test-analytics-id',
+    persistedState: overrides.persistedState ?? {},
+  };
+}
+
+function getAccountsSubscribeCallback(
+  initMessengerMock: jest.Mocked<AnalyticsControllerInitMessenger>,
+): (accounts: InternalAccounts) => void {
+  const subscribeCall = initMessengerMock.subscribe.mock.calls.find(
+    ([event]) => event === 'AccountsController:stateChange',
+  );
+  if (!subscribeCall) throw new Error('AccountsController subscribe not found');
+  return subscribeCall[1] as (accounts: InternalAccounts) => void;
+}
+
+function buildMockAccounts(
+  overrides: Partial<InternalAccounts> = {},
+): InternalAccounts {
+  return {
+    'account-1': {
+      id: 'account-1',
+      address: '0x1234',
+      type: 'eip155:eoa',
+      options: { entropy: { id: 'entropy-1', groupIndex: 0 } },
+      methods: [],
+      metadata: {
+        keyring: { type: 'HD Key Tree' },
+        importTime: 0,
+        name: 'Account 1',
+        nameLastUpdatedAt: 0,
+      },
+    },
+    ...overrides,
+  } as unknown as InternalAccounts;
+}
+
+describe('analyticsControllerInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('controller initialization', () => {
+    it('returns the initialized controller', () => {
+      const { controller } = analyticsControllerInit(getInitRequestMock());
+      expect(controller).toBeDefined();
+    });
+
+    it('creates AnalyticsController with correct arguments', () => {
+      analyticsControllerInit(getInitRequestMock());
+
+      expect(AnalyticsController).toHaveBeenCalledWith({
+        messenger: expect.any(Object),
+        state: expect.objectContaining({ analyticsId: 'test-analytics-id' }),
+        platformAdapter: expect.any(Object),
+        isAnonymousEventsFeatureEnabled: true,
+      });
+    });
+
+    it('uses persisted optedIn state when available', () => {
+      analyticsControllerInit(
+        getInitRequestMock({
+          persistedState: { AnalyticsController: { optedIn: true } },
+        }),
+      );
+
+      expect(AnalyticsController).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ optedIn: true }),
+        }),
+      );
+    });
+
+    it('calls controller.init()', () => {
+      analyticsControllerInit(getInitRequestMock());
+
+      const controllerMock = jest.mocked(AnalyticsController);
+      expect(controllerMock.mock.results[0].value.init).toHaveBeenCalled();
+    });
+  });
+
+  describe('platform adapter', () => {
+    it('uses standard platform adapter when not in E2E', () => {
+      const { createPlatformAdapter } = jest.requireMock('./platform-adapter');
+      analyticsControllerInit(getInitRequestMock());
+      expect(createPlatformAdapter).toHaveBeenCalled();
+    });
+
+    it('uses E2E platform adapter when isE2E is true', () => {
+      jest.resetModules();
+      jest.doMock('../../../../util/test/utils', () => ({ isE2E: true }));
+      const { createPlatformAdapter: createE2E } = jest.requireMock(
+        './platform-adapter-e2e',
+      );
+      // Re-require to pick up the new isE2E mock
+      const { analyticsControllerInit: initFn } = jest.requireMock(
+        './analytics-controller-init',
+      );
+      initFn?.(getInitRequestMock());
+      // The E2E mock was registered; verify it was set up
+      expect(createE2E).toBeDefined();
+    });
+  });
+
+  describe('RemoteFeatureFlagController:stateChange subscription', () => {
+    it('subscribes to RemoteFeatureFlagController:stateChange', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      expect(initMessenger.subscribe).toHaveBeenCalledWith(
+        'RemoteFeatureFlagController:stateChange',
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it('passes syncBrazeAllowlists as the subscriber callback', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const [, callback] = initMessenger.subscribe.mock.calls.find(
+        ([event]) => event === 'RemoteFeatureFlagController:stateChange',
+      ) as Parameters<typeof initMessenger.subscribe>;
+
+      expect(callback).toBe(mockSyncBrazeAllowlists);
+    });
+
+    it('uses brazeSegmentForwarding as the selector', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const [, , selector] = initMessenger.subscribe.mock.calls.find(
+        ([event]) => event === 'RemoteFeatureFlagController:stateChange',
+      ) as Parameters<typeof initMessenger.subscribe>;
+
+      const mockFlags = {
+        remoteFeatureFlags: { brazeSegmentForwarding: { allowedEvents: [] } },
+      };
+      const result = (selector as (state: typeof mockFlags) => unknown)(
+        mockFlags,
+      );
+      expect(result).toBe(mockFlags.remoteFeatureFlags.brazeSegmentForwarding);
+    });
+  });
+
+  describe('initial Braze sync', () => {
+    it('calls getState on RemoteFeatureFlagController', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      expect(initMessenger.call).toHaveBeenCalledWith(
+        'RemoteFeatureFlagController:getState',
+      );
+    });
+
+    it('calls syncBrazeAllowlists with the braze segment forwarding flags', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      expect(mockSyncBrazeAllowlists).toHaveBeenCalledWith(
+        MOCK_BRAZE_SEGMENT_FORWARDING,
+      );
+    });
+  });
+
+  describe('AccountsController:stateChange subscription', () => {
+    it('subscribes to AccountsController:stateChange', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      expect(initMessenger.subscribe).toHaveBeenCalledWith(
+        'AccountsController:stateChange',
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it('uses internalAccounts.accounts as the selector', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const [, , selector] = initMessenger.subscribe.mock.calls.find(
+        ([event]) => event === 'AccountsController:stateChange',
+      ) as Parameters<typeof initMessenger.subscribe>;
+
+      const mockState = {
+        internalAccounts: { accounts: buildMockAccounts() },
+      };
+      const result = (selector as (state: typeof mockState) => unknown)(
+        mockState,
+      );
+      expect(result).toBe(mockState.internalAccounts.accounts);
+    });
+
+    it('calls analytics.identify when account composition changes', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const callback = getAccountsSubscribeCallback(initMessenger);
+      const accounts = buildMockAccounts();
+      callback(accounts);
+
+      expect(mockAnalyticsIdentify).toHaveBeenCalledWith({ trait: 'value' });
+      expect(mockGetAccountCompositionTraits).toHaveBeenCalledWith(accounts);
+    });
+
+    it('does not call analytics.identify when account composition has not changed', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const callback = getAccountsSubscribeCallback(initMessenger);
+      const accounts = buildMockAccounts();
+
+      callback(accounts);
+      jest.clearAllMocks();
+      callback(accounts);
+
+      expect(mockAnalyticsIdentify).not.toHaveBeenCalled();
+    });
+
+    it('calls analytics.identify again when account composition changes after initial call', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      const accounts1 = buildMockAccounts();
+      callback(accounts1);
+      jest.clearAllMocks();
+
+      const accounts2 = buildMockAccounts({
+        'account-2': {
+          id: 'account-2',
+          address: '0x5678',
+          type: 'eip155:eoa',
+          options: {},
+          methods: [],
+          metadata: {
+            keyring: { type: 'Simple Key Pair' },
+            importTime: 0,
+            name: 'Account 2',
+            nameLastUpdatedAt: 0,
+          },
+        } as unknown as InternalAccounts[string],
+      });
+      callback(accounts2);
+
+      expect(mockAnalyticsIdentify).toHaveBeenCalled();
+    });
+
+    it('logs an error when analytics.identify throws', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+
+      const mockError = new Error('identify failed');
+      mockAnalyticsIdentify.mockImplementationOnce(() => {
+        throw mockError;
+      });
+
+      const callback = getAccountsSubscribeCallback(initMessenger);
+      callback(buildMockAccounts());
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        mockError,
+        'analyticsControllerInit: Error updating account composition traits',
+      );
+    });
+  });
+
+  describe('getCompositionFingerprint', () => {
+    it('produces stable fingerprint including keyring type and entropy', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      const accounts = buildMockAccounts();
+      callback(accounts);
+      jest.clearAllMocks();
+      // Same accounts, same fingerprint — should not re-identify
+      callback(accounts);
+      expect(mockAnalyticsIdentify).not.toHaveBeenCalled();
+    });
+
+    it('produces different fingerprint when keyring type changes', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      callback(buildMockAccounts());
+      jest.clearAllMocks();
+
+      const accountsChanged = {
+        'account-1': {
+          id: 'account-1',
+          address: '0x1234',
+          type: 'eip155:eoa',
+          options: { entropy: { id: 'entropy-1', groupIndex: 0 } },
+          methods: [],
+          metadata: {
+            keyring: { type: 'Simple Key Pair' }, // changed
+            importTime: 0,
+            name: 'Account 1',
+            nameLastUpdatedAt: 0,
+          },
+        },
+      } as unknown as InternalAccounts;
+
+      callback(accountsChanged);
+      expect(mockAnalyticsIdentify).toHaveBeenCalled();
+    });
+
+    it('handles accounts with missing entropy gracefully', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      const accountsNoEntropy = {
+        'account-1': {
+          id: 'account-1',
+          address: '0x1234',
+          type: 'eip155:eoa',
+          options: {},
+          methods: [],
+          metadata: {
+            keyring: { type: 'HD Key Tree' },
+            importTime: 0,
+            name: 'Account 1',
+            nameLastUpdatedAt: 0,
+          },
+        },
+      } as unknown as InternalAccounts;
+
+      expect(() => callback(accountsNoEntropy)).not.toThrow();
+      expect(mockAnalyticsIdentify).toHaveBeenCalled();
+    });
+
+    it('handles accounts with missing keyring metadata gracefully', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      const accountsNoKeyring = {
+        'account-1': {
+          id: 'account-1',
+          address: '0x1234',
+          type: 'eip155:eoa',
+          options: {},
+          methods: [],
+          metadata: {
+            importTime: 0,
+            name: 'Account 1',
+            nameLastUpdatedAt: 0,
+          },
+        },
+      } as unknown as InternalAccounts;
+
+      expect(() => callback(accountsNoKeyring)).not.toThrow();
+    });
+
+    it('produces sorted, stable output for multiple accounts', () => {
+      const initMessenger = buildInitMessengerMock();
+      analyticsControllerInit(getInitRequestMock({ initMessenger }));
+      const callback = getAccountsSubscribeCallback(initMessenger);
+
+      const accountsAB = {
+        'account-a': {
+          id: 'account-a',
+          address: '0xaaa',
+          type: 'eip155:eoa',
+          options: {},
+          methods: [],
+          metadata: {
+            keyring: { type: 'HD Key Tree' },
+            importTime: 0,
+            name: 'A',
+            nameLastUpdatedAt: 0,
+          },
+        },
+        'account-b': {
+          id: 'account-b',
+          address: '0xbbb',
+          type: 'eip155:eoa',
+          options: {},
+          methods: [],
+          metadata: {
+            keyring: { type: 'Simple Key Pair' },
+            importTime: 0,
+            name: 'B',
+            nameLastUpdatedAt: 0,
+          },
+        },
+      } as unknown as InternalAccounts;
+
+      callback(accountsAB);
+      jest.clearAllMocks();
+
+      // Same accounts, different insertion order — fingerprint should be identical (sorted)
+      const accountsBA = {
+        'account-b': accountsAB['account-b'],
+        'account-a': accountsAB['account-a'],
+      } as unknown as InternalAccounts;
+
+      callback(accountsBA);
+      expect(mockAnalyticsIdentify).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
@@ -39,7 +39,6 @@ jest.mock('../../../../util/test/utils', () => ({
 
 jest.mock('../../../Braze', () => ({
   getBrazePlugin: jest.fn().mockReturnValue({}),
-  syncBrazeAllowlists: jest.fn(),
 }));
 
 jest.mock('../../../../util/analytics/analytics', () => ({
@@ -62,24 +61,16 @@ jest.mock('../../../../util/Logger', () => ({
   },
 }));
 
-const mockSyncBrazeAllowlists = jest.requireMock('../../../Braze')
-  .syncBrazeAllowlists as jest.Mock;
 const mockAnalyticsIdentify = jest.mocked(analytics.identify);
 const mockGetAccountCompositionTraits = jest.mocked(
   getAccountCompositionTraits,
 );
 const mockLoggerError = jest.mocked(Logger.error);
 
-const MOCK_BRAZE_SEGMENT_FORWARDING = { allowedEvents: ['event1'] };
-
 function buildInitMessengerMock(): jest.Mocked<AnalyticsControllerInitMessenger> {
   return {
     subscribe: jest.fn(),
-    call: jest.fn().mockReturnValue({
-      remoteFeatureFlags: {
-        brazeSegmentForwarding: MOCK_BRAZE_SEGMENT_FORWARDING,
-      },
-    }),
+    call: jest.fn(),
   } as unknown as jest.Mocked<AnalyticsControllerInitMessenger>;
 }
 
@@ -205,67 +196,6 @@ describe('analyticsControllerInit', () => {
       initFn?.(getInitRequestMock());
       // The E2E mock was registered; verify it was set up
       expect(createE2E).toBeDefined();
-    });
-  });
-
-  describe('RemoteFeatureFlagController:stateChange subscription', () => {
-    it('subscribes to RemoteFeatureFlagController:stateChange', () => {
-      const initMessenger = buildInitMessengerMock();
-      analyticsControllerInit(getInitRequestMock({ initMessenger }));
-
-      expect(initMessenger.subscribe).toHaveBeenCalledWith(
-        'RemoteFeatureFlagController:stateChange',
-        expect.any(Function),
-        expect.any(Function),
-      );
-    });
-
-    it('passes syncBrazeAllowlists as the subscriber callback', () => {
-      const initMessenger = buildInitMessengerMock();
-      analyticsControllerInit(getInitRequestMock({ initMessenger }));
-
-      const [, callback] = initMessenger.subscribe.mock.calls.find(
-        ([event]) => event === 'RemoteFeatureFlagController:stateChange',
-      ) as Parameters<typeof initMessenger.subscribe>;
-
-      expect(callback).toBe(mockSyncBrazeAllowlists);
-    });
-
-    it('uses brazeSegmentForwarding as the selector', () => {
-      const initMessenger = buildInitMessengerMock();
-      analyticsControllerInit(getInitRequestMock({ initMessenger }));
-
-      const [, , selector] = initMessenger.subscribe.mock.calls.find(
-        ([event]) => event === 'RemoteFeatureFlagController:stateChange',
-      ) as Parameters<typeof initMessenger.subscribe>;
-
-      const mockFlags = {
-        remoteFeatureFlags: { brazeSegmentForwarding: { allowedEvents: [] } },
-      };
-      const result = (
-        selector as unknown as (state: typeof mockFlags) => unknown
-      )(mockFlags);
-      expect(result).toBe(mockFlags.remoteFeatureFlags.brazeSegmentForwarding);
-    });
-  });
-
-  describe('initial Braze sync', () => {
-    it('calls getState on RemoteFeatureFlagController', () => {
-      const initMessenger = buildInitMessengerMock();
-      analyticsControllerInit(getInitRequestMock({ initMessenger }));
-
-      expect(initMessenger.call).toHaveBeenCalledWith(
-        'RemoteFeatureFlagController:getState',
-      );
-    });
-
-    it('calls syncBrazeAllowlists with the braze segment forwarding flags', () => {
-      const initMessenger = buildInitMessengerMock();
-      analyticsControllerInit(getInitRequestMock({ initMessenger }));
-
-      expect(mockSyncBrazeAllowlists).toHaveBeenCalledWith(
-        MOCK_BRAZE_SEGMENT_FORWARDING,
-      );
     });
   });
 

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
@@ -15,6 +15,10 @@ import { analytics } from '../../../../util/analytics/analytics';
 import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
 import Logger from '../../../../util/Logger';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { createMockInternalAccount } from '../../../../util/test/accountsControllerTestUtils';
 
 type InternalAccounts = AccountsControllerState['internalAccounts']['accounts'];
 
@@ -116,20 +120,19 @@ function buildMockAccounts(
 ): InternalAccounts {
   return {
     'account-1': {
+      ...createMockInternalAccount('0x1234', 'Account 1', KeyringTypes.hd),
       id: 'account-1',
-      address: '0x1234',
-      type: 'eip155:eoa',
-      options: { entropy: { id: 'entropy-1', groupIndex: 0 } },
-      methods: [],
-      metadata: {
-        keyring: { type: 'HD Key Tree' },
-        importTime: 0,
-        name: 'Account 1',
-        nameLastUpdatedAt: 0,
-      },
+      options: {
+        entropy: {
+          type: KeyringAccountEntropyTypeOption.Mnemonic,
+          id: 'entropy-1',
+          derivationPath: "m/44'/60'/0'/0/0",
+          groupIndex: 0,
+        },
+      } as InternalAccount['options'],
     },
     ...overrides,
-  } as unknown as InternalAccounts;
+  };
 }
 
 describe('analyticsControllerInit', () => {
@@ -266,18 +269,13 @@ describe('analyticsControllerInit', () => {
 
       const accounts2 = buildMockAccounts({
         'account-2': {
+          ...createMockInternalAccount(
+            '0x5678',
+            'Account 2',
+            KeyringTypes.simple,
+          ),
           id: 'account-2',
-          address: '0x5678',
-          type: 'eip155:eoa',
-          options: {},
-          methods: [],
-          metadata: {
-            keyring: { type: 'Simple Key Pair' },
-            importTime: 0,
-            name: 'Account 2',
-            nameLastUpdatedAt: 0,
-          },
-        } as unknown as InternalAccounts[string],
+        },
       });
       callback(accounts2);
 
@@ -325,21 +323,16 @@ describe('analyticsControllerInit', () => {
       callback(buildMockAccounts());
       jest.clearAllMocks();
 
-      const accountsChanged = {
+      const accountsChanged: InternalAccounts = {
         'account-1': {
+          ...createMockInternalAccount(
+            '0x1234',
+            'Account 1',
+            KeyringTypes.simple,
+          ),
           id: 'account-1',
-          address: '0x1234',
-          type: 'eip155:eoa',
-          options: { entropy: { id: 'entropy-1', groupIndex: 0 } },
-          methods: [],
-          metadata: {
-            keyring: { type: 'Simple Key Pair' }, // changed
-            importTime: 0,
-            name: 'Account 1',
-            nameLastUpdatedAt: 0,
-          },
         },
-      } as unknown as InternalAccounts;
+      };
 
       callback(accountsChanged);
       expect(mockAnalyticsIdentify).toHaveBeenCalled();
@@ -350,21 +343,12 @@ describe('analyticsControllerInit', () => {
       analyticsControllerInit(getInitRequestMock({ initMessenger }));
       const callback = getAccountsSubscribeCallback(initMessenger);
 
-      const accountsNoEntropy = {
+      const accountsNoEntropy: InternalAccounts = {
         'account-1': {
+          ...createMockInternalAccount('0x1234', 'Account 1', KeyringTypes.hd),
           id: 'account-1',
-          address: '0x1234',
-          type: 'eip155:eoa',
-          options: {},
-          methods: [],
-          metadata: {
-            keyring: { type: 'HD Key Tree' },
-            importTime: 0,
-            name: 'Account 1',
-            nameLastUpdatedAt: 0,
-          },
         },
-      } as unknown as InternalAccounts;
+      };
 
       expect(() => callback(accountsNoEntropy)).not.toThrow();
       expect(mockAnalyticsIdentify).toHaveBeenCalled();
@@ -375,20 +359,16 @@ describe('analyticsControllerInit', () => {
       analyticsControllerInit(getInitRequestMock({ initMessenger }));
       const callback = getAccountsSubscribeCallback(initMessenger);
 
-      const accountsNoKeyring = {
+      const accountsNoKeyring: InternalAccounts = {
         'account-1': {
+          ...createMockInternalAccount('0x1234', 'Account 1', KeyringTypes.hd),
           id: 'account-1',
-          address: '0x1234',
-          type: 'eip155:eoa',
-          options: {},
-          methods: [],
           metadata: {
             importTime: 0,
             name: 'Account 1',
-            nameLastUpdatedAt: 0,
-          },
+          } as InternalAccount['metadata'],
         },
-      } as unknown as InternalAccounts;
+      };
 
       expect(() => callback(accountsNoKeyring)).not.toThrow();
     });
@@ -398,43 +378,25 @@ describe('analyticsControllerInit', () => {
       analyticsControllerInit(getInitRequestMock({ initMessenger }));
       const callback = getAccountsSubscribeCallback(initMessenger);
 
-      const accountsAB = {
+      const accountsAB: InternalAccounts = {
         'account-a': {
+          ...createMockInternalAccount('0xaaa', 'A', KeyringTypes.hd),
           id: 'account-a',
-          address: '0xaaa',
-          type: 'eip155:eoa',
-          options: {},
-          methods: [],
-          metadata: {
-            keyring: { type: 'HD Key Tree' },
-            importTime: 0,
-            name: 'A',
-            nameLastUpdatedAt: 0,
-          },
         },
         'account-b': {
+          ...createMockInternalAccount('0xbbb', 'B', KeyringTypes.simple),
           id: 'account-b',
-          address: '0xbbb',
-          type: 'eip155:eoa',
-          options: {},
-          methods: [],
-          metadata: {
-            keyring: { type: 'Simple Key Pair' },
-            importTime: 0,
-            name: 'B',
-            nameLastUpdatedAt: 0,
-          },
         },
-      } as unknown as InternalAccounts;
+      };
 
       callback(accountsAB);
       jest.clearAllMocks();
 
       // Same accounts, different insertion order — fingerprint should be identical (sorted)
-      const accountsBA = {
+      const accountsBA: InternalAccounts = {
         'account-b': accountsAB['account-b'],
         'account-a': accountsAB['account-a'],
-      } as unknown as InternalAccounts;
+      };
 
       callback(accountsBA);
       expect(mockAnalyticsIdentify).not.toHaveBeenCalled();

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -32,7 +32,7 @@ function getCompositionFingerprint(accounts: InternalAccounts): string {
       )?.entropy;
       return `${id}|${keyringType}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
     })
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .join(';');
 }
 

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -10,6 +10,31 @@ import { createPlatformAdapter as createE2EPlatformAdapter } from './platform-ad
 import { isE2E } from '../../../../util/test/utils';
 import { getBrazePlugin, syncBrazeAllowlists } from '../../../Braze';
 import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { analytics } from '../../../../util/analytics/analytics';
+import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
+import Logger from '../../../../util/Logger';
+
+/**
+ * Produces a stable string fingerprint from only the fields that affect wallet
+ * composition metrics. Fields like `lastSelected` and account names are
+ * intentionally excluded so that account switches and renames do not trigger
+ * an unnecessary identify call.
+ */
+function getCompositionFingerprint(
+  accounts: Record<string, InternalAccount>,
+): string {
+  return Object.entries(accounts)
+    .map(([id, acct]) => {
+      const keyringType = acct.metadata?.keyring?.type ?? '';
+      const entropy = (
+        acct.options as { entropy?: { id?: string; groupIndex?: number } }
+      )?.entropy;
+      return `${id}|${keyringType}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
+    })
+    .sort()
+    .join(';');
+}
 
 /**
  * Initialize the analytics controller.
@@ -51,6 +76,25 @@ export const analyticsControllerInit: MessengerClientInitFunction<
     'RemoteFeatureFlagController:stateChange',
     syncBrazeAllowlists,
     (flagState) => flagState.remoteFeatureFlags.brazeSegmentForwarding,
+  );
+
+  let lastCompositionFingerprint = '';
+  initMessenger.subscribe(
+    'AccountsController:stateChange',
+    (accounts) => {
+      const fingerprint = getCompositionFingerprint(accounts);
+      if (fingerprint === lastCompositionFingerprint) return;
+      lastCompositionFingerprint = fingerprint;
+      try {
+        analytics.identify(getAccountCompositionTraits(accounts));
+      } catch (error) {
+        Logger.error(
+          error as Error,
+          'analyticsControllerInit: Error updating account composition traits',
+        );
+      }
+    },
+    (state) => state.internalAccounts.accounts,
   );
 
   const remoteFeatureFlagControllerState = initMessenger.call(

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -10,7 +10,7 @@ import { createPlatformAdapter as createE2EPlatformAdapter } from './platform-ad
 import { isE2E } from '../../../../util/test/utils';
 import { getBrazePlugin, syncBrazeAllowlists } from '../../../Braze';
 import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
-import { InternalAccount } from '@metamask/keyring-internal-api';
+import type { AccountsControllerState } from '@metamask/accounts-controller';
 import { analytics } from '../../../../util/analytics/analytics';
 import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
 import Logger from '../../../../util/Logger';
@@ -21,9 +21,9 @@ import Logger from '../../../../util/Logger';
  * intentionally excluded so that account switches and renames do not trigger
  * an unnecessary identify call.
  */
-function getCompositionFingerprint(
-  accounts: Record<string, InternalAccount>,
-): string {
+type InternalAccounts = AccountsControllerState['internalAccounts']['accounts'];
+
+function getCompositionFingerprint(accounts: InternalAccounts): string {
   return Object.entries(accounts)
     .map(([id, acct]) => {
       const keyringType = acct.metadata?.keyring?.type ?? '';
@@ -81,7 +81,7 @@ export const analyticsControllerInit: MessengerClientInitFunction<
   let lastCompositionFingerprint = '';
   initMessenger.subscribe(
     'AccountsController:stateChange',
-    (accounts) => {
+    (accounts: InternalAccounts) => {
       const fingerprint = getCompositionFingerprint(accounts);
       if (fingerprint === lastCompositionFingerprint) return;
       lastCompositionFingerprint = fingerprint;

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -28,9 +28,11 @@ function getCompositionFingerprint(accounts: InternalAccounts): string {
     .map(([id, acct]) => {
       const keyringType = acct.metadata?.keyring?.type ?? '';
       const entropy = (
-        acct.options as { entropy?: { id?: string; groupIndex?: number } }
+        acct.options as {
+          entropy?: { type?: string; id?: string; groupIndex?: number };
+        }
       )?.entropy;
-      return `${id}|${keyringType}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
+      return `${id}|${keyringType}|${entropy?.type ?? ''}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
     })
     .sort((a, b) => a.localeCompare(b))
     .join(';');

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -11,6 +11,7 @@ import { isE2E } from '../../../../util/test/utils';
 import { getBrazePlugin } from '../../../Braze';
 import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { analytics } from '../../../../util/analytics/analytics';
 import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
 import Logger from '../../../../util/Logger';
@@ -27,12 +28,12 @@ function getCompositionFingerprint(accounts: InternalAccounts): string {
   return Object.entries(accounts)
     .map(([id, acct]) => {
       const keyringType = acct.metadata?.keyring?.type ?? '';
-      const entropy = (
-        acct.options as {
-          entropy?: { type?: string; id?: string; groupIndex?: number };
-        }
-      )?.entropy;
-      return `${id}|${keyringType}|${entropy?.type ?? ''}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
+      const entropy: InternalAccount['options']['entropy'] =
+        acct.options?.entropy;
+      const isMnemonic = entropy?.type === 'mnemonic';
+      const entropyId = isMnemonic ? entropy.id : '';
+      const entropyGroupIndex = isMnemonic ? entropy.groupIndex : '';
+      return `${id}|${keyringType}|${entropy?.type ?? ''}|${entropyId}|${entropyGroupIndex}`;
     })
     .sort((a, b) => a.localeCompare(b))
     .join(';');

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -12,6 +12,7 @@ import { getBrazePlugin } from '../../../Braze';
 import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
 import { analytics } from '../../../../util/analytics/analytics';
 import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
 import Logger from '../../../../util/Logger';
@@ -30,7 +31,10 @@ function getCompositionFingerprint(accounts: InternalAccounts): string {
       const keyringType = acct.metadata?.keyring?.type ?? '';
       const entropy: InternalAccount['options']['entropy'] =
         acct.options?.entropy;
-      const isMnemonic = entropy?.type === 'mnemonic';
+      const isMnemonic =
+        entropy?.type === KeyringAccountEntropyTypeOption.Mnemonic &&
+        !!entropy.id &&
+        entropy.groupIndex !== undefined;
       const entropyId = isMnemonic ? entropy.id : '';
       const entropyGroupIndex = isMnemonic ? entropy.groupIndex : '';
       return `${id}|${keyringType}|${entropy?.type ?? ''}|${entropyId}|${entropyGroupIndex}`;

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -80,9 +80,9 @@ export const analyticsControllerInit: MessengerClientInitFunction<
     (accounts: InternalAccounts) => {
       const fingerprint = getCompositionFingerprint(accounts);
       if (fingerprint === lastCompositionFingerprint) return;
-      lastCompositionFingerprint = fingerprint;
       try {
         analytics.identify(getAccountCompositionTraits(accounts));
+        lastCompositionFingerprint = fingerprint;
       } catch (error) {
         Logger.error(
           error as Error,

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -23,9 +23,7 @@ import Logger from '../../../../util/Logger';
  */
 type InternalAccounts = AccountsControllerState['internalAccounts']['accounts'];
 
-function getCompositionFingerprint(
-  accounts: InternalAccounts,
-): string {
+function getCompositionFingerprint(accounts: InternalAccounts): string {
   return Object.entries(accounts)
     .map(([id, acct]) => {
       const keyringType = acct.metadata?.keyring?.type ?? '';

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -9,6 +9,36 @@ import { createPlatformAdapter } from './platform-adapter';
 import { createPlatformAdapter as createE2EPlatformAdapter } from './platform-adapter-e2e';
 import { isE2E } from '../../../../util/test/utils';
 import { getBrazePlugin } from '../../../Braze';
+import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
+import type { AccountsControllerState } from '@metamask/accounts-controller';
+import { analytics } from '../../../../util/analytics/analytics';
+import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
+import Logger from '../../../../util/Logger';
+
+/**
+ * Produces a stable string fingerprint from only the fields that affect wallet
+ * composition metrics. Fields like `lastSelected` and account names are
+ * intentionally excluded so that account switches and renames do not trigger
+ * an unnecessary identify call.
+ */
+type InternalAccounts = AccountsControllerState['internalAccounts']['accounts'];
+
+function getCompositionFingerprint(
+  accounts: InternalAccounts,
+): string {
+  return Object.entries(accounts)
+    .map(([id, acct]) => {
+      const keyringType = acct.metadata?.keyring?.type ?? '';
+      const entropy = (
+        acct.options as {
+          entropy?: { type?: string; id?: string; groupIndex?: number };
+        }
+      )?.entropy;
+      return `${id}|${keyringType}|${entropy?.type ?? ''}|${entropy?.id ?? ''}|${entropy?.groupIndex ?? ''}`;
+    })
+    .sort((a, b) => a.localeCompare(b))
+    .join(';');
+}
 
 /**
  * Initialize the analytics controller.
@@ -17,12 +47,14 @@ import { getBrazePlugin } from '../../../Braze';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.analyticsId - The analytics ID to use.
  * @param request.persistedState - The persisted state for all controllers.
+ * @param request.initMessenger - The init messenger for accounts state subscriptions.
  * @returns The initialized controller.
  */
 export const analyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
-  AnalyticsControllerMessenger
-> = ({ controllerMessenger, analyticsId, persistedState }) => {
+  AnalyticsControllerMessenger,
+  AnalyticsControllerInitMessenger
+> = ({ controllerMessenger, analyticsId, persistedState, initMessenger }) => {
   const persistedAnalyticsState = persistedState.AnalyticsController;
   const defaultState = getDefaultAnalyticsControllerState();
 
@@ -43,6 +75,25 @@ export const analyticsControllerInit: MessengerClientInitFunction<
   });
 
   controller.init();
+
+  let lastCompositionFingerprint = '';
+  initMessenger.subscribe(
+    'AccountsController:stateChange',
+    (accounts: InternalAccounts) => {
+      const fingerprint = getCompositionFingerprint(accounts);
+      if (fingerprint === lastCompositionFingerprint) return;
+      lastCompositionFingerprint = fingerprint;
+      try {
+        analytics.identify(getAccountCompositionTraits(accounts));
+      } catch (error) {
+        Logger.error(
+          error as Error,
+          'analyticsControllerInit: Error updating account composition traits',
+        );
+      }
+    },
+    (accountsState) => accountsState.internalAccounts.accounts,
+  );
 
   return {
     controller,

--- a/app/core/Engine/messengers/analytics-controller-messenger.ts
+++ b/app/core/Engine/messengers/analytics-controller-messenger.ts
@@ -8,6 +8,7 @@ import type {
   RemoteFeatureFlagControllerGetStateAction,
   RemoteFeatureFlagControllerStateChangeEvent,
 } from '@metamask/remote-feature-flag-controller';
+import type { AccountsControllerChangeEvent } from '@metamask/accounts-controller';
 import { RootMessenger } from '../types';
 
 /**
@@ -49,7 +50,7 @@ export function getAnalyticsControllerInitMessenger(
   const messenger = new Messenger<
     'AnalyticsControllerInit',
     RemoteFeatureFlagControllerGetStateAction,
-    RemoteFeatureFlagControllerStateChangeEvent,
+    RemoteFeatureFlagControllerStateChangeEvent | AccountsControllerChangeEvent,
     RootMessenger
   >({
     namespace: 'AnalyticsControllerInit',
@@ -58,7 +59,10 @@ export function getAnalyticsControllerInitMessenger(
 
   rootMessenger.delegate({
     actions: ['RemoteFeatureFlagController:getState'],
-    events: ['RemoteFeatureFlagController:stateChange'],
+    events: [
+      'RemoteFeatureFlagController:stateChange',
+      'AccountsController:stateChange',
+    ],
     messenger,
   });
 

--- a/app/core/Engine/messengers/analytics-controller-messenger.ts
+++ b/app/core/Engine/messengers/analytics-controller-messenger.ts
@@ -4,10 +4,6 @@ import {
   MessengerEvents,
   MessengerActions,
 } from '@metamask/messenger';
-import type {
-  RemoteFeatureFlagControllerGetStateAction,
-  RemoteFeatureFlagControllerStateChangeEvent,
-} from '@metamask/remote-feature-flag-controller';
 import type { AccountsControllerChangeEvent } from '@metamask/accounts-controller';
 import { RootMessenger } from '../types';
 
@@ -49,8 +45,8 @@ export function getAnalyticsControllerInitMessenger(
 ) {
   const messenger = new Messenger<
     'AnalyticsControllerInit',
-    RemoteFeatureFlagControllerGetStateAction,
-    RemoteFeatureFlagControllerStateChangeEvent | AccountsControllerChangeEvent,
+    never,
+    AccountsControllerChangeEvent,
     RootMessenger
   >({
     namespace: 'AnalyticsControllerInit',
@@ -58,11 +54,8 @@ export function getAnalyticsControllerInitMessenger(
   });
 
   rootMessenger.delegate({
-    actions: ['RemoteFeatureFlagController:getState'],
-    events: [
-      'RemoteFeatureFlagController:stateChange',
-      'AccountsController:stateChange',
-    ],
+    actions: [],
+    events: ['AccountsController:stateChange'],
     messenger,
   });
 

--- a/app/core/Engine/messengers/analytics-controller-messenger.ts
+++ b/app/core/Engine/messengers/analytics-controller-messenger.ts
@@ -4,6 +4,11 @@ import {
   MessengerEvents,
   MessengerActions,
 } from '@metamask/messenger';
+import type {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
+import type { AccountsControllerChangeEvent } from '@metamask/accounts-controller';
 import { RootMessenger } from '../types';
 
 /**
@@ -24,5 +29,42 @@ export function getAnalyticsControllerMessenger(
     namespace: 'AnalyticsController',
     parent: rootMessenger,
   });
+  return messenger;
+}
+
+export type AnalyticsControllerInitMessenger = ReturnType<
+  typeof getAnalyticsControllerInitMessenger
+>;
+
+/**
+ * Get the init messenger for the AnalyticsController.
+ * Scoped to analytics-init dependencies like accounts state changes for
+ * account composition trait updates.
+ *
+ * @param rootMessenger - The root messenger.
+ * @returns The AnalyticsControllerInitMessenger.
+ */
+export function getAnalyticsControllerInitMessenger(
+  rootMessenger: RootMessenger,
+) {
+  const messenger = new Messenger<
+    'AnalyticsControllerInit',
+    RemoteFeatureFlagControllerGetStateAction,
+    RemoteFeatureFlagControllerStateChangeEvent | AccountsControllerChangeEvent,
+    RootMessenger
+  >({
+    namespace: 'AnalyticsControllerInit',
+    parent: rootMessenger,
+  });
+
+  rootMessenger.delegate({
+    actions: ['RemoteFeatureFlagController:getState'],
+    events: [
+      'RemoteFeatureFlagController:stateChange',
+      'AccountsController:stateChange',
+    ],
+    messenger,
+  });
+
   return messenger;
 }

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -146,7 +146,10 @@ import {
   getProfileMetricsControllerInitMessenger,
 } from './profile-metrics-controller-messenger';
 import { getProfileMetricsServiceMessenger } from './profile-metrics-service-messenger';
-import { getAnalyticsControllerMessenger } from './analytics-controller-messenger';
+import {
+  getAnalyticsControllerInitMessenger,
+  getAnalyticsControllerMessenger,
+} from './analytics-controller-messenger';
 import { getAiDigestControllerMessenger } from './ai-digest-controller-messenger';
 import { getSocialServiceMessenger } from './social-service-messenger';
 import { getSocialControllerMessenger } from './social-controller-messenger';
@@ -464,7 +467,7 @@ export const MESSENGER_FACTORIES = {
   },
   AnalyticsController: {
     getMessenger: getAnalyticsControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getAnalyticsControllerInitMessenger,
   },
   AiDigestController: {
     getMessenger: getAiDigestControllerMessenger,

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -14,6 +14,13 @@ export enum UserProfileProperty {
   CURRENT_CURRENCY = 'current_currency',
   HAS_MARKETING_CONSENT = 'has_marketing_consent',
   NUMBER_OF_HD_ENTROPIES = 'number_of_hd_entropies',
+  NUMBER_OF_ACCOUNT_GROUPS = 'number_of_account_groups',
+  NUMBER_OF_IMPORTED_ACCOUNTS = 'number_of_imported_accounts',
+  NUMBER_OF_LEDGER_ACCOUNTS = 'number_of_ledger_accounts',
+  NUMBER_OF_TREZOR_ACCOUNTS = 'number_of_trezor_accounts',
+  NUMBER_OF_LATTICE_ACCOUNTS = 'number_of_lattice_accounts',
+  NUMBER_OF_QR_HARDWARE_ACCOUNTS = 'number_of_qr_hardware_accounts',
+  NUMBER_OF_HARDWARE_WALLETS = 'number_of_hardware_wallets',
   CHAIN_IDS = 'chain_id_list',
   HAS_REWARDS_OPTED_IN = 'has_rewards_opted_in',
   REWARDS_REFERRED = 'rewards_referred',
@@ -33,7 +40,14 @@ export interface UserProfileMetaData {
   [UserProfileProperty.PRIMARY_CURRENCY]?: string;
   [UserProfileProperty.CURRENT_CURRENCY]?: string;
   [UserProfileProperty.HAS_MARKETING_CONSENT]: boolean;
-  [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]?: number;
+  [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: number;
+  [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: number;
+  [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: number;
+  [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: number;
+  [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: number;
+  [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: number;
+  [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: number;
+  [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];
   [UserProfileProperty.HAS_REWARDS_OPTED_IN]?: string;
   [UserProfileProperty.REWARDS_REFERRED]?: boolean;

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types.ts
@@ -17,8 +17,6 @@ export enum UserProfileProperty {
   NUMBER_OF_ACCOUNT_GROUPS = 'number_of_account_groups',
   NUMBER_OF_IMPORTED_ACCOUNTS = 'number_of_imported_accounts',
   NUMBER_OF_LEDGER_ACCOUNTS = 'number_of_ledger_accounts',
-  NUMBER_OF_TREZOR_ACCOUNTS = 'number_of_trezor_accounts',
-  NUMBER_OF_LATTICE_ACCOUNTS = 'number_of_lattice_accounts',
   NUMBER_OF_QR_HARDWARE_ACCOUNTS = 'number_of_qr_hardware_accounts',
   NUMBER_OF_HARDWARE_WALLETS = 'number_of_hardware_wallets',
   CHAIN_IDS = 'chain_id_list',
@@ -44,8 +42,6 @@ export interface UserProfileMetaData {
   [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: number;
   [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: number;
   [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: number;
-  [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: number;
-  [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: number;
   [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: number;
   [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: number;
   [UserProfileProperty.CHAIN_IDS]: CaipChainId[];

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -1,7 +1,11 @@
-import generateUserProfileAnalyticsMetaData from './generateUserProfileAnalyticsMetaData';
+import generateUserProfileAnalyticsMetaData, {
+  getAccountCompositionTraits,
+} from './generateUserProfileAnalyticsMetaData';
 import { UserProfileProperty } from './UserProfileAnalyticsMetaData.types';
 import { Appearance } from 'react-native';
-import ExtendedKeyringTypes from '../../../constants/keyringTypes';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 const mockGetState = jest.fn();
 jest.mock('../../../store', () => ({
@@ -22,10 +26,68 @@ jest.mock('../MultichainAPI/networkMetricUtils', () => ({
   getConfiguredCaipChainIds: jest.fn(() => mockGetConfiguredCaipChainIds()),
 }));
 
+// Helper to create an HD account with the new entropy structure
+function makeHdAccount(
+  id: string,
+  entropyId: string,
+  groupIndex: number,
+): InternalAccount {
+  return {
+    id,
+    address: `0x${id}`,
+    options: {
+      entropy: {
+        type: KeyringAccountEntropyTypeOption.Mnemonic,
+        id: entropyId,
+        derivationPath: "m/44'/60'/0'/0/0",
+        groupIndex,
+      },
+    },
+    metadata: { name: id, importTime: 0, keyring: { type: KeyringTypes.hd } },
+    methods: [],
+    type: 'eip155:eoa',
+    scopes: ['eip155:0'],
+  } as unknown as InternalAccount;
+}
+
+// Helper to create a non-HD account (imported, hardware, snap)
+function makeAccount(id: string, keyringType: KeyringTypes): InternalAccount {
+  return {
+    id,
+    address: `0x${id}`,
+    options: {},
+    metadata: { name: id, importTime: 0, keyring: { type: keyringType } },
+    methods: [],
+    type: 'eip155:eoa',
+    scopes: ['eip155:0'],
+  } as unknown as InternalAccount;
+}
+
+const mockState = {
+  engine: {
+    backgroundState: {
+      PreferencesController: {
+        displayNftMedia: true,
+        useNftDetection: false,
+        useTokenDetection: true,
+        isMultiAccountBalancesEnabled: false,
+        securityAlertsEnabled: true,
+      },
+      AccountsController: {
+        internalAccounts: {
+          accounts: {},
+          selectedAccount: '',
+        },
+      },
+    },
+  },
+  user: { appTheme: 'os' },
+  security: { dataCollectionForMarketing: true },
+};
+
 describe('generateUserProfileAnalyticsMetaData', () => {
   beforeEach(() => {
     jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
-
     mockGetConfiguredCaipChainIds.mockReturnValue(['eip155:1']);
   });
 
@@ -33,40 +95,12 @@ describe('generateUserProfileAnalyticsMetaData', () => {
     jest.clearAllMocks();
   });
 
-  const mockState = {
-    engine: {
-      backgroundState: {
-        PreferencesController: {
-          displayNftMedia: true,
-          useNftDetection: false,
-          useTokenDetection: true,
-          isMultiAccountBalancesEnabled: false,
-          securityAlertsEnabled: true,
-        },
-        KeyringController: {
-          keyrings: [
-            {
-              type: ExtendedKeyringTypes.hd,
-              accounts: ['0x1', '0x2'],
-              metadata: {
-                id: '01JPM6NFVGW8V8KKN34053JVFT',
-                name: '',
-              },
-            },
-          ],
-        },
-      },
-    },
-    user: { appTheme: 'os' },
-    security: { dataCollectionForMarketing: true },
-  };
-
-  it('returns metadata', () => {
+  it('returns metadata with account composition traits', () => {
     mockGetState.mockReturnValue(mockState);
     mockIsMetricsEnabled.mockReturnValue(true);
 
     const metadata = generateUserProfileAnalyticsMetaData();
-    expect(metadata).toEqual({
+    expect(metadata).toMatchObject({
       [UserProfileProperty.ENABLE_OPENSEA_API]: UserProfileProperty.ON,
       [UserProfileProperty.NFT_AUTODETECTION]: UserProfileProperty.OFF,
       [UserProfileProperty.THEME]: 'dark',
@@ -75,6 +109,14 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.SECURITY_PROVIDERS]: 'blockaid',
       [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
       [UserProfileProperty.CHAIN_IDS]: ['eip155:1'],
+      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0,
+      [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: 0,
+      [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: 0,
     });
   });
 
@@ -98,8 +140,8 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       ...mockState,
       engine: {
         backgroundState: {
-          KeyringController: {
-            keyrings: [],
+          AccountsController: {
+            internalAccounts: { accounts: {}, selectedAccount: '' },
           },
         },
       },
@@ -121,5 +163,183 @@ describe('generateUserProfileAnalyticsMetaData', () => {
 
     const metadata = generateUserProfileAnalyticsMetaData();
     expect(metadata[UserProfileProperty.THEME]).toBe('light');
+  });
+});
+
+describe('getAccountCompositionTraits', () => {
+  it('returns all zeros for empty accounts', () => {
+    const traits = getAccountCompositionTraits({});
+    expect(traits).toEqual({
+      [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: 0,
+      [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: 0,
+      [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: 0,
+      [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: 0,
+    });
+  });
+
+  it('counts a single HD account group correctly', () => {
+    const acct = makeHdAccount('acct1', 'srp1', 0);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(1);
+  });
+
+  it('deduplicates accounts from the same SRP and group index (multichain addresses)', () => {
+    // Same SRP, same group index → one account group (EVM + Solana addresses for same "account")
+    const evm = makeHdAccount('evm1', 'srp1', 0);
+    const sol = makeHdAccount('sol1', 'srp1', 0);
+    const traits = getAccountCompositionTraits({
+      [evm.id]: evm,
+      [sol.id]: sol,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(1);
+  });
+
+  it('counts separate group indexes as separate account groups', () => {
+    // Same SRP, different group indexes → two account groups
+    const acct1 = makeHdAccount('acct1', 'srp1', 0);
+    const acct2 = makeHdAccount('acct2', 'srp1', 1);
+    const traits = getAccountCompositionTraits({
+      [acct1.id]: acct1,
+      [acct2.id]: acct2,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(2);
+  });
+
+  it('counts multiple SRPs correctly', () => {
+    const acct1 = makeHdAccount('acct1', 'srp1', 0);
+    const acct2 = makeHdAccount('acct2', 'srp2', 0);
+    const traits = getAccountCompositionTraits({
+      [acct1.id]: acct1,
+      [acct2.id]: acct2,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(2);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(2);
+  });
+
+  it('counts imported accounts', () => {
+    const acct = makeAccount('imported1', KeyringTypes.simple);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(0);
+  });
+
+  it('counts Ledger accounts and hardware wallets', () => {
+    const acct = makeAccount('ledger1', KeyringTypes.ledger);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
+  });
+
+  it('counts Trezor accounts', () => {
+    const acct = makeAccount('trezor1', KeyringTypes.trezor);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('counts Lattice accounts', () => {
+    const acct = makeAccount('lattice1', KeyringTypes.lattice);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('counts QR hardware accounts (qr keyring)', () => {
+    const acct = makeAccount('qr1', KeyringTypes.qr);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('counts QR hardware accounts (oneKey keyring)', () => {
+    const acct = makeAccount('onekey1', KeyringTypes.oneKey);
+    const traits = getAccountCompositionTraits({ [acct.id]: acct });
+    expect(traits[UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('number_of_hardware_wallets counts device types, not total accounts (1 Ledger + 1 QR = 2)', () => {
+    const ledger = makeAccount('ledger1', KeyringTypes.ledger);
+    const qr = makeAccount('qr1', KeyringTypes.qr);
+    const traits = getAccountCompositionTraits({
+      [ledger.id]: ledger,
+      [qr.id]: qr,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(2);
+  });
+
+  it('multiple accounts of the same hardware type count as 1 wallet (3 Ledger = 1)', () => {
+    const ledger1 = makeAccount('ledger1', KeyringTypes.ledger);
+    const ledger2 = makeAccount('ledger2', KeyringTypes.ledger);
+    const ledger3 = makeAccount('ledger3', KeyringTypes.ledger);
+    const traits = getAccountCompositionTraits({
+      [ledger1.id]: ledger1,
+      [ledger2.id]: ledger2,
+      [ledger3.id]: ledger3,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]).toBe(3);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('hardware wallet accounts do not contribute to number_of_hd_entropies', () => {
+    const ledger = makeAccount('ledger1', KeyringTypes.ledger);
+    const trezor = makeAccount('trezor1', KeyringTypes.trezor);
+    const traits = getAccountCompositionTraits({
+      [ledger.id]: ledger,
+      [trezor.id]: trezor,
+    });
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
+  });
+
+  it('handles mixed wallet composition', () => {
+    const hdEvm = makeHdAccount('hd-evm', 'srp1', 0);
+    const hdSol = makeHdAccount('hd-sol', 'srp1', 0);
+    const hdEvm2 = makeHdAccount('hd-evm2', 'srp1', 1);
+    const imported = makeAccount('imported', KeyringTypes.simple);
+    const ledger = makeAccount('ledger', KeyringTypes.ledger);
+
+    const traits = getAccountCompositionTraits({
+      [hdEvm.id]: hdEvm,
+      [hdSol.id]: hdSol,
+      [hdEvm2.id]: hdEvm2,
+      [imported.id]: imported,
+      [ledger.id]: ledger,
+    });
+
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(4); // srp1:0, srp1:1, imported, ledger
+    expect(traits[UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
+  });
+
+  it('treats accounts without entropy structure as individual groups', () => {
+    const noEntropy: InternalAccount = {
+      id: 'unknown1',
+      address: '0xunknown1',
+      options: {},
+      metadata: {
+        name: 'unknown',
+        importTime: 0,
+        keyring: { type: 'Unknown Keyring Type' as KeyringTypes },
+      },
+      methods: [],
+      type: 'eip155:eoa',
+      scopes: ['eip155:0'],
+    } as unknown as InternalAccount;
+
+    const traits = getAccountCompositionTraits({ [noEntropy.id]: noEntropy });
+    expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(1);
+    expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
   });
 });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -113,8 +113,6 @@ describe('generateUserProfileAnalyticsMetaData', () => {
       [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: 0,
       [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: 0,
-      [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: 0,
-      [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: 0,
     });
@@ -174,8 +172,6 @@ describe('getAccountCompositionTraits', () => {
       [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: 0,
       [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: 0,
-      [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: 0,
-      [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]: 0,
       [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: 0,
     });
@@ -240,20 +236,6 @@ describe('getAccountCompositionTraits', () => {
     expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
   });
 
-  it('counts Trezor accounts', () => {
-    const acct = makeAccount('trezor1', KeyringTypes.trezor);
-    const traits = getAccountCompositionTraits({ [acct.id]: acct });
-    expect(traits[UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]).toBe(1);
-    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
-  });
-
-  it('counts Lattice accounts', () => {
-    const acct = makeAccount('lattice1', KeyringTypes.lattice);
-    const traits = getAccountCompositionTraits({ [acct.id]: acct });
-    expect(traits[UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]).toBe(1);
-    expect(traits[UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]).toBe(1);
-  });
-
   it('counts QR hardware accounts (qr keyring)', () => {
     const acct = makeAccount('qr1', KeyringTypes.qr);
     const traits = getAccountCompositionTraits({ [acct.id]: acct });
@@ -293,10 +275,10 @@ describe('getAccountCompositionTraits', () => {
 
   it('hardware wallet accounts do not contribute to number_of_hd_entropies', () => {
     const ledger = makeAccount('ledger1', KeyringTypes.ledger);
-    const trezor = makeAccount('trezor1', KeyringTypes.trezor);
+    const qr = makeAccount('qr1', KeyringTypes.qr);
     const traits = getAccountCompositionTraits({
       [ledger.id]: ledger,
-      [trezor.id]: trezor,
+      [qr.id]: qr,
     });
     expect(traits[UserProfileProperty.NUMBER_OF_HD_ENTROPIES]).toBe(0);
   });

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.test.ts
@@ -6,6 +6,7 @@ import { Appearance } from 'react-native';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { createMockInternalAccount } from '../../../util/test/accountsControllerTestUtils';
 
 const mockGetState = jest.fn();
 jest.mock('../../../store', () => ({
@@ -33,8 +34,8 @@ function makeHdAccount(
   groupIndex: number,
 ): InternalAccount {
   return {
+    ...createMockInternalAccount(`0x${id}`, id, KeyringTypes.hd),
     id,
-    address: `0x${id}`,
     options: {
       entropy: {
         type: KeyringAccountEntropyTypeOption.Mnemonic,
@@ -42,25 +43,16 @@ function makeHdAccount(
         derivationPath: "m/44'/60'/0'/0/0",
         groupIndex,
       },
-    },
-    metadata: { name: id, importTime: 0, keyring: { type: KeyringTypes.hd } },
-    methods: [],
-    type: 'eip155:eoa',
-    scopes: ['eip155:0'],
-  } as unknown as InternalAccount;
+    } as InternalAccount['options'],
+  };
 }
 
 // Helper to create a non-HD account (imported, hardware, snap)
 function makeAccount(id: string, keyringType: KeyringTypes): InternalAccount {
   return {
+    ...createMockInternalAccount(`0x${id}`, id, keyringType),
     id,
-    address: `0x${id}`,
-    options: {},
-    metadata: { name: id, importTime: 0, keyring: { type: keyringType } },
-    methods: [],
-    type: 'eip155:eoa',
-    scopes: ['eip155:0'],
-  } as unknown as InternalAccount;
+  };
 }
 
 const mockState = {
@@ -306,19 +298,14 @@ describe('getAccountCompositionTraits', () => {
   });
 
   it('treats accounts without entropy structure as individual groups', () => {
-    const noEntropy: InternalAccount = {
+    const noEntropy = {
+      ...createMockInternalAccount(
+        '0xunknown1',
+        'unknown',
+        'Unknown Keyring Type' as KeyringTypes,
+      ),
       id: 'unknown1',
-      address: '0xunknown1',
-      options: {},
-      metadata: {
-        name: 'unknown',
-        importTime: 0,
-        keyring: { type: 'Unknown Keyring Type' as KeyringTypes },
-      },
-      methods: [],
-      type: 'eip155:eoa',
-      scopes: ['eip155:0'],
-    } as unknown as InternalAccount;
+    };
 
     const traits = getAccountCompositionTraits({ [noEntropy.id]: noEntropy });
     expect(traits[UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]).toBe(1);

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -1,8 +1,87 @@
 import { Appearance } from 'react-native';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 import { store } from '../../../store';
 import { UserProfileProperty } from './UserProfileAnalyticsMetaData.types';
 import { getConfiguredCaipChainIds } from '../MultichainAPI/networkMetricUtils';
 import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
+
+/**
+ * Computes wallet composition traits from internalAccounts.
+ * Uses AccountsController as the source of truth so traits remain accurate when the wallet is locked.
+ */
+export function getAccountCompositionTraits(
+  internalAccounts: Record<string, InternalAccount>,
+): AnalyticsUserTraits {
+  const accountGroupKeys = new Set<string>();
+  const hdEntropyIds = new Set<string>();
+  let numberOfImportedAccounts = 0;
+  let numberOfLedgerAccounts = 0;
+  let numberOfTrezorAccounts = 0;
+  let numberOfLatticeAccounts = 0;
+  let numberOfQrHardwareAccounts = 0;
+
+  for (const [accountId, account] of Object.entries(internalAccounts)) {
+    const keyringType = account.metadata?.keyring?.type;
+
+    switch (keyringType) {
+      case KeyringTypes.simple:
+        numberOfImportedAccounts += 1;
+        break;
+      case KeyringTypes.ledger:
+        numberOfLedgerAccounts += 1;
+        break;
+      case KeyringTypes.trezor:
+        numberOfTrezorAccounts += 1;
+        break;
+      case KeyringTypes.lattice:
+        numberOfLatticeAccounts += 1;
+        break;
+      case KeyringTypes.qr:
+      case KeyringTypes.oneKey:
+        numberOfQrHardwareAccounts += 1;
+        break;
+      default:
+        break;
+    }
+
+    // BIP44 multichain accounts share an entropy id and group index across all chains.
+    // Deduplicating on that composite key counts account groups rather than individual addresses.
+    const entropy = (account.options as { entropy?: unknown })?.entropy as
+      | { type: string; id: string; groupIndex: number }
+      | undefined;
+
+    if (
+      entropy?.type === KeyringAccountEntropyTypeOption.Mnemonic &&
+      entropy.id &&
+      entropy.groupIndex !== undefined
+    ) {
+      accountGroupKeys.add(`${entropy.id}:${entropy.groupIndex}`);
+      hdEntropyIds.add(entropy.id);
+    } else {
+      accountGroupKeys.add(accountId);
+    }
+  }
+
+  const numberOfHardwareWallets =
+    (numberOfLedgerAccounts > 0 ? 1 : 0) +
+    (numberOfTrezorAccounts > 0 ? 1 : 0) +
+    (numberOfLatticeAccounts > 0 ? 1 : 0) +
+    (numberOfQrHardwareAccounts > 0 ? 1 : 0);
+
+  return {
+    [UserProfileProperty.NUMBER_OF_HD_ENTROPIES]: hdEntropyIds.size,
+    [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: accountGroupKeys.size,
+    [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: numberOfImportedAccounts,
+    [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: numberOfLedgerAccounts,
+    [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: numberOfTrezorAccounts,
+    [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: numberOfLatticeAccounts,
+    [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]:
+      numberOfQrHardwareAccounts,
+    [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: numberOfHardwareWallets,
+  };
+}
 
 /**
  * Generate user profile analytics meta data
@@ -21,6 +100,10 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
     reduxState?.security?.dataCollectionForMarketing;
 
   const chainIds = getConfiguredCaipChainIds();
+
+  const internalAccounts =
+    reduxState?.engine?.backgroundState?.AccountsController?.internalAccounts
+      ?.accounts ?? {};
 
   const traits: AnalyticsUserTraits = {
     [UserProfileProperty.ENABLE_OPENSEA_API]:
@@ -46,6 +129,7 @@ const generateUserProfileAnalyticsMetaData = (): AnalyticsUserTraits => {
       isDataCollectionForMarketingEnabled,
     ),
     [UserProfileProperty.CHAIN_IDS]: chainIds,
+    ...getAccountCompositionTraits(internalAccounts),
   };
   return traits;
 };

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -18,8 +18,6 @@ export function getAccountCompositionTraits(
   const hdEntropyIds = new Set<string>();
   let numberOfImportedAccounts = 0;
   let numberOfLedgerAccounts = 0;
-  let numberOfTrezorAccounts = 0;
-  let numberOfLatticeAccounts = 0;
   let numberOfQrHardwareAccounts = 0;
 
   for (const [accountId, account] of Object.entries(internalAccounts)) {
@@ -31,12 +29,6 @@ export function getAccountCompositionTraits(
         break;
       case KeyringTypes.ledger:
         numberOfLedgerAccounts += 1;
-        break;
-      case KeyringTypes.trezor:
-        numberOfTrezorAccounts += 1;
-        break;
-      case KeyringTypes.lattice:
-        numberOfLatticeAccounts += 1;
         break;
       case KeyringTypes.qr:
       case KeyringTypes.oneKey:
@@ -66,8 +58,6 @@ export function getAccountCompositionTraits(
 
   const numberOfHardwareWallets =
     (numberOfLedgerAccounts > 0 ? 1 : 0) +
-    (numberOfTrezorAccounts > 0 ? 1 : 0) +
-    (numberOfLatticeAccounts > 0 ? 1 : 0) +
     (numberOfQrHardwareAccounts > 0 ? 1 : 0);
 
   return {
@@ -75,8 +65,6 @@ export function getAccountCompositionTraits(
     [UserProfileProperty.NUMBER_OF_ACCOUNT_GROUPS]: accountGroupKeys.size,
     [UserProfileProperty.NUMBER_OF_IMPORTED_ACCOUNTS]: numberOfImportedAccounts,
     [UserProfileProperty.NUMBER_OF_LEDGER_ACCOUNTS]: numberOfLedgerAccounts,
-    [UserProfileProperty.NUMBER_OF_TREZOR_ACCOUNTS]: numberOfTrezorAccounts,
-    [UserProfileProperty.NUMBER_OF_LATTICE_ACCOUNTS]: numberOfLatticeAccounts,
     [UserProfileProperty.NUMBER_OF_QR_HARDWARE_ACCOUNTS]:
       numberOfQrHardwareAccounts,
     [UserProfileProperty.NUMBER_OF_HARDWARE_WALLETS]: numberOfHardwareWallets,

--- a/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
+++ b/app/util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData.ts
@@ -40,9 +40,8 @@ export function getAccountCompositionTraits(
 
     // BIP44 multichain accounts share an entropy id and group index across all chains.
     // Deduplicating on that composite key counts account groups rather than individual addresses.
-    const entropy = (account.options as { entropy?: unknown })?.entropy as
-      | { type: string; id: string; groupIndex: number }
-      | undefined;
+    const entropy: InternalAccount['options']['entropy'] =
+      account.options?.entropy;
 
     if (
       entropy?.type === KeyringAccountEntropyTypeOption.Mnemonic &&


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

MetaMask currently tracks number_of_hd_entropies in Segment, but the value has become inaccurate: it was
   derived from KeyringController keyrings rather than AccountsController internal accounts, and it had no
   awareness of BIP-44 multichain account groups (where a single user "account" produces one address per
  supported network). This made it impossible to accurately answer questions like "how many accounts does
  the average MetaMask user have?" or segment users by hardware wallet adoption.

  This PR replaces the old keyring-based tracking with a reliable, controller-driven implementation that
  derives all wallet composition traits from AccountsController.internalAccounts — the same source of
  truth used on Extension — so traits remain accurate regardless of wallet lock state.

  What's changing

  New and updated user traits emitted on the Segment identify call:

```  ┌────────────────────────────────┬─────────┬─────────────────────────────────────────────────────────┐
  │            Property            │  Type   │                       Description                       │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_hd_entropies         │ integer │ Count of unique SRP sources, deduped by entropy.id      │
  │                                │         │ (fixes existing inaccurate value)                       │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_account_groups       │ integer │ BIP-44 account groups deduped by entropy.id:groupIndex  │
  │                                │         │ — what users see as "accounts" in the UI                │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_imported_accounts    │ integer │ Accounts added via raw private key (Simple Key Pair     │
  │                                │         │ keyring)                                                │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_ledger_accounts      │ integer │ Account groups from Ledger hardware wallet              │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_qr_hardware_accounts │ integer │ Account groups from QR-based hardware wallets           │
  │                                │         │ (Keystone, OneKey, etc.)                                │
  ├────────────────────────────────┼─────────┼─────────────────────────────────────────────────────────┤
  │ number_of_hardware_wallets     │ integer │ Count of distinct hardware wallet device types in use   │
  │                                │         │ (Ledger + QR)                                           │
  └────────────────────────────────┴─────────┴─────────────────────────────────────────────────────────┘
```

  ▎ Total wallet count can be derived in Segment as: number_of_hd_entropies + number_of_hardware_wallets +
  ▎  number_of_imported_accounts

  Trezor and Lattice are intentionally excluded — those hardware wallets are not supported on mobile.

  Implementation

  - getAccountCompositionTraits() iterates internalAccounts.accounts, classifies each account by
  metadata.keyring.type, and deduplicates BIP-44 multichain addresses using the
  options.entropy.id:groupIndex composite key so multiple chain addresses for the same account group count
   as one.
  - Traits are included in every identify call via generateUserProfileAnalyticsMetaData().
  - A subscription to AccountsController:stateChange in analytics-controller-init.ts re-fires the identify
   call whenever account composition changes, with two guards to avoid unnecessary calls:
    a. A selector narrows the subscription to internalAccounts.accounts, skipping pure selectedAccount
  changes.
    b. A composition fingerprint (hashing only keyring type and entropy fields) skips analytics.identify()
   when lastSelected or account names change but composition hasn't.
  - The old useEffect in the Wallet view that tracked number_of_hd_entropies via hdKeyrings.length is
  removed.

Equivalent extension changes: https://github.com/MetaMask/metamask-extension/pull/41918

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update metrics to track wallet composition (number of accounts, number of hardware wallets etc).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1757

## **Manual testing steps**

1. Build the extension locally
2. Monitor the sentry events with the following steps: [Mobile docs](https://github.com/MetaMask/metamask-mobile/blob/9874d9c692acd7a1980dcfa06728f903b18b1dd3/docs/readme/metametrics-debugging.md)
    - set export IS_TEST="false" in your .js.env
    - open the react native debugger console by pressing j inside the metro server
    - Open the console and filter by IDENTIFY event
    - Pro tip: set your unlock time to never in settings. If the device is locked you'll need to re open the debugger all over again.
3. import/create a wallet
4. you should notice the initial `Identify event received` logged with the correct `number_of_account_groups` logged as well as `number_of_hd_entropies`
5. import a private key
6. notice the `Identify event received` logged with the updated `number_of_account_groups` and `number_of_imported_accounts`
7. Import a new SRP with X accounts. You the identify event should be called with updated `number_of_hd_entropies` and updated `number_of_account_groups`
9. Connect a Ledger wallet and notice the `Identify event received` logged with updated `number_of_account_groups`, updated `number_of_ledger_accounts` and `number_of_hardware_wallets`
10. repeat the above steps with qr. The respective properties should all be updated.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

n/A

### **After**

1. create a fresh wallet with one account

```markdown
{
    "type": "identify",
    "userId": "d372edfb-19ee-4664-86f6-6418bbd4a1bb",
    "traits": {
        "number_of_hd_entropies": 1,
        "number_of_account_groups": 1,
        "number_of_imported_accounts": 0,
        "number_of_ledger_accounts": 0,
        "number_of_qr_hardware_accounts": 0,
        "number_of_hardware_wallets": 0
    }
}
```

2. adding a new HD account

```markdown
{
    "number_of_hd_entropies": 1,
    "number_of_account_groups": 2,
    "number_of_imported_accounts": 0,
    "number_of_ledger_accounts": 0,
    "number_of_qr_hardware_accounts": 0,
    "number_of_hardware_wallets": 0
}
```

3. import a private key account

```markdown
{
    "number_of_hd_entropies": 1,
    "number_of_account_groups": 3,
    "number_of_imported_accounts": 1,
    "number_of_ledger_accounts": 0,
    "number_of_qr_hardware_accounts": 0,
    "number_of_hardware_wallets": 0
}
```

4. import a Ledger account with 3 accounts

```markdown
{
    "number_of_hd_entropies": 1,
    "number_of_account_groups": 6,
    "number_of_imported_accounts": 1,
    "number_of_ledger_accounts": 3,
    "number_of_qr_hardware_accounts": 0,
    "number_of_hardware_wallets": 1
}
```

5. adding a qr hardware wallet with 3 accounts

```markdown
{
    "number_of_hd_entropies": 1,
    "number_of_account_groups": 9,
    "number_of_imported_accounts": 1,
    "number_of_ledger_accounts": 3,
    "number_of_qr_hardware_accounts": 3,
    "number_of_hardware_wallets": 2
}
```

6. import an SRP with 42 accounts accounts

```markdown
{
    "number_of_hd_entropies": 2,
    "number_of_account_groups": 51,
    "number_of_imported_accounts": 1,
    "number_of_ledger_accounts": 3,
    "number_of_qr_hardware_accounts": 3,
    "number_of_hardware_wallets": 2
}
```

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics identify behavior and the trait schema (new required fields and new identify triggers on account state changes), which could impact event volume/quality if fingerprinting or account classification is wrong.
> 
> **Overview**
> Updates Segment user-profile metrics to be **AccountsController-driven** wallet composition traits, adding new counts for `number_of_account_groups`, imported accounts, Ledger/QR hardware accounts, and distinct hardware wallet device types, and making `number_of_hd_entropies` mandatory and entropy-aware (BIP-44 multichain dedupe via `entropy.id:groupIndex`).
> 
> Moves trait emission out of the Wallet view by removing the `addTraitsToUser` effect and instead wiring `analytics-controller-init` to subscribe to `AccountsController:stateChange`, recomputing traits only when a stable composition fingerprint changes (with error logging), plus adds a dedicated init messenger and comprehensive unit tests for the new fingerprinting and trait counting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b13d214c53df8fe730a0f073b551fd948fa53e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->