### PR TITLE
feat: Skeleton migration (`assets` team)

### DIFF
--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
@@ -224,10 +224,6 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render with new balance
     rerender(<AccountGroupBalance />);
 
-    // Balance should display immediately without waiting for timeout.
-    // The new DSRN Skeleton hides children with `accessibilityElementsHidden`
-    // while loading, so include hidden elements to assert the balance node is
-    // present in the tree (matches pre-migration assertion behavior).
     const el = getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
       includeHiddenElements: true,
     });
@@ -289,10 +285,6 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render
     rerender(<AccountGroupBalance />);
 
-    // Should show balance immediately after update (hasChanged condition).
-    // The new DSRN Skeleton hides children with `accessibilityElementsHidden`
-    // while loading, so include hidden elements to assert the balance node is
-    // present in the tree (matches pre-migration assertion behavior).
     expect(
       getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
         includeHiddenElements: true,

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
@@ -224,8 +224,13 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render with new balance
     rerender(<AccountGroupBalance />);
 
-    // Balance should display immediately without waiting for timeout
-    const el = getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT);
+    // Balance should display immediately without waiting for timeout.
+    // The new DSRN Skeleton hides children with `accessibilityElementsHidden`
+    // while loading, so include hidden elements to assert the balance node is
+    // present in the tree (matches pre-migration assertion behavior).
+    const el = getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
+      includeHiddenElements: true,
+    });
     expect(el).toBeOnTheScreen();
   });
 
@@ -284,9 +289,14 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render
     rerender(<AccountGroupBalance />);
 
-    // Should show balance immediately after update (hasChanged condition)
+    // Should show balance immediately after update (hasChanged condition).
+    // The new DSRN Skeleton hides children with `accessibilityElementsHidden`
+    // while loading, so include hidden elements to assert the balance node is
+    // present in the tree (matches pre-migration assertion behavior).
     expect(
-      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT),
+      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
+        includeHiddenElements: true,
+      }),
     ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
@@ -224,6 +224,7 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render with new balance
     rerender(<AccountGroupBalance />);
 
+    // Balance should display immediately without waiting for timeout
     const el = getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
       includeHiddenElements: true,
     });
@@ -285,6 +286,7 @@ describe('AccountGroupBalance', () => {
     // Trigger re-render
     rerender(<AccountGroupBalance />);
 
+    // Should show balance immediately after update (hasChanged condition)
     expect(
       getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
         includeHiddenElements: true,

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
@@ -24,7 +24,7 @@ import SensitiveText, {
 } from '../../../../../component-library/components/Texts/SensitiveText';
 import { TextVariant } from '../../../../../component-library/components/Texts/Text';
 import { WalletViewSelectorsIDs } from '../../../../Views/Wallet/WalletView.testIds';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import AccountGroupBalanceChange from '../../components/BalanceChange/AccountGroupBalanceChange';
 import BalanceEmptyState from '../../../BalanceEmptyState';

--- a/app/components/UI/TokenDetails/components/TokenDetailsActions.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsActions.test.tsx
@@ -90,7 +90,7 @@ describe('TokenDetailsActions', () => {
       );
 
       const { Skeleton } = jest.requireActual(
-        '../../../../component-library/components/Skeleton',
+        '../../../../component-library/components-temp/Skeleton',
       );
       const skeletons = UNSAFE_queryAllByType(Skeleton);
       expect(skeletons).toHaveLength(4);

--- a/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useStyles } from '../../../../component-library/hooks';
 import MainActionButton from '../../../../component-library/components-temp/MainActionButton';
-import { Skeleton } from '../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../component-library/components-temp/Skeleton';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { TokenOverviewSelectorsIDs } from '../../AssetOverview/TokenOverview.testIds';

--- a/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
@@ -11,7 +11,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import { NetworkBadgeSource } from '../../../../UI/AssetOverview/Balance/Balance';
 import { FlashList } from '@shopify/flash-list';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useAssetFromTheme } from '../../../../../util/theme';
 import emptyStateDefiLight from '../../../../../images/empty-state-defi-light.png';
 import emptyStateDefiDark from '../../../../../images/empty-state-defi-dark.png';

--- a/app/components/Views/Wallet/Wallet.view.test.tsx
+++ b/app/components/Views/Wallet/Wallet.view.test.tsx
@@ -38,7 +38,9 @@ describeForPlatforms('Wallet', () => {
       getByTestId(WalletViewSelectorsIDs.WALLET_CONTAINER),
     ).toBeOnTheScreen();
     expect(
-      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT),
+      getByTestId(WalletViewSelectorsIDs.TOTAL_BALANCE_TEXT, {
+        includeHiddenElements: true,
+      }),
     ).toBeOnTheScreen();
     expect(
       getByTestId(WalletViewSelectorsIDs.WALLET_SEND_BUTTON),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Finished `Skeleton` migration for assets team.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-465

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/4445b49f-2c29-4e46-a967-586c75ee0e47

### **After**

https://github.com/user-attachments/assets/48129bc5-f25c-41d0-8556-56e7b524c0b2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps multiple user-facing screens to a new `Skeleton` implementation, which could subtly change loading/layout behavior and visibility of sensitive/hidden text. Test updates reduce the chance of regressions but runtime UI differences remain possible.
> 
> **Overview**
> Completes the assets-team `Skeleton` migration by switching `AccountGroupBalance`, `TokenDetailsActions`, and `SearchTokenResults` to import `Skeleton` from `component-library/components-temp` instead of the legacy component.
> 
> Updates affected tests to match the new skeleton behavior, including querying `TOTAL_BALANCE_TEXT` with `includeHiddenElements` (and adjusting the token actions skeleton test to `requireActual` from the new path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca80ab63a530c762dae9e7a3678dc55ac3c7b1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->