### PR TITLE
feat: make object/array feature flags editable in dev override menu

### DIFF
--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -514,17 +514,22 @@ describe('FeatureFlagOverride', () => {
       expect(numberInput).toBeTruthy();
     });
 
-    it('renders View/Edit button for array flags', () => {
+    it('renders JSON TextInput for array flags', () => {
       renderWithProviders();
 
-      expect(screen.getByText('View/Edit')).toBeTruthy();
+      expect(
+        screen.getByDisplayValue(JSON.stringify(['item1', 'item2'], null, 2)),
+      ).toBeTruthy();
     });
 
-    it('renders object properties for object flags', () => {
+    it('renders JSON TextInput for object flags', () => {
       renderWithProviders();
 
-      expect(screen.getByText('key: "value"')).toBeTruthy();
-      expect(screen.getByText('nested: {"prop":"data"}')).toBeTruthy();
+      expect(
+        screen.getByDisplayValue(
+          JSON.stringify({ key: 'value', nested: { prop: 'data' } }, null, 2),
+        ),
+      ).toBeTruthy();
     });
 
     it('renders minimum version info for version-gated flags', () => {
@@ -596,6 +601,77 @@ describe('FeatureFlagOverride', () => {
       fireEvent.press(resetButton);
 
       expect(mockRemoveFlagOverride).toHaveBeenCalledWith('testFlag');
+    });
+
+    it('handles valid JSON input for object flags', () => {
+      renderWithProviders({ objFlag: { key: 'value' } }, {});
+
+      const jsonInput = screen.getByDisplayValue(
+        JSON.stringify({ key: 'value' }, null, 2),
+      );
+      fireEvent.changeText(jsonInput, '{"key":"updated"}');
+      fireEvent(jsonInput, 'endEditing');
+
+      expect(mockSetFlagOverride).toHaveBeenCalledWith('objFlag', {
+        key: 'updated',
+      });
+    });
+
+    it('handles valid JSON input for array flags', () => {
+      renderWithProviders({ arrFlag: ['a', 'b'] }, {});
+
+      const jsonInput = screen.getByDisplayValue(
+        JSON.stringify(['a', 'b'], null, 2),
+      );
+      fireEvent.changeText(jsonInput, '["a","b","c"]');
+      fireEvent(jsonInput, 'endEditing');
+
+      expect(mockSetFlagOverride).toHaveBeenCalledWith('arrFlag', [
+        'a',
+        'b',
+        'c',
+      ]);
+    });
+
+    it('shows error for invalid JSON input', () => {
+      renderWithProviders({ objFlag: { key: 'value' } }, {});
+
+      const jsonInput = screen.getByDisplayValue(
+        JSON.stringify({ key: 'value' }, null, 2),
+      );
+      fireEvent.changeText(jsonInput, '{invalid json}');
+      fireEvent(jsonInput, 'endEditing');
+
+      expect(screen.getByText('Invalid JSON')).toBeTruthy();
+      expect(mockSetFlagOverride).not.toHaveBeenCalled();
+    });
+
+    it('clears JSON error when user types new input', () => {
+      renderWithProviders({ objFlag: { key: 'value' } }, {});
+
+      const jsonInput = screen.getByDisplayValue(
+        JSON.stringify({ key: 'value' }, null, 2),
+      );
+      // First trigger an error
+      fireEvent.changeText(jsonInput, '{invalid}');
+      fireEvent(jsonInput, 'endEditing');
+      expect(screen.getByText('Invalid JSON')).toBeTruthy();
+
+      // Then type new input — error should clear
+      fireEvent.changeText(jsonInput, '{"key":"new"}');
+      expect(screen.queryByText('Invalid JSON')).toBeNull();
+    });
+
+    it('handles reset override for object flags', () => {
+      renderWithProviders(
+        { objFlag: { key: 'original' } },
+        { objFlag: { key: 'overridden' } },
+      );
+
+      const resetButton = screen.getByText('Reset');
+      fireEvent.press(resetButton);
+
+      expect(mockRemoveFlagOverride).toHaveBeenCalledWith('objFlag');
     });
   });
 
@@ -841,15 +917,19 @@ describe('FeatureFlagOverride', () => {
 
       expect(screen.getByText('nestedObj')).toBeTruthy();
       expect(
-        screen.getByText('level1: {"level2":{"deep":"value"}}'),
+        screen.getByDisplayValue(
+          JSON.stringify({ level1: { level2: { deep: 'value' } } }, null, 2),
+        ),
       ).toBeTruthy();
     });
 
-    it('renders array flag with correct label', () => {
+    it('renders array flag with JSON TextInput', () => {
       renderWithProviders({ myArray: [1, 2, 3, 4, 5] }, {});
 
       expect(screen.getByText('myArray')).toBeTruthy();
-      expect(screen.getByText('View/Edit')).toBeTruthy();
+      expect(
+        screen.getByDisplayValue(JSON.stringify([1, 2, 3, 4, 5], null, 2)),
+      ).toBeTruthy();
     });
   });
 

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ScrollView, Alert, TextInput, Switch, View } from 'react-native';
+import { ScrollView, Alert, TextInput, Switch } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -59,6 +59,13 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
   // Track whether a reset is in progress to prevent onEndEditing from
   // reinstating the override with stale closure values
   const isResettingRef = useRef(false);
+  const [jsonText, setJsonText] = useState(() =>
+    flag.type === FeatureFlagType.FeatureFlagObject ||
+    flag.type === FeatureFlagType.FeatureFlagArray
+      ? JSON.stringify(flag.value, null, 2)
+      : '',
+  );
+  const [jsonError, setJsonError] = useState<string | null>(null);
 
   useEffect(() => {
     // Sync localValue with flag.value when the flag is not overridden
@@ -67,8 +74,15 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
     // while preventing race conditions during user input.
     if (!flag.isOverridden && !isEditingRef.current) {
       setLocalValue(flag.value);
+      if (
+        flag.type === FeatureFlagType.FeatureFlagObject ||
+        flag.type === FeatureFlagType.FeatureFlagArray
+      ) {
+        setJsonText(JSON.stringify(flag.value, null, 2));
+        setJsonError(null);
+      }
     }
-  }, [flag.value, flag.isOverridden]);
+  }, [flag.value, flag.isOverridden, flag.type]);
   const minimumVersion = (localValue as MinimumVersionFlagValue)
     ?.minimumVersion;
   const isVersionSupported = useMemo(
@@ -81,6 +95,13 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
     // with stale closure values when the input loses focus due to button press
     isResettingRef.current = true;
     setLocalValue(flag.originalValue);
+    if (
+      flag.type === FeatureFlagType.FeatureFlagObject ||
+      flag.type === FeatureFlagType.FeatureFlagArray
+    ) {
+      setJsonText(JSON.stringify(flag.originalValue, null, 2));
+      setJsonError(null);
+    }
     onToggle(flag.key, null); // null indicates removal of override
   };
 
@@ -254,35 +275,61 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
         );
 
       case FeatureFlagType.FeatureFlagObject:
-        return (
-          <View>
-            {Object.keys((localValue as object) || {}).map(
-              (itemKey: string) => (
-                <Text key={itemKey}>
-                  {itemKey}:{' '}
-                  {JSON.stringify(
-                    (localValue as object)[itemKey as keyof object],
-                  )}
-                </Text>
-              ),
-            )}
-          </View>
-        );
       case FeatureFlagType.FeatureFlagArray:
         return (
-          <Button
-            variant={ButtonVariant.Secondary}
-            size={ButtonSize.Sm}
-            onPress={() => {
-              Alert.alert(
-                `${flag.key} (${flag.type})`,
-                JSON.stringify(localValue, null, 2),
-                [{ text: 'Cancel', style: 'cancel' }],
-              );
-            }}
-          >
-            View/Edit
-          </Button>
+          <Box twClassName="flex-1 mt-2">
+            <TextInput
+              value={jsonText}
+              multiline
+              onFocus={() => {
+                isEditingRef.current = true;
+                isResettingRef.current = false;
+              }}
+              onChangeText={(text) => {
+                setJsonText(text);
+                setJsonError(null);
+              }}
+              onEndEditing={() => {
+                isEditingRef.current = false;
+                if (isResettingRef.current) {
+                  isResettingRef.current = false;
+                  return;
+                }
+                try {
+                  const parsed = JSON.parse(jsonText);
+                  setLocalValue(parsed);
+                  setJsonError(null);
+                  onToggle(flag.key, parsed);
+                } catch {
+                  setJsonError('Invalid JSON');
+                }
+              }}
+              onBlur={() => {
+                isEditingRef.current = false;
+              }}
+              style={[
+                tw.style('border rounded p-2 text-sm font-mono min-h-[80px]'),
+                {
+                  borderColor: jsonError
+                    ? theme.colors.error.default
+                    : theme.colors.border.default,
+                  color: theme.colors.text.default,
+                  backgroundColor: theme.colors.background.default,
+                },
+              ]}
+              placeholder={`Enter JSON ${flag.type}`}
+              placeholderTextColor={theme.colors.text.muted}
+            />
+            {jsonError && (
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.ErrorDefault}
+                twClassName="mt-1"
+              >
+                {jsonError}
+              </Text>
+            )}
+          </Box>
         );
 
       default:
@@ -315,10 +362,13 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
               Original: {JSON.stringify(flag.originalValue)}
             </Text>
           )}
-          {flag.type === 'object' && renderValueEditor()}
+          {(flag.type === 'object' || flag.type === 'array') &&
+            renderValueEditor()}
         </Box>
         <Box twClassName="ml-4 items-end">
-          {flag.type !== 'object' && renderValueEditor()}
+          {flag.type !== 'object' &&
+            flag.type !== 'array' &&
+            renderValueEditor()}
           {flag.isOverridden && (
             <Box twClassName="ml-2 px-2 py-1 my-2 bg-warning-muted rounded">
               <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

The Feature Flag Override dev menu previously only allowed viewing object and array type flags - objects were rendered as a read-only key/value list, and arrays showed a "View/Edit" button that opened a non-editable Alert popup.

This PR replaces both with a multiline JSON `TextInput` so developers can directly edit object and array flag values inline, matching the editing experience already available for boolean, string, and number flags.

Key changes:
- Shared JSON editor for both `FeatureFlagObject` and `FeatureFlagArray` types with `JSON.parse` validation on submit
- Red border + "Invalid JSON" error message when input is malformed
- Monospace font and `minHeight` for comfortable editing of nested structures
- Full-width layout (below flag name) since multiline JSON needs horizontal space
- Proper sync with background config refreshes and reset via existing `isEditingRef` / `isResettingRef` pattern

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Edit object/array feature flags in dev override menu

  Scenario: Developer edits an object feature flag
    Given the Feature Flag Override screen is open
    And an object-type feature flag is visible with its JSON value in a text box

    When the developer taps the JSON text box and changes the value to valid JSON
    Then the flag override is applied and "OVERRIDDEN" badge appears

  Scenario: Developer enters invalid JSON
    Given the Feature Flag Override screen is open
    And an object-type feature flag is visible

    When the developer enters invalid JSON and taps away
    Then the text box shows a red border and "Invalid JSON" error message
    And the flag value is not updated

  Scenario: Developer resets an overridden object flag
    Given the Feature Flag Override screen is open
    And an object-type feature flag is overridden

    When the developer presses the "Reset" button
    Then the JSON text box reverts to the original value
    And the "OVERRIDDEN" badge disappears

  Scenario: Developer edits an array feature flag
    Given the Feature Flag Override screen is open
    And an array-type feature flag is visible with its JSON value in a text box

    When the developer taps the JSON text box and changes the array contents
    Then the flag override is applied and "OVERRIDDEN" badge appears
```

## **Screenshots/Recordings**

### **Before**

<img width="591" height="1280" alt="photo_2026-04-22 11 27 13" src="https://github.com/user-attachments/assets/c0e109e5-f422-4a19-b020-f3063538ade8" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="591" height="1280" alt="photo_2026-04-22 11 27 09" src="https://github.com/user-attachments/assets/a8735837-b6e8-4868-a07e-980d313645ef" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to the feature-flag override dev screen, adding JSON parsing/validation and minor layout updates without affecting production flows or auth/data handling.
> 
> **Overview**
> **Object and array feature flags in the override dev menu are now editable inline.** The previous read-only object rendering and array "View/Edit" alert are replaced with a multiline JSON `TextInput` shared by both types.
> 
> Edits are applied on `onEndEditing` via `JSON.parse`, with a red border + "Invalid JSON" message on parse failures, and the JSON input now stays in sync on background refresh/reset. Tests are updated/added to assert JSON rendering, successful override application, error handling, and reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b34c9fb99a99bf98755ccb839ed2023ef1aa2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->