### PR TITLE
feat: show suspcious and malicious labels on swaps asset picker

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -509,7 +509,7 @@ describe('TokenSelectorItem', () => {
           <TokenSelectorItem token={token} onPress={mockOnPress} />,
         );
 
-        expect(getByText('bridge.token_suspicious')).toBeTruthy();
+        expect(getByText('bridge.token_suspicious')).toBeOnTheScreen();
       },
     );
 
@@ -522,7 +522,7 @@ describe('TokenSelectorItem', () => {
         <TokenSelectorItem token={token} onPress={mockOnPress} />,
       );
 
-      expect(getByText('bridge.token_malicious')).toBeTruthy();
+      expect(getByText('bridge.token_malicious')).toBeOnTheScreen();
     });
 
     it.each([

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Text as RNText } from 'react-native';
-import { TokenSelectorItem } from './TokenSelectorItem';
+import { TokenSelectorItem, getSecurityTag } from './TokenSelectorItem';
 import { ethers } from 'ethers';
 import { useABTest } from '../../../../hooks';
 import { createMockTokenWithBalance } from '../testUtils/fixtures';
@@ -89,9 +89,17 @@ jest.mock('@metamask/design-system-react-native', () => {
     default: Icon,
     Icon,
     __mockIcon: Icon,
-    IconColor: { InfoDefault: 'InfoDefault' },
-    IconName: { VerifiedFilled: 'VerifiedFilled' },
-    IconSize: { Sm: 'Sm' },
+    IconColor: {
+      InfoDefault: 'InfoDefault',
+      WarningDefault: 'WarningDefault',
+      ErrorDefault: 'ErrorDefault',
+    },
+    IconName: {
+      VerifiedFilled: 'VerifiedFilled',
+      Warning: 'Warning',
+      Danger: 'Danger',
+    },
+    IconSize: { Sm: 'Sm', Xs: 'Xs' },
   };
 });
 
@@ -103,13 +111,26 @@ const { __mockIcon: mockDSIcon } = jest.requireMock(
 
 jest.mock('../../../../component-library/base-components/TagBase', () => {
   const { createElement } = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
+  const { Text, View } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ children }: { children: React.ReactNode }) =>
-      createElement(Text, null, children),
-    TagShape: { Rectangle: 'Rectangle' },
-    TagSeverity: { Info: 'Info' },
+    default: ({
+      children,
+      startAccessory,
+    }: {
+      children: React.ReactNode;
+      startAccessory?: React.ReactNode;
+    }) =>
+      createElement(
+        View,
+        null,
+        startAccessory,
+        typeof children === 'string'
+          ? createElement(Text, null, children)
+          : children,
+      ),
+    TagShape: { Rectangle: 'Rectangle', Pill: 'Pill' },
+    TagSeverity: { Info: 'Info', Warning: 'Warning', Danger: 'Danger' },
   };
 });
 
@@ -475,6 +496,96 @@ describe('TokenSelectorItem', () => {
     });
   });
 
+  describe('security badges', () => {
+    it.each(['Warning', 'Spam'] as const)(
+      'shows Suspicious badge for %s type',
+      (securityType) => {
+        const token = createMockTokenWithBalance({
+          securityData: { type: securityType },
+        });
+
+        const { getByText } = render(
+          <TokenSelectorItem token={token} onPress={mockOnPress} />,
+        );
+
+        expect(getByText('bridge.token_suspicious')).toBeTruthy();
+      },
+    );
+
+    it('shows Malicious badge for Malicious type', () => {
+      const token = createMockTokenWithBalance({
+        securityData: { type: 'Malicious' },
+      });
+
+      const { getByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      expect(getByText('bridge.token_malicious')).toBeTruthy();
+    });
+
+    it.each(['Info', 'Benign', 'Verified'] as const)(
+      'does not show a security badge for %s type',
+      (securityType) => {
+        const token = createMockTokenWithBalance({
+          securityData: { type: securityType },
+        });
+
+        const { queryByText } = render(
+          <TokenSelectorItem token={token} onPress={mockOnPress} />,
+        );
+
+        expect(queryByText('bridge.token_suspicious')).toBeNull();
+        expect(queryByText('bridge.token_malicious')).toBeNull();
+      },
+    );
+
+    it('does not show a security badge when securityData is absent', () => {
+      const token = createMockTokenWithBalance({ securityData: undefined });
+
+      const { queryByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
+
+      expect(queryByText('bridge.token_suspicious')).toBeNull();
+      expect(queryByText('bridge.token_malicious')).toBeNull();
+    });
+
+    it('renders Warning icon with WarningDefault color for Suspicious badge', () => {
+      const token = createMockTokenWithBalance({
+        securityData: { type: 'Warning' },
+      });
+
+      render(<TokenSelectorItem token={token} onPress={mockOnPress} />);
+
+      expect(mockDSIcon).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Danger',
+          color: 'WarningDefault',
+          size: 'Sm',
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('renders Danger icon with ErrorDefault color for Malicious badge', () => {
+      const token = createMockTokenWithBalance({
+        securityData: { type: 'Malicious' },
+      });
+
+      render(<TokenSelectorItem token={token} onPress={mockOnPress} />);
+
+      expect(mockDSIcon).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Warning',
+          color: 'ErrorDefault',
+          size: 'Sm',
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
   describe('A/B variants', () => {
     it('keeps fiat above token balance in the control layout', () => {
       const token = createMockTokenWithBalance({
@@ -525,5 +636,45 @@ describe('TokenSelectorItem', () => {
         treatmentTextOrder.indexOf('$500'),
       );
     });
+  });
+});
+
+describe('getSecurityTag', () => {
+  it.each(['Warning', 'Spam'] as const)(
+    'returns Warning severity config for %s type',
+    (securityType) => {
+      const result = getSecurityTag(securityType);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          severity: 'Warning',
+          iconName: 'Danger',
+          iconColor: 'WarningDefault',
+        }),
+      );
+    },
+  );
+
+  it('returns Danger severity config for Malicious type', () => {
+    const result = getSecurityTag('Malicious');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        severity: 'Danger',
+        iconName: 'Warning',
+        iconColor: 'ErrorDefault',
+      }),
+    );
+  });
+
+  it.each(['Info', 'Benign', 'Verified'] as const)(
+    'returns null for %s type',
+    (securityType) => {
+      expect(getSecurityTag(securityType)).toBeNull();
+    },
+  );
+
+  it('returns null when securityType is undefined', () => {
+    expect(getSecurityTag(undefined)).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Text as RNText } from 'react-native';
 import { TokenSelectorItem, getSecurityTag } from './TokenSelectorItem';
+import { SecurityDataType } from '../hooks/usePopularTokens';
 import { ethers } from 'ethers';
 import { useABTest } from '../../../../hooks';
 import { createMockTokenWithBalance } from '../testUtils/fixtures';
@@ -497,7 +498,7 @@ describe('TokenSelectorItem', () => {
   });
 
   describe('security badges', () => {
-    it.each(['Warning', 'Spam'] as const)(
+    it.each([SecurityDataType.Warning, SecurityDataType.Spam])(
       'shows Suspicious badge for %s type',
       (securityType) => {
         const token = createMockTokenWithBalance({
@@ -514,7 +515,7 @@ describe('TokenSelectorItem', () => {
 
     it('shows Malicious badge for Malicious type', () => {
       const token = createMockTokenWithBalance({
-        securityData: { type: 'Malicious' },
+        securityData: { type: SecurityDataType.Malicious },
       });
 
       const { getByText } = render(
@@ -524,21 +525,22 @@ describe('TokenSelectorItem', () => {
       expect(getByText('bridge.token_malicious')).toBeTruthy();
     });
 
-    it.each(['Info', 'Benign', 'Verified'] as const)(
-      'does not show a security badge for %s type',
-      (securityType) => {
-        const token = createMockTokenWithBalance({
-          securityData: { type: securityType },
-        });
+    it.each([
+      SecurityDataType.Info,
+      SecurityDataType.Benign,
+      SecurityDataType.Verified,
+    ])('does not show a security badge for %s type', (securityType) => {
+      const token = createMockTokenWithBalance({
+        securityData: { type: securityType },
+      });
 
-        const { queryByText } = render(
-          <TokenSelectorItem token={token} onPress={mockOnPress} />,
-        );
+      const { queryByText } = render(
+        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+      );
 
-        expect(queryByText('bridge.token_suspicious')).toBeNull();
-        expect(queryByText('bridge.token_malicious')).toBeNull();
-      },
-    );
+      expect(queryByText('bridge.token_suspicious')).toBeNull();
+      expect(queryByText('bridge.token_malicious')).toBeNull();
+    });
 
     it('does not show a security badge when securityData is absent', () => {
       const token = createMockTokenWithBalance({ securityData: undefined });
@@ -553,7 +555,7 @@ describe('TokenSelectorItem', () => {
 
     it('renders Warning icon with WarningDefault color for Suspicious badge', () => {
       const token = createMockTokenWithBalance({
-        securityData: { type: 'Warning' },
+        securityData: { type: SecurityDataType.Warning },
       });
 
       render(<TokenSelectorItem token={token} onPress={mockOnPress} />);
@@ -570,7 +572,7 @@ describe('TokenSelectorItem', () => {
 
     it('renders Danger icon with ErrorDefault color for Malicious badge', () => {
       const token = createMockTokenWithBalance({
-        securityData: { type: 'Malicious' },
+        securityData: { type: SecurityDataType.Malicious },
       });
 
       render(<TokenSelectorItem token={token} onPress={mockOnPress} />);
@@ -640,7 +642,7 @@ describe('TokenSelectorItem', () => {
 });
 
 describe('getSecurityTag', () => {
-  it.each(['Warning', 'Spam'] as const)(
+  it.each([SecurityDataType.Warning, SecurityDataType.Spam])(
     'returns Warning severity config for %s type',
     (securityType) => {
       const result = getSecurityTag(securityType);
@@ -656,7 +658,7 @@ describe('getSecurityTag', () => {
   );
 
   it('returns Danger severity config for Malicious type', () => {
-    const result = getSecurityTag('Malicious');
+    const result = getSecurityTag(SecurityDataType.Malicious);
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -667,12 +669,13 @@ describe('getSecurityTag', () => {
     );
   });
 
-  it.each(['Info', 'Benign', 'Verified'] as const)(
-    'returns null for %s type',
-    (securityType) => {
-      expect(getSecurityTag(securityType)).toBeNull();
-    },
-  );
+  it.each([
+    SecurityDataType.Info,
+    SecurityDataType.Benign,
+    SecurityDataType.Verified,
+  ])('returns null for %s type', (securityType) => {
+    expect(getSecurityTag(securityType)).toBeNull();
+  });
 
   it('returns null when securityType is undefined', () => {
     expect(getSecurityTag(undefined)).toBeNull();

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -307,6 +307,24 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     ? ACCOUNT_TYPE_LABELS[token.accountType]
     : undefined;
 
+  const securityType = token.securityData?.type;
+  const securityTag =
+    securityType === 'Warning' || securityType === 'Spam'
+      ? {
+          severity: TagSeverity.Warning,
+          label: strings('bridge.token_suspicious'),
+          iconName: IconName.Danger,
+          iconColor: IconColor.WarningDefault,
+        }
+      : securityType === 'Malicious'
+        ? {
+            severity: TagSeverity.Danger,
+            label: strings('bridge.token_malicious'),
+            iconName: IconName.Warning,
+            iconColor: IconColor.ErrorDefault,
+          }
+        : null;
+
   return (
     <Box
       flexDirection={FlexDirection.Row}
@@ -384,6 +402,23 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                     />
                   )}
                 </Box>
+                {securityTag && (
+                  <TagBase
+                    shape={TagShape.Pill}
+                    severity={securityTag.severity}
+                    startAccessory={
+                      <Icon
+                        name={securityTag.iconName}
+                        size={IconSize.Sm}
+                        color={securityTag.iconColor}
+                      />
+                    }
+                    textProps={{ variant: TextVariant.BodySM }}
+                    style={styles.noFeeBadge}
+                  >
+                    {securityTag.label}
+                  </TagBase>
+                )}
                 {label && <Tag label={label} />}
                 {showNoFeeBadge && (
                   <TagBase

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -169,6 +169,28 @@ const isLoadingBalance = (balance?: string) =>
   balance === TOKEN_BALANCE_LOADING ||
   balance === TOKEN_BALANCE_LOADING_UPPERCASE;
 
+export const getSecurityTag = (
+  securityType: NonNullable<BridgeToken['securityData']>['type'] | undefined,
+) => {
+  if (securityType === 'Warning' || securityType === 'Spam') {
+    return {
+      severity: TagSeverity.Warning,
+      label: strings('bridge.token_suspicious'),
+      iconName: IconName.Danger,
+      iconColor: IconColor.WarningDefault,
+    };
+  }
+  if (securityType === 'Malicious') {
+    return {
+      severity: TagSeverity.Danger,
+      label: strings('bridge.token_malicious'),
+      iconName: IconName.Warning,
+      iconColor: IconColor.ErrorDefault,
+    };
+  }
+  return null;
+};
+
 const FiatBalanceView = ({
   balance,
   isSelected,
@@ -307,23 +329,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     ? ACCOUNT_TYPE_LABELS[token.accountType]
     : undefined;
 
-  const securityType = token.securityData?.type;
-  const securityTag =
-    securityType === 'Warning' || securityType === 'Spam'
-      ? {
-          severity: TagSeverity.Warning,
-          label: strings('bridge.token_suspicious'),
-          iconName: IconName.Danger,
-          iconColor: IconColor.WarningDefault,
-        }
-      : securityType === 'Malicious'
-        ? {
-            severity: TagSeverity.Danger,
-            label: strings('bridge.token_malicious'),
-            iconName: IconName.Warning,
-            iconColor: IconColor.ErrorDefault,
-          }
-        : null;
+  const securityTag = getSecurityTag(token.securityData?.type);
 
   return (
     <Box

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -409,24 +409,24 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
                       style={styles.verifiedIcon}
                     />
                   )}
+                  {securityTag && (
+                    <TagBase
+                      shape={TagShape.Pill}
+                      severity={securityTag.severity}
+                      startAccessory={
+                        <Icon
+                          name={securityTag.iconName}
+                          size={IconSize.Sm}
+                          color={securityTag.iconColor}
+                        />
+                      }
+                      textProps={{ variant: TextVariant.BodySM }}
+                      style={styles.verifiedIcon}
+                    >
+                      {securityTag.label}
+                    </TagBase>
+                  )}
                 </Box>
-                {securityTag && (
-                  <TagBase
-                    shape={TagShape.Pill}
-                    severity={securityTag.severity}
-                    startAccessory={
-                      <Icon
-                        name={securityTag.iconName}
-                        size={IconSize.Sm}
-                        color={securityTag.iconColor}
-                      />
-                    }
-                    textProps={{ variant: TextVariant.BodySM }}
-                    style={styles.noFeeBadge}
-                  >
-                    {securityTag.label}
-                  </TagBase>
-                )}
                 {label && <Tag label={label} />}
                 {showNoFeeBadge && (
                   <TagBase

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -35,6 +35,7 @@ import StockBadge from '../../shared/StockBadge';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';
 import { BridgeToken } from '../types';
+import { SecurityDataType } from '../hooks/usePopularTokens';
 import { RootState } from '../../../../reducers';
 import { fontStyles } from '../../../../styles/common';
 import {
@@ -169,10 +170,11 @@ const isLoadingBalance = (balance?: string) =>
   balance === TOKEN_BALANCE_LOADING ||
   balance === TOKEN_BALANCE_LOADING_UPPERCASE;
 
-export const getSecurityTag = (
-  securityType: NonNullable<BridgeToken['securityData']>['type'] | undefined,
-) => {
-  if (securityType === 'Warning' || securityType === 'Spam') {
+export const getSecurityTag = (securityType: SecurityDataType | undefined) => {
+  if (
+    securityType === SecurityDataType.Warning ||
+    securityType === SecurityDataType.Spam
+  ) {
     return {
       severity: TagSeverity.Warning,
       label: strings('bridge.token_suspicious'),
@@ -180,7 +182,7 @@ export const getSecurityTag = (
       iconColor: IconColor.WarningDefault,
     };
   }
-  if (securityType === 'Malicious') {
+  if (securityType === SecurityDataType.Malicious) {
     return {
       severity: TagSeverity.Danger,
       label: strings('bridge.token_malicious'),

--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -109,6 +109,41 @@ describe('usePopularTokens', () => {
       );
     });
 
+    it('preserves securityData in the response', async () => {
+      const tokenWithSecurity = createMockPopularToken({
+        symbol: 'SAFE',
+        securityData: {
+          type: 'Warning',
+          metadata: {
+            features: [
+              {
+                featureId: 'HONEYPOT',
+                type: 'Warning',
+                description: 'Honeypot risk',
+              },
+            ],
+          },
+        },
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: async () => [tokenWithSecurity],
+      });
+
+      const { result } = renderHook(() =>
+        usePopularTokens({
+          chainIds: [MOCK_CHAIN_IDS.ethereum],
+          includeAssets: '[]',
+        }),
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.popularTokens[0].securityData).toEqual(
+        tokenWithSecurity.securityData,
+      );
+    });
+
     it('falls back to an empty array for malformed responses', async () => {
       mockedEngine.context.AuthenticationController.getBearerToken.mockReturnValue(
         new Promise(() => undefined),

--- a/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.test.ts
@@ -1,5 +1,9 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
-import { usePopularTokens, clearPopularTokensCache } from './usePopularTokens';
+import {
+  usePopularTokens,
+  clearPopularTokensCache,
+  SecurityDataType,
+} from './usePopularTokens';
 import {
   createMockPopularToken,
   createMockIncludeAsset,
@@ -113,12 +117,12 @@ describe('usePopularTokens', () => {
       const tokenWithSecurity = createMockPopularToken({
         symbol: 'SAFE',
         securityData: {
-          type: 'Warning',
+          type: SecurityDataType.Warning,
           metadata: {
             features: [
               {
                 featureId: 'HONEYPOT',
-                type: 'Warning',
+                type: SecurityDataType.Warning,
                 description: 'Honeypot risk',
               },
             ],

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -6,19 +6,20 @@ import { TokenRwaData } from '@metamask/assets-controllers';
 import Engine from '../../../../core/Engine';
 import { getBaseSemVerVersion } from '../../../../util/version';
 
-export interface SecurityFeature {
-  featureId: string;
-  type: 'Warning' | 'Spam';
-  description: string;
+export enum SecurityDataType {
+  Info = 'Info',
+  Benign = 'Benign',
+  Verified = 'Verified',
+  Warning = 'Warning',
+  Spam = 'Spam',
+  Malicious = 'Malicious',
 }
 
-export type SecurityDataType =
-  | 'Info'
-  | 'Benign'
-  | 'Verified'
-  | 'Warning'
-  | 'Spam'
-  | 'Malicious';
+export interface SecurityFeature {
+  featureId: string;
+  type: SecurityDataType;
+  description: string;
+}
 
 export interface SecurityData {
   type: SecurityDataType;

--- a/app/components/UI/Bridge/hooks/usePopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/usePopularTokens.ts
@@ -6,6 +6,25 @@ import { TokenRwaData } from '@metamask/assets-controllers';
 import Engine from '../../../../core/Engine';
 import { getBaseSemVerVersion } from '../../../../util/version';
 
+export interface SecurityFeature {
+  featureId: string;
+  type: 'Warning' | 'Spam';
+  description: string;
+}
+
+export type SecurityDataType =
+  | 'Info'
+  | 'Benign'
+  | 'Verified'
+  | 'Warning'
+  | 'Spam'
+  | 'Malicious';
+
+export interface SecurityData {
+  type: SecurityDataType;
+  metadata?: { features: SecurityFeature[] };
+}
+
 export interface PopularToken {
   assetId: CaipAssetType;
   decimals: number;
@@ -17,6 +36,7 @@ export interface PopularToken {
     isSource: boolean;
     isDestination: boolean;
   };
+  securityData?: SecurityData;
 }
 
 export interface IncludeAsset {

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -14,6 +14,7 @@ import {
   calcTokenFiatValue,
   calcUsdAmountFromFiat,
 } from '../../utils/exchange-rates';
+import { getSecurityWarnings } from '../../utils/tokenUtils';
 
 export const useUnifiedSwapBridgeContext = () => {
   const smartTransactionsEnabled = useSelector(selectShouldUseSmartTransaction);
@@ -61,7 +62,7 @@ export const useUnifiedSwapBridgeContext = () => {
       stx_enabled: smartTransactionsEnabled,
       token_symbol_source: fromToken?.symbol ?? '',
       token_symbol_destination: toToken?.symbol ?? '',
-      security_warnings: [], // TODO
+      security_warnings: getSecurityWarnings(toToken),
       warnings: [], // TODO
       usd_amount_source: usdAmountSource,
     }),

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -103,6 +103,77 @@ describe('useUnifiedSwapBridgeContext', () => {
     });
   });
 
+  it('collects security_warnings from destination token features', () => {
+    mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+    mockSelectSourceToken.mockReturnValue({ symbol: 'ETH' });
+    mockSelectDestToken.mockReturnValue({
+      symbol: 'SHADY',
+      securityData: {
+        type: 'Warning',
+        metadata: {
+          features: [
+            {
+              featureId: 'HONEYPOT',
+              type: 'Warning',
+              description: 'Honeypot risk detected',
+            },
+            {
+              featureId: 'CONCENTRATED_SUPPLY',
+              type: 'Warning',
+              description: 'Concentrated supply risk',
+            },
+          ],
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useUnifiedSwapBridgeContext(),
+      { state: initialRootState },
+    );
+
+    expect(result.current.security_warnings).toEqual([
+      'Honeypot risk detected',
+      'Concentrated supply risk',
+    ]);
+  });
+
+  it('returns empty security_warnings when source token has warnings but destination does not', () => {
+    mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+    mockSelectSourceToken.mockReturnValue({
+      symbol: 'SCAM',
+      securityData: {
+        type: 'Malicious',
+        metadata: {
+          features: [
+            { featureId: 'F1', type: 'Warning', description: 'Source warning' },
+          ],
+        },
+      },
+    });
+    mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
+
+    const { result } = renderHookWithProvider(
+      () => useUnifiedSwapBridgeContext(),
+      { state: initialRootState },
+    );
+
+    expect(result.current.security_warnings).toEqual([]);
+  });
+
+  it('returns empty security_warnings when destination token has no securityData', () => {
+    mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+    mockSelectSourceToken.mockReturnValue({ symbol: 'ETH' });
+    mockSelectDestToken.mockReturnValue({ symbol: 'USDC' });
+
+    const { result } = renderHookWithProvider(
+      () => useUnifiedSwapBridgeContext(),
+      { state: initialRootState },
+    );
+
+    expect(result.current.security_warnings).toEqual([]);
+  });
+
   it('returns empty token symbols when tokens are undefined', () => {
     mockSelectShouldUseSmartTransaction.mockReturnValue(false);
     mockSelectSourceToken.mockReturnValue(undefined);

--- a/app/components/UI/Bridge/types.ts
+++ b/app/components/UI/Bridge/types.ts
@@ -1,5 +1,6 @@
 import { Asset, TokenRwaData } from '@metamask/assets-controllers';
 import { Hex, CaipChainId } from '@metamask/utils';
+import { SecurityData } from './hooks/usePopularTokens';
 
 // This is slightly different from the BridgeToken type in @metamask/bridge-controller
 export interface BridgeToken {
@@ -25,6 +26,7 @@ export interface BridgeToken {
   aggregators?: string[];
   metadata?: Record<string, unknown>;
   rwaData?: TokenRwaData;
+  securityData?: SecurityData;
 }
 
 export enum BridgeViewMode {

--- a/app/components/UI/Bridge/utils/tokenUtils.test.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.test.ts
@@ -3,6 +3,7 @@ import {
   getNativeSourceToken,
   getDefaultDestToken,
   tokenMatchesQuery,
+  getSecurityWarnings,
 } from './tokenUtils';
 import { BridgeToken } from '../types';
 import {
@@ -11,6 +12,8 @@ import {
 } from '@metamask/bridge-controller';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { DefaultSwapDestTokens } from '../constants/default-swap-dest-tokens';
+import { createMockToken } from '../testUtils/fixtures';
+import { SecurityDataType } from '../hooks/usePopularTokens';
 
 // Mock dependencies
 jest.mock('@metamask/utils', () => {
@@ -305,5 +308,54 @@ describe('tokenUtils', () => {
       expect(tokenMatchesQuery(token, 'bit')).toBe(true);
       expect(tokenMatchesQuery(token, 'btc')).toBe(true);
     });
+  });
+});
+
+describe('getSecurityWarnings', () => {
+  it('returns descriptions from all features', () => {
+    const token = createMockToken({
+      securityData: {
+        type: SecurityDataType.Malicious,
+        metadata: {
+          features: [
+            {
+              featureId: 'HONEYPOT',
+              type: SecurityDataType.Warning,
+              description: 'Honeypot risk',
+            },
+            {
+              featureId: 'FAKE_TOKEN',
+              type: SecurityDataType.Warning,
+              description: 'Fake token warning',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(getSecurityWarnings(token)).toEqual([
+      'Honeypot risk',
+      'Fake token warning',
+    ]);
+  });
+
+  it('returns empty array when metadata is absent', () => {
+    const token = createMockToken({
+      securityData: { type: SecurityDataType.Warning },
+    });
+    expect(getSecurityWarnings(token)).toEqual([]);
+  });
+
+  it('returns empty array when securityData is absent', () => {
+    const token = createMockToken({ securityData: undefined });
+    expect(getSecurityWarnings(token)).toEqual([]);
+  });
+
+  it('returns empty array for undefined token', () => {
+    expect(getSecurityWarnings(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for null token', () => {
+    expect(getSecurityWarnings(null)).toEqual([]);
   });
 });

--- a/app/components/UI/Bridge/utils/tokenUtils.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.ts
@@ -13,6 +13,15 @@ import { IncludeAsset } from '../hooks/usePopularTokens';
 import { POLYGON_NATIVE_TOKEN } from '../constants/assets';
 
 /**
+ * Extracts security warning descriptions from a token's securityData metadata features.
+ * Returns an empty array when the token has no security warnings.
+ */
+export const getSecurityWarnings = (
+  token: BridgeToken | undefined | null,
+): string[] =>
+  token?.securityData?.metadata?.features?.map((f) => f.description) ?? [];
+
+/**
  * Normalizes chain-specific native token addresses to the zero address for the bridge flow.
  *
  * Some chains use a non-zero contract address for their native token

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6905,6 +6905,8 @@
     "fetching_quote": "Fetching quote",
     "fee_disclaimer": "Includes {{feePercentage}}% MetaMask fee.",
     "no_mm_fee": "No MM fee",
+    "token_suspicious": "Suspicious",
+    "token_malicious": "Malicious",
     "no_mm_fee_disclaimer": "No MetaMask fee swapping into {{destTokenSymbol}}.",
     "hardware_wallet_not_supported": "Hardware wallets aren't supported yet. Use a hot wallet to continue.",
     "hardware_wallet_not_supported_solana": "Hardware wallets aren't supported for Solana yet. Use a hot wallet to continue.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The popular and search token endpoints now return a `securityData` field that classifies tokens by security risk level. This PR surfaces that information in the Swaps/Bridge asset picker so users can make informed decisions before selecting a token.

**What changed:**
- Added `SecurityData`, `SecurityDataType`, and `SecurityFeature` types to `PopularToken` (and propagated `securityData` to `BridgeToken` via the existing spread in `useTokensWithBalances`)
- Extracted a `getSecurityTag` pure function that maps a security type to the appropriate badge config (severity, icon, color)
- The `TokenSelectorItem` now renders a `TagBase` pill badge next to the token symbol:
  - **Suspicious** (`Warning` / `Spam` types) — triangle warning icon, warning-colored pill
  - **Malicious** (`Malicious` type) — danger circle icon, danger-colored pill
  - `Info`, `Benign`, `Verified` — no badge (no change to the existing verified checkmark)
- Send up destination token warning descriptions in `security_warning` field for metrics for `QuoteReceived` and `QuoteError` events.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Suspicious and Malicious security badges to tokens in the Swaps/Bridge asset picker

## **Related issues**

Resolves https://consensyssoftware.atlassian.net/browse/SWAPS-4372

## **Manual testing steps**

```gherkin
Feature: Token security badges in asset picker

  Scenario: user sees a Suspicious badge on a Warning/Spam token
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Warning" or "Spam" display an orange "Suspicious" pill with a triangle icon next to the token symbol

  Scenario: user sees a Malicious badge on a Malicious token
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Malicious" display a red "Malicious" pill with a danger circle icon next to the token symbol

  Scenario: user sees no security badge on safe tokens
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Info", "Benign", or "Verified" display no security badge
    And the existing verified checkmark still appears for tokens with isVerified=true
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/1092e79b-070a-4a4f-a6c8-2adc93f5515b


<img width="1438" height="508" alt="Screenshot 2026-04-20 at 6 11 44 PM" src="https://github.com/user-attachments/assets/7687eb2c-0be8-4100-a445-e78b5a8f96bc" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-shape change that adds optional `securityData` fields and renders new badges; main risk is incorrect labeling or styling regressions in the token picker/context payloads.
> 
> **Overview**
> Adds support for an optional `securityData` payload on bridge/swap tokens (including new `SecurityDataType`/metadata types) and propagates it through `BridgeToken`.
> 
> Updates the token picker `TokenSelectorItem` to render a **pill security badge** next to the symbol for `Warning`/`Spam` (*Suspicious*) and `Malicious` (*Malicious*), via a new `getSecurityTag` mapper, and adds the corresponding i18n strings.
> 
> Introduces `getSecurityWarnings()` to extract feature descriptions and wires `useUnifiedSwapBridgeContext` to emit these as `security_warnings`, with expanded unit tests covering badge rendering/mapping and warning extraction/preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df9897c7bfd7970e68611b8888463a4cb1c3511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->