### PR TITLE
feat(hw): shared files for QR context and hardware wallet context merger

### DIFF
--- a/app/components/UI/LedgerModals/LedgerTransactionModal.test.tsx
+++ b/app/components/UI/LedgerModals/LedgerTransactionModal.test.tsx
@@ -148,6 +148,21 @@ describe('LedgerTransactionModal', () => {
       expect(mockOnConfirmationComplete).toHaveBeenCalledWith(true);
       expect(mockGoBack).toHaveBeenCalled();
     });
+
+    it('passes undefined to stopTransaction when eip1559 replacement params are incomplete', async () => {
+      mockParams.replacementParams = {
+        type: LedgerReplacementTxTypes.CANCEL,
+        eip1559GasFee: {
+          maxFeePerGas: '0x789',
+        },
+      };
+
+      render(<LedgerTransactionModal />);
+
+      await capturedOnConfirmation?.();
+
+      expect(mockStopTransaction).toHaveBeenCalledWith('test-tx-id', undefined);
+    });
   });
 
   describe('onRejection', () => {

--- a/app/components/UI/LedgerModals/LedgerTransactionModal.tsx
+++ b/app/components/UI/LedgerModals/LedgerTransactionModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import Engine from '../../../core/Engine';
+import { normalizeReplacementGasFeeParams } from '../../../util/confirmation/gas';
 import LedgerConfirmationModal from './LedgerConfirmationModal';
 import {
   createNavigationDetails,
@@ -56,11 +57,9 @@ const LedgerTransactionModal = () => {
   }, [navigation]);
 
   const executeOnLedger = useCallback(async () => {
-    const gasFeeParams =
-      replacementParams?.legacyGasFee ?? replacementParams?.eip1559GasFee;
+    const gasFeeParams = normalizeReplacementGasFeeParams(replacementParams);
 
     if (replacementParams?.type === LedgerReplacementTxTypes.SPEED_UP) {
-      //@ts-expect-error Will defer this typescript issue to the hardware wallet team, confirmations or transactions team
       await speedUpTransaction(transactionId, gasFeeParams);
     } else if (replacementParams?.type === LedgerReplacementTxTypes.CANCEL) {
       await TransactionController.stopTransaction(transactionId, gasFeeParams);

--- a/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
+++ b/app/core/HardwareWallet/contexts/HardwareWalletContext.tsx
@@ -22,7 +22,7 @@ export interface HardwareWalletContextValue {
    */
   ensureDeviceReady: (deviceId?: string | null) => Promise<boolean>;
   /** Set the target wallet type for "Add Hardware Wallet" flows (no account yet). */
-  setTargetWalletType: (walletType: HardwareWalletType) => void;
+  setTargetWalletType: (walletType: HardwareWalletType | null) => void;
   /** Show a hardware wallet error in the bottom sheet. Use after ensureDeviceReady succeeds. */
   showHardwareWalletError: (error: unknown) => void;
   /** Show "awaiting confirmation" bottom sheet. */

--- a/app/core/HardwareWallet/helpers.test.ts
+++ b/app/core/HardwareWallet/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   getHardwareWalletTypeName,
   getHardwareWalletTypeForAddress,
   getConnectionTipsForWalletType,
+  getDeviceIdForAddress,
 } from './helpers';
 import { HardwareWalletType } from '@metamask/hw-wallet-sdk';
 
@@ -27,6 +28,12 @@ jest.mock('../../constants/keyringTypes', () => ({
     ledger: 'Ledger Hardware',
     qr: 'QR Hardware Wallet Device',
   },
+}));
+
+const mockGetDeviceId = jest.fn();
+
+jest.mock('../Ledger/Ledger', () => ({
+  getDeviceId: () => mockGetDeviceId(),
 }));
 
 describe('HardwareWallet helpers', () => {
@@ -123,16 +130,57 @@ describe('HardwareWallet helpers', () => {
       ]);
     });
 
-    it('returns empty array for QR wallet type', () => {
+    it('returns QR-specific tips for QR wallet type', () => {
       const tips = getConnectionTipsForWalletType(HardwareWalletType.Qr);
 
-      expect(tips).toEqual([]);
+      expect(tips).toEqual([
+        'hardware_wallet.connecting.qr_tip_scan',
+        'hardware_wallet.connecting.qr_tip_align',
+        'hardware_wallet.connecting.qr_tip_lighting',
+      ]);
     });
 
     it('returns empty array for null wallet type', () => {
       const tips = getConnectionTipsForWalletType(null);
 
       expect(tips).toEqual([]);
+    });
+  });
+
+  describe('getDeviceIdForAddress', () => {
+    const testAddress = '0x1234567890abcdef1234567890abcdef12345678';
+
+    it('returns the Ledger device id for Ledger accounts', async () => {
+      mockIsHardwareAccount.mockReset();
+      mockIsHardwareAccount
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      mockGetDeviceId.mockResolvedValue('ledger-device-id');
+
+      await expect(getDeviceIdForAddress(testAddress)).resolves.toBe(
+        'ledger-device-id',
+      );
+      expect(mockGetDeviceId).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined for QR accounts', async () => {
+      mockIsHardwareAccount.mockReset();
+      mockIsHardwareAccount
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+
+      await expect(getDeviceIdForAddress(testAddress)).resolves.toBeUndefined();
+      expect(mockGetDeviceId).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined for non-hardware accounts', async () => {
+      mockIsHardwareAccount.mockReset();
+      mockIsHardwareAccount
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false);
+
+      await expect(getDeviceIdForAddress(testAddress)).resolves.toBeUndefined();
+      expect(mockGetDeviceId).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/HardwareWallet/helpers.ts
+++ b/app/core/HardwareWallet/helpers.ts
@@ -2,6 +2,7 @@ import { isHardwareAccount } from '../../util/address';
 import ExtendedKeyringTypes from '../../constants/keyringTypes';
 import { HardwareWalletType } from '@metamask/hw-wallet-sdk';
 import { strings } from '../../../locales/i18n';
+import { getDeviceId } from '../Ledger/Ledger';
 
 /**
  * Helper to get wallet type display name
@@ -38,6 +39,25 @@ export function getHardwareWalletTypeForAddress(
 }
 
 /**
+ * Resolve the transport-specific device id for a hardware wallet address.
+ *
+ * Some hardware wallets, like Ledger over BLE, require a persisted device id
+ * to reconnect. Others, like QR signers, do not.
+ */
+export async function getDeviceIdForAddress(
+  address: string,
+): Promise<string | undefined> {
+  const walletType = getHardwareWalletTypeForAddress(address);
+
+  switch (walletType) {
+    case HardwareWalletType.Ledger:
+      return await getDeviceId();
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Returns i18n keys for connection tips based on the wallet type.
  */
 export function getConnectionTipsForWalletType(
@@ -49,6 +69,12 @@ export function getConnectionTipsForWalletType(
         'hardware_wallet.connecting.tip_unlock',
         'hardware_wallet.connecting.tip_open_app',
         'hardware_wallet.connecting.tip_enable_bluetooth',
+      ];
+    case HardwareWalletType.Qr:
+      return [
+        'hardware_wallet.connecting.qr_tip_scan',
+        'hardware_wallet.connecting.qr_tip_align',
+        'hardware_wallet.connecting.qr_tip_lighting',
       ];
     default:
       return [];

--- a/app/util/confirmation/gas.test.ts
+++ b/app/util/confirmation/gas.test.ts
@@ -10,6 +10,7 @@ import {
   getMediumPriorityFeeGwei,
   gasEstimateGreaterThanGasUsedPlusTenPercent,
   getGasValuesForReplacement,
+  normalizeReplacementGasFeeParams,
   type GasFeeEstimatesInput,
 } from './gas';
 
@@ -261,6 +262,44 @@ describe('getMediumPriorityFeeGwei', () => {
       expect(getMediumPriorityFeeGwei(estimates)).toBe(expected);
     },
   );
+});
+
+describe('normalizeReplacementGasFeeParams', () => {
+  it('returns a legacy gas price object without unexpected properties', () => {
+    const result = normalizeReplacementGasFeeParams({
+      legacyGasFee: {
+        gasPrice: '0x123',
+      },
+    });
+
+    expect(result).toEqual({
+      gasPrice: '0x123',
+    });
+  });
+
+  it('returns an eip1559 gas object when both fee fields are present', () => {
+    const result = normalizeReplacementGasFeeParams({
+      eip1559GasFee: {
+        maxFeePerGas: '0x456',
+        maxPriorityFeePerGas: '0x789',
+      },
+    });
+
+    expect(result).toEqual({
+      maxFeePerGas: '0x456',
+      maxPriorityFeePerGas: '0x789',
+    });
+  });
+
+  it('returns undefined for incomplete eip1559 gas fees', () => {
+    const result = normalizeReplacementGasFeeParams({
+      eip1559GasFee: {
+        maxFeePerGas: '0x456',
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe('gasEstimateGreaterThanGasUsedPlusTenPercent', () => {

--- a/app/util/confirmation/gas.ts
+++ b/app/util/confirmation/gas.ts
@@ -30,6 +30,16 @@ interface ResolvedMediumEstimate {
   scalarGwei?: string;
 }
 
+interface ReplacementGasFeeParamsInput {
+  legacyGasFee?: {
+    gasPrice?: string;
+  } | null;
+  eip1559GasFee?: {
+    maxFeePerGas?: string;
+    maxPriorityFeePerGas?: string;
+  } | null;
+}
+
 /**
  * Extracts the medium-level gas fee estimate from various possible shapes of gas fee estimates.
  */
@@ -169,6 +179,33 @@ export function gasEstimateGreaterThanGasUsedPlusTenPercent(
   }
 
   return new BigNumber(String(estimateGwei)).gt(bumpedGwei);
+}
+
+/**
+ * Normalizes replacement gas params so only controller-supported fee fields
+ * are forwarded to replacement transaction flows.
+ */
+export function normalizeReplacementGasFeeParams(
+  replacementParams?: ReplacementGasFeeParamsInput | null,
+): GasPriceValue | FeeMarketEIP1559Values | undefined {
+  if (replacementParams?.legacyGasFee?.gasPrice) {
+    return {
+      gasPrice: replacementParams.legacyGasFee.gasPrice,
+    };
+  }
+
+  if (
+    replacementParams?.eip1559GasFee?.maxFeePerGas &&
+    replacementParams?.eip1559GasFee?.maxPriorityFeePerGas
+  ) {
+    return {
+      maxFeePerGas: replacementParams.eip1559GasFee.maxFeePerGas,
+      maxPriorityFeePerGas:
+        replacementParams.eip1559GasFee.maxPriorityFeePerGas,
+    };
+  }
+
+  return undefined;
 }
 
 export interface PreviousGasParams {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8450,7 +8450,10 @@
       "tip_enable_bluetooth": "Bluetooth is turned on",
       "tip_bluetooth_permission": "Location and Bluetooth permission is granted",
       "tip_bluetooth_permission_v12": "Nearby devices permission is granted",
-      "tip_stay_close": "Your device stays close to your phone"
+      "tip_stay_close": "Your device stays close to your phone",
+      "qr_tip_scan": "Your camera is ready to scan the QR code",
+      "qr_tip_align": "Align the QR code within the frame",
+      "qr_tip_lighting": "Ensure good lighting for clear scanning"
     },
     "awaiting_app": {
       "title": "Open {{app}}",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related to: https://consensyssoftware.atlassian.net/browse/MUL-1741

## **Manual testing steps**

This can only be tested via https://github.com/MetaMask/metamask-mobile/pull/29087

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the gas fee parameters forwarded into cancel/speed-up transaction flows and adjusts hardware wallet context typing, which could affect transaction replacement behavior and hardware wallet connection UX.
> 
> **Overview**
> Improves hardware-wallet and replacement-transaction handling by **normalizing replacement gas fee params** before calling `speedUpTransaction`/`stopTransaction`, ensuring only complete controller-supported fee fields are forwarded (otherwise `undefined`). Tests were added to cover legacy vs EIP-1559 normalization and the incomplete-fee edge case in `LedgerTransactionModal`.
> 
> Extends hardware wallet utilities by adding `getDeviceIdForAddress` (Ledger-only) and updating connection tips to include **QR-specific guidance** with new i18n strings. The hardware wallet context API is also loosened to allow `setTargetWalletType(null)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da33c392d902b2f3f743d5f462f3483b5dd15832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->