### PR TITLE
chore(ci): fix bundle size report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,28 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ios-bundle
-          path: ios/main.jsbundle
+          path: ios
+
+      - name: Verify iOS bundle artifact layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -la ios/
+          if [[ ! -f ios/main.jsbundle ]]; then
+            echo "::error::Expected ios/main.jsbundle to be a regular file (artifact layout may be wrong)."
+            exit 1
+          fi
+
+      - name: Report iOS JS bundle size and commit (main)
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          BUNDLE_PATH='ios/main.jsbundle'
+          BYTES="$(stat -f%z "$BUNDLE_PATH" 2>/dev/null || stat -c%s "$BUNDLE_PATH")"
+          MB="$(awk -v b="$BYTES" 'BEGIN { printf "%.2f", b/1024/1024 }')"
+          echo "commit_short=$SHORT_SHA"
+          echo "ios_js_bundle_size_bytes=$BYTES"
+          echo "ios_js_bundle_size_mb=$MB"
+          echo "::notice::iOS JS bundle (main): ${MB} MiB @ ${SHORT_SHA}"
 
       - name: Push bundle size to mobile_bundlesize_stats repo
         run: ./scripts/push-bundle-size.sh


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The **Ship JS bundle size check** job downloaded the `ios-bundle` artifact to `path: ios/main.jsbundle`. For `actions/download-artifact@v4`, that value is a **destination directory**, so the bundle was extracted as `ios/main.jsbundle/main.jsbundle` and `ios/main.jsbundle` became a directory. `stat` and `push-bundle-size.sh` then measured the directory size (typically **4096** bytes on Linux), which is why [mobile_bundlesize_stats](https://github.com/MetaMask/mobile_bundlesize_stats) showed a constant incorrect value.

**Changes:**
- Set the download `path` to `ios` so `main.jsbundle` lands as a regular file at `ios/main.jsbundle`.
- Add a **Verify iOS bundle artifact layout** step (`test -f ios/main.jsbundle`, plus `ls -la ios/`) so a bad layout fails fast with a clear error instead of publishing bogus stats.
- Add **Report iOS JS bundle size and commit (main)** so the job logs `ios_js_bundle_size_bytes`, `ios_js_bundle_size_mb`, and a GitHub notice with the short SHA for easier verification.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

<!-- [screenshots/recordings] -->

### **After**

N/A

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.