### PR TITLE
perf(accessibility): fix iOS accessibility in WhatsHappening and TopT…

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -4,13 +4,11 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { View } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
-import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import { SectionRefreshHandle } from '../../types';
@@ -23,6 +21,11 @@ import useHomeViewedEvent, {
 import { TopTraderCard, TopTraderCardSkeleton } from './components';
 import { useTopTraders } from './hooks';
 import { useSectionPerformance } from '../../hooks/useSectionPerformance';
+import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
+
+const styles = StyleSheet.create({
+  sectionGap: { gap: 12 },
+});
 
 const HOME_TRADER_LIMIT = 3;
 const SKELETON_KEYS = Array.from(
@@ -106,28 +109,30 @@ const TopTradersSection = forwardRef<
       ref={sectionViewRef}
       onLayout={onLayout}
       testID="homepage-top-traders-section-root"
+      style={styles.sectionGap}
     >
-      <Box gap={3}>
-        <SectionHeader title={title} onPress={handleViewAll} />
-
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('px-4 gap-3 pb-2')}
-          testID="homepage-top-traders-carousel"
-        >
-          {isLoading
-            ? SKELETON_KEYS.map((key) => <TopTraderCardSkeleton key={key} />)
-            : traders.map((trader) => (
-                <TopTraderCard
-                  key={trader.id}
-                  trader={trader}
-                  onFollowPress={toggleFollow}
-                  onTraderPress={handleTraderPress}
-                />
-              ))}
-        </ScrollView>
-      </Box>
+      <SectionHeader
+        title={title}
+        onPress={handleViewAll}
+        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('top-traders')}
+      />
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={tw.style('px-4 gap-3 pb-2')}
+        testID="homepage-top-traders-carousel"
+      >
+        {isLoading
+          ? SKELETON_KEYS.map((key) => <TopTraderCardSkeleton key={key} />)
+          : traders.map((trader) => (
+              <TopTraderCard
+                key={trader.id}
+                trader={trader}
+                onFollowPress={toggleFollow}
+                onTraderPress={handleTraderPress}
+              />
+            ))}
+      </ScrollView>
     </View>
   );
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -68,8 +68,10 @@ const TopTradersSection = forwardRef<
     [refresh],
   );
 
+  const willRender = isEnabled && (isLoading || traders.length > 0);
+
   const { onLayout } = useHomeViewedEvent({
-    sectionRef: sectionViewRef,
+    sectionRef: willRender ? sectionViewRef : null,
     isLoading,
     sectionName: HomeSectionNames.TOP_TRADERS,
     sectionIndex,

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -25,6 +25,7 @@ import { SectionRefreshHandle } from '../../types';
 import { TopTraderCard, TopTraderCardSkeleton } from './components';
 import { TOP_TRADER_CARD_WIDTH } from './components/TopTraderCard';
 import { useTopTraders } from './hooks';
+import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
 
 const HOME_TRADER_LIMIT = 10;
 const SKELETON_KEYS = Array.from(
@@ -111,7 +112,11 @@ const TopTradersSection = forwardRef<
       testID="homepage-top-traders-section-root"
     >
       <Box gap={3}>
-        <SectionHeader title={title} onPress={handleViewAll} />
+        <SectionHeader
+          title={title}
+          onPress={handleViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('top-traders')}
+        />
 
         <ScrollView
           horizontal

--- a/app/components/Views/Homepage/Sections/WhatsHappening/WhatsHappeningSection.tsx
+++ b/app/components/Views/Homepage/Sections/WhatsHappening/WhatsHappeningSection.tsx
@@ -4,11 +4,11 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box, TextVariant } from '@metamask/design-system-react-native';
+import { TextVariant } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import ErrorState from '../../components/ErrorState';
 import ViewMoreCard from '../../components/ViewMoreCard';
@@ -22,6 +22,7 @@ import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
 import { useSectionPerformance } from '../../hooks/useSectionPerformance';
+import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
 
 const MAX_ITEMS_DISPLAYED = 5;
 
@@ -37,6 +38,10 @@ const SKELETON_KEYS = Array.from(
   { length: MAX_ITEMS_DISPLAYED },
   (__, i) => `skeleton-${i}`,
 );
+
+const styles = StyleSheet.create({
+  sectionGap: { gap: 12 },
+});
 
 interface WhatsHappeningSectionProps {
   sectionIndex: number;
@@ -113,16 +118,20 @@ const WhatsHappeningSection = forwardRef<
 
   if (hasError) {
     return (
-      <View ref={sectionViewRef} onLayout={onLayout}>
-        <Box gap={3}>
-          <SectionHeader title={title} onPress={handleViewAll} />
-          <ErrorState
-            title={strings('homepage.error.unable_to_load', {
-              section: title.toLowerCase(),
-            })}
-            onRetry={refresh}
-          />
-        </Box>
+      <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
+        <SectionHeader
+          title={title}
+          onPress={handleViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+            'whats-happening',
+          )}
+        />
+        <ErrorState
+          title={strings('homepage.error.unable_to_load', {
+            section: title.toLowerCase(),
+          })}
+          onRetry={refresh}
+        />
       </View>
     );
   }
@@ -132,37 +141,35 @@ const WhatsHappeningSection = forwardRef<
   }
 
   return (
-    <View ref={sectionViewRef} onLayout={onLayout}>
-      <Box gap={3}>
-        <SectionHeader title={title} onPress={handleViewAll} />
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('px-4 gap-3')}
-          snapToOffsets={SNAP_OFFSETS}
-          decelerationRate="fast"
-          testID="homepage-whats-happening-carousel"
-        >
-          {isLoading ? (
-            SKELETON_KEYS.map((key) => <WhatsHappeningCardSkeleton key={key} />)
-          ) : (
-            <>
-              {items.map((item, index) => (
-                <WhatsHappeningCard
-                  key={item.id}
-                  item={item}
-                  onPress={() => handleCardPress(index)}
-                />
-              ))}
-              <ViewMoreCard
-                onPress={handleViewAll}
-                twClassName="w-[180px] h-[248px]"
-                textVariant={TextVariant.BodyLg}
+    <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
+      <SectionHeader title={title} onPress={handleViewAll} />
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={tw.style('px-4 gap-3')}
+        snapToOffsets={SNAP_OFFSETS}
+        decelerationRate="fast"
+        testID="homepage-whats-happening-carousel"
+      >
+        {isLoading ? (
+          SKELETON_KEYS.map((key) => <WhatsHappeningCardSkeleton key={key} />)
+        ) : (
+          <>
+            {items.map((item, index) => (
+              <WhatsHappeningCard
+                key={item.id}
+                item={item}
+                onPress={() => handleCardPress(index)}
               />
-            </>
-          )}
-        </ScrollView>
-      </Box>
+            ))}
+            <ViewMoreCard
+              onPress={handleViewAll}
+              twClassName="w-[180px] h-[248px]"
+              textVariant={TextVariant.BodyLg}
+            />
+          </>
+        )}
+      </ScrollView>
     </View>
   );
 });

--- a/app/components/Views/Homepage/Sections/WhatsHappening/WhatsHappeningSection.tsx
+++ b/app/components/Views/Homepage/Sections/WhatsHappening/WhatsHappeningSection.tsx
@@ -142,7 +142,13 @@ const WhatsHappeningSection = forwardRef<
 
   return (
     <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
-      <SectionHeader title={title} onPress={handleViewAll} />
+      <SectionHeader
+        title={title}
+        onPress={handleViewAll}
+        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+          'whats-happening',
+        )}
+      />
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/app/components/Views/Homepage/Sections/WhatsHappening/components/WhatsHappeningCard.tsx
+++ b/app/components/Views/Homepage/Sections/WhatsHappening/components/WhatsHappeningCard.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  BoxJustifyContent,
   Text,
   TextVariant,
   TextColor,
@@ -23,90 +23,85 @@ const WhatsHappeningCard: React.FC<WhatsHappeningCardProps> = ({
   item,
   onPress,
 }) => {
+  const tw = useTailwind();
   const formattedDate = useMemo(() => formatShortDate(item.date), [item.date]);
 
   const handlePress = () => onPress?.(item);
 
   return (
-    <TouchableOpacity onPress={handlePress} activeOpacity={0.7}>
-      <Box
-        twClassName="w-[280px] h-[248px] rounded-2xl bg-background-muted overflow-hidden"
-        padding={4}
-        justifyContent={BoxJustifyContent.Between}
-        gap={3}
-      >
-        <Box gap={3}>
-          {/* Category badge */}
-          {item.category && (
-            <Box twClassName="self-start">
-              <Box twClassName="rounded-full bg-background-default px-2 py-0.5">
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.TextAlternative}
-                  fontWeight={FontWeight.Medium}
-                >
-                  {strings(
-                    `homepage.sections.whats_happening_categories.${item.category}`,
-                  )}
-                </Text>
-              </Box>
-            </Box>
-          )}
-
-          {/* Title */}
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-            numberOfLines={3}
-          >
-            {item.title}
-          </Text>
-
-          {/* Description */}
-          <Text
-            variant={TextVariant.BodySm}
-            color={TextColor.TextAlternative}
-            numberOfLines={3}
-          >
-            {item.description}
-          </Text>
-        </Box>
-
-        {/* Footer: asset pills + date */}
-        <Box gap={2}>
-          {item.relatedAssets.length > 0 && (
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              twClassName="flex-wrap gap-1"
-            >
-              {item.relatedAssets.map((asset) => (
-                <Box
-                  key={asset.sourceAssetId}
-                  twClassName="rounded-full bg-background-default px-2 py-0.5"
-                >
-                  <Text
-                    variant={TextVariant.BodyXs}
-                    color={TextColor.TextDefault}
-                    fontWeight={FontWeight.Medium}
-                  >
-                    {asset.symbol}
-                  </Text>
-                </Box>
-              ))}
-            </Box>
-          )}
-
-          {formattedDate && (
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={0.7}
+      style={tw.style(
+        'w-[280px] h-[248px] rounded-2xl bg-background-muted overflow-hidden p-4 justify-between gap-3',
+      )}
+    >
+      <Box gap={3}>
+        {/* Category badge */}
+        {item.category && (
+          <Box twClassName="self-start rounded-full bg-background-default px-2 py-0.5">
             <Text
               variant={TextVariant.BodyXs}
               color={TextColor.TextAlternative}
+              fontWeight={FontWeight.Medium}
             >
-              {formattedDate}
+              {strings(
+                `homepage.sections.whats_happening_categories.${item.category}`,
+              )}
             </Text>
-          )}
-        </Box>
+          </Box>
+        )}
+
+        {/* Title */}
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+          numberOfLines={3}
+        >
+          {item.title}
+        </Text>
+
+        {/* Description */}
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          numberOfLines={3}
+        >
+          {item.description}
+        </Text>
+      </Box>
+
+      {/* Footer: asset pills + date */}
+      <Box gap={2}>
+        {item.relatedAssets.length > 0 && (
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="flex-wrap gap-1"
+          >
+            {item.relatedAssets.map((asset) => (
+              <Box
+                key={asset.sourceAssetId}
+                twClassName="rounded-full bg-background-default px-2 py-0.5"
+              >
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.TextDefault}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {asset.symbol}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {formattedDate && (
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+            {formattedDate}
+          </Text>
+        )}
       </Box>
     </TouchableOpacity>
   );


### PR DESCRIPTION
…raders sections

- WhatsHappeningCard: collapse double Box wrapper to single node (–1 native node per card)
- WhatsHappeningSection, TopTradersSection: View ref + Box gap → View ref style

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor focused on layout/styling and analytics/view tracking wiring; main risk is subtle spacing or event-firing behavior changes when sections are empty/loading.
> 
> **Overview**
> Improves homepage section rendering and instrumentation for **Top Traders** and **What’s Happening**.
> 
> `TopTradersSection` and `WhatsHappeningSection` now pass a `null` `sectionRef` to `useHomeViewedEvent` when the section won’t render, avoiding measuring a non-mounted view while preserving the hook’s empty/immediate-fire behavior. Both section headers also gain stable `testID`s via `WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(...)`.
> 
> `WhatsHappeningSection` removes the extra `Box` wrapper (replacing `gap` with a `StyleSheet` style on the root `View`), and `WhatsHappeningCard` collapses layout into the `TouchableOpacity` via Tailwind `style` to reduce one native node per card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75d976d287868f3666c481dd8251c8b74923cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->