### PR TITLE
fix: fallback classic tx for smart-contract deployment

### DIFF
--- a/app/util/transaction-controller/index.test.ts
+++ b/app/util/transaction-controller/index.test.ts
@@ -5,7 +5,7 @@ import {
   TransactionEnvelopeType,
   IsAtomicBatchSupportedRequest,
 } from '@metamask/transaction-controller';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 //eslint-disable-next-line import-x/no-namespace
 import * as TransactionControllerUtils from './index';
 import Engine from '../../core/Engine';
@@ -270,6 +270,31 @@ describe('Transaction Controller Util', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('calls regular addTransaction without extra params when transaction is a contract deployment', async () => {
+      jest
+        .mocked(Engine.context.TransactionController.addTransactionBatch)
+        .mockReturnValueOnce(
+          Promise.resolve({
+            batchId: BATCHID_MOCK,
+          }),
+        );
+      jest
+        .mocked(Engine.context.TransactionController.getTransactions)
+        .mockReturnValueOnce([BATCH_TRANSACTION_META_MOCK]);
+
+      const eip1559TxWithoutToField = omit(
+        EIP_1559_TRANSACTION_PARAMS_MOCK,
+        'to',
+      );
+      await addTransaction(eip1559TxWithoutToField, TRANSACTION_OPTIONS_MOCK);
+      expect(
+        Engine.context.TransactionController.addTransaction,
+      ).toHaveBeenCalledWith(eip1559TxWithoutToField, TRANSACTION_OPTIONS_MOCK);
+      expect(
+        Engine.context.TransactionController.addTransactionBatch,
+      ).not.toHaveBeenCalled();
+    });
+
     it('calls addTransactionBatch when transaction is type 0x76', async () => {
       jest
         .mocked(Engine.context.TransactionController.addTransactionBatch)
@@ -324,7 +349,7 @@ describe('Transaction Controller Util', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('does not call addTransactionBatch if accountSupports7702 resolves to false', async () => {
+    it('does not call addTransactionBatch if accountSupports7702 resolves to false for Tempo Transaction', async () => {
       (accountSupports7702 as jest.Mock).mockResolvedValueOnce(false);
       await expect(
         addTransaction(TEMPO_TRANSACTION_PARAMS_MOCK, TRANSACTION_OPTIONS_MOCK),

--- a/app/util/transaction-controller/index.ts
+++ b/app/util/transaction-controller/index.ts
@@ -61,6 +61,13 @@ async function addTempoTransaction({
   // and add excludeNativeTokenForFee to signal to ignore native.
   // We enter this flow is dApp non-0x76 txs as well as send flow.
   if (!isTempoTransactionType(transaction)) {
+    // We use the `to` field to determine if the tx is a contract deployment.
+    if (!transaction.to) {
+      Logger.log(
+        'addTransactionOnTempo: Smart-Contract deployment tx detected. Fallback to classic tx.',
+      );
+      return TransactionController.addTransaction(transaction, options);
+    }
     if (!isEip7702SupportedByAccount) {
       Logger.log(
         'addTransactionOnTempo: Tempo chain but wallet does not support 7702. Falling back to legacy transactions',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Smart contract deployment cannot technically be done when using EIP-7702.
- MetaMask Tempo support relies on EIP-7702, meaning that smart-contract deployments will fail. 
- However, with Tempo we fallback to classic transactions when EIP-7702 is not available (ex: Hardware Wallets), so this PR applies a similar logic but for when the transaction is detected as a smart-contract deployment transaction.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: tempo fallback to classic transaction if contract deployment

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-969?atlOrigin=eyJpIjoiMTE3NzVjMzBjMTJhNDE3NGFhNzE4ZjM5ZTZiNGQ5ZDgiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

1. Go to https://metamask.github.io/test-dapp/ with an account funded with `pathUSD`.
2. Find the "ERC20" section and attempt to create a token.
3. The transaction should succeed, unlike before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction submission behavior on Tempo networks by bypassing Tempo-specific fee-token/EIP-7702 handling for contract deployments, which could affect how some dApp transactions are routed. Risk is limited in scope but touches core transaction-creation logic.
> 
> **Overview**
> Ensures **contract deployment transactions on Tempo networks** (detected by missing `txParams.to`) **skip Tempo/EIP-7702 handling** and instead use the standard `TransactionController.addTransaction` path.
> 
> Adds/updates unit tests to cover this fallback behavior and clarifies the existing Tempo 7702-unsupported test description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072e2d0f1073c9088da795816a55e0ad41849311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->