### PR TITLE
feat(MUSD-601): Money Home milestone state after first deposit

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -14,6 +14,7 @@ import { MoneyMetaMaskCardTestIds } from '../../components/MoneyMetaMaskCard/Mon
 import { MoneyWhatYouGetTestIds } from '../../components/MoneyWhatYouGet/MoneyWhatYouGet.testIds';
 import { MoneyFooterTestIds } from '../../components/MoneyFooter/MoneyFooter.testIds';
 import { MoneyActivityListTestIds } from '../../components/MoneyActivityList/MoneyActivityList.testIds';
+import { MoneyCondensedInfoCardsTestIds } from '../../components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import MOCK_MONEY_TRANSACTIONS from '../../constants/mockActivityData';
@@ -190,10 +191,11 @@ describe('MoneyHomeView', () => {
     expect(getByTestId(MoneyEarningsTestIds.CONTAINER)).toBeOnTheScreen();
   });
 
-  it('renders the how it works section', () => {
-    const { getByTestId } = renderWithProvider(<MoneyHomeView />);
-
-    expect(getByTestId(MoneyHowItWorksTestIds.CONTAINER)).toBeOnTheScreen();
+  it('hides the how it works section in filled state', () => {
+    const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+    expect(
+      queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders the potential earnings section when tokens exist', () => {
@@ -210,10 +212,11 @@ describe('MoneyHomeView', () => {
     expect(getByTestId(MoneyMetaMaskCardTestIds.CONTAINER)).toBeOnTheScreen();
   });
 
-  it('renders the why MetaMask Money section', () => {
-    const { getByTestId } = renderWithProvider(<MoneyHomeView />);
-
-    expect(getByTestId(MoneyWhatYouGetTestIds.CONTAINER)).toBeOnTheScreen();
+  it('hides the what you get section in filled state', () => {
+    const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+    expect(
+      queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders the footer', () => {
@@ -236,5 +239,101 @@ describe('MoneyHomeView', () => {
     fireEvent.press(getByTestId(MoneyActivityListTestIds.VIEW_ALL_BUTTON));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ACTIVITY);
+  });
+
+  describe('milestone state (1-9 transactions)', () => {
+    beforeEach(() => {
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: Array.from({ length: 3 }, (_, index) => ({
+          ...MOCK_MONEY_TRANSACTIONS[index % MOCK_MONEY_TRANSACTIONS.length],
+          id: `milestone-${index}`,
+        })),
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+      });
+    });
+
+    it('renders onboarding card with step 2', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.STEP_LABEL),
+      ).toHaveTextContent('Step 2 of 2');
+    });
+
+    it('renders the activity list', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyActivityListTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it('renders condensed info cards', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyCondensedInfoCardsTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides expanded HowItWorks section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides expanded WhatYouGet section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders the MetaMask Card section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyMetaMaskCardTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+  });
+
+  describe('empty state (0 transactions)', () => {
+    beforeEach(() => {
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: [],
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+      });
+    });
+
+    it('renders onboarding card with step 1', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.STEP_LABEL),
+      ).toHaveTextContent('Step 1 of 2');
+    });
+
+    it('does not render the activity list', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyActivityListTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('does not render condensed info cards', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyCondensedInfoCardsTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders expanded HowItWorks section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyHowItWorksTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it('renders expanded WhatYouGet section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyWhatYouGetTestIds.CONTAINER)).toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -74,7 +74,9 @@ const MoneyHomeView = () => {
   const handleEarnCryptoPress = displayUnderConstructionAlert;
   const handleLearnMorePress = displayUnderConstructionAlert;
   const handleAddMoneyPress = displayUnderConstructionAlert;
-  const handleHowItWorksHeaderPress = displayUnderConstructionAlert;
+  const handleHowItWorksHeaderPress = useCallback(() => {
+    navigation.navigate(Routes.MONEY.HOW_IT_WORKS as never);
+  }, [navigation]);
 
   const handleViewAllActivityPress = useCallback(() => {
     navigation.navigate(Routes.MONEY.ACTIVITY as never);

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -136,6 +136,18 @@ const MoneyHomeView = () => {
             <Divider />
           </>
         )}
+        {allTransactions.length >= 1 && (
+          <>
+            <MoneyActivityList
+              transactions={allTransactions}
+              moneyAddress={moneyAddress}
+              onViewAllPress={handleViewAllActivityPress}
+              onHeaderPress={handleActivityHeaderPress}
+              onItemPress={handleActivityItemPress}
+            />
+            <Divider />
+          </>
+        )}
         {hasConvertibleTokensWithBalance(conversionTokens) && (
           <>
             <MoneyPotentialEarnings
@@ -149,29 +161,17 @@ const MoneyHomeView = () => {
             <Divider />
           </>
         )}
+        <MoneyMetaMaskCard
+          onGetNowPress={handleGetNowPress}
+          onHeaderPress={handleHeaderPress}
+        />
+        <Divider />
         {isMilestone && (
           <>
             <MoneyCondensedInfoCards
               onHowItWorksPress={handleHowItWorksHeaderPress}
               onMusdPress={handleMusdRowPress}
               onWhatYouGetPress={handleLearnMorePress}
-            />
-            <Divider />
-          </>
-        )}
-        <MoneyMetaMaskCard
-          onGetNowPress={handleGetNowPress}
-          onHeaderPress={handleHeaderPress}
-        />
-        <Divider />
-        {allTransactions.length >= 1 && (
-          <>
-            <MoneyActivityList
-              transactions={allTransactions}
-              moneyAddress={moneyAddress}
-              onViewAllPress={handleViewAllActivityPress}
-              onHeaderPress={handleActivityHeaderPress}
-              onItemPress={handleActivityItemPress}
             />
             <Divider />
           </>

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView , Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Box } from '@metamask/design-system-react-native';
@@ -25,6 +25,10 @@ import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTo
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import { showMoneyActivityUnderConstructionAlert } from '../../constants/showMoneyActivityUnderConstructionAlert';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { MUSD_MAINNET_ASSET_FOR_DETAILS } from '../../../../Views/Homepage/Sections/Cash/CashGetMusdEmptyState.constants';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
+import AppConstants from '../../../../../core/AppConstants';
+import NavigationService from '../../../../../core/NavigationService';
 
 const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
 
@@ -66,13 +70,20 @@ const MoneyHomeView = () => {
   const handleApyInfoPress = displayUnderConstructionAlert;
   const handleProjectedEarningsPress = displayUnderConstructionAlert;
   const handleGetNowPress = displayUnderConstructionAlert;
-  const handleMusdRowPress = displayUnderConstructionAlert;
+  const handleMusdRowPress = useCallback(() => {
+    NavigationService.navigation.navigate('Asset', {
+      ...MUSD_MAINNET_ASSET_FOR_DETAILS,
+      source: TokenDetailsSource.MobileTokenListPage,
+    });
+  }, []);
   const handleHeaderPress = displayUnderConstructionAlert;
 
   const handleTokenConvertPress = displayUnderConstructionAlert;
 
   const handleEarnCryptoPress = displayUnderConstructionAlert;
-  const handleLearnMorePress = displayUnderConstructionAlert;
+  const handleLearnMorePress = useCallback(() => {
+    Linking.openURL(AppConstants.URLS.MUSD_LEARN_MORE);
+  }, []);
   const handleAddMoneyPress = displayUnderConstructionAlert;
   const handleHowItWorksHeaderPress = useCallback(() => {
     navigation.navigate(Routes.MONEY.HOW_IT_WORKS as never);

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -10,6 +10,7 @@ import MoneyActionButtonRow from '../../components/MoneyActionButtonRow';
 import MoneyEarnings from '../../components/MoneyEarnings';
 import MoneyMusdTokenRow from '../../components/MoneyMusdTokenRow';
 import MoneyOnboardingCard from '../../components/MoneyOnboardingCard';
+import MoneyCondensedInfoCards from '../../components/MoneyCondensedInfoCards';
 import MoneyHowItWorks from '../../components/MoneyHowItWorks';
 import MoneyPotentialEarnings from '../../components/MoneyPotentialEarnings';
 import { hasConvertibleTokensWithBalance } from '../../components/MoneyPotentialEarnings/MoneyPotentialEarnings';
@@ -27,6 +28,14 @@ import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 
 const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
 
+type MoneyHomeState = 'empty' | 'milestone' | 'filled';
+
+const getMoneyHomeState = (transactionCount: number): MoneyHomeState => {
+  if (transactionCount === 0) return 'empty';
+  if (transactionCount < 10) return 'milestone';
+  return 'filled';
+};
+
 /** Placeholder until Money home actions are implemented */
 // eslint-disable-next-line no-alert
 const displayUnderConstructionAlert = () => alert('Under construction 🚧');
@@ -41,6 +50,9 @@ const MoneyHomeView = () => {
 
   const { tokens: conversionTokens } = useMusdConversionTokens();
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
+
+  const homeState = getMoneyHomeState(allTransactions.length);
+  const isMilestone = homeState === 'milestone' || homeState === 'filled';
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -103,28 +115,46 @@ const MoneyHomeView = () => {
           onTransferPress={handleTransferPress}
           onCardPress={handleCardPress}
         />
-        <MoneyOnboardingCard onAddPress={handleAddPress} />
+        <MoneyOnboardingCard
+          currentStep={isMilestone ? 2 : 1}
+          onCtaPress={isMilestone ? handleCardPress : handleAddPress}
+        />
         <Divider />
         <MoneyEarnings onProjectedPress={handleProjectedEarningsPress} />
         <Divider />
-        <MoneyHowItWorks
-          apy={DEV_APY}
-          onHeaderPress={handleHowItWorksHeaderPress}
-          isLoading={vaultApyQuery.isLoading}
-        />
-        <MoneyMusdTokenRow
-          onPress={handleMusdRowPress}
-          onAddPress={handleAddPress}
-        />
-        <Divider />
+        {!isMilestone && (
+          <>
+            <MoneyHowItWorks
+              apy={DEV_APY}
+              onHeaderPress={handleHowItWorksHeaderPress}
+              isLoading={vaultApyQuery.isLoading}
+            />
+            <MoneyMusdTokenRow
+              onPress={handleMusdRowPress}
+              onAddPress={handleAddPress}
+            />
+            <Divider />
+          </>
+        )}
         {hasConvertibleTokensWithBalance(conversionTokens) && (
           <>
             <MoneyPotentialEarnings
               tokens={conversionTokens}
               apy={DEV_APY}
+              condensed={isMilestone}
               onTokenPress={handleTokenConvertPress}
               onViewAllPress={handleEarnCryptoPress}
               onHeaderPress={handleEarnCryptoPress}
+            />
+            <Divider />
+          </>
+        )}
+        {isMilestone && (
+          <>
+            <MoneyCondensedInfoCards
+              onHowItWorksPress={handleHowItWorksHeaderPress}
+              onMusdPress={handleMusdRowPress}
+              onWhatYouGetPress={handleLearnMorePress}
             />
             <Divider />
           </>
@@ -134,7 +164,7 @@ const MoneyHomeView = () => {
           onHeaderPress={handleHeaderPress}
         />
         <Divider />
-        {allTransactions.length >= 10 && (
+        {allTransactions.length >= 1 && (
           <>
             <MoneyActivityList
               transactions={allTransactions}
@@ -146,10 +176,12 @@ const MoneyHomeView = () => {
             <Divider />
           </>
         )}
-        <MoneyWhatYouGet
-          apy={DEV_APY}
-          onLearnMorePress={handleLearnMorePress}
-        />
+        {!isMilestone && (
+          <MoneyWhatYouGet
+            apy={DEV_APY}
+            onLearnMorePress={handleLearnMorePress}
+          />
+        )}
       </ScrollView>
       <MoneyFooter onAddMoneyPress={handleAddMoneyPress} />
     </Box>

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ScrollView , Linking } from 'react-native';
+import { ScrollView, Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Box } from '@metamask/design-system-react-native';

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MoneyHowItWorksView from './MoneyHowItWorksView';
+import { MoneyHowItWorksViewTestIds } from './MoneyHowItWorksView.testIds';
+
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+      navigate: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 48, bottom: 34, left: 0, right: 0 }),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en-US' },
+  strings: (key: string) => {
+    const map: Record<string, string> = {
+      'money.how_it_works_page.header_title': 'Money',
+      'money.how_it_works_page.section_title': 'How it works',
+      'money.how_it_works_page.description_1':
+        'Your Money account earns 4% APY (variable) automatically. Funds go into a curated DeFi vault that generates returns across audited lending markets—no staking, no claiming, no lock-ups.',
+      'money.how_it_works_page.description_2':
+        'Your Money balance is your spending balance. Link your MetaMask Card to spend at 150M+ merchants worldwide. Your money keeps earning until the moment you use it.',
+      'money.how_it_works_page.faq_title': 'FAQ',
+      'money.how_it_works_page.faq_placeholder_answer': 'Coming soon.',
+      'money.how_it_works_page.faq_q1': 'What is the Money account?',
+      'money.how_it_works_page.faq_q2': 'What is mUSD?',
+      'money.how_it_works_page.faq_q3': 'Where does the yield come from?',
+      'money.how_it_works_page.faq_q4':
+        'Is my money locked? Can I withdraw anytime?',
+      'money.how_it_works_page.faq_q5':
+        'How does spending with the MetaMask Card work?',
+      'money.how_it_works_page.faq_q6': 'Are there any fees?',
+      'money.how_it_works_page.faq_q7': 'Does the APY rate change?',
+      'money.how_it_works_page.faq_q8':
+        'Is this a savings account or a spending account?',
+      'money.how_it_works_page.faq_q9': 'Who controls my money?',
+      'money.how_it_works_page.faq_q10':
+        'What cash back do I get with the MetaMask Card?',
+      'money.how_it_works_page.sounds_good': 'Sounds good',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+describe('MoneyHowItWorksView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the section title', () => {
+    const { getByTestId } = renderWithProvider(<MoneyHowItWorksView />);
+
+    expect(
+      getByTestId(MoneyHowItWorksViewTestIds.SECTION_TITLE),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders both description paragraphs', () => {
+    const { getByTestId } = renderWithProvider(<MoneyHowItWorksView />);
+
+    expect(
+      getByTestId(MoneyHowItWorksViewTestIds.DESCRIPTION_1),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyHowItWorksViewTestIds.DESCRIPTION_2),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the FAQ title', () => {
+    const { getByTestId } = renderWithProvider(<MoneyHowItWorksView />);
+
+    expect(getByTestId(MoneyHowItWorksViewTestIds.FAQ_TITLE)).toBeOnTheScreen();
+  });
+
+  it('renders all 10 FAQ questions', () => {
+    const { getByText } = renderWithProvider(<MoneyHowItWorksView />);
+
+    expect(getByText('What is the Money account?')).toBeOnTheScreen();
+    expect(getByText('What is mUSD?')).toBeOnTheScreen();
+    expect(getByText('Where does the yield come from?')).toBeOnTheScreen();
+    expect(
+      getByText('Is my money locked? Can I withdraw anytime?'),
+    ).toBeOnTheScreen();
+    expect(
+      getByText('How does spending with the MetaMask Card work?'),
+    ).toBeOnTheScreen();
+    expect(getByText('Are there any fees?')).toBeOnTheScreen();
+    expect(getByText('Does the APY rate change?')).toBeOnTheScreen();
+    expect(
+      getByText('Is this a savings account or a spending account?'),
+    ).toBeOnTheScreen();
+    expect(getByText('Who controls my money?')).toBeOnTheScreen();
+    expect(
+      getByText('What cash back do I get with the MetaMask Card?'),
+    ).toBeOnTheScreen();
+  });
+
+  it('pressing the back button calls navigation.goBack', () => {
+    const { getByTestId } = renderWithProvider(<MoneyHowItWorksView />);
+
+    fireEvent.press(getByTestId(MoneyHowItWorksViewTestIds.BACK_BUTTON));
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing the Sounds good button calls navigation.goBack', () => {
+    const { getByTestId } = renderWithProvider(<MoneyHowItWorksView />);
+
+    fireEvent.press(getByTestId(MoneyHowItWorksViewTestIds.SOUNDS_GOOD_BUTTON));
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.testIds.ts
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.testIds.ts
@@ -1,0 +1,11 @@
+export const MoneyHowItWorksViewTestIds = {
+  CONTAINER: 'money-how-it-works-view-container',
+  BACK_BUTTON: 'money-how-it-works-view-back',
+  TITLE: 'money-how-it-works-view-title',
+  SECTION_TITLE: 'money-how-it-works-view-section-title',
+  DESCRIPTION_1: 'money-how-it-works-view-description-1',
+  DESCRIPTION_2: 'money-how-it-works-view-description-2',
+  FAQ_TITLE: 'money-how-it-works-view-faq-title',
+  FAQ_ITEM: (n: number) => `money-how-it-works-view-faq-item-${n}`,
+  SOUNDS_GOOD_BUTTON: 'money-how-it-works-view-sounds-good',
+};

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -37,7 +37,8 @@ const localStyles = StyleSheet.create({
   headerSpacer: { width: 40 },
 });
 
-const Divider = () => <Box twClassName="h-px bg-border-muted" />;
+const SectionDivider = () => <Box twClassName="h-px bg-border-muted my-5" />;
+const FaqDivider = () => <Box twClassName="h-px bg-border-muted" />;
 
 const FAQ_KEYS = [
   'faq_q1',
@@ -193,9 +194,7 @@ const MoneyHowItWorksView = () => {
           </Text>
         </Box>
 
-        <Box twClassName="my-5">
-          <Divider />
-        </Box>
+        <SectionDivider />
 
         <Box twClassName="pb-3 px-4">
           <Text
@@ -209,7 +208,7 @@ const MoneyHowItWorksView = () => {
 
         {FAQ_KEYS.map((key, index) => (
           <React.Fragment key={key}>
-            <Divider />
+            <FaqDivider />
             <FaqItem
               question={strings(`money.how_it_works_page.${key}`)}
               answer={strings('money.how_it_works_page.faq_placeholder_answer')}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -194,7 +194,9 @@ const MoneyHowItWorksView = () => {
           </Text>
         </Box>
 
-        <Box twClassName="pb-3 px-4 pt-6">
+        <SectionDivider />
+
+        <Box twClassName="py-5 px-4">
           <Text
             variant={TextVariant.HeadingMd}
             fontWeight={FontWeight.Bold}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -196,7 +196,7 @@ const MoneyHowItWorksView = () => {
 
         <SectionDivider />
 
-        <Box twClassName="py-5 px-4">
+        <Box twClassName="pt-8 pb-5 px-4">
           <Text
             variant={TextVariant.HeadingMd}
             fontWeight={FontWeight.Bold}
@@ -208,7 +208,7 @@ const MoneyHowItWorksView = () => {
 
         {FAQ_KEYS.map((key, index) => (
           <React.Fragment key={key}>
-            <FaqDivider />
+            {index > 0 && <FaqDivider />}
             <FaqItem
               question={strings(`money.how_it_works_page.${key}`)}
               answer={strings('money.how_it_works_page.faq_placeholder_answer')}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -217,7 +217,6 @@ const MoneyHowItWorksView = () => {
             />
           </React.Fragment>
         ))}
-        <Divider />
       </ScrollView>
 
       <Box twClassName="px-4" style={{ paddingBottom: insets.bottom + 16 }}>

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -196,7 +196,7 @@ const MoneyHowItWorksView = () => {
 
         <SectionDivider />
 
-        <Box twClassName="pt-8 pb-5 px-4">
+        <Box twClassName="py-5 px-4">
           <Text
             variant={TextVariant.HeadingMd}
             fontWeight={FontWeight.Bold}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import {
@@ -12,22 +12,32 @@ import {
   ButtonIcon,
   ButtonSize,
   ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
   IconName,
+  IconSize,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
 import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
-import Accordion from '../../../../../component-library/components/Accordions/Accordion';
 import { MoneyHowItWorksViewTestIds } from './MoneyHowItWorksView.testIds';
 
-const styles = StyleSheet.create({
+const localStyles = StyleSheet.create({
   safeArea: { flex: 1 },
   graphicPlaceholder: { height: 140 },
   headerSpacer: { width: 40 },
 });
 
-const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
+const Divider = () => <Box twClassName="h-px bg-border-muted" />;
 
 const FAQ_KEYS = [
   'faq_q1',
@@ -41,6 +51,69 @@ const FAQ_KEYS = [
   'faq_q9',
   'faq_q10',
 ] as const;
+
+const ANIMATION_DURATION = 200;
+
+const FaqItem = ({
+  question,
+  answer,
+  testID,
+}: {
+  question: string;
+  answer: string;
+  testID: string;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const rotation = useSharedValue(0);
+
+  const animatedArrowStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  const handlePress = useCallback(() => {
+    setExpanded((prev) => !prev);
+    rotation.value = withTiming(expanded ? 0 : 180, {
+      duration: ANIMATION_DURATION,
+      easing: Easing.out(Easing.ease),
+    });
+  }, [expanded, rotation]);
+
+  return (
+    <Pressable onPress={handlePress} testID={testID}>
+      <Box twClassName="py-3 px-4">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="gap-2"
+        >
+          <Box twClassName="flex-1">
+            <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
+              {question}
+            </Text>
+          </Box>
+          <Animated.View style={animatedArrowStyle}>
+            <Icon
+              name={IconName.ArrowDown}
+              size={IconSize.Md}
+              color={IconColor.IconDefault}
+            />
+          </Animated.View>
+        </Box>
+        {expanded && (
+          <Box twClassName="mt-3">
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {answer}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Pressable>
+  );
+};
 
 const MoneyHowItWorksView = () => {
   const navigation = useNavigation();
@@ -58,7 +131,7 @@ const MoneyHowItWorksView = () => {
   return (
     <Box
       style={[
-        styles.safeArea,
+        localStyles.safeArea,
         { paddingTop: insets.top, backgroundColor: colors.background.default },
       ]}
       twClassName="flex-1 bg-default"
@@ -68,8 +141,7 @@ const MoneyHowItWorksView = () => {
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Between}
-        paddingVertical={2}
-        twClassName="px-2"
+        twClassName="px-1 py-2"
       >
         <ButtonIcon
           iconName={IconName.ArrowLeft}
@@ -78,10 +150,10 @@ const MoneyHowItWorksView = () => {
           accessibilityLabel="Back"
           testID={MoneyHowItWorksViewTestIds.BACK_BUTTON}
         />
-        <Text variant={TextVariant.HeadingSm}>
+        <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
           {strings('money.how_it_works_page.header_title')}
         </Text>
-        <Box style={styles.headerSpacer} />
+        <Box style={localStyles.headerSpacer} />
       </Box>
 
       <ScrollView
@@ -90,76 +162,69 @@ const MoneyHowItWorksView = () => {
       >
         <View
           style={[
-            styles.graphicPlaceholder,
+            localStyles.graphicPlaceholder,
             { backgroundColor: colors.background.alternative },
           ]}
           accessibilityRole="image"
           accessibilityLabel="How it works graphic"
         />
 
-        <Box paddingHorizontal={4} paddingTop={6} paddingBottom={2}>
+        <Box twClassName="px-4 pt-6 pb-3 gap-3">
           <Text
-            variant={TextVariant.HeadingLg}
+            variant={TextVariant.HeadingMd}
+            fontWeight={FontWeight.Bold}
             testID={MoneyHowItWorksViewTestIds.SECTION_TITLE}
           >
             {strings('money.how_it_works_page.section_title')}
           </Text>
-        </Box>
-
-        <Box paddingHorizontal={4} paddingTop={3}>
           <Text
             variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             testID={MoneyHowItWorksViewTestIds.DESCRIPTION_1}
           >
             {strings('money.how_it_works_page.description_1')}
           </Text>
-        </Box>
-
-        <Box paddingHorizontal={4} paddingTop={3} paddingBottom={4}>
           <Text
             variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             testID={MoneyHowItWorksViewTestIds.DESCRIPTION_2}
           >
             {strings('money.how_it_works_page.description_2')}
           </Text>
         </Box>
 
-        <Divider />
+        <Box twClassName="my-5">
+          <Divider />
+        </Box>
 
-        <Box paddingHorizontal={4} paddingBottom={3}>
+        <Box twClassName="pb-3 px-4">
           <Text
-            variant={TextVariant.HeadingLg}
+            variant={TextVariant.HeadingMd}
+            fontWeight={FontWeight.Bold}
             testID={MoneyHowItWorksViewTestIds.FAQ_TITLE}
           >
             {strings('money.how_it_works_page.faq_title')}
           </Text>
         </Box>
 
-        <Box paddingHorizontal={4}>
-          {FAQ_KEYS.map((key, index) => (
-            <React.Fragment key={key}>
-              <Accordion
-                title={strings(`money.how_it_works_page.${key}`)}
-                testID={MoneyHowItWorksViewTestIds.FAQ_ITEM(index + 1)}
-              >
-                <Box paddingHorizontal={4} paddingBottom={3}>
-                  <Text variant={TextVariant.BodyMd}>
-                    {strings('money.how_it_works_page.faq_placeholder_answer')}
-                  </Text>
-                </Box>
-              </Accordion>
-              {index < FAQ_KEYS.length - 1 && (
-                <Box twClassName="h-px bg-border-muted" />
-              )}
-            </React.Fragment>
-          ))}
-        </Box>
+        {FAQ_KEYS.map((key, index) => (
+          <React.Fragment key={key}>
+            <Divider />
+            <FaqItem
+              question={strings(`money.how_it_works_page.${key}`)}
+              answer={strings('money.how_it_works_page.faq_placeholder_answer')}
+              testID={MoneyHowItWorksViewTestIds.FAQ_ITEM(index + 1)}
+            />
+          </React.Fragment>
+        ))}
+        <Divider />
       </ScrollView>
 
-      <Box paddingHorizontal={4} style={{ paddingBottom: insets.bottom + 16 }}>
+      <Box twClassName="px-4" style={{ paddingBottom: insets.bottom + 16 }}>
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
+          isFullWidth
           onPress={handleSoundsGoodPress}
           testID={MoneyHowItWorksViewTestIds.SOUNDS_GOOD_BUTTON}
         >

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -1,0 +1,173 @@
+import React, { useCallback } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonIconSize,
+  ButtonIcon,
+  ButtonSize,
+  ButtonVariant,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
+import Accordion from '../../../../../component-library/components/Accordions/Accordion';
+import { MoneyHowItWorksViewTestIds } from './MoneyHowItWorksView.testIds';
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1 },
+  graphicPlaceholder: { height: 140 },
+  headerSpacer: { width: 40 },
+});
+
+const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
+
+const FAQ_KEYS = [
+  'faq_q1',
+  'faq_q2',
+  'faq_q3',
+  'faq_q4',
+  'faq_q5',
+  'faq_q6',
+  'faq_q7',
+  'faq_q8',
+  'faq_q9',
+  'faq_q10',
+] as const;
+
+const MoneyHowItWorksView = () => {
+  const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  const handleBackPress = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleSoundsGoodPress = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  return (
+    <Box
+      style={[
+        styles.safeArea,
+        { paddingTop: insets.top, backgroundColor: colors.background.default },
+      ]}
+      twClassName="flex-1 bg-default"
+      testID={MoneyHowItWorksViewTestIds.CONTAINER}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        paddingVertical={2}
+        twClassName="px-2"
+      >
+        <ButtonIcon
+          iconName={IconName.ArrowLeft}
+          size={ButtonIconSize.Md}
+          onPress={handleBackPress}
+          accessibilityLabel="Back"
+          testID={MoneyHowItWorksViewTestIds.BACK_BUTTON}
+        />
+        <Text variant={TextVariant.HeadingSm}>
+          {strings('money.how_it_works_page.header_title')}
+        </Text>
+        <Box style={styles.headerSpacer} />
+      </Box>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+      >
+        <View
+          style={[
+            styles.graphicPlaceholder,
+            { backgroundColor: colors.background.alternative },
+          ]}
+          accessibilityRole="image"
+          accessibilityLabel="How it works graphic"
+        />
+
+        <Box paddingHorizontal={4} paddingTop={6} paddingBottom={2}>
+          <Text
+            variant={TextVariant.HeadingLg}
+            testID={MoneyHowItWorksViewTestIds.SECTION_TITLE}
+          >
+            {strings('money.how_it_works_page.section_title')}
+          </Text>
+        </Box>
+
+        <Box paddingHorizontal={4} paddingTop={3}>
+          <Text
+            variant={TextVariant.BodyMd}
+            testID={MoneyHowItWorksViewTestIds.DESCRIPTION_1}
+          >
+            {strings('money.how_it_works_page.description_1')}
+          </Text>
+        </Box>
+
+        <Box paddingHorizontal={4} paddingTop={3} paddingBottom={4}>
+          <Text
+            variant={TextVariant.BodyMd}
+            testID={MoneyHowItWorksViewTestIds.DESCRIPTION_2}
+          >
+            {strings('money.how_it_works_page.description_2')}
+          </Text>
+        </Box>
+
+        <Divider />
+
+        <Box paddingHorizontal={4} paddingBottom={3}>
+          <Text
+            variant={TextVariant.HeadingLg}
+            testID={MoneyHowItWorksViewTestIds.FAQ_TITLE}
+          >
+            {strings('money.how_it_works_page.faq_title')}
+          </Text>
+        </Box>
+
+        <Box paddingHorizontal={4}>
+          {FAQ_KEYS.map((key, index) => (
+            <React.Fragment key={key}>
+              <Accordion
+                title={strings(`money.how_it_works_page.${key}`)}
+                testID={MoneyHowItWorksViewTestIds.FAQ_ITEM(index + 1)}
+              >
+                <Box paddingHorizontal={4} paddingBottom={3}>
+                  <Text variant={TextVariant.BodyMd}>
+                    {strings('money.how_it_works_page.faq_placeholder_answer')}
+                  </Text>
+                </Box>
+              </Accordion>
+              {index < FAQ_KEYS.length - 1 && (
+                <Box twClassName="h-px bg-border-muted" />
+              )}
+            </React.Fragment>
+          ))}
+        </Box>
+      </ScrollView>
+
+      <Box paddingHorizontal={4} style={{ paddingBottom: insets.bottom + 16 }}>
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={handleSoundsGoodPress}
+          testID={MoneyHowItWorksViewTestIds.SOUNDS_GOOD_BUTTON}
+        >
+          {strings('money.how_it_works_page.sounds_good')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default MoneyHowItWorksView;

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -81,7 +81,7 @@ const FaqItem = ({
 
   return (
     <Pressable onPress={handlePress} testID={testID}>
-      <Box twClassName="py-3 px-4">
+      <Box twClassName="py-5 px-4">
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
@@ -194,9 +194,7 @@ const MoneyHowItWorksView = () => {
           </Text>
         </Box>
 
-        <SectionDivider />
-
-        <Box twClassName="pb-3 px-4">
+        <Box twClassName="pb-3 px-4 pt-6">
           <Text
             variant={TextVariant.HeadingMd}
             fontWeight={FontWeight.Bold}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/MoneyHowItWorksView.tsx
@@ -72,12 +72,14 @@ const FaqItem = ({
   }));
 
   const handlePress = useCallback(() => {
-    setExpanded((prev) => !prev);
-    rotation.value = withTiming(expanded ? 0 : 180, {
-      duration: ANIMATION_DURATION,
-      easing: Easing.out(Easing.ease),
+    setExpanded((prev) => {
+      rotation.value = withTiming(prev ? 0 : 180, {
+        duration: ANIMATION_DURATION,
+        easing: Easing.out(Easing.ease),
+      });
+      return !prev;
     });
-  }, [expanded, rotation]);
+  }, [rotation]);
 
   return (
     <Pressable onPress={handlePress} testID={testID}>
@@ -121,11 +123,7 @@ const MoneyHowItWorksView = () => {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
-  const handleBackPress = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
-
-  const handleSoundsGoodPress = useCallback(() => {
+  const handleGoBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
@@ -135,7 +133,7 @@ const MoneyHowItWorksView = () => {
         localStyles.safeArea,
         { paddingTop: insets.top, backgroundColor: colors.background.default },
       ]}
-      twClassName="flex-1 bg-default"
+      twClassName="flex-1"
       testID={MoneyHowItWorksViewTestIds.CONTAINER}
     >
       <Box
@@ -147,7 +145,7 @@ const MoneyHowItWorksView = () => {
         <ButtonIcon
           iconName={IconName.ArrowLeft}
           size={ButtonIconSize.Md}
-          onPress={handleBackPress}
+          onPress={handleGoBack}
           accessibilityLabel="Back"
           testID={MoneyHowItWorksViewTestIds.BACK_BUTTON}
         />
@@ -223,7 +221,7 @@ const MoneyHowItWorksView = () => {
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           isFullWidth
-          onPress={handleSoundsGoodPress}
+          onPress={handleGoBack}
           testID={MoneyHowItWorksViewTestIds.SOUNDS_GOOD_BUTTON}
         >
           {strings('money.how_it_works_page.sounds_good')}

--- a/app/components/UI/Money/Views/MoneyHowItWorksView/index.ts
+++ b/app/components/UI/Money/Views/MoneyHowItWorksView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MoneyHowItWorksView';

--- a/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.test.tsx
+++ b/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import MoneyCondensedInfoCards from './MoneyCondensedInfoCards';
+import { MoneyCondensedInfoCardsTestIds } from './MoneyCondensedInfoCards.testIds';
+import { strings } from '../../../../../../locales/i18n';
+
+describe('MoneyCondensedInfoCards', () => {
+  it('renders all three cards', () => {
+    const { getByTestId } = render(<MoneyCondensedInfoCards />);
+
+    expect(
+      getByTestId(MoneyCondensedInfoCardsTestIds.HOW_IT_WORKS_CARD),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyCondensedInfoCardsTestIds.MUSD_CARD),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyCondensedInfoCardsTestIds.WHAT_YOU_GET_CARD),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders correct titles and subtitles', () => {
+    const { getByText } = render(<MoneyCondensedInfoCards />);
+
+    expect(
+      getByText(strings('money.condensed_cards.how_it_works_title')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('money.condensed_cards.how_it_works_subtitle')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('money.condensed_cards.musd_title')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('money.condensed_cards.musd_subtitle')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('money.condensed_cards.what_you_get_title')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('money.condensed_cards.what_you_get_subtitle')),
+    ).toBeOnTheScreen();
+  });
+
+  it('calls onHowItWorksPress when How it works card is pressed', () => {
+    const mock = jest.fn();
+    const { getByTestId } = render(
+      <MoneyCondensedInfoCards onHowItWorksPress={mock} />,
+    );
+    fireEvent.press(
+      getByTestId(MoneyCondensedInfoCardsTestIds.HOW_IT_WORKS_CARD),
+    );
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onMusdPress when MetaMask USD card is pressed', () => {
+    const mock = jest.fn();
+    const { getByTestId } = render(
+      <MoneyCondensedInfoCards onMusdPress={mock} />,
+    );
+    fireEvent.press(getByTestId(MoneyCondensedInfoCardsTestIds.MUSD_CARD));
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onWhatYouGetPress when What you get card is pressed', () => {
+    const mock = jest.fn();
+    const { getByTestId } = render(
+      <MoneyCondensedInfoCards onWhatYouGetPress={mock} />,
+    );
+    fireEvent.press(
+      getByTestId(MoneyCondensedInfoCardsTestIds.WHAT_YOU_GET_CARD),
+    );
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when cards are pressed without handlers', () => {
+    const { getByTestId } = render(<MoneyCondensedInfoCards />);
+    expect(() => {
+      fireEvent.press(
+        getByTestId(MoneyCondensedInfoCardsTestIds.HOW_IT_WORKS_CARD),
+      );
+      fireEvent.press(getByTestId(MoneyCondensedInfoCardsTestIds.MUSD_CARD));
+      fireEvent.press(
+        getByTestId(MoneyCondensedInfoCardsTestIds.WHAT_YOU_GET_CARD),
+      );
+    }).not.toThrow();
+  });
+});

--- a/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds.ts
+++ b/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds.ts
@@ -1,0 +1,6 @@
+export const MoneyCondensedInfoCardsTestIds = {
+  CONTAINER: 'money-condensed-info-cards-container',
+  HOW_IT_WORKS_CARD: 'money-condensed-info-cards-how-it-works',
+  MUSD_CARD: 'money-condensed-info-cards-musd',
+  WHAT_YOU_GET_CARD: 'money-condensed-info-cards-what-you-get',
+} as const;

--- a/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.tsx
+++ b/app/components/UI/Money/components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { MoneyCondensedInfoCardsTestIds } from './MoneyCondensedInfoCards.testIds';
+
+interface MoneyCondensedInfoCardsProps {
+  onHowItWorksPress?: () => void;
+  onMusdPress?: () => void;
+  onWhatYouGetPress?: () => void;
+}
+
+const CondensedCard = ({
+  iconName,
+  title,
+  subtitle,
+  onPress,
+  testID,
+}: {
+  iconName: IconName;
+  title: string;
+  subtitle: string;
+  onPress?: () => void;
+  testID: string;
+}) => (
+  <Pressable onPress={onPress} testID={testID}>
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="bg-muted rounded-xl p-4 gap-4"
+    >
+      <Box
+        alignItems={BoxAlignItems.Center}
+        twClassName="bg-muted rounded-xl size-[78px] justify-center"
+      >
+        <Icon
+          name={iconName}
+          size={IconSize.Xl}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+      <Box twClassName="flex-1 gap-1">
+        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+          {title}
+        </Text>
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Regular}
+          color={TextColor.TextAlternative}
+        >
+          {subtitle}
+        </Text>
+      </Box>
+    </Box>
+  </Pressable>
+);
+
+const MoneyCondensedInfoCards = ({
+  onHowItWorksPress,
+  onMusdPress,
+  onWhatYouGetPress,
+}: MoneyCondensedInfoCardsProps) => (
+  <Box
+    twClassName="px-4 py-3 gap-3"
+    testID={MoneyCondensedInfoCardsTestIds.CONTAINER}
+  >
+    <CondensedCard
+      iconName={IconName.Stake}
+      title={strings('money.condensed_cards.how_it_works_title')}
+      subtitle={strings('money.condensed_cards.how_it_works_subtitle')}
+      onPress={onHowItWorksPress}
+      testID={MoneyCondensedInfoCardsTestIds.HOW_IT_WORKS_CARD}
+    />
+    <CondensedCard
+      iconName={IconName.Coin}
+      title={strings('money.condensed_cards.musd_title')}
+      subtitle={strings('money.condensed_cards.musd_subtitle')}
+      onPress={onMusdPress}
+      testID={MoneyCondensedInfoCardsTestIds.MUSD_CARD}
+    />
+    <CondensedCard
+      iconName={IconName.SwapHorizontal}
+      title={strings('money.condensed_cards.what_you_get_title')}
+      subtitle={strings('money.condensed_cards.what_you_get_subtitle')}
+      onPress={onWhatYouGetPress}
+      testID={MoneyCondensedInfoCardsTestIds.WHAT_YOU_GET_CARD}
+    />
+  </Box>
+);
+
+export default MoneyCondensedInfoCards;

--- a/app/components/UI/Money/components/MoneyCondensedInfoCards/index.ts
+++ b/app/components/UI/Money/components/MoneyCondensedInfoCards/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MoneyCondensedInfoCards';

--- a/app/components/UI/Money/components/MoneyEarnings/MoneyEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyEarnings/MoneyEarnings.test.tsx
@@ -78,4 +78,11 @@ describe('MoneyEarnings', () => {
       fireEvent.press(getByTestId(MoneyEarningsTestIds.PROJECTED));
     }).not.toThrow();
   });
+
+  it('renders lifetime earnings in success color when value starts with +', () => {
+    const { getByTestId } = render(<MoneyEarnings lifetimeEarnings="+$2.84" />);
+
+    const lifetimeValue = getByTestId(MoneyEarningsTestIds.LIFETIME_VALUE);
+    expect(lifetimeValue).toHaveTextContent('+$2.84');
+  });
 });

--- a/app/components/UI/Money/components/MoneyEarnings/MoneyEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyEarnings/MoneyEarnings.tsx
@@ -49,13 +49,16 @@ interface MoneyEarningsProps {
 const ValueText = ({
   children,
   testID,
+  color,
 }: {
   children: string;
   testID: string;
+  color?: TextColor;
 }) => (
   <Text
     variant={TextVariant.BodyMd}
     fontWeight={FontWeight.Medium}
+    color={color}
     testID={testID}
   >
     {children}
@@ -91,7 +94,14 @@ const MoneyEarnings = ({
             testID={MoneyEarningsTestIds.LIFETIME_SKELETON}
           />
         ) : (
-          <ValueText testID={MoneyEarningsTestIds.LIFETIME_VALUE}>
+          <ValueText
+            testID={MoneyEarningsTestIds.LIFETIME_VALUE}
+            color={
+              lifetimeEarnings.startsWith('+')
+                ? TextColor.SuccessDefault
+                : undefined
+            }
+          >
             {lifetimeEarnings}
           </ValueText>
         )}

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -46,22 +46,57 @@ describe('MoneyOnboardingCard', () => {
     ).toHaveTextContent(strings('money.onboarding.description'));
   });
 
-  it('calls onAddPress when Add is tapped', () => {
+  it('calls onCtaPress when CTA is tapped', () => {
+    const mockCta = jest.fn();
+    const { getByTestId } = render(
+      <MoneyOnboardingCard onCtaPress={mockCta} />,
+    );
+
+    fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
+
+    expect(mockCta).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to onAddPress when onCtaPress is not provided', () => {
     const mockAdd = jest.fn();
     const { getByTestId } = render(
       <MoneyOnboardingCard onAddPress={mockAdd} />,
     );
 
-    fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.ADD_BUTTON));
+    fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
 
     expect(mockAdd).toHaveBeenCalledTimes(1);
   });
 
-  it('does not throw when Add is tapped without a handler', () => {
+  it('does not throw when CTA is tapped without a handler', () => {
     const { getByTestId } = render(<MoneyOnboardingCard />);
 
     expect(() => {
-      fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.ADD_BUTTON));
+      fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
     }).not.toThrow();
+  });
+
+  it('renders step 2 title when currentStep is 2', () => {
+    const { getByTestId } = render(<MoneyOnboardingCard currentStep={2} />);
+
+    expect(getByTestId(MoneyOnboardingCardTestIds.TITLE)).toHaveTextContent(
+      strings('money.onboarding.step2_title'),
+    );
+  });
+
+  it('renders step 2 description when currentStep is 2', () => {
+    const { getByTestId } = render(<MoneyOnboardingCard currentStep={2} />);
+
+    expect(
+      getByTestId(MoneyOnboardingCardTestIds.DESCRIPTION),
+    ).toHaveTextContent(strings('money.onboarding.step2_description'));
+  });
+
+  it('renders step 2 CTA label when currentStep is 2', () => {
+    const { getByTestId } = render(<MoneyOnboardingCard currentStep={2} />);
+
+    expect(
+      getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON),
+    ).toHaveTextContent(strings('money.onboarding.step2_cta'));
   });
 });

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
@@ -5,5 +5,5 @@ export const MoneyOnboardingCardTestIds = {
   COIN_ILLUSTRATION: 'money-onboarding-card-coin-illustration',
   TITLE: 'money-onboarding-card-title',
   DESCRIPTION: 'money-onboarding-card-description',
-  ADD_BUTTON: 'money-onboarding-card-add-button',
+  CTA_BUTTON: 'money-onboarding-card-cta-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -21,6 +21,11 @@ import { MoneyOnboardingCardTestIds } from './MoneyOnboardingCard.testIds';
 
 interface MoneyOnboardingCardProps {
   /**
+   * Handler fired when the CTA button is pressed.
+   */
+  onCtaPress?: () => void;
+  /**
+   * @deprecated Use onCtaPress instead.
    * Handler fired when the "Add" action is pressed. Opens the Add money sheet (MUSD-487).
    */
   onAddPress?: () => void;
@@ -35,73 +40,88 @@ interface MoneyOnboardingCardProps {
 }
 
 const MoneyOnboardingCard = ({
-  onAddPress = () => undefined,
+  onCtaPress,
+  onAddPress,
   currentStep = 1,
   totalSteps = 2,
-}: MoneyOnboardingCardProps) => (
-  <Box
-    twClassName="mx-4 my-3 rounded-2xl bg-muted overflow-hidden"
-    testID={MoneyOnboardingCardTestIds.CONTAINER}
-  >
-    <Box twClassName="p-4 gap-2">
-      <Text
-        variant={TextVariant.HeadingSm}
-        fontWeight={FontWeight.Bold}
-        testID={MoneyOnboardingCardTestIds.STEP_LABEL}
-      >
-        {strings('money.onboarding.step_progress', {
-          current: currentStep,
-          total: totalSteps,
-        })}
-      </Text>
-      <MoneyProgressBar
-        current={currentStep}
-        total={totalSteps}
-        testID={MoneyOnboardingCardTestIds.PROGRESS_BAR}
-      />
-    </Box>
+}: MoneyOnboardingCardProps) => {
+  const isStep2 = currentStep >= 2;
+  const title = isStep2
+    ? strings('money.onboarding.step2_title')
+    : strings('money.onboarding.title');
+  const description = isStep2
+    ? strings('money.onboarding.step2_description')
+    : strings('money.onboarding.description');
+  const ctaLabel = isStep2
+    ? strings('money.onboarding.step2_cta')
+    : strings('money.onboarding.add');
+  const handleCtaPress = onCtaPress ?? onAddPress ?? (() => undefined);
 
+  return (
     <Box
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Center}
-      twClassName="h-[202px]"
-      testID={MoneyOnboardingCardTestIds.COIN_ILLUSTRATION}
+      twClassName="mx-4 my-3 rounded-2xl bg-muted overflow-hidden"
+      testID={MoneyOnboardingCardTestIds.CONTAINER}
     >
-      <Icon
-        name={IconName.Stake}
-        size={IconSize.Xl}
-        color={IconColor.IconAlternative}
-      />
-    </Box>
-
-    <Box twClassName="p-4 gap-4">
-      <Box twClassName="gap-1">
+      <Box twClassName="p-4 gap-2">
         <Text
-          variant={TextVariant.HeadingLg}
+          variant={TextVariant.HeadingSm}
           fontWeight={FontWeight.Bold}
-          testID={MoneyOnboardingCardTestIds.TITLE}
+          testID={MoneyOnboardingCardTestIds.STEP_LABEL}
         >
-          {strings('money.onboarding.title')}
+          {strings('money.onboarding.step_progress', {
+            current: currentStep,
+            total: totalSteps,
+          })}
         </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          color={TextColor.TextAlternative}
-          testID={MoneyOnboardingCardTestIds.DESCRIPTION}
-        >
-          {strings('money.onboarding.description')}
-        </Text>
+        <MoneyProgressBar
+          current={currentStep}
+          total={totalSteps}
+          testID={MoneyOnboardingCardTestIds.PROGRESS_BAR}
+        />
       </Box>
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Lg}
-        isFullWidth
-        onPress={onAddPress}
-        testID={MoneyOnboardingCardTestIds.ADD_BUTTON}
+
+      <Box
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        twClassName="h-[202px]"
+        testID={MoneyOnboardingCardTestIds.COIN_ILLUSTRATION}
       >
-        {strings('money.onboarding.add')}
-      </Button>
+        <Icon
+          name={IconName.Stake}
+          size={IconSize.Xl}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+
+      <Box twClassName="p-4 gap-4">
+        <Box twClassName="gap-1">
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Bold}
+            testID={MoneyOnboardingCardTestIds.TITLE}
+          >
+            {title}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            testID={MoneyOnboardingCardTestIds.DESCRIPTION}
+          >
+            {description}
+          </Text>
+        </Box>
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={handleCtaPress}
+          testID={MoneyOnboardingCardTestIds.CTA_BUTTON}
+        >
+          {ctaLabel}
+        </Button>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
 export default MoneyOnboardingCard;

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -19,6 +19,8 @@ import { strings } from '../../../../../../locales/i18n';
 import MoneyProgressBar from '../MoneyProgressBar';
 import { MoneyOnboardingCardTestIds } from './MoneyOnboardingCard.testIds';
 
+const NOOP = () => undefined;
+
 interface MoneyOnboardingCardProps {
   /**
    * Handler fired when the CTA button is pressed.
@@ -60,7 +62,7 @@ const MoneyOnboardingCard = ({
 }: MoneyOnboardingCardProps) => {
   const content =
     STEP_CONTENT[currentStep as keyof typeof STEP_CONTENT] ?? STEP_CONTENT[1];
-  const handleCtaPress = onCtaPress ?? onAddPress ?? (() => undefined);
+  const handleCtaPress = onCtaPress ?? onAddPress ?? NOOP;
 
   return (
     <Box

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -39,22 +39,27 @@ interface MoneyOnboardingCardProps {
   totalSteps?: number;
 }
 
+const STEP_CONTENT = {
+  1: {
+    title: 'money.onboarding.title',
+    description: 'money.onboarding.description',
+    cta: 'money.onboarding.add',
+  },
+  2: {
+    title: 'money.onboarding.step2_title',
+    description: 'money.onboarding.step2_description',
+    cta: 'money.onboarding.step2_cta',
+  },
+} as const;
+
 const MoneyOnboardingCard = ({
   onCtaPress,
   onAddPress,
   currentStep = 1,
   totalSteps = 2,
 }: MoneyOnboardingCardProps) => {
-  const isStep2 = currentStep >= 2;
-  const title = isStep2
-    ? strings('money.onboarding.step2_title')
-    : strings('money.onboarding.title');
-  const description = isStep2
-    ? strings('money.onboarding.step2_description')
-    : strings('money.onboarding.description');
-  const ctaLabel = isStep2
-    ? strings('money.onboarding.step2_cta')
-    : strings('money.onboarding.add');
+  const content =
+    STEP_CONTENT[currentStep as keyof typeof STEP_CONTENT] ?? STEP_CONTENT[1];
   const handleCtaPress = onCtaPress ?? onAddPress ?? (() => undefined);
 
   return (
@@ -100,14 +105,14 @@ const MoneyOnboardingCard = ({
             fontWeight={FontWeight.Bold}
             testID={MoneyOnboardingCardTestIds.TITLE}
           >
-            {title}
+            {strings(content.title)}
           </Text>
           <Text
             variant={TextVariant.BodyMd}
             color={TextColor.TextAlternative}
             testID={MoneyOnboardingCardTestIds.DESCRIPTION}
           >
-            {description}
+            {strings(content.description)}
           </Text>
         </Box>
         <Button
@@ -117,7 +122,7 @@ const MoneyOnboardingCard = ({
           onPress={handleCtaPress}
           testID={MoneyOnboardingCardTestIds.CTA_BUTTON}
         >
-          {ctaLabel}
+          {strings(content.cta)}
         </Button>
       </Box>
     </Box>

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
@@ -229,4 +229,82 @@ describe('MoneyPotentialEarnings', () => {
     // which fails isPositiveNumber and hides the "+$..." text in each token row.
     expect(queryByText(/^\+\$/)).not.toBeOnTheScreen();
   });
+
+  describe('condensed mode', () => {
+    it('renders the gradient amount and description in condensed mode', () => {
+      const { getByTestId, getByText } = render(
+        <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} condensed />,
+      );
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.AMOUNT),
+      ).toBeOnTheScreen();
+      expect(
+        getByText(strings('money.potential_earnings.description')),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides token rows in condensed mode', () => {
+      const { queryByText } = render(
+        <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} condensed />,
+      );
+      expect(queryByText('USDC')).not.toBeOnTheScreen();
+    });
+
+    it('hides the View all button in condensed mode', () => {
+      const { queryByTestId } = render(
+        <MoneyPotentialEarnings
+          apy={4}
+          tokens={[MOCK_USDC]}
+          condensed
+          onViewAllPress={jest.fn()}
+        />,
+      );
+      expect(
+        queryByTestId(MoneyPotentialEarningsTestIds.VIEW_ALL_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders the View potential earnings button in condensed mode', () => {
+      const { getByTestId } = render(
+        <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} condensed />,
+      );
+      expect(
+        getByTestId(
+          MoneyPotentialEarningsTestIds.VIEW_POTENTIAL_EARNINGS_BUTTON,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('calls onViewAllPress when View potential earnings is pressed', () => {
+      const onViewAll = jest.fn();
+      const { getByTestId } = render(
+        <MoneyPotentialEarnings
+          apy={4}
+          tokens={[MOCK_USDC]}
+          condensed
+          onViewAllPress={onViewAll}
+        />,
+      );
+      fireEvent.press(
+        getByTestId(
+          MoneyPotentialEarningsTestIds.VIEW_POTENTIAL_EARNINGS_BUTTON,
+        ),
+      );
+      expect(onViewAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('still renders section header with onHeaderPress in condensed mode', () => {
+      const onHeader = jest.fn();
+      const { getByText } = render(
+        <MoneyPotentialEarnings
+          apy={4}
+          tokens={[MOCK_USDC]}
+          condensed
+          onHeaderPress={onHeader}
+        />,
+      );
+      fireEvent.press(getByText(strings('money.potential_earnings.title')));
+      expect(onHeader).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.testIds.ts
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.testIds.ts
@@ -2,4 +2,6 @@ export const MoneyPotentialEarningsTestIds = {
   CONTAINER: 'money-potential-earnings-container',
   AMOUNT: 'money-potential-earnings-amount',
   VIEW_ALL_BUTTON: 'money-potential-earnings-view-all-button',
+  VIEW_POTENTIAL_EARNINGS_BUTTON:
+    'money-potential-earnings-view-potential-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -69,6 +69,8 @@ interface MoneyPotentialEarningsProps {
   onTokenPress?: (token: AssetType) => void;
   onViewAllPress?: () => void;
   onHeaderPress?: () => void;
+  /** When true, hides token rows and shows a single "View potential earnings" button. */
+  condensed?: boolean;
 }
 
 const GradientAmountText = ({ value }: { value: string }) => {
@@ -211,6 +213,7 @@ const MoneyPotentialEarnings = ({
   onTokenPress,
   onViewAllPress,
   onHeaderPress,
+  condensed = false,
 }: MoneyPotentialEarningsProps) => {
   const formatFiat = useFiatFormatter();
   const projectedMultiplier = useMemo(
@@ -275,27 +278,45 @@ const MoneyPotentialEarnings = ({
         </Text>
       </Box>
 
-      {visibleTokens.map((token) => (
-        <TokenRow
-          key={`${token.address}-${token.chainId}`}
-          token={token}
-          hasSubsidizedFee={STABLECOIN_SYMBOLS.has(token.symbol)}
-          projectedMultiplier={projectedMultiplier}
-          onPress={handleTokenPress(token)}
-        />
-      ))}
+      {condensed ? (
+        <Box twClassName="px-4 py-3">
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            onPress={onViewAllPress}
+            testID={
+              MoneyPotentialEarningsTestIds.VIEW_POTENTIAL_EARNINGS_BUTTON
+            }
+          >
+            {strings('money.potential_earnings.view_potential_earnings')}
+          </Button>
+        </Box>
+      ) : (
+        <>
+          {visibleTokens.map((token) => (
+            <TokenRow
+              key={`${token.address}-${token.chainId}`}
+              token={token}
+              hasSubsidizedFee={STABLECOIN_SYMBOLS.has(token.symbol)}
+              projectedMultiplier={projectedMultiplier}
+              onPress={handleTokenPress(token)}
+            />
+          ))}
 
-      <Box twClassName="px-4 py-3">
-        <Button
-          variant={ButtonVariant.Secondary}
-          size={ButtonSize.Lg}
-          isFullWidth
-          onPress={onViewAllPress}
-          testID={MoneyPotentialEarningsTestIds.VIEW_ALL_BUTTON}
-        >
-          {strings('money.potential_earnings.view_all')}
-        </Button>
-      </Box>
+          <Box twClassName="px-4 py-3">
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={onViewAllPress}
+              testID={MoneyPotentialEarningsTestIds.VIEW_ALL_BUTTON}
+            >
+              {strings('money.potential_earnings.view_all')}
+            </Button>
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -4,6 +4,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../util/theme';
 import MoneyHomeView from '../Views/MoneyHomeView';
 import MoneyActivityView from '../Views/MoneyActivityView';
+import MoneyHowItWorksView from '../Views/MoneyHowItWorksView';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
 import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 
@@ -24,6 +25,10 @@ const MoneyScreenStack = () => {
       <Stack.Screen
         name={Routes.MONEY.ACTIVITY}
         component={MoneyActivityView}
+      />
+      <Stack.Screen
+        name={Routes.MONEY.HOW_IT_WORKS}
+        component={MoneyHowItWorksView}
       />
       <Stack.Screen
         name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -414,6 +414,7 @@ const Routes = {
     ROOT: 'MoneyScreens',
     HOME: 'MoneyHome',
     ACTIVITY: 'MoneyActivity',
+    HOW_IT_WORKS: 'MoneyHowItWorks',
   },
   FULL_SCREEN_CONFIRMATIONS: {
     REDESIGNED_CONFIRMATIONS: 'RedesignedConfirmations',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6307,7 +6307,10 @@
       "step_progress": "Step {{current}} of {{total}}",
       "title": "Add money",
       "description": "Buy mUSD and start earning APY today.",
-      "add": "Add"
+      "add": "Add",
+      "step2_title": "Get your MetaMask Card",
+      "step2_description": "Spend your Money balance while it earns, anywhere Mastercard is accepted.",
+      "step2_cta": "Get card"
     },
     "action": {
       "add": "Add",
@@ -6332,7 +6335,8 @@
       "description": "See how your money can grow over time by converting your crypto to mUSD.",
       "convert": "Convert",
       "no_fee": "No MetaMask fee",
-      "view_all": "View all"
+      "view_all": "View all",
+      "view_potential_earnings": "View potential earnings"
     },
     "metamask_card": {
       "title": "MetaMask Card",
@@ -6363,6 +6367,14 @@
       "filter_all": "All",
       "filter_deposits": "Deposits",
       "filter_transfers": "Transfers"
+    },
+    "condensed_cards": {
+      "how_it_works_title": "How it works",
+      "how_it_works_subtitle": "See how your money works for you",
+      "musd_title": "MetaMask USD",
+      "musd_subtitle": "Learn more about mUSD",
+      "what_you_get_title": "What you get",
+      "what_you_get_subtitle": "Explore your benefits"
     },
     "transaction": {
       "added": "Added",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6398,6 +6398,25 @@
       "learn_more": "Learn more",
       "swap": "Swap",
       "buy": "Buy"
+    },
+    "how_it_works_page": {
+      "header_title": "Money",
+      "section_title": "How it works",
+      "description_1": "Your Money account earns 4% APY (variable) automatically. Funds go into a curated DeFi vault that generates returns across audited lending markets—no staking, no claiming, no lock-ups.",
+      "description_2": "Your Money balance is your spending balance. Link your MetaMask Card to spend at 150M+ merchants worldwide. Your money keeps earning until the moment you use it.",
+      "faq_title": "FAQ",
+      "faq_placeholder_answer": "Coming soon.",
+      "faq_q1": "What is the Money account?",
+      "faq_q2": "What is mUSD?",
+      "faq_q3": "Where does the yield come from?",
+      "faq_q4": "Is my money locked? Can I withdraw anytime?",
+      "faq_q5": "How does spending with the MetaMask Card work?",
+      "faq_q6": "Are there any fees?",
+      "faq_q7": "Does the APY rate change?",
+      "faq_q8": "Is this a savings account or a spending account?",
+      "faq_q9": "Who controls my money?",
+      "faq_q10": "What cash back do I get with the MetaMask Card?",
+      "sounds_good": "Sounds good"
     }
   },
   "stake": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Implements the Money Account homepage milestone state (MUSD-601) that appears after the user's first deposit (1–9 transactions). This state celebrates the milestone, shows real activity and earnings, and shifts focus from "add money" to "get your card."

Key changes:
- `MoneyHomeView` derives a `MoneyHomeState` (`empty` | `milestone` | `filled`) from transaction count and conditionally renders sections
- `MoneyOnboardingCard` is now step-aware: step 1 = "Add money", step 2 = "Get your MetaMask Card"
- `MoneyEarnings` shows green text for positive lifetime earnings
- `MoneyPotentialEarnings` gains a `condensed` mode (hides token rows, shows single "View potential earnings" button)
- New `MoneyCondensedInfoCards` component replaces expanded educational sections with compact tappable cards
- New `MoneyHowItWorksView` detail page with FAQ accordion section, navigated from the condensed "How it works" card
- Activity section threshold lowered from 10 to 1 transaction

Sub-tickets covered: MUSD-602, MUSD-603, MUSD-604, MUSD-605, MUSD-606, MUSD-607, MUSD-608.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-601

## **Manual testing steps**

```gherkin
Feature: Money Home milestone state

  Scenario: user sees milestone state after first deposit
    Given the user has a Money account with 1-9 transactions

    When user navigates to the Money Home screen
    Then the balance shows the real funded amount
    And the onboarding card shows "Step 2 of 2: Get your MetaMask Card"
    And the Activity section is visible with transactions
    And "Earn on your crypto" shows in condensed mode (no token list)
    And three condensed educational cards appear (How it works, MetaMask USD, What you get)
    And the expanded How it Works, mUSD token row, and What you get sections are hidden

  Scenario: user navigates to How it works detail page
    Given the user is on the Money Home screen in milestone state

    When user taps the "How it works" condensed card
    Then the How it works detail page opens
    And it shows explanatory text and an FAQ accordion section
    And tapping "Sounds good" navigates back

  Scenario: user sees empty state with 0 transactions
    Given the user has a Money account with 0 transactions

    When user navigates to the Money Home screen
    Then the onboarding card shows "Step 1 of 2: Add money"
    And the expanded How it Works, mUSD token row, and What you get sections are visible
    And condensed cards and Activity section are hidden
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f6946f0f-39dd-4f85-be3d-f030f8e1a2c3" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/b8e45def-37a4-4cb0-8e0a-8dc193e84e77" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/b9477af7-4593-46f7-8875-60e6f22ceb7c" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e191dd66-1d58-4c92-8373-14e65c476cf2" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9962c278-9bf9-401f-b7d9-a61ab289a39a" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes Money Home rendering logic based on transaction count and introduces new navigation paths (asset details + new How It Works screen), which could affect user flows and regress UI states.
> 
> **Overview**
> Adds a new transaction-count–driven `MoneyHomeState` (0 = *empty*, 1–9 = *milestone*, 10+ = *filled*) and reworks `MoneyHomeView` to conditionally show/hide onboarding, education, activity, and potential-earnings sections accordingly.
> 
> Introduces a compact education surface via `MoneyCondensedInfoCards` (links to How it works, mUSD details, and “what you get”) plus a new `MoneyHowItWorksView` (FAQ accordion) wired into the Money stack via `Routes.MONEY.HOW_IT_WORKS`. Updates onboarding copy/CTA for step 2 (“Get card”), adds a condensed mode to `MoneyPotentialEarnings`, and tweaks `MoneyEarnings` to render positive lifetime earnings in success color; expands tests and English strings to cover these new states and UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2850190b4160d67940768ae2776e5b17d5a7348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->