### PR TITLE
fix(perps): use available-to-trade balance for funded state

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -772,6 +772,7 @@ describe('PerpsMarketDetailsView', () => {
     mockUsePerpsAccount.mockReturnValue({
       account: {
         availableBalance: '1000.00',
+        availableToTradeBalance: '1000.00',
         marginUsed: '0.00',
         unrealizedPnl: '0.00',
         returnOnEquity: '0.00',
@@ -783,6 +784,7 @@ describe('PerpsMarketDetailsView', () => {
     mockUsePerpsLiveAccount.mockReturnValue({
       account: {
         availableBalance: '1000',
+        availableToTradeBalance: '1000',
         marginUsed: '0',
         unrealizedPnl: '0',
         returnOnEquity: '0',
@@ -1009,6 +1011,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          availableToTradeBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1020,6 +1023,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          availableToTradeBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1056,6 +1060,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          availableToTradeBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1066,6 +1071,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          availableToTradeBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1092,11 +1098,44 @@ describe('PerpsMarketDetailsView', () => {
       ).toBeNull();
     });
 
+    it('shows long and short actions when availableToTradeBalance is positive even if availableBalance is zero', () => {
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          availableBalance: '0',
+          availableToTradeBalance: '100.76',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '101.14',
+        },
+        isInitialLoading: false,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        { state: initialState },
+      );
+
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.LONG_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.SHORT_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        queryByTestId(PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON),
+      ).toBeNull();
+    });
+
     it('calls navigateToConfirmation and depositWithConfirmation when add funds is pressed', async () => {
       mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          availableToTradeBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1107,6 +1146,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          availableToTradeBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1145,6 +1185,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          availableToTradeBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1155,6 +1196,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          availableToTradeBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1189,6 +1231,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '1000.00',
+          availableToTradeBalance: '1000.00',
           marginUsed: '500.00',
           unrealizedPnl: '50.00',
           returnOnEquity: '3.33',

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -446,8 +446,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     useDefaultPayWithTokenWhenNoPerpsBalance();
   const { depositWithConfirmation } = usePerpsTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
-  const availableBalance = Number.parseFloat(
-    account?.availableBalance?.toString() ?? '0',
+  const availableToTradeBalance = Number.parseFloat(
+    account?.availableToTradeBalance?.toString() ?? '0',
   );
   const showAddFundsCTA =
     isEligible &&
@@ -455,7 +455,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     !existingPosition &&
     !isAtOICap &&
     !isLoadingAccount &&
-    availableBalance < PERPS_MIN_BALANCE_THRESHOLD &&
+    availableToTradeBalance < PERPS_MIN_BALANCE_THRESHOLD &&
     defaultPayTokenWhenNoPerpsBalance === null;
 
   const handleAddFunds = useCallback(async () => {

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -2148,6 +2148,7 @@ describe('HyperLiquidProvider', () => {
       const accountState = await provider.getAccountState();
 
       expect(accountState).toBeDefined();
+      expect(accountState.availableToTradeBalance).toBe('19500');
       expect(accountState.totalBalance).toBe('20500'); // 10000 (spot) + 10500 (perps marginSummary)
       expect(
         mockClientService.getInfoClient().clearinghouseState,
@@ -3768,6 +3769,7 @@ describe('HyperLiquidProvider', () => {
 
         const accountState = await hip3Provider.getAccountState();
 
+        expect(parseFloat(accountState.availableToTradeBalance)).toBe(19500);
         expect(parseFloat(accountState.totalBalance)).toBe(20500);
         expect(parseFloat(accountState.marginUsed)).toBe(500);
         expect(mockInfoClient.clearinghouseState).toHaveBeenCalledWith({
@@ -9074,6 +9076,7 @@ describe('HyperLiquidProvider', () => {
         // Assert — all DEX queries failed, aggregateAccountStates([]) returns fallback
         expect(result).toEqual({
           availableBalance: '--',
+          availableToTradeBalance: '--',
           totalBalance: '--',
           marginUsed: '--',
           unrealizedPnl: '--',

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -109,7 +109,10 @@ import type {
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
 import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
-import { aggregateAccountStates } from '../utils/accountUtils';
+import {
+  addSpotUsdcToAvailableToTradeBalance,
+  aggregateAccountStates,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptAccountStateFromSDK,
@@ -5691,6 +5694,10 @@ export class HyperLiquidProvider implements PerpsProvider {
       aggregatedAccountState.totalBalance = (
         parseFloat(aggregatedAccountState.totalBalance) + spotBalance
       ).toString();
+      const spotAdjustedAccountState = addSpotUsdcToAvailableToTradeBalance(
+        aggregatedAccountState,
+        spotState,
+      );
 
       // Build per-sub-account breakdown (HIP-3 DEXs map to sub-accounts)
       const subAccountBreakdown: Record<
@@ -5709,14 +5716,14 @@ export class HyperLiquidProvider implements PerpsProvider {
       });
 
       // Add sub-account breakdown to result
-      aggregatedAccountState.subAccountBreakdown = subAccountBreakdown;
+      spotAdjustedAccountState.subAccountBreakdown = subAccountBreakdown;
 
       this.#deps.debugLogger.log(
         'Aggregated account state:',
-        aggregatedAccountState,
+        spotAdjustedAccountState,
       );
 
-      return aggregatedAccountState;
+      return spotAdjustedAccountState;
     } catch (error) {
       this.#deps.logger.error(
         ensureError(error, 'HyperLiquidProvider.getAccountState'),

--- a/app/controllers/perps/providers/MYXProvider.ts
+++ b/app/controllers/perps/providers/MYXProvider.ts
@@ -687,6 +687,7 @@ export class MYXProvider implements PerpsProvider {
       });
       return {
         availableBalance: '0',
+        availableToTradeBalance: '0',
         totalBalance: '0',
         marginUsed: '0',
         unrealizedPnl: '0',

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -66,6 +66,7 @@ jest.mock('../utils/hyperLiquidAdapter', () => ({
   })),
   adaptAccountStateFromSDK: jest.fn(() => ({
     availableBalance: '1000.00',
+    availableToTradeBalance: '1000.00',
     marginUsed: '500.00',
     unrealizedPnl: '100.00',
     returnOnEquity: '20.0',
@@ -378,6 +379,11 @@ describe('HyperLiquidSubscriptionService', () => {
     mockClientService = {
       ensureSubscriptionClient: jest.fn().mockResolvedValue(undefined),
       getSubscriptionClient: jest.fn(() => mockSubscriptionClient),
+      getInfoClient: jest.fn(() => ({
+        spotClearinghouseState: jest.fn().mockResolvedValue({
+          balances: [{ coin: 'USDC', total: '0' }],
+        }),
+      })),
       isTestnetMode: jest.fn(() => false),
       ensureTransportReady: jest.fn().mockResolvedValue(undefined),
       getConnectionState: jest.fn(() => 'connected'),
@@ -3674,6 +3680,69 @@ describe('HyperLiquidSubscriptionService', () => {
       unsubscribe1();
       unsubscribe2();
     });
+
+    it('adds spot usdc to availableToTradeBalance without changing withdrawable balance', async () => {
+      mockClientService.getInfoClient = jest.fn(() => ({
+        spotClearinghouseState: jest.fn().mockResolvedValue({
+          balances: [
+            { coin: 'USDC', total: '100.76531791' },
+            { coin: 'HYPE', total: '0.36975137' },
+          ],
+        }),
+      }));
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '0',
+        availableToTradeBalance: '0',
+        totalBalance: '0',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+      }));
+
+      mockSubscriptionClient.clearinghouseState.mockImplementation(
+        (_params: any, callback: any) => {
+          setTimeout(() => {
+            callback({
+              dex: _params.dex || '',
+              clearinghouseState: {
+                assetPositions: [],
+                marginSummary: {
+                  accountValue: '0',
+                  totalMarginUsed: '0',
+                },
+                withdrawable: '0',
+              },
+            });
+          }, 0);
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+      mockSubscriptionClient.openOrders.mockImplementation(
+        (_params: any, callback: any) => {
+          setTimeout(() => callback({ dex: _params.dex || '', orders: [] }), 0);
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const mockCallback = jest.fn();
+      const unsubscribe = service.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      const accountState = mockCallback.mock.calls.at(-1)[0];
+      expect(accountState.availableBalance).toBe('0');
+      expect(accountState.availableToTradeBalance).toBe('100.76531791');
+
+      unsubscribe();
+    });
   });
 
   describe('aggregateAccountStates - returnOnEquity calculation', () => {
@@ -3681,6 +3750,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '100',
+        availableToTradeBalance: '100',
         totalBalance: '1100',
         marginUsed: '1000',
         unrealizedPnl: '100',
@@ -3726,6 +3796,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '0',
+        availableToTradeBalance: '0',
         totalBalance: '950',
         marginUsed: '1000',
         unrealizedPnl: '-50',
@@ -3771,6 +3842,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '1000',
+        availableToTradeBalance: '1000',
         totalBalance: '1000',
         marginUsed: '0',
         unrealizedPnl: '0',
@@ -3816,6 +3888,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '75',
+        availableToTradeBalance: '75',
         totalBalance: '1575',
         marginUsed: '1500',
         unrealizedPnl: '75',
@@ -3862,6 +3935,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '200',
+        availableToTradeBalance: '200',
         totalBalance: '300',
         marginUsed: '100',
         unrealizedPnl: '200',
@@ -3907,6 +3981,7 @@ describe('HyperLiquidSubscriptionService', () => {
       // Override the adapter mock
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
         availableBalance: '100',
+        availableToTradeBalance: '100',
         totalBalance: '433',
         marginUsed: '333',
         unrealizedPnl: '100',

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -38,7 +38,11 @@ import type {
   PerpsPlatformDependencies,
   PerpsLogger,
 } from '../types';
-import { calculateWeightedReturnOnEquity } from '../utils/accountUtils';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
+import {
+  addSpotUsdcToAvailableToTradeBalance,
+  calculateWeightedReturnOnEquity,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptPositionFromSDK,
@@ -156,6 +160,12 @@ export class HyperLiquidSubscriptionService {
   readonly #dexOrdersCache = new Map<string, Order[]>(); // Per-DEX orders
 
   readonly #dexAccountCache = new Map<string, AccountState>(); // Per-DEX account state
+
+  #cachedSpotState: SpotClearinghouseStateResponse | null = null;
+
+  #cachedSpotStateUserAddress: string | null = null;
+
+  #spotStatePromise?: Promise<void>;
 
   #cachedPositions: Position[] | null = null; // Aggregated positions
 
@@ -684,7 +694,7 @@ export class HyperLiquidSubscriptionService {
   }
 
   #hashAccountState(account: AccountState): string {
-    return `${account.availableBalance}:${account.totalBalance}:${account.marginUsed}:${account.unrealizedPnl}`;
+    return `${account.availableBalance}:${account.availableToTradeBalance}:${account.totalBalance}:${account.marginUsed}:${account.unrealizedPnl}`;
   }
 
   // Cache hashes to avoid recomputation
@@ -943,6 +953,7 @@ export class HyperLiquidSubscriptionService {
       { availableBalance: string; totalBalance: string }
     > = {};
     let totalAvailableBalance = 0;
+    let totalAvailableToTradeBalance = 0;
     let totalBalance = 0;
     let totalMarginUsed = 0;
     let totalUnrealizedPnl = 0;
@@ -962,6 +973,7 @@ export class HyperLiquidSubscriptionService {
           totalBalance: state.totalBalance,
         };
         totalAvailableBalance += parseFloat(state.availableBalance);
+        totalAvailableToTradeBalance += parseFloat(state.availableToTradeBalance);
         totalBalance += parseFloat(state.totalBalance);
         totalMarginUsed += parseFloat(state.marginUsed);
         totalUnrealizedPnl += parseFloat(state.unrealizedPnl);
@@ -981,15 +993,63 @@ export class HyperLiquidSubscriptionService {
     // Calculate weighted returnOnEquity across all DEXs
     const returnOnEquity = calculateWeightedReturnOnEquity(accountStatesForROE);
 
-    return {
-      ...firstDexAccount,
-      availableBalance: totalAvailableBalance.toString(),
-      totalBalance: totalBalance.toString(),
-      marginUsed: totalMarginUsed.toString(),
-      unrealizedPnl: totalUnrealizedPnl.toString(),
-      subAccountBreakdown,
-      returnOnEquity,
-    };
+    return addSpotUsdcToAvailableToTradeBalance(
+      {
+        ...firstDexAccount,
+        availableBalance: totalAvailableBalance.toString(),
+        availableToTradeBalance: totalAvailableToTradeBalance.toString(),
+        totalBalance: totalBalance.toString(),
+        marginUsed: totalMarginUsed.toString(),
+        unrealizedPnl: totalUnrealizedPnl.toString(),
+        subAccountBreakdown,
+        returnOnEquity,
+      },
+      this.#cachedSpotState,
+    );
+  }
+
+  async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    if (
+      this.#cachedSpotState &&
+      this.#cachedSpotStateUserAddress === userAddress
+    ) {
+      return;
+    }
+
+    if (this.#spotStatePromise) {
+      await this.#spotStatePromise;
+      return;
+    }
+
+    this.#spotStatePromise = this.#refreshSpotState(userAddress);
+
+    try {
+      await this.#spotStatePromise;
+    } finally {
+      this.#spotStatePromise = undefined;
+    }
+  }
+
+  async #refreshSpotState(userAddress: string): Promise<void> {
+    try {
+      const infoClient = this.#clientService.getInfoClient();
+      this.#cachedSpotState = await infoClient.spotClearinghouseState({
+        user: userAddress,
+      });
+      this.#cachedSpotStateUserAddress = userAddress;
+
+      if (this.#dexAccountCache.size > 0) {
+        this.#aggregateAndNotifySubscribers();
+      }
+    } catch (error) {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.refreshSpotState'),
+        this.#getErrorContext('refreshSpotState'),
+      );
+    }
   }
 
   /**
@@ -1943,6 +2003,8 @@ export class HyperLiquidSubscriptionService {
       this.#cachedPositions = null;
       this.#cachedOrders = null;
       this.#cachedAccount = null;
+      this.#cachedSpotState = null;
+      this.#cachedSpotStateUserAddress = null;
       this.#ordersCacheInitialized = false; // Reset cache initialization flag
       this.#positionsCacheInitialized = false; // Reset cache initialization flag
 
@@ -2252,10 +2314,17 @@ export class HyperLiquidSubscriptionService {
     // Increment account subscriber count
     this.#accountSubscriberCount += 1;
 
-    // Immediately provide cached data if available
-    if (this.#cachedAccount) {
+    // Immediately provide cached data if available and already spot-adjusted
+    if (this.#cachedAccount && this.#cachedSpotState) {
       callback(this.#cachedAccount);
     }
+
+    this.#ensureSpotState(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureSpotState'),
+      );
+    });
 
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
@@ -3654,6 +3723,8 @@ export class HyperLiquidSubscriptionService {
     this.#cachedPositions = null;
     this.#cachedOrders = null;
     this.#cachedAccount = null;
+    this.#cachedSpotState = null;
+    this.#cachedSpotStateUserAddress = null;
     this.#cachedFills = null;
     this.#ordersCacheInitialized = false; // Reset cache initialization flag
     this.#positionsCacheInitialized = false; // Reset cache initialization flag

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -213,6 +213,7 @@ export type Position = {
 // Using 'type' instead of 'interface' for BaseController Json compatibility
 export type AccountState = {
   availableBalance: string; // Based on HyperLiquid: withdrawable
+  availableToTradeBalance: string; // Buying power for funded-state checks (HyperLiquid: withdrawable + spot USDC)
   totalBalance: string; // Based on HyperLiquid: accountValue
   marginUsed: string; // Based on HyperLiquid: marginUsed
   unrealizedPnl: string; // Based on HyperLiquid: unrealizedPnl

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -1,14 +1,18 @@
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState } from '../types';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
 
 import {
+  addSpotUsdcToAvailableToTradeBalance,
   aggregateAccountStates,
   calculateWeightedReturnOnEquity,
+  getSpotBalanceByCoin,
 } from './accountUtils';
 
 describe('aggregateAccountStates', () => {
   const fallback: AccountState = {
     availableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    availableToTradeBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     totalBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     marginUsed: PERPS_CONSTANTS.FallbackDataDisplay,
     unrealizedPnl: PERPS_CONSTANTS.FallbackDataDisplay,
@@ -22,6 +26,7 @@ describe('aggregateAccountStates', () => {
   it('returns the single state unchanged when given one element', () => {
     const single: AccountState = {
       availableBalance: '100',
+      availableToTradeBalance: '100',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -33,6 +38,7 @@ describe('aggregateAccountStates', () => {
   it('sums numeric fields from two states and recalculates ROE', () => {
     const stateA: AccountState = {
       availableBalance: '100',
+      availableToTradeBalance: '100',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -40,6 +46,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '50',
+      availableToTradeBalance: '50',
       totalBalance: '150',
       marginUsed: '30',
       unrealizedPnl: '6',
@@ -49,6 +56,7 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates([stateA, stateB]);
 
     expect(parseFloat(result.availableBalance)).toBe(150);
+    expect(parseFloat(result.availableToTradeBalance)).toBe(150);
     expect(parseFloat(result.totalBalance)).toBe(350);
     expect(parseFloat(result.marginUsed)).toBe(80);
     expect(parseFloat(result.unrealizedPnl)).toBe(16);
@@ -60,6 +68,7 @@ describe('aggregateAccountStates', () => {
     const states: AccountState[] = [
       {
         availableBalance: '100',
+        availableToTradeBalance: '100',
         totalBalance: '200',
         marginUsed: '50',
         unrealizedPnl: '10',
@@ -67,6 +76,7 @@ describe('aggregateAccountStates', () => {
       },
       {
         availableBalance: '200',
+        availableToTradeBalance: '200',
         totalBalance: '300',
         marginUsed: '100',
         unrealizedPnl: '30',
@@ -74,6 +84,7 @@ describe('aggregateAccountStates', () => {
       },
       {
         availableBalance: '50',
+        availableToTradeBalance: '50',
         totalBalance: '100',
         marginUsed: '50',
         unrealizedPnl: '5',
@@ -84,6 +95,7 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates(states);
 
     expect(parseFloat(result.availableBalance)).toBe(350);
+    expect(parseFloat(result.availableToTradeBalance)).toBe(350);
     expect(parseFloat(result.totalBalance)).toBe(600);
     expect(parseFloat(result.marginUsed)).toBe(200);
     expect(parseFloat(result.unrealizedPnl)).toBe(45);
@@ -94,6 +106,7 @@ describe('aggregateAccountStates', () => {
   it('does not mutate the input state object', () => {
     const single: AccountState = {
       availableBalance: '100',
+      availableToTradeBalance: '100',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -109,6 +122,7 @@ describe('aggregateAccountStates', () => {
   it('sets ROE to 0 when total marginUsed is 0', () => {
     const state: AccountState = {
       availableBalance: '100',
+      availableToTradeBalance: '100',
       totalBalance: '100',
       marginUsed: '0',
       unrealizedPnl: '0',
@@ -121,6 +135,7 @@ describe('aggregateAccountStates', () => {
   it('handles negative unrealizedPnl correctly', () => {
     const stateA: AccountState = {
       availableBalance: '80',
+      availableToTradeBalance: '80',
       totalBalance: '180',
       marginUsed: '100',
       unrealizedPnl: '-20',
@@ -128,6 +143,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '40',
+      availableToTradeBalance: '40',
       totalBalance: '90',
       marginUsed: '50',
       unrealizedPnl: '-10',
@@ -145,6 +161,7 @@ describe('aggregateAccountStates', () => {
   it('handles decimal values correctly', () => {
     const stateA: AccountState = {
       availableBalance: '100.50',
+      availableToTradeBalance: '100.50',
       totalBalance: '200.75',
       marginUsed: '50.25',
       unrealizedPnl: '10.10',
@@ -152,6 +169,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '50.50',
+      availableToTradeBalance: '50.50',
       totalBalance: '150.25',
       marginUsed: '30.75',
       unrealizedPnl: '6.90',
@@ -161,9 +179,43 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates([stateA, stateB]);
 
     expect(parseFloat(result.availableBalance)).toBeCloseTo(151, 0);
+    expect(parseFloat(result.availableToTradeBalance)).toBeCloseTo(151, 0);
     expect(parseFloat(result.totalBalance)).toBeCloseTo(351, 0);
     expect(parseFloat(result.marginUsed)).toBeCloseTo(81, 0);
     expect(parseFloat(result.unrealizedPnl)).toBeCloseTo(17, 0);
+  });
+});
+
+describe('spot balance helpers', () => {
+  const spotState: SpotClearinghouseStateResponse = {
+    balances: [
+      { coin: 'USDC', total: '100.50' },
+      { coin: 'HYPE', total: '5.25' },
+    ],
+  } as SpotClearinghouseStateResponse;
+
+  it('returns the balance for a matching spot coin', () => {
+    expect(getSpotBalanceByCoin(spotState, 'USDC')).toBe(100.5);
+  });
+
+  it('returns zero when the spot coin is missing', () => {
+    expect(getSpotBalanceByCoin(spotState, 'USDH')).toBe(0);
+  });
+
+  it('adds spot usdc to availableToTradeBalance without mutating the input', () => {
+    const accountState: AccountState = {
+      availableBalance: '0',
+      availableToTradeBalance: '0',
+      totalBalance: '100',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotUsdcToAvailableToTradeBalance(accountState, spotState);
+
+    expect(result.availableToTradeBalance).toBe('100.5');
+    expect(accountState.availableToTradeBalance).toBe('0');
   });
 });
 

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -6,6 +6,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
 
 const EVM_ACCOUNT_TYPES = new Set(['eip155:eoa', 'eip155:erc4337']);
 
@@ -89,6 +90,71 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
+export function getSpotBalance(
+  spotState?: SpotClearinghouseStateResponse | null,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  return spotState.balances.reduce(
+    (sum: number, balance: { total?: string }) =>
+      sum + parseFloat(balance.total ?? '0'),
+    0,
+  );
+}
+
+export function getSpotBalanceByCoin(
+  spotState: SpotClearinghouseStateResponse | null | undefined,
+  coin: string,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  const matchingBalance = spotState.balances.find(
+    (balance: { coin?: string }) => balance.coin === coin,
+  );
+
+  return matchingBalance ? parseFloat(matchingBalance.total ?? '0') : 0;
+}
+
+export function addSpotBalanceToAccountState(
+  accountState: AccountState,
+  spotState?: SpotClearinghouseStateResponse | null,
+): AccountState {
+  const spotBalance = getSpotBalance(spotState);
+
+  if (spotBalance === 0) {
+    return accountState;
+  }
+
+  return {
+    ...accountState,
+    totalBalance: (
+      parseFloat(accountState.totalBalance) + spotBalance
+    ).toString(),
+  };
+}
+
+export function addSpotUsdcToAvailableToTradeBalance(
+  accountState: AccountState,
+  spotState?: SpotClearinghouseStateResponse | null,
+): AccountState {
+  const spotUsdcBalance = getSpotBalanceByCoin(spotState, 'USDC');
+
+  if (spotUsdcBalance === 0) {
+    return accountState;
+  }
+
+  return {
+    ...accountState,
+    availableToTradeBalance: (
+      parseFloat(accountState.availableToTradeBalance) + spotUsdcBalance
+    ).toString(),
+  };
+}
+
 /**
  * Aggregate multiple per-DEX AccountState objects into one by summing numeric fields.
  * ROE is recalculated as (totalUnrealizedPnl / totalMarginUsed) * 100.
@@ -99,6 +165,7 @@ export function calculateWeightedReturnOnEquity(
 export function aggregateAccountStates(states: AccountState[]): AccountState {
   const fallback: AccountState = {
     availableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    availableToTradeBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     totalBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     marginUsed: PERPS_CONSTANTS.FallbackDataDisplay,
     unrealizedPnl: PERPS_CONSTANTS.FallbackDataDisplay,
@@ -116,6 +183,10 @@ export function aggregateAccountStates(states: AccountState[]): AccountState {
     return {
       availableBalance: (
         parseFloat(acc.availableBalance) + parseFloat(state.availableBalance)
+      ).toString(),
+      availableToTradeBalance: (
+        parseFloat(acc.availableToTradeBalance) +
+        parseFloat(state.availableToTradeBalance)
       ).toString(),
       totalBalance: (
         parseFloat(acc.totalBalance) + parseFloat(state.totalBalance)

--- a/app/controllers/perps/utils/hyperLiquidAdapter.ts
+++ b/app/controllers/perps/utils/hyperLiquidAdapter.ts
@@ -1,5 +1,6 @@
 import { hasProperty, Hex, isHexString } from '@metamask/utils';
 
+import { getSpotBalance, getSpotBalanceByCoin } from './accountUtils';
 import {
   countSignificantFigures,
   roundToSignificantFigures,
@@ -287,20 +288,15 @@ export function adaptAccountStateFromSDK(
       : '0';
 
   const perpsBalance = parseFloat(perpsState.marginSummary.accountValue);
-
-  let spotBalance = 0;
-  if (spotState?.balances && Array.isArray(spotState.balances)) {
-    spotBalance = spotState.balances.reduce(
-      (sum: number, balance: { total?: string }) =>
-        sum + parseFloat(balance.total ?? '0'),
-      0,
-    );
-  }
-
+  const spotBalance = getSpotBalance(spotState);
+  const spotUsdcBalance = getSpotBalanceByCoin(spotState, 'USDC');
   const totalBalance = (spotBalance + perpsBalance).toString();
 
   const accountState: AccountState = {
     availableBalance: perpsState.withdrawable || '0',
+    availableToTradeBalance: (
+      parseFloat(perpsState.withdrawable || '0') + spotUsdcBalance
+    ).toString(),
     totalBalance: totalBalance || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',

--- a/app/controllers/perps/utils/myxAdapter.ts
+++ b/app/controllers/perps/utils/myxAdapter.ts
@@ -466,6 +466,7 @@ export function adaptAccountStateFromMYX(
 
   return {
     availableBalance: availableBalance.toString(),
+    availableToTradeBalance: availableBalance.toString(),
     totalBalance: totalBalance.toString(),
     marginUsed: marginUsed.toString(),
     unrealizedPnl: unrealizedPnl.toString(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change fixes a Perps funded-state bug on mobile for HyperLiquid accounts that have spot USDC buying power but zero perps withdrawable balance.

Previously, the mobile Perps market details flow treated availableBalance as both withdrawable funds and trading-ready balance, which caused users with usable spot-backed buying power to still see the unfunded Add funds state.

  The fix keeps those two concepts separate. availableBalance remains the raw withdrawable value, while account state now also includes availableToTradeBalance, which for HyperLiquid is computed from withdrawable funds plus spot USDC. 

The market details funded state check now uses availableToTradeBalance, so users with real buying power are no longer incorrectly treated as unfunded, without changing withdraw logic or order entry calculations.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
