### PR TITLE
feat: `Skeleton` migration (`predict` team)

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.test.tsx
@@ -43,7 +43,7 @@ jest.mock('../../../../components/PredictAmountDisplay', () => {
 });
 
 jest.mock(
-  '../../../../../../../component-library/components/Skeleton/Skeleton',
+  '../../../../../../../component-library/components-temp/Skeleton/Skeleton',
   () => {
     const { View: RNView } = jest.requireActual('react-native');
     return function MockSkeleton(props: Record<string, unknown>) {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx
@@ -11,7 +11,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useEffect, useRef } from 'react';
 import { Animated } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import Skeleton from '../../../../../../../component-library/components/Skeleton/Skeleton';
+import Skeleton from '../../../../../../../component-library/components-temp/Skeleton/Skeleton';
 import { formatPrice } from '../../../../utils/format';
 import PredictAmountDisplay from '../../../../components/PredictAmountDisplay';
 import type { PredictKeypadHandles } from '../../../../components/PredictKeypad';

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -19,7 +19,7 @@ import { strings } from '../../../../../../../../locales/i18n';
 import KeyValueRow from '../../../../../../../component-library/components-temp/KeyValueRow';
 import { TooltipSizes } from '../../../../../../../component-library/components-temp/KeyValueRow/KeyValueRow.types';
 import { IconName as IconNameLegacy } from '../../../../../../../component-library/components/Icons/Icon';
-import Skeleton from '../../../../../../../component-library/components/Skeleton/Skeleton';
+import Skeleton from '../../../../../../../component-library/components-temp/Skeleton/Skeleton';
 import {
   TextColor as LegacyTextColor,
   TextVariant as LegacyTextVariant,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrate `Skeleton` component (predict team).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-465

## **Manual testing steps**

```gherkin
Feature: skeleton migration

  Scenario: user checks prediction
    Given the user on prediction page

    When user clicks yes for a prediction
    Then skeleton should be visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/82e49081-c108-4588-b972-df29cc8acc48" />

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f41fa30c-1245-4114-9340-b9b9799f6130" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only design-system path updates with no behavior changes; low regression risk beyond loading UI appearance if the temp Skeleton API differs.
> 
> **Overview**
> Updates Predict buy flow UI to import **Skeleton** from `component-library/components-temp/Skeleton` instead of the legacy `components/Skeleton` path.
> 
> **PredictBuyAmountSection** and **PredictFeeSummary** keep the same loading placeholders; only the module path changes. The **PredictBuyAmountSection** test mock is updated to match the new import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d9b1d0ac48cc8c8668da908f479ab3f894a61b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->