### PR TITLE
feat: remove Braze Segment events filtering cp-7.74.0

### DIFF
--- a/app/core/Braze/index.test.ts
+++ b/app/core/Braze/index.test.ts
@@ -2,15 +2,12 @@ import {
   setBrazeUser,
   clearBrazeUser,
   getBrazePlugin,
-  syncBrazeAllowlists,
   resetBrazePluginForTesting,
 } from './index';
 import { BrazePlugin } from '../Engine/controllers/analytics-controller/BrazePlugin';
 
 const mockGetSessionProfile = jest.fn();
 const mockSetBrazeProfileId = jest.fn();
-const mockSetAllowedEvents = jest.fn();
-const mockSetAllowedTraits = jest.fn();
 const mockSetLanguage = jest.fn();
 
 jest.mock('../Engine/Engine', () => ({
@@ -29,8 +26,6 @@ jest.mock('../Engine/controllers/analytics-controller/BrazePlugin', () => ({
     type: 'destination',
     key: 'Appboy',
     setBrazeProfileId: mockSetBrazeProfileId,
-    setAllowedEvents: mockSetAllowedEvents,
-    setAllowedTraits: mockSetAllowedTraits,
     setLanguage: mockSetLanguage,
   })),
 }));
@@ -91,87 +86,6 @@ describe('Braze service', () => {
       clearBrazeUser();
 
       expect(mockSetBrazeProfileId).toHaveBeenCalledWith(undefined);
-    });
-  });
-
-  describe('syncBrazeAllowlists', () => {
-    it('updates both allowlists from a valid config', () => {
-      syncBrazeAllowlists({
-        allowedEvents: ['Event A', 'Event B'],
-        allowedTraits: ['trait_x', 'trait_y'],
-      });
-
-      expect(mockSetAllowedEvents).toHaveBeenCalledWith(['Event A', 'Event B']);
-      expect(mockSetAllowedTraits).toHaveBeenCalledWith(['trait_x', 'trait_y']);
-    });
-
-    it('handles partial config (only events)', () => {
-      syncBrazeAllowlists({ allowedEvents: ['Event A'] });
-
-      expect(mockSetAllowedEvents).toHaveBeenCalledWith(['Event A']);
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('handles partial config (only traits)', () => {
-      syncBrazeAllowlists({ allowedTraits: ['trait_a'] });
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).toHaveBeenCalledWith(['trait_a']);
-    });
-
-    it('no-ops when flag value is undefined', () => {
-      syncBrazeAllowlists(undefined);
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('no-ops when flag value is null', () => {
-      syncBrazeAllowlists(null);
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('rejects non-object flag values', () => {
-      syncBrazeAllowlists('not-an-object');
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('rejects arrays as flag values', () => {
-      syncBrazeAllowlists(['not', 'a', 'config']);
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('ignores allowedEvents when it contains non-strings', () => {
-      syncBrazeAllowlists({
-        allowedEvents: ['valid', 123, null],
-        allowedTraits: ['trait_a'],
-      });
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).toHaveBeenCalledWith(['trait_a']);
-    });
-
-    it('ignores allowedTraits when it is not an array', () => {
-      syncBrazeAllowlists({
-        allowedEvents: ['Event A'],
-        allowedTraits: 'not-an-array',
-      });
-
-      expect(mockSetAllowedEvents).toHaveBeenCalledWith(['Event A']);
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
-    });
-
-    it('no-ops when object has no valid arrays', () => {
-      syncBrazeAllowlists({ allowedEvents: 42, allowedTraits: true });
-
-      expect(mockSetAllowedEvents).not.toHaveBeenCalled();
-      expect(mockSetAllowedTraits).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/Braze/index.ts
+++ b/app/core/Braze/index.ts
@@ -26,67 +26,6 @@ export function getBrazePlugin(): BrazePlugin {
 }
 
 /**
- * Validate that a remote flag value has the expected BrazeAllowedConfig shape.
- *
- * @param value - The raw flag value from RemoteFeatureFlagController.
- * @returns Validated allowedEvents/allowedTraits arrays, or undefined.
- */
-function validateBrazeAllowedConfig(
-  value: unknown,
-): { allowedEvents?: string[]; allowedTraits?: string[] } | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const record = value as Record<string, unknown>;
-  const result: { allowedEvents?: string[]; allowedTraits?: string[] } = {};
-
-  if (
-    Array.isArray(record.allowedEvents) &&
-    record.allowedEvents.every((e: unknown) => typeof e === 'string')
-  ) {
-    result.allowedEvents = record.allowedEvents as string[];
-  }
-
-  if (
-    Array.isArray(record.allowedTraits) &&
-    record.allowedTraits.every((t: unknown) => typeof t === 'string')
-  ) {
-    result.allowedTraits = record.allowedTraits as string[];
-  }
-
-  return result.allowedEvents || result.allowedTraits ? result : undefined;
-}
-
-/**
- * Update the Braze plugin allowlists from a remote feature flag value.
- * Called by analytics-controller-init on startup and on flag updates.
- *
- * @param flagValue - The raw remote feature flag value for brazeAllowedConfig.
- */
-export function syncBrazeAllowlists(flagValue: unknown): void {
-  try {
-    const brazeConfig = validateBrazeAllowedConfig(flagValue);
-    if (!brazeConfig) {
-      return;
-    }
-
-    const plugin = getBrazePlugin();
-    if (brazeConfig.allowedEvents) {
-      plugin.setAllowedEvents(brazeConfig.allowedEvents);
-    }
-    if (brazeConfig.allowedTraits) {
-      plugin.setAllowedTraits(brazeConfig.allowedTraits);
-    }
-  } catch (error) {
-    Logger.error(
-      error as Error,
-      '[Braze] Failed to sync allowlists from remote config',
-    );
-  }
-}
-
-/**
  * Resolve the profile ID from the current session and forward it to the
  * Braze Segment plugin so all subsequent identify / track / flush calls
  * are attributed to this identity.

--- a/app/core/Engine/controllers/analytics-controller/BrazePlugin.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/BrazePlugin.test.ts
@@ -5,11 +5,6 @@ import type {
   TrackEventType,
 } from '@segment/analytics-react-native';
 
-const defaultAllowedEvents = {
-  allowedEvents: ['Allowed event 1', 'Allowed event 2'],
-  allowedTraits: ['allowed_trait_1', 'allowed_trait_2'],
-};
-
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
   default: {
@@ -65,29 +60,23 @@ describe('BrazePlugin', () => {
     });
 
     it('flushes pending traits when profileId is set', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const [trait1, trait2] = defaultAllowedEvents.allowedTraits;
-
-      plugin.identify(makeIdentifyEvent({ [trait1]: 'a', [trait2]: 'b' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'a', trait2: 'b' }));
       expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalled();
 
       plugin.setBrazeProfileId('profile-123');
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        trait1,
+        'trait1',
         'a',
       );
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        trait2,
+        'trait2',
         'b',
       );
     });
 
     it('clears pending traits after flushing so they are not sent again', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const trait = defaultAllowedEvents.allowedTraits[0];
-
-      plugin.identify(makeIdentifyEvent({ [trait]: 'buffered' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'buffered' }));
       plugin.setBrazeProfileId('profile-123');
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledTimes(1);
@@ -99,10 +88,7 @@ describe('BrazePlugin', () => {
     });
 
     it('discards pending traits when profileId is cleared', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const trait = defaultAllowedEvents.allowedTraits[0];
-
-      plugin.identify(makeIdentifyEvent({ [trait]: 'buffered' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'buffered' }));
       plugin.setBrazeProfileId(undefined);
 
       expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalled();
@@ -114,28 +100,16 @@ describe('BrazePlugin', () => {
   });
 
   describe('track', () => {
-    it('forwards allowed events to Braze when profileId is set', () => {
+    it('forwards events to Braze when profileId is set', () => {
       plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedEvents(defaultAllowedEvents.allowedEvents);
-      const allowedName = defaultAllowedEvents.allowedEvents[0];
-      const event = makeTrackEvent(allowedName, { screen: 'home' });
+      const event = makeTrackEvent('Some Event', { screen: 'home' });
 
       const result = plugin.track(event);
 
-      expect(mockBraze.logCustomEvent).toHaveBeenCalledWith(allowedName, {
+      expect(mockBraze.logCustomEvent).toHaveBeenCalledWith('Some Event', {
         screen: 'home',
       });
       expect(result).toBe(event);
-    });
-
-    it('blocks events not in the allowlist', () => {
-      plugin.setBrazeProfileId('profile-123');
-      const event = makeTrackEvent('Some Random Event');
-
-      const result = plugin.track(event);
-
-      expect(mockBraze.logCustomEvent).not.toHaveBeenCalled();
-      expect(result).toBeUndefined();
     });
 
     it('passes events through when profileId is not set', () => {
@@ -148,11 +122,9 @@ describe('BrazePlugin', () => {
     });
 
     it('stops forwarding after profileId is cleared', () => {
-      plugin.setAllowedEvents(defaultAllowedEvents.allowedEvents);
       plugin.setBrazeProfileId('profile-123');
       plugin.setBrazeProfileId(undefined);
-      const allowedName = defaultAllowedEvents.allowedEvents[0];
-      const event = makeTrackEvent(allowedName);
+      const event = makeTrackEvent('Some Event');
 
       const result = plugin.track(event);
 
@@ -161,68 +133,29 @@ describe('BrazePlugin', () => {
     });
   });
 
-  describe('setAllowedEvents', () => {
-    it('replaces the allowlist at runtime', () => {
-      plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedEvents(['Custom Event A', 'Custom Event B']);
-
-      const allowed = makeTrackEvent('Custom Event A');
-      const blocked = makeTrackEvent(defaultAllowedEvents.allowedEvents[0]);
-
-      expect(plugin.track(allowed)).toBe(allowed);
-      expect(plugin.track(blocked)).toBeUndefined();
-
-      expect(mockBraze.logCustomEvent).toHaveBeenCalledTimes(1);
-      expect(mockBraze.logCustomEvent).toHaveBeenCalledWith(
-        'Custom Event A',
-        undefined,
-      );
-    });
-
-    it('can set an empty allowlist to block everything', () => {
-      plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedEvents([]);
-
-      const event = makeTrackEvent(defaultAllowedEvents.allowedEvents[0]);
-
-      expect(plugin.track(event)).toBeUndefined();
-      expect(mockBraze.logCustomEvent).not.toHaveBeenCalled();
-    });
-  });
-
   describe('identify', () => {
-    it('forwards allowed custom attributes to Braze when profileId is set', () => {
+    it('forwards all custom attributes to Braze when profileId is set', () => {
       plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const allowedTrait1 = defaultAllowedEvents.allowedTraits[0];
-      const allowedTrait2 = defaultAllowedEvents.allowedTraits[1];
       const event = makeIdentifyEvent({
-        [allowedTrait1]: true,
-        [allowedTrait2]: 'dark',
-        blocked_trait: 'should_not_be_sent',
+        trait1: true,
+        trait2: 'dark',
       });
 
       const result = plugin.identify(event);
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        allowedTrait1,
+        'trait1',
         true,
       );
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        allowedTrait2,
+        'trait2',
         'dark',
-      );
-      expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalledWith(
-        'blocked_trait',
-        expect.anything(),
       );
       expect(result).toBe(event);
     });
 
     it('buffers traits when profileId is not set', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const allowedTrait = defaultAllowedEvents.allowedTraits[0];
-      const event = makeIdentifyEvent({ [allowedTrait]: true });
+      const event = makeIdentifyEvent({ trait1: true });
 
       const result = plugin.identify(event);
 
@@ -231,38 +164,32 @@ describe('BrazePlugin', () => {
     });
 
     it('merges traits from multiple identify calls before profileId is set', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const [trait1, trait2] = defaultAllowedEvents.allowedTraits;
-
-      plugin.identify(makeIdentifyEvent({ [trait1]: 'value1' }));
-      plugin.identify(makeIdentifyEvent({ [trait2]: 'value2' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'value1' }));
+      plugin.identify(makeIdentifyEvent({ trait2: 'value2' }));
 
       expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalled();
 
       plugin.setBrazeProfileId('profile-123');
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        trait1,
+        'trait1',
         'value1',
       );
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        trait2,
+        'trait2',
         'value2',
       );
     });
 
     it('uses last value when the same trait is identified multiple times before profileId', () => {
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const trait = defaultAllowedEvents.allowedTraits[0];
-
-      plugin.identify(makeIdentifyEvent({ [trait]: 'first' }));
-      plugin.identify(makeIdentifyEvent({ [trait]: 'second' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'first' }));
+      plugin.identify(makeIdentifyEvent({ trait1: 'second' }));
 
       plugin.setBrazeProfileId('profile-123');
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledTimes(1);
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        trait,
+        'trait1',
         'second',
       );
     });
@@ -279,79 +206,26 @@ describe('BrazePlugin', () => {
 
     it('skips undefined trait values', () => {
       plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedTraits(defaultAllowedEvents.allowedTraits);
-      const allowedTrait1 = defaultAllowedEvents.allowedTraits[0];
-      const allowedTrait2 = defaultAllowedEvents.allowedTraits[1];
       const event = makeIdentifyEvent({
-        [allowedTrait1]: 'dark',
+        trait1: 'dark',
         undefinedField: undefined,
-        [allowedTrait2]: 42,
+        trait2: 42,
       });
 
       plugin.identify(event);
 
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        allowedTrait1,
+        'trait1',
         'dark',
       );
       expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        allowedTrait2,
+        'trait2',
         42,
       );
       expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalledWith(
         'undefinedField',
         expect.anything(),
       );
-    });
-
-    it('blocks traits not in the allowlist', () => {
-      plugin.setBrazeProfileId('profile-123');
-      const event = makeIdentifyEvent({
-        random_trait: 'value',
-        another_blocked: 123,
-      });
-
-      const result = plugin.identify(event);
-
-      expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalled();
-      expect(result).toBe(event);
-    });
-  });
-
-  describe('setAllowedTraits', () => {
-    it('replaces the trait allowlist at runtime', () => {
-      plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedTraits(['custom_trait_a', 'custom_trait_b']);
-
-      const event = makeIdentifyEvent({
-        custom_trait_a: 'allowed',
-        [defaultAllowedEvents.allowedTraits[0]]: 'blocked',
-      });
-
-      plugin.identify(event);
-
-      expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledTimes(1);
-      expect(mockBraze.setCustomUserAttribute).toHaveBeenCalledWith(
-        'custom_trait_a',
-        'allowed',
-      );
-      expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalledWith(
-        defaultAllowedEvents.allowedTraits[0],
-        expect.anything(),
-      );
-    });
-
-    it('can set an empty trait allowlist to block everything', () => {
-      plugin.setBrazeProfileId('profile-123');
-      plugin.setAllowedTraits([]);
-
-      const event = makeIdentifyEvent({
-        [defaultAllowedEvents.allowedTraits[0]]: 'value',
-      });
-
-      plugin.identify(event);
-
-      expect(mockBraze.setCustomUserAttribute).not.toHaveBeenCalled();
     });
   });
 

--- a/app/core/Engine/controllers/analytics-controller/BrazePlugin.ts
+++ b/app/core/Engine/controllers/analytics-controller/BrazePlugin.ts
@@ -13,18 +13,12 @@ import { captureException } from '@sentry/react-native';
  * Segment destination plugin that forwards events to the native Braze SDK
  * using a MetaMask profile ID rather than Segment's default userId.
  *
- * Only track events whose name appears in the allowlist are forwarded.
- * The allowlist is loaded from a local JSON file by default and can be
- * replaced at runtime (e.g. from a CDN) via {@link setAllowedEvents}.
- *
  * When no profileId is set the plugin is a no-op — nothing is sent to Braze.
  */
 export class BrazePlugin extends EventPlugin {
   type = PluginType.destination;
 
   private brazeProfileId: string | undefined;
-  private allowedEvents: Set<string> = new Set();
-  private allowedTraits: Set<string> = new Set();
   private pendingIdentifyTraits: Record<string, unknown> | undefined;
   private currentLanguage: string | undefined;
 
@@ -74,28 +68,6 @@ export class BrazePlugin extends EventPlugin {
   }
 
   /**
-   * Replace the event-name allowlist at runtime.
-   * Pass the full list of event names that should be forwarded to Braze.
-   */
-  setAllowedEvents(eventNames: string[]): void {
-    this.allowedEvents = new Set(eventNames);
-    Logger.log(
-      `[BrazePlugin] Updated allowed events (${eventNames.length} events)`,
-    );
-  }
-
-  /**
-   * Replace the trait-name allowlist at runtime.
-   * Pass the full list of trait keys that should be forwarded to Braze.
-   */
-  setAllowedTraits(traitNames: string[]): void {
-    this.allowedTraits = new Set(traitNames);
-    Logger.log(
-      `[BrazePlugin] Updated allowed traits (${traitNames.length} traits)`,
-    );
-  }
-
-  /**
    * Set the app language on Braze using the native setLanguage API.
    *
    * Always stores the value so it can be sent when a profileId becomes
@@ -138,10 +110,6 @@ export class BrazePlugin extends EventPlugin {
   track(event: TrackEventType): TrackEventType | undefined {
     if (this.brazeProfileId === undefined) {
       return event;
-    }
-
-    if (!this.allowedEvents.has(event.event)) {
-      return undefined;
     }
 
     try {
@@ -196,7 +164,6 @@ export class BrazePlugin extends EventPlugin {
     // and never uses standard Braze profile fields like email/firstName/etc
     for (const [key, value] of Object.entries(traits)) {
       if (value === undefined) continue;
-      if (!this.allowedTraits.has(key)) continue;
 
       const sanitized = this.sanitizeAttribute(value);
       if (sanitized !== undefined) {

--- a/app/core/Engine/controllers/analytics-controller/README.md
+++ b/app/core/Engine/controllers/analytics-controller/README.md
@@ -5,7 +5,6 @@
 MetaMask Mobile integrates with Braze via a custom Segment destination plugin that:
 
 - Uses MetaMask `profileId` for user identification (not Segment's `deviceId`)
-- Filters events and traits via an allowlist loaded from remote feature flags
 - Operates in device-mode (direct Braze SDK calls) while still allowing cloud-mode destinations
 
 ## Architecture
@@ -16,7 +15,6 @@ Segment Event Pipeline
 MetaMetricsPrivacySegmentPlugin (enrichment)
   ↓
 BrazePlugin (destination, device-mode)
-  ├─ Allowlist check (event name / trait key)
   ├─ profileId guard (no-op if undefined)
   └─ Braze SDK calls (Braze.logCustomEvent, Braze.setCustomUserAttribute)
   ↓
@@ -25,92 +23,39 @@ Segment Cloud (for cloud-mode destinations & Destination Filters)
 
 ## Files
 
-| File                           | Purpose                                                              |
-| ------------------------------ | -------------------------------------------------------------------- |
-| `BrazePlugin.ts`               | Segment destination plugin with allowlist filtering                  |
-| `BrazePlugin.test.ts`          | Unit tests (18 tests)                                                |
-| `braze-allowed-events.json`    | Default allowlists (hardcoded fallback)                              |
-| `app/core/Braze/index.ts`      | Public API (`setBrazeUser`, `clearBrazeUser`, `syncBrazeAllowlists`) |
-| `analytics-controller-init.ts` | Wires up remote config sync on init + flag updates                   |
-
-## Remote Configuration
-
-### Backend Setup
-
-Add a new feature flag to the `client-config` API (`https://client-config.api.cx.metamask.io`) with key **`brazeAllowedConfig`**:
-
-```json
-{
-  "allowedEvents": [
-    "Wallet Opened",
-    "Swap Completed",
-    "On-ramp Purchase Completed"
-  ],
-  "allowedTraits": [
-    "has_marketing_consent",
-    "has_rewards_opted_in",
-    "authentication_type"
-  ]
-}
-```
-
-### How It Works
-
-1. **Initial load**: `BrazePlugin` starts with allowlists from `braze-allowed-events.json`
-2. **First sync**: `syncBrazeAllowlists()` called after `AnalyticsController.init()` via `initMessenger.call('RemoteFeatureFlagController:getState')`
-3. **Periodic updates**: Subscribed to `RemoteFeatureFlagController:stateChange` (fires every 15 minutes in production, 1 second in dev)
-4. **Graceful fallback**: If flag is missing or malformed, local defaults remain in effect
-
-### Updating Allowlists at Runtime
-
-From backend (via remote feature flags):
-
-```json
-// POST to client-config API to update brazeAllowedConfig
-{
-  "allowedEvents": ["New Event"],
-  "allowedTraits": ["new_trait"]
-}
-```
-
-For testing/debugging:
-
-```typescript
-import { getBrazePlugin } from 'app/core/Braze';
-
-getBrazePlugin().setAllowedEvents(['Event A', 'Event B']);
-getBrazePlugin().setAllowedTraits(['trait_x', 'trait_y']);
-```
+| File                           | Purpose                                       |
+| ------------------------------ | --------------------------------------------- |
+| `BrazePlugin.ts`               | Segment destination plugin                    |
+| `BrazePlugin.test.ts`          | Unit tests                                    |
+| `app/core/Braze/index.ts`      | Public API (`setBrazeUser`, `clearBrazeUser`) |
+| `analytics-controller-init.ts` | Wires up plugin on init                       |
 
 ## Event Flow
 
-### Track Events (filtered)
+### Track Events
 
 ```typescript
 analytics.track('Swap Completed', { amount: 100 });
   ↓
 BrazePlugin.track()
-  ↓ Check: is "Swap Completed" in allowedEvents?
-  ↓ YES → Braze.logCustomEvent('Swap Completed', { amount: 100 })
-  ↓ NO  → silently dropped
+  ↓ profileId set? YES → Braze.logCustomEvent('Swap Completed', { amount: 100 })
+  ↓ NO  → no-op
   ↓ ALWAYS → return event (continues to Segment cloud)
 ```
 
-### Identify Traits (filtered)
+### Identify Traits
 
 ```typescript
-analytics.identify({ has_marketing_consent: true, random_trait: 'x' });
+analytics.identify({ has_marketing_consent: true });
   ↓
 BrazePlugin.identify()
-  ↓ For each trait:
-    ├─ "has_marketing_consent" in allowedTraits? YES → Braze.setCustomUserAttribute(...)
-    └─ "random_trait" in allowedTraits? NO → skip
+  ↓ profileId set? YES → Braze.setCustomUserAttribute(...)
+  ↓ NO  → no-op
   ↓ ALWAYS → return event (continues to Segment cloud)
 ```
 
-### Flush / Screen Events (not filtered)
+### Flush / Screen Events
 
-- **`identify()`** — all traits in the allowlist are forwarded
 - **`flush()`** — always calls `Braze.requestImmediateDataFlush()` when `profileId` is set
 - **`screen()`** — not forwarded to Braze (passes through unchanged)
 
@@ -129,30 +74,3 @@ Run tests:
 yarn jest app/core/Engine/controllers/analytics-controller/BrazePlugin.test.ts
 yarn jest app/core/Braze/index.test.ts
 ```
-
-## Adding Events to the Allowlist
-
-1. **Temporary (for testing)**: Add to `braze-allowed-events.json` in the codebase
-2. **Production**: Update the `brazeAllowedConfig` feature flag on the backend
-3. **Event names must match exactly** — use values from `app/core/Analytics/MetaMetrics.events.ts`
-
-### Example Event Names
-
-From `MetaMetrics.events.ts`:
-
-- `"App Opened"`
-- `"Wallet Opened"`
-- `"Swap Completed"`
-- `"Dapp Transaction Completed"`
-- `"Token Added"`
-
-### Example Trait Names
-
-From `UserProfileProperty` enum:
-
-- `"has_marketing_consent"`
-- `"has_rewards_opted_in"`
-- `"authentication_type"`
-- `"theme"`
-- `"primary_currency"`
-- `"chain_id_list"`

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -8,7 +8,7 @@ import {
 import { createPlatformAdapter } from './platform-adapter';
 import { createPlatformAdapter as createE2EPlatformAdapter } from './platform-adapter-e2e';
 import { isE2E } from '../../../../util/test/utils';
-import { getBrazePlugin, syncBrazeAllowlists } from '../../../Braze';
+import { getBrazePlugin } from '../../../Braze';
 import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
 
 /**
@@ -18,14 +18,13 @@ import type { AnalyticsControllerInitMessenger } from '../../messengers/analytic
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.analyticsId - The analytics ID to use.
  * @param request.persistedState - The persisted state for all controllers.
- * @param request.initMessenger - The init messenger for remote feature flag subscriptions.
  * @returns The initialized controller.
  */
 export const analyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
   AnalyticsControllerMessenger,
   AnalyticsControllerInitMessenger
-> = ({ controllerMessenger, analyticsId, persistedState, initMessenger }) => {
+> = ({ controllerMessenger, analyticsId, persistedState }) => {
   const persistedAnalyticsState = persistedState.AnalyticsController;
   const defaultState = getDefaultAnalyticsControllerState();
 
@@ -46,20 +45,6 @@ export const analyticsControllerInit: MessengerClientInitFunction<
   });
 
   controller.init();
-
-  initMessenger.subscribe(
-    'RemoteFeatureFlagController:stateChange',
-    syncBrazeAllowlists,
-    (flagState) => flagState.remoteFeatureFlags.brazeSegmentForwarding,
-  );
-
-  const remoteFeatureFlagControllerState = initMessenger.call(
-    'RemoteFeatureFlagController:getState',
-  );
-
-  syncBrazeAllowlists(
-    remoteFeatureFlagControllerState.remoteFeatureFlags.brazeSegmentForwarding,
-  );
 
   return {
     controller,

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -9,7 +9,6 @@ import { createPlatformAdapter } from './platform-adapter';
 import { createPlatformAdapter as createE2EPlatformAdapter } from './platform-adapter-e2e';
 import { isE2E } from '../../../../util/test/utils';
 import { getBrazePlugin } from '../../../Braze';
-import type { AnalyticsControllerInitMessenger } from '../../messengers/analytics-controller-messenger';
 
 /**
  * Initialize the analytics controller.
@@ -22,8 +21,7 @@ import type { AnalyticsControllerInitMessenger } from '../../messengers/analytic
  */
 export const analyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
-  AnalyticsControllerMessenger,
-  AnalyticsControllerInitMessenger
+  AnalyticsControllerMessenger
 > = ({ controllerMessenger, analyticsId, persistedState }) => {
   const persistedAnalyticsState = persistedState.AnalyticsController;
   const defaultState = getDefaultAnalyticsControllerState();

--- a/app/core/Engine/messengers/analytics-controller-messenger.ts
+++ b/app/core/Engine/messengers/analytics-controller-messenger.ts
@@ -4,10 +4,6 @@ import {
   MessengerEvents,
   MessengerActions,
 } from '@metamask/messenger';
-import type {
-  RemoteFeatureFlagControllerGetStateAction,
-  RemoteFeatureFlagControllerStateChangeEvent,
-} from '@metamask/remote-feature-flag-controller';
 import { RootMessenger } from '../types';
 
 /**
@@ -28,39 +24,5 @@ export function getAnalyticsControllerMessenger(
     namespace: 'AnalyticsController',
     parent: rootMessenger,
   });
-  return messenger;
-}
-
-export type AnalyticsControllerInitMessenger = ReturnType<
-  typeof getAnalyticsControllerInitMessenger
->;
-
-/**
- * Get the init messenger for the AnalyticsController.
- * Scoped to reading remote feature flags during initialization and
- * reacting to flag updates at runtime (Braze allowlists).
- *
- * @param rootMessenger - The root messenger.
- * @returns The AnalyticsControllerInitMessenger.
- */
-export function getAnalyticsControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'AnalyticsControllerInit',
-    RemoteFeatureFlagControllerGetStateAction,
-    RemoteFeatureFlagControllerStateChangeEvent,
-    RootMessenger
-  >({
-    namespace: 'AnalyticsControllerInit',
-    parent: rootMessenger,
-  });
-
-  rootMessenger.delegate({
-    actions: ['RemoteFeatureFlagController:getState'],
-    events: ['RemoteFeatureFlagController:stateChange'],
-    messenger,
-  });
-
   return messenger;
 }

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -146,10 +146,7 @@ import {
   getProfileMetricsControllerInitMessenger,
 } from './profile-metrics-controller-messenger';
 import { getProfileMetricsServiceMessenger } from './profile-metrics-service-messenger';
-import {
-  getAnalyticsControllerMessenger,
-  getAnalyticsControllerInitMessenger,
-} from './analytics-controller-messenger';
+import { getAnalyticsControllerMessenger } from './analytics-controller-messenger';
 import { getAiDigestControllerMessenger } from './ai-digest-controller-messenger';
 import { getSocialServiceMessenger } from './social-service-messenger';
 import { getSocialControllerMessenger } from './social-controller-messenger';
@@ -466,7 +463,7 @@ export const MESSENGER_FACTORIES = {
   },
   AnalyticsController: {
     getMessenger: getAnalyticsControllerMessenger,
-    getInitMessenger: getAnalyticsControllerInitMessenger,
+    getInitMessenger: noop,
   },
   AiDigestController: {
     getMessenger: getAiDigestControllerMessenger,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Remove Braze Segment events filtering. As a consequence, all Segments events will be forwarded to Braze

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-199

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens analytics forwarding to Braze by removing allowlist gates and remote-flag syncing, which could increase data volume and risk unintentionally sending sensitive traits/events if upstream payloads aren’t tightly controlled.
> 
> **Overview**
> **Removes Braze allowlist-based filtering** so `BrazePlugin` forwards *all* `track` events and `identify` traits to the native Braze SDK whenever a `profileId` is set.
> 
> This deletes the remote-feature-flag plumbing (`syncBrazeAllowlists`, init-messenger wiring, and `setAllowedEvents`/`setAllowedTraits`) and updates unit tests accordingly; `analytics-controller-init` now only injects `getBrazePlugin()` without subscribing to RemoteFeatureFlag updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32565655c208f18723a80336da8d242b7431b914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->