### PR TITLE
feat(hw): add QR signing context and state management hook

### DIFF
--- a/app/core/HardwareWallet/contexts/QRSigningContext.test.tsx
+++ b/app/core/HardwareWallet/contexts/QRSigningContext.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { useQRSigning } from './QRSigningContext';
+
+describe('QRSigningContext', () => {
+  describe('useQRSigning', () => {
+    it('throws when used outside HardwareWalletProvider', () => {
+      const TestConsumer: React.FC = () => {
+        useQRSigning();
+        return null;
+      };
+
+      expect(() => render(<TestConsumer />)).toThrow(
+        'useQRSigning must be used within a HardwareWalletProvider',
+      );
+    });
+  });
+});

--- a/app/core/HardwareWallet/contexts/QRSigningContext.tsx
+++ b/app/core/HardwareWallet/contexts/QRSigningContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+import { QrScanRequest } from '@metamask/eth-qr-keyring';
+
+export interface QRSigningContextValue {
+  /** The pending QR scan request from the keyring, if any. */
+  pendingScanRequest?: QrScanRequest;
+  /** Whether the pending request is a SIGN-type QR object. */
+  isSigningQRObject: boolean;
+  /** Mark the current QR scan request as completed (suppresses cancel-on-navigate). */
+  setRequestCompleted: () => void;
+  /** Whether the request has been completed. */
+  isRequestCompleted: boolean;
+  /** Reject the pending QR scan request if one exists. */
+  cancelQRScanRequestIfPresent: () => Promise<void>;
+}
+
+const QRSigningContext = createContext<QRSigningContextValue | undefined>(
+  undefined,
+);
+
+QRSigningContext.displayName = 'QRSigningContext';
+
+export const useQRSigning = (): QRSigningContextValue => {
+  const context = useContext(QRSigningContext);
+  if (context === undefined) {
+    throw new Error(
+      'useQRSigning must be used within a HardwareWalletProvider',
+    );
+  }
+  return context;
+};
+
+export default QRSigningContext;

--- a/app/core/HardwareWallet/contexts/index.ts
+++ b/app/core/HardwareWallet/contexts/index.ts
@@ -3,3 +3,5 @@
  */
 
 export { useHardwareWallet } from './HardwareWalletContext';
+export { useQRSigning } from './QRSigningContext';
+export type { QRSigningContextValue } from './QRSigningContext';

--- a/app/core/HardwareWallet/hooks/index.ts
+++ b/app/core/HardwareWallet/hooks/index.ts
@@ -8,3 +8,4 @@ export { useAdapterLifecycle } from './useAdapterLifecycle';
 export { useTransportMonitoring } from './useTransportMonitoring';
 export { useDeviceDiscovery } from './useDeviceDiscovery';
 export { useDeviceConnectionFlow } from './useDeviceConnectionFlow';
+export { useQRSigningState } from './useQRSigningState';

--- a/app/core/HardwareWallet/hooks/useQRSigningState.test.ts
+++ b/app/core/HardwareWallet/hooks/useQRSigningState.test.ts
@@ -1,0 +1,143 @@
+import { act } from '@testing-library/react-native';
+import { QrScanRequestType } from '@metamask/eth-qr-keyring';
+
+import { renderHookWithProvider } from '../../../util/test/renderWithProvider';
+import { scanRequested } from '../../redux/slices/qrKeyringScanner';
+import { useQRSigningState } from './useQRSigningState';
+
+const mockQrScanner = {
+  rejectPendingScan: jest.fn(),
+};
+
+jest.mock('../../Engine', () => ({
+  getQrKeyringScanner: jest.fn(() => mockQrScanner),
+}));
+
+describe('useQRSigningState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns initial state when no pending scan request', () => {
+    const { result } = renderHookWithProvider(() => useQRSigningState(), {
+      state: { qrKeyringScanner: {} },
+    });
+
+    expect(result.current.pendingScanRequest).toBeUndefined();
+    expect(result.current.isSigningQRObject).toBe(false);
+    expect(result.current.isRequestCompleted).toBe(false);
+  });
+
+  it('detects signing QR object from Redux state', () => {
+    const { result } = renderHookWithProvider(() => useQRSigningState(), {
+      state: {
+        qrKeyringScanner: {
+          pendingScanRequest: {
+            type: QrScanRequestType.SIGN,
+            request: {
+              requestId: 'test-id',
+              payload: { type: 'eth-sign-request', cbor: 'abc' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.current.isSigningQRObject).toBe(true);
+    expect(result.current.pendingScanRequest).toBeDefined();
+  });
+
+  it('marks request as completed', () => {
+    const { result } = renderHookWithProvider(() => useQRSigningState(), {
+      state: { qrKeyringScanner: {} },
+    });
+
+    expect(result.current.isRequestCompleted).toBe(false);
+
+    act(() => {
+      result.current.setRequestCompleted();
+    });
+
+    expect(result.current.isRequestCompleted).toBe(true);
+  });
+
+  it('resets request completion when a new signing request arrives', () => {
+    const { result, store } = renderHookWithProvider(
+      () => useQRSigningState(),
+      {
+        state: {
+          qrKeyringScanner: {
+            pendingScanRequest: {
+              type: QrScanRequestType.SIGN,
+              request: {
+                requestId: 'first-request',
+                payload: { type: 'eth-sign-request', cbor: 'abc' },
+              },
+            },
+          },
+        },
+      },
+    );
+
+    act(() => {
+      result.current.setRequestCompleted();
+    });
+
+    expect(result.current.isRequestCompleted).toBe(true);
+
+    act(() => {
+      store.dispatch(
+        scanRequested({
+          type: QrScanRequestType.SIGN,
+          request: {
+            requestId: 'second-request',
+            payload: { type: 'eth-sign-request', cbor: 'def' },
+          },
+        }),
+      );
+    });
+
+    expect(result.current.pendingScanRequest?.request?.requestId).toBe(
+      'second-request',
+    );
+    expect(result.current.isRequestCompleted).toBe(false);
+  });
+
+  it('cancelQRScanRequestIfPresent rejects pending scan when signing', async () => {
+    const { result } = renderHookWithProvider(() => useQRSigningState(), {
+      state: {
+        qrKeyringScanner: {
+          pendingScanRequest: {
+            type: QrScanRequestType.SIGN,
+            request: {
+              requestId: 'test-id',
+              payload: { type: 'eth-sign-request', cbor: 'abc' },
+            },
+          },
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.cancelQRScanRequestIfPresent();
+    });
+
+    expect(mockQrScanner.rejectPendingScan).toHaveBeenCalledTimes(1);
+    expect(mockQrScanner.rejectPendingScan).toHaveBeenCalledWith(
+      expect.any(Error),
+    );
+    expect(result.current.isRequestCompleted).toBe(true);
+  });
+
+  it('cancelQRScanRequestIfPresent is a no-op when not signing', async () => {
+    const { result } = renderHookWithProvider(() => useQRSigningState(), {
+      state: { qrKeyringScanner: {} },
+    });
+
+    await act(async () => {
+      await result.current.cancelQRScanRequestIfPresent();
+    });
+
+    expect(mockQrScanner.rejectPendingScan).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/HardwareWallet/hooks/useQRSigningState.ts
+++ b/app/core/HardwareWallet/hooks/useQRSigningState.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { QrScanRequestType } from '@metamask/eth-qr-keyring';
+
+import Engine from '../../Engine';
+import type { RootState } from '../../../reducers';
+import type { QRSigningContextValue } from '../contexts/QRSigningContext';
+
+/**
+ * Manages all QR signing state for the HardwareWalletProvider.
+ *
+ * Scanner visibility is intentionally NOT part of this context — the
+ * awaiting-confirmation bottom-sheet content manages its own internal phase
+ * (QR display vs. camera) as local component state.
+ */
+export const useQRSigningState = (): QRSigningContextValue => {
+  const qrState = useSelector((state: RootState) => state.qrKeyringScanner);
+  const pendingScanRequest = qrState?.pendingScanRequest;
+
+  const isSigningQRObject = pendingScanRequest?.type === QrScanRequestType.SIGN;
+
+  // This provider outlives individual QR signing requests, so completion state
+  // must be cleared whenever Redux surfaces a new pending request.
+  const [isRequestCompleted, setIsRequestCompleted] = useState(false);
+
+  useEffect(() => {
+    // `isRequestCompleted` suppresses cancel-on-navigate for the active request
+    // only; reset it when a fresh request becomes pending.
+    if (pendingScanRequest) {
+      setIsRequestCompleted(false);
+    }
+  }, [pendingScanRequest]);
+
+  const cancelQRScanRequestIfPresent = useCallback(async () => {
+    if (!isSigningQRObject) {
+      return;
+    }
+    Engine.getQrKeyringScanner().rejectPendingScan(
+      new Error('Request cancelled'),
+    );
+    setIsRequestCompleted(true);
+  }, [isSigningQRObject]);
+
+  const setRequestCompleted = useCallback(() => {
+    setIsRequestCompleted(true);
+  }, []);
+
+  return useMemo(
+    () => ({
+      pendingScanRequest,
+      isSigningQRObject,
+      setRequestCompleted,
+      isRequestCompleted,
+      cancelQRScanRequestIfPresent,
+    }),
+    [
+      pendingScanRequest,
+      isSigningQRObject,
+      isRequestCompleted,
+      setRequestCompleted,
+      cancelQRScanRequestIfPresent,
+    ],
+  );
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds:

- `QRSigningContext` for QR hardware wallet signing state
- `useQRSigningState` hook for managing QR scan request lifecycle
- Index files. 

Note: This is currently dead code until 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/MUL-1741

## **Manual testing steps**

This can only be tested via https://github.com/MetaMask/metamask-mobile/pull/29087

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new QR-signing context/hook and tests without modifying existing signing/connection flows; primary risk is incorrect cancellation/completion behavior once wired into navigation.
> 
> **Overview**
> Adds a new `QRSigningContext` (and `useQRSigning`) to standardize access to pending QR keyring scan requests and related lifecycle actions.
> 
> Introduces `useQRSigningState`, which derives the current pending scan request from Redux, tracks per-request completion state, and provides `cancelQRScanRequestIfPresent()` to reject an active SIGN request via the QR keyring scanner. Exports the new context/hook via the HardwareWallet `contexts`/`hooks` index files and adds unit tests for both the context guard and hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe188dd6b484f25d3f0cf47bcb643ec00a22b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->