### PR TITLE
[POC] Support pUSD collateral wrapping for Predict deposits

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -60,6 +60,7 @@ import {
   MATIC_CONTRACTS,
   POLYMARKET_PROVIDER_ID,
 } from '../providers/polymarket/constants';
+
 import { Signer } from '../providers/types';
 
 import {
@@ -1760,7 +1761,7 @@ export class PredictController extends BaseController<
         throw new Error('Deposit preparation returned undefined');
       }
 
-      const { transactions, chainId } = depositPreparation;
+      const { transactions, chainId, requiredAssets } = depositPreparation;
 
       if (!transactions || transactions.length === 0) {
         throw new Error('No transactions returned from deposit preparation');
@@ -1804,6 +1805,7 @@ export class PredictController extends BaseController<
         disableHook: true,
         disableSequential: true,
         skipInitialGasEstimate: true,
+        requiredAssets,
         transactions,
       });
 
@@ -1896,7 +1898,7 @@ export class PredictController extends BaseController<
         throw new Error('Deposit preparation returned undefined');
       }
 
-      const { transactions, chainId } = depositPreparation;
+      const { transactions, chainId, requiredAssets } = depositPreparation;
 
       if (!transactions || transactions.length === 0) {
         throw new Error('No transactions returned from deposit preparation');
@@ -1949,6 +1951,7 @@ export class PredictController extends BaseController<
         disableHook: true,
         disableSequential: true,
         skipInitialGasEstimate: true,
+        requiredAssets,
         transactions: depositAndOrderTransactions,
       });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -4,12 +4,14 @@ import {
 } from '@metamask/keyring-controller';
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex, numberToHex } from '@metamask/utils';
+import { Interface } from '@ethersproject/abi';
 import { parseUnits } from 'ethers/lib/utils';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import Logger, { type LoggerErrorOptions } from '../../../../../util/Logger';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { UserProfileProperty } from '../../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import {
+  generateApprovalData,
   generateTransferData,
   isSmartContractAddress,
 } from '../../../../../util/transactions';
@@ -60,6 +62,7 @@ import {
   SignWithdrawResponse,
 } from '../types';
 import {
+  COLLATERAL_ONRAMP_WRAP_ABI,
   MATIC_CONTRACTS,
   MIN_COLLATERAL_BALANCE_FOR_CLAIM,
   ORDER_RATE_LIMIT_MS,
@@ -1879,27 +1882,45 @@ export class PolymarketProvider implements PredictProvider {
       transactions.push(allowanceTransaction);
     }
 
-    const depositTransactionCallData = generateTransferData('transfer', {
-      toAddress: accountState.address,
-      amount: '0x0',
-    });
+    const { collateralUnderlying, collateralOnramp } = MATIC_CONTRACTS;
 
-    if (!depositTransactionCallData) {
-      throw new Error(
-        'Failed to generate transfer data for deposit transaction',
-      );
-    }
+    const approveOnrampCallData = generateApprovalData({
+      spender: collateralOnramp,
+      value: '0x0',
+    });
 
     transactions.push({
       params: {
-        to: collateral as Hex,
-        data: depositTransactionCallData as Hex,
+        to: collateralUnderlying as Hex,
+        data: approveOnrampCallData as Hex,
+      },
+    });
+
+    const onrampInterface = new Interface(COLLATERAL_ONRAMP_WRAP_ABI);
+
+    const wrapCallData = onrampInterface.encodeFunctionData('wrap', [
+      collateralUnderlying,
+      accountState.address,
+      '0x0',
+    ]);
+
+    transactions.push({
+      params: {
+        to: collateralOnramp as Hex,
+        data: wrapCallData as Hex,
       },
       type: TransactionType.predictDeposit,
     });
 
     return {
       chainId: CHAIN_IDS.POLYGON,
+      requiredAssets: [
+        {
+          address: collateralUnderlying as Hex,
+          amount: '0x0' as Hex,
+          standard: 'erc20',
+        },
+      ],
       transactions,
     };
   }

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -77,12 +77,37 @@ export const MATIC_CONTRACTS: ContractConfig = {
   exchange: '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E',
   negRiskAdapter: '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
   negRiskExchange: '0xC5d563A36AE78145C45a50134d48A1215220f80a',
-  collateral: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+  collateral: '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
+  collateralUnderlying: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+  collateralOnramp: '0x93070a847efEf7F70739046A929D47a521F5B8ee',
   conditionalTokens: '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
 };
 
+/**
+ * ABI fragment for the Collateral Onramp wrap function.
+ * Wraps USDC/USDC.e into pUSD and sends to recipient.
+ * Selector: 0x62355638
+ *
+ * @param token - The input token address (USDC or USDC.e)
+ * @param to - The recipient address for minted pUSD
+ * @param amount - The amount to wrap
+ */
+export const COLLATERAL_ONRAMP_WRAP_ABI = [
+  {
+    inputs: [
+      { name: 'token', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    name: 'wrap',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
 export const POLYGON_USDC_CAIP_ASSET_ID =
-  `${POLYGON_MAINNET_CAIP_CHAIN_ID}/erc20:${MATIC_CONTRACTS.collateral}` as const;
+  `${POLYGON_MAINNET_CAIP_CHAIN_ID}/erc20:${MATIC_CONTRACTS.collateralUnderlying}` as const;
 
 export const SPORTS_MARKET_TYPE_TO_GROUP: Record<string, string> = {
   first_half_moneyline: 'first_half',

--- a/app/components/UI/Predict/providers/polymarket/pusd.ts
+++ b/app/components/UI/Predict/providers/polymarket/pusd.ts
@@ -1,0 +1,95 @@
+import { Interface } from '@ethersproject/abi';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import { generateApprovalData } from '../../../../../util/transactions';
+import {
+  updateAtomicBatchData,
+  updateTransaction,
+} from '../../../../../util/transaction-controller';
+import Logger from '../../../../../util/Logger';
+import { COLLATERAL_ONRAMP_WRAP_ABI } from './constants';
+
+const FOUR_BYTE_APPROVE = '0x095ea7b3';
+const FOUR_BYTE_WRAP = '0x62355638';
+
+const onrampInterface = new Interface(COLLATERAL_ONRAMP_WRAP_ABI);
+
+/**
+ * Update the pUSD deposit batch amount across all related fields.
+ *
+ * Updates the approve calldata, wrap calldata, and requiredAssets amount so
+ * the TransactionPayController sources the correct USDC.e amount for quoting.
+ *
+ * NOTE: Each update currently triggers its own state change event, which
+ * causes multiple re-parses and re-quotes in the TransactionPayController.
+ * Ideally this would be a single atomic state update — pending a batch
+ * update API on the TransactionController that can set nested call data and
+ * top-level fields together.
+ */
+export function updatePredictDepositData({
+  transactionId,
+  transactionMeta,
+  amountHex,
+}: {
+  transactionId: string;
+  transactionMeta: TransactionMeta;
+  amountHex: string;
+}): void {
+  const { nestedTransactions, requiredAssets } = transactionMeta;
+
+  if (requiredAssets?.[0]) {
+    updateTransaction(
+      {
+        ...transactionMeta,
+        requiredAssets: [
+          { ...requiredAssets[0], amount: `0x${amountHex}` as Hex },
+          ...requiredAssets.slice(1),
+        ],
+      },
+      'Predict deposit amount update',
+    );
+  }
+
+  nestedTransactions?.forEach((nestedTx, index) => {
+    const fourByte = nestedTx.data?.slice(0, 10);
+
+    if (fourByte === FOUR_BYTE_APPROVE && nestedTx.data) {
+      const spender = `0x${nestedTx.data.slice(34, 74)}`;
+
+      const approveData = generateApprovalData({
+        spender,
+        value: amountHex,
+      }) as Hex;
+
+      updateAtomicBatchData({
+        transactionId,
+        transactionIndex: index,
+        transactionData: approveData,
+      }).catch((error) => {
+        Logger.error(error, 'Failed to update approve amount');
+      });
+    }
+
+    if (fourByte === FOUR_BYTE_WRAP) {
+      const decoded = onrampInterface.decodeFunctionData(
+        'wrap',
+        nestedTx.data as string,
+      );
+
+      const wrapData = onrampInterface.encodeFunctionData('wrap', [
+        decoded.token,
+        decoded.to,
+        `0x${amountHex}`,
+      ]) as Hex;
+
+      updateAtomicBatchData({
+        transactionId,
+        transactionIndex: index,
+        transactionData: wrapData,
+      }).catch((error) => {
+        Logger.error(error, 'Failed to update wrap amount');
+      });
+    }
+  });
+}

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -220,6 +220,8 @@ export interface ContractConfig {
   negRiskAdapter: string;
   negRiskExchange: string;
   collateral: string;
+  collateralUnderlying: string;
+  collateralOnramp: string;
   conditionalTokens: string;
 }
 

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -26,7 +26,10 @@ import {
   UnrealizedPnL,
 } from '../types';
 import { Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  RequiredAsset,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { PredictFeatureFlags } from '../types/flags';
 
 // Re-export shared types so existing provider-layer imports continue to work
@@ -68,6 +71,7 @@ export interface PrepareWithdrawParams {
 
 export interface PrepareDepositResponse {
   chainId: Hex;
+  requiredAssets?: RequiredAsset[];
   transactions: {
     params: {
       to: Hex;

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -14,9 +14,13 @@ import {
 } from '../../../../../util/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import { parseStandardTokenTransactionData } from '../../utils/transaction';
-import { getTokenTransferData } from '../../utils/transaction-pay';
+import {
+  getTokenAddress,
+  getTokenTransferData,
+} from '../../utils/transaction-pay';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import Logger from '../../../../../util/Logger';
+import { updateTransactionPayData } from '../../utils/external/update-transaction-pay-data';
 
 export function useUpdateTokenAmount() {
   const dispatch = useDispatch();
@@ -26,21 +30,30 @@ export function useUpdateTokenAmount() {
   const transactionId = transactionMeta?.id ?? '';
   const [previousAmountRaw, setPreviousAmountRaw] = useState<string>();
 
-  const {
-    data,
-    to,
-    index: nestedCallIndex,
-  } = (transactionMeta && getTokenTransferData(transactionMeta)) ?? {};
+  const { data, index: nestedCallIndex } =
+    (transactionMeta && getTokenTransferData(transactionMeta)) ?? {};
+
+  const tokenAddress = getTokenAddress(transactionMeta);
 
   const { decimals } =
     useSelector((state: RootState) =>
-      selectSingleTokenByAddressAndChainId(state, to as Hex, chainId as Hex),
+      selectSingleTokenByAddressAndChainId(
+        state,
+        tokenAddress as Hex,
+        chainId as Hex,
+      ),
     ) ?? {};
 
   const amountRaw = useMemo(() => {
+    const requiredAssetAmount = transactionMeta?.requiredAssets?.[0]?.amount;
+
+    if (requiredAssetAmount) {
+      return new BigNumber(requiredAssetAmount).toString(10);
+    }
+
     const transactionData = parseStandardTokenTransactionData(data);
     return new BigNumber(transactionData?.args?._value.toString()).toString(10);
-  }, [data]);
+  }, [data, transactionMeta]);
 
   const isUpdating =
     Boolean(previousAmountRaw) && amountRaw === previousAmountRaw;
@@ -64,15 +77,28 @@ export function useUpdateTokenAmount() {
         return;
       }
 
+      const newAmountHex = newAmountRaw.toString(16);
+
+      setPreviousAmountRaw(amountRaw);
+
+      if (
+        transactionMeta &&
+        updateTransactionPayData({
+          transactionId,
+          transactionMeta,
+          amountHex: newAmountHex,
+        })
+      ) {
+        return;
+      }
+
       const transactionData = parseStandardTokenTransactionData(data);
       const recipient = transactionData?.args?._to;
 
       const newData = generateTransferData('transfer', {
         toAddress: recipient,
-        amount: newAmountRaw.toString(16),
+        amount: newAmountHex,
       }) as Hex;
-
-      setPreviousAmountRaw(amountRaw);
 
       if (nestedCallIndex !== undefined) {
         updateAtomicBatchData({
@@ -94,7 +120,14 @@ export function useUpdateTokenAmount() {
         updateType: false,
       });
     },
-    [amountRaw, data, decimals, nestedCallIndex, transactionId],
+    [
+      amountRaw,
+      data,
+      decimals,
+      nestedCallIndex,
+      transactionId,
+      transactionMeta,
+    ],
   );
 
   return {

--- a/app/components/Views/confirmations/utils/external/update-transaction-pay-data.ts
+++ b/app/components/Views/confirmations/utils/external/update-transaction-pay-data.ts
@@ -1,0 +1,29 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+import { updatePredictDepositData } from '../../../../UI/Predict/providers/polymarket/pusd';
+import { hasTransactionType } from '../transaction';
+
+export function updateTransactionPayData({
+  transactionId,
+  transactionMeta,
+  amountHex,
+}: {
+  transactionId: string;
+  transactionMeta: TransactionMeta;
+  amountHex: string;
+}): boolean {
+  if (
+    hasTransactionType(transactionMeta, [
+      TransactionType.predictDeposit,
+      TransactionType.predictDepositAndOrder,
+    ])
+  ) {
+    updatePredictDepositData({ transactionId, transactionMeta, amountHex });
+    return true;
+  }
+
+  return false;
+}

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -79,6 +79,12 @@ export function getTokenTransferData(
 export function getTokenAddress(
   transactionMeta: TransactionMeta | undefined,
 ): Hex {
+  const requiredAsset = transactionMeta?.requiredAssets?.[0];
+
+  if (requiredAsset) {
+    return requiredAsset.address;
+  }
+
   const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
 
   if (nestedCall) {


### PR DESCRIPTION
## Summary

POC exploring the impact to MetaMask Pay of Polymarket's CLOB V2 migration, specifically the switch from USDC.e to pUSD as the collateral token.

**Not ready for merge** — shared as a reference for the approach.

## Context

Polymarket is migrating to CLOB V2, which introduces a new collateral token ([pUSD](https://polygonscan.com/address/0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB)) that wraps USDC/USDC.e 1:1. pUSD has no DEX liquidity — the only way to obtain it is via the [Permissionless Collateral Onramp](https://polygonscan.com/address/0x93070a847efEf7F70739046A929D47a521F5B8ee) contract's `wrap(address token, address to, uint256 amount)` function.

This means Pay can't swap directly to pUSD — every Predict deposit needs to swap to USDC.e first, then wrap into pUSD before landing in the Safe proxy.

## Approach

**Deposit batch** — `PolymarketProvider.prepareDeposit()` now produces:
1. `approve(onramp, amount)` on USDC.e (EOA → onramp)
2. `wrap(USDC.e, safeAddress, amount)` on onramp (mints pUSD directly to Safe)

No separate pUSD transfer needed — wrap's `to` param sends pUSD directly to the Safe. All happens atomically on the EOA side via 7702 delegation.

**Telling Pay the source token** — `prepareDeposit` returns `requiredAssets: [{ address: USDC_E, amount, standard: 'erc20' }]` on the batch response. `PredictController` passes it through to `addTransactionBatch`, so `TransactionPayController` knows to source USDC.e instead of parsing the (now non-existent) ERC-20 transfer.

**Keeping Pay in sync on amount changes** — when the user changes the deposit amount, `updatePredictDepositData()` updates:
- The `approve` calldata (new amount)
- The `wrap` calldata (new amount)
- `requiredAssets[0].amount` on the `TransactionMeta` (so Pay quotes for the right amount)

**No core changes** — uses the existing `requiredAssets` field on `TransactionMeta`. The Pay controller re-parses on every state change.

## Architecture

- `polymarket/pusd.ts` — owns all wrap/approve calldata manipulation
- `confirmations/utils/external/update-transaction-pay-data.ts` — thin junction that checks transaction type and routes to Predict (future integrations add branches here, not in the hook)
- `useUpdateTokenAmount` — generic hook, no Predict-specific logic

## Known Gaps

- `updatePredictDepositData` fires multiple `updateAtomicBatchData` + `updateTransaction` calls. Each triggers a state change and re-quote cycle. Ideally this would be a single atomic update — pending a batch API on the `TransactionController`.
- No tests, no telemetry, no edge case handling — POC scope.
- Contract addresses in constants still point at mainnet V1 exchange. V2 migration work (exchange addresses, allowance changes) not included in this POC.
- Across support breaks because wrap requires `msg.sender` to hold the USDC and Across doesn't support 7702 upgrades. Relay still works.

## Notes

Full context in [Polymarket CLOB V2 Migration Guide](https://polymarket.notion.site/clob-v2-migration-guide).

Tested on-chain: [Tenderly simulation](https://dashboard.tenderly.co/shared/simulation/5cd7b498-cf93-41e4-b860-159f44d99f3a) confirmed the deposit batch executes correctly after fixing the wrap ABI (3 params: `wrap(address token, address to, uint256 amount)`, selector `0x62355638`).