### PR TITLE
fix(perps): complete spot-balance parity cp-7.72.2

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1092,6 +1092,47 @@ describe('PerpsMarketDetailsView', () => {
       ).toBeNull();
     });
 
+    it('shows add funds CTA when total balance is funded but spendable balance has no direct order path', () => {
+      mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
+      mockUsePerpsAccount.mockReturnValue({
+        account: {
+          availableBalance: '0.00',
+          marginUsed: '0.00',
+          unrealizedPnl: '0.00',
+          returnOnEquity: '0.00',
+          totalBalance: '100.00',
+        },
+        isInitialLoading: false,
+      });
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          availableBalance: '0',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '100',
+        },
+        isInitialLoading: false,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        { state: initialState },
+      );
+
+      expect(
+        getByTestId(PerpsMarketDetailsViewSelectorsIDs.ADD_FUNDS_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        queryByTestId(PerpsMarketDetailsViewSelectorsIDs.LONG_BUTTON),
+      ).toBeNull();
+      expect(
+        queryByTestId(PerpsMarketDetailsViewSelectorsIDs.SHORT_BUTTON),
+      ).toBeNull();
+    });
+
     it('calls navigateToConfirmation and depositWithConfirmation when add funds is pressed', async () => {
       mockUseDefaultPayWithTokenWhenNoPerpsBalance.mockReturnValue(null);
       mockUsePerpsAccount.mockReturnValue({

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -446,8 +446,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     useDefaultPayWithTokenWhenNoPerpsBalance();
   const { depositWithConfirmation } = usePerpsTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
-  const availableBalance = Number.parseFloat(
-    account?.availableBalance?.toString() ?? '0',
+  const totalBalance = Number.parseFloat(
+    account?.totalBalance?.toString() ?? '0',
   );
   const showAddFundsCTA =
     isEligible &&
@@ -455,7 +455,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     !existingPosition &&
     !isAtOICap &&
     !isLoadingAccount &&
-    availableBalance < PERPS_MIN_BALANCE_THRESHOLD &&
+    totalBalance < PERPS_MIN_BALANCE_THRESHOLD &&
     defaultPayTokenWhenNoPerpsBalance === null;
 
   const handleAddFunds = useCallback(async () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -449,21 +449,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const availableBalance = Number.parseFloat(
     account?.availableBalance?.toString() ?? '0',
   );
-  const totalBalance = Number.parseFloat(
-    account?.totalBalance?.toString() ?? '0',
-  );
   const hasDirectOrderFundingPath =
     !isLoadingAccount &&
     (availableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
       defaultPayTokenWhenNoPerpsBalance !== null);
-  const showAddFundsCTA =
-    isEligible &&
-    !isLoadingPosition &&
-    !existingPosition &&
-    !isAtOICap &&
-    !isLoadingAccount &&
-    totalBalance < PERPS_MIN_BALANCE_THRESHOLD &&
-    !hasDirectOrderFundingPath;
 
   const handleAddFunds = useCallback(async () => {
     if (!isEligible) {
@@ -1199,9 +1188,12 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
   const shouldShowNewPositionActions =
     hasLongShortButtons && !existingPosition && !isAtOICap;
-  const shouldShowAddFundsCTASection = shouldShowNewPositionActions
-    ? showAddFundsCTA || !hasDirectOrderFundingPath
-    : false;
+  const shouldShowAddFundsCTASection =
+    shouldShowNewPositionActions &&
+    isEligible &&
+    !isLoadingAccount &&
+    !isLoadingPosition &&
+    !hasDirectOrderFundingPath;
   const shouldShowLongShortButtonsOnly =
     shouldShowNewPositionActions && !shouldShowAddFundsCTASection;
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -446,9 +446,16 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     useDefaultPayWithTokenWhenNoPerpsBalance();
   const { depositWithConfirmation } = usePerpsTrading();
   const { navigateToConfirmation } = useConfirmNavigation();
+  const availableBalance = Number.parseFloat(
+    account?.availableBalance?.toString() ?? '0',
+  );
   const totalBalance = Number.parseFloat(
     account?.totalBalance?.toString() ?? '0',
   );
+  const hasDirectOrderFundingPath =
+    !isLoadingAccount &&
+    (availableBalance >= PERPS_MIN_BALANCE_THRESHOLD ||
+      defaultPayTokenWhenNoPerpsBalance !== null);
   const showAddFundsCTA =
     isEligible &&
     !isLoadingPosition &&
@@ -456,7 +463,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     !isAtOICap &&
     !isLoadingAccount &&
     totalBalance < PERPS_MIN_BALANCE_THRESHOLD &&
-    defaultPayTokenWhenNoPerpsBalance === null;
+    !hasDirectOrderFundingPath;
 
   const handleAddFunds = useCallback(async () => {
     if (!isEligible) {
@@ -1192,10 +1199,11 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
   const shouldShowNewPositionActions =
     hasLongShortButtons && !existingPosition && !isAtOICap;
-  const shouldShowAddFundsCTASection =
-    shouldShowNewPositionActions && showAddFundsCTA;
+  const shouldShowAddFundsCTASection = shouldShowNewPositionActions
+    ? showAddFundsCTA || !hasDirectOrderFundingPath
+    : false;
   const shouldShowLongShortButtonsOnly =
-    shouldShowNewPositionActions && !showAddFundsCTA;
+    shouldShowNewPositionActions && !shouldShowAddFundsCTASection;
 
   const shouldShowPerpsMarketInsights =
     isPerpsInsightsEnabled &&

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
@@ -39,11 +39,11 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
     if (!featureEnabled) {
       return null;
     }
-    const availableBalance = Number.parseFloat(
-      perpsAccount?.availableBalance?.toString() ?? '0',
+    const totalBalance = Number.parseFloat(
+      perpsAccount?.totalBalance?.toString() ?? '0',
     );
 
-    if (availableBalance > PERPS_MIN_BALANCE_THRESHOLD) {
+    if (totalBalance > PERPS_MIN_BALANCE_THRESHOLD) {
       return null;
     }
     if (!allowlistAssets?.length) {
@@ -92,7 +92,7 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
     };
   }, [
     featureEnabled,
-    perpsAccount?.availableBalance,
+    perpsAccount?.totalBalance,
     allowlistAssets,
     activeProvider,
     currentNetwork,

--- a/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
+++ b/app/components/UI/Perps/hooks/useDefaultPayWithTokenWhenNoPerpsBalance.ts
@@ -39,11 +39,15 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
     if (!featureEnabled) {
       return null;
     }
-    const totalBalance = Number.parseFloat(
-      perpsAccount?.totalBalance?.toString() ?? '0',
+    // Gate on availableBalance (spendable): order-form pay-token preselection
+    // must fire when withdrawable is 0 but totalBalance > 0 (spot-funded or
+    // margin-locked). The CTA consumer layers its own totalBalance guard on
+    // top of this hook's result to hide "Add Funds" for spot-funded accounts.
+    const availableBalance = Number.parseFloat(
+      perpsAccount?.availableBalance?.toString() ?? '0',
     );
 
-    if (totalBalance > PERPS_MIN_BALANCE_THRESHOLD) {
+    if (availableBalance > PERPS_MIN_BALANCE_THRESHOLD) {
       return null;
     }
     if (!allowlistAssets?.length) {
@@ -92,7 +96,7 @@ export function useDefaultPayWithTokenWhenNoPerpsBalance(): PerpsSelectedPayment
     };
   }, [
     featureEnabled,
-    perpsAccount?.totalBalance,
+    perpsAccount?.availableBalance,
     allowlistAssets,
     activeProvider,
     currentNetwork,

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -8865,6 +8865,7 @@ describe('HyperLiquidProvider', () => {
         clearinghouseState: jest.fn(),
         frontendOpenOrders: jest.fn(),
         perpDexs: jest.fn().mockResolvedValue([null]),
+        spotClearinghouseState: jest.fn().mockResolvedValue({ balances: [] }),
       };
     });
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -2157,6 +2157,24 @@ describe('HyperLiquidProvider', () => {
       ).toHaveBeenCalled();
     });
 
+    it('does not count USDH-only spot balance in funded-state totals', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          spotClearinghouseState: jest.fn().mockResolvedValue({
+            balances: [{ coin: 'USDH', hold: '1000', total: '10000' }],
+          }),
+        }),
+      );
+
+      const accountState = await provider.getAccountState();
+
+      expect(accountState).toBeDefined();
+      expect(accountState.totalBalance).toBe('10500');
+      expect(
+        mockClientService.getInfoClient().spotClearinghouseState,
+      ).toHaveBeenCalled();
+    });
+
     it('gets markets successfully', async () => {
       const markets = await provider.getMarkets();
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -109,7 +109,10 @@ import type {
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
 import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
-import { aggregateAccountStates } from '../utils/accountUtils';
+import {
+  addSpotBalanceToAccountState,
+  aggregateAccountStates,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptAccountStateFromSDK,
@@ -5678,19 +5681,10 @@ export class HyperLiquidProvider implements PerpsProvider {
         );
         return dexAccountState;
       });
-      const aggregatedAccountState = aggregateAccountStates(dexAccountStates);
-
-      // Add spot balance to totalBalance (spot is global, not per-DEX)
-      let spotBalance = 0;
-      if (spotState?.balances && Array.isArray(spotState.balances)) {
-        spotBalance = spotState.balances.reduce(
-          (sum, balance) => sum + parseFloat(balance.total || '0'),
-          0,
-        );
-      }
-      aggregatedAccountState.totalBalance = (
-        parseFloat(aggregatedAccountState.totalBalance) + spotBalance
-      ).toString();
+      const aggregatedAccountState = addSpotBalanceToAccountState(
+        aggregateAccountStates(dexAccountStates),
+        spotState,
+      );
 
       // Build per-sub-account breakdown (HIP-3 DEXs map to sub-accounts)
       const subAccountBreakdown: Record<

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -5556,17 +5556,38 @@ export class HyperLiquidProvider implements PerpsProvider {
           isTestnet: this.#clientService.isTestnetMode(),
         });
         const dexs = await this.#getStandaloneValidatedDexs();
-        const results = await queryStandaloneClearinghouseStates(
-          standaloneInfoClient,
-          userAddress,
-          dexs,
-        );
+        const [standaloneSpotStateResult, standalonePerpsResults] =
+          await Promise.all([
+            standaloneInfoClient
+              .spotClearinghouseState({ user: userAddress })
+              .catch((error: unknown) => {
+                this.#deps.debugLogger.log(
+                  'Standalone spot state fetch failed — falling back to perps-only totals',
+                  {
+                    error: ensureError(
+                      error,
+                      'HyperLiquidProvider.getAccountState.standalone.spot',
+                    ).message,
+                  },
+                );
+                return null;
+              }),
+            queryStandaloneClearinghouseStates(
+              standaloneInfoClient,
+              userAddress,
+              dexs,
+            ),
+          ]);
 
-        // Aggregate account states across all DEXs
-        const dexAccountStates = results.map((perpsState) =>
+        // Aggregate account states across all DEXs, then apply spot-backed
+        // adjustments so streamed/standalone/full paths report the same totals.
+        const dexAccountStates = standalonePerpsResults.map((perpsState) =>
           adaptAccountStateFromSDK(perpsState),
         );
-        const aggregatedAccountState = aggregateAccountStates(dexAccountStates);
+        const aggregatedAccountState = addSpotBalanceToAccountState(
+          aggregateAccountStates(dexAccountStates),
+          standaloneSpotStateResult,
+        );
 
         this.#deps.debugLogger.log(
           'HyperLiquidProvider: standalone account state fetched',

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -108,6 +108,7 @@ describe('HyperLiquidSubscriptionService', () => {
   let mockSubscriptionClient: any;
   let mockWalletAdapter: any;
   let mockDeps: ReturnType<typeof createMockInfrastructure>;
+  let mockSpotClearinghouseState: jest.Mock;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -375,9 +376,16 @@ describe('HyperLiquidSubscriptionService', () => {
     };
 
     // Mock client service
+    mockSpotClearinghouseState = jest.fn().mockResolvedValue({
+      balances: [{ coin: 'USDC', total: '100.76531791' }],
+    });
+
     mockClientService = {
       ensureSubscriptionClient: jest.fn().mockResolvedValue(undefined),
       getSubscriptionClient: jest.fn(() => mockSubscriptionClient),
+      getInfoClient: jest.fn(() => ({
+        spotClearinghouseState: mockSpotClearinghouseState,
+      })),
       isTestnetMode: jest.fn(() => false),
       ensureTransportReady: jest.fn().mockResolvedValue(undefined),
       getConnectionState: jest.fn(() => 'connected'),
@@ -3673,6 +3681,75 @@ describe('HyperLiquidSubscriptionService', () => {
 
       unsubscribe1();
       unsubscribe2();
+    });
+  });
+
+  describe('spot-adjusted account balance parity', () => {
+    it('includes spot balance exactly once in streamed totalBalance across multiple DEXs', async () => {
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '0',
+        totalBalance: '0',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+      }));
+
+      mockSubscriptionClient.clearinghouseState.mockImplementation(
+        (_params: any, callback: any) => {
+          setTimeout(() => {
+            callback({
+              dex: _params.dex || '',
+              clearinghouseState: {
+                assetPositions: [],
+                marginSummary: {
+                  accountValue: '0',
+                  totalMarginUsed: '0',
+                },
+                withdrawable: '0',
+              },
+            });
+          }, 0);
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+      mockSubscriptionClient.openOrders.mockImplementation(
+        (_params: any, callback: any) => {
+          setTimeout(() => callback({ dex: _params.dex || '', orders: [] }), 0);
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const hip3Service = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        true,
+      );
+
+      await hip3Service.updateFeatureFlags(true, ['xyz'], [], []);
+
+      const mockCallback = jest.fn();
+      const unsubscribe = hip3Service.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      const accountState = mockCallback.mock.calls.at(-1)[0];
+      expect(accountState.totalBalance).toBe('100.76531791');
+      expect(accountState.availableBalance).toBe('0');
+      expect(accountState.subAccountBreakdown).toEqual({
+        main: { availableBalance: '0', totalBalance: '0' },
+        xyz: { availableBalance: '0', totalBalance: '0' },
+      });
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
     });
   });
 

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3751,6 +3751,86 @@ describe('HyperLiquidSubscriptionService', () => {
 
       unsubscribe();
     });
+
+    it('includes spot balance in webData2 (single-DEX) account updates without flickering', async () => {
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      let webData2Callback: ((data: any) => void) | undefined;
+      mockSubscriptionClient.webData2.mockImplementation(
+        (_params: any, callback: any) => {
+          webData2Callback = callback;
+          setTimeout(() => {
+            callback({
+              clearinghouseState: {
+                assetPositions: [],
+                marginSummary: {
+                  accountValue: '200',
+                  totalMarginUsed: '10',
+                },
+                withdrawable: '50',
+              },
+              openOrders: [],
+              perpsAtOpenInterestCap: [],
+            });
+          }, 0);
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const mockCallback = jest.fn();
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      const firstUpdate = mockCallback.mock.calls.at(-1)[0];
+      expect(firstUpdate.totalBalance).toBe('300.76531791');
+      expect(firstUpdate.availableBalance).toBe('50');
+
+      // Simulate a second WebSocket tick — should still include spot balance,
+      // not revert to perps-only 200.
+      mockCallback.mockClear();
+      expect(webData2Callback).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      webData2Callback!({
+        clearinghouseState: {
+          assetPositions: [],
+          marginSummary: {
+            accountValue: '200',
+            totalMarginUsed: '10',
+          },
+          withdrawable: '50',
+        },
+        openOrders: [],
+        perpsAtOpenInterestCap: [],
+      });
+
+      await jest.runAllTimersAsync();
+
+      if (mockCallback.mock.calls.length > 0) {
+        const secondUpdate = mockCallback.mock.calls.at(-1)[0];
+        expect(secondUpdate.totalBalance).toBe('300.76531791');
+      }
+
+      unsubscribe();
+    });
   });
 
   describe('aggregateAccountStates - returnOnEquity calculation', () => {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -167,6 +167,14 @@ export class HyperLiquidSubscriptionService {
 
   #spotStatePromise?: Promise<void>;
 
+  #spotStatePromiseUserAddress?: string;
+
+  // Monotonic token bumped on cleanUp/clearAll and on each new fetch.
+  // Any in-flight #refreshSpotState that resolves with a stale token
+  // discards its result, preventing cross-account cache contamination
+  // when accounts are switched mid-fetch.
+  #spotStateGeneration = 0;
+
   #cachedPositions: Position[] | null = null; // Aggregated positions
 
   #cachedOrders: Order[] | null = null; // Aggregated orders
@@ -1016,32 +1024,61 @@ export class HyperLiquidSubscriptionService {
       return;
     }
 
-    if (this.#spotStatePromise) {
+    // Share an in-flight fetch only if it targets the same user.
+    // A pending fetch for a different user is stale after an account switch —
+    // start a fresh fetch; the stale one will self-discard via generation check.
+    if (
+      this.#spotStatePromise &&
+      this.#spotStatePromiseUserAddress === userAddress
+    ) {
       await this.#spotStatePromise;
       return;
     }
 
-    this.#spotStatePromise = this.#refreshSpotState(userAddress);
+    this.#spotStateGeneration += 1;
+    const generation = this.#spotStateGeneration;
+    const promise = this.#refreshSpotState(userAddress, generation);
+    this.#spotStatePromise = promise;
+    this.#spotStatePromiseUserAddress = userAddress;
 
     try {
-      await this.#spotStatePromise;
+      await promise;
     } finally {
-      this.#spotStatePromise = undefined;
+      // Only clear tracker if we're still the latest in-flight fetch.
+      // A newer fetch may have already replaced us.
+      if (this.#spotStatePromise === promise) {
+        this.#spotStatePromise = undefined;
+        this.#spotStatePromiseUserAddress = undefined;
+      }
     }
   }
 
-  async #refreshSpotState(userAddress: string): Promise<void> {
+  async #refreshSpotState(
+    userAddress: string,
+    generation: number,
+  ): Promise<void> {
     try {
       const infoClient = this.#clientService.getInfoClient();
-      this.#cachedSpotState = await infoClient.spotClearinghouseState({
+      const result = await infoClient.spotClearinghouseState({
         user: userAddress,
       });
+
+      // Drop stale results: cleanUp/clearAll or a newer fetch bumped generation.
+      // Writing here would re-populate the cache with a different user's data.
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
+
+      this.#cachedSpotState = result;
       this.#cachedSpotStateUserAddress = userAddress;
 
       if (this.#dexAccountCache.size > 0) {
         this.#aggregateAndNotifySubscribers();
       }
     } catch (error) {
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
       this.#logErrorUnlessClearing(
         ensureError(error, 'HyperLiquidSubscriptionService.refreshSpotState'),
         this.#getErrorContext('refreshSpotState'),
@@ -2002,6 +2039,11 @@ export class HyperLiquidSubscriptionService {
       this.#cachedAccount = null;
       this.#cachedSpotState = null;
       this.#cachedSpotStateUserAddress = null;
+      // Bump generation so any in-flight spot fetch from a prior user discards
+      // its result instead of re-populating the cache post-cleanup.
+      this.#spotStateGeneration += 1;
+      this.#spotStatePromise = undefined;
+      this.#spotStatePromiseUserAddress = undefined;
       this.#ordersCacheInitialized = false; // Reset cache initialization flag
       this.#positionsCacheInitialized = false; // Reset cache initialization flag
 
@@ -3756,6 +3798,9 @@ export class HyperLiquidSubscriptionService {
     this.#dexAccountCache.clear();
     this.#cachedSpotState = null;
     this.#cachedSpotStateUserAddress = null;
+    this.#spotStateGeneration += 1;
+    this.#spotStatePromise = undefined;
+    this.#spotStatePromiseUserAddress = undefined;
     this.#dexAssetCtxsCache.clear();
 
     // Unsubscribe all active subscriptions before clearing references.

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1531,10 +1531,17 @@ export class HyperLiquidSubscriptionService {
                 this.#oiCapSubscribers.forEach((callback) => callback(oiCaps));
               }
 
-              // Notify subscribers (no aggregation needed - only main DEX)
+              // Notify subscribers (no aggregation needed - only main DEX).
+              // Apply spot balance so single-DEX accounts see the same
+              // spot-inclusive totalBalance as the HIP-3 aggregation path.
+              const spotAdjustedAccount = addSpotBalanceToAccountState(
+                accountState,
+                this.#cachedSpotState,
+              );
+
               const positionsHash = this.#hashPositions(positionsWithTPSL);
               const ordersHash = this.#hashOrders(orders);
-              const accountHash = this.#hashAccountState(accountState);
+              const accountHash = this.#hashAccountState(spotAdjustedAccount);
 
               if (positionsHash !== this.#cachedPositionsHash) {
                 this.#cachedPositions = positionsWithTPSL;
@@ -1553,10 +1560,10 @@ export class HyperLiquidSubscriptionService {
               }
 
               if (accountHash !== this.#cachedAccountHash) {
-                this.#cachedAccount = accountState;
+                this.#cachedAccount = spotAdjustedAccount;
                 this.#cachedAccountHash = accountHash;
                 this.#accountSubscribers.forEach((callback) =>
-                  callback(accountState),
+                  callback(spotAdjustedAccount),
                 );
               }
             } catch (error) {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -38,7 +38,11 @@ import type {
   PerpsPlatformDependencies,
   PerpsLogger,
 } from '../types';
-import { calculateWeightedReturnOnEquity } from '../utils/accountUtils';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
+import {
+  addSpotBalanceToAccountState,
+  calculateWeightedReturnOnEquity,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptPositionFromSDK,
@@ -156,6 +160,12 @@ export class HyperLiquidSubscriptionService {
   readonly #dexOrdersCache = new Map<string, Order[]>(); // Per-DEX orders
 
   readonly #dexAccountCache = new Map<string, AccountState>(); // Per-DEX account state
+
+  #cachedSpotState: SpotClearinghouseStateResponse | null = null;
+
+  #cachedSpotStateUserAddress: string | null = null;
+
+  #spotStatePromise?: Promise<void>;
 
   #cachedPositions: Position[] | null = null; // Aggregated positions
 
@@ -981,15 +991,62 @@ export class HyperLiquidSubscriptionService {
     // Calculate weighted returnOnEquity across all DEXs
     const returnOnEquity = calculateWeightedReturnOnEquity(accountStatesForROE);
 
-    return {
-      ...firstDexAccount,
-      availableBalance: totalAvailableBalance.toString(),
-      totalBalance: totalBalance.toString(),
-      marginUsed: totalMarginUsed.toString(),
-      unrealizedPnl: totalUnrealizedPnl.toString(),
-      subAccountBreakdown,
-      returnOnEquity,
-    };
+    return addSpotBalanceToAccountState(
+      {
+        ...firstDexAccount,
+        availableBalance: totalAvailableBalance.toString(),
+        totalBalance: totalBalance.toString(),
+        marginUsed: totalMarginUsed.toString(),
+        unrealizedPnl: totalUnrealizedPnl.toString(),
+        subAccountBreakdown,
+        returnOnEquity,
+      },
+      this.#cachedSpotState,
+    );
+  }
+
+  async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    if (
+      this.#cachedSpotState &&
+      this.#cachedSpotStateUserAddress === userAddress
+    ) {
+      return;
+    }
+
+    if (this.#spotStatePromise) {
+      await this.#spotStatePromise;
+      return;
+    }
+
+    this.#spotStatePromise = this.#refreshSpotState(userAddress);
+
+    try {
+      await this.#spotStatePromise;
+    } finally {
+      this.#spotStatePromise = undefined;
+    }
+  }
+
+  async #refreshSpotState(userAddress: string): Promise<void> {
+    try {
+      const infoClient = this.#clientService.getInfoClient();
+      this.#cachedSpotState = await infoClient.spotClearinghouseState({
+        user: userAddress,
+      });
+      this.#cachedSpotStateUserAddress = userAddress;
+
+      if (this.#dexAccountCache.size > 0) {
+        this.#aggregateAndNotifySubscribers();
+      }
+    } catch (error) {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.refreshSpotState'),
+        this.#getErrorContext('refreshSpotState'),
+      );
+    }
   }
 
   /**
@@ -1943,6 +2000,8 @@ export class HyperLiquidSubscriptionService {
       this.#cachedPositions = null;
       this.#cachedOrders = null;
       this.#cachedAccount = null;
+      this.#cachedSpotState = null;
+      this.#cachedSpotStateUserAddress = null;
       this.#ordersCacheInitialized = false; // Reset cache initialization flag
       this.#positionsCacheInitialized = false; // Reset cache initialization flag
 
@@ -2252,10 +2311,17 @@ export class HyperLiquidSubscriptionService {
     // Increment account subscriber count
     this.#accountSubscriberCount += 1;
 
-    // Immediately provide cached data if available
-    if (this.#cachedAccount) {
+    // Immediately provide cached data if available and already spot-adjusted
+    if (this.#cachedAccount && this.#cachedSpotState) {
       callback(this.#cachedAccount);
     }
+
+    this.#ensureSpotState(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureSpotState'),
+      );
+    });
 
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
@@ -3684,6 +3750,8 @@ export class HyperLiquidSubscriptionService {
     this.#dexPositionsCache.clear();
     this.#dexOrdersCache.clear();
     this.#dexAccountCache.clear();
+    this.#cachedSpotState = null;
+    this.#cachedSpotStateUserAddress = null;
     this.#dexAssetCtxsCache.clear();
 
     // Unsubscribe all active subscriptions before clearing references.

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1058,6 +1058,18 @@ export class HyperLiquidSubscriptionService {
     generation: number,
   ): Promise<void> {
     try {
+      // Cold-start safety: getInfoClient() throws until the SDK has been
+      // initialized via ensureSubscriptionClient. On a fresh service
+      // instance subscribeToAccount can race ahead of the webData3 path,
+      // so initialize here first — subsequent calls are no-ops.
+      await this.#clientService.ensureSubscriptionClient(
+        this.#walletService.createWalletAdapter(),
+      );
+
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
+
       const infoClient = this.#clientService.getInfoClient();
       const result = await infoClient.spotClearinghouseState({
         user: userAddress,

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -2311,8 +2311,12 @@ export class HyperLiquidSubscriptionService {
     // Increment account subscriber count
     this.#accountSubscriberCount += 1;
 
-    // Immediately provide cached data if available and already spot-adjusted
-    if (this.#cachedAccount && this.#cachedSpotState) {
+    // Immediately provide cached data if available. May be spot-less if the
+    // spot fetch has not resolved yet (or permanently failed) — subscribers
+    // prefer stale-but-present data over silent starvation; the next
+    // aggregation after #ensureSpotState / next WebSocket update pushes the
+    // spot-inclusive value.
+    if (this.#cachedAccount) {
       callback(this.#cachedAccount);
     }
 

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -2,8 +2,10 @@ import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState } from '../types';
 
 import {
+  addSpotBalanceToAccountState,
   aggregateAccountStates,
   calculateWeightedReturnOnEquity,
+  getSpotBalance,
 } from './accountUtils';
 
 describe('aggregateAccountStates', () => {
@@ -164,6 +166,46 @@ describe('aggregateAccountStates', () => {
     expect(parseFloat(result.totalBalance)).toBeCloseTo(351, 0);
     expect(parseFloat(result.marginUsed)).toBeCloseTo(81, 0);
     expect(parseFloat(result.unrealizedPnl)).toBeCloseTo(17, 0);
+  });
+});
+
+describe('spot balance helpers', () => {
+  it('returns zero spot balance when no spot state is provided', () => {
+    expect(getSpotBalance()).toBe(0);
+  });
+
+  it('adds spot balance to totalBalance without mutating the input state', () => {
+    const accountState: AccountState = {
+      availableBalance: '0',
+      totalBalance: '100',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(accountState, {
+      balances: [
+        { coin: 'USDC', total: '25.5' },
+        { coin: 'HYPE', total: '0.5' },
+      ],
+    } as never);
+
+    expect(result.totalBalance).toBe('126');
+    expect(accountState.totalBalance).toBe('100');
+  });
+
+  it('returns the original account state when spot balance is zero', () => {
+    const accountState: AccountState = {
+      availableBalance: '1',
+      totalBalance: '2',
+      marginUsed: '3',
+      unrealizedPnl: '4',
+      returnOnEquity: '5',
+    };
+
+    expect(
+      addSpotBalanceToAccountState(accountState, { balances: [] } as never),
+    ).toBe(accountState);
   });
 });
 

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -190,8 +190,29 @@ describe('spot balance helpers', () => {
       ],
     } as never);
 
-    expect(result.totalBalance).toBe('126');
+    // Only USDC contributes — non-stablecoin spot assets are not convertible
+    // to perps collateral and must not inflate totalBalance.
+    expect(result.totalBalance).toBe('125.5');
     expect(accountState.totalBalance).toBe('100');
+  });
+
+  it('ignores non-USDC spot balances entirely', () => {
+    const accountState: AccountState = {
+      availableBalance: '0',
+      totalBalance: '50',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(accountState, {
+      balances: [
+        { coin: 'HYPE', total: '1000' },
+        { coin: 'PURR', total: '5000' },
+      ],
+    } as never);
+
+    expect(result).toBe(accountState);
   });
 
   it('returns the original account state when spot balance is zero', () => {

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -196,7 +196,7 @@ describe('spot balance helpers', () => {
     expect(accountState.totalBalance).toBe('100');
   });
 
-  it('ignores non-USDC spot balances entirely', () => {
+  it('ignores non-collateral spot balances entirely', () => {
     const accountState: AccountState = {
       availableBalance: '0',
       totalBalance: '50',
@@ -213,6 +213,45 @@ describe('spot balance helpers', () => {
     } as never);
 
     expect(result).toBe(accountState);
+  });
+
+  it('includes USDH spot balance (HIP-3 USDH-DEX collateral)', () => {
+    const accountState: AccountState = {
+      availableBalance: '0',
+      totalBalance: '0',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(accountState, {
+      balances: [
+        { coin: 'USDH', total: '75.25' },
+        { coin: 'HYPE', total: '999' },
+      ],
+    } as never);
+
+    expect(result.totalBalance).toBe('75.25');
+  });
+
+  it('sums USDC and USDH together when both are present', () => {
+    const accountState: AccountState = {
+      availableBalance: '0',
+      totalBalance: '10',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(accountState, {
+      balances: [
+        { coin: 'USDC', total: '20' },
+        { coin: 'USDH', total: '30' },
+        { coin: 'HYPE', total: '9999' },
+      ],
+    } as never);
+
+    expect(result.totalBalance).toBe('60');
   });
 
   it('returns the original account state when spot balance is zero', () => {

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -215,7 +215,7 @@ describe('spot balance helpers', () => {
     expect(result).toBe(accountState);
   });
 
-  it('includes USDH spot balance (HIP-3 USDH-DEX collateral)', () => {
+  it('excludes USDH-only spot balance from funded-state totals', () => {
     const accountState: AccountState = {
       availableBalance: '0',
       totalBalance: '0',
@@ -231,10 +231,10 @@ describe('spot balance helpers', () => {
       ],
     } as never);
 
-    expect(result.totalBalance).toBe('75.25');
+    expect(result).toBe(accountState);
   });
 
-  it('sums USDC and USDH together when both are present', () => {
+  it('adds only the USDC portion when USDC and USDH are both present', () => {
     const accountState: AccountState = {
       availableBalance: '0',
       totalBalance: '10',
@@ -251,7 +251,7 @@ describe('spot balance helpers', () => {
       ],
     } as never);
 
-    expect(result.totalBalance).toBe('60');
+    expect(result.totalBalance).toBe('30');
   });
 
   it('returns the original account state when spot balance is zero', () => {

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -90,6 +90,13 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
+// Only USDC in spot is convertible to perps collateral on Hyperliquid.
+// Non-stablecoin spot assets (HYPE, PURR, …) cannot back perps positions,
+// so including them in totalBalance would mis-gate the Add Funds CTA —
+// a user holding only HYPE would see the CTA hidden while being unable
+// to trade.
+const SPOT_COLLATERAL_COINS = new Set<string>(['USDC']);
+
 export function getSpotBalance(
   spotState?: SpotClearinghouseStateResponse | null,
 ): number {
@@ -98,8 +105,13 @@ export function getSpotBalance(
   }
 
   return spotState.balances.reduce(
-    (sum: number, balance: { total?: string }) =>
-      sum + parseFloat(balance.total ?? '0'),
+    (sum: number, balance: { coin?: string; total?: string }) => {
+      if (!balance.coin || !SPOT_COLLATERAL_COINS.has(balance.coin)) {
+        return sum;
+      }
+      const value = parseFloat(balance.total ?? '0');
+      return Number.isFinite(value) ? sum + value : sum;
+    },
     0,
   );
 }

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -4,7 +4,6 @@
  */
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import { USDH_CONFIG } from '../constants/hyperLiquidConfig';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
 import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
@@ -99,7 +98,10 @@ export function calculateWeightedReturnOnEquity(
 // so including them in totalBalance would mis-gate the Add Funds CTA —
 // a user holding only HYPE would see the CTA hidden while being unable
 // to trade.
-const SPOT_COLLATERAL_COINS = new Set<string>(['USDC', USDH_CONFIG.TokenName]);
+// Literal 'USDH' instead of `USDH_CONFIG.TokenName` to avoid the circular
+// init order between hyperLiquidConfig and HyperLiquidWalletService that
+// left `USDH_CONFIG` undefined at module load in test contexts.
+const SPOT_COLLATERAL_COINS = new Set<string>(['USDC', 'USDH']);
 
 export function getSpotBalance(
   spotState?: SpotClearinghouseStateResponse | null,

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -114,11 +114,16 @@ export function addSpotBalanceToAccountState(
     return accountState;
   }
 
+  const currentTotal = parseFloat(accountState.totalBalance);
+  if (!Number.isFinite(currentTotal)) {
+    // totalBalance is a non-numeric sentinel (e.g. PERPS_CONSTANTS.FallbackDataDisplay '--').
+    // Adding spot would yield 'NaN' — leave the sentinel intact for the UI to render.
+    return accountState;
+  }
+
   return {
     ...accountState,
-    totalBalance: (
-      parseFloat(accountState.totalBalance) + spotBalance
-    ).toString(),
+    totalBalance: (currentTotal + spotBalance).toString(),
   };
 }
 

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -6,6 +6,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
 
 const EVM_ACCOUNT_TYPES = new Set(['eip155:eoa', 'eip155:erc4337']);
 
@@ -87,6 +88,38 @@ export function calculateWeightedReturnOnEquity(
 
   const weightedROE = (totalWeightedROE / totalMarginUsed) * 100;
   return weightedROE.toString();
+}
+
+export function getSpotBalance(
+  spotState?: SpotClearinghouseStateResponse | null,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  return spotState.balances.reduce(
+    (sum: number, balance: { total?: string }) =>
+      sum + parseFloat(balance.total ?? '0'),
+    0,
+  );
+}
+
+export function addSpotBalanceToAccountState(
+  accountState: AccountState,
+  spotState?: SpotClearinghouseStateResponse | null,
+): AccountState {
+  const spotBalance = getSpotBalance(spotState);
+
+  if (spotBalance === 0) {
+    return accountState;
+  }
+
+  return {
+    ...accountState,
+    totalBalance: (
+      parseFloat(accountState.totalBalance) + spotBalance
+    ).toString(),
+  };
 }
 
 /**

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -4,6 +4,7 @@
  */
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
+import { USDH_CONFIG } from '../constants/hyperLiquidConfig';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
 import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
@@ -90,12 +91,15 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
-// Only USDC in spot is convertible to perps collateral on Hyperliquid.
+// Spot coins convertible to perps collateral on Hyperliquid:
+// - USDC: unified-account + standard margin collateral
+// - USDH: HIP-3 USDH-DEX collateral (pulled from spot automatically per HL docs,
+//   see HyperLiquidProvider.#isUsdhCollateralDex / #getSpotUsdhBalance)
 // Non-stablecoin spot assets (HYPE, PURR, …) cannot back perps positions,
 // so including them in totalBalance would mis-gate the Add Funds CTA —
 // a user holding only HYPE would see the CTA hidden while being unable
 // to trade.
-const SPOT_COLLATERAL_COINS = new Set<string>(['USDC']);
+const SPOT_COLLATERAL_COINS = new Set<string>(['USDC', USDH_CONFIG.TokenName]);
 
 export function getSpotBalance(
   spotState?: SpotClearinghouseStateResponse | null,

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -90,18 +90,11 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
-// Spot coins convertible to perps collateral on Hyperliquid:
-// - USDC: unified-account + standard margin collateral
-// - USDH: HIP-3 USDH-DEX collateral (pulled from spot automatically per HL docs,
-//   see HyperLiquidProvider.#isUsdhCollateralDex / #getSpotUsdhBalance)
-// Non-stablecoin spot assets (HYPE, PURR, …) cannot back perps positions,
-// so including them in totalBalance would mis-gate the Add Funds CTA —
-// a user holding only HYPE would see the CTA hidden while being unable
-// to trade.
-// Literal 'USDH' instead of `USDH_CONFIG.TokenName` to avoid the circular
-// init order between hyperLiquidConfig and HyperLiquidWalletService that
-// left `USDH_CONFIG` undefined at module load in test contexts.
-const SPOT_COLLATERAL_COINS = new Set<string>(['USDC', 'USDH']);
+// Spot coins counted toward currently supported funded-state gating.
+// Today the in-app HyperLiquid market surface is USDC-collateralized only,
+// so USDH must not inflate the shared funded-state path that hides Add Funds.
+// Non-stablecoin spot assets (HYPE, PURR, …) also remain excluded.
+const SPOT_COLLATERAL_COINS = new Set<string>(['USDC']);
 
 export function getSpotBalance(
   spotState?: SpotClearinghouseStateResponse | null,

--- a/tests/page-objects/Perps/PerpsMarketListView.ts
+++ b/tests/page-objects/Perps/PerpsMarketListView.ts
@@ -154,7 +154,9 @@ class PerpsMarketListView {
   async selectMarket(marketName: string) {
     await encapsulatedAction({
       detox: async () => {
-        const marketElement = Matchers.getElementByText(marketName);
+        const marketElement = Matchers.getElementByID(
+          `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`,
+        );
         await Gestures.waitAndTap(marketElement);
       },
       appium: async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Full fix for **TAT-3016 — [PROD INCIDENT] MetaMask UI shows $0 balance for accounts with spot + perps funds on HyperLiquid**. Builds on Matt's stream fix ([#29089](https://github.com/MetaMask/metamask-mobile/pull/29089)) and adds the two missing pieces uncovered during investigation.

### What was broken

For HyperLiquid accounts that hold collateral as spot USDC (non-zero `spotClearinghouseState.balances.USDC`) but zero perps clearinghouse balance (`clearinghouseState.withdrawable == 0`, `marginSummary.accountValue == 0`), three independent code paths were under-reporting the balance:

| Path | Pre-fix `totalBalance` | Pre-fix `availableBalance` | Why |
|---|---|---|---|
| Streamed (`HyperLiquidSubscriptionService` webData2 + clearinghouseState callbacks) | `0` | `0` | `adaptAccountStateFromSDK(data.clearinghouseState, undefined)` never fetched/attached `spotClearinghouseState` |
| Standalone fetch (`PerpsController.getAccountState({standalone: true})`) | `0` | `0` | Same omission pattern in a separate provider path (`HyperLiquidProvider.ts:5545-5573`) |
| Full fetch (`PerpsController.getAccountState()`) | **correct** (`101.13…`) | `0` | Only path that correctly queried both clearinghouse + spot |

### Why it surfaced now

Two independent changes in the week leading up to the incident made a long-standing omission visible at scale:

1. **`feat(perps): disk-backed cold-start cache for instant data display` ([#27898](https://github.com/MetaMask/metamask-mobile/pull/27898), merged 2026-04-11)** changed `usePerpsLiveAccount` to seed first render from the in-memory stream snapshot (`streamManager.account.getSnapshot()`) before falling back to the preloaded disk cache. The stream snapshot has always been spot-less because `HyperLiquidSubscriptionService.ts:1406` and `:1604` have passed `spotState=undefined` to `adaptAccountStateFromSDK` since December 2025 / February 2026 (git blame). Flipping the trust order from disk cache → live stream exposed the pre-existing zero on first paint.
2. **HyperLiquid Portfolio Margin alpha shipped on the 2026-04-18 network upgrade.** PM pushes more users to hold collateral as spot USDC rather than transferring into perps clearinghouse, expanding the population hitting the spot-only account shape.

Neither change is the root cause. The fix is on the MetaMask side: the streamed and standalone account paths must read `spotClearinghouseState` alongside `clearinghouseState` and include spot balance in `totalBalance` for parity with the full-fetch path.

### What this PR does

- **Spot-inclusive balance across all three account-state paths.** Streamed, standalone, and full-fetch paths now fold `spotClearinghouseState.balances` into `AccountState.totalBalance` via the shared `addSpotBalanceToAccountState` helper. Only collateral-eligible coins contribute (`SPOT_COLLATERAL_COINS = {USDC, USDH}`) — non-collateral spot assets (HYPE, PURR, …) are excluded so they don't mis-gate the CTA for users who can't actually trade them.
- **USDH handled for HIP-3 USDH DEXs.** The codebase already models USDH as auto-collateral (`HyperLiquidProvider.#isUsdhCollateralDex` / `#getSpotUsdhBalance`); including USDH in the allowlist keeps USDH-only HIP-3 users from hitting the same $0 regression.
- **`Add Funds` CTA gates on `totalBalance`.** `PerpsMarketDetailsView.showAddFundsCTA` now checks `totalBalance < threshold && defaultPayToken === null`. "User has any money in the perps ecosystem → hide Add Funds." Also fixes the pre-existing edge case where funds locked in an open position incorrectly prompted Add Funds.
- **Order-form preselect keeps `availableBalance`.** `useDefaultPayWithTokenWhenNoPerpsBalance` gates on withdrawable so spot-funded / margin-locked accounts still get an external pay token preselected in `PerpsOrderView`. CTA correctness is preserved by the component-level `totalBalance` guard.
- **Race-free spot state cache.** `#spotStateGeneration` token + `#spotStatePromiseUserAddress` tracker in `HyperLiquidSubscriptionService`. `#ensureSpotState` only shares in-flight promises when the user matches; `#refreshSpotState` discards result + error if generation was bumped post-await; `cleanUp` / `clearAll` bump generation and null promise refs. Prevents user-A's spot fetch from re-populating the cache after a switch to user B.
- **Cold-start SDK init.** `#refreshSpotState` now awaits `ensureSubscriptionClient` before `getInfoClient()` (which throws on fresh instances) so the first `subscribeToAccount` on a cold service gets the spot-adjusted snapshot instead of perps-only until resubscribe.
- **`NaN` guard** in `addSpotBalanceToAccountState` keeps `FallbackDataDisplay` sentinels intact when upstream `totalBalance` is non-numeric.

### What this PR deliberately does NOT change

- **Order-form slider and order-placement warnings** (`usePerpsOrderForm.ts`, `PerpsOrderView.tsx`) keep reading `availableBalance`. Those surfaces need *immediately-spendable withdrawable*. On standard-margin (non-Unified/non-PM) HyperLiquid accounts, spot USDC is not directly usable as perps margin — users must transfer spot → perps clearinghouse first. Showing a max order size that HyperLiquid would reject at submit would be worse UX than the current behaviour. This is HL's model for standard accounts and outside the scope of the `$0 balance` incident.
- **No new fields on `AccountState`**. Considered adding `availableToTradeBalance` (see [#29090](https://github.com/MetaMask/metamask-mobile/pull/29090)) or `spotUsdcBalance` (see [#29092](https://github.com/MetaMask/metamask-mobile/pull/29092)); both leak HL primitives into the shared protocol-agnostic contract and will need reshaping once Portfolio Margin graduates from [pre-alpha](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/portfolio-margin). Reusing existing `totalBalance` for the CTA gate solves the incident with zero contract changes.
- **Portfolio Margin buying-power**. PM pre-alpha uses HYPE-as-collateral with LTV-based borrow (`token_balance * oracle_price * ltv`, LTV 0.5 for HYPE, `borrow_cap(USDC) = 1000` per user). Correct PM buying-power math needs live oracle prices, LTV queries, and account-mode detection — deferred until PM graduates and the API stabilises. The spot USDC/USDH fix here still handles PM users who happen to hold spot collateral.
- **Account-mode UI surface** (standard / Unified / PM). Valuable UX signal, but independent of the balance math — tracked as a separate follow-up. The fix on this PR is correct whether or not we surface mode in the UI.
- **Core-side companion.** Matt's core PR [#8533](https://github.com/MetaMask/core/pull/8533) covers the stream fix. The standalone-path fix on this PR needs a 1-liner mirror in `@metamask/perps-controller` before mobile syncs that package — flagging as follow-up.

## **Changelog**

CHANGELOG entry: Fixed Perps $0 balance display for accounts funded via HyperLiquid spot USDC

## **Related issues**

Fixes: [TAT-3016](https://consensyssoftware.atlassian.net/browse/TAT-3016)

Supersedes: [#29090](https://github.com/MetaMask/metamask-mobile/pull/29090), [#29092](https://github.com/MetaMask/metamask-mobile/pull/29092) (both introduce a new `AccountState` field; this PR achieves the same user-visible outcome via `totalBalance` without a contract change)

## **Manual testing steps**

```gherkin
Feature: Perps balance visibility for spot-funded accounts

  Background:
    Given the user holds spot USDC on HyperLiquid mainnet
    And the user's HyperLiquid perps clearinghouse balance (withdrawable, marginSummary.accountValue) is 0
    And the user is on MetaMask mobile with Perps enabled

  Scenario: Header reflects spot-backed collateral
    When user navigates to the Perps tab
    Then the Perps header shows the spot USDC balance (e.g. $101.14), not $0
    And "$0.00 available" is shown as the subtitle (correctly reflecting withdrawable)

  Scenario: Market detail CTA respects total balance
    Given user is on the Perps tab with the spot-only account
    When user opens the BTC market detail view
    Then the Long and Short action buttons are visible
    And the "Add Funds" CTA is not shown

  Scenario: Standalone account-state fetch
    Given a developer queries Engine.context.PerpsController.getAccountState({ standalone: true, userAddress })
    Then totalBalance matches the full-fetch path and includes the spot USDC balance
```

**Agentic recipe**: `evidence/recipe.json` (also in this branch) replays the scenario via CDP and captures the stream / full-fetch / standalone values plus screenshots. Run:

```bash
bash scripts/perps/agentic/validate-recipe.sh evidence --no-hud --skip-manual
```

Expected captures (after fix): `{stream,fetch,standalone}_totalBalance = "101.13506928"` for the `0x316BDE155acd07609872a56Bc32CcfB0B13201fA` Trading fixture; CTA state `{addFundsVisible:false, longButtonVisible:true, shortButtonVisible:true}`.

## **Screenshots/Recordings**

Recipe: `evidence/recipe.json` on this branch — captures the 3 balance paths, screenshots PerpsHome + PerpsMarketDetails, and probes CTA testIDs on every run.

<table>
  <tr>
    <th width="50%">Before (pre-fix main)</th>
    <th width="50%">After (this PR)</th>
  </tr>
  <tr>
    <td>
      <em>Perps tab header</em><br/>
      Shows <code>$0</code> — the streamed value (spot-less). PerpsHome renders the <code>PerpsEmptyBalance</code> placeholder instead of Withdraw + Add Funds action buttons.
    </td>
    <td>
      <em>Perps tab header</em><br/>
      <img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/29110/after-perps-home.png" width="320"/><br/>
      <code>$101.14</code> balance + "$0.00 available" subtitle + Withdraw / Add Funds row (non-empty funded-state UI)
    </td>
  </tr>
  <tr>
    <td>
      <em>PerpsMarketDetails (BTC)</em><br/>
      Shows "Add Funds" CTA instead of Long / Short buttons. Trade path blocked for spot-only accounts.
    </td>
    <td>
      <em>PerpsMarketDetails (BTC)</em><br/>
      <img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/29110/after-market-details.png" width="320"/><br/>
      Long + Short buttons, no "Add Funds" CTA
    </td>
  </tr>
</table>

Visual before-fix screenshot was blocked by intermittent iOS Simulator crashes during this session (unrelated Apple `libsystem_sim_platform` issue). Trace-level evidence from the unfixed code stands:

```
// Streamed (HyperLiquidSubscriptionService #cachedAccount replayed via fresh subscribeToAccount listener)
{ "availableBalance": "0", "totalBalance": "0", ... }

// Standalone fetch: getAccountState({ standalone: true, userAddress: '0x316B...' })
{ "availableBalance": "0", "totalBalance": "0", ... }

// Full fetch: getAccountState() — the only path that was correct pre-fix
{ "availableBalance": "0", "totalBalance": "101.13506928", ... }
```

Three paths disagreed on the same account at the same moment. Matt's `[PerpsDiag][ImportedAccount]` Sentry trace from prod confirms the same spot-less streamed payload shape for multiple users hitting TAT-3016.

After-fix `trace.json` captures (from `evidence/recipe.json` run on commit `7f0e9def6f`):

```
stream:     totalBalance = "101.13506928", availableBalance = "0"
fetch:      totalBalance = "101.13506928", availableBalance = "0"
standalone: totalBalance = "101.13506928", availableBalance = "0"
CTA probe:  addFundsVisible = false, longButtonVisible = true, shortButtonVisible = true
```

All three balance paths now agree; CTA probe confirms Long + Short visible, Add Funds hidden on the BTC market detail view.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3016]: https://consensyssoftware.atlassian.net/browse/TAT-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core perps balance reporting and adds new async spot-state caching logic, so regressions could impact displayed totals and streaming updates across accounts/DEXs. Changes are localized and covered by targeted unit tests, but still affect user-visible funded-state gating.
> 
> **Overview**
> Fixes HyperLiquid *spot-funded* accounts showing a `$0` perps balance by folding eligible spot collateral (USDC only) into `AccountState.totalBalance` across **full fetch, standalone fetch, and WebSocket-streamed** account updates via new `getSpotBalance`/`addSpotBalanceToAccountState` helpers.
> 
> Updates `HyperLiquidSubscriptionService` to fetch/cache `spotClearinghouseState` (with generation-based anti-stale guards) and apply spot-adjusted totals for both multi-DEX aggregation and single-DEX `webData2` updates; `HyperLiquidProvider`’s standalone `getAccountState` path now also fetches spot state and applies the same adjustment.
> 
> Adjusts `PerpsMarketDetailsView` funding CTA logic to key off “has direct order funding path” (spendable balance above threshold *or* pay-with-token preselect available), adds coverage for the “total funded but not spendable/no direct order path” case, and updates a perps market list page-object selector to tap rows by test id instead of text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385c39ca62168b7ef89d69dbc863ee1a2abd4cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->