### PR TITLE
chore: add zero to decimal inputs

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyAmountInput.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyAmountInput.test.tsx
@@ -56,6 +56,24 @@ describe('QuickBuyAmountInput', () => {
     expect(screen.getByText('$50')).toBeOnTheScreen();
   });
 
+  it('renders a leading decimal without dropping the zero prefix', () => {
+    renderWithProvider(
+      <QuickBuyAmountInput {...defaultProps} usdAmount="0." />,
+    );
+
+    expect(screen.getByText('$0.')).toBeOnTheScreen();
+    expect(screen.queryByText('$.')).not.toBeOnTheScreen();
+  });
+
+  it('renders a leading decimal with digits without dropping the zero prefix', () => {
+    renderWithProvider(
+      <QuickBuyAmountInput {...defaultProps} usdAmount="0.5" />,
+    );
+
+    expect(screen.getByText('$0.5')).toBeOnTheScreen();
+    expect(screen.queryByText('$.5')).not.toBeOnTheScreen();
+  });
+
   it('shows a loading spinner while fetching a quote for a valid amount', () => {
     const { UNSAFE_getByType } = renderWithProvider(
       <QuickBuyAmountInput

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
@@ -258,6 +258,32 @@ describe('useQuickBuyBottomSheet', () => {
 
       expect(result.current.usdAmount).toBe('20');
     });
+
+    it('normalizes a leading decimal without digits', () => {
+      const { result } = renderHook(() =>
+        useQuickBuyBottomSheet(createPosition(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleAmountChange('.');
+      });
+
+      expect(result.current.usdAmount).toBe('0.');
+      expect(result.current.hasValidAmount).toBe(false);
+    });
+
+    it('normalizes a leading decimal with digits', () => {
+      const { result } = renderHook(() =>
+        useQuickBuyBottomSheet(createPosition(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleAmountChange('.5');
+      });
+
+      expect(result.current.usdAmount).toBe('0.5');
+      expect(result.current.hasValidAmount).toBe(true);
+    });
   });
 
   describe('handlePresetPress', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -263,10 +263,11 @@ export function useQuickBuyBottomSheet(
 
   const handleAmountChange = useCallback((text: string) => {
     const cleaned = text.replace(/[^0-9.]/g, '');
-    const parts = cleaned.split('.');
+    const normalized = cleaned.startsWith('.') ? `0${cleaned}` : cleaned;
+    const parts = normalized.split('.');
     if (parts.length > 2) return;
     if (parts.length === 2 && parts[1].length > 2) return;
-    setUsdAmount(cleaned);
+    setUsdAmount(normalized);
   }, []);
 
   const handleConfirm = useCallback(async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the case where the user provides a decimal input using a .xx without a zero prefix. E.g. converts input `.33` into `0.33`

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Quick Buy amount parsing used to request bridge quotes, so a regression could affect entered purchase amounts or quote/validation behavior. Scope is small and covered by new unit tests for the edge cases.
> 
> **Overview**
> Quick Buy now **normalizes USD inputs that start with a decimal point** by prefixing a `0` (e.g. `.5`  `0.5`, `.`  `0.`) in `useQuickBuyBottomSheet.handleAmountChange`, while keeping existing validation for multiple decimals and max 2 fractional digits.
> 
> Adds tests to ensure the hook stores the normalized value and validity flags correctly, and that `QuickBuyAmountInput` renders `$0.` / `$0.5` (not `$.` / `$.5`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7344717da69e8554df9e2a96030da65641fcc438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->