### PR TITLE
fix: display Banners confetti on empty state

### DIFF
--- a/app/components/UI/Carousel/StackCardEmpty/StackCardEmpty.test.tsx
+++ b/app/components/UI/Carousel/StackCardEmpty/StackCardEmpty.test.tsx
@@ -92,7 +92,9 @@ describe('StackCardEmpty', () => {
     it('calls onTransitionToEmpty after idle timeout', () => {
       render(<StackCardEmpty {...defaultProps} />);
 
-      jest.advanceTimersByTime(ANIMATION_TIMINGS.EMPTY_STATE_IDLE_TIME);
+      // The dismiss timer only starts after the card reaches full visibility
+      // and the confetti-trigger delay (50ms) elapses, so advance past both.
+      jest.advanceTimersByTime(ANIMATION_TIMINGS.EMPTY_STATE_IDLE_TIME + 100);
 
       expect(defaultProps.onTransitionToEmpty).toHaveBeenCalledTimes(1);
     });

--- a/app/components/UI/Carousel/StackCardEmpty/StackCardEmpty.tsx
+++ b/app/components/UI/Carousel/StackCardEmpty/StackCardEmpty.tsx
@@ -36,59 +36,61 @@ export const StackCardEmpty: React.FC<StackCardEmptyProps> = ({
 }) => {
   const tw = useTailwind();
   const riveRef = useRef<RiveRef>(null);
-  const hasTriggeredAnimation = useRef(false);
-  const timeoutIdRef = useRef<NodeJS.Timeout | null>(null);
   const [riveError, setRiveError] = useState(false);
 
-  // Fire the confetti animation when the card transitions to full visibility (becomes current)
-  useEffect(() => {
-    // Use animated value listener to detect when opacity reaches ~1 (fully visible)
-    const listenerId = emptyStateOpacity.addListener(({ value }) => {
-      // Trigger animation when opacity is close to 1 (card is fully visible/current)
-      if (
-        value >= OPACITY_TRIGGER_THRESHOLD &&
-        !hasTriggeredAnimation.current
-      ) {
-        // Clear any existing timeout before creating a new one
-        if (timeoutIdRef.current) {
-          clearTimeout(timeoutIdRef.current);
-        }
+  // Keep the latest callback in a ref so the parent re-rendering (which passes
+  // a new inline arrow each time) doesn't tear down the timers below.
+  const onTransitionToEmptyRef = useRef(onTransitionToEmpty);
+  onTransitionToEmptyRef.current = onTransitionToEmpty;
 
-        timeoutIdRef.current = setTimeout(() => {
-          if (riveRef.current && !hasTriggeredAnimation.current) {
-            try {
-              // Fire the Confetti state machine with "Start" trigger
-              riveRef.current.fireState('Confetti', 'Start');
-              hasTriggeredAnimation.current = true;
-            } catch (error) {
-              console.warn('Error triggering Rive confetti animation:', error);
-            }
-          }
-          timeoutIdRef.current = null;
-        }, CONFETTI_TRIGGER_DELAY);
+  // Fire confetti and start the idle-dismiss timer once the card is fully visible.
+  useEffect(() => {
+    let listenerId: string | null = null;
+    let confettiTimer: NodeJS.Timeout | null = null;
+    let dismissTimer: NodeJS.Timeout | null = null;
+
+    const onVisible = () => {
+      if (listenerId !== null) {
+        emptyStateOpacity.removeListener(listenerId);
+        listenerId = null;
       }
+
+      confettiTimer = setTimeout(() => {
+        try {
+          riveRef.current?.fireState('Confetti', 'Start');
+        } catch (error) {
+          console.warn('Error triggering Rive confetti animation:', error);
+        }
+      }, CONFETTI_TRIGGER_DELAY);
+
+      dismissTimer = setTimeout(
+        () => onTransitionToEmptyRef.current?.(),
+        CONFETTI_TRIGGER_DELAY + ANIMATION_TIMINGS.EMPTY_STATE_IDLE_TIME,
+      );
+    };
+
+    listenerId = emptyStateOpacity.addListener(({ value }) => {
+      if (value >= OPACITY_TRIGGER_THRESHOLD) onVisible();
     });
 
+    // addListener doesn't fire with the current value; handle the case where
+    // the card mounts already at full opacity.
+    const initialValue = (
+      emptyStateOpacity as Animated.Value & { __getValue?: () => number }
+    ).__getValue?.();
+    if (
+      typeof initialValue === 'number' &&
+      initialValue >= OPACITY_TRIGGER_THRESHOLD
+    ) {
+      onVisible();
+    }
+
     return () => {
-      emptyStateOpacity.removeListener(listenerId);
-      // Clear any pending timeout when the effect cleanup runs
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current);
-        timeoutIdRef.current = null;
-      }
+      if (listenerId !== null) emptyStateOpacity.removeListener(listenerId);
+      if (confettiTimer) clearTimeout(confettiTimer);
+      if (dismissTimer) clearTimeout(dismissTimer);
     };
   }, [emptyStateOpacity]);
-
-  // Auto-dismiss empty card after 2000ms when rendered
-  useEffect(() => {
-    if (onTransitionToEmpty) {
-      const timer = setTimeout(() => {
-        onTransitionToEmpty();
-      }, ANIMATION_TIMINGS.EMPTY_STATE_IDLE_TIME);
-
-      return () => clearTimeout(timer);
-    }
-  }, [onTransitionToEmpty]);
 
   return (
     <Animated.View


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When all carousel banners were dismissed, the "You're all caught up!" empty state had two bugs:

Confetti never played. The parent carousel swaps emptyStateOpacity to a brand-new Animated.Value that is already animated to 1 by the time StackCardEmpty mounts. Animated.Value.addListener only fires on subsequent changes, not on the initial value, so the confetti trigger (and the dismiss timer) were never scheduled.

Dismiss timer fired too early. The auto-dismiss useEffect ran on mount unconditionally, so the card started counting down to dismissal before it had finished animating in, making the "all caught up" message disappear almost immediately.

Fix: Both effects were merged into one. An addListener is registered as before, but right after subscribing the current value of emptyStateOpacity is read via __getValue() and checked against the threshold immediately. If the card is already fully visible on mount, onVisible() is called synchronously — triggering confetti and starting the dismiss timer in one shot. The listener self-unsubscribes after firing so it cannot trigger twice. The dismiss timer is chained after the confetti delay (CONFETTI_TRIGGER_DELAY + EMPTY_STATE_IDLE_TIME) so the card stays visible long enough for the animation to play. The latest onTransitionToEmpty callback is tracked in a ref so parent re-renders (which pass a new arrow function each time) never cause the effect to tear down and restart mid-flight.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timer/listener lifecycle around the empty-state card, which could affect dismissal timing and animation firing if opacity/listeners behave unexpectedly across platforms. Scope is limited to UI/animation behavior with cleanup improvements.
> 
> **Overview**
> Ensures the empty-state confetti and auto-dismiss only start once the empty-state card reaches (near) full opacity, instead of starting immediately on render.
> 
> Refactors `StackCardEmpty` to use a single opacity listener with explicit cleanup, schedules confetti and dismissal timers off the visibility event (including handling when the component mounts already visible), and stabilizes `onTransitionToEmpty` via a ref to avoid timer teardown on parent re-renders. Updates the unit test to advance timers past the new visibility/confetti delay before asserting dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab12bcaeb08ec847b7277e60d1b76838f727498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->