### PR TITLE
docs: add WebSocket mocking guide for E2E test authors (MMQA-1369)

### DIFF
--- a/.agents/skills/e2e-test/references/mocking.md
+++ b/.agents/skills/e2e-test/references/mocking.md
@@ -127,15 +127,17 @@ Add a mock for every such request to ensure test determinism.
 
 ## Features using WebSockets or complex transport
 
-Some features depend on **WebSockets** or other non-HTTP transport (e.g. Perps/HyperLiquid, real-time data). The HTTP mock server cannot intercept these. The repo uses two patterns:
+Some features depend on **WebSockets** or other non-HTTP transport (e.g. Perps/HyperLiquid, real-time data). The HTTP mock server cannot intercept these. The repo uses three patterns:
 
-1. **Controller-level mocking** — A mixin under `tests/controller-mocking/mock-config/` replaces provider SDK touchpoints so E2E runs with stable, test-controlled data. Example: `perps-controller-mixin.ts` for HyperLiquid. See **`tests/docs/CONTROLLER_MOCKING.md`** for when and how to use it.
-2. **Command queue / test server** — Tests that need to drive the app (e.g. inject state or commands) can use **`CommandQueueServer`** (`tests/framework/fixtures/CommandQueueServer.ts`). Enable it in the fixture with `useCommandQueueServer: true`. Used by Perps specs (e.g. `tests/smoke/perps/perps-add-funds.spec.ts`, `tests/regression/perps/perps-limit-long-fill.spec.ts`). The app consumes the queue in E2E context.
+1. **WebSocket mocking** — A `LocalWebSocketServer` (`tests/websocket/server.ts`) intercepts production WebSocket connections via URL rewriting in the E2E shim. Protocol-specific mocks handle subscribe/unsubscribe and push notifications. See **`tests/docs/WEBSOCKET_MOCKING.md`** for full usage guide and how to add new services. Example: `tests/websocket/account-activity-mocks.ts` for AccountActivity.
+2. **Controller-level mocking** — A mixin under `tests/controller-mocking/mock-config/` replaces provider SDK touchpoints so E2E runs with stable, test-controlled data. Example: `perps-controller-mixin.ts` for HyperLiquid. See **`tests/docs/CONTROLLER_MOCKING.md`** for when and how to use it.
+3. **Command queue / test server** — Tests that need to drive the app (e.g. inject state or commands) can use **`CommandQueueServer`** (`tests/framework/fixtures/CommandQueueServer.ts`). Enable it in the fixture with `useCommandQueueServer: true`. Used by Perps specs (e.g. `tests/smoke/perps/perps-add-funds.spec.ts`, `tests/regression/perps/perps-limit-long-fill.spec.ts`). The app consumes the queue in E2E context.
 
 **When adding support for a new feature that uses WebSockets or similar:**
 
-- Follow the **same pattern** as existing features (controller mixin and/or CommandQueueServer).
-- Implement under `tests/controller-mocking/mock-config/` or extend the command-queue protocol as needed.
+- For WebSocket services: add a service config in `tests/websocket/constants.ts` and a protocol mock. See `tests/docs/WEBSOCKET_MOCKING.md`.
+- For SDK-level mocking: implement under `tests/controller-mocking/mock-config/`.
+- For test-driven commands: extend the command-queue protocol as needed.
 - Add or update **tests/specs** that cover the mock infrastructure and the E2E flow.
 
-Prefer HTTP mocking whenever the feature’s API is plain HTTP; use controller mocking or the command server only when necessary.
+Prefer HTTP mocking whenever the feature’s API is plain HTTP; use WebSocket mocking for WS connections; use controller mocking or the command server only when necessary.

--- a/tests/docs/README.md
+++ b/tests/docs/README.md
@@ -18,6 +18,7 @@
 - **Selectors (`tests/selectors/`)**: Element selectors organized by feature
 - **Fixtures (`tests/framework/fixtures/`)**: Test data and state management
 - **API Mocking (`tests/api-mocking/`)**: Comprehensive API mocking system
+- **WebSocket Mocking (`tests/websocket/`)**: Local WebSocket server for mocking real-time connections ([docs](WEBSOCKET_MOCKING.md))
 
 **Core E2E Framework Classes:**
 

--- a/tests/docs/WEBSOCKET_MOCKING.md
+++ b/tests/docs/WEBSOCKET_MOCKING.md
@@ -1,0 +1,166 @@
+# WebSocket Mocking in E2E Tests
+
+The E2E framework includes a local WebSocket server that intercepts production WebSocket connections during tests. This enables deterministic testing of features that use real-time data streams (e.g., account activity notifications).
+
+## Architecture
+
+```
+App (E2E build)
+  │
+  ├─ shim.js rewrites wss://gateway.api.cx.metamask.io → ws://localhost:<port>
+  │
+  └─ LocalWebSocketServer (tests/websocket/server.ts)
+       │
+       └─ Protocol mock (e.g. account-activity-mocks.ts)
+            └─ Handles subscribe/unsubscribe, sends mock notifications
+```
+
+**Key files:**
+
+| File                                        | Purpose                                                                          |
+| ------------------------------------------- | -------------------------------------------------------------------------------- |
+| `tests/websocket/server.ts`                 | `LocalWebSocketServer` — generic WS server implementing the `Resource` interface |
+| `tests/websocket/constants.ts`              | Service definitions (production URL, fallback port, launch arg key)              |
+| `tests/websocket/account-activity-mocks.ts` | Protocol-specific mock for AccountActivity WS                                    |
+| `tests/framework/fixtures/FixtureHelper.ts` | Creates and manages the WS server per test run                                   |
+
+## How It Works
+
+1. `withFixtures` in `FixtureHelper.ts` creates a `LocalWebSocketServer` instance for every test run
+2. The server is started via `startResourceWithRetry` with automatic port allocation
+3. `setupAccountActivityMocks()` attaches protocol-specific message handlers
+4. The allocated port is passed to the app via launch args (`accountActivityWsPort`)
+5. The app's E2E shim rewrites the production WebSocket URL to `ws://localhost:<port>`
+6. After the test, the server is stopped and connections are cleaned up
+
+## Using the Existing AccountActivity Mock
+
+The AccountActivity WebSocket mock is available in every test automatically. For most tests, you don't need to do anything — the mock server handles subscribe/unsubscribe handshakes in the background.
+
+To explicitly test WebSocket behavior, use the helpers from `account-activity-mocks.ts`:
+
+```typescript
+import {
+  waitForAccountActivitySubscription,
+  getAccountActivitySubscriptionCount,
+  waitForAccountActivityDisconnection,
+  createBalanceUpdateNotification,
+} from '../../websocket/account-activity-mocks';
+```
+
+### Waiting for a subscription
+
+```typescript
+// Set up the waiter BEFORE the action that triggers the connection
+const subscriptionPromise = waitForAccountActivitySubscription();
+await loginToApp();
+const subscriptionId = await subscriptionPromise;
+```
+
+### Checking subscription count
+
+```typescript
+assertEqual(getAccountActivitySubscriptionCount(), 1);
+```
+
+### Waiting for disconnection
+
+```typescript
+await device.sendToHome();
+await waitForAccountActivityDisconnection();
+```
+
+### Sending a mock balance update
+
+```typescript
+const notification = createBalanceUpdateNotification({
+  subscriptionId,
+  channel: 'account-activity.v1',
+  address: '0x1234...',
+  chain: 'eip155:1',
+  updates: [
+    {
+      asset: { fungible: true, type: 'native', unit: 'ETH', decimals: 18 },
+      postBalance: { amount: '1000000000000000000' },
+      transfers: [
+        { from: '0x0...', to: '0x1234...', amount: '500000000000000000' },
+      ],
+    },
+  ],
+});
+
+// Broadcast to all connected clients
+accountActivityWsServer.sendMessage(JSON.stringify(notification));
+```
+
+### Example spec
+
+See `tests/smoke/account-activity/web-socket-connection.spec.ts` for a complete example with three tests covering subscribe-on-login, resubscribe-after-background, and resubscribe-after-lock.
+
+## Adding a New WebSocket Service Mock
+
+To mock a new WebSocket service (e.g., a new real-time data feed):
+
+### 1. Define the service in `tests/websocket/constants.ts`
+
+```typescript
+export const MY_NEW_WS: WebSocketServiceConfig = {
+  url: 'wss://my-service.example.com',
+  fallbackPort: 8090, // pick a unique port
+  launchArgKey: 'myNewWsPort',
+};
+
+// Add it to the services array
+export const WS_SERVICES: WebSocketServiceConfig[] = [
+  ACCOUNT_ACTIVITY_WS,
+  MY_NEW_WS,
+];
+```
+
+### 2. Create a protocol mock in `tests/websocket/`
+
+```typescript
+// tests/websocket/my-service-mocks.ts
+import type LocalWebSocketServer from './server.ts';
+import { WebSocket } from 'ws';
+
+export async function setupMyServiceMocks(
+  server: LocalWebSocketServer,
+): Promise<void> {
+  const wsServer = server.getServer();
+
+  wsServer.on('connection', (socket: WebSocket) => {
+    // Handle incoming messages
+    socket.on('message', (data) => {
+      const raw = data.toString();
+      // Parse and respond based on your protocol
+    });
+
+    // Send initial data on connection
+    socket.send(JSON.stringify({ type: 'connected' }));
+  });
+}
+```
+
+### 3. Register in `FixtureHelper.ts`
+
+Add the server creation, startup, and cleanup alongside the existing `accountActivityWsServer` pattern:
+
+```typescript
+const myNewWsServer = new LocalWebSocketServer('myNewService');
+// ...
+await startResourceWithRetry(ResourceType.MY_NEW_WS, myNewWsServer);
+await setupMyServiceMocks(myNewWsServer);
+```
+
+Pass the port via launch args:
+
+```typescript
+[MY_NEW_WS.launchArgKey]: isAndroid
+  ? `${MY_NEW_WS.fallbackPort}`
+  : `${myNewWsServer.getServerPort()}`,
+```
+
+### 4. Register the port in PortManager
+
+Add the new `ResourceType` and fallback port in `tests/framework/PortManager.ts` so the framework can manage port allocation and Android `adb reverse` forwarding.


### PR DESCRIPTION
## **Description**

Add documentation for the WebSocket mocking infrastructure in the E2E test framework. The framework already supports WebSocket mocking (`tests/websocket/`), but there was no guide for test authors on how to use it or add new service mocks.

Changes:
- New `tests/docs/WEBSOCKET_MOCKING.md` — full guide covering architecture, existing AccountActivity mock API, helper usage examples, and step-by-step instructions for adding new WebSocket service mocks
- Updated `tests/docs/README.md` — added WebSocket mocking to the framework structure section
- Updated `.agents/skills/e2e-test/references/mocking.md` — added WebSocket mocking as the first pattern for non-HTTP transport, with link to the new doc

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1369](https://consensyssoftware.atlassian.net/browse/MMQA-1369)

## **Manual testing steps**

```gherkin
Feature: WebSocket mocking documentation

  Scenario: test author finds WebSocket mocking guide
    Given a developer needs to mock a WebSocket service in E2E tests

    When they navigate to tests/docs/WEBSOCKET_MOCKING.md
    Then they find architecture overview, API reference, code examples, and step-by-step guide for adding new services
```

## **Screenshots/Recordings**

### **Before**

No dedicated WebSocket mocking documentation. Only two passing references in CONTROLLER_MOCKING.md and vague guidance in the agent skill reference.

### **After**

Full guide at `tests/docs/WEBSOCKET_MOCKING.md` covering:
- Architecture diagram (shim URL rewriting → LocalWebSocketServer → protocol mock)
- Key files table
- Existing AccountActivity mock API with code examples
- Step-by-step guide for adding new WebSocket service mocks

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1369]: https://consensyssoftware.atlassian.net/browse/MMQA-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or test framework behavior is modified, so risk is limited to potential confusion from inaccurate guidance.
> 
> **Overview**
> Adds a new `tests/docs/WEBSOCKET_MOCKING.md` guide describing how the E2E `LocalWebSocketServer` intercepts production WebSocket URLs, how to use the existing AccountActivity mock helpers, and how to add/register new WebSocket service mocks.
> 
> Updates E2E author references to include WebSocket mocking as a first-class option for non-HTTP transports, and links it from `tests/docs/README.md` and the agent mocking reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e26b5cf94e63a61082512094bf50d54030e1d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->