### PR TITLE
fix: prevent invalid bridge tx hashes from being persisted in txHistory

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BridgeStepDescription.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BridgeStepDescription.test.tsx
@@ -387,6 +387,7 @@ describe('BridgeStepDescription', () => {
       slippagePercentage: 0,
       account: '0x123',
       hasApprovalTx: false,
+      startTime: Date.now(),
     };
 
     const mockSrcChainTxMeta: TransactionMeta = {

--- a/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
@@ -37,15 +37,13 @@ export function getBridgeStatusControllerMessenger(
       'SnapController:handleRequest',
       'TransactionController:getState',
       'AuthenticationController:getBearerToken',
+      'RemoteFeatureFlagController:getState',
       'TransactionController:addTransaction',
       'TransactionController:updateTransaction',
       'TransactionController:estimateGasFee',
       'TransactionController:isAtomicBatchSupported',
     ],
-    events: [
-      'TransactionController:transactionConfirmed',
-      'TransactionController:transactionFailed',
-    ],
+    events: ['TransactionController:transactionStatusUpdated'],
     messenger,
   });
   return messenger;

--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.10.1",
     "@metamask/bridge-controller": "^70.0.0",
-    "@metamask/bridge-status-controller": "^70.0.4",
+    "@metamask/bridge-status-controller": "^71.0.0",
     "@metamask/chain-agnostic-permission": "^1.3.0",
     "@metamask/client-controller": "^1.0.1",
     "@metamask/compliance-controller": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8073,7 +8073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^70.0.0, @metamask/bridge-controller@npm:^70.0.1, @metamask/bridge-controller@npm:^70.2.0":
+"@metamask/bridge-controller@npm:^70.0.0, @metamask/bridge-controller@npm:^70.2.0":
   version: 70.2.0
   resolution: "@metamask/bridge-controller@npm:70.2.0"
   dependencies:
@@ -8103,30 +8103,6 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/5e3ff900bbcdbe2bee0e143cfb06076fb0a27d1c582d88dff9eba57458207dc2c76a47b178403ae4c36ec8a48e5fb1ddbefc310f73a4baaf24b4528a488514b1
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-status-controller@npm:^70.0.4":
-  version: 70.0.5
-  resolution: "@metamask/bridge-status-controller@npm:70.0.5"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^37.1.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/bridge-controller": "npm:^70.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/gas-fee-controller": "npm:^26.1.1"
-    "@metamask/keyring-controller": "npm:^25.1.1"
-    "@metamask/messenger": "npm:^1.0.0"
-    "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/polling-controller": "npm:^16.0.4"
-    "@metamask/profile-sync-controller": "npm:^28.0.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^64.0.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    uuid: "npm:^8.3.2"
-  checksum: 10/4b3948641ce977a09373023ed8f558ff23e3c486b5f73bda2e230554917c999a53784862c64a609dff6d9aa0f4f11d24da69f62323d9dd92027d977f7d303c1f
   languageName: node
   linkType: hard
 
@@ -35876,7 +35852,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.1"
     "@metamask/bridge-controller": "npm:^70.0.0"
-    "@metamask/bridge-status-controller": "npm:^70.0.4"
+    "@metamask/bridge-status-controller": "npm:^71.0.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"
     "@metamask/build-utils": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Bumps the bridge-controller and bridge-status-controller packages. The new bridge-status-controller version prevents invalid src tx hashes from being added to the `txHistory`. Additionally, old pending transactions are removed from state so they don't get polled indefinitely

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: prevent invalid bridge tx hashes from being persisted in txHistory

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4380

## **Manual testing steps**

```gherkin
Feature: bridge tx status polling

  Scenario: user submits a tx
    Given they have STX enabled

    When user submits a bridge
    Then the status gets updated correctly in the Activity log


  Scenario: user submits a tx
    Given they have STX disabled, 7702 is supported

    When user submits a bridge
    Then the status gets updated correctly in the Activity log

  Scenario: user submits a Solana tx
    Given they have STX enabled

    When user submits a bridge
    Then the status gets updated correctly in the Activity log

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A
<!-- [screenshots/recordings] -->

### **After**

N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bridge-status integration and dependency versions, including switching to a new transaction status event; this can affect bridge status polling and activity updates if event semantics differ.
> 
> **Overview**
> Bumps `@metamask/bridge-status-controller` to `^71.0.0` (with corresponding `yarn.lock` updates) to pick up fixes around bridge tx history persistence.
> 
> Updates the BridgeStatus controller messenger wiring to delegate `RemoteFeatureFlagController:getState` and to listen to `TransactionController:transactionStatusUpdated` instead of separate confirmed/failed events.
> 
> Adjusts `BridgeStepDescription` tests to include the new `startTime` field on mocked `BridgeHistoryItem` data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e169e5ab1f1a92122a2f0a727321f3f9b78b6609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->