### PR TITLE
fix: add chain id guard

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuySetup.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuySetup.test.ts
@@ -1,16 +1,24 @@
 import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import type { Position } from '@metamask/social-controllers';
 import {
   useAssetMetadata,
   AssetType,
 } from '../../../../../UI/Bridge/hooks/useAssetMetadata';
+import { selectIsBridgeEnabledSourceFactory } from '../../../../../../core/redux/slices/bridge';
 import { useQuickBuySetup } from './useQuickBuySetup';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
 
 jest.mock('../../../../../UI/Bridge/hooks/useAssetMetadata', () => ({
   ...jest.requireActual('../../../../../UI/Bridge/hooks/useAssetMetadata'),
   useAssetMetadata: jest.fn(),
 }));
 
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseAssetMetadata = useAssetMetadata as jest.MockedFunction<
   typeof useAssetMetadata
 >;
@@ -27,6 +35,12 @@ const createPosition = (overrides: Partial<Position> = {}): Position =>
 describe('useQuickBuySetup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsBridgeEnabledSourceFactory) {
+        return () => true;
+      }
+      return undefined;
+    });
     mockUseAssetMetadata.mockReturnValue({
       assetMetadata: undefined,
       pending: false,
@@ -47,6 +61,25 @@ describe('useQuickBuySetup', () => {
       isUnsupportedChain: false,
     });
     expect(mockUseAssetMetadata).toHaveBeenCalledWith('', false, undefined);
+  });
+
+  it('marks chain as unsupported when not bridge-enabled', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsBridgeEnabledSourceFactory) {
+        return () => false;
+      }
+      return undefined;
+    });
+
+    const position = createPosition({ chain: 'base' });
+    const { result } = renderHook(() => useQuickBuySetup(position));
+
+    expect(result.current).toEqual({
+      chainId: undefined,
+      destToken: undefined,
+      isLoading: false,
+      isUnsupportedChain: true,
+    });
   });
 
   it('marks unsupported chains when the position chain is not mapped', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuySetup.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuySetup.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   formatChainIdToHex,
@@ -8,6 +9,7 @@ import type { Position } from '@metamask/social-controllers';
 import { useAssetMetadata } from '../../../../../UI/Bridge/hooks/useAssetMetadata';
 import { chainNameToId } from '../../../utils/chainMapping';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
+import { selectIsBridgeEnabledSourceFactory } from '../../../../../../core/redux/slices/bridge';
 
 export interface QuickBuySetupResult {
   /** The destination chain ID (hex or CAIP) for this position's chain */
@@ -29,16 +31,17 @@ export interface QuickBuySetupResult {
 export const useQuickBuySetup = (
   position: Position | null,
 ): QuickBuySetupResult => {
+  const isBridgeEnabledSource = useSelector(selectIsBridgeEnabledSourceFactory);
+
   // Destination chain from the position — hex for EVM, CAIP for non-EVM
   const destChainId = useMemo(() => {
     if (!position) return undefined;
     const caipId = chainNameToId(position.chain);
-    return caipId
-      ? isNonEvmChainId(caipId)
-        ? caipId
-        : formatChainIdToHex(caipId)
-      : undefined;
-  }, [position]);
+    if (!caipId) return undefined;
+    if (isNonEvmChainId(caipId)) return caipId;
+    if (!isBridgeEnabledSource(caipId)) return undefined;
+    return formatChainIdToHex(caipId);
+  }, [position, isBridgeEnabledSource]);
 
   const isUnsupportedChain = Boolean(position && !destChainId);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds small fixes and improvements to Quickbuy:

- Add chain id guard check

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes QuickBuy chain resolution to depend on the bridge enablement selector, which can disable previously-available EVM chains and alter downstream token/metadata fetching behavior.
> 
> **Overview**
> **QuickBuy now blocks unsupported EVM destination chains earlier.** `useQuickBuySetup` gates EVM `destChainId` resolution behind `selectIsBridgeEnabledSourceFactory`, returning `undefined` (and marking the position as unsupported) when the chain is not bridge-enabled.
> 
> Tests were updated to mock `react-redux` `useSelector` and add coverage for the new “not bridge-enabled” unsupported-chain behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b1b870aa618557541c415fd1b7efc44fbbadb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->