### PR TITLE
fix: max mUSD conversion displays wrong value

### DIFF
--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -391,7 +391,6 @@ export const NETWORK_CHAIN_ID: {
   readonly TEMPO_MAINNET: '0x1079';
   readonly CHILIZ: '0x15b38';
   readonly STABLE_MAINNET: '0x3dc';
-  readonly MANTLE: '0x1388';
 } & typeof CHAIN_IDS = {
   FLARE_MAINNET: '0xe',
   SONGBIRD_TESTNET: '0x13',
@@ -438,7 +437,6 @@ export const NETWORK_CHAIN_ID: {
   TEMPO_MAINNET: '0x1079',
   CHILIZ: '0x15b38',
   STABLE_MAINNET: '0x3dc',
-  MANTLE: '0x1388',
   ...CHAIN_IDS,
 };
 

--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^64.2.0",
-    "@metamask/transaction-pay-controller": "^19.1.1",
+    "@metamask/transaction-pay-controller": "^19.2.1",
     "@metamask/tron-wallet-snap": "^1.25.2",
     "@metamask/utils": "^11.11.0",
     "@myx-trade/sdk": "^0.1.265",

--- a/package.json
+++ b/package.json
@@ -198,7 +198,9 @@
     "expo-web-browser@npm:~14.0.2": "patch:expo-web-browser@npm%3A14.0.2#~/.yarn/patches/expo-web-browser-npm-14.0.2-98d00ce880.patch",
     "@metamask/messenger@^0.3.0": "^1.0.0",
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/profile-sync-controller": "^28.0.2"
+    "@metamask/profile-sync-controller": "^28.0.2",
+    "@metamask/transaction-controller@^63.0.0": "^64.2.0",
+    "@metamask/transaction-controller@^63.3.1": "^64.2.0"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",

--- a/patches/@metamask+transaction-pay-controller+19.2.1.patch
+++ b/patches/@metamask+transaction-pay-controller+19.2.1.patch
@@ -1,0 +1,80 @@
+diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
+index 66884ed..3763145 100644
+--- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
++++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
+@@ -238,7 +238,13 @@ exports.getPayStrategiesConfig = getPayStrategiesConfig;
+ function isRelayExecuteEnabled(messenger) {
+     const state = messenger.call('RemoteFeatureFlagController:getState');
+     const featureFlags = state.remoteFeatureFlags?.confirmations_pay ?? {};
+-    return featureFlags.payStrategies?.relay?.executeEnabled ?? false;
++    // Read from `gaslessEnabled` instead of `executeEnabled`. The original
++    // flag name predates per-version gating in the feature flag service, so
++    // any previously shipped client that only looks at `executeEnabled` would
++    // re-enable the flow on older, broken builds as soon as the flag is
++    // turned on. Renaming the key here ensures only clients carrying this
++    // patch (i.e. >=19.2.1) pick up the flag.
++    return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
+ }
+ exports.isRelayExecuteEnabled = isRelayExecuteEnabled;
+ /**
+diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
+index c8b2f8a..c7122c6 100644
+--- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
++++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
+@@ -232,7 +232,13 @@ export function getPayStrategiesConfig(messenger) {
+ export function isRelayExecuteEnabled(messenger) {
+     const state = messenger.call('RemoteFeatureFlagController:getState');
+     const featureFlags = state.remoteFeatureFlags?.confirmations_pay ?? {};
+-    return featureFlags.payStrategies?.relay?.executeEnabled ?? false;
++    // Read from `gaslessEnabled` instead of `executeEnabled`. The original
++    // flag name predates per-version gating in the feature flag service, so
++    // any previously shipped client that only looks at `executeEnabled` would
++    // re-enable the flow on older, broken builds as soon as the flag is
++    // turned on. Renaming the key here ensures only clients carrying this
++    // patch (i.e. >=19.2.1) pick up the flag.
++    return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
+ }
+ /**
+  * Get the origin gas overhead to include in Relay quote requests
+diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
+index 0ef444d..a23a5e6 100644
+--- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
++++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
+@@ -41,7 +41,15 @@ export type PayStrategiesConfigRaw = {
+     across?: AcrossConfigRaw;
+     relay?: {
+         enabled?: boolean;
+-        executeEnabled?: boolean;
++        /**
++         * Renamed from `executeEnabled`. The original flag name predates
++         * per-version gating in the feature flag service, so older clients
++         * that only recognise `executeEnabled` would re-enable the Relay
++         * /execute gasless flow on previously broken builds as soon as the
++         * flag is toggled on. This patched name is only read by clients
++         * carrying the rename patch (i.e. >=19.2.1).
++         */
++        gaslessEnabled?: boolean;
+         originGasOverhead?: string;
+         pollingInterval?: number;
+         pollingTimeout?: number;
+diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
+index e08336e..42ade48 100644
+--- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
++++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
+@@ -41,7 +41,15 @@ export type PayStrategiesConfigRaw = {
+     across?: AcrossConfigRaw;
+     relay?: {
+         enabled?: boolean;
+-        executeEnabled?: boolean;
++        /**
++         * Renamed from `executeEnabled`. The original flag name predates
++         * per-version gating in the feature flag service, so older clients
++         * that only recognise `executeEnabled` would re-enable the Relay
++         * /execute gasless flow on previously broken builds as soon as the
++         * flag is toggled on. This patched name is only read by clients
++         * carrying the rename patch (i.e. >=19.2.1).
++         */
++        gaslessEnabled?: boolean;
+         originGasOverhead?: string;
+         pollingInterval?: number;
+         pollingTimeout?: number;

--- a/patches/@metamask+transaction-pay-controller+19.2.1.patch
+++ b/patches/@metamask+transaction-pay-controller+19.2.1.patch
@@ -1,79 +1,52 @@
 diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
-index 66884ed..3763145 100644
+index 66884ed..d475de2 100644
 --- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
 +++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.cjs
-@@ -238,7 +238,13 @@ exports.getPayStrategiesConfig = getPayStrategiesConfig;
+@@ -238,7 +238,8 @@ exports.getPayStrategiesConfig = getPayStrategiesConfig;
  function isRelayExecuteEnabled(messenger) {
      const state = messenger.call('RemoteFeatureFlagController:getState');
      const featureFlags = state.remoteFeatureFlags?.confirmations_pay ?? {};
 -    return featureFlags.payStrategies?.relay?.executeEnabled ?? false;
-+    // Read from `gaslessEnabled` instead of `executeEnabled`. The original
-+    // flag name predates per-version gating in the feature flag service, so
-+    // any previously shipped client that only looks at `executeEnabled` would
-+    // re-enable the flow on older, broken builds as soon as the flag is
-+    // turned on. Renaming the key here ensures only clients carrying this
-+    // patch (i.e. >=19.2.1) pick up the flag.
++    // Renamed from `executeEnabled` so the flag cannot re-enable the flow on older broken versions (predates version support).
 +    return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
  }
  exports.isRelayExecuteEnabled = isRelayExecuteEnabled;
  /**
 diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
-index c8b2f8a..c7122c6 100644
+index c8b2f8a..5ab03a9 100644
 --- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
 +++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.mjs
-@@ -232,7 +232,13 @@ export function getPayStrategiesConfig(messenger) {
+@@ -232,7 +232,7 @@ export function getPayStrategiesConfig(messenger) {
  export function isRelayExecuteEnabled(messenger) {
      const state = messenger.call('RemoteFeatureFlagController:getState');
      const featureFlags = state.remoteFeatureFlags?.confirmations_pay ?? {};
 -    return featureFlags.payStrategies?.relay?.executeEnabled ?? false;
-+    // Read from `gaslessEnabled` instead of `executeEnabled`. The original
-+    // flag name predates per-version gating in the feature flag service, so
-+    // any previously shipped client that only looks at `executeEnabled` would
-+    // re-enable the flow on older, broken builds as soon as the flag is
-+    // turned on. Renaming the key here ensures only clients carrying this
-+    // patch (i.e. >=19.2.1) pick up the flag.
 +    return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
  }
  /**
   * Get the origin gas overhead to include in Relay quote requests
 diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
-index 0ef444d..a23a5e6 100644
+index 0ef444d..0538026 100644
 --- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
 +++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.cts
-@@ -41,7 +41,15 @@ export type PayStrategiesConfigRaw = {
+@@ -41,7 +41,7 @@ export type PayStrategiesConfigRaw = {
      across?: AcrossConfigRaw;
      relay?: {
          enabled?: boolean;
 -        executeEnabled?: boolean;
-+        /**
-+         * Renamed from `executeEnabled`. The original flag name predates
-+         * per-version gating in the feature flag service, so older clients
-+         * that only recognise `executeEnabled` would re-enable the Relay
-+         * /execute gasless flow on previously broken builds as soon as the
-+         * flag is toggled on. This patched name is only read by clients
-+         * carrying the rename patch (i.e. >=19.2.1).
-+         */
 +        gaslessEnabled?: boolean;
          originGasOverhead?: string;
          pollingInterval?: number;
          pollingTimeout?: number;
 diff --git a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
-index e08336e..42ade48 100644
+index e08336e..8dd8f42 100644
 --- a/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
 +++ b/node_modules/@metamask/transaction-pay-controller/dist/utils/feature-flags.d.mts
-@@ -41,7 +41,15 @@ export type PayStrategiesConfigRaw = {
+@@ -41,7 +41,7 @@ export type PayStrategiesConfigRaw = {
      across?: AcrossConfigRaw;
      relay?: {
          enabled?: boolean;
 -        executeEnabled?: boolean;
-+        /**
-+         * Renamed from `executeEnabled`. The original flag name predates
-+         * per-version gating in the feature flag service, so older clients
-+         * that only recognise `executeEnabled` would re-enable the Relay
-+         * /execute gasless flow on previously broken builds as soon as the
-+         * flag is toggled on. This patched name is only read by clients
-+         * carrying the rename patch (i.e. >=19.2.1).
-+         */
 +        gaslessEnabled?: boolean;
          originGasOverhead?: string;
          pollingInterval?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7777,6 +7777,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/account-tree-controller@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@metamask/account-tree-controller@npm:7.1.0"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^37.2.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/keyring-api": "npm:^21.6.0"
+    "@metamask/keyring-controller": "npm:^25.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/multichain-account-service": "npm:^8.0.1"
+    "@metamask/profile-sync-controller": "npm:^28.0.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/e27b60d874408480567f5e39f60354aed08f2a924f74088786525fa1183c05850e0cb81daa62fa76846384d2f2be999f8800214aca39732b6856f69edb709a5e
+  languageName: node
+  linkType: hard
+
 "@metamask/accounts-controller@npm:^37.2.0":
   version: 37.2.0
   resolution: "@metamask/accounts-controller@npm:37.2.0"
@@ -7957,6 +7982,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/assets-controller@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/assets-controller@npm:6.0.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/account-tree-controller": "npm:^7.1.0"
+    "@metamask/accounts-controller": "npm:^37.2.0"
+    "@metamask/assets-controllers": "npm:^104.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/client-controller": "npm:^1.0.1"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/core-backend": "npm:^6.2.1"
+    "@metamask/keyring-api": "npm:^21.6.0"
+    "@metamask/keyring-controller": "npm:^25.2.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-snap-client": "npm:^8.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/network-controller": "npm:^30.0.1"
+    "@metamask/network-enablement-controller": "npm:^5.0.2"
+    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/phishing-controller": "npm:^17.1.1"
+    "@metamask/polling-controller": "npm:^16.0.4"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/transaction-controller": "npm:^64.2.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/f7c008e6090a7909ad159023f46470292dcb22a7235aa76022d1bf93cb4273a6a9cf2acf82ecc9324c882a9dfdec73b4cb2cb73cfc27b67a569fdc1fe912fc51
+  languageName: node
+  linkType: hard
+
 "@metamask/assets-controllers@npm:^103.1.0, @metamask/assets-controllers@npm:^103.1.1":
   version: 103.1.1
   resolution: "@metamask/assets-controllers@npm:103.1.1"
@@ -8010,6 +8072,62 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/c23cc1fc680f50dd3a0801b5afc4ef8ad9a950274b64f91aecee6c22f17b4336f6c6b11913ae81351992eb634d87e1115f30d726bd4739ac38c66cb9989e288b
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@npm:^104.0.0":
+  version: 104.2.0
+  resolution: "@metamask/assets-controllers@npm:104.2.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/account-tree-controller": "npm:^7.1.0"
+    "@metamask/accounts-controller": "npm:^37.2.0"
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/contract-metadata": "npm:^2.4.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/core-backend": "npm:^6.2.1"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/keyring-api": "npm:^23.0.1"
+    "@metamask/keyring-controller": "npm:^25.2.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-account-service": "npm:^8.0.1"
+    "@metamask/network-controller": "npm:^30.0.1"
+    "@metamask/network-enablement-controller": "npm:^5.0.2"
+    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/phishing-controller": "npm:^17.1.1"
+    "@metamask/polling-controller": "npm:^16.0.4"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/profile-sync-controller": "npm:^28.0.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/storage-service": "npm:^1.0.1"
+    "@metamask/transaction-controller": "npm:^64.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@types/bn.js": "npm:^5.1.5"
+    "@types/uuid": "npm:^8.3.0"
+    async-mutex: "npm:^0.5.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+    multiformats: "npm:^9.9.0"
+    reselect: "npm:^5.1.1"
+    single-call-balance-checker-abi: "npm:^1.0.0"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/429228b49d64c6f8bc4452e0eb9ce73d621a3a72d6c57b35f8131c4d26870d93ce874b2da0e990f8dc41059a417c16a6709c9d99263b37d6f0f1a396a447232f
   languageName: node
   linkType: hard
 
@@ -8125,6 +8243,39 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/90c878f80638f2fe271fc7c900e93a24e23c656155e7745fd8fa61123c615587ed054e8c9afd590285590d284b7aacd9d72eee83f4cef2b6b26e1d8b60fcaaf1
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-controller@npm:^70.1.1":
+  version: 70.1.1
+  resolution: "@metamask/bridge-controller@npm:70.1.1"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^37.2.0"
+    "@metamask/assets-controller": "npm:^6.0.0"
+    "@metamask/assets-controllers": "npm:^104.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/gas-fee-controller": "npm:^26.1.1"
+    "@metamask/keyring-api": "npm:^21.6.0"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.0.6"
+    "@metamask/network-controller": "npm:^30.0.1"
+    "@metamask/polling-controller": "npm:^16.0.4"
+    "@metamask/profile-sync-controller": "npm:^28.0.2"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/transaction-controller": "npm:^64.2.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/d906b6ad4086caf9833b2c8fb53a509808ef3fb6c835f54837ee054fe800c0972692b6f772f0e762724dd745f84dd28ecd621e3c6efacf58df9ffb098153aca8
   languageName: node
   linkType: hard
 
@@ -8974,6 +9125,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/keyring-api@npm:^23.0.1":
+  version: 23.0.1
+  resolution: "@metamask/keyring-api@npm:23.0.1"
+  dependencies:
+    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+  checksum: 10/a74f302edda5035f999b714f16ee4934f757695bfd47414932efc34ba14d5e10d37c6632c49ee0cf19cb83729bf453bddb1367ccf1affeb7b92400b2bd6ca105
+  languageName: node
+  linkType: hard
+
 "@metamask/keyring-controller@npm:^25.1.0, @metamask/keyring-controller@npm:^25.1.1, @metamask/keyring-controller@npm:^25.2.0":
   version: 25.2.0
   resolution: "@metamask/keyring-controller@npm:25.2.0"
@@ -9626,7 +9789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^13.1.0, @metamask/ramps-controller@npm:^13.2.0":
+"@metamask/ramps-controller@npm:^13.2.0":
   version: 13.2.0
   resolution: "@metamask/ramps-controller@npm:13.2.0"
   dependencies:
@@ -10352,32 +10515,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^19.1.1":
-  version: 19.1.1
-  resolution: "@metamask/transaction-pay-controller@npm:19.1.1"
+"@metamask/transaction-controller@npm:^64.3.0":
+  version: 64.3.0
+  resolution: "@metamask/transaction-controller@npm:64.3.0"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^37.2.0"
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/core-backend": "npm:^6.2.1"
+    "@metamask/gas-fee-controller": "npm:^26.1.1"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^30.0.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/80d83bf63abb4071b45ff38da626c3465a34723d6bb58f19f529df8facf6c9ac7d8c692e9897828cab36f0bd46d95421363455c7c1aca3cda66bc2148a00cfae
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-pay-controller@npm:^19.2.1":
+  version: 19.2.1
+  resolution: "@metamask/transaction-pay-controller@npm:19.2.1"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controller": "npm:^5.0.0"
-    "@metamask/assets-controllers": "npm:^103.1.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/bridge-controller": "npm:^70.0.1"
+    "@metamask/assets-controller": "npm:^6.0.0"
+    "@metamask/assets-controllers": "npm:^104.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^70.1.1"
     "@metamask/bridge-status-controller": "npm:^70.0.5"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/gas-fee-controller": "npm:^26.1.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/ramps-controller": "npm:^13.1.0"
+    "@metamask/ramps-controller": "npm:^13.2.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
-    "@metamask/transaction-controller": "npm:^64.2.0"
+    "@metamask/transaction-controller": "npm:^64.3.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/e233f86d06d6436faaf0efe3a2897bc71f33d3a02413428f6c2932e634d2224aaabcf01e4c3a63c84ce83449bcc0e04a1535fbdde97a7c00621588d3822c27a7
+  checksum: 10/9eee9ad75797529fa0d525a0cd917a0000a70c7540319df60f58d7176f4533f73770ac568cbe3948e1f68eca134f927d69c920e482cee4bbcf7f84acf9254c8e
   languageName: node
   linkType: hard
 
@@ -35959,7 +36160,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^64.2.0"
-    "@metamask/transaction-pay-controller": "npm:^19.1.1"
+    "@metamask/transaction-pay-controller": "npm:^19.2.1"
     "@metamask/tron-wallet-snap": "npm:^1.25.2"
     "@metamask/utils": "npm:^11.11.0"
     "@myx-trade/sdk": "npm:^0.1.265"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7752,32 +7752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@metamask/account-tree-controller@npm:7.0.0"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^37.1.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/keyring-api": "npm:^21.6.0"
-    "@metamask/keyring-controller": "npm:^25.1.1"
-    "@metamask/messenger": "npm:^1.0.0"
-    "@metamask/multichain-account-service": "npm:^8.0.1"
-    "@metamask/profile-sync-controller": "npm:^28.0.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-    fast-deep-equal: "npm:^3.1.3"
-    lodash: "npm:^4.17.21"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/d5383892f0962e7ea9d6215992a0a7de918cdf4009cc53f51baa0dae3d4f4e428d3ca3a6931e0919b3ac9ac9d1f1ec7f3ecae211bdafca00c34b1edd35046e27
-  languageName: node
-  linkType: hard
-
-"@metamask/account-tree-controller@npm:^7.1.0":
+"@metamask/account-tree-controller@npm:^7.0.0, @metamask/account-tree-controller@npm:^7.1.0":
   version: 7.1.0
   resolution: "@metamask/account-tree-controller@npm:7.1.0"
   dependencies:
@@ -7907,42 +7882,6 @@ __metadata:
     "@metamask/utils": "npm:^11.9.0"
     nanoid: "npm:^3.3.8"
   checksum: 10/980e7ded7022a887c11693226922f9814d160c93fe5297380addafebe9b6e9191ba3acc7bf54775c8c8eeb7e07bcfcaaf79cc90361ff18fa04c1d449eab2ed33
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controller@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/assets-controller@npm:4.0.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/account-tree-controller": "npm:^7.0.0"
-    "@metamask/assets-controllers": "npm:^103.1.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/client-controller": "npm:^1.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/core-backend": "npm:^6.2.1"
-    "@metamask/keyring-api": "npm:^21.6.0"
-    "@metamask/keyring-controller": "npm:^25.1.1"
-    "@metamask/keyring-internal-api": "npm:^10.0.0"
-    "@metamask/keyring-snap-client": "npm:^8.2.0"
-    "@metamask/messenger": "npm:^1.0.0"
-    "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/network-enablement-controller": "npm:^5.0.2"
-    "@metamask/permission-controller": "npm:^12.3.0"
-    "@metamask/phishing-controller": "npm:^17.1.1"
-    "@metamask/polling-controller": "npm:^16.0.4"
-    "@metamask/preferences-controller": "npm:^23.1.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/transaction-controller": "npm:^64.0.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-  checksum: 10/4d717c04b6bc3446655b360990017af9081df3cee7025d51a1b522551c86f99a997de3bda1300e28aef59210727483ed2c029a19dda73f262c1ed15b9fb36362
   languageName: node
   linkType: hard
 
@@ -8213,40 +8152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^70.0.0, @metamask/bridge-controller@npm:^70.0.1":
-  version: 70.0.1
-  resolution: "@metamask/bridge-controller@npm:70.0.1"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^37.1.1"
-    "@metamask/assets-controller": "npm:^4.0.0"
-    "@metamask/assets-controllers": "npm:^103.1.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/gas-fee-controller": "npm:^26.1.1"
-    "@metamask/keyring-api": "npm:^21.6.0"
-    "@metamask/messenger": "npm:^1.0.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.0.6"
-    "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/polling-controller": "npm:^16.0.4"
-    "@metamask/profile-sync-controller": "npm:^28.0.2"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^64.0.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/90c878f80638f2fe271fc7c900e93a24e23c656155e7745fd8fa61123c615587ed054e8c9afd590285590d284b7aacd9d72eee83f4cef2b6b26e1d8b60fcaaf1
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-controller@npm:^70.1.1":
+"@metamask/bridge-controller@npm:^70.0.0, @metamask/bridge-controller@npm:^70.0.1, @metamask/bridge-controller@npm:^70.1.1":
   version: 70.1.1
   resolution: "@metamask/bridge-controller@npm:70.1.1"
   dependencies:
@@ -10438,84 +10344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^63.0.0, @metamask/transaction-controller@npm:^63.3.1":
-  version: 63.3.1
-  resolution: "@metamask/transaction-controller@npm:63.3.1"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^37.1.0"
-    "@metamask/approval-controller": "npm:^9.0.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/core-backend": "npm:^6.2.1"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/gas-fee-controller": "npm:^26.1.1"
-    "@metamask/messenger": "npm:^1.0.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/0e661e59a00595258d01a3de9dbee7529899234f2f10d315cbfd92cccfdc692af5c3f573b8dcbe7b2fc05a35e060c9f6b5f573cb38d046657b7fb79a4d24d6dc
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@npm:^64.0.0, @metamask/transaction-controller@npm:^64.2.0":
-  version: 64.2.0
-  resolution: "@metamask/transaction-controller@npm:64.2.0"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^37.2.0"
-    "@metamask/approval-controller": "npm:^9.0.1"
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/core-backend": "npm:^6.2.1"
-    "@metamask/gas-fee-controller": "npm:^26.1.1"
-    "@metamask/messenger": "npm:^1.1.1"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^30.0.1"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/30fecb0deab98befde5cbdef1368a089ca4a636abea8734ee14cf8020214deda0ea3f00bc552aaecff6a8d1d07b9e83b369078fdef3c19ad8443e2c0369b4325
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@npm:^64.3.0":
+"@metamask/transaction-controller@npm:^64.0.0, @metamask/transaction-controller@npm:^64.2.0, @metamask/transaction-controller@npm:^64.3.0":
   version: 64.3.0
   resolution: "@metamask/transaction-controller@npm:64.3.0"
   dependencies:


### PR DESCRIPTION
## **Description**

Fixes the max mUSD conversion showing an inflated receive amount. Relay previously charged a fee and reimbursed it on the destination side; they have since stopped charging the fee, so our compensating adjustment now over-reports the received value.

Bumps `@metamask/transaction-pay-controller` from `^19.1.1` to `^19.2.1`, which stops double-counting the subsidised fee in Relay quote target amounts, and patches the installed package to rename the Relay gasless feature flag from `executeEnabled` to `gaslessEnabled` so older, known-broken versions cannot be re-enabled by the flag (which predates per-version gating).

## **Changelog**

CHANGELOG entry: Fixed max mUSD conversion displaying an inflated receive amount.

## **Related issues**

Fixes: #29173

## **Manual testing steps**

```gherkin
Feature: Max mUSD conversion displays correct value

  Scenario: user converts max USDC to mUSD
    Given a 7.74 build with this patch installed
    And the user holds some USDC
    When the user taps max on the mUSD conversion screen
    Then the displayed mUSD receive amount matches the USDC balance (no inflation)
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core transaction/pay controller dependencies and applies a patch that changes which remote feature flag enables Relay gasless execution, which could affect pay/quote flows if flag configuration or dependency behavior differs from expectations.
> 
> **Overview**
> Fixes an inflated “max” conversion receive amount by bumping `@metamask/transaction-pay-controller` to `^19.2.1` (and aligning related controller versions via `yarn.lock`/resolutions).
> 
> Adds a patch to `@metamask/transaction-pay-controller` that switches the Relay enablement check from `confirmations_pay.payStrategies.relay.executeEnabled` to `...relay.gaslessEnabled`, preventing older broken builds from being re-enabled by the previous flag name.
> 
> Separately removes the locally-defined `MANTLE` entry from `NETWORK_CHAIN_ID` in `customNetworks.tsx` (relying on `CHAIN_IDS` for it instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e50b979d91f3ccc11d658776c1f1c65f11d8f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->