### PR TITLE
chore(homepage): scaffold Hub Page Discovery Tabs A/B test

### DIFF
--- a/app/components/Views/Homepage/abTestConfig.ts
+++ b/app/components/Views/Homepage/abTestConfig.ts
@@ -2,6 +2,41 @@ import { EVENT_NAME } from '../../../core/Analytics/MetaMetrics.events';
 import type { ABTestAnalyticsMapping } from '../../../util/analytics/abTestAnalytics.types';
 import type { TransactionActiveAbTestEntry } from '../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
+// ─── Hub Page Discovery Tabs ────────────────────────────────────────────────
+
+/**
+ * LaunchDarkly / remote flag key. Pattern: `{team}{TICKET}Abtest{Name}` — keep in
+ * sync with the flag in LD (team `core`, ticket MCU-589).
+ */
+export const HUB_PAGE_DISCOVERY_TABS_AB_KEY =
+  'coreMCU589AbtestHubPageDiscoveryTabs';
+
+export enum HubPageDiscoveryTabsVariant {
+  Control = 'control',
+  Treatment = 'treatment',
+}
+
+interface HubPageDiscoveryTabsVariantConfig {
+  discoveryTabsEnabled: boolean;
+}
+
+export const HUB_PAGE_DISCOVERY_TABS_VARIANTS: Record<
+  HubPageDiscoveryTabsVariant,
+  HubPageDiscoveryTabsVariantConfig
+> = {
+  [HubPageDiscoveryTabsVariant.Control]: { discoveryTabsEnabled: false },
+  [HubPageDiscoveryTabsVariant.Treatment]: { discoveryTabsEnabled: true },
+};
+
+export const HUB_PAGE_DISCOVERY_TABS_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping =
+  {
+    flagKey: HUB_PAGE_DISCOVERY_TABS_AB_KEY,
+    validVariants: Object.values(HubPageDiscoveryTabsVariant),
+    eventNames: [EVENT_NAME.HOME_VIEWED],
+  };
+
+// ─── Trending Sections ───────────────────────────────────────────────────────
+
 /**
  * LaunchDarkly / remote flag key. Pattern: `{team}{TICKET}Abtest{Name}` — keep in
  * sync with the flag in LD (team `home`, ticket TMCU-470).

--- a/app/selectors/featureFlagController/homepage/index.test.ts
+++ b/app/selectors/featureFlagController/homepage/index.test.ts
@@ -1,4 +1,7 @@
-import { selectHomepageSectionsV1Enabled } from '.';
+import {
+  selectHomepageSectionsV1Enabled,
+  selectHubPageDiscoveryTabsABTest,
+} from '.';
 // eslint-disable-next-line import-x/no-namespace
 import * as remoteFeatureFlagModule from '../../../util/remoteFeatureFlag';
 
@@ -67,6 +70,41 @@ describe('Homepage Feature Flag Selectors', () => {
     it('returns false when remote feature flags are empty', () => {
       const result = selectHomepageSectionsV1Enabled.resultFunc({});
       expect(result).toBe(false);
+    });
+  });
+
+  describe('selectHubPageDiscoveryTabsABTest', () => {
+    it('returns treatment assignment when flag is set to treatment string', () => {
+      const result = selectHubPageDiscoveryTabsABTest.resultFunc({
+        coreMCU589AbtestHubPageDiscoveryTabs: 'treatment',
+      });
+      expect(result).toEqual({ variantName: 'treatment', isActive: true });
+    });
+
+    it('returns control assignment when flag is set to control string', () => {
+      const result = selectHubPageDiscoveryTabsABTest.resultFunc({
+        coreMCU589AbtestHubPageDiscoveryTabs: 'control',
+      });
+      expect(result).toEqual({ variantName: 'control', isActive: true });
+    });
+
+    it('resolves controller object format ({ name }) for treatment', () => {
+      const result = selectHubPageDiscoveryTabsABTest.resultFunc({
+        coreMCU589AbtestHubPageDiscoveryTabs: { name: 'treatment' },
+      });
+      expect(result).toEqual({ variantName: 'treatment', isActive: true });
+    });
+
+    it('falls back to control and isActive false when flag is missing', () => {
+      const result = selectHubPageDiscoveryTabsABTest.resultFunc({});
+      expect(result).toEqual({ variantName: 'control', isActive: false });
+    });
+
+    it('falls back to control and isActive false when flag value is invalid', () => {
+      const result = selectHubPageDiscoveryTabsABTest.resultFunc({
+        coreMCU589AbtestHubPageDiscoveryTabs: 'unknown_variant',
+      });
+      expect(result).toEqual({ variantName: 'control', isActive: false });
     });
   });
 });

--- a/app/selectors/featureFlagController/homepage/index.ts
+++ b/app/selectors/featureFlagController/homepage/index.ts
@@ -4,6 +4,11 @@ import {
   validatedVersionGatedFeatureFlag,
   VersionGatedFeatureFlag,
 } from '../../../util/remoteFeatureFlag';
+import { resolveABTestAssignment } from '../../../util/abTest';
+import {
+  HUB_PAGE_DISCOVERY_TABS_AB_KEY,
+  HUB_PAGE_DISCOVERY_TABS_VARIANTS,
+} from '../../../components/Views/Homepage/abTestConfig';
 
 const homepageSectionsV1Key = 'homepageSectionsV1';
 
@@ -15,4 +20,14 @@ export const selectHomepageSectionsV1Enabled = createSelector(
     ] as unknown as VersionGatedFeatureFlag;
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
+);
+
+export const selectHubPageDiscoveryTabsABTest = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    resolveABTestAssignment(
+      remoteFeatureFlags,
+      HUB_PAGE_DISCOVERY_TABS_AB_KEY,
+      Object.keys(HUB_PAGE_DISCOVERY_TABS_VARIANTS),
+    ),
 );

--- a/app/util/analytics/abTestAnalyticsRegistry.ts
+++ b/app/util/analytics/abTestAnalyticsRegistry.ts
@@ -2,7 +2,10 @@ import type { ABTestAnalyticsMapping } from './abTestAnalytics.types';
 import { CARD_BUTTON_BADGE_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/Card/components/CardButton/abTestConfig';
 import { NUMPAD_QUICK_ACTIONS_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/Bridge/components/GaslessQuickPickOptions/abTestConfig';
 import { TOKEN_SELECTOR_BALANCE_LAYOUT_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/Bridge/components/TokenSelectorItem.abTestConfig';
-import { HOMEPAGE_TRENDING_SECTIONS_AB_TEST_ANALYTICS_MAPPING } from '../../components/Views/Homepage/abTestConfig';
+import {
+  HOMEPAGE_TRENDING_SECTIONS_AB_TEST_ANALYTICS_MAPPING,
+  HUB_PAGE_DISCOVERY_TABS_AB_TEST_ANALYTICS_MAPPING,
+} from '../../components/Views/Homepage/abTestConfig';
 import { STICKY_FOOTER_SWAP_LABEL_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/TokenDetails/components/abTestConfig';
 
 export const AB_TEST_ANALYTICS_MAPPINGS: readonly ABTestAnalyticsMapping[] = [
@@ -15,6 +18,8 @@ export const AB_TEST_ANALYTICS_MAPPINGS: readonly ABTestAnalyticsMapping[] = [
 
   // Homepage
   HOMEPAGE_TRENDING_SECTIONS_AB_TEST_ANALYTICS_MAPPING,
+  HUB_PAGE_DISCOVERY_TABS_AB_TEST_ANALYTICS_MAPPING,
+
   // Token Details
   STICKY_FOOTER_SWAP_LABEL_AB_TEST_ANALYTICS_MAPPING,
 ];

--- a/app/util/analytics/enrichWithABTests.test.ts
+++ b/app/util/analytics/enrichWithABTests.test.ts
@@ -120,6 +120,19 @@ describe('enrichWithABTests', () => {
     });
   });
 
+  it('enriches Home Viewed events with hub page discovery tabs assignment', () => {
+    const event =
+      AnalyticsEventBuilder.createEventBuilder('Home Viewed').build();
+
+    const result = enrichWithABTests(event, {
+      coreMCU589AbtestHubPageDiscoveryTabs: 'treatment',
+    });
+
+    expect(result.properties.active_ab_tests).toEqual([
+      { key: 'coreMCU589AbtestHubPageDiscoveryTabs', value: 'treatment' },
+    ]);
+  });
+
   it('leaves non-A/B properties and sensitive properties unchanged', () => {
     const event = AnalyticsEventBuilder.createEventBuilder('Card Button Viewed')
       .addProperties({


### PR DESCRIPTION
## **Description**

Scaffolds the LaunchDarkly A/B test for the Hub Page Navigational Discovery
Tabs experiment ([MCU-589](https://consensyssoftware.atlassian.net/browse/TMCU-590)). This PR wires up the flag config, Redux selector,
and analytics enrichment; **no UI behaviour is changed yet**

Changes:
- Added `HUB_PAGE_DISCOVERY_TABS_AB_KEY`, `HubPageDiscoveryTabsVariant` enum,
  `HUB_PAGE_DISCOVERY_TABS_VARIANTS`, and analytics mapping to
  `app/components/Views/Homepage/abTestConfig.ts`
- Added `selectHubPageDiscoveryTabsABTest` selector to
  `app/selectors/featureFlagController/homepage/index.ts` — resolves
  `{ variantName, isActive }` from remote feature flags via
  `resolveABTestAssignment`
- Registered `HUB_PAGE_DISCOVERY_TABS_AB_TEST_ANALYTICS_MAPPING` in
  `app/util/analytics/abTestAnalyticsRegistry.ts` so `Home Viewed` events
  are auto-enriched with `active_ab_tests` when the flag is active

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-590

## **Manual testing steps**

```gherkin
Feature: Hub Page Discovery Tabs A/B test flag

  Scenario: user opens the homepage with the flag active
    Given the LaunchDarkly flag coreMCU589AbtestHubPageDiscoveryTabs is enabled
      And the user is assigned to the treatment variant

    When user navigates to the Homepage
    Then the Home Viewed analytics event includes
      active_ab_tests: [{ key: 'coreMCU589AbtestHubPageDiscoveryTabs', value: 'treatment' }]

  Scenario: user opens the homepage with the flag inactive
    Given the LaunchDarkly flag coreMCU589AbtestHubPageDiscoveryTabs is off

    When user navigates to the Homepage
    Then the Home Viewed analytics event has no active_ab_tests entry
      for coreMCU589AbtestHubPageDiscoveryTabs
```

## **Screenshots/Recordings**

Feature flag logging correctly based on Launch Darkly configurations

<img width="750"  alt="Screenshot 2026-04-20 at 1 31 57 PM" src="https://github.com/user-attachments/assets/9755d531-a74f-412e-827f-3fc5572b73c9" />


### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new A/B test constants/selector/analytics registration without changing UI behavior or core data flows; main risk is misconfigured flag/variant names affecting analytics enrichment.
> 
> **Overview**
> Adds scaffolding for the `coreMCU589AbtestHubPageDiscoveryTabs` LaunchDarkly A/B test, including variant definitions (`control`/`treatment`) and a config mapping indicating whether discovery tabs are enabled.
> 
> Wires the experiment into state and analytics: introduces `selectHubPageDiscoveryTabsABTest` (via `resolveABTestAssignment`) and registers the test in `AB_TEST_ANALYTICS_MAPPINGS` so `Home Viewed` events are enriched with the experiment’s `active_ab_tests` entry when the assignment is active, with new unit tests covering selector resolution and analytics enrichment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d37144458b3826f13667d052c3b313114d4ef72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->