### PR TITLE
refactor: serialize metamask connect connection restore and reconnect flows

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -1011,6 +1011,113 @@ describe('ConnectionRegistry', () => {
       expect(Connection.create).toHaveBeenCalledTimes(3);
     });
 
+    it('continues processing later connections when an earlier Connection.create fails', async () => {
+      // Given: three persisted connections, the first fails at Connection.create
+      const persistedConnections: ConnectionInfo[] = [
+        createPersistedConnection('conn-1'),
+        createPersistedConnection('conn-2'),
+        createPersistedConnection('conn-3'),
+      ];
+
+      const mockConnection2 = createMockConnection('conn-2');
+      const mockConnection3 = createMockConnection('conn-3');
+
+      mockStore.list.mockClear();
+      mockStore.list.mockResolvedValue(persistedConnections);
+      (Connection.create as jest.Mock)
+        .mockClear()
+        .mockRejectedValueOnce(new Error('Create failed for conn-1'))
+        .mockResolvedValueOnce(mockConnection2)
+        .mockResolvedValueOnce(mockConnection3);
+
+      // When: creating a new registry (which triggers initialize)
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then: Connection.create was attempted for all three, and the later
+      // connections were still resumed despite the first one failing.
+      expect(Connection.create).toHaveBeenCalledTimes(3);
+      expect(mockConnection2.resume).toHaveBeenCalledTimes(1);
+      expect(mockConnection3.resume).toHaveBeenCalledTimes(1);
+
+      // And the surviving connections are synced to the host app.
+      expect(mockHostApp.syncConnectionList).toHaveBeenCalledWith([
+        mockConnection2,
+        mockConnection3,
+      ]);
+    });
+
+    it('processes persisted connections sequentially, not concurrently', async () => {
+      // Given: three persisted connections whose Connection.create resolution
+      // is controlled so we can observe the ordering of awaited work.
+      const persistedConnections: ConnectionInfo[] = [
+        createPersistedConnection('conn-1'),
+        createPersistedConnection('conn-2'),
+        createPersistedConnection('conn-3'),
+      ];
+
+      const mockConnection1 = createMockConnection('conn-1');
+      const mockConnection2 = createMockConnection('conn-2');
+      const mockConnection3 = createMockConnection('conn-3');
+
+      const deferreds: {
+        promise: Promise<Connection>;
+        resolve: (value: Connection) => void;
+      }[] = [];
+      for (let i = 0; i < 3; i++) {
+        let resolveFn!: (value: Connection) => void;
+        const promise = new Promise<Connection>((resolve) => {
+          resolveFn = resolve;
+        });
+        deferreds.push({ promise, resolve: resolveFn });
+      }
+
+      mockStore.list.mockClear();
+      mockStore.list.mockResolvedValue(persistedConnections);
+      (Connection.create as jest.Mock)
+        .mockClear()
+        .mockImplementationOnce(() => deferreds[0].promise)
+        .mockImplementationOnce(() => deferreds[1].promise)
+        .mockImplementationOnce(() => deferreds[2].promise);
+
+      // When: creating a new registry (which triggers initialize)
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      // Let initialize() reach the first await.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then: only the first Connection.create has been invoked; later
+      // connections must wait for it to settle.
+      expect(Connection.create).toHaveBeenCalledTimes(1);
+
+      // Resolve the first, then the second should start.
+      deferreds[0].resolve(mockConnection1 as unknown as Connection);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(Connection.create).toHaveBeenCalledTimes(2);
+
+      deferreds[1].resolve(mockConnection2 as unknown as Connection);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(Connection.create).toHaveBeenCalledTimes(3);
+
+      deferreds[2].resolve(mockConnection3 as unknown as Connection);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockConnection1.resume).toHaveBeenCalledTimes(1);
+      expect(mockConnection2.resume).toHaveBeenCalledTimes(1);
+      expect(mockConnection3.resume).toHaveBeenCalledTimes(1);
+    });
+
     it('evicts the oldest connection when at MAX_CONNECTIONS', async () => {
       const count = MAX_CONNECTIONS + 5;
       const baseTime = Date.now();
@@ -1256,14 +1363,14 @@ describe('ConnectionRegistry', () => {
       expect(mockConnection2.client.reconnect).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle errors gracefully when some connections fail to reconnect', async () => {
-      // Given: some connections where one will fail to reconnect
-      const mockConnection1 = createMockConnection('conn-1');
-      const mockConnection2 = createMockConnection('conn-2', {
+    it('continues reconnecting later connections when an earlier one fails', async () => {
+      // Given: three connections where the first fails to reconnect
+      const mockConnection1 = createMockConnection('conn-1', {
         client: {
           reconnect: jest.fn().mockRejectedValue(new Error('Network error')),
         },
       });
+      const mockConnection2 = createMockConnection('conn-2');
       const mockConnection3 = createMockConnection('conn-3');
 
       const persistedConnections: ConnectionInfo[] = [
@@ -1289,7 +1396,6 @@ describe('ConnectionRegistry', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      // Clear mocks from initialization
       mockConnection1.client.reconnect.mockClear();
       mockConnection2.client.reconnect.mockClear();
       mockConnection3.client.reconnect.mockClear();
@@ -1299,10 +1405,85 @@ describe('ConnectionRegistry', () => {
       const reconnectPromise = (registry as any).reconnectAll();
       await expect(reconnectPromise).resolves.not.toThrow();
 
-      // Then: all connections should be attempted, even if one fails
+      // Then: all connections were attempted even though conn-1 failed
       expect(mockConnection1.client.reconnect).toHaveBeenCalledTimes(1);
-      expect(mockConnection2.client.reconnect).toHaveBeenCalledTimes(1); // Attempted even though it fails
+      expect(mockConnection2.client.reconnect).toHaveBeenCalledTimes(1);
       expect(mockConnection3.client.reconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconnects sequentially, not concurrently', async () => {
+      // Given: three connections whose client.reconnect resolution is
+      // controlled so we can observe the ordering of awaited work.
+      const deferreds: {
+        promise: Promise<void>;
+        resolve: () => void;
+      }[] = [];
+      for (let i = 0; i < 3; i++) {
+        let resolveFn!: () => void;
+        const promise = new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        });
+        deferreds.push({ promise, resolve: resolveFn });
+      }
+
+      const mockConnection1 = createMockConnection('conn-1', {
+        client: { reconnect: jest.fn(() => deferreds[0].promise) },
+      });
+      const mockConnection2 = createMockConnection('conn-2', {
+        client: { reconnect: jest.fn(() => deferreds[1].promise) },
+      });
+      const mockConnection3 = createMockConnection('conn-3', {
+        client: { reconnect: jest.fn(() => deferreds[2].promise) },
+      });
+
+      const persistedConnections: ConnectionInfo[] = [
+        createPersistedConnection('conn-1'),
+        createPersistedConnection('conn-2'),
+        createPersistedConnection('conn-3'),
+      ];
+
+      mockStore.list.mockResolvedValue(persistedConnections);
+      (Connection.create as jest.Mock)
+        .mockClear()
+        .mockResolvedValueOnce(mockConnection1)
+        .mockResolvedValueOnce(mockConnection2)
+        .mockResolvedValueOnce(mockConnection3);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      mockConnection1.client.reconnect.mockClear();
+      mockConnection2.client.reconnect.mockClear();
+      mockConnection3.client.reconnect.mockClear();
+
+      // When: calling reconnectAll without awaiting
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reconnectPromise = (registry as any).reconnectAll();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Then: only the first reconnect has started; later reconnects must
+      // wait for earlier ones to settle.
+      expect(mockConnection1.client.reconnect).toHaveBeenCalledTimes(1);
+      expect(mockConnection2.client.reconnect).not.toHaveBeenCalled();
+      expect(mockConnection3.client.reconnect).not.toHaveBeenCalled();
+
+      deferreds[0].resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockConnection2.client.reconnect).toHaveBeenCalledTimes(1);
+      expect(mockConnection3.client.reconnect).not.toHaveBeenCalled();
+
+      deferreds[1].resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockConnection3.client.reconnect).toHaveBeenCalledTimes(1);
+
+      deferreds[2].resolve();
+      await reconnectPromise;
     });
   });
 });

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -88,13 +88,18 @@ export class ConnectionRegistry {
 
   /**
    * One-time initialization to resume all persisted connections on app cold start.
+   *
+   * Connections are resumed sequentially so a user with N persisted sessions
+   * does not trigger N concurrent relay handshakes at cold start. A single
+   * failure is logged and does not stop subsequent connections from being
+   * processed.
    */
   private async initialize(): Promise<void> {
     await whenStoreReady();
 
     const persisted = await this.store.list().catch(() => []);
 
-    const promises = persisted.map(async (connInfo) => {
+    for (const connInfo of persisted) {
       try {
         const conn = await Connection.create(
           connInfo,
@@ -108,9 +113,7 @@ export class ConnectionRegistry {
       } catch (error) {
         logger.error('Failed to resume connection', connInfo.id, error);
       }
-    });
-
-    await Promise.allSettled(promises);
+    }
 
     await this.trimToCapacity();
 
@@ -424,19 +427,22 @@ export class ConnectionRegistry {
   /**
    * Proactively refreshes all active connections. This is the primary mechanism
    * for preventing stale/zombie connections after the app was put in the background.
+   *
+   * Reconnections are processed sequentially so a user with N active sessions
+   * does not trigger N concurrent relay handshakes on every foreground event.
+   * A single failure is logged and does not stop subsequent connections from
+   * being processed.
    */
   private async reconnectAll(): Promise<void> {
     const connections = Array.from(this.connections.values());
 
-    const promises = connections.map((conn) =>
-      conn.client
-        .reconnect()
-        .then(() => logger.debug('Connection reconnected:', conn.id))
-        .catch((err: Error) =>
-          logger.error('Failed to reconnect connection:', err, conn.id),
-        ),
-    );
-
-    await Promise.allSettled(promises);
+    for (const conn of connections) {
+      try {
+        await conn.client.reconnect();
+        logger.debug('Connection reconnected:', conn.id);
+      } catch (err) {
+        logger.error('Failed to reconnect connection:', err, conn.id);
+      }
+    }
   }
 }


### PR DESCRIPTION
## **Description**

Refactor `ConnectionRegistry.initialize()` and `ConnectionRegistry.reconnectAll()` to process persisted SDKConnectV2 connections **sequentially** instead of concurrently.

### Motivation

Previously, both methods fired all N saved connections in parallel via `connections.map(...)` + `Promise.allSettled(...)`:

- **Cold start (`initialize`)** — for every persisted session, we created a `Connection` and called `resume()` concurrently, firing N concurrent relay WebSocket handshakes on every launch.
- **Foreground (`reconnectAll`)** — every time the app transitioned from background to foreground, we fired N concurrent `client.reconnect()` calls.

Without a session cap, N grows unbounded over time, so those bursts get proportionally worse as users accumulate sessions. A session cap is being introduced separately ([WAPI-1369](https://consensyssoftware.atlassian.net/browse/WAPI-1369)), but even with a cap the bursty pattern is undesirable: it spikes network, CPU, and relay load at exactly the moments the app is most resource-constrained (cold start, resume-from-background).

### Solution

Process persisted connections one-at-a-time using a `for..of` loop with `await`, wrapped in a per-iteration `try/catch` so a single failure is logged and does not stop later connections from being processed.

- `initialize()` — `await Connection.create(...)` then `await conn.resume()` per iteration.
- `reconnectAll()` — `await conn.client.reconnect()` per iteration.

Both methods remain resilient: a thrown error inside one iteration is caught and logged, and the loop continues with the next connection.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: [WAPI-1369](https://consensyssoftware.atlassian.net/browse/WAPI-1369) (session cap)

Fixes: [WAPI-1368](https://consensyssoftware.atlassian.net/browse/WAPI-1368)

## **Manual testing steps**

```gherkin
Feature: SDKConnectV2 sequential session processing

  Scenario: Cold start with multiple persisted sessions
    Given I have multiple active SDKConnectV2 sessions persisted
    And I force-quit MetaMask Mobile
    When I relaunch the app
    Then each session is resumed one after another (no N-way concurrent relay handshakes)
    And all sessions appear in the connections list
    And if one session fails to resume, the others are still resumed

  Scenario: Foregrounding with multiple active sessions
    Given I have multiple active SDKConnectV2 sessions
    And the app is in the background
    When I bring the app to the foreground
    Then each session is reconnected one after another
    And if one reconnect fails, the others are still reconnected
```

## **Screenshots/Recordings**

Not applicable — internal refactor with no user-visible surface.

### **Before**

<!-- N/A -->

### **After**

<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WAPI-1369]: https://consensyssoftware.atlassian.net/browse/WAPI-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WAPI-1369]: https://consensyssoftware.atlassian.net/browse/WAPI-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the cold-start restore and foreground reconnect behavior for all SDKConnectV2 sessions, which could affect connection timing and perceived responsiveness under load. Logic is straightforward but touches core connection lifecycle and error handling paths.
> 
> **Overview**
> **Serializes SDKConnectV2 session restoration and reconnection.** `ConnectionRegistry.initialize()` and `reconnectAll()` are refactored from `Promise.allSettled` fan-out to `for...of` + `await`, ensuring connections are processed one-at-a-time and individual failures are logged without aborting the rest.
> 
> **Strengthens test coverage for the new semantics.** Adds/updates unit tests to assert sequential ordering and that later connections still `resume`/`reconnect` when an earlier `Connection.create` or `client.reconnect` fails, and that `syncConnectionList` reflects only successfully restored connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5811010ddd51ccbc7914c70fcaa6c3c630c458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->