### PR TITLE
refactor(social): drop addressOrUid from follow/unfollow/updateFollowing

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -18,13 +18,6 @@ jest.mock('../../../../../../util/Logger', () => ({
 }));
 
 jest.mock('../../../../../../core/Engine', () => ({
-  context: {
-    AuthenticationController: {
-      getSessionProfile: jest
-        .fn()
-        .mockResolvedValue({ profileId: 'mock-profile-id' }),
-    },
-  },
   controllerMessenger: {
     call: jest.fn(),
     subscribe: jest.fn(),
@@ -217,10 +210,7 @@ describe('useTopTraders', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:followTrader',
-        {
-          addressOrUid: 'mock-profile-id',
-          targets: [mockTraders[0].profileId],
-        },
+        { targets: [mockTraders[0].profileId] },
       );
     });
 
@@ -234,10 +224,7 @@ describe('useTopTraders', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:unfollowTrader',
-        {
-          addressOrUid: 'mock-profile-id',
-          targets: [mockTraders[0].profileId],
-        },
+        { targets: [mockTraders[0].profileId] },
       );
     });
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
@@ -18,13 +18,6 @@ jest.mock('../../../../../util/Logger', () => ({
 }));
 
 jest.mock('../../../../../core/Engine', () => ({
-  context: {
-    AuthenticationController: {
-      getSessionProfile: jest
-        .fn()
-        .mockResolvedValue({ profileId: 'mock-profile-id' }),
-    },
-  },
   controllerMessenger: {
     call: jest.fn(),
     subscribe: jest.fn(),
@@ -201,7 +194,7 @@ describe('useTraderProfile', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:followTrader',
-        { addressOrUid: 'mock-profile-id', targets: ['trader-1'] },
+        { targets: ['trader-1'] },
       );
     });
 
@@ -215,7 +208,7 @@ describe('useTraderProfile', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:unfollowTrader',
-        { addressOrUid: 'mock-profile-id', targets: ['trader-1'] },
+        { targets: ['trader-1'] },
       );
     });
 

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -17,13 +17,6 @@ jest.mock('../../util/Logger', () => ({
 }));
 
 jest.mock('../../core/Engine', () => ({
-  context: {
-    AuthenticationController: {
-      getSessionProfile: jest
-        .fn()
-        .mockResolvedValue({ profileId: 'mock-profile-id' }),
-    },
-  },
   controllerMessenger: {
     call: jest.fn(),
     subscribe: jest.fn(),
@@ -69,7 +62,7 @@ describe('useFollowToggle', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:followTrader',
-        { addressOrUid: 'mock-profile-id', targets: ['trader-1'] },
+        { targets: ['trader-1'] },
       );
     });
 
@@ -84,7 +77,7 @@ describe('useFollowToggle', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
         'SocialController:unfollowTrader',
-        { addressOrUid: 'mock-profile-id', targets: ['trader-1'] },
+        { targets: ['trader-1'] },
       );
     });
 

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -11,8 +11,9 @@ export interface UseFollowToggleManyResult {
 
 /**
  * Shared primitive that optimistically toggles follow/unfollow state for one
- * or more traders against `SocialController`, using the current session's
- * `profileId` from `AuthenticationController`.
+ * or more traders against `SocialController`. The caller is identified
+ * server-side from the JWT attached by `SocialService`, so no `profileId`
+ * needs to be passed from the UI.
  *
  * Local optimistic overrides are kept per trader id and cleared automatically
  * once Redux catches up with the intended value, or when the underlying
@@ -51,9 +52,7 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
       }));
 
       try {
-        const { profileId } =
-          await Engine.context.AuthenticationController.getSessionProfile();
-        const opts = { addressOrUid: profileId, targets: [addressOrId] };
+        const opts = { targets: [addressOrId] };
         await (Engine.controllerMessenger.call as CallableFunction)(
           nextValue
             ? 'SocialController:followTrader'

--- a/app/core/Engine/controllers/social-controller-hydration.test.ts
+++ b/app/core/Engine/controllers/social-controller-hydration.test.ts
@@ -3,11 +3,6 @@ import Logger from '../../../util/Logger';
 import { hydrateSocialFollowing } from './social-controller-hydration';
 
 jest.mock('../../Engine', () => ({
-  context: {
-    AuthenticationController: {
-      getSessionProfile: jest.fn(),
-    },
-  },
   controllerMessenger: {
     call: jest.fn(),
   },
@@ -22,10 +17,7 @@ describe('hydrateSocialFollowing', () => {
     jest.clearAllMocks();
   });
 
-  it('calls updateFollowing with the user profileId', async () => {
-    (
-      Engine.context.AuthenticationController.getSessionProfile as jest.Mock
-    ).mockResolvedValue({ profileId: 'user-123' });
+  it('calls updateFollowing without any options', async () => {
     (Engine.controllerMessenger.call as jest.Mock).mockResolvedValue({
       following: [],
     });
@@ -34,28 +26,10 @@ describe('hydrateSocialFollowing', () => {
 
     expect(Engine.controllerMessenger.call).toHaveBeenCalledWith(
       'SocialController:updateFollowing',
-      { addressOrUid: 'user-123' },
-    );
-  });
-
-  it('logs and does not throw when getSessionProfile fails', async () => {
-    const err = new Error('not authenticated');
-    (
-      Engine.context.AuthenticationController.getSessionProfile as jest.Mock
-    ).mockRejectedValue(err);
-
-    await hydrateSocialFollowing();
-
-    expect(Logger.error).toHaveBeenCalledWith(
-      err,
-      'hydrateSocialFollowing failed',
     );
   });
 
   it('logs and does not throw when updateFollowing fails', async () => {
-    (
-      Engine.context.AuthenticationController.getSessionProfile as jest.Mock
-    ).mockResolvedValue({ profileId: 'user-123' });
     const err = new Error('network error');
     (Engine.controllerMessenger.call as jest.Mock).mockRejectedValue(err);
 

--- a/app/core/Engine/controllers/social-controller-hydration.ts
+++ b/app/core/Engine/controllers/social-controller-hydration.ts
@@ -2,20 +2,18 @@ import Engine from '../../Engine';
 import Logger from '../../../util/Logger';
 
 /**
- * Fetches the current user's following list from the server
- * and populates SocialController.followingProfileIds in state.
+ * Fetches the current user's following list from the server and populates
+ * SocialController.followingProfileIds in state. The caller is identified
+ * server-side from the JWT attached by SocialService.
  *
- * Called once at Engine startup. Failures are non-fatal — the
- * controller's persisted state from the previous session is
- * used until the next successful hydration.
+ * Called once at Engine startup. Failures are non-fatal — the controller's
+ * persisted state from the previous session is used until the next successful
+ * hydration.
  */
 export async function hydrateSocialFollowing(): Promise<void> {
   try {
-    const { profileId } =
-      await Engine.context.AuthenticationController.getSessionProfile();
     await (Engine.controllerMessenger.call as CallableFunction)(
       'SocialController:updateFollowing',
-      { addressOrUid: profileId },
     );
   } catch (err) {
     Logger.error(err as Error, 'hydrateSocialFollowing failed');

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@metamask/snaps-rpc-methods": "^15.1.1",
     "@metamask/snaps-sdk": "^11.1.0",
     "@metamask/snaps-utils": "^12.2.0",
-    "@metamask/social-controllers": "^1.0.0",
+    "@metamask/social-controllers": "^2.0.0",
     "@metamask/solana-wallet-snap": "^2.8.0",
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/stake-sdk": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10141,9 +10141,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/social-controllers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/social-controllers@npm:1.0.0"
+"@metamask/social-controllers@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/social-controllers@npm:2.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/base-data-service": "npm:^0.1.1"
@@ -10151,7 +10151,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/70925f3bba681b001f40ff3aa0ca675027a80fdd52c64921bba62ae83a5bf4530e45bc1835d0816ff03a5a09c5e332372ffb40f6aee115fd2b1edb50a01404e3
+  checksum: 10/0165cf574f46415c4208bede2d9676423f5c75d8eb181ee48fd801254aec9e53aa4b4cd2aca7a9093f0ced3a262f7b648851025e52dc8a336fd9e82eee000be5
   languageName: node
   linkType: hard
 
@@ -35970,7 +35970,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^15.1.1"
     "@metamask/snaps-sdk": "npm:^11.1.0"
     "@metamask/snaps-utils": "npm:^12.2.0"
-    "@metamask/social-controllers": "npm:^1.0.0"
+    "@metamask/social-controllers": "npm:^2.0.0"
     "@metamask/solana-wallet-snap": "npm:^2.8.0"
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@metamask/stake-sdk": "npm:^3.4.0"


### PR DESCRIPTION
## **Description**

Part of [TSA-398](https://consensyssoftware.atlassian.net/browse/TSA-398).

The social-api now derives the caller's `profileId` from the OIDC JWT instead of accepting it as a path parameter, and `@metamask/social-controllers` has been updated accordingly (breaking change). This PR updates the mobile consumer:

- `useFollowToggle`: calls `SocialController:followTrader` / `SocialController:unfollowTrader` with only `{ targets }`; no longer resolves the current profile client-side before firing the action.
- `hydrateSocialFollowing`: calls `SocialController:updateFollowing` with no arguments.
- Updates the affected hook and hydration tests to match the new options shape.

No user-visible behavior change: the optimistic UI, error-rollback and hydration flows are preserved.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TSA-398](https://consensyssoftware.atlassian.net/browse/TSA-398)

Depends on:

- Social API: consensys-vertical-apps/va-mmcx-social-api#49
- Core (breaking change to `@metamask/social-controllers`): MetaMask/core#8520

## **Manual testing steps**

```gherkin
Feature: Follow / unfollow a trader from the JWT-authenticated caller

  Scenario: user follows a trader from the leaderboard
    Given the user is signed in and the social-api has their JWT
    And the user is viewing a trader they don't follow yet

    When the user taps the Follow button
    Then the UI updates optimistically to "Following"
    And the app issues PUT /v1/users/me/follows with { targets: [traderId] }
    And the server responds 200 OK

  Scenario: user unfollows a trader
    Given the user is signed in and is already following a trader
    When the user taps the Following button
    Then the UI updates optimistically to "Follow"
    And the app issues DELETE /v1/users/me/follows?targets=<traderId>
    And the server responds 200 OK

  Scenario: app hydrates the following list on startup
    Given the user is signed in
    When the app starts
    Then it issues GET /v1/users/me/following
    And the SocialController state reflects the response
```

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Made with [Cursor](https://cursor.com)

[TSA-398]: https://consensyssoftware.atlassian.net/browse/TSA-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TSA-398]: https://consensyssoftware.atlassian.net/browse/TSA-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the follow/unfollow and following-hydration calls to match a breaking `@metamask/social-controllers` v2 API, which could impact social follow behavior if any call sites/options are missed. Risk is moderate because the change touches user-affecting social actions but is largely a parameter-shape refactor with test updates.
> 
> **Overview**
> Removes client-side passing of the caller identity (`addressOrUid`/`profileId`) when following/unfollowing traders and when hydrating the following list; these requests now rely on server-side identification via the JWT.
> 
> Updates `useFollowToggleMany` and `hydrateSocialFollowing` to call `SocialController:followTrader`, `SocialController:unfollowTrader`, and `SocialController:updateFollowing` with only `targets` (or no args), and adjusts related hook/hydration tests accordingly. Bumps `@metamask/social-controllers` to `^2.0.0` (lockfile updated) to pick up the breaking API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778b2c31ffb93e32f45228f5db21e3f06fac4f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->