### PR TITLE
fix: correct minimum TRX locked period time

### DIFF
--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Die Fiat-Werte sind vorübergehend nicht verfügbar.",
       "estimated_annual_reward": "Geschätzte jährliche Belohnung",
       "trx_locked_for": "TRX gesperrt für",
-      "trx_locked_for_minimum_time": "~3 Tage",
+      "trx_locked_for_minimum_time": "~14 Tage",
       "trx_released_in": "TRX freigegeben in",
       "trx_released_in_minimum_time": "~14 Tage",
       "fee": "Gebühr",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Οι αξίες σε παραδοσιακά νομίσματα είναι προσωρινά μη διαθέσιμες.",
       "estimated_annual_reward": "Εκτ. ετήσια ανταμοιβή",
       "trx_locked_for": "Τα TRX κλειδωμένα για",
-      "trx_locked_for_minimum_time": "~3 ημέρες",
+      "trx_locked_for_minimum_time": "~14 ημέρες",
       "trx_released_in": "Τα TRX θα είναι διαθέσιμα σε",
       "trx_released_in_minimum_time": "~14 ημέρες",
       "fee": "Τέλη",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6395,7 +6395,7 @@
       "fiat_unavailable": "Fiat values are temporarily unavailable.",
       "estimated_annual_reward": "Est. annual reward",
       "trx_locked_for": "TRX locked for",
-      "trx_locked_for_minimum_time": "~3 days",
+      "trx_locked_for_minimum_time": "~14 days",
       "trx_released_in": "TRX released in",
       "trx_released_in_minimum_time": "~14 days",
       "fee": "Fee",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Los valores en moneda fiduciaria no están disponibles temporalmente.",
       "estimated_annual_reward": "Recompensa anual est.",
       "trx_locked_for": "TRX bloqueado durante",
-      "trx_locked_for_minimum_time": "~3 días",
+      "trx_locked_for_minimum_time": "~14 días",
       "trx_released_in": "TRX liberado en",
       "trx_released_in_minimum_time": "~14 días",
       "fee": "Tarifa",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Les valeurs en monnaies fiduciaires sont temporairement indisponibles.",
       "estimated_annual_reward": "Estimation de la récompense annuelle",
       "trx_locked_for": "TRX bloqué pour",
-      "trx_locked_for_minimum_time": "environ 3 jours",
+      "trx_locked_for_minimum_time": "environ 14 jours",
       "trx_released_in": "TRX libéré dans",
       "trx_released_in_minimum_time": "environ 14 jours",
       "fee": "Frais",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Fiat वैल्यूज़ फिलहाल उपलब्ध नहीं हैं।",
       "estimated_annual_reward": "अनुमानित वार्षिक रिवॉर्ड",
       "trx_locked_for": "के लिए TRX लॉक किया गया",
-      "trx_locked_for_minimum_time": "~3 दिन के लिए",
+      "trx_locked_for_minimum_time": "~14 दिन के लिए",
       "trx_released_in": "TRX रिलीज़ किया गया",
       "trx_released_in_minimum_time": "~14 दिनों में",
       "fee": "फीस",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Nilai mata uang fiat tidak tersedia untuk sementara waktu.",
       "estimated_annual_reward": "Estimasi reward tahunan",
       "trx_locked_for": "TRX dikunci selama",
-      "trx_locked_for_minimum_time": "~3 hari",
+      "trx_locked_for_minimum_time": "~14 hari",
       "trx_released_in": "TRX dirilis dalam",
       "trx_released_in_minimum_time": "~14 hari",
       "fee": "Biaya",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "フィアット価値は一時的に利用できません。",
       "estimated_annual_reward": "予想年間報酬",
       "trx_locked_for": "TRXのロック期間",
-      "trx_locked_for_minimum_time": "最大3日",
+      "trx_locked_for_minimum_time": "最大14日",
       "trx_released_in": "TRXのロック解除までの待機期間",
       "trx_released_in_minimum_time": "最大14日",
       "fee": "手数料",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "법정화폐 기준 금액을 일시적으로 사용할 수 없습니다.",
       "estimated_annual_reward": "예상 연간 보상",
       "trx_locked_for": "TRX 잠김:",
-      "trx_locked_for_minimum_time": "~3일",
+      "trx_locked_for_minimum_time": "~14일",
       "trx_released_in": "TRX 해제 예정일:",
       "trx_released_in_minimum_time": "~14일",
       "fee": "수수료",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Valores em moeda fiduciária temporariamente indisponíveis.",
       "estimated_annual_reward": "Recompensa anual estimada",
       "trx_locked_for": "TRX bloqueado por",
-      "trx_locked_for_minimum_time": "cerca de 3 dias",
+      "trx_locked_for_minimum_time": "cerca de 14 dias",
       "trx_released_in": "TRX lançado em",
       "trx_released_in_minimum_time": "cerca de 14 dias",
       "fee": "Taxa",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Значения фиатных валют временно недоступны.",
       "estimated_annual_reward": "Прим. вознаграждение за год",
       "trx_locked_for": "TRX заблокированы на",
-      "trx_locked_for_minimum_time": "~3 дня",
+      "trx_locked_for_minimum_time": "~14 дней",
       "trx_released_in": "TRX разблокируются через",
       "trx_released_in_minimum_time": "~14 дней",
       "fee": "Комиссия",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Ang mga halaga ng fiat ay pansamantalang hindi available.",
       "estimated_annual_reward": "Tinatayang taunang reward",
       "trx_locked_for": "Naka-lock ang TRX ng",
-      "trx_locked_for_minimum_time": "~3 araw",
+      "trx_locked_for_minimum_time": "~14 araw",
       "trx_released_in": "Ilalabas ang TRX pagkalipas ng",
       "trx_released_in_minimum_time": "~14 na araw",
       "fee": "Bayarin",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Fiat para değerleri geçici olarak kullanılamıyor.",
       "estimated_annual_reward": "Tahmini yıllık ödül",
       "trx_locked_for": "TRX kilitli kalma süresi",
-      "trx_locked_for_minimum_time": "~3 gün",
+      "trx_locked_for_minimum_time": "~14 gün",
       "trx_released_in": "TRX serbest bırakılmasına kalan süre",
       "trx_released_in_minimum_time": "~14 gün",
       "fee": "Ücret",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "Giá trị tiền pháp định tạm thời không khả dụng.",
       "estimated_annual_reward": "Phần thưởng hằng năm ước tính",
       "trx_locked_for": "TRX bị khóa trong",
-      "trx_locked_for_minimum_time": "~3 ngày",
+      "trx_locked_for_minimum_time": "~14 ngày",
       "trx_released_in": "TRX được mở khóa sau",
       "trx_released_in_minimum_time": "~14 ngày",
       "fee": "Phí",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -6348,7 +6348,7 @@
       "fiat_unavailable": "法币价值暂时无法获取。",
       "estimated_annual_reward": "预计年度奖励",
       "trx_locked_for": "TRX 锁定时长",
-      "trx_locked_for_minimum_time": "约 3 天",
+      "trx_locked_for_minimum_time": "约 14 天",
       "trx_released_in": "TRX 释放时间",
       "trx_released_in_minimum_time": "约 14 天",
       "fee": "费用",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Correctly display the minimum amount of days TRX is locked for when staking, which is 14 days.

## **Changelog**

CHANGELOG entry: Fixed incorrect TRX "locked for" value

## **Related issues**

n/a

## **Manual testing steps**

```gherkin
Feature: TRX Staking Locked Period Display

  Scenario: User views the minimum TRX locked period when staking
    Given the user has a wallet with TRX tokens
    And the user navigates to the TRX staking flow

    When the user views the staking details screen
    Then the "TRX locked for" minimum time should display "~14 days"
    And the "TRX locked for" minimum time should NOT display "~3 days"

  Scenario: User views the TRX locked period in a non-English locale
    Given the user has a wallet with TRX tokens
    And the app language is set to a non-English locale (e.g., Spanish, French, Portuguese)
    And the user navigates to the TRX staking flow

    When the user views the staking details screen
    Then the "TRX locked for" minimum time should display the localized equivalent of "~14 days"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c84aa28d-39bb-46b8-9934-dede44e58817" />

### **After**

<img width="506" height="947" alt="Screenshot 2026-04-20 at 12 54 15" src="https://github.com/user-attachments/assets/9dd8793f-c174-430e-af89-a252f772014d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization updates; no functional, security, or data-handling logic is changed.
> 
> **Overview**
> Updates staking/unstaking localization strings to **correct the displayed minimum TRX lock period** from `~3 days` to `~14 days` across all supported locales (e.g., `en`, `de`, `es`, `fr`, `pt`, `zh`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ee6501e541f1d729402faea698000d09e60bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->