### PR TITLE
fix(sentry): read metrics consent from AnalyticsController state

### DIFF
--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -43,12 +43,6 @@ import generateDeviceAnalyticsMetaData, {
 } from '../../../util/metrics';
 import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { getConfiguredCaipChainIds } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
-import {
-  updateCachedConsent,
-  flushBufferedTraces,
-  discardBufferedTraces,
-} from '../../../util/trace';
-import { setupSentry } from '../../../util/sentry/utils';
 import PrivacyIllustration from '../../../images/privacy_metrics_illustration.png';
 import Device from '../../../util/device';
 import { HOWTO_MANAGE_METAMETRICS } from '../../../constants/urls';
@@ -157,15 +151,11 @@ const OptinMetrics = () => {
    * Callback on press confirm
    */
   const onConfirm = useCallback(async () => {
+    // `metrics.enable()` updates AnalyticsController state, which is mirrored
+    // to Sentry config, the SENTRY_CONSENT storage key, and the trace buffer
+    // by the subscription registered in EngineService (`consentSync`). No
+    // per-call-site wiring needed here.
     await metrics.enable(isBasicUsageChecked);
-    await setupSentry(); // enabled/disabled depend on the isBasicUsageChecked
-
-    if (isBasicUsageChecked) {
-      await flushBufferedTraces();
-    } else {
-      discardBufferedTraces();
-    }
-    updateCachedConsent(isBasicUsageChecked);
 
     dispatch(setDataCollectionForMarketing(isMarketingChecked));
 

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -70,8 +70,6 @@ import {
   TraceContext,
   endTrace,
   trace,
-  hasMetricsConsent,
-  discardBufferedTraces,
 } from '../../../util/trace';
 import { getTraceTags } from '../../../util/sentry/tags';
 import { store } from '../../../store';
@@ -88,7 +86,6 @@ import { OAuthError, OAuthErrorType } from '../../../core/OAuthService/error';
 import { createLoginHandler } from '../../../core/OAuthService/OAuthLoginHandlers';
 import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { setupSentry } from '../../../util/sentry/utils';
 import ErrorBoundary from '../ErrorBoundary';
 import FastOnboarding from './FastOnboarding';
 import {
@@ -352,9 +349,9 @@ const Onboarding = () => {
     // This ensures users starting a new wallet flow are prompted to make a fresh choice.
     await resetMetricsOptInUISeen();
 
+    // Reset opt-in for the new flow. The EngineService consent subscription
+    // mirrors this to Sentry + SENTRY_CONSENT + the trace cache.
     await metrics.enable(false);
-    // need to call hasMetricConset to update the cached consent state
-    await hasMetricsConsent();
 
     trace({ name: TraceName.OnboardingCreateWallet });
     const action = () => {
@@ -398,8 +395,9 @@ const Onboarding = () => {
     // This ensures users starting a new wallet flow are prompted to make a fresh choice.
     await resetMetricsOptInUISeen();
 
+    // Reset opt-in for the new flow. The EngineService consent subscription
+    // mirrors this to Sentry + SENTRY_CONSENT + the trace cache.
     await metrics.enable(false);
-    await hasMetricsConsent();
 
     const action = async () => {
       trace({
@@ -729,10 +727,9 @@ const Onboarding = () => {
       // Continue with the social login flow
       navigation.navigate('Onboarding');
 
-      // Enable metrics for OAuth users
+      // Enable metrics for OAuth users. The EngineService consent subscription
+      // flushes buffered traces, re-inits Sentry, and persists SENTRY_CONSENT.
       await metrics.enable(true);
-      discardBufferedTraces();
-      await setupSentry();
 
       const accountType = getSocialAccountType(provider, !createWallet);
       metrics.trackEvent(

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -44,6 +44,18 @@ export const METAMETRICS_ID = `${prefix}MetaMetricsId`;
 export const MIXPANEL_METAMETRICS_ID = `${prefix}MixpanelMetaMetricsId`;
 export const ANALYTICS_ID = `${prefix}AnalyticsId`;
 
+/**
+ * Mirrors `AnalyticsController.state.optedIn` to AsyncStorage so that
+ * {@link setupSentry} in `index.js` can decide whether to enable Sentry
+ * during the very early boot window — before the Redux store has been
+ * rehydrated and controller state is available.
+ *
+ * Kept in sync with the controller via the subscription registered in
+ * {@link EngineService} on every `AnalyticsController:stateChange`.
+ * This key is the sole source of truth for Sentry's early-boot `enabled` flag.
+ */
+export const SENTRY_CONSENT = `${prefix}sentryConsent`;
+
 export const LAST_INCOMING_TX_BLOCK_INFO = `${prefix}lastIncomingTxBlockInfo`;
 
 export const PUSH_NOTIFICATIONS_PROMPT_COUNT = `${prefix}pushNotificationsPromptCount`;

--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -40,6 +40,11 @@ jest.mock('../../util/analytics/whenEngineReady', () => ({
   whenEngineReady: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Mock consent sync so Engine start does not touch Sentry / AsyncStorage.
+jest.mock('../../util/sentry/consentSync', () => ({
+  subscribeSentryToAnalyticsConsent: jest.fn().mockResolvedValue(undefined),
+}));
+
 // Mock analytics module
 jest.mock('../../util/analytics/analytics', () => ({
   analytics: {

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -31,6 +31,7 @@ import { StateConstraint } from '@metamask/base-controller';
 import { hasPersistedState } from './utils/persistence-utils';
 import { setExistingUser } from '../../actions/user';
 import { hydrateSocialFollowing } from '../Engine/controllers/social-controller-hydration';
+import { subscribeSentryToAnalyticsConsent } from '../../util/sentry/consentSync';
 
 export class EngineService {
   private engineInitialized = false;
@@ -174,6 +175,19 @@ export class EngineService {
       this.initializeControllers(
         Engine as unknown as TypedEngine,
         state as Record<string, unknown>,
+      );
+
+      // Mirror AnalyticsController opt-in state into AsyncStorage / Sentry /
+      // trace cache. Must run after Engine.init() so the messenger and
+      // AnalyticsController exist. Fire-and-forget: Sentry/tracing degrade
+      // gracefully if this fails — the next cold boot retries.
+      subscribeSentryToAnalyticsConsent(Engine as unknown as TypedEngine).catch(
+        (error) => {
+          Logger.error(
+            error as Error,
+            'EngineService: failed to subscribe Sentry to AnalyticsController consent',
+          );
+        },
       );
 
       // Fire-and-forget: refresh social following state from the server.

--- a/app/util/sentry/consentSync.test.ts
+++ b/app/util/sentry/consentSync.test.ts
@@ -1,0 +1,167 @@
+import { subscribeSentryToAnalyticsConsent } from './consentSync';
+import { AGREED, DENIED, SENTRY_CONSENT } from '../../constants/storage';
+
+jest.mock('../../store/storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+  },
+}));
+
+jest.mock('./utils', () => ({
+  setupSentry: jest.fn(),
+}));
+
+jest.mock('../trace', () => ({
+  updateCachedConsent: jest.fn(),
+  flushBufferedTraces: jest.fn(),
+  discardBufferedTraces: jest.fn(),
+}));
+
+jest.mock('../Logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@metamask/analytics-controller', () => ({
+  analyticsControllerSelectors: {
+    selectOptedIn: (state: { optedIn?: boolean } | undefined) => state?.optedIn,
+  },
+}));
+
+const mockedStorageWrapper = jest.requireMock('../../store/storage-wrapper')
+  .default as { setItem: jest.Mock };
+const mockedSetupSentry = jest.requireMock('./utils').setupSentry as jest.Mock;
+const mockedTrace = jest.requireMock('../trace') as {
+  updateCachedConsent: jest.Mock;
+  flushBufferedTraces: jest.Mock;
+  discardBufferedTraces: jest.Mock;
+};
+
+type StateChangeHandler = (state: { optedIn?: boolean }) => void;
+
+const buildEngineMock = (initialOptedIn: boolean | undefined) => {
+  let handler: StateChangeHandler | undefined;
+  const subscribe = jest.fn((_eventType: string, fn: StateChangeHandler) => {
+    handler = fn;
+  });
+  return {
+    engine: {
+      context: {
+        AnalyticsController: { state: { optedIn: initialOptedIn } },
+      },
+      controllerMessenger: { subscribe },
+    } as unknown as Parameters<typeof subscribeSentryToAnalyticsConsent>[0],
+    subscribe,
+    emit: (state: { optedIn?: boolean }) => handler?.(state),
+  };
+};
+
+describe('subscribeSentryToAnalyticsConsent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('performs an initial sync from the current AnalyticsController state', async () => {
+    const { engine } = buildEngineMock(true);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+
+    expect(mockedTrace.updateCachedConsent).toHaveBeenCalledWith(true);
+    expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+      SENTRY_CONSENT,
+      AGREED,
+    );
+    expect(mockedSetupSentry).toHaveBeenCalledTimes(1);
+    expect(mockedTrace.flushBufferedTraces).toHaveBeenCalledTimes(1);
+    expect(mockedTrace.discardBufferedTraces).not.toHaveBeenCalled();
+  });
+
+  it('writes DENIED and discards buffered traces when controller state is opted out', async () => {
+    const { engine } = buildEngineMock(false);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+
+    expect(mockedTrace.updateCachedConsent).toHaveBeenCalledWith(false);
+    expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+      SENTRY_CONSENT,
+      DENIED,
+    );
+    expect(mockedTrace.discardBufferedTraces).toHaveBeenCalledTimes(1);
+    expect(mockedTrace.flushBufferedTraces).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing/undefined optedIn as opted out during initial sync', async () => {
+    const { engine } = buildEngineMock(undefined);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+
+    expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+      SENTRY_CONSENT,
+      DENIED,
+    );
+  });
+
+  it('subscribes to AnalyticsController:stateChange after initial sync', async () => {
+    const { engine, subscribe } = buildEngineMock(false);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+
+    expect(subscribe).toHaveBeenCalledWith(
+      'AnalyticsController:stateChange',
+      expect.any(Function),
+    );
+  });
+
+  it('re-applies consent whenever the controller emits a state change', async () => {
+    const { engine, emit } = buildEngineMock(false);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+    jest.clearAllMocks();
+
+    emit({ optedIn: true });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockedTrace.updateCachedConsent).toHaveBeenCalledWith(true);
+    expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+      SENTRY_CONSENT,
+      AGREED,
+    );
+    expect(mockedSetupSentry).toHaveBeenCalledTimes(1);
+    expect(mockedTrace.flushBufferedTraces).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards buffered traces when the user opts back out at runtime', async () => {
+    const { engine, emit } = buildEngineMock(true);
+
+    await subscribeSentryToAnalyticsConsent(engine);
+    jest.clearAllMocks();
+
+    emit({ optedIn: false });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockedTrace.updateCachedConsent).toHaveBeenCalledWith(false);
+    expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+      SENTRY_CONSENT,
+      DENIED,
+    );
+    expect(mockedTrace.discardBufferedTraces).toHaveBeenCalledTimes(1);
+  });
+
+  it('is resilient when storage, setupSentry, or flush fails', async () => {
+    mockedStorageWrapper.setItem.mockRejectedValueOnce(
+      new Error('storage full'),
+    );
+    mockedSetupSentry.mockRejectedValueOnce(new Error('sentry down'));
+    mockedTrace.flushBufferedTraces.mockRejectedValueOnce(
+      new Error('flush failed'),
+    );
+
+    const { engine } = buildEngineMock(true);
+
+    await expect(
+      subscribeSentryToAnalyticsConsent(engine),
+    ).resolves.not.toThrow();
+  });
+});

--- a/app/util/sentry/consentSync.ts
+++ b/app/util/sentry/consentSync.ts
@@ -1,0 +1,107 @@
+import {
+  analyticsControllerSelectors,
+  type AnalyticsControllerState,
+} from '@metamask/analytics-controller';
+import type { Engine as TypedEngine } from '../../core/Engine/Engine';
+import { AGREED, DENIED, SENTRY_CONSENT } from '../../constants/storage';
+import StorageWrapper from '../../store/storage-wrapper';
+import Logger from '../Logger';
+import {
+  discardBufferedTraces,
+  flushBufferedTraces,
+  updateCachedConsent,
+} from '../trace';
+import { setupSentry } from './utils';
+
+/**
+ * Fan out a single source of truth — `AnalyticsController.state.optedIn` —
+ * to every consumer that needs to know about Sentry/metrics consent:
+ * 1. The {@link SENTRY_CONSENT} AsyncStorage key, read by `setupSentry` in
+ * `index.js` at the very next cold boot (before Redux rehydration).
+ * 2. The live Sentry client, re-initialised via {@link setupSentry} so the
+ * current session reflects the new consent without requiring a restart.
+ * 3. The in-memory trace consent cache, used by `trace()` to decide whether
+ * to forward spans to Sentry or buffer them.
+ * 4. The buffered trace queue, flushed on opt-in and discarded on opt-out.
+ *
+ * The helper performs one initial sync using the controller's current state
+ * (to backfill storage for users whose consent was captured before this key
+ * existed) and then subscribes to `AnalyticsController:stateChange` so every
+ * subsequent toggle — onboarding, settings, social login — is handled in one
+ * place instead of being re-implemented at each call site.
+ */
+export async function subscribeSentryToAnalyticsConsent(
+  engine: TypedEngine,
+): Promise<void> {
+  const getOptedIn = (): boolean => {
+    try {
+      const state = engine.context?.AnalyticsController?.state;
+      return state
+        ? Boolean(analyticsControllerSelectors.selectOptedIn(state))
+        : false;
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'SentryConsentSync: failed to read AnalyticsController state',
+      );
+      return false;
+    }
+  };
+
+  await applyConsent(getOptedIn());
+
+  const onAnalyticsStateChange = (state: AnalyticsControllerState): void => {
+    const optedIn = Boolean(analyticsControllerSelectors.selectOptedIn(state));
+    applyConsent(optedIn).catch((error) => {
+      Logger.error(
+        error as Error,
+        'SentryConsentSync: failed to apply consent change',
+      );
+    });
+  };
+
+  // The `controllerMessenger.subscribe` overloads in this codebase do not
+  // narrow on the event type string, so cast via `unknown` to match the
+  // existing pattern used throughout Engine.ts / EngineService.ts.
+  (
+    engine.controllerMessenger.subscribe as unknown as (
+      eventType: 'AnalyticsController:stateChange',
+      handler: (state: AnalyticsControllerState) => void,
+    ) => void
+  )('AnalyticsController:stateChange', onAnalyticsStateChange);
+}
+
+async function applyConsent(optedIn: boolean): Promise<void> {
+  updateCachedConsent(optedIn);
+
+  try {
+    await StorageWrapper.setItem(SENTRY_CONSENT, optedIn ? AGREED : DENIED);
+  } catch (error) {
+    Logger.error(
+      error as Error,
+      'SentryConsentSync: failed to persist consent to storage',
+    );
+  }
+
+  try {
+    await setupSentry();
+  } catch (error) {
+    Logger.error(
+      error as Error,
+      'SentryConsentSync: failed to re-initialise Sentry',
+    );
+  }
+
+  if (optedIn) {
+    try {
+      await flushBufferedTraces();
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'SentryConsentSync: failed to flush buffered traces',
+      );
+    }
+  } else {
+    discardBufferedTraces();
+  }
+}

--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -14,8 +14,8 @@ import {
   bufferTraceEndCallLocal,
   discardBufferedTraces,
   updateCachedConsent,
+  hasMetricsConsent,
 } from './trace';
-import { AGREED, DENIED } from '../constants/storage';
 
 jest.mock('@sentry/react-native', () => ({
   startSpan: jest.fn(),
@@ -36,6 +36,10 @@ jest.mock('../store', () => ({
     dispatch: jest.fn(),
     getState: jest.fn(),
   },
+}));
+
+jest.mock('../selectors/analyticsController', () => ({
+  selectAnalyticsOptedIn: jest.fn(),
 }));
 
 jest.mock('../core/redux/ReduxService', () => ({
@@ -402,9 +406,6 @@ describe('Trace', () => {
   });
 
   describe('flushBufferedTraces', () => {
-    const StorageWrapper = jest.requireMock('../store/storage-wrapper');
-    const storageGetItemMock = jest.mocked(StorageWrapper.getItem);
-
     beforeEach(() => {
       jest.clearAllMocks();
       discardBufferedTraces();
@@ -424,14 +425,11 @@ describe('Trace', () => {
     });
 
     it('should clear buffer and not process traces when consent is not given', async () => {
-      storageGetItemMock.mockResolvedValue(DENIED);
-
       bufferTraceStartCallLocal({ name: TraceName.Middleware });
       bufferTraceEndCallLocal({ name: TraceName.Middleware });
 
       await flushBufferedTraces();
 
-      storageGetItemMock.mockResolvedValue(AGREED);
       jest.clearAllMocks();
 
       await flushBufferedTraces();
@@ -442,9 +440,6 @@ describe('Trace', () => {
     });
 
     it('should flush buffered traces when consent is given', async () => {
-      storageGetItemMock.mockResolvedValue(DENIED);
-
-      // Mock selectBufferedTraces to return the buffered traces we expect
       const mockBufferedTraces = [
         {
           type: 'start',
@@ -470,7 +465,6 @@ describe('Trace', () => {
           : bufferTraceEndCallLocal(t.request);
       });
 
-      storageGetItemMock.mockResolvedValue(AGREED);
       updateCachedConsent(true);
 
       await flushBufferedTraces();
@@ -512,6 +506,70 @@ describe('Trace', () => {
       // Both traces should be processed (2 start calls)
       expect(startSpanManualMock).toHaveBeenCalledTimes(2);
       expect(withIsolationScopeMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('hasMetricsConsent', () => {
+    const storeMock = jest.requireMock('../store').store as {
+      getState: jest.Mock;
+    };
+    const { selectAnalyticsOptedIn } = jest.requireMock(
+      '../selectors/analyticsController',
+    );
+    const selectAnalyticsOptedInMock = jest.mocked(selectAnalyticsOptedIn);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns true when AnalyticsController state has optedIn=true', async () => {
+      storeMock.getState.mockReturnValue({
+        engine: { backgroundState: { AnalyticsController: { optedIn: true } } },
+      });
+      selectAnalyticsOptedInMock.mockReturnValue(true);
+
+      await expect(hasMetricsConsent()).resolves.toBe(true);
+    });
+
+    it('returns false when AnalyticsController state has optedIn=false', async () => {
+      storeMock.getState.mockReturnValue({
+        engine: {
+          backgroundState: { AnalyticsController: { optedIn: false } },
+        },
+      });
+      selectAnalyticsOptedInMock.mockReturnValue(false);
+
+      await expect(hasMetricsConsent()).resolves.toBe(false);
+    });
+
+    it('returns false when selector returns undefined (state not yet hydrated)', async () => {
+      storeMock.getState.mockReturnValue({});
+      selectAnalyticsOptedInMock.mockReturnValue(undefined);
+
+      await expect(hasMetricsConsent()).resolves.toBe(false);
+    });
+
+    it('returns false and does not throw when store.getState throws', async () => {
+      storeMock.getState.mockImplementation(() => {
+        throw new Error('store not ready');
+      });
+
+      await expect(hasMetricsConsent()).resolves.toBe(false);
+    });
+
+    it('updates the cached consent state used by trace buffering', async () => {
+      selectAnalyticsOptedInMock.mockReturnValue(true);
+      storeMock.getState.mockReturnValue({});
+
+      updateCachedConsent(false);
+      await hasMetricsConsent();
+
+      // After consent is granted, a traced callback should execute without
+      // being buffered (verified indirectly by Sentry being invoked).
+      trace({ name: NAME_MOCK }, () => true);
+      endTrace({ name: NAME_MOCK });
+
+      expect(withIsolationScopeMock).toHaveBeenCalled();
     });
   });
 });

--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -28,18 +28,11 @@ jest.mock('@sentry/core', () => ({
 }));
 
 jest.mock('../store/storage-wrapper', () => ({
-  getItem: jest.fn(),
-}));
-
-jest.mock('../store', () => ({
-  store: {
-    dispatch: jest.fn(),
-    getState: jest.fn(),
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
   },
-}));
-
-jest.mock('../selectors/analyticsController', () => ({
-  selectAnalyticsOptedIn: jest.fn(),
 }));
 
 jest.mock('../core/redux/ReduxService', () => ({
@@ -510,56 +503,39 @@ describe('Trace', () => {
   });
 
   describe('hasMetricsConsent', () => {
-    const storeMock = jest.requireMock('../store').store as {
-      getState: jest.Mock;
-    };
-    const { selectAnalyticsOptedIn } = jest.requireMock(
-      '../selectors/analyticsController',
-    );
-    const selectAnalyticsOptedInMock = jest.mocked(selectAnalyticsOptedIn);
+    const storageMock = jest.requireMock('../store/storage-wrapper')
+      .default as { getItem: jest.Mock; setItem: jest.Mock };
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it('returns true when AnalyticsController state has optedIn=true', async () => {
-      storeMock.getState.mockReturnValue({
-        engine: { backgroundState: { AnalyticsController: { optedIn: true } } },
-      });
-      selectAnalyticsOptedInMock.mockReturnValue(true);
+    it('returns true when the SENTRY_CONSENT storage key equals AGREED', async () => {
+      storageMock.getItem.mockResolvedValue('agreed');
 
       await expect(hasMetricsConsent()).resolves.toBe(true);
     });
 
-    it('returns false when AnalyticsController state has optedIn=false', async () => {
-      storeMock.getState.mockReturnValue({
-        engine: {
-          backgroundState: { AnalyticsController: { optedIn: false } },
-        },
-      });
-      selectAnalyticsOptedInMock.mockReturnValue(false);
+    it('returns false when the SENTRY_CONSENT storage key equals DENIED', async () => {
+      storageMock.getItem.mockResolvedValue('denied');
 
       await expect(hasMetricsConsent()).resolves.toBe(false);
     });
 
-    it('returns false when selector returns undefined (state not yet hydrated)', async () => {
-      storeMock.getState.mockReturnValue({});
-      selectAnalyticsOptedInMock.mockReturnValue(undefined);
+    it('returns false when the SENTRY_CONSENT storage key is missing', async () => {
+      storageMock.getItem.mockResolvedValue(null);
 
       await expect(hasMetricsConsent()).resolves.toBe(false);
     });
 
-    it('returns false and does not throw when store.getState throws', async () => {
-      storeMock.getState.mockImplementation(() => {
-        throw new Error('store not ready');
-      });
+    it('returns false and does not throw when storage access rejects', async () => {
+      storageMock.getItem.mockRejectedValue(new Error('storage unavailable'));
 
       await expect(hasMetricsConsent()).resolves.toBe(false);
     });
 
     it('updates the cached consent state used by trace buffering', async () => {
-      selectAnalyticsOptedInMock.mockReturnValue(true);
-      storeMock.getState.mockReturnValue({});
+      storageMock.getItem.mockResolvedValue('agreed');
 
       updateCachedConsent(false);
       await hasMetricsConsent();

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -11,8 +11,8 @@ import {
 } from '@sentry/core';
 import performance from 'react-native-performance';
 import { createModuleLogger, createProjectLogger } from '@metamask/utils';
-import { AGREED, METRICS_OPT_IN } from '../constants/storage';
-import StorageWrapper from '../store/storage-wrapper';
+import { store } from '../store';
+import { selectAnalyticsOptedIn } from '../selectors/analyticsController';
 
 // Cannot create this 'sentry' logger in Sentry util file because of circular dependency
 const projectLogger = createProjectLogger('sentry');
@@ -543,11 +543,22 @@ export async function flushBufferedTraces() {
 let cachedConsent: boolean | null = null;
 
 /**
- * Check if user has given consent for metrics
+ * Check if user has given consent for metrics.
+ *
+ * Reads from `AnalyticsController.state.optedIn` (the source of truth after
+ * migration 110). Returns `false` when the store or controller state is not
+ * yet available (e.g. during very early app startup before rehydration), so
+ * Sentry stays disabled by default until the user actually opts in.
  */
 export async function hasMetricsConsent(): Promise<boolean> {
-  const metricsOptIn = await StorageWrapper.getItem(METRICS_OPT_IN);
-  const hasConsent = metricsOptIn === AGREED;
+  let hasConsent = false;
+  try {
+    const state = store?.getState?.();
+    const optedIn = state ? selectAnalyticsOptedIn(state) : undefined;
+    hasConsent = optedIn === true;
+  } catch {
+    hasConsent = false;
+  }
   cachedConsent = hasConsent;
   return hasConsent;
 }

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -11,8 +11,8 @@ import {
 } from '@sentry/core';
 import performance from 'react-native-performance';
 import { createModuleLogger, createProjectLogger } from '@metamask/utils';
-import { store } from '../store';
-import { selectAnalyticsOptedIn } from '../selectors/analyticsController';
+import { AGREED, SENTRY_CONSENT } from '../constants/storage';
+import StorageWrapper from '../store/storage-wrapper';
 
 // Cannot create this 'sentry' logger in Sentry util file because of circular dependency
 const projectLogger = createProjectLogger('sentry');
@@ -545,17 +545,21 @@ let cachedConsent: boolean | null = null;
 /**
  * Check if user has given consent for metrics.
  *
- * Reads from `AnalyticsController.state.optedIn` (the source of truth after
- * migration 110). Returns `false` when the store or controller state is not
- * yet available (e.g. during very early app startup before rehydration), so
- * Sentry stays disabled by default until the user actually opts in.
+ * Reads from the dedicated {@link SENTRY_CONSENT} AsyncStorage key, which is
+ * kept in sync with `AnalyticsController.state.optedIn` (the SSOT after
+ * migration 110) by the subscription registered in `EngineService`.
+ *
+ * This is deliberately a storage read rather than a Redux read: `setupSentry`
+ * runs at `index.js` load time, long before the Redux store is rehydrated, so
+ * an in-memory controller lookup would return `undefined` and Sentry would
+ * start disabled for returning opted-in users — losing any early-boot crash
+ * reports for the rest of the session.
  */
 export async function hasMetricsConsent(): Promise<boolean> {
   let hasConsent = false;
   try {
-    const state = store?.getState?.();
-    const optedIn = state ? selectAnalyticsOptedIn(state) : undefined;
-    hasConsent = optedIn === true;
+    const value = await StorageWrapper.getItem(SENTRY_CONSENT);
+    hasConsent = value === AGREED;
   } catch {
     hasConsent = false;
   }


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`hasMetricsConsent()` in `app/util/trace.ts` was reading from the deprecated `METRICS_OPT_IN` AsyncStorage key to decide whether to initialise Sentry with `enabled: true`. Migration 110 migrated the source of truth for opt-in state into `AnalyticsController.state.optedIn` and intentionally kept `METRICS_OPT_IN` intact for backward compatibility — but no production code path ever writes that key again for new users.

As a result, new users who onboard after migration 110 never have `METRICS_OPT_IN` set. `hasMetricsConsent()` therefore always returns `false`, so:

1. `setupSentry()` (called at app boot via `index.js`) initialises Sentry with `enabled: false`.
2. When the user opts in during onboarding, `OptinMetrics.onConfirm` calls `metrics.enable(true)` (which updates `AnalyticsController.state.optedIn`) and then immediately calls `setupSentry()` again — which still reads the stale `METRICS_OPT_IN` key and re-initialises Sentry with `enabled: false`. Sentry remains silently disabled for the rest of the session and across restarts.

**Fix:** make `hasMetricsConsent()` read from `AnalyticsController.state.optedIn` via the existing `selectAnalyticsOptedIn` Redux selector, which is the SSOT established by migration 110. The function safely returns `false` when the store is not yet hydrated (very early boot) and swallows any selector errors, preserving the safe default of "disabled until confirmed".

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!--
Link a real GitHub or Jira issue using `Fixes:`, `Closes:`, or `Refs:`. If no issue exists,
write an explicit one-line rationale (e.g. `No issue: maintenance-only refactor`).
-->

No issue: bug discovered through code analysis; no tracked issue exists.

## **Manual testing steps**

```gherkin
Feature: Sentry error reporting respects metrics opt-in for new users

  Background:
    Given the app is installed fresh (no prior METRICS_OPT_IN key in storage)
    And migration 110 has run (AnalyticsController is the source of truth)

  Scenario: new user opts in to metrics during onboarding
    Given I am on the MetaMetrics opt-in screen during onboarding

    When I enable the "Help improve MetaMask" toggle
    And I tap "Agree"
    Then AnalyticsController.state.optedIn should be true
    And Sentry should be initialised with enabled: true
    And subsequent Sentry events should be captured (verify via Sentry dashboard or dev logs)

  Scenario: new user opts out of metrics during onboarding
    Given I am on the MetaMetrics opt-in screen during onboarding

    When I leave the "Help improve MetaMask" toggle off
    And I tap "No thanks"
    Then AnalyticsController.state.optedIn should be false
    And Sentry should be initialised with enabled: false

  Scenario: app is restarted after opt-in
    Given I previously opted in to metrics
    And the app is restarted cold (store rehydrated from persistence)

    When the app finishes loading
    Then Sentry should be initialised with enabled: true
    And error reporting should work correctly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — internal Sentry initialisation change, no UI change

### **After**

N/A — internal Sentry initialisation change, no UI change

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)