### PR TITLE
fix(e2e): rebuild bigint-buffer native addon on iOS runners

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -215,7 +215,7 @@ runs:
       with:
         path: |
           node_modules
-        key: ${{ inputs.cache-prefix }}-yarn-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        key: ${{ inputs.cache-prefix }}-yarn-${{ inputs.platform }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
 
     - name: Install JavaScript dependencies with retry
       id: yarn-install
@@ -228,6 +228,25 @@ runs:
       env:
         NODE_OPTIONS: --max-old-space-size=4096
         YARN_ENABLE_GLOBAL_CACHE: 'true'
+
+    - name: Rebuild native Node.js addons (iOS)
+      if: ${{ inputs.platform == 'ios' }}
+      shell: bash
+      run: |
+        # Yarn caches node_modules verbatim, so when a warm cache is restored
+        # the bigint-buffer install lifecycle script does not re-run. If the
+        # cached build/ artefact is missing or was compiled for a different
+        # Node.js / architecture, require('bindings')('bigint_buffer') fails
+        # silently and bigint-buffer falls back to pure JS — adding measurable
+        # overhead to every chain interaction in the iOS E2E suite.
+        # Explicitly rebuilding here ensures the native addon is always compiled
+        # for the exact runtime present on this runner.
+        echo "Rebuilding bigint-buffer native addon for iOS..."
+        if npm rebuild bigint-buffer 2>&1; then
+          echo "✅ bigint-buffer native addon rebuilt successfully"
+        else
+          echo "⚠️  bigint-buffer native rebuild failed — pure JS fallback will be active"
+        fi
 
     - name: Install Foundry
       shell: bash


### PR DESCRIPTION
The bigint-buffer package compiles a native N-API addon (bigint_buffer.node) during yarn install. When the Yarn node_modules cache is restored on a subsequent run, the install lifecycle script does not re-execute, so the build/ directory may be absent or stale (different Node.js ABI or runner architecture). The require('bindings')('bigint_buffer') call then fails silently, and every chain interaction in the iOS E2E suite falls back to the pure-JS implementation - adding measurable latency per shard.

Fix:
- Add an iOS-only step in setup-e2e-env that explicitly runs npm rebuild bigint-buffer after yarn install, ensuring the native addon is always compiled for the exact runtime present on the runner.
- Include runner.arch in the Yarn cache key so arm64 and x86_64 runners never share native-addon builds.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts caching and adds an iOS-only rebuild step; main risk is longer CI runs or unexpected rebuild failures affecting iOS E2E jobs.
> 
> **Overview**
> Improves iOS E2E runner reliability/performance when `node_modules` is restored from cache by ensuring `bigint-buffer`’s native addon is rebuilt after `yarn install`.
> 
> Updates the Yarn cache key to include `runner.arch`, preventing cross-architecture reuse of cached `node_modules` that can lead to missing/stale native build artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96d71b4718fc2b9d97b5c901b37655999ef3bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->