### PR TITLE
fix: improve conditional object spreading in usePerpsActions and usePerpsNavigationHandlers

### DIFF
--- a/app/components/UI/TokenDetails/hooks/usePerpsActions.ts
+++ b/app/components/UI/TokenDetails/hooks/usePerpsActions.ts
@@ -64,7 +64,9 @@ export const usePerpsActions = ({
           direction,
           asset: marketData.symbol,
           fromTokenDetails,
-          ...(transactionActiveAbTests?.length && { transactionActiveAbTests }),
+          ...(transactionActiveAbTests?.length
+            ? { transactionActiveAbTests }
+            : {}),
         },
       });
     },

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.tsx
@@ -114,9 +114,11 @@ const usePerpsNavigationHandlers = ({
         market,
         source: PERPS_EVENT_VALUE.SOURCE.HOME_SECTION,
         ...(isDedicatedTrendingSection &&
-          trendingTransactionActiveAbTests?.length && {
-            transactionActiveAbTests: trendingTransactionActiveAbTests,
-          }),
+        trendingTransactionActiveAbTests?.length
+          ? {
+              transactionActiveAbTests: trendingTransactionActiveAbTests,
+            }
+          : {}),
       });
     },
     [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replaces `...(condition && { ... })` style spreads with explicit ternaries so we only spread a plain object (`{ transactionActiveAbTests }` or `{}`). This avoids accidentally spreading a non-object falsy value when the AB-test array is empty or the length check is falsey, for both the homepage Perps trending navigation params and the token-details perps analytics payload.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to navigation parameter construction; behavior should be identical except for eliminating edge-case spread errors.
> 
> **Overview**
> Tightens how `transactionActiveAbTests` is conditionally included in Perps navigation params from Token Details and the homepage trending Perps section.
> 
> Replaces `...(cond && { ... })` spreads with explicit ternaries so only a plain object (`{...}`) or `{}` is spread, avoiding accidental spreading of falsy non-object values when the AB-test array is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ee2c605edbe2ca67be96f6e59e77f272ac3adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->