### PR TITLE
fix(card): unauthenticated balance always showing 0

### DIFF
--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -774,6 +774,129 @@ describe('BaanxProvider', () => {
         tokenA.toLowerCase(),
       );
     });
+
+    it('sets spendableBalance to wallet balance when wallet is below allowance', async () => {
+      spendersMock.mockResolvedValue([limitedTuple('50'), limitedTuple('0')]);
+      contractSpy.mockImplementation((address: string) => {
+        if (address.toLowerCase() === scannerAddr.toLowerCase()) {
+          return {
+            spendersAllowancesForTokens: spendersMock,
+          } as unknown as ethers.Contract;
+        }
+        if (address.toLowerCase() === tokenA.toLowerCase()) {
+          return {
+            balanceOf: jest
+              .fn()
+              .mockResolvedValue(ethers.utils.parseUnits('25', 6)),
+          } as unknown as ethers.Contract;
+        }
+        return {
+          balanceOf: jest
+            .fn()
+            .mockResolvedValue(ethers.utils.parseUnits('100', 6)),
+        } as unknown as ethers.Contract;
+      });
+
+      const p = new BaanxProvider({ service, cardFeatureFlag });
+      const result = await p.getOnChainAssets(ownerAddr);
+
+      expect(result.primaryFundingAsset?.spendableBalance).toBe('25');
+    });
+
+    it('sets spendableBalance to zero when on-chain wallet balance is zero', async () => {
+      spendersMock.mockResolvedValue([limitedTuple('50'), limitedTuple('0')]);
+      contractSpy.mockImplementation((address: string) => {
+        if (address.toLowerCase() === scannerAddr.toLowerCase()) {
+          return {
+            spendersAllowancesForTokens: spendersMock,
+          } as unknown as ethers.Contract;
+        }
+        return {
+          balanceOf: jest.fn().mockResolvedValue(ethers.constants.Zero),
+        } as unknown as ethers.Contract;
+      });
+
+      const p = new BaanxProvider({ service, cardFeatureFlag });
+      const result = await p.getOnChainAssets(ownerAddr);
+
+      expect(result.primaryFundingAsset?.spendableBalance).toBe('0');
+    });
+
+    it('treats balanceOf failure as zero wallet balance and logs an error', async () => {
+      spendersMock.mockResolvedValue([limitedTuple('50'), limitedTuple('0')]);
+      contractSpy.mockImplementation((address: string) => {
+        if (address.toLowerCase() === scannerAddr.toLowerCase()) {
+          return {
+            spendersAllowancesForTokens: spendersMock,
+          } as unknown as ethers.Contract;
+        }
+        if (address.toLowerCase() === tokenA.toLowerCase()) {
+          return {
+            balanceOf: jest
+              .fn()
+              .mockRejectedValue(new Error('balanceOf reverted')),
+          } as unknown as ethers.Contract;
+        }
+        return {
+          balanceOf: jest
+            .fn()
+            .mockResolvedValue(ethers.utils.parseUnits('100', 6)),
+        } as unknown as ethers.Contract;
+      });
+
+      const p = new BaanxProvider({ service, cardFeatureFlag });
+      const result = await p.getOnChainAssets(ownerAddr);
+
+      expect(result.primaryFundingAsset?.spendableBalance).toBe('0');
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            name: 'BaanxProvider',
+            data: expect.objectContaining({
+              method: 'fetchOnChainAllowances/balanceOf',
+              tokenAddr: tokenA,
+              owner: ownerAddr,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('calls balanceOf on each token contract with the owner address', async () => {
+      spendersMock.mockResolvedValue([limitedTuple('50'), limitedTuple('0')]);
+      const balanceOfTokenA = jest
+        .fn()
+        .mockResolvedValue(ethers.utils.parseUnits('100', 6));
+      const balanceOfTokenB = jest
+        .fn()
+        .mockResolvedValue(ethers.utils.parseUnits('100', 6));
+
+      contractSpy.mockImplementation((address: string) => {
+        if (address.toLowerCase() === scannerAddr.toLowerCase()) {
+          return {
+            spendersAllowancesForTokens: spendersMock,
+          } as unknown as ethers.Contract;
+        }
+        if (address.toLowerCase() === tokenA.toLowerCase()) {
+          return {
+            balanceOf: balanceOfTokenA,
+          } as unknown as ethers.Contract;
+        }
+        if (address.toLowerCase() === tokenB.toLowerCase()) {
+          return {
+            balanceOf: balanceOfTokenB,
+          } as unknown as ethers.Contract;
+        }
+        return {} as unknown as ethers.Contract;
+      });
+
+      const p = new BaanxProvider({ service, cardFeatureFlag });
+      await p.getOnChainAssets(ownerAddr);
+
+      expect(balanceOfTokenA).toHaveBeenCalledWith(ownerAddr);
+      expect(balanceOfTokenB).toHaveBeenCalledWith(ownerAddr);
+    });
   });
 
   describe('getCardHomeData — #fetchOriginalSpendingCap', () => {

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -654,12 +654,20 @@ describe('BaanxProvider', () => {
               getLogs: getLogsMock,
             }) as unknown as ethers.providers.JsonRpcProvider,
         );
-      contractSpy = jest.spyOn(ethers, 'Contract').mockImplementation(
-        () =>
-          ({
-            spendersAllowancesForTokens: spendersMock,
-          }) as unknown as ethers.Contract,
-      );
+      contractSpy = jest
+        .spyOn(ethers, 'Contract')
+        .mockImplementation((address: string) => {
+          if (address.toLowerCase() === scannerAddr.toLowerCase()) {
+            return {
+              spendersAllowancesForTokens: spendersMock,
+            } as unknown as ethers.Contract;
+          }
+          return {
+            balanceOf: jest
+              .fn()
+              .mockResolvedValue(ethers.utils.parseUnits('100', 6)),
+          } as unknown as ethers.Contract;
+        });
     });
 
     afterEach(() => {
@@ -686,6 +694,11 @@ describe('BaanxProvider', () => {
       expect(result.primaryFundingAsset?.status).toBe(
         FundingAssetStatus.Limited,
       );
+      expect(result.primaryFundingAsset?.spendableBalance).toBe('50');
+      const assetB = result.fundingAssets.find(
+        (a) => a.address.toLowerCase() === tokenB.toLowerCase(),
+      );
+      expect(assetB?.spendableBalance).toBe('0');
     });
 
     it('uses #findLastApprovedToken when multiple tokens have non-zero allowance and prefers latest Approval log', async () => {

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -91,6 +91,10 @@ function getErrorContext(method: string, extra?: Record<string, unknown>) {
   };
 }
 
+const ERC20_BALANCE_OF_ABI = [
+  'function balanceOf(address account) view returns (uint256)',
+];
+
 function mapLoginError(error: unknown, hasOtpCode: boolean): CardProviderError {
   if (error instanceof CardApiError) {
     const body =
@@ -808,6 +812,7 @@ export class BaanxProvider implements ICardProvider {
       address: string;
       globalAllowance: ethers.BigNumber;
       usAllowance: ethers.BigNumber;
+      walletBalance: ethers.BigNumber;
     }[]
   > {
     const rpcUrl = cardNetworkInfos.linea?.rpcUrl;
@@ -838,12 +843,35 @@ export class BaanxProvider implements ICardProvider {
         spenders,
       );
 
+    const walletBalances = await Promise.all(
+      tokenAddresses.map(async (tokenAddr) => {
+        try {
+          const erc20 = new ethers.Contract(
+            tokenAddr,
+            ERC20_BALANCE_OF_ABI,
+            provider,
+          );
+          return (await erc20.balanceOf(owner)) as ethers.BigNumber;
+        } catch (error) {
+          Logger.error(
+            error as Error,
+            getErrorContext('fetchOnChainAllowances/balanceOf', {
+              tokenAddr,
+              owner,
+            }),
+          );
+          return ethers.BigNumber.from(0);
+        }
+      }),
+    );
+
     return tokenAddresses.map((addr, i) => {
       const [globalTuple, usTuple] = results[i];
       return {
         address: addr,
         globalAllowance: ethers.BigNumber.from(globalTuple[1]),
         usAllowance: ethers.BigNumber.from(usTuple[1]),
+        walletBalance: walletBalances[i] ?? ethers.BigNumber.from(0),
       };
     });
   }
@@ -853,6 +881,7 @@ export class BaanxProvider implements ICardProvider {
       address: string;
       globalAllowance: ethers.BigNumber;
       usAllowance: ethers.BigNumber;
+      walletBalance: ethers.BigNumber;
     }[],
     supportedTokens: (SupportedToken & { address: string })[],
     chainId: string,
@@ -868,9 +897,14 @@ export class BaanxProvider implements ICardProvider {
         const allowance = raw.usAllowance.isZero()
           ? raw.globalAllowance
           : raw.usAllowance;
+        const decimals = tokenInfo.decimals ?? 6;
         const allowanceFloat = parseFloat(
-          ethers.utils.formatUnits(allowance, tokenInfo.decimals ?? 6),
+          ethers.utils.formatUnits(allowance, decimals),
         );
+        const balanceFloat = parseFloat(
+          ethers.utils.formatUnits(raw.walletBalance, decimals),
+        );
+        const availableBalance = Math.min(balanceFloat, allowanceFloat);
 
         return {
           symbol: tokenInfo.symbol ?? '',
@@ -879,7 +913,7 @@ export class BaanxProvider implements ICardProvider {
           walletAddress: ownerAddress,
           decimals: tokenInfo.decimals ?? 0,
           chainId,
-          spendableBalance: '0',
+          spendableBalance: availableBalance.toString(),
           spendingCap: allowance.toString(),
           priority: 0,
           status: mapAllowanceToFundingStatus(allowanceFloat),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

When the user is a **MetaMask Card** cardholder but **not authenticated** with the card provider, `CardController` loads home data through `BaanxProvider.getOnChainAssets`. That path mapped allowances to `CardFundingAsset` with **`spendableBalance` hardcoded to `'0'`** while `status` could be **Limited** or **Active**. The Card UI merges balances in `useAssetBalances`, which treats **Limited/Enabled** tokens as delegation-backed and prefers `spendableBalance` first; the literal string **`'0'`** is truthy in JavaScript, so the UI never fell back to wallet balances and **always showed zero**.

This change fetches each supported Linea token’s **ERC-20 `balanceOf(owner)`** in parallel (same RPC session as the existing balance scanner), then sets **`spendableBalance` to `min(walletBalance, allowance)`** in human units, matching the authenticated API mapping in `mapWalletDetailsToAssets`. Failed `balanceOf` calls are logged and treated as zero balance.

Tests: `ethers.Contract` mocks distinguish the scanner contract from token contracts; assertions verify non-zero spendable when allowance and mocked wallet balance allow it, and zero when allowance is zero.

## **Changelog**

CHANGELOG entry: Fixed MetaMask Card home showing zero balance for token balances when the user is not authenticated with the card provider.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: MetaMask Card unauthenticated cardholder balance

  Scenario: Card home shows non-zero spendable when wallet holds tokens and allowance is set
    Given the Card feature is enabled and the user has a linked cardholder account on Linea
    And the user is logged out of card provider authentication (session expired or logged out)
    And the selected wallet account is the card-linked account
    And that account holds a supported card funding token (e.g. USDC) with a positive balance
    And the account has a non-zero allowance to the card spender contracts

    When the user opens Card Home

    Then the primary funding asset balance is not stuck at zero
    And the displayed amount reflects at most the wallet token balance and the on-chain allowance (whichever is lower)

  Scenario: Pull-to-refresh still updates card home data
    Given the user is on Card Home in the unauthenticated cardholder state described above

    When the user pulls to refresh

    Then card home data reloads without error
    And balances remain consistent with on-chain wallet balance and allowances
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Card Home primary balance showed 0.00 for the funding token despite a positive wallet balance and delegation. -->

### **After**

<!-- Card Home shows min(wallet, allowance) for the primary funding token when not authenticated. -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds extra on-chain `balanceOf` RPC calls and changes how unauthenticated funding balances are computed, which could affect Card Home display and relies on RPC availability (with error fallback).
> 
> **Overview**
> Fixes unauthenticated Card Home balances by fetching each supported token’s on-chain ERC-20 `balanceOf(owner)` alongside the existing allowance scan, then setting `spendableBalance` to `min(walletBalance, allowance)` instead of always `'0'`.
> 
> Extends `getOnChainAssets` tests to mock both the scanner and per-token contracts, and adds coverage for wallet-below-allowance, zero balance, `balanceOf` failure (logged and treated as zero), and verifying `balanceOf` is called per token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0edaf8b9267f4b378ea51ab6b400394b09905511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->