### PR TITLE
fix(social-leaderboard): prevent rank dot from wrapping in top traders list

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -171,6 +171,20 @@ describe('TraderRow', () => {
       expect(resolveMinWidth(buttonWithMinWidth as ReactTestInstance)).toBe(96);
     });
 
+    it('renders the rank on a single line so the trailing dot does not wrap for double-digit ranks', () => {
+      const doubleDigitTrader: TopTrader = { ...baseTrader, rank: 20 };
+      renderWithProvider(
+        <TraderRow
+          trader={doubleDigitTrader}
+          onFollowPress={mockOnFollowPress}
+        />,
+      );
+
+      const rankText = screen.getByText('20.');
+
+      expect(rankText.props.numberOfLines).toBe(1);
+    });
+
     it('keeps the same minimum width when toggling between Follow and Following', () => {
       const { rerender } = renderWithProvider(
         <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -76,7 +76,8 @@ const TraderRow: React.FC<TraderRowProps> = ({
             variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
             color={TextColor.TextDefault}
-            twClassName="w-6 text-right"
+            numberOfLines={1}
+            twClassName="w-8 text-right"
           >
             {`${trader.rank}.`}
           </Text>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -22,7 +22,7 @@ const TraderRowSkeleton: React.FC = () => {
       >
         <View style={tw.style('flex-row items-center')}>
           {/* Rank placeholder */}
-          <View style={tw.style('w-6 h-4 rounded mr-3')} />
+          <View style={tw.style('w-8 h-4 rounded mr-3')} />
 
           {/* Avatar placeholder */}
           <View style={tw.style('w-10 h-10 rounded-full mr-3')} />


### PR DESCRIPTION
---

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In the Top Traders list, double-digit ranks (e.g. `20.`) looked misaligned and appeared to be missing their trailing dot. The rank `Text` in `TraderRow` used a `w-6` (24px) column, which is too narrow to fit `"20."` on a single line at `BodyMd`, so the period wrapped to a second line. That made the row taller than the avatar and caused the visual misalignment the user reported.

This PR:

- Widens the rank column to `w-8` (32px) and adds `numberOfLines={1}` so the label never wraps (up to `999.` fits comfortably, and the list is capped at 50).
- Mirrors the same width in `TraderRowSkeleton` so the loading placeholder stays aligned with the loaded row.
- Adds a regression test asserting the rank renders with `numberOfLines={1}` for a double-digit rank.

## **Changelog**

CHANGELOG entry: Fixed a visual alignment issue in the Top Traders list where double-digit ranks appeared to be missing their trailing dot.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Top Traders rank alignment

  Scenario: Double-digit ranks keep their trailing dot
    Given the user is on the Top Traders list
    When the user scrolls to ranks 10 through 50
    Then every rank label is rendered on a single line with its trailing dot visible
    And avatars and usernames stay vertically centered next to the rank
```

## **Screenshots/Recordings**

### **Before**


Rank `20.` visually shows only `20`; the period wraps onto a second line and pushes the avatar off-center.

<img width="403" height="136" alt="image" src="https://github.com/user-attachments/assets/024aa73e-a247-4117-90c3-b502cd30ca4b" />

### **After**

Rank `20.` renders on one line; rows 19 and 20 are vertically aligned.
<img width="403" height="136" alt="image" src="https://github.com/user-attachments/assets/0e177e50-eaac-454a-bc33-4c36e123797f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak with a small test addition; no data flow or business logic changes.
> 
> **Overview**
> Fixes a Top Traders layout issue where double-digit rank labels like `20.` could wrap the trailing dot onto a second line.
> 
> The rank column in `TraderRow` is widened (`w-6` → `w-8`) and the rank `Text` is constrained with `numberOfLines={1}`; the skeleton placeholder width is updated to match, and a regression test asserts double-digit ranks render on a single line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b78f2d086e347c72bc114e181ceb04aef0034f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->