### PR TITLE
fix(rewards): scope Ondo campaign participant status by subscriptionId:campaignId

### DIFF
--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useGetCampaignParticipantStatus } from './useGetCampaignParticipantStatus';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignParticipantStatusById } from '../../../../reducers/rewards/selectors';
+import { selectCampaignParticipantStatus } from '../../../../reducers/rewards/selectors';
 import { setCampaignParticipantStatus } from '../../../../reducers/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 import type { CampaignParticipantStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
@@ -26,7 +26,7 @@ jest.mock('../../../../selectors/rewards', () => ({
 }));
 
 jest.mock('../../../../reducers/rewards/selectors', () => ({
-  selectCampaignParticipantStatusById: jest.fn(),
+  selectCampaignParticipantStatus: jest.fn(),
 }));
 
 jest.mock('../../../../reducers/rewards', () => ({
@@ -44,14 +44,14 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 const mockSetCampaignParticipantStatus =
   setCampaignParticipantStatus as unknown as jest.MockedFunction<
-    (payload: { campaignId: string; status: CampaignParticipantStatusDto }) => {
+    (payload: { subscriptionId: string; campaignId: string; status: CampaignParticipantStatusDto }) => {
       type: string;
-      payload: { campaignId: string; status: CampaignParticipantStatusDto };
+      payload: { subscriptionId: string; campaignId: string; status: CampaignParticipantStatusDto };
     }
   >;
-const mockSelectCampaignParticipantStatusById =
-  selectCampaignParticipantStatusById as jest.MockedFunction<
-    typeof selectCampaignParticipantStatusById
+const mockSelectCampaignParticipantStatus =
+  selectCampaignParticipantStatus as jest.MockedFunction<
+    typeof selectCampaignParticipantStatus
   >;
 
 const SUB_ID = 'sub-123';
@@ -66,7 +66,7 @@ function setupSelectors(
   participantStatus: CampaignParticipantStatusDto | null = null,
 ) {
   mockParticipantStatusSelector.mockReturnValue(participantStatus);
-  mockSelectCampaignParticipantStatusById.mockReturnValue(
+  mockSelectCampaignParticipantStatus.mockReturnValue(
     mockParticipantStatusSelector,
   );
 
@@ -117,6 +117,7 @@ describe('useGetCampaignParticipantStatus', () => {
     );
     expect(mockDispatch).toHaveBeenCalledWith(
       mockSetCampaignParticipantStatus({
+        subscriptionId: SUB_ID,
         campaignId: CAMPAIGN_ID,
         status: STATUS,
       }),

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.test.ts
@@ -44,9 +44,17 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 const mockSetCampaignParticipantStatus =
   setCampaignParticipantStatus as unknown as jest.MockedFunction<
-    (payload: { subscriptionId: string; campaignId: string; status: CampaignParticipantStatusDto }) => {
+    (payload: {
+      subscriptionId: string;
+      campaignId: string;
+      status: CampaignParticipantStatusDto;
+    }) => {
       type: string;
-      payload: { subscriptionId: string; campaignId: string; status: CampaignParticipantStatusDto };
+      payload: {
+        subscriptionId: string;
+        campaignId: string;
+        status: CampaignParticipantStatusDto;
+      };
     }
   >;
 const mockSelectCampaignParticipantStatus =

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
@@ -27,7 +27,7 @@ export const useGetCampaignParticipantStatus = (
 ): UseGetCampaignParticipantStatusResult => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const status = useSelector(
-    selectCampaignParticipantStatus(subscriptionId, campaignId),
+    selectCampaignParticipantStatus(subscriptionId ?? undefined, campaignId),
   );
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
@@ -26,7 +26,9 @@ export const useGetCampaignParticipantStatus = (
   campaignId: string | undefined,
 ): UseGetCampaignParticipantStatusResult => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const status = useSelector(selectCampaignParticipantStatus(subscriptionId, campaignId));
+  const status = useSelector(
+    selectCampaignParticipantStatus(subscriptionId, campaignId),
+  );
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(
     () => !status && Boolean(subscriptionId) && Boolean(campaignId),
@@ -46,7 +48,13 @@ export const useGetCampaignParticipantStatus = (
         campaignId,
         subscriptionId,
       );
-      dispatch(setCampaignParticipantStatus({ subscriptionId, campaignId, status: result }));
+      dispatch(
+        setCampaignParticipantStatus({
+          subscriptionId,
+          campaignId,
+          status: result,
+        }),
+      );
     } catch {
       setHasError(true);
     } finally {

--- a/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
+++ b/app/components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectCampaignParticipantStatusById } from '../../../../reducers/rewards/selectors';
+import { selectCampaignParticipantStatus } from '../../../../reducers/rewards/selectors';
 import { setCampaignParticipantStatus } from '../../../../reducers/rewards';
 import type { CampaignParticipantStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
@@ -26,7 +26,7 @@ export const useGetCampaignParticipantStatus = (
   campaignId: string | undefined,
 ): UseGetCampaignParticipantStatusResult => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const status = useSelector(selectCampaignParticipantStatusById(campaignId));
+  const status = useSelector(selectCampaignParticipantStatus(subscriptionId, campaignId));
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(
     () => !status && Boolean(subscriptionId) && Boolean(campaignId),
@@ -46,7 +46,7 @@ export const useGetCampaignParticipantStatus = (
         campaignId,
         subscriptionId,
       );
-      dispatch(setCampaignParticipantStatus({ campaignId, status: result }));
+      dispatch(setCampaignParticipantStatus({ subscriptionId, campaignId, status: result }));
     } catch {
       setHasError(true);
     } finally {

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4847,47 +4847,50 @@ describe('setCampaignsError', () => {
 });
 
 describe('setCampaignParticipantStatus', () => {
-  it('should set participant status for a campaign', () => {
+  it('should set participant status keyed by subscriptionId:campaignId', () => {
     const action = setCampaignParticipantStatus({
+      subscriptionId: 'sub-1',
       campaignId: 'campaign-1',
       status: { optedIn: true, participantCount: 42 },
     });
 
     const state = rewardsReducer(initialState, action);
 
-    expect(state.campaignParticipantStatuses['campaign-1']).toEqual({
+    expect(state.campaignParticipantStatuses['sub-1:campaign-1']).toEqual({
       optedIn: true,
       participantCount: 42,
     });
   });
 
-  it('should update existing participant status for a campaign', () => {
+  it('should update existing participant status for the same subscriptionId:campaignId', () => {
     const stateWithStatus: RewardsState = {
       ...initialState,
       campaignParticipantStatuses: {
-        'campaign-1': { optedIn: false, participantCount: 10 },
+        'sub-1:campaign-1': { optedIn: false, participantCount: 10 },
       },
     };
 
     const action = setCampaignParticipantStatus({
+      subscriptionId: 'sub-1',
       campaignId: 'campaign-1',
       status: { optedIn: true, participantCount: 50 },
     });
 
     const state = rewardsReducer(stateWithStatus, action);
 
-    expect(state.campaignParticipantStatuses['campaign-1']).toEqual({
+    expect(state.campaignParticipantStatuses['sub-1:campaign-1']).toEqual({
       optedIn: true,
       participantCount: 50,
     });
   });
 
-  it('should store statuses for multiple campaigns independently', () => {
+  it('should store statuses independently per subscriptionId:campaignId', () => {
     let currentState = initialState;
 
     currentState = rewardsReducer(
       currentState,
       setCampaignParticipantStatus({
+        subscriptionId: 'sub-1',
         campaignId: 'campaign-1',
         status: { optedIn: true, participantCount: 42 },
       }),
@@ -4896,16 +4899,17 @@ describe('setCampaignParticipantStatus', () => {
     currentState = rewardsReducer(
       currentState,
       setCampaignParticipantStatus({
-        campaignId: 'campaign-2',
+        subscriptionId: 'sub-2',
+        campaignId: 'campaign-1',
         status: { optedIn: false, participantCount: 0 },
       }),
     );
 
-    expect(currentState.campaignParticipantStatuses['campaign-1']).toEqual({
+    expect(currentState.campaignParticipantStatuses['sub-1:campaign-1']).toEqual({
       optedIn: true,
       participantCount: 42,
     });
-    expect(currentState.campaignParticipantStatuses['campaign-2']).toEqual({
+    expect(currentState.campaignParticipantStatuses['sub-2:campaign-1']).toEqual({
       optedIn: false,
       participantCount: 0,
     });

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4905,11 +4905,15 @@ describe('setCampaignParticipantStatus', () => {
       }),
     );
 
-    expect(currentState.campaignParticipantStatuses['sub-1:campaign-1']).toEqual({
+    expect(
+      currentState.campaignParticipantStatuses['sub-1:campaign-1'],
+    ).toEqual({
       optedIn: true,
       participantCount: 42,
     });
-    expect(currentState.campaignParticipantStatuses['sub-2:campaign-1']).toEqual({
+    expect(
+      currentState.campaignParticipantStatuses['sub-2:campaign-1'],
+    ).toEqual({
       optedIn: false,
       participantCount: 0,
     });

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -133,7 +133,7 @@ export interface RewardsState {
   campaignsError: boolean;
   campaignsHasLoaded: boolean;
 
-  // Campaign participant status (keyed by campaignId)
+  // Campaign participant status (keyed by `${subscriptionId}:${campaignId}`)
   campaignParticipantStatuses: Record<string, CampaignParticipantStatusDto>;
 
   // Version guard state
@@ -554,12 +554,13 @@ const rewardsSlice = createSlice({
     setCampaignParticipantStatus: (
       state,
       action: PayloadAction<{
+        subscriptionId: string;
         campaignId: string;
         status: CampaignParticipantStatusDto;
       }>,
     ) => {
-      state.campaignParticipantStatuses[action.payload.campaignId] =
-        action.payload.status;
+      const key = `${action.payload.subscriptionId}:${action.payload.campaignId}`;
+      state.campaignParticipantStatuses[key] = action.payload.status;
     },
 
     // Version guard reducers

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -50,7 +50,7 @@ import {
   selectCampaignsLoading,
   selectCampaignsError,
   selectCampaignParticipantStatuses,
-  selectCampaignParticipantStatusById,
+  selectCampaignParticipantStatus,
   selectCampaignParticipantCount,
   selectIsRewardsVersionBlocked,
   selectVersionGuardMinimumMobileVersion,
@@ -3227,71 +3227,96 @@ describe('Rewards selectors', () => {
     });
   });
 
-  describe('selectCampaignParticipantStatusById', () => {
+  describe('selectCampaignParticipantStatus', () => {
+    it('returns null when subscriptionId is undefined', () => {
+      const state = createMockRootState({
+        campaignParticipantStatuses: {
+          'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
+        },
+      });
+      expect(selectCampaignParticipantStatus(undefined, 'campaign-1')(state)).toBeNull();
+    });
+
     it('returns null when campaignId is undefined', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {
-          'campaign-1': { optedIn: true, participantCount: 42 },
+          'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantStatusById(undefined)(state)).toBeNull();
+      expect(selectCampaignParticipantStatus('sub-1', undefined)(state)).toBeNull();
     });
 
-    it('returns null when campaign has no status', () => {
+    it('returns null when composite key has no status', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {},
       });
       expect(
-        selectCampaignParticipantStatusById('campaign-1')(state),
+        selectCampaignParticipantStatus('sub-1', 'campaign-1')(state),
       ).toBeNull();
     });
 
-    it('returns status for a specific campaign', () => {
+    it('returns status for the correct subscriptionId:campaignId', () => {
       const status = { optedIn: true, participantCount: 42 };
       const state = createMockRootState({
         campaignParticipantStatuses: {
-          'campaign-1': status,
+          'sub-1:campaign-1': status,
         },
       });
-      expect(selectCampaignParticipantStatusById('campaign-1')(state)).toEqual(
+      expect(selectCampaignParticipantStatus('sub-1', 'campaign-1')(state)).toEqual(
         status,
       );
+    });
+
+    it('does not return status for a different subscriptionId', () => {
+      const state = createMockRootState({
+        campaignParticipantStatuses: {
+          'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
+        },
+      });
+      expect(selectCampaignParticipantStatus('sub-2', 'campaign-1')(state)).toBeNull();
     });
   });
 
   describe('selectCampaignParticipantCount', () => {
-    it('returns null when campaignId is undefined', () => {
+    it('returns null when subscriptionId is undefined', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {
-          'campaign-1': { optedIn: true, participantCount: 42 },
+          'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantCount(undefined)(state)).toBeNull();
+      expect(selectCampaignParticipantCount(undefined, 'campaign-1')(state)).toBeNull();
     });
 
-    it('returns null when campaign has no status', () => {
+    it('returns null when campaignId is undefined', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {},
       });
-      expect(selectCampaignParticipantCount('campaign-1')(state)).toBeNull();
+      expect(selectCampaignParticipantCount('sub-1', undefined)(state)).toBeNull();
     });
 
-    it('returns participantCount for a specific campaign', () => {
+    it('returns null when composite key has no status', () => {
+      const state = createMockRootState({
+        campaignParticipantStatuses: {},
+      });
+      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBeNull();
+    });
+
+    it('returns participantCount for the correct subscriptionId:campaignId', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {
-          'campaign-1': { optedIn: true, participantCount: 42 },
+          'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantCount('campaign-1')(state)).toBe(42);
+      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(42);
     });
 
     it('returns 0 when participantCount is zero', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {
-          'campaign-1': { optedIn: false, participantCount: 0 },
+          'sub-1:campaign-1': { optedIn: false, participantCount: 0 },
         },
       });
-      expect(selectCampaignParticipantCount('campaign-1')(state)).toBe(0);
+      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(0);
     });
   });
 

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3234,7 +3234,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantStatus(undefined, 'campaign-1')(state)).toBeNull();
+      expect(
+        selectCampaignParticipantStatus(undefined, 'campaign-1')(state),
+      ).toBeNull();
     });
 
     it('returns null when campaignId is undefined', () => {
@@ -3243,7 +3245,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantStatus('sub-1', undefined)(state)).toBeNull();
+      expect(
+        selectCampaignParticipantStatus('sub-1', undefined)(state),
+      ).toBeNull();
     });
 
     it('returns null when composite key has no status', () => {
@@ -3262,9 +3266,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': status,
         },
       });
-      expect(selectCampaignParticipantStatus('sub-1', 'campaign-1')(state)).toEqual(
-        status,
-      );
+      expect(
+        selectCampaignParticipantStatus('sub-1', 'campaign-1')(state),
+      ).toEqual(status);
     });
 
     it('does not return status for a different subscriptionId', () => {
@@ -3273,7 +3277,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantStatus('sub-2', 'campaign-1')(state)).toBeNull();
+      expect(
+        selectCampaignParticipantStatus('sub-2', 'campaign-1')(state),
+      ).toBeNull();
     });
   });
 
@@ -3284,21 +3290,27 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantCount(undefined, 'campaign-1')(state)).toBeNull();
+      expect(
+        selectCampaignParticipantCount(undefined, 'campaign-1')(state),
+      ).toBeNull();
     });
 
     it('returns null when campaignId is undefined', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {},
       });
-      expect(selectCampaignParticipantCount('sub-1', undefined)(state)).toBeNull();
+      expect(
+        selectCampaignParticipantCount('sub-1', undefined)(state),
+      ).toBeNull();
     });
 
     it('returns null when composite key has no status', () => {
       const state = createMockRootState({
         campaignParticipantStatuses: {},
       });
-      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBeNull();
+      expect(
+        selectCampaignParticipantCount('sub-1', 'campaign-1')(state),
+      ).toBeNull();
     });
 
     it('returns participantCount for the correct subscriptionId:campaignId', () => {
@@ -3307,7 +3319,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: true, participantCount: 42 },
         },
       });
-      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(42);
+      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(
+        42,
+      );
     });
 
     it('returns 0 when participantCount is zero', () => {
@@ -3316,7 +3330,9 @@ describe('Rewards selectors', () => {
           'sub-1:campaign-1': { optedIn: false, participantCount: 0 },
         },
       });
-      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(0);
+      expect(selectCampaignParticipantCount('sub-1', 'campaign-1')(state)).toBe(
+        0,
+      );
     });
   });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -190,7 +190,9 @@ export const selectCampaignParticipantCount =
   (state: RootState) => {
     if (!subscriptionId || !campaignId) return null;
     const key = `${subscriptionId}:${campaignId}`;
-    return state.rewards.campaignParticipantStatuses?.[key]?.participantCount ?? null;
+    return (
+      state.rewards.campaignParticipantStatuses?.[key]?.participantCount ?? null
+    );
   };
 
 // Version guard selectors

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -177,18 +177,21 @@ export const selectCampaignsHasLoaded = (state: RootState) =>
 export const selectCampaignParticipantStatuses = (state: RootState) =>
   state.rewards.campaignParticipantStatuses;
 
-export const selectCampaignParticipantStatusById =
-  (campaignId: string | undefined) => (state: RootState) =>
-    campaignId
-      ? (state.rewards.campaignParticipantStatuses?.[campaignId] ?? null)
-      : null;
+export const selectCampaignParticipantStatus =
+  (subscriptionId: string | undefined, campaignId: string | undefined) =>
+  (state: RootState) => {
+    if (!subscriptionId || !campaignId) return null;
+    const key = `${subscriptionId}:${campaignId}`;
+    return state.rewards.campaignParticipantStatuses?.[key] ?? null;
+  };
 
 export const selectCampaignParticipantCount =
-  (campaignId: string | undefined) => (state: RootState) =>
-    campaignId
-      ? (state.rewards.campaignParticipantStatuses?.[campaignId]
-          ?.participantCount ?? null)
-      : null;
+  (subscriptionId: string | undefined, campaignId: string | undefined) =>
+  (state: RootState) => {
+    if (!subscriptionId || !campaignId) return null;
+    const key = `${subscriptionId}:${campaignId}`;
+    return state.rewards.campaignParticipantStatuses?.[key]?.participantCount ?? null;
+  };
 
 // Version guard selectors
 export const selectVersionGuardMinimumMobileVersion = (state: RootState) =>


### PR DESCRIPTION
## **Description**

The Redux state `campaignParticipantStatuses` was keyed by `campaignId` alone. This meant that if a user switched subscriptions (e.g. re-enrolled or switched to a different account with a separate subscription), the opted-in status from the previous subscription would bleed through for the same campaign — causing stale UI where the opt-in CTA was incorrectly hidden.

Fix: key the Redux state and all related selectors using the same composite `${subscriptionId}:${campaignId}` pattern that `RewardsController` already uses internally.

**Changes:**
- `setCampaignParticipantStatus` reducer now accepts `subscriptionId` alongside `campaignId` and stores by composite key
- `selectCampaignParticipantStatusById` renamed to `selectCampaignParticipantStatus(subscriptionId, campaignId)` to reflect new signature
- `selectCampaignParticipantCount` updated to same composite key signature
- `useGetCampaignParticipantStatus` hook passes `subscriptionId` (already available from `selectRewardsSubscriptionId`) to both the selector and dispatch

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ondo campaign opt-in state isolation per subscription

  Scenario: user switches subscriptions and sees correct opt-in state
    Given user is opted in to the Ondo campaign on subscription A

    When user switches to an account with a different subscription B
    Then the Ondo campaign opt-in CTA is visible (not falsely hidden by subscription A's state)
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redux state shape and selector/action signatures; existing persisted or in-memory status entries keyed only by `campaignId` may no longer be read until refreshed, so regressions are possible if any call sites weren’t updated.
> 
> **Overview**
> Fixes stale Ondo campaign opt-in UI by scoping `campaignParticipantStatuses` in Redux to a composite `${subscriptionId}:${campaignId}` key instead of `campaignId` alone.
> 
> Updates `setCampaignParticipantStatus` to require `subscriptionId`, replaces `selectCampaignParticipantStatusById` with `selectCampaignParticipantStatus(subscriptionId, campaignId)` (and updates `selectCampaignParticipantCount` similarly), and wires `useGetCampaignParticipantStatus` + tests to read/write the new keyed status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed69883c66c35d7c2f644fbea3a7a99e183c3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->