### PR TITLE
fix(perps): use spot USDC balance for funded-state checks

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -772,6 +772,7 @@ describe('PerpsMarketDetailsView', () => {
     mockUsePerpsAccount.mockReturnValue({
       account: {
         availableBalance: '1000.00',
+        spotUsdcBalance: '0.00',
         marginUsed: '0.00',
         unrealizedPnl: '0.00',
         returnOnEquity: '0.00',
@@ -783,6 +784,7 @@ describe('PerpsMarketDetailsView', () => {
     mockUsePerpsLiveAccount.mockReturnValue({
       account: {
         availableBalance: '1000',
+        spotUsdcBalance: '0',
         marginUsed: '0',
         unrealizedPnl: '0',
         returnOnEquity: '0',
@@ -1009,6 +1011,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          spotUsdcBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1020,6 +1023,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          spotUsdcBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1056,6 +1060,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          spotUsdcBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1066,6 +1071,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          spotUsdcBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1097,6 +1103,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          spotUsdcBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1107,6 +1114,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          spotUsdcBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1145,6 +1153,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '0.00',
+          spotUsdcBalance: '0.00',
           marginUsed: '0.00',
           unrealizedPnl: '0.00',
           returnOnEquity: '0.00',
@@ -1155,6 +1164,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {
           availableBalance: '0',
+          spotUsdcBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',
           returnOnEquity: '0',
@@ -1189,6 +1199,7 @@ describe('PerpsMarketDetailsView', () => {
       mockUsePerpsAccount.mockReturnValue({
         account: {
           availableBalance: '1000.00',
+          spotUsdcBalance: '0.00',
           marginUsed: '500.00',
           unrealizedPnl: '50.00',
           returnOnEquity: '3.33',
@@ -1266,6 +1277,49 @@ describe('PerpsMarketDetailsView', () => {
       expect(
         getByTestId(PerpsMarketDetailsViewSelectorsIDs.SHORT_BUTTON),
       ).toBeOnTheScreen();
+    });
+
+    it('renders long/short buttons when withdrawable is zero but spot USDC funds trading', () => {
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUsePerpsAccount.mockReturnValue({
+        account: {
+          availableBalance: '0.00',
+          spotUsdcBalance: '100.76',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0.00',
+          totalBalance: '100.76',
+        },
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          availableBalance: '0',
+          spotUsdcBalance: '100.76',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '100.76',
+        },
+        isInitialLoading: false,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        { state: initialState },
+      );
+
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.LONG_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.SHORT_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        queryByTestId(PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON),
+      ).toBeNull();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -449,13 +449,17 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const availableBalance = Number.parseFloat(
     account?.availableBalance?.toString() ?? '0',
   );
+  const spotUsdcBalance = Number.parseFloat(
+    account?.spotUsdcBalance?.toString() ?? '0',
+  );
+  const fundedStateBalance = availableBalance + spotUsdcBalance;
   const showAddFundsCTA =
     isEligible &&
     !isLoadingPosition &&
     !existingPosition &&
     !isAtOICap &&
     !isLoadingAccount &&
-    availableBalance < PERPS_MIN_BALANCE_THRESHOLD &&
+    fundedStateBalance < PERPS_MIN_BALANCE_THRESHOLD &&
     defaultPayTokenWhenNoPerpsBalance === null;
 
   const handleAddFunds = useCallback(async () => {

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.test.ts
@@ -18,7 +18,7 @@ const mockUsePerpsPaymentTokens = jest.requireMock<
 
 function getState(
   overrides: {
-    perpsAccount?: { availableBalance: string } | null;
+    perpsAccount?: { availableBalance: string; spotUsdcBalance?: string } | null;
     allowlistAssets?: string[];
     isTestnet?: boolean;
     activeProvider?: 'hyperliquid' | 'myx' | 'aggregated';
@@ -26,7 +26,7 @@ function getState(
   } = {},
 ) {
   const {
-    perpsAccount = { availableBalance: '0' },
+    perpsAccount = { availableBalance: '0', spotUsdcBalance: '0' },
     allowlistAssets = [],
     isTestnet = false,
     activeProvider,
@@ -179,6 +179,30 @@ describe('useDefaultPayWithTokenWhenNoPerpsBalance', () => {
     expect(result.current?.address).toBe('0xusdc');
     expect(result.current?.chainId).toBe('0xa4b1');
     expect(result.current?.description).toBe('USDC');
+  });
+
+  it('returns null when spot USDC balance already covers funded state', () => {
+    mockUsePerpsPaymentTokens.mockReturnValue([
+      {
+        address: '0xusdc',
+        chainId: '0xa4b1',
+        symbol: 'USDC',
+        balanceFiat: 'US$500',
+        decimals: 6,
+      },
+    ] as PerpsToken[]);
+
+    const { result } = runHook(
+      getState({
+        perpsAccount: {
+          availableBalance: '0',
+          spotUsdcBalance: '100.76',
+        },
+        allowlistAssets: ['0xa4b1.0xusdc'],
+      }),
+    );
+
+    expect(result.current).toBeNull();
   });
 
   it('treats null perps account as zero balance and returns default token when allowlist has balance', () => {

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
@@ -42,8 +42,12 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
     const availableBalance = Number.parseFloat(
       perpsAccount?.availableBalance?.toString() ?? '0',
     );
+    const spotUsdcBalance = Number.parseFloat(
+      perpsAccount?.spotUsdcBalance?.toString() ?? '0',
+    );
+    const fundedStateBalance = availableBalance + spotUsdcBalance;
 
-    if (availableBalance > PERPS_MIN_BALANCE_THRESHOLD) {
+    if (fundedStateBalance > PERPS_MIN_BALANCE_THRESHOLD) {
       return null;
     }
     if (!allowlistAssets?.length) {
@@ -93,6 +97,7 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
   }, [
     featureEnabled,
     perpsAccount?.availableBalance,
+    perpsAccount?.spotUsdcBalance,
     allowlistAssets,
     activeProvider,
     currentNetwork,

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -8863,6 +8863,9 @@ describe('HyperLiquidProvider', () => {
       // Reset standalone client mock
       mockStandaloneInfoClient = {
         clearinghouseState: jest.fn(),
+        spotClearinghouseState: jest.fn().mockResolvedValue({
+          balances: [{ coin: 'USDC', hold: '1000', total: '10000' }],
+        }),
         frontendOpenOrders: jest.fn(),
         perpDexs: jest.fn().mockResolvedValue([null]),
       };
@@ -9035,6 +9038,7 @@ describe('HyperLiquidProvider', () => {
           mockStandaloneInfoClient.clearinghouseState,
         ).toHaveBeenCalledWith({ user: mockUserAddress });
         expect(accountState.totalBalance).toBeDefined();
+        expect(accountState.spotUsdcBalance).toBeDefined();
       });
 
       it('uses testnet endpoint when provider is in testnet mode', async () => {
@@ -9074,6 +9078,7 @@ describe('HyperLiquidProvider', () => {
         // Assert — all DEX queries failed, aggregateAccountStates([]) returns fallback
         expect(result).toEqual({
           availableBalance: '--',
+          spotUsdcBalance: '10000',
           totalBalance: '--',
           marginUsed: '--',
           unrealizedPnl: '--',
@@ -9456,6 +9461,7 @@ describe('HyperLiquidProvider', () => {
         // Assert - balances should be aggregated
         expect(parseFloat(accountState.totalBalance)).toBe(55000);
         expect(parseFloat(accountState.marginUsed)).toBe(1500);
+        expect(parseFloat(accountState.spotUsdcBalance ?? '0')).toBe(10000);
       });
 
       it('does not poison fully-initialized cache when standalone perpDexs() fails', async () => {

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -109,7 +109,10 @@ import type {
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
 import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
-import { aggregateAccountStates } from '../utils/accountUtils';
+import {
+  aggregateAccountStates,
+  getSpotBalanceByCoin,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptAccountStateFromSDK,
@@ -5553,17 +5556,24 @@ export class HyperLiquidProvider implements PerpsProvider {
           isTestnet: this.#clientService.isTestnetMode(),
         });
         const dexs = await this.#getStandaloneValidatedDexs();
-        const results = await queryStandaloneClearinghouseStates(
-          standaloneInfoClient,
-          userAddress,
-          dexs,
-        );
+        const [spotState, results] = await Promise.all([
+          standaloneInfoClient.spotClearinghouseState({ user: userAddress }),
+          queryStandaloneClearinghouseStates(
+            standaloneInfoClient,
+            userAddress,
+            dexs,
+          ),
+        ]);
 
         // Aggregate account states across all DEXs
         const dexAccountStates = results.map((perpsState) =>
           adaptAccountStateFromSDK(perpsState),
         );
         const aggregatedAccountState = aggregateAccountStates(dexAccountStates);
+        aggregatedAccountState.spotUsdcBalance = getSpotBalanceByCoin(
+          spotState,
+          'USDC',
+        ).toString();
 
         this.#deps.debugLogger.log(
           'HyperLiquidProvider: standalone account state fetched',
@@ -5688,6 +5698,10 @@ export class HyperLiquidProvider implements PerpsProvider {
           0,
         );
       }
+      aggregatedAccountState.spotUsdcBalance = getSpotBalanceByCoin(
+        spotState,
+        'USDC',
+      ).toString();
       aggregatedAccountState.totalBalance = (
         parseFloat(aggregatedAccountState.totalBalance) + spotBalance
       ).toString();

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -381,6 +381,14 @@ describe('HyperLiquidSubscriptionService', () => {
       isTestnetMode: jest.fn(() => false),
       ensureTransportReady: jest.fn().mockResolvedValue(undefined),
       getConnectionState: jest.fn(() => 'connected'),
+      getInfoClient: jest.fn(
+        () =>
+          ({
+            spotClearinghouseState: jest.fn().mockResolvedValue({
+              balances: [{ coin: 'USDC', hold: '0', total: '100.76' }],
+            }),
+          }) as any,
+      ),
     } as any;
 
     // Mock wallet service
@@ -3673,6 +3681,35 @@ describe('HyperLiquidSubscriptionService', () => {
 
       unsubscribe1();
       unsubscribe2();
+    });
+
+    it('includes spot USDC balance in aggregated account updates', async () => {
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '0',
+        totalBalance: '0',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+        spotUsdcBalance: '0',
+      }));
+
+      const mockCallback = jest.fn();
+
+      const unsubscribe = service.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      expect(mockCallback).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          availableBalance: '0',
+          spotUsdcBalance: '100.76',
+        }),
+      );
+
+      unsubscribe();
     });
   });
 

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -38,7 +38,11 @@ import type {
   PerpsPlatformDependencies,
   PerpsLogger,
 } from '../types';
-import { calculateWeightedReturnOnEquity } from '../utils/accountUtils';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
+import {
+  calculateWeightedReturnOnEquity,
+  getSpotBalanceByCoin,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptPositionFromSDK,
@@ -162,6 +166,12 @@ export class HyperLiquidSubscriptionService {
   #cachedOrders: Order[] | null = null; // Aggregated orders
 
   #cachedAccount: AccountState | null = null; // Aggregated account
+
+  #cachedSpotState: SpotClearinghouseStateResponse | null = null;
+
+  #cachedSpotStateUserAddress: string | null = null;
+
+  #spotStatePromise?: Promise<void>;
 
   #ordersCacheInitialized = false; // Track if orders cache has received WebSocket data
 
@@ -684,7 +694,7 @@ export class HyperLiquidSubscriptionService {
   }
 
   #hashAccountState(account: AccountState): string {
-    return `${account.availableBalance}:${account.totalBalance}:${account.marginUsed}:${account.unrealizedPnl}`;
+    return `${account.availableBalance}:${account.spotUsdcBalance ?? '0'}:${account.totalBalance}:${account.marginUsed}:${account.unrealizedPnl}`;
   }
 
   // Cache hashes to avoid recomputation
@@ -984,12 +994,54 @@ export class HyperLiquidSubscriptionService {
     return {
       ...firstDexAccount,
       availableBalance: totalAvailableBalance.toString(),
+      spotUsdcBalance: getSpotBalanceByCoin(
+        this.#cachedSpotState,
+        'USDC',
+      ).toString(),
       totalBalance: totalBalance.toString(),
       marginUsed: totalMarginUsed.toString(),
       unrealizedPnl: totalUnrealizedPnl.toString(),
       subAccountBreakdown,
       returnOnEquity,
     };
+  }
+
+  async #refreshSpotState(userAddress: string): Promise<void> {
+    const infoClient = this.#clientService.getInfoClient();
+    this.#cachedSpotState = await infoClient.spotClearinghouseState({
+      user: userAddress,
+    });
+    this.#cachedSpotStateUserAddress = userAddress;
+
+    if (this.#dexAccountCache.size > 0) {
+      this.#aggregateAndNotifySubscribers();
+    }
+  }
+
+  async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
+    const userAddress = await this.#walletService.getUserAddressWithDefault(
+      accountId,
+    );
+
+    if (
+      this.#cachedSpotState &&
+      this.#cachedSpotStateUserAddress === userAddress
+    ) {
+      return;
+    }
+
+    if (this.#spotStatePromise) {
+      await this.#spotStatePromise;
+      return;
+    }
+
+    this.#spotStatePromise = this.#refreshSpotState(userAddress);
+
+    try {
+      await this.#spotStatePromise;
+    } finally {
+      this.#spotStatePromise = undefined;
+    }
   }
 
   /**
@@ -1943,6 +1995,8 @@ export class HyperLiquidSubscriptionService {
       this.#cachedPositions = null;
       this.#cachedOrders = null;
       this.#cachedAccount = null;
+      this.#cachedSpotState = null;
+      this.#cachedSpotStateUserAddress = null;
       this.#ordersCacheInitialized = false; // Reset cache initialization flag
       this.#positionsCacheInitialized = false; // Reset cache initialization flag
 
@@ -2253,9 +2307,16 @@ export class HyperLiquidSubscriptionService {
     this.#accountSubscriberCount += 1;
 
     // Immediately provide cached data if available
-    if (this.#cachedAccount) {
+    if (this.#cachedAccount && this.#cachedSpotState) {
       callback(this.#cachedAccount);
     }
+
+    this.#ensureSpotState(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureSpotState'),
+      );
+    });
 
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
@@ -2268,6 +2329,8 @@ export class HyperLiquidSubscriptionService {
     return () => {
       unsubscribe();
       this.#accountSubscriberCount -= 1;
+      this.#cachedSpotState = null;
+      this.#cachedSpotStateUserAddress = null;
       this.#cleanupSharedWebData3ISubscription();
     };
   }
@@ -3654,6 +3717,8 @@ export class HyperLiquidSubscriptionService {
     this.#cachedPositions = null;
     this.#cachedOrders = null;
     this.#cachedAccount = null;
+    this.#cachedSpotState = null;
+    this.#cachedSpotStateUserAddress = null;
     this.#cachedFills = null;
     this.#ordersCacheInitialized = false; // Reset cache initialization flag
     this.#positionsCacheInitialized = false; // Reset cache initialization flag

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -213,6 +213,7 @@ export type Position = {
 // Using 'type' instead of 'interface' for BaseController Json compatibility
 export type AccountState = {
   availableBalance: string; // Based on HyperLiquid: withdrawable
+  spotUsdcBalance?: string; // Raw spot USDC balance used for funded-state checks on HyperLiquid
   totalBalance: string; // Based on HyperLiquid: accountValue
   marginUsed: string; // Based on HyperLiquid: marginUsed
   unrealizedPnl: string; // Based on HyperLiquid: unrealizedPnl

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -4,11 +4,13 @@ import type { AccountState } from '../types';
 import {
   aggregateAccountStates,
   calculateWeightedReturnOnEquity,
+  getSpotBalanceByCoin,
 } from './accountUtils';
 
 describe('aggregateAccountStates', () => {
   const fallback: AccountState = {
     availableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    spotUsdcBalance: '0',
     totalBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     marginUsed: PERPS_CONSTANTS.FallbackDataDisplay,
     unrealizedPnl: PERPS_CONSTANTS.FallbackDataDisplay,
@@ -22,6 +24,7 @@ describe('aggregateAccountStates', () => {
   it('returns the single state unchanged when given one element', () => {
     const single: AccountState = {
       availableBalance: '100',
+      spotUsdcBalance: '25',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -33,6 +36,7 @@ describe('aggregateAccountStates', () => {
   it('sums numeric fields from two states and recalculates ROE', () => {
     const stateA: AccountState = {
       availableBalance: '100',
+      spotUsdcBalance: '10',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -40,6 +44,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '50',
+      spotUsdcBalance: '5',
       totalBalance: '150',
       marginUsed: '30',
       unrealizedPnl: '6',
@@ -49,6 +54,7 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates([stateA, stateB]);
 
     expect(parseFloat(result.availableBalance)).toBe(150);
+    expect(parseFloat(result.spotUsdcBalance ?? '0')).toBe(15);
     expect(parseFloat(result.totalBalance)).toBe(350);
     expect(parseFloat(result.marginUsed)).toBe(80);
     expect(parseFloat(result.unrealizedPnl)).toBe(16);
@@ -60,6 +66,7 @@ describe('aggregateAccountStates', () => {
     const states: AccountState[] = [
       {
         availableBalance: '100',
+        spotUsdcBalance: '10',
         totalBalance: '200',
         marginUsed: '50',
         unrealizedPnl: '10',
@@ -67,6 +74,7 @@ describe('aggregateAccountStates', () => {
       },
       {
         availableBalance: '200',
+        spotUsdcBalance: '20',
         totalBalance: '300',
         marginUsed: '100',
         unrealizedPnl: '30',
@@ -74,6 +82,7 @@ describe('aggregateAccountStates', () => {
       },
       {
         availableBalance: '50',
+        spotUsdcBalance: '5',
         totalBalance: '100',
         marginUsed: '50',
         unrealizedPnl: '5',
@@ -84,6 +93,7 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates(states);
 
     expect(parseFloat(result.availableBalance)).toBe(350);
+    expect(parseFloat(result.spotUsdcBalance ?? '0')).toBe(35);
     expect(parseFloat(result.totalBalance)).toBe(600);
     expect(parseFloat(result.marginUsed)).toBe(200);
     expect(parseFloat(result.unrealizedPnl)).toBe(45);
@@ -94,6 +104,7 @@ describe('aggregateAccountStates', () => {
   it('does not mutate the input state object', () => {
     const single: AccountState = {
       availableBalance: '100',
+      spotUsdcBalance: '0',
       totalBalance: '200',
       marginUsed: '50',
       unrealizedPnl: '10',
@@ -109,6 +120,7 @@ describe('aggregateAccountStates', () => {
   it('sets ROE to 0 when total marginUsed is 0', () => {
     const state: AccountState = {
       availableBalance: '100',
+      spotUsdcBalance: '0',
       totalBalance: '100',
       marginUsed: '0',
       unrealizedPnl: '0',
@@ -121,6 +133,7 @@ describe('aggregateAccountStates', () => {
   it('handles negative unrealizedPnl correctly', () => {
     const stateA: AccountState = {
       availableBalance: '80',
+      spotUsdcBalance: '0',
       totalBalance: '180',
       marginUsed: '100',
       unrealizedPnl: '-20',
@@ -128,6 +141,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '40',
+      spotUsdcBalance: '0',
       totalBalance: '90',
       marginUsed: '50',
       unrealizedPnl: '-10',
@@ -145,6 +159,7 @@ describe('aggregateAccountStates', () => {
   it('handles decimal values correctly', () => {
     const stateA: AccountState = {
       availableBalance: '100.50',
+      spotUsdcBalance: '0.25',
       totalBalance: '200.75',
       marginUsed: '50.25',
       unrealizedPnl: '10.10',
@@ -152,6 +167,7 @@ describe('aggregateAccountStates', () => {
     };
     const stateB: AccountState = {
       availableBalance: '50.50',
+      spotUsdcBalance: '0.75',
       totalBalance: '150.25',
       marginUsed: '30.75',
       unrealizedPnl: '6.90',
@@ -161,9 +177,37 @@ describe('aggregateAccountStates', () => {
     const result = aggregateAccountStates([stateA, stateB]);
 
     expect(parseFloat(result.availableBalance)).toBeCloseTo(151, 0);
+    expect(parseFloat(result.spotUsdcBalance ?? '0')).toBeCloseTo(1, 0);
     expect(parseFloat(result.totalBalance)).toBeCloseTo(351, 0);
     expect(parseFloat(result.marginUsed)).toBeCloseTo(81, 0);
     expect(parseFloat(result.unrealizedPnl)).toBeCloseTo(17, 0);
+  });
+});
+
+describe('getSpotBalanceByCoin', () => {
+  it('returns only the requested spot coin balance', () => {
+    expect(
+      getSpotBalanceByCoin(
+        {
+          balances: [
+            { coin: 'USDC', total: '100.76', hold: '0.0' },
+            { coin: 'HYPE', total: '0.36', hold: '0.0' },
+          ],
+        },
+        'USDC',
+      ),
+    ).toBeCloseTo(100.76, 5);
+  });
+
+  it('returns zero when the coin is missing', () => {
+    expect(
+      getSpotBalanceByCoin(
+        {
+          balances: [{ coin: 'HYPE', total: '0.36', hold: '0.0' }],
+        },
+        'USDC',
+      ),
+    ).toBe(0);
   });
 });
 

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -3,6 +3,7 @@
  * Handles account selection and EVM account filtering
  */
 import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { SpotClearinghouseStateResponse } from '@nktkas/hyperliquid';
 
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
@@ -99,6 +100,7 @@ export function calculateWeightedReturnOnEquity(
 export function aggregateAccountStates(states: AccountState[]): AccountState {
   const fallback: AccountState = {
     availableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    spotUsdcBalance: '0',
     totalBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     marginUsed: PERPS_CONSTANTS.FallbackDataDisplay,
     unrealizedPnl: PERPS_CONSTANTS.FallbackDataDisplay,
@@ -116,6 +118,10 @@ export function aggregateAccountStates(states: AccountState[]): AccountState {
     return {
       availableBalance: (
         parseFloat(acc.availableBalance) + parseFloat(state.availableBalance)
+      ).toString(),
+      spotUsdcBalance: (
+        parseFloat(acc.spotUsdcBalance ?? '0') +
+        parseFloat(state.spotUsdcBalance ?? '0')
       ).toString(),
       totalBalance: (
         parseFloat(acc.totalBalance) + parseFloat(state.totalBalance)
@@ -143,4 +149,19 @@ export function aggregateAccountStates(states: AccountState[]): AccountState {
   }
 
   return aggregated;
+}
+
+export function getSpotBalanceByCoin(
+  spotState: SpotClearinghouseStateResponse | null | undefined,
+  coin: string,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  return spotState.balances.reduce(
+    (sum, balance) =>
+      balance.coin === coin ? sum + parseFloat(balance.total ?? '0') : sum,
+    0,
+  );
 }

--- a/app/controllers/perps/utils/hyperLiquidAdapter.ts
+++ b/app/controllers/perps/utils/hyperLiquidAdapter.ts
@@ -1,5 +1,6 @@
 import { hasProperty, Hex, isHexString } from '@metamask/utils';
 
+import { getSpotBalanceByCoin } from './accountUtils';
 import {
   countSignificantFigures,
   roundToSignificantFigures,
@@ -298,9 +299,11 @@ export function adaptAccountStateFromSDK(
   }
 
   const totalBalance = (spotBalance + perpsBalance).toString();
+  const spotUsdcBalance = getSpotBalanceByCoin(spotState, 'USDC');
 
   const accountState: AccountState = {
     availableBalance: perpsState.withdrawable || '0',
+    spotUsdcBalance: spotUsdcBalance.toString(),
     totalBalance: totalBalance || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change fixes a HyperLiquid funded-state bug on mobile for accounts that have usable spot USDC but zero perps withdrawable balance. Previously, the market details flow and default pay token logic treated availableBalance as the only signal for whether the account was funded enough to trade, which caused users with real spot backed buying power to still see Add funds and other unfunded behavior.

  The fix keeps the controller data explicit. availableBalance still means HyperLiquid withdrawable, and the controller now also exposes raw spotUsdcBalance. Mobile then uses availableBalance + spotUsdcBalance only for funded state decisions, without changing withdraw behavior, order sizing, or margin calculations. This keeps the production fix narrow while making the trading-ready checks match the actual account state.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
