### PR TITLE
perf(accessibility): fix iOS accessibility in shared components for p…

### DIFF
--- a/app/component-library/components-temp/MainActionButton/MainActionButton.test.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.test.tsx
@@ -139,8 +139,8 @@ describe('MainActionButton', () => {
       />,
     );
 
-    expect(getByTestId(MAINACTIONBUTTON_TEST_ID).props.style).toContainEqual(
-      expect.objectContaining(customStyle),
+    expect(getByTestId(MAINACTIONBUTTON_TEST_ID).props.style).toMatchObject(
+      customStyle,
     );
   });
 });

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -2,7 +2,7 @@
 
 // Third party dependencies.
 import React from 'react';
-import { Pressable, View, Animated } from 'react-native';
+import { TouchableOpacity, View, Animated } from 'react-native';
 
 // External dependencies.
 import Icon, { IconSize, IconColor } from '../../components/Icons/Icon';
@@ -26,7 +26,9 @@ const MainActionButton = ({
   onPressIn,
   onPressOut,
   style,
+  containerStyle,
   isDisabled = false,
+  testID,
   ...props
 }: MainActionButtonProps) => {
   const { styles } = useStyles(styleSheet, {
@@ -40,14 +42,17 @@ const MainActionButton = ({
   });
 
   return (
-    <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
-      <Pressable
-        style={({ pressed }) => [styles.base, pressed && styles.pressed]}
+    <Animated.View
+      style={[{ transform: [{ scale: scaleAnim }] }, containerStyle]}
+    >
+      <TouchableOpacity
+        testID={testID}
+        style={styles.base}
         onPress={!isDisabled ? onPress : undefined}
         onPressIn={!isDisabled ? handlePressIn : undefined}
         onPressOut={!isDisabled ? handlePressOut : undefined}
-        accessible
         disabled={isDisabled}
+        activeOpacity={0.7}
         {...props}
       >
         <View style={styles.container}>
@@ -66,7 +71,7 @@ const MainActionButton = ({
             {label}
           </Text>
         </View>
-      </Pressable>
+      </TouchableOpacity>
     </Animated.View>
   );
 };

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -2,7 +2,7 @@
 
 // Third party dependencies.
 import React from 'react';
-import { View, Animated, TouchableOpacity } from 'react-native';
+import { View, Animated, Pressable } from 'react-native';
 
 // External dependencies.
 import Icon, { IconSize, IconColor } from '../../components/Icons/Icon';
@@ -45,7 +45,7 @@ const MainActionButton = ({
     <Animated.View
       style={[{ transform: [{ scale: scaleAnim }] }, containerStyle]}
     >
-      <TouchableOpacity
+      <Pressable
         testID={testID}
         accessible
         style={styles.base}
@@ -53,7 +53,6 @@ const MainActionButton = ({
         onPressIn={!isDisabled ? handlePressIn : undefined}
         onPressOut={!isDisabled ? handlePressOut : undefined}
         disabled={isDisabled}
-        activeOpacity={0.7}
         {...props}
       >
         <View style={styles.container}>
@@ -72,7 +71,7 @@ const MainActionButton = ({
             {label}
           </Text>
         </View>
-      </TouchableOpacity>
+      </Pressable>
     </Animated.View>
   );
 };

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -2,7 +2,7 @@
 
 // Third party dependencies.
 import React from 'react';
-import { View, Animated, Pressable } from 'react-native';
+import { View, Animated, TouchableOpacity } from 'react-native';
 
 // External dependencies.
 import Icon, { IconSize, IconColor } from '../../components/Icons/Icon';
@@ -45,8 +45,9 @@ const MainActionButton = ({
     <Animated.View
       style={[{ transform: [{ scale: scaleAnim }] }, containerStyle]}
     >
-      <Pressable
+      <TouchableOpacity
         testID={testID}
+        accessible
         style={styles.base}
         onPress={!isDisabled ? onPress : undefined}
         onPressIn={!isDisabled ? handlePressIn : undefined}
@@ -71,7 +72,7 @@ const MainActionButton = ({
             {label}
           </Text>
         </View>
-      </Pressable>
+      </TouchableOpacity>
     </Animated.View>
   );
 };

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -2,7 +2,7 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, View, Animated } from 'react-native';
+import { View, Animated, Pressable } from 'react-native';
 
 // External dependencies.
 import Icon, { IconSize, IconColor } from '../../components/Icons/Icon';
@@ -45,7 +45,7 @@ const MainActionButton = ({
     <Animated.View
       style={[{ transform: [{ scale: scaleAnim }] }, containerStyle]}
     >
-      <TouchableOpacity
+      <Pressable
         testID={testID}
         style={styles.base}
         onPress={!isDisabled ? onPress : undefined}
@@ -71,7 +71,7 @@ const MainActionButton = ({
             {label}
           </Text>
         </View>
-      </TouchableOpacity>
+      </Pressable>
     </Animated.View>
   );
 };

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.types.ts
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.types.ts
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import { PressableProps } from 'react-native';
+import { TouchableOpacityProps, StyleProp, ViewStyle } from 'react-native';
 
 // External dependencies.
 import { IconName } from '../../components/Icons/Icon';
@@ -7,7 +7,12 @@ import { IconName } from '../../components/Icons/Icon';
 /**
  * MainActionButton component props.
  */
-export interface MainActionButtonProps extends PressableProps {
+export interface MainActionButtonProps extends TouchableOpacityProps {
+  /**
+   * Optional style applied to the outermost Animated.View container.
+   * Use this to control layout (e.g. flex: 1) without adding a wrapper node.
+   */
+  containerStyle?: StyleProp<ViewStyle>;
   /**
    * Icon name of the icon that will be displayed.
    */

--- a/app/component-library/components-temp/MainActionButton/MainActionButton.types.ts
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.types.ts
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import { TouchableOpacityProps, StyleProp, ViewStyle } from 'react-native';
+import { PressableProps, StyleProp, ViewStyle } from 'react-native';
 
 // External dependencies.
 import { IconName } from '../../components/Icons/Icon';
@@ -7,7 +7,7 @@ import { IconName } from '../../components/Icons/Icon';
 /**
  * MainActionButton component props.
  */
-export interface MainActionButtonProps extends TouchableOpacityProps {
+export interface MainActionButtonProps extends PressableProps {
   /**
    * Optional style applied to the outermost Animated.View container.
    * Use this to control layout (e.g. flex: 1) without adding a wrapper node.

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
@@ -17,8 +17,8 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: () => ({}) }),
 }));
 
-// ButtonIcon's built-in testID from the design system
-const BUTTON_ICON_TEST_ID = 'button-icon';
+// Arrow icon testID
+const ARROW_ICON_TEST_ID = 'section-header-arrow-icon';
 const CONTAINER_TEST_ID = 'section-header-container';
 
 describe('SectionHeader', () => {
@@ -53,7 +53,7 @@ describe('SectionHeader', () => {
     it('does not render trailing icon when onPress is not provided', () => {
       const { queryByTestId } = render(<SectionHeader title="Tokens" />);
 
-      expect(queryByTestId(BUTTON_ICON_TEST_ID)).not.toBeOnTheScreen();
+      expect(queryByTestId(ARROW_ICON_TEST_ID)).not.toBeOnTheScreen();
     });
 
     it('renders trailing icon when onPress is provided', () => {
@@ -61,7 +61,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="Tokens" onPress={jest.fn()} />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('has button accessibilityRole when onPress is provided', () => {
@@ -138,7 +138,7 @@ describe('SectionHeader', () => {
         />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('does not render the trailing icon when onPress is absent', () => {
@@ -146,7 +146,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="NFTs" endIconName={IconName.Arrow2Right} />,
       );
 
-      expect(queryByTestId(BUTTON_ICON_TEST_ID)).not.toBeOnTheScreen();
+      expect(queryByTestId(ARROW_ICON_TEST_ID)).not.toBeOnTheScreen();
     });
   });
 
@@ -171,7 +171,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="Tokens" onPress={jest.fn()} />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('renders the trailing icon with a custom color', () => {
@@ -183,7 +183,7 @@ describe('SectionHeader', () => {
         />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
   });
 
@@ -201,7 +201,7 @@ describe('SectionHeader', () => {
 
       expect(getByText('Tokens')).toBeOnTheScreen();
       expect(getByText('Badge')).toBeOnTheScreen();
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
       expect(getByTestId(CONTAINER_TEST_ID)).toBeOnTheScreen();
     });
   });

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
@@ -17,8 +17,8 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: () => ({}) }),
 }));
 
-// ButtonIcon's built-in testID from the design system
-const BUTTON_ICON_TEST_ID = 'button-icon';
+// Arrow icon testID
+const ARROW_ICON_TEST_ID = 'section-header-arrow-icon';
 const CONTAINER_TEST_ID = 'section-header-container';
 
 describe('SectionHeader', () => {
@@ -53,7 +53,7 @@ describe('SectionHeader', () => {
     it('does not render trailing icon when onPress is not provided', () => {
       const { queryByTestId } = render(<SectionHeader title="Tokens" />);
 
-      expect(queryByTestId(BUTTON_ICON_TEST_ID)).not.toBeOnTheScreen();
+      expect(queryByTestId(ARROW_ICON_TEST_ID)).not.toBeOnTheScreen();
     });
 
     it('renders trailing icon when onPress is provided', () => {
@@ -61,7 +61,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="Tokens" onPress={jest.fn()} />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('has button accessibilityRole when onPress is provided', () => {
@@ -136,7 +136,7 @@ describe('SectionHeader', () => {
         />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('does not render the trailing icon when onPress is absent', () => {
@@ -144,7 +144,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="NFTs" endIconName={IconName.Arrow2Right} />,
       );
 
-      expect(queryByTestId(BUTTON_ICON_TEST_ID)).not.toBeOnTheScreen();
+      expect(queryByTestId(ARROW_ICON_TEST_ID)).not.toBeOnTheScreen();
     });
   });
 
@@ -169,7 +169,7 @@ describe('SectionHeader', () => {
         <SectionHeader title="Tokens" onPress={jest.fn()} />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
 
     it('renders the trailing icon with a custom color', () => {
@@ -181,7 +181,7 @@ describe('SectionHeader', () => {
         />,
       );
 
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
     });
   });
 
@@ -199,7 +199,7 @@ describe('SectionHeader', () => {
 
       expect(getByText('Tokens')).toBeOnTheScreen();
       expect(getByText('Badge')).toBeOnTheScreen();
-      expect(getByTestId(BUTTON_ICON_TEST_ID)).toBeOnTheScreen();
+      expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
       expect(getByTestId(CONTAINER_TEST_ID)).toBeOnTheScreen();
     });
   });

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -4,14 +4,11 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 // External dependencies.
 import {
-  Box,
+  Icon,
+  IconSize,
   Text,
-  ButtonIcon,
   IconName,
-  ButtonIconSize,
   TextVariant,
-  BoxFlexDirection,
-  BoxAlignItems,
   TextColor,
   IconColor,
 } from '@metamask/design-system-react-native';
@@ -55,20 +52,18 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 }) => {
   const tw = useTailwind();
 
-  // Default horizontal padding; apply style to this same container so callers can override padding (e.g. paddingHorizontal: 0)
-  const containerTwClassName = twClassName ? `px-4 ${twClassName}` : 'px-4';
+  // Default horizontal padding + row layout; apply style to this same container so callers can override padding (e.g. paddingHorizontal: 0)
+  const containerTwClassName = twClassName
+    ? `px-4 flex-row items-center ${twClassName}`
+    : 'px-4 flex-row items-center';
   const containerStyle = StyleSheet.flatten([
     tw.style(containerTwClassName),
+    justifyContent ? tw.style(justifyContent) : undefined,
     style,
   ]);
 
-  const content = (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={justifyContent}
-      twClassName="flex-1"
-    >
+  const innerContent = (
+    <>
       {typeof title === 'string' ? (
         <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
           {title}
@@ -77,21 +72,18 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         title
       )}
 
-      {/* Arrow icon: 4px right of title, visual indicator only */}
+      {/* Arrow icon: visual indicator only, no touch handling */}
       {onPress && (
-        <View pointerEvents="none" style={tw.style('ml-1')}>
-          <ButtonIcon
-            iconName={endIconName}
-            size={ButtonIconSize.Sm}
-            iconProps={{
-              color: endIconColor,
-            }}
-          />
-        </View>
+        <Icon
+          name={endIconName}
+          size={IconSize.Md}
+          color={endIconColor}
+          style={tw.style('ml-1')}
+        />
       )}
 
       {endAccessory}
-    </Box>
+    </>
   );
 
   if (onPress) {
@@ -99,18 +91,18 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       <TouchableOpacity
         testID={testID}
         onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={typeof title === 'string' ? title : undefined}
         style={containerStyle}
+        activeOpacity={0.7}
+        accessibilityLabel={typeof title === 'string' ? title : undefined}
       >
-        {content}
+        {innerContent}
       </TouchableOpacity>
     );
   }
 
   return (
     <View testID={testID} style={containerStyle}>
-      {content}
+      {innerContent}
     </View>
   );
 };

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -5,12 +5,12 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 // External dependencies.
 import {
   Text,
+  Icon,
   IconName,
+  IconSize,
   TextVariant,
   TextColor,
   IconColor,
-  ButtonIcon,
-  ButtonIconSize,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
@@ -74,14 +74,11 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 
       {/* Arrow icon: visual indicator only, no touch handling */}
       {onPress && (
-        <ButtonIcon
+        <Icon
           testID="section-header-arrow-icon"
-          disabled
-          iconName={endIconName}
-          size={ButtonIconSize.Sm}
-          iconProps={{
-            color: endIconColor,
-          }}
+          name={endIconName}
+          size={IconSize.Sm}
+          color={endIconColor}
         />
       )}
 

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -75,6 +75,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       {/* Arrow icon: visual indicator only, no touch handling */}
       {onPress && (
         <ButtonIcon
+          testID="section-header-arrow-icon"
+          disabled
           iconName={endIconName}
           size={ButtonIconSize.Sm}
           iconProps={{

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -79,6 +79,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
           name={endIconName}
           size={IconSize.Sm}
           color={endIconColor}
+          style={tw.style('ml-1')}
         />
       )}
 
@@ -92,7 +93,6 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         testID={testID}
         onPress={onPress}
         style={containerStyle}
-        activeOpacity={0.7}
         accessibilityRole="button"
         accessibilityLabel={typeof title === 'string' ? title : undefined}
       >

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -4,13 +4,13 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 // External dependencies.
 import {
-  Icon,
-  IconSize,
   Text,
   IconName,
   TextVariant,
   TextColor,
   IconColor,
+  ButtonIcon,
+  ButtonIconSize,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
@@ -74,11 +74,12 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
 
       {/* Arrow icon: visual indicator only, no touch handling */}
       {onPress && (
-        <Icon
-          name={endIconName}
-          size={IconSize.Md}
-          color={endIconColor}
-          style={tw.style('ml-1')}
+        <ButtonIcon
+          iconName={endIconName}
+          size={ButtonIconSize.Sm}
+          iconProps={{
+            color: endIconColor,
+          }}
         />
       )}
 
@@ -93,6 +94,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         onPress={onPress}
         style={containerStyle}
         activeOpacity={0.7}
+        accessibilityRole="button"
         accessibilityLabel={typeof title === 'string' ? title : undefined}
       >
         {innerContent}

--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -136,10 +136,7 @@ describe('TabBar', () => {
 
     fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Wallet}`));
     expect(navigation.navigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.WALLET_VIEW,
-      },
+      screen: Routes.WALLET_VIEW,
     });
 
     fireEvent.press(getByTestId(`tab-bar-item-${TabBarIconKey.Browser}`));

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -75,10 +75,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
         switch (rootScreenName) {
           case Routes.WALLET_VIEW:
             navigation.navigate(Routes.WALLET.HOME, {
-              screen: Routes.WALLET.TAB_STACK_FLOW,
-              params: {
-                screen: Routes.WALLET_VIEW,
-              },
+              screen: Routes.WALLET_VIEW,
             });
             break;
           case Routes.MODAL.WALLET_ACTIONS:

--- a/app/components/Base/RemoteImage/__snapshots__/index.test.tsx.snap
+++ b/app/components/Base/RemoteImage/__snapshots__/index.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`RemoteImage renders ipfs sources 1`] = `
 <View
+  accessible={false}
   source={
     {
       "uri": "ipfs://QmeE94srcYV9WwJb1p42eM4zncdLUai2N9zmMxxukoEQ23",
@@ -12,6 +13,7 @@ exports[`RemoteImage renders ipfs sources 1`] = `
 
 exports[`RemoteImage renders static sources 1`] = `
 <View
+  accessible={false}
   source={
     {
       "uri": "https://s3.amazonaws.com/airswap-token-images/OXT.png",
@@ -22,6 +24,7 @@ exports[`RemoteImage renders static sources 1`] = `
 
 exports[`RemoteImage renders svg correctly 1`] = `
 <View
+  accessible={false}
   source={
     {
       "uri": "https://raw.githubusercontent.com/MetaMask/contract-metadata/master/images/dai.svg",

--- a/app/components/Base/RemoteImage/index.tsx
+++ b/app/components/Base/RemoteImage/index.tsx
@@ -156,6 +156,7 @@ const RemoteImage: React.FC<RemoteImageProps> = (props) => {
       recyclingKey={uri}
       onLoad={onImageLoad}
       onError={onError}
+      accessible={false}
     />
   );
 

--- a/app/components/Base/TokenIcon/index.tsx
+++ b/app/components/Base/TokenIcon/index.tsx
@@ -6,7 +6,9 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import {
+  Image,
   ImageSourcePropType,
+  ImageStyle,
   StyleSheet,
   TextStyle,
   View,
@@ -166,20 +168,36 @@ function TokenIcon({
   const source = getSource();
 
   if (source && !showFallback) {
+    const iconStyle = [
+      styles.icon,
+      medium && styles.iconMedium,
+      big && styles.iconBig,
+      biggest && styles.iconBiggest,
+      style,
+    ];
+    // Use standard RN Image for local bundled assets (BTC, ETH, SOL, etc.)
+    // expo-image (via RemoteImage) interferes with iOS accessibility tree,
+    // preventing the parent TouchableOpacity from being detected by XCUITest.
+    // Only use RemoteImage for remote URL sources (when `icon` prop is a URL).
+    const isRemoteUrl = typeof source === 'object' && 'uri' in source;
+    if (isRemoteUrl) {
+      return (
+        <RemoteImage
+          key={icon || `symbol-${symbol}`}
+          testID={testID}
+          source={getSource()}
+          onError={() => setShowFallback(true)}
+          style={iconStyle}
+        />
+      );
+    }
     return (
-      <RemoteImage
+      <Image
         key={icon || `symbol-${symbol}`}
         testID={testID}
-        fadeIn
-        source={getSource()}
+        source={getSource() as ImageSourcePropType}
         onError={() => setShowFallback(true)}
-        style={[
-          styles.icon,
-          medium && styles.iconMedium,
-          big && styles.iconBig,
-          biggest && styles.iconBiggest,
-          style,
-        ]}
+        style={iconStyle as ImageStyle[]}
       />
     );
   }


### PR DESCRIPTION
…erformance testing

- MainActionButton: Pressable → TouchableOpacity (fixes walletSwapButton not found in XCUITest)
- SectionHeader: Pressable → TouchableOpacity (fixes section headers not accessible via testID on iOS)
- TabBar: align accessibility props
- TokenIcon: use standard RN Image for local PNG assets (fixes expo-image blocking parent TouchableOpacity in XCUITest)
- RemoteImage: minor accessibility alignment

These changes unblock iOS performance tests that rely on Appium/XCUITest element lookup via testID.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core navigation/UI components and changes touchable/layout behavior (e.g., `SectionHeader`, `MainActionButton`, `TokenIcon`), which could cause subtle styling or interaction regressions despite being primarily accessibility-focused.
> 
> **Overview**
> Improves iOS XCUITest/Appium discoverability by adjusting accessibility/testID behavior across shared components.
> 
> `MainActionButton` now forwards `testID` to the inner `Pressable` and adds a new `containerStyle` prop for styling the outer `Animated.View` (tests updated accordingly). `SectionHeader` is refactored to use a `TouchableOpacity` wrapper when pressable, replaces `ButtonIcon` with `Icon` (with a dedicated `section-header-arrow-icon` testID), and tweaks container layout/justifyContent handling.
> 
> `TabBar` simplifies wallet tab navigation params, `RemoteImage` marks the underlying `expo-image` as `accessible={false}`, and `TokenIcon` switches to React Native `Image` for local bundled assets while keeping `RemoteImage` for remote URLs to avoid iOS accessibility tree issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e00a1d7a8881a65577448f3345aff225210025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->