### PR TITLE
fix(rewards): resolve Ondo position swap account picker missing balances for checksummed token addresses cp-7.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed Ondo campaign portfolio swap account picker not recognising token balances when token addresses are stored in checksummed (EIP-55) form
-
 ## [7.72.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ondo campaign portfolio swap account picker not recognising token balances when token addresses are stored in checksummed (EIP-55) form
+
 ## [7.72.1]
 
 ### Fixed

--- a/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
@@ -17,7 +17,6 @@ import {
 } from '@metamask/design-system-react-native';
 import type { AccountGroupObject } from '@metamask/account-tree-controller';
 import { Hex } from '@metamask/utils';
-import { BigNumber } from 'bignumber.js';
 
 import Badge, {
   BadgeVariant,
@@ -88,12 +87,7 @@ const OndoAccountPickerSheet: React.FC<OndoAccountPickerSheetProps> = ({
             />
           </BadgeWrapper>
           <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
-            {` ${pendingPicker.row.tokenSymbol} ${pendingPicker.entries
-              .reduce(
-                (sum, e) => sum.plus(new BigNumber(e.balance)),
-                new BigNumber(0),
-              )
-              .toFixed(2)}`}
+            {` ${pendingPicker.row.tokenSymbol}`}
           </Text>
         </Box>
       </BottomSheetHeader>

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -75,14 +75,14 @@ jest.mock('../../../../../selectors/tokensController', () => ({
 }));
 
 jest.mock('../../../../../selectors/accountsController', () => ({
-  selectInternalAccountByAddresses: jest.fn(() => () => []),
+  selectInternalAccounts: jest.fn(() => []),
 }));
 
 jest.mock(
   '../../../../../selectors/multichainAccounts/accountTreeController',
   () => ({
     selectAccountToGroupMap: jest.fn(() => ({})),
-    selectResolvedSelectedAccountGroup: jest.fn(() => null),
+    selectSelectedAccountGroup: jest.fn(() => null),
   }),
 );
 
@@ -427,8 +427,6 @@ describe('OndoPortfolio', () => {
     const buildPropsWithBalance = (rawHexBalance: string) => {
       const mockOnOpenAccountPicker = jest.fn();
 
-      // Set up two groups so that if balance leaks through the filter the
-      // component would open the account picker instead of navigating.
       (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
         const { selectCurrentSubscriptionAccounts } = jest.requireMock(
           '../../../../../selectors/rewards',
@@ -439,11 +437,16 @@ describe('OndoPortfolio', () => {
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
-        const { selectInternalAccountByAddresses } = jest.requireMock(
+        const { selectInternalAccounts } = jest.requireMock(
           '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap } = jest.requireMock(
+          '../../../../../selectors/multichainAccounts/accountTreeController',
         );
         if (selector === selectCurrentSubscriptionAccounts)
           return [{ account: CAIP_ACCOUNT }];
+        if (selector === selectInternalAccounts)
+          return [{ id: 'acc-test', address: ACCOUNT_ADDRESS }];
         if (selector === selectAllTokenBalances)
           return {
             [ACCOUNT_ADDRESS.toLowerCase()]: {
@@ -451,7 +454,7 @@ describe('OndoPortfolio', () => {
             },
           };
         if (selector === selectAllTokens) return {};
-        if (selector === selectInternalAccountByAddresses) return () => [];
+        if (selector === selectAccountToGroupMap) return {};
         return null;
       });
 
@@ -489,14 +492,10 @@ describe('OndoPortfolio', () => {
 
     it('treats a non-zero hex balance as non-zero', () => {
       const props = buildPropsWithBalance('0x1');
-      // With one account holding balance in one group, the component navigates
-      // directly (groups.length === 1) — picker is still not opened. What we
-      // want to confirm is that the account IS considered to have balance (i.e.
-      // selectInternalAccountByAddresses is called with a non-empty array).
-      // We verify this indirectly: if the account were filtered out the
-      // component would call navigateToSwap via the groups.length === 0 branch,
-      // which is the same observable outcome. So we just assert the render
-      // doesn't throw and the row is pressable.
+      // The account has a non-zero balance, so it passes the filter. Because no
+      // accountToGroupMap entry exists for the test account, groupsForRow is
+      // empty and the component navigates directly (length === 0 branch).
+      // Picker not opened either way — we just confirm no throw.
       const { getByText } = render(<OndoPortfolio {...props} />);
       expect(() => fireEvent.press(getByText('Apple Inc.'))).not.toThrow();
     });
@@ -632,7 +631,7 @@ describe('OndoPortfolio', () => {
       (useSelector as jest.Mock).mockReturnValue(null);
     });
 
-    it('opens account picker when exactly one group has the token balance', () => {
+    it('opens account picker when one group has the balance but user is on a different group', () => {
       const onOpenAccountPicker = jest.fn();
 
       (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
@@ -645,16 +644,18 @@ describe('OndoPortfolio', () => {
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
-        const { selectInternalAccountByAddresses } = jest.requireMock(
+        const { selectInternalAccounts } = jest.requireMock(
           '../../../../../selectors/accountsController',
         );
-        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+        const { selectAccountToGroupMap, selectSelectedAccountGroup } =
           jest.requireMock(
             '../../../../../selectors/multichainAccounts/accountTreeController',
           );
 
         if (selector === selectCurrentSubscriptionAccounts)
           return [{ account: CAIP_1 }];
+        if (selector === selectInternalAccounts)
+          return [{ id: 'acc-1', address: ACCOUNT_1 }];
         if (selector === selectAllTokenBalances)
           return {
             [ACCOUNT_1]: {
@@ -662,10 +663,9 @@ describe('OndoPortfolio', () => {
             },
           };
         if (selector === selectAllTokens) return {};
-        if (selector === selectInternalAccountByAddresses)
-          return () => [{ id: 'acc-1', address: ACCOUNT_1 }];
         if (selector === selectAccountToGroupMap) return { 'acc-1': GROUP_1 };
-        if (selector === selectResolvedSelectedAccountGroup) return null;
+        // User is on GROUP_2, not GROUP_1 — picker should still open
+        if (selector === selectSelectedAccountGroup) return GROUP_2;
         return null;
       });
 
@@ -682,6 +682,57 @@ describe('OndoPortfolio', () => {
       expect(onOpenAccountPicker).toHaveBeenCalledTimes(1);
       const config = (onOpenAccountPicker as jest.Mock).mock.calls[0][0];
       expect(config.entries).toHaveLength(1);
+    });
+
+    it('navigates directly without picker when single group with balance is the currently selected group', () => {
+      const onOpenAccountPicker = jest.fn();
+
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccounts } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap, selectSelectedAccountGroup } =
+          jest.requireMock(
+            '../../../../../selectors/multichainAccounts/accountTreeController',
+          );
+
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_1 }];
+        if (selector === selectInternalAccounts)
+          return [{ id: 'acc-1', address: ACCOUNT_1 }];
+        if (selector === selectAllTokenBalances)
+          return {
+            [ACCOUNT_1]: {
+              '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
+            },
+          };
+        if (selector === selectAllTokens) return {};
+        if (selector === selectAccountToGroupMap) return { 'acc-1': GROUP_1 };
+        // User IS on the group that holds the balance
+        if (selector === selectSelectedAccountGroup) return GROUP_1;
+        return null;
+      });
+
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+
+      fireEvent.press(getByText('Apple Inc.'));
+
+      expect(onOpenAccountPicker).not.toHaveBeenCalled();
     });
 
     it('finds balance when token key in allTokenBalances is checksummed (mixed case)', () => {
@@ -708,16 +759,18 @@ describe('OndoPortfolio', () => {
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
-        const { selectInternalAccountByAddresses } = jest.requireMock(
+        const { selectInternalAccounts } = jest.requireMock(
           '../../../../../selectors/accountsController',
         );
-        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+        const { selectAccountToGroupMap, selectSelectedAccountGroup } =
           jest.requireMock(
             '../../../../../selectors/multichainAccounts/accountTreeController',
           );
 
         if (selector === selectCurrentSubscriptionAccounts)
           return [{ account: CAIP_1 }];
+        if (selector === selectInternalAccounts)
+          return [{ id: 'acc-1', address: ACCOUNT_1 }];
         if (selector === selectAllTokenBalances)
           return {
             [ACCOUNT_1]: {
@@ -726,10 +779,8 @@ describe('OndoPortfolio', () => {
             },
           };
         if (selector === selectAllTokens) return {};
-        if (selector === selectInternalAccountByAddresses)
-          return () => [{ id: 'acc-1', address: ACCOUNT_1 }];
         if (selector === selectAccountToGroupMap) return { 'acc-1': GROUP_1 };
-        if (selector === selectResolvedSelectedAccountGroup) return null;
+        if (selector === selectSelectedAccountGroup) return null;
         return null;
       });
 
@@ -764,16 +815,21 @@ describe('OndoPortfolio', () => {
         const { selectAllTokens } = jest.requireMock(
           '../../../../../selectors/tokensController',
         );
-        const { selectInternalAccountByAddresses } = jest.requireMock(
+        const { selectInternalAccounts } = jest.requireMock(
           '../../../../../selectors/accountsController',
         );
-        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+        const { selectAccountToGroupMap, selectSelectedAccountGroup } =
           jest.requireMock(
             '../../../../../selectors/multichainAccounts/accountTreeController',
           );
 
         if (selector === selectCurrentSubscriptionAccounts)
           return [{ account: CAIP_1 }, { account: CAIP_2 }];
+        if (selector === selectInternalAccounts)
+          return [
+            { id: 'acc-1', address: ACCOUNT_1 },
+            { id: 'acc-2', address: ACCOUNT_2 },
+          ];
         if (selector === selectAllTokenBalances)
           return {
             [ACCOUNT_1]: {
@@ -784,14 +840,9 @@ describe('OndoPortfolio', () => {
             },
           };
         if (selector === selectAllTokens) return {};
-        if (selector === selectInternalAccountByAddresses)
-          return () => [
-            { id: 'acc-1', address: ACCOUNT_1 },
-            { id: 'acc-2', address: ACCOUNT_2 },
-          ];
         if (selector === selectAccountToGroupMap)
           return { 'acc-1': GROUP_1, 'acc-2': GROUP_2 };
-        if (selector === selectResolvedSelectedAccountGroup) return null;
+        if (selector === selectSelectedAccountGroup) return null;
         return null;
       });
 
@@ -808,6 +859,63 @@ describe('OndoPortfolio', () => {
       expect(onOpenAccountPicker).toHaveBeenCalledTimes(1);
       const config = (onOpenAccountPicker as jest.Mock).mock.calls[0][0];
       expect(config.entries).toHaveLength(2);
+    });
+
+    it('excludes accounts not in the subscription even if they hold the token balance', () => {
+      const onOpenAccountPicker = jest.fn();
+      // ACCOUNT_2 has balance but is NOT in the subscription
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccounts } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap, selectSelectedAccountGroup } =
+          jest.requireMock(
+            '../../../../../selectors/multichainAccounts/accountTreeController',
+          );
+
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_1 }]; // only ACCOUNT_1 is subscribed
+        if (selector === selectInternalAccounts)
+          return [
+            { id: 'acc-1', address: ACCOUNT_1 },
+            { id: 'acc-2', address: ACCOUNT_2 },
+          ];
+        if (selector === selectAllTokenBalances)
+          return {
+            // ACCOUNT_1 has zero balance, ACCOUNT_2 has balance but not subscribed
+            [ACCOUNT_1]: { '0x1': { [TOKEN_ADDRESS]: '0x0' } },
+            [ACCOUNT_2]: {
+              '0x1': { [TOKEN_ADDRESS]: '0x56bc75e2d63100000' },
+            },
+          };
+        if (selector === selectAllTokens) return {};
+        if (selector === selectAccountToGroupMap)
+          return { 'acc-1': GROUP_1, 'acc-2': GROUP_2 };
+        if (selector === selectSelectedAccountGroup) return null;
+        return null;
+      });
+
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+
+      fireEvent.press(getByText('Apple Inc.'));
+
+      // No subscribed account has balance → navigate directly, picker not opened
+      expect(onOpenAccountPicker).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.test.tsx
@@ -632,7 +632,7 @@ describe('OndoPortfolio', () => {
       (useSelector as jest.Mock).mockReturnValue(null);
     });
 
-    it('navigates directly when exactly one group has the token balance', () => {
+    it('opens account picker when exactly one group has the token balance', () => {
       const onOpenAccountPicker = jest.fn();
 
       (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
@@ -679,8 +679,76 @@ describe('OndoPortfolio', () => {
 
       fireEvent.press(getByText('Apple Inc.'));
 
-      // Single group → navigates directly, picker NOT opened
-      expect(onOpenAccountPicker).not.toHaveBeenCalled();
+      expect(onOpenAccountPicker).toHaveBeenCalledTimes(1);
+      const config = (onOpenAccountPicker as jest.Mock).mock.calls[0][0];
+      expect(config.entries).toHaveLength(1);
+    });
+
+    it('finds balance when token key in allTokenBalances is checksummed (mixed case)', () => {
+      // Regression test: allTokenBalances stores token addresses in EIP-55 checksum
+      // form, but tokenHex is lowercased. The lookup must be case-insensitive.
+      const CHECKSUMMED_TOKEN = '0x14C3AbF95cB9c93a8b82c1cdCb76D72Cb87b2D4c';
+      const onOpenAccountPicker = jest.fn();
+
+      jest
+        .requireMock('../../utils/formatUtils')
+        .parseCaip19.mockReturnValueOnce({
+          namespace: 'eip155',
+          chainId: '1',
+          assetReference: CHECKSUMMED_TOKEN,
+        });
+
+      (useSelector as jest.Mock).mockImplementation((selector: unknown) => {
+        const { selectCurrentSubscriptionAccounts } = jest.requireMock(
+          '../../../../../selectors/rewards',
+        );
+        const { selectAllTokenBalances } = jest.requireMock(
+          '../../../../../selectors/tokenBalancesController',
+        );
+        const { selectAllTokens } = jest.requireMock(
+          '../../../../../selectors/tokensController',
+        );
+        const { selectInternalAccountByAddresses } = jest.requireMock(
+          '../../../../../selectors/accountsController',
+        );
+        const { selectAccountToGroupMap, selectResolvedSelectedAccountGroup } =
+          jest.requireMock(
+            '../../../../../selectors/multichainAccounts/accountTreeController',
+          );
+
+        if (selector === selectCurrentSubscriptionAccounts)
+          return [{ account: CAIP_1 }];
+        if (selector === selectAllTokenBalances)
+          return {
+            [ACCOUNT_1]: {
+              // Key is checksummed — the old direct lookup would miss this
+              '0x1': { [CHECKSUMMED_TOKEN]: '0x56bc75e2d63100000' },
+            },
+          };
+        if (selector === selectAllTokens) return {};
+        if (selector === selectInternalAccountByAddresses)
+          return () => [{ id: 'acc-1', address: ACCOUNT_1 }];
+        if (selector === selectAccountToGroupMap) return { 'acc-1': GROUP_1 };
+        if (selector === selectResolvedSelectedAccountGroup) return null;
+        return null;
+      });
+
+      const { getByText } = render(
+        <OndoPortfolio
+          {...baseProps}
+          portfolio={MOCK_PORTFOLIO}
+          onOpenAccountPicker={onOpenAccountPicker}
+        />,
+      );
+
+      fireEvent.press(getByText('Apple Inc.'));
+
+      // Account must be found despite key case mismatch → picker opened
+      expect(onOpenAccountPicker).toHaveBeenCalledTimes(1);
+      const config = (onOpenAccountPicker as jest.Mock).mock.calls[0][0];
+      expect(config.entries).toHaveLength(1);
+      // Balance must also be computed correctly from the checksummed key
+      expect(parseFloat(config.entries[0].balance)).toBeGreaterThan(0);
     });
 
     it('opens account picker when multiple groups hold the token', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -7,13 +7,6 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
-  Button,
-  ButtonVariant,
-  ButtonSize,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
   Skeleton,
   Text,
   TextColor,
@@ -50,20 +43,15 @@ import {
   isPnlNonNegative,
   sanitizeOndoTokenName,
 } from './OndoPortfolio.utils';
-import { formatComputedAt } from './OndoLeaderboard.utils';
 import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
 import { selectAllTokenBalances } from '../../../../../selectors/tokenBalancesController';
 import { selectAllTokens } from '../../../../../selectors/tokensController';
 import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
-import {
-  selectAccountToGroupMap,
-  selectResolvedSelectedAccountGroup,
-} from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
 import { VerticalAlignment } from '../../../../../component-library/components/List/ListItem';
 import AvatarAccount from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { selectIconSeedAddressByAccountGroupId } from '../../../../../selectors/multichainAccounts/accounts';
-import Engine from '../../../../../core/Engine';
 import RewardsNoPositionsImage from '../../../../../images/rewards/rewards-no-positions.svg';
 
 const styles = StyleSheet.create({
@@ -170,7 +158,6 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   const allTokenBalances = useSelector(selectAllTokenBalances);
   const allTokens = useSelector(selectAllTokens);
   const accountToGroupMap = useSelector(selectAccountToGroupMap);
-  const selectedGroup = useSelector(selectResolvedSelectedAccountGroup);
   const resolveAccountsByAddresses = useSelector(
     selectInternalAccountByAddresses,
   );
@@ -192,10 +179,14 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
       const tokenHex = parsed.assetReference.toLowerCase() as Hex;
       const addresses = subscriptionAccounts.flatMap((a) => {
         const address = parseCaipAccountId(a.account).address;
-        const bal =
-          allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex]?.[
-            tokenHex
-          ];
+        const chainBalances =
+          allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex];
+        const balEntry = chainBalances
+          ? Object.entries(chainBalances).find(
+              ([key]) => key.toLowerCase() === tokenHex,
+            )
+          : undefined;
+        const bal = balEntry?.[1];
         return bal !== undefined && !!parseInt(bal, 16) ? [address] : [];
       });
       return resolveAccountsByAddresses(addresses);
@@ -255,10 +246,13 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
       );
       let total = new BigNumber(0);
       for (const account of groupAccounts) {
-        const hexBal =
-          allTokenBalances?.[account.address.toLowerCase() as Hex]?.[
-            chainHex
-          ]?.[tokenHex];
+        const chainBalances =
+          allTokenBalances?.[account.address.toLowerCase() as Hex]?.[chainHex];
+        const hexBal = chainBalances
+          ? Object.entries(chainBalances).find(
+              ([key]) => key.toLowerCase() === tokenHex,
+            )?.[1]
+          : undefined;
         if (hexBal) {
           try {
             total = total.plus(new BigNumber(hexBal).shiftedBy(-decimals));
@@ -301,18 +295,8 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
         navigateToSwap(row);
         return;
       }
-      if (groupsForRow.length === 1) {
-        const [group] = groupsForRow;
-        if (group.id !== selectedGroup?.id) {
-          Engine.context.AccountTreeController.setSelectedAccountGroup(
-            group.id,
-          );
-        }
-        navigateToSwap(row);
-        return;
-      }
 
-      // Multiple groups hold this token — delegate picker to parent
+      // Another group or group(s) hold this token — delegate picker to parent
       const decimals = resolveTokenDecimals(row);
       onOpenAccountPicker({
         row,
@@ -330,7 +314,6 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
       getAccountsWithBalance,
       getGroupsFromAccounts,
       getGroupBalance,
-      selectedGroup,
       onOpenAccountPicker,
       resolveTokenDecimals,
     ],

--- a/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoPortfolio.tsx
@@ -43,16 +43,20 @@ import {
   isPnlNonNegative,
   sanitizeOndoTokenName,
 } from './OndoPortfolio.utils';
-import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
 import { selectAllTokenBalances } from '../../../../../selectors/tokenBalancesController';
 import { selectAllTokens } from '../../../../../selectors/tokensController';
-import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
-import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectInternalAccounts } from '../../../../../selectors/accountsController';
+import { selectCurrentSubscriptionAccounts } from '../../../../../selectors/rewards';
+import {
+  selectAccountToGroupMap,
+  selectSelectedAccountGroup,
+} from '../../../../../selectors/multichainAccounts/accountTreeController';
 import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
 import { VerticalAlignment } from '../../../../../component-library/components/List/ListItem';
 import AvatarAccount from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { selectIconSeedAddressByAccountGroupId } from '../../../../../selectors/multichainAccounts/accounts';
 import RewardsNoPositionsImage from '../../../../../images/rewards/rewards-no-positions.svg';
+import type { InternalAccount } from '@metamask/keyring-internal-api/dist/types.d.cts';
 
 const styles = StyleSheet.create({
   skeletonLg: { height: 128, borderRadius: 12 },
@@ -154,51 +158,53 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
 }) => {
   const navigation = useNavigation();
 
+  const allInternalAccounts = useSelector(selectInternalAccounts);
   const subscriptionAccounts = useSelector(selectCurrentSubscriptionAccounts);
   const allTokenBalances = useSelector(selectAllTokenBalances);
   const allTokens = useSelector(selectAllTokens);
   const accountToGroupMap = useSelector(selectAccountToGroupMap);
-  const resolveAccountsByAddresses = useSelector(
-    selectInternalAccountByAddresses,
-  );
+  const selectedAccountGroup = useSelector(selectSelectedAccountGroup);
   const grouped = useMemo(
     () =>
       portfolio ? groupPortfolioPositionsByAsset(portfolio.positions) : [],
     [portfolio],
   );
 
-  /** Returns InternalAccounts from the subscription that hold a non-zero balance of the given token. */
+  /** Returns InternalAccounts that hold a non-zero balance of the given token. */
   const getAccountsWithBalance = useCallback(
-    (row: OndoGmPortfolioPositionDto) => {
-      if (!subscriptionAccounts) return [];
+    (row: OndoGmPortfolioPositionDto): InternalAccount[] => {
       const parsed = parseCaip19(row.tokenAsset);
       if (!parsed || parsed.namespace !== 'eip155') return [];
       const chainHex = caipChainIdToHex(
         `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
       );
       const tokenHex = parsed.assetReference.toLowerCase() as Hex;
-      const addresses = subscriptionAccounts.flatMap((a) => {
-        const address = parseCaipAccountId(a.account).address;
+      const subscriptionAddresses = new Set(
+        (subscriptionAccounts ?? []).map((a) =>
+          parseCaipAccountId(a.account).address.toLowerCase(),
+        ),
+      );
+      return (allInternalAccounts ?? []).filter((account) => {
+        if (!subscriptionAddresses.has(account.address.toLowerCase())) {
+          return false;
+        }
         const chainBalances =
-          allTokenBalances?.[address.toLowerCase() as Hex]?.[chainHex];
+          allTokenBalances?.[account.address.toLowerCase() as Hex]?.[chainHex];
         const balEntry = chainBalances
           ? Object.entries(chainBalances).find(
               ([key]) => key.toLowerCase() === tokenHex,
             )
           : undefined;
         const bal = balEntry?.[1];
-        return bal !== undefined && !!parseInt(bal, 16) ? [address] : [];
+        return bal !== undefined && !!parseInt(bal, 16);
       });
-      return resolveAccountsByAddresses(addresses);
     },
-    [subscriptionAccounts, allTokenBalances, resolveAccountsByAddresses],
+    [allInternalAccounts, subscriptionAccounts, allTokenBalances],
   );
 
   /** Returns unique AccountGroups from a pre-computed list of accounts. */
   const getGroupsFromAccounts = useCallback(
-    (
-      accounts: ReturnType<typeof resolveAccountsByAddresses>,
-    ): AccountGroupObject[] => {
+    (accounts: InternalAccount[]): AccountGroupObject[] => {
       const seenGroups = new Map<string, AccountGroupObject>();
       for (const account of accounts) {
         const group = accountToGroupMap[account.id];
@@ -231,7 +237,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
   const getGroupBalance = useCallback(
     (
       group: AccountGroupObject,
-      accounts: ReturnType<typeof resolveAccountsByAddresses>,
+      accounts: InternalAccount[],
       row: OndoGmPortfolioPositionDto,
       decimals: number,
     ): string => {
@@ -296,7 +302,16 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
         return;
       }
 
-      // Another group or group(s) hold this token — delegate picker to parent
+      if (
+        groupsForRow.length === 1 &&
+        selectedAccountGroup?.id === groupsForRow[0].id
+      ) {
+        // Already on the only group that holds this token — no picker needed
+        navigateToSwap(row);
+        return;
+      }
+
+      // Multiple groups or current group differs — delegate picker to parent
       const decimals = resolveTokenDecimals(row);
       onOpenAccountPicker({
         row,
@@ -316,6 +331,7 @@ const OndoPortfolio: React.FC<OndoPortfolioProps> = ({
       getGroupBalance,
       onOpenAccountPicker,
       resolveTokenDecimals,
+      selectedAccountGroup,
     ],
   );
 


### PR DESCRIPTION
## **Description**

 The account picker opens when tapping a position and the token balance is either spread across  multiple accounts, or held entirely on an account other than the currently active one. This lets the user select which account's balance they want to swap from.

## **Changelog**

CHANGELOG entry: null

## **Screenshots/Recordings**

What is opened if a position is spread around more than 1 account, or if the position is completely tied to another account different then the active one. 

<img width="859" height="374" alt="image" src="https://github.com/user-attachments/assets/ba743f47-61dd-48aa-9848-7d1858566dd4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches balance lookup and account-group selection branching for the Ondo swap flow; errors could cause incorrect picker behavior or misreported balances, but the change is localized and covered by new regression tests.
> 
> **Overview**
> Fixes Ondo portfolio swap balance detection by making `allTokenBalances` lookups **case-insensitive** (so EIP-55 checksummed token-address keys no longer read as zero), affecting both per-account filtering and per-group balance totals.
> 
> Updates the account-picker decision logic to only bypass the picker when the *currently selected* group is the sole group with balance (removing the implicit group-switch side effect), and simplifies the picker sheet header by dropping the incorrect total-balance label. Tests are updated/expanded to cover the checksummed-address regression, subscription filtering, and selected-group branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73db3abe375e7ba0623f6c683009172d959e307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->