### PR TITLE
feat: Skeleton migration (no codeowners)

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewSkeleton.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsViewSkeleton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollView } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { MarketInsightsSelectorsIDs } from '../../MarketInsights.testIds';
 import MarketInsightsViewHeader from './MarketInsightsViewHeader';
 

--- a/app/components/UI/Sites/components/SiteSkeleton/SiteSkeleton.test.tsx
+++ b/app/components/UI/Sites/components/SiteSkeleton/SiteSkeleton.test.tsx
@@ -4,7 +4,7 @@ import SiteSkeleton from './SiteSkeleton';
 
 // Mock Skeleton component
 jest.mock(
-  '../../../../../component-library/components/Skeleton/Skeleton',
+  '../../../../../component-library/components-temp/Skeleton/Skeleton',
   () => {
     const ReactNative = jest.requireActual('react-native');
     const SkeletonMock = ({

--- a/app/components/UI/Sites/components/SiteSkeleton/SiteSkeleton.tsx
+++ b/app/components/UI/Sites/components/SiteSkeleton/SiteSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, type ViewStyle } from 'react-native';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import Skeleton from '../../../../../component-library/components-temp/Skeleton/Skeleton';
 
 const styles = StyleSheet.create({
   container: {

--- a/app/components/UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton.test.tsx
@@ -4,7 +4,7 @@ import TrendingTokensSkeleton from './TrendingTokensSkeleton';
 
 // Mock Skeleton component
 jest.mock(
-  '../../../../../component-library/components/Skeleton/Skeleton',
+  '../../../../../component-library/components-temp/Skeleton/Skeleton',
   () => {
     const ReactNative = jest.requireActual('react-native');
     const SkeletonMock = ({

--- a/app/components/UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet, type ViewStyle } from 'react-native';
-import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import Skeleton from '../../../../../component-library/components-temp/Skeleton/Skeleton';
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated Skeleton component to DSRN usage (no codeowners scope).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-465

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/1667d483-345f-4513-ba2a-ff026fc481ff



### **After**


https://github.com/user-attachments/assets/61f6c95d-530d-4761-a57f-9a017c8928b4



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk import-path migration for UI loading placeholders; main failure mode is missing/incorrect module resolution causing render/test breakage.
> 
> **Overview**
> Updates Market Insights, Sites, and Trending loading UIs to import `Skeleton` from `component-library/components-temp/Skeleton` instead of the previous `component-library/components/Skeleton` path.
> 
> Adjusts the related Jest tests to mock the new `Skeleton` module path so existing skeleton rendering assertions continue to pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b97ec7ed2c34a5abece5a5ae814924191b52e34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->