### PR TITLE
fix: tempo and eip 7702 txs activity remove nonce row cp-7.74.0

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -443,19 +443,19 @@ class TransactionDetails extends PureComponent {
             </View>
           </DetailsModal.Column>
         </DetailsModal.Section>
-        <DetailsModal.Section>
-          <DetailsModal.Column>
-            <DetailsModal.SectionTitle upper>
-              {strings('transactions.nonce')}
-            </DetailsModal.SectionTitle>
-            {!!txParams?.nonce && (
+        {!!txParams?.nonce && (
+          <DetailsModal.Section>
+            <DetailsModal.Column>
+              <DetailsModal.SectionTitle upper>
+                {strings('transactions.nonce')}
+              </DetailsModal.SectionTitle>
               <Text small primary>{`#${parseInt(
                 txParams.nonce.replace(regex.transactionNonce, ''),
                 16,
               )}`}</Text>
-            )}
-          </DetailsModal.Column>
-        </DetailsModal.Section>
+            </DetailsModal.Column>
+          </DetailsModal.Section>
+        )}
         <View
           style={[
             styles.summaryWrapper,

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -151,8 +151,15 @@ const renderComponent = ({
 
 describe('TransactionDetails', () => {
   it('should render correctly', () => {
-    renderComponent({ state: initialState });
+    renderComponent({ state: initialState, txParams: { nonce: '0x1a' } });
     expect(screen.getByText('Nonce')).toBeOnTheScreen();
+    expect(screen.getByText('Total amount')).toBeOnTheScreen();
+    expect(screen.getByText('Date')).toBeOnTheScreen();
+  });
+
+  it('should render correctly without nonce', () => {
+    renderComponent({ state: initialState, txParams: { nonce: undefined } });
+    expect(screen.queryByText('Nonce')).not.toBeOnTheScreen();
     expect(screen.getByText('Total amount')).toBeOnTheScreen();
     expect(screen.getByText('Date')).toBeOnTheScreen();
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove the nonce line from tx activity popin when nonce is missing.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-966?atlOrigin=eyJpIjoiZTNjN2MyZGZiYmNhNDNjYTllNWUxNGFmNmE1YmMwYmMiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

1. You can perform any tx from Mobile on Tempo (as long as you don't use a Hardware Wallet) to generate an activity in the Activity tab. 
2. Click on the successful tx on Activity tab
3. Observe absence of any nonce line (vs. empty "nonce" field before).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b8c61089-8844-415b-ba96-db7c65594024" />


<!-- [screenshots/recordings] -->

### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f34b9e8a-4f29-42d3-a7d0-e62d3d226563" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only conditional rendering change with a small accompanying test update; no changes to transaction processing or network logic.
> 
> **Overview**
> The transaction details modal now **omits the “Nonce” section** entirely when `txParams.nonce` is not provided, instead of rendering an empty row.
> 
> Tests were updated to cover both cases (nonce present vs. missing) to ensure the UI consistently hides/shows the nonce row as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e8b70ff005996226c91b529d5848bdd813f731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->