### PR TITLE
fix(perps): add transparency to volume bars

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -1,5 +1,13 @@
 import { Theme } from '../../../../../util/theme/models';
 
+const hexToRgba = (hex: string, alpha: number): string => {
+  const clean = hex.length === 9 && hex.startsWith('#') ? hex.slice(0, 7) : hex;
+  const r = parseInt(clean.slice(1, 3), 16);
+  const g = parseInt(clean.slice(3, 5), 16);
+  const b = parseInt(clean.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
 export const createTradingViewChartTemplate = (
   theme: Theme,
   lightweightChartsLib: string,
@@ -808,7 +816,7 @@ export const createTradingViewChartTemplate = (
                 // Use the old API: chart.addSeries(SeriesType, options, paneIndex)
                 // Pane index 1 creates a NEW separate pane below the default pane 0
                 window.volumeSeries = window.chart.addSeries(window.LightweightCharts.HistogramSeries, {
-                    color: '${theme.colors.success.default}',
+                    color: '${hexToRgba(theme.colors.success.default, 0.3)}',
                     priceFormat: {
                         type: 'custom',
                         formatter: window.formatVolumeEmpty, // Use empty formatter to hide Y-axis labels
@@ -1005,8 +1013,8 @@ export const createTradingViewChartTemplate = (
                                     time: candle.time,
                                     value: (parseFloat(candle.volume) * parseFloat(candle.close)) || 0,
                                     color: window.coloredVolume
-                                        ? (candle.close >= candle.open ? '${theme.colors.success.default}' : '${theme.colors.error.default}')
-                                        : '${theme.colors.border.muted}'
+                                        ? (candle.close >= candle.open ? '${hexToRgba(theme.colors.success.default, 0.3)}' : '${hexToRgba(theme.colors.error.default, 0.3)}')
+                                        : '${hexToRgba(theme.colors.border.muted, 0.3)}'
                                 }));
                                 window.volumeSeries.setData(volumeData);
 
@@ -1380,8 +1388,8 @@ export const createTradingViewChartTemplate = (
                                                 time: candle.time,
                                                 value: (parseFloat(candle.volume) * parseFloat(candle.close)) || 0, // USD notional = volume × price
                                                 color: window.coloredVolume
-                                                    ? (candle.close >= candle.open ? '${theme.colors.success.default}' : '${theme.colors.error.default}')
-                                                    : '${theme.colors.border.muted}'
+                                                    ? (candle.close >= candle.open ? '${hexToRgba(theme.colors.success.default, 0.3)}' : '${hexToRgba(theme.colors.error.default, 0.3)}')
+                                                    : '${hexToRgba(theme.colors.border.muted, 0.3)}'
                                             }));
 
                                             window.volumeSeries.setData(volumeData);
@@ -1534,8 +1542,8 @@ export const createTradingViewChartTemplate = (
                                                 time: candle.time,
                                                 value: (parseFloat(candle.volume) * parseFloat(candle.close)) || 0, // USD notional = volume × price
                                                 color: window.coloredVolume
-                                                    ? (candle.close >= candle.open ? '${theme.colors.success.default}' : '${theme.colors.error.default}')
-                                                    : '${theme.colors.border.muted}'
+                                                    ? (candle.close >= candle.open ? '${hexToRgba(theme.colors.success.default, 0.3)}' : '${hexToRgba(theme.colors.error.default, 0.3)}')
+                                                    : '${hexToRgba(theme.colors.border.muted, 0.3)}'
                                             }));
                                             window.volumeSeries.setData(volumeData);
                                         }


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The volume bars on the perps candlestick chart were rendered as solid opaque colors, making them visually heavy and inconsistent with the token details (spot) chart. The spot chart's `AdvancedChart` applies `volume.transparency: 70` (30% opacity) to its volume study bars, giving them a lighter, less intrusive appearance.

This change aligns the perps chart visual style by applying the same 30% opacity to all volume histogram bars. A `hexToRgba` helper converts the design-token hex colors (which may include an alpha byte) to `rgba()` strings at template generation time, so both light and dark mode are covered automatically with no additional runtime cost. The four code sites that set volume bar colors (`createVolumeSeries` default, `SET_CANDLESTICK_DATA` handler, resize handler, and `TOGGLE_VOLUME_VISIBILITY` handler) are all updated consistently.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated perps chart volume bars to use 30% opacity, matching the transparency style of the spot token details chart

## **Related issues**

Fixes: TAT-2820

## **Manual testing steps**

```gherkin
Feature: Perps chart volume bar transparency

  Background:
    Given I am logged into MetaMask Mobile
    And the Perps feature is enabled

  Scenario: volume bars appear semi-transparent in dark mode
    Given I am on the Perps market details screen
    And candlestick chart data is loaded with volume bars visible

    When I view the volume histogram pane below the candlestick chart
    Then the green (bullish) volume bars should appear at ~30% opacity
    And the red (bearish) volume bars should appear at ~30% opacity

  Scenario: volume bars appear semi-transparent in light mode
    Given I have switched the app to light mode
    And I am on the Perps market details screen
    And candlestick chart data is loaded with volume bars visible

    When I view the volume histogram pane below the candlestick chart
    Then the green (bullish) volume bars should appear at ~30% opacity
    And the red (bearish) volume bars should appear at ~30% opacity

  Scenario: volume bars retain transparency after toggling visibility
    Given I am on the Perps market details screen
    And volume bars are currently visible

    When I toggle volume bars off
    And I toggle volume bars back on
    Then the volume bars should reappear at ~30% opacity

  Scenario: volume bar transparency matches spot chart
    Given I am on the Perps market details screen
    And I am on the token details screen for the same asset

    When I compare the volume bar opacity on both charts
    Then the volume bars should appear visually similar in transparency
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-21 at 17 50 25" src="https://github.com/user-attachments/assets/206332ab-37f9-4de4-8269-6a7c0cb4a883" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-21 at 17 49 03" src="https://github.com/user-attachments/assets/56100669-20b6-4c13-9185-ea5eab3123c3" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.