### PR TITLE
feat: add security badge on trending list

### DIFF
--- a/app/components/UI/SecurityTrust/utils/securityUtils.test.ts
+++ b/app/components/UI/SecurityTrust/utils/securityUtils.test.ts
@@ -1,4 +1,5 @@
 import type {
+  TokenSecurityData,
   TokenSecurityFeature,
   TokenSecurityFinancialStats,
 } from '../types';
@@ -8,6 +9,7 @@ import {
   getTop10HoldingPct,
   formatCompactSupply,
   getResultTypeConfig,
+  getSecurityBadgeConfig,
 } from './securityUtils';
 import {
   TextColor,
@@ -361,6 +363,98 @@ describe('securityUtils', () => {
 
     it('does not adjust when decimals is 0', () => {
       expect(formatCompactSupply(5_000_000, 0)).toBe('5.00M');
+    });
+  });
+
+  describe('getSecurityBadgeConfig', () => {
+    it('returns verified badge config for Verified result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Verified',
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toEqual({
+        icon: IconName.VerifiedFilled,
+        iconColor: IconColor.PrimaryDefault,
+        label: null,
+        bg: null,
+        textColor: undefined,
+      });
+    });
+
+    it('returns null for Benign result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Benign',
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toBeNull();
+    });
+
+    it('returns warning badge config for Warning result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Warning',
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toEqual({
+        icon: IconName.Warning,
+        iconColor: IconColor.WarningDefault,
+        label: strings('security_trust.risky'),
+        bg: 'bg-warning-muted',
+        textColor: TextColor.WarningDefault,
+      });
+    });
+
+    it('returns warning badge config for Spam result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Spam',
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toEqual({
+        icon: IconName.Warning,
+        iconColor: IconColor.WarningDefault,
+        label: strings('security_trust.risky'),
+        bg: 'bg-warning-muted',
+        textColor: TextColor.WarningDefault,
+      });
+    });
+
+    it('returns danger badge config for Malicious result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Malicious',
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toEqual({
+        icon: IconName.Danger,
+        iconColor: IconColor.ErrorDefault,
+        label: strings('security_trust.malicious'),
+        bg: 'bg-error-muted',
+        textColor: TextColor.ErrorDefault,
+      });
+    });
+
+    it('returns null for undefined securityData', () => {
+      const config = getSecurityBadgeConfig(undefined);
+
+      expect(config).toBeNull();
+    });
+
+    it('returns null for null securityData', () => {
+      const config = getSecurityBadgeConfig(null);
+
+      expect(config).toBeNull();
+    });
+
+    it('returns null for unknown result type', () => {
+      const config = getSecurityBadgeConfig({
+        resultType: 'Unknown' as TokenSecurityData['resultType'],
+        features: [],
+      } as unknown as TokenSecurityData);
+
+      expect(config).toBeNull();
     });
   });
 });

--- a/app/components/UI/SecurityTrust/utils/securityUtils.ts
+++ b/app/components/UI/SecurityTrust/utils/securityUtils.ts
@@ -19,6 +19,14 @@ export interface ResultTypeConfig {
   iconColor?: IconColor;
 }
 
+export interface SecurityBadgeConfig {
+  icon: IconName;
+  iconColor: IconColor;
+  label: string | null;
+  bg: string | null;
+  textColor: TextColor | undefined;
+}
+
 export const getResultTypeConfig = (
   resultType: string | undefined,
 ): ResultTypeConfig => {
@@ -281,4 +289,44 @@ export const formatCompactSupply = (
     }
   }
   return adjusted.toFixed(0);
+};
+
+/**
+ * Get security badge configuration based on security data result type.
+ * Returns null for Benign tokens (no badge needed).
+ */
+export const getSecurityBadgeConfig = (
+  securityData: TokenSecurityData | null | undefined,
+): SecurityBadgeConfig | null => {
+  switch (securityData?.resultType) {
+    case 'Verified':
+      return {
+        icon: IconName.VerifiedFilled,
+        iconColor: IconColor.PrimaryDefault,
+        label: null,
+        bg: null,
+        textColor: undefined,
+      };
+    case 'Benign':
+      return null;
+    case 'Warning':
+    case 'Spam':
+      return {
+        icon: IconName.Warning,
+        iconColor: IconColor.WarningDefault,
+        label: strings('security_trust.risky'),
+        bg: 'bg-warning-muted',
+        textColor: TextColor.WarningDefault,
+      };
+    case 'Malicious':
+      return {
+        icon: IconName.Danger,
+        iconColor: IconColor.ErrorDefault,
+        label: strings('security_trust.malicious'),
+        bg: 'bg-error-muted',
+        textColor: TextColor.ErrorDefault,
+      };
+    default:
+      return null;
+  }
 };

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -61,6 +61,7 @@ import { formatAddressToAssetId } from '@metamask/bridge-controller';
 import type { TokenSecurityData } from '@metamask/assets-controllers';
 import SecurityTrustEntryCard from '../../SecurityTrust/components/SecurityTrustEntryCard/SecurityTrustEntryCard';
 import type { TokenDetailsRouteParams } from '../constants/constants';
+import { getSecurityBadgeConfig } from '../../SecurityTrust/utils/securityUtils';
 import {
   Box,
   BoxFlexDirection,
@@ -333,39 +334,10 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     [isMerklClaimingEnabled, token.chainId, token.address],
   );
 
-  const securityBadge = useMemo(() => {
-    switch (securityData?.resultType) {
-      case 'Verified':
-        return {
-          icon: IconName.VerifiedFilled,
-          iconColor: IconColor.PrimaryDefault,
-          label: null,
-          bg: null,
-          textColor: undefined,
-        };
-      case 'Benign':
-        return null;
-      case 'Warning':
-      case 'Spam':
-        return {
-          icon: IconName.Warning,
-          iconColor: IconColor.WarningDefault,
-          label: strings('security_trust.risky'),
-          bg: 'bg-warning-muted',
-          textColor: TextColor.WarningDefault,
-        };
-      case 'Malicious':
-        return {
-          icon: IconName.Danger,
-          iconColor: IconColor.ErrorDefault,
-          label: strings('security_trust.malicious'),
-          bg: 'bg-error-muted',
-          textColor: TextColor.ErrorDefault,
-        };
-      default:
-        return null;
-    }
-  }, [securityData?.resultType]);
+  const securityBadge = useMemo(
+    () => getSecurityBadgeConfig(securityData),
+    [securityData],
+  );
 
   const handleSecurityBadgePress = useCallback(() => {
     if (!securityData?.resultType || securityData.resultType === 'Benign')

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.styles.ts
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.styles.ts
@@ -23,6 +23,10 @@ const styleSheet = (_params: { theme: Theme }) =>
       flexDirection: 'row',
       alignItems: 'center',
       gap: 4,
+      flexShrink: 1,
+    },
+    tokenName: {
+      flexShrink: 1,
     },
     rightContainer: {
       display: 'flex',

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1729,7 +1729,7 @@ describe('TrendingTokenRowItem', () => {
   });
 
   describe('security badge', () => {
-    it('renders verified badge for verified tokens', () => {
+    it('renders verified icon badge for verified tokens', () => {
       const token = createMockToken({
         securityData: {
           resultType: 'Verified',
@@ -1746,7 +1746,7 @@ describe('TrendingTokenRowItem', () => {
       expect(getByTestId('security-badge-icon')).toBeTruthy();
     });
 
-    it('renders warning badge for warning tokens', () => {
+    it('renders warning badge with label for warning tokens', () => {
       const token = createMockToken({
         securityData: {
           resultType: 'Warning',
@@ -1754,16 +1754,16 @@ describe('TrendingTokenRowItem', () => {
         } as unknown as TrendingAsset['securityData'],
       });
 
-      const { getByTestId } = renderWithProvider(
+      const { getByText } = renderWithProvider(
         <TrendingTokenRowItem token={token} />,
         { state: mockState },
         false,
       );
 
-      expect(getByTestId('security-badge-icon')).toBeTruthy();
+      expect(getByText('Risky')).toBeTruthy();
     });
 
-    it('renders danger badge for malicious tokens', () => {
+    it('renders malicious badge with label for malicious tokens', () => {
       const token = createMockToken({
         securityData: {
           resultType: 'Malicious',
@@ -1771,13 +1771,13 @@ describe('TrendingTokenRowItem', () => {
         } as unknown as TrendingAsset['securityData'],
       });
 
-      const { getByTestId } = renderWithProvider(
+      const { getByText } = renderWithProvider(
         <TrendingTokenRowItem token={token} />,
         { state: mockState },
         false,
       );
 
-      expect(getByTestId('security-badge-icon')).toBeTruthy();
+      expect(getByText('Malicious')).toBeTruthy();
     });
 
     it('does not render badge for benign tokens', () => {
@@ -1788,13 +1788,15 @@ describe('TrendingTokenRowItem', () => {
         } as unknown as TrendingAsset['securityData'],
       });
 
-      const { queryByTestId } = renderWithProvider(
+      const { queryByTestId, queryByText } = renderWithProvider(
         <TrendingTokenRowItem token={token} />,
         { state: mockState },
         false,
       );
 
       expect(queryByTestId('security-badge-icon')).toBeNull();
+      expect(queryByText('Risky')).toBeNull();
+      expect(queryByText('Malicious')).toBeNull();
     });
 
     it('does not render badge when securityData is undefined', () => {
@@ -1802,13 +1804,15 @@ describe('TrendingTokenRowItem', () => {
         securityData: undefined,
       });
 
-      const { queryByTestId } = renderWithProvider(
+      const { queryByTestId, queryByText } = renderWithProvider(
         <TrendingTokenRowItem token={token} />,
         { state: mockState },
         false,
       );
 
       expect(queryByTestId('security-badge-icon')).toBeNull();
+      expect(queryByText('Risky')).toBeNull();
+      expect(queryByText('Malicious')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1743,7 +1743,7 @@ describe('TrendingTokenRowItem', () => {
         false,
       );
 
-      expect(getByTestId('security-badge-icon')).toBeTruthy();
+      expect(getByTestId('security-badge-icon')).toBeOnTheScreen();
     });
 
     it('renders warning badge with label for warning tokens', () => {
@@ -1760,7 +1760,7 @@ describe('TrendingTokenRowItem', () => {
         false,
       );
 
-      expect(getByText('Risky')).toBeTruthy();
+      expect(getByText('Risky')).toBeOnTheScreen();
     });
 
     it('renders malicious badge with label for malicious tokens', () => {
@@ -1777,7 +1777,7 @@ describe('TrendingTokenRowItem', () => {
         false,
       );
 
-      expect(getByText('Malicious')).toBeTruthy();
+      expect(getByText('Malicious')).toBeOnTheScreen();
     });
 
     it('does not render badge for benign tokens', () => {

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1727,4 +1727,88 @@ describe('TrendingTokenRowItem', () => {
       expect(mockOnPress).not.toHaveBeenCalled();
     });
   });
+
+  describe('security badge', () => {
+    it('renders verified badge for verified tokens', () => {
+      const token = createMockToken({
+        securityData: {
+          resultType: 'Verified',
+          features: [],
+        } as unknown as TrendingAsset['securityData'],
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      expect(getByTestId('security-badge-icon')).toBeTruthy();
+    });
+
+    it('renders warning badge for warning tokens', () => {
+      const token = createMockToken({
+        securityData: {
+          resultType: 'Warning',
+          features: [],
+        } as unknown as TrendingAsset['securityData'],
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      expect(getByTestId('security-badge-icon')).toBeTruthy();
+    });
+
+    it('renders danger badge for malicious tokens', () => {
+      const token = createMockToken({
+        securityData: {
+          resultType: 'Malicious',
+          features: [],
+        } as unknown as TrendingAsset['securityData'],
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      expect(getByTestId('security-badge-icon')).toBeTruthy();
+    });
+
+    it('does not render badge for benign tokens', () => {
+      const token = createMockToken({
+        securityData: {
+          resultType: 'Benign',
+          features: [],
+        } as unknown as TrendingAsset['securityData'],
+      });
+
+      const { queryByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      expect(queryByTestId('security-badge-icon')).toBeNull();
+    });
+
+    it('does not render badge when securityData is undefined', () => {
+      const token = createMockToken({
+        securityData: undefined,
+      });
+
+      const { queryByTestId } = renderWithProvider(
+        <TrendingTokenRowItem token={token} />,
+        { state: mockState },
+        false,
+      );
+
+      expect(queryByTestId('security-badge-icon')).toBeNull();
+    });
+  });
 });

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -22,7 +22,16 @@ import {
   isCaipChainId,
   parseCaipChainId,
 } from '@metamask/utils';
-import { Icon, IconSize } from '@metamask/design-system-react-native';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  Icon,
+  IconSize,
+  Text as DesignSystemText,
+  TextVariant as DesignSystemTextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import { getSecurityBadgeConfig } from '../../../SecurityTrust/utils/securityUtils';
 
 /**
@@ -342,16 +351,39 @@ const TrendingTokenRowItem = ({
             color={TextColor.Default}
             numberOfLines={1}
             ellipsizeMode="tail"
+            style={styles.tokenName}
           >
             {token?.name ?? token?.symbol}
           </Text>
-          {securityBadge && (
+          {securityBadge && securityBadge.label === null && (
             <Icon
               name={securityBadge.icon}
               size={IconSize.Sm}
               color={securityBadge.iconColor}
               testID="security-badge-icon"
             />
+          )}
+          {securityBadge && securityBadge.label !== null && (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName={`rounded min-w-[22px] px-1.5 gap-1 shrink-0 ${securityBadge.bg}`}
+            >
+              <Icon
+                name={securityBadge.icon}
+                size={IconSize.Sm}
+                color={securityBadge.iconColor}
+              />
+              <DesignSystemText
+                variant={DesignSystemTextVariant.BodySm}
+                color={securityBadge.textColor}
+                fontWeight={FontWeight.Medium}
+                numberOfLines={1}
+                twClassName="whitespace-nowrap"
+              >
+                {securityBadge.label}
+              </DesignSystemText>
+            </Box>
           )}
         </View>
         <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -22,6 +22,8 @@ import {
   isCaipChainId,
   parseCaipChainId,
 } from '@metamask/utils';
+import { Icon, IconSize } from '@metamask/design-system-react-native';
+import { getSecurityBadgeConfig } from '../../../SecurityTrust/utils/securityUtils';
 
 /**
  * Converts CAIP chain ID to hex chain ID
@@ -223,6 +225,11 @@ const TrendingTokenRowItem = ({
     [caipChainId],
   );
 
+  const securityBadge = useMemo(
+    () => getSecurityBadgeConfig(token.securityData),
+    [token.securityData],
+  );
+
   // Parse price change percentage from API (comes as string like "-3.44" or "+0.456")
   // Use the correct field based on selected time option
   const priceChangeFieldKey = getPriceChangeFieldKey(selectedTimeOption);
@@ -338,6 +345,14 @@ const TrendingTokenRowItem = ({
           >
             {token?.name ?? token?.symbol}
           </Text>
+          {securityBadge && (
+            <Icon
+              name={securityBadge.icon}
+              size={IconSize.Sm}
+              color={securityBadge.iconColor}
+              testID="security-badge-icon"
+            />
+          )}
         </View>
         <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
           {formatMarketStats(


### PR DESCRIPTION


## **Description**

Adds security badges to the trending tokens list to display token security status (Verified, Warning/Spam, Malicious) inline with token names.
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds security badges to trending tokens list.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3103?atlOrigin=eyJpIjoiMGU5NTM2ZTYwOGE5NGE0YzlkMjAyNWVkZmQ1NGE4NDciLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="407" height="842" alt="Screenshot 2026-04-21 at 15 13 42" src="https://github.com/user-attachments/assets/54b4deba-5961-4880-9598-82562fa8b2f4" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI presentation changes plus a small refactor to share badge-mapping logic; minimal impact beyond how security status is displayed.
> 
> **Overview**
> Adds inline Security & Trust badges to `TrendingTokenRowItem`, showing a verified icon or a labeled warning/malicious pill next to the token name, and hides the badge for `Benign`/missing security data.
> 
> Centralizes badge mapping into a new `getSecurityBadgeConfig` helper in `securityUtils` (and refactors token details to use it), with new unit tests for the helper plus UI tests covering badge rendering and minor style tweaks to prevent name/badge truncation issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3fcf07965518c038a2c48c05efc92a9481a5dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->