### PR TITLE
fix(ramp): show PayPal in payment selector for UB2 (TRAM-3462) cp-7.74.0

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -351,6 +351,7 @@ describe('PaymentSelectionModal', () => {
       amount: 100,
       walletAddress: '0x123',
       assetId: 'eip155:1/slip44:60',
+      redirectUrl: expect.stringContaining('/regions/fake-callback'),
       providers: ['/providers/transak'],
       paymentMethods: [
         '/payments/debit-credit-card-1',
@@ -359,7 +360,7 @@ describe('PaymentSelectionModal', () => {
     });
   });
 
-  it('filters out payment method when only custom-action quote matches', () => {
+  it('keeps payment method visible when only custom-action quote matches', () => {
     const customActionQuote = {
       provider: '/providers/transak',
       quote: {
@@ -378,11 +379,41 @@ describe('PaymentSelectionModal', () => {
       loading: false,
     }));
 
-    const { queryAllByText, getByText } = renderWithProvider(
+    const { queryAllByText, queryByText } = renderWithProvider(
       PaymentSelectionModal,
     );
-    // Payment methods with only custom-action quotes are filtered out
-    expect(queryAllByText('Debit or Credit').length).toBe(0);
-    expect(getByText('fiat_on_ramp.no_payment_methods_available')).toBeTruthy();
+    // debit-credit-card-1 matches the custom-action quote → visible.
+    // debit-credit-card-2 has no matching quote → filtered out.
+    expect(queryAllByText('Debit or Credit').length).toBe(1);
+    expect(queryByText('fiat_on_ramp.no_payment_methods_available')).toBeNull();
+  });
+
+  it('does not use custom-action quote amount for price preview', () => {
+    // amountOut would render as "0.12345..." text if the per-item matchedQuote
+    // find accepted custom-action quotes. It should be filtered out and no
+    // price text should render for the row.
+    const customActionQuote = {
+      provider: '/providers/transak',
+      quote: {
+        paymentMethod: '/payments/debit-credit-card-1',
+        amountOut: 0.12345,
+        amountOutInFiat: 67.89,
+        isCustomAction: true,
+      },
+    };
+    mockUseRampsQuotes.mockImplementation(() => ({
+      ...defaultQuotesReturn,
+      data: {
+        success: [customActionQuote],
+        error: [],
+        sorted: [],
+        customActions: [],
+      },
+      loading: false,
+    }));
+
+    const { queryByText } = renderWithProvider(PaymentSelectionModal);
+    expect(queryByText(/0\.12345/)).toBeNull();
+    expect(queryByText(/67\.89/)).toBeNull();
   });
 });

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import type { CaipChainId } from '@metamask/utils';
 import type { PaymentMethod } from '@metamask/ramps-controller';
 import { useWindowDimensions, View, ScrollView } from 'react-native';

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { CaipChainId } from '@metamask/utils';
 import type { PaymentMethod } from '@metamask/ramps-controller';
 import { useWindowDimensions, View, ScrollView } from 'react-native';
@@ -31,6 +31,7 @@ import { PAYMENT_SELECTION_MODAL_TEST_IDS } from './PaymentSelectionModal.testId
 import { useRampsController } from '../../../hooks/useRampsController';
 import { useRampsQuotes } from '../../../hooks/useRampsQuotes';
 import useRampAccountAddress from '../../../hooks/useRampAccountAddress';
+import { getRampCallbackBaseUrl } from '../../../utils/getRampCallbackBaseUrl';
 import { isCustomAction } from '../../../types';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -92,6 +93,7 @@ function PaymentSelectionModal() {
             amount,
             walletAddress,
             assetId,
+            redirectUrl: getRampCallbackBaseUrl(),
             providers: selectedProvider ? [selectedProvider.id] : undefined,
             paymentMethods: paymentMethodIds,
           }
@@ -219,12 +221,12 @@ function PaymentSelectionModal() {
     }
     // Filter out payment methods that have no available quote once quotes
     // have loaded. This avoids showing dead-end options to the user.
+    // Custom-action quotes (e.g. PayPal) count as available since they have
+    // their own checkout flow even without a standard priced quote.
     const visiblePaymentMethods =
       !quotesLoading && quotes
         ? paymentMethods.filter((pm) =>
-            quotes.success?.some(
-              (q) => q.quote?.paymentMethod === pm.id && !isCustomAction(q),
-            ),
+            quotes.success?.some((q) => q.quote?.paymentMethod === pm.id),
           )
         : paymentMethods;
 

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.test.tsx
@@ -215,6 +215,7 @@ describe('ProviderSelectionModal', () => {
         amount: 100,
         walletAddress: '0x123',
         assetId: 'eip155:1/slip44:60',
+        redirectUrl: expect.stringContaining('/regions/fake-callback'),
         providers: ['/providers/transak', '/providers/moonpay'],
         paymentMethods: ['/payments/debit-credit-card-1'],
       }),

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useWindowDimensions, View } from 'react-native';
 import type { CaipChainId } from '@metamask/utils';
 import type { Provider } from '@metamask/ramps-controller';
@@ -17,6 +17,7 @@ import ProviderSelection from './ProviderSelection';
 import { useRampsController } from '../../../hooks/useRampsController';
 import { useRampsQuotes } from '../../../hooks/useRampsQuotes';
 import useRampAccountAddress from '../../../hooks/useRampAccountAddress';
+import { getRampCallbackBaseUrl } from '../../../utils/getRampCallbackBaseUrl';
 import { getOrdersProviders } from '../../../../../../reducers/fiatOrders';
 import { selectRampsOrdersForSelectedAccountGroup } from '../../../../../../selectors/rampsController';
 import { completedOrdersFromRampsOrders } from '../../../utils/determinePreferredProvider';
@@ -112,6 +113,7 @@ function ProviderSelectionModal() {
             amount,
             walletAddress,
             assetId,
+            redirectUrl: getRampCallbackBaseUrl(),
             providers: providerIds,
             paymentMethods: [selectedPaymentMethod.id],
           }

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useWindowDimensions, View } from 'react-native';
 import type { CaipChainId } from '@metamask/utils';
 import type { Provider } from '@metamask/ramps-controller';


### PR DESCRIPTION
## **Description**

In Unified Buy V2, PayPal is not shown in the Pay With bottom sheet even when the server would accept it. Two defects stack:

1. `PaymentSelectionModal` and `ProviderSelectionModal` called `useRampsQuotes` without `redirectUrl`. The quotes API only materializes a PayPal dummy quote when both `redirectUrl` and `walletAddress` are provided; otherwise PayPal is only returned under `customActions`. `BuildQuote` already sends `redirectUrl`, but the selection-stage modals were inconsistent.
2. `PaymentSelectionModal`'s visibility filter in `renderListContent` excluded any `success` entry with `quote.isCustomAction: true`, so even when PayPal surfaced in `success` (e.g. when we do pass `redirectUrl`), its payment method row was still filtered out and the "No payment methods are available." banner was shown.

This PR:

- Passes `redirectUrl: getRampCallbackBaseUrl()` from `PaymentSelectionModal` and `ProviderSelectionModal`, matching `BuildQuote`'s existing shape so the quotes request is consistent across selection stages.
- Drops `!isCustomAction(q)` from the `visiblePaymentMethods` filter so custom-action quotes count as "available" for listing. The per-item `matchedQuote` find remains strict, so custom-action rows still do not render a misleading priced preview.

## **Changelog**

CHANGELOG entry: Fixed a bug where PayPal was missing from the Pay With list in Unified Buy V2 and the selector showed "No payment methods are available." instead.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/TRAM/boards/1568?assignee=712020%3Afd12f7ea-d9e1-4a0a-8a26-36804c9e11c9&selectedIssue=TRAM-3462

## **Manual testing steps**

```gherkin
Feature: Pay With selector surfaces PayPal (UB2)

  Scenario: PayPal is available as a payment method
    Given the user is in the Unified Buy V2 flow with PayPal supported in their region
    And the user has selected a crypto asset and amount

    When the user opens the Pay With bottom sheet
    Then the PayPal row appears in the list
    And the "No payment methods are available." banner is not shown

  Scenario: PayPal row does not show a misleading price
    Given PayPal is available in the Pay With list
    When the user views the PayPal row
    Then no crypto amount or fiat amount is rendered for the row
    And the row remains tappable

  Scenario: Selecting PayPal continues into its checkout flow
    Given PayPal is listed in the Pay With sheet
    When the user taps the PayPal row
    Then the sheet closes and the existing custom-action checkout flow runs
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->
https://www.loom.com/share/865aefe1f2024ed28f0564192c01bf0b

### **After**

<!-- [screenshots/recordings] -->
https://www.loom.com/share/556420ed2f3c41028cc9a1fc21b0d847

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI selection logic change plus added test coverage; risk is limited to which payment methods are shown and the quote request parameters sent.
> 
> **Overview**
> Fixes Unified Buy V2 payment/provider selection so quote fetches from `PaymentSelectionModal` and `ProviderSelectionModal` include `redirectUrl: getRampCallbackBaseUrl()`, aligning them with the Build Quote flow and enabling providers that require a redirect URL to surface correctly.
> 
> Updates the payment-method visibility filter to treat custom-action quotes as “available” (so their rows remain listed), while keeping per-row price previews gated by non-custom-action quotes; tests were updated/added to cover both the new `redirectUrl` param and the custom-action visibility/no-price behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4209ed85da8db8d6a4ee37b77540565740d0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->