### PR TITLE
fix: support stocks in token import flow cp-7.74.0

### DIFF
--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -314,6 +314,71 @@ describe('useTrendingSearch', () => {
     });
   });
 
+  describe('includeStocks option', () => {
+    const mockSearchResultsWithRwa = [
+      ...mockSearchResults,
+      {
+        assetId: 'eip155:1/erc20:0xrwa' as CaipChainId,
+        symbol: 'AAPL',
+        name: 'Apple Stock',
+        decimals: 18,
+        price: '150',
+        aggregatedUsdVolume: 200000,
+        marketCap: 2000000000,
+        pricePercentChange1d: '0.5',
+        rwaData: { instrumentType: 'equity' },
+      },
+    ];
+
+    it('filters out items with rwaData by default (includeStocks: false)', async () => {
+      mockUseSearchRequest.mockReturnValue({
+        results: mockSearchResultsWithRwa,
+        isLoading: false,
+        error: null,
+        search: jest.fn(),
+      });
+
+      const { result } = renderHookWithProvider(() =>
+        useTrendingSearch({ searchQuery: 'USDC' }),
+      );
+
+      jest.advanceTimersByTime(200);
+
+      await waitFor(() => {
+        expect(result.current.data).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ symbol: 'AAPL' })]),
+        );
+        expect(result.current.data).toEqual(
+          expect.arrayContaining([expect.objectContaining({ symbol: 'USDC' })]),
+        );
+      });
+    });
+
+    it('includes items with rwaData when includeStocks is true', async () => {
+      mockUseSearchRequest.mockReturnValue({
+        results: mockSearchResultsWithRwa,
+        isLoading: false,
+        error: null,
+        search: jest.fn(),
+      });
+
+      const { result } = renderHookWithProvider(() =>
+        useTrendingSearch({ searchQuery: 'USDC', includeStocks: true }),
+      );
+
+      jest.advanceTimersByTime(200);
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ symbol: 'USDC' }),
+            expect.objectContaining({ symbol: 'AAPL' }),
+          ]),
+        );
+      });
+    });
+  });
+
   it('uses search immediately when debounce disabled', async () => {
     mockUseSearchRequest.mockReturnValue({
       results: mockSearchResults,

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -29,6 +29,7 @@ const useStableReference = <T>(value: T) => {
  * @param sortBy - Sort option for trending tokens
  * @param chainIds - Chain IDs to filter by
  * @param enableDebounce - Whether to debounce (default: true)
+ * @param includeStocks - When true, items with rwaData are included in results (default: false)
  * @returns Trending/search results, loading state, and refetch function
  */
 export const useTrendingSearch = (opts?: {
@@ -37,6 +38,7 @@ export const useTrendingSearch = (opts?: {
   chainIds?: CaipChainId[] | null;
   enableDebounce?: boolean;
   includeMarketData?: boolean;
+  includeStocks?: boolean;
   sortTrendingTokensOptions?: {
     option: PriceChangeOption;
     direction: SortDirection;
@@ -48,6 +50,7 @@ export const useTrendingSearch = (opts?: {
     chainIds,
     enableDebounce = true,
     includeMarketData = true,
+    includeStocks = false,
     sortTrendingTokensOptions = {
       option: PriceChangeOption.PriceChange,
       direction: SortDirection.Descending,
@@ -105,7 +108,7 @@ export const useTrendingSearch = (opts?: {
     );
 
     searchResults
-      .filter((item) => !item.rwaData)
+      .filter((item) => includeStocks || !item.rwaData)
       .forEach((asset) => {
         if (!resultMap.has(asset.assetId)) {
           resultMap.set(asset.assetId, {
@@ -133,6 +136,7 @@ export const useTrendingSearch = (opts?: {
     trendingResults,
     searchResults,
     sortTrendingTokensOptions,
+    includeStocks,
   ]);
 
   // Loading state: show loading while waiting for results

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -92,6 +92,7 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
       option: PriceChangeOption.MarketCap,
       direction: SortDirection.Descending,
     },
+    includeStocks: true,
   });
 
   // Convert API search results to ImportAsset format


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Adds an includeStocks option to useTrendingSearch that controls whether real-world asset (RWA) search results are included. When false (default), items with rwaData are filtered out — preserving existing behavior. When true, stock/RWA assets are included in results. The SearchTokenAutocomplete component opts in with includeStocks: true so users can find RWA tokens when importing assets.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: support stocks in token import flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3110

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes which assets can appear in the token import search results (RWA/stocks), potentially affecting user-facing selection and downstream import behavior, though default behavior remains unchanged.
> 
> **Overview**
> Adds an `includeStocks` option to `useTrendingSearch` to control whether search results containing `rwaData` are filtered out (default) or included.
> 
> Updates the token import autocomplete (`SearchTokenAutocomplete`) to opt into stock/RWA results via `includeStocks: true`, and extends `useTrendingSearch` tests to cover both default filtering and opt-in inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c844282aa21bd7367a1667b14a89516d0a8a700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->