### PR TITLE
feat(money): card linking homepage state (MUSD-609)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -19,6 +19,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import MOCK_MONEY_TRANSACTIONS from '../../constants/mockActivityData';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { selectIsCardholder } from '../../../../../selectors/cardController';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
@@ -61,6 +62,13 @@ jest.mock('../../hooks/useMoneyAccountBalance', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+
+jest.mock('../../../../../selectors/cardController', () => ({
+  ...jest.requireActual('../../../../../selectors/cardController'),
+  selectIsCardholder: jest.fn(),
+}));
+
+const mockSelectIsCardholder = jest.mocked(selectIsCardholder);
 
 const mockUseMoneyAccountTransactions = jest.mocked(
   useMoneyAccountTransactions,
@@ -106,6 +114,8 @@ jest.mock('../../../../UI/AssetOverview/Balance/Balance', () => ({
 describe('MoneyHomeView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockSelectIsCardholder.mockReturnValue(false);
 
     mockUseMoneyAccountBalance.mockReturnValue({
       totalFiatFormatted: '$3.00',
@@ -291,6 +301,101 @@ describe('MoneyHomeView', () => {
     it('renders the MetaMask Card section', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(getByTestId(MoneyMetaMaskCardTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+  });
+
+  describe('card-unlinked state (milestone + has cardholder)', () => {
+    beforeEach(() => {
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: Array.from({ length: 3 }, (_, index) => ({
+          ...MOCK_MONEY_TRANSACTIONS[index % MOCK_MONEY_TRANSACTIONS.length],
+          id: `card-unlinked-${index}`,
+        })),
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+      });
+      mockSelectIsCardholder.mockReturnValue(true);
+    });
+
+    it('renders onboarding card with step 2 and link-card variant', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.STEP_LABEL),
+      ).toHaveTextContent('Step 2 of 2');
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders MetaMask Card section in link mode', () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <MoneyHomeView />,
+      );
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders the balance summary section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyBalanceSummaryTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders the action button row', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyActionButtonRowTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders the earnings section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyEarningsTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it('renders the activity list', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyActivityListTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it('renders condensed info cards', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyCondensedInfoCardsTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders the potential earnings section', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides expanded HowItWorks section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides expanded WhatYouGet section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders the footer', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(getByTestId(MoneyFooterTestIds.CONTAINER)).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -17,6 +17,7 @@ import { MoneyActivityListTestIds } from '../../components/MoneyActivityList/Mon
 import { MoneyCondensedInfoCardsTestIds } from '../../components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
+import { strings } from '../../../../../../locales/i18n';
 import MOCK_MONEY_TRANSACTIONS from '../../constants/mockActivityData';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import { selectIsCardholder } from '../../../../../selectors/cardController';
@@ -324,9 +325,9 @@ describe('MoneyHomeView', () => {
       expect(
         getByTestId(MoneyOnboardingCardTestIds.STEP_LABEL),
       ).toHaveTextContent('Step 2 of 2');
-      expect(
-        getByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
-      ).toBeOnTheScreen();
+      expect(getByTestId(MoneyOnboardingCardTestIds.TITLE)).toHaveTextContent(
+        strings('money.onboarding.link_card_title'),
+      );
     });
 
     it('renders MetaMask Card section in link mode', () => {

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -115,6 +115,7 @@ jest.mock('../../../../UI/AssetOverview/Balance/Balance', () => ({
 describe('MoneyHomeView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    global.alert = jest.fn();
 
     mockSelectIsCardholder.mockReturnValue(false);
 
@@ -303,6 +304,13 @@ describe('MoneyHomeView', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(getByTestId(MoneyMetaMaskCardTestIds.CONTAINER)).toBeOnTheScreen();
     });
+
+    it('fires handleCardPress when onboarding CTA is tapped', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(() => {
+        fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
+      }).not.toThrow();
+    });
   });
 
   describe('card-unlinked state (milestone + has cardholder)', () => {
@@ -398,6 +406,13 @@ describe('MoneyHomeView', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(getByTestId(MoneyFooterTestIds.CONTAINER)).toBeOnTheScreen();
     });
+
+    it('fires handleLinkCardPress when onboarding CTA is tapped', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(() => {
+        fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
+      }).not.toThrow();
+    });
   });
 
   describe('empty state (0 transactions)', () => {
@@ -440,6 +455,13 @@ describe('MoneyHomeView', () => {
     it('renders expanded WhatYouGet section', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(getByTestId(MoneyWhatYouGetTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it('fires handleAddPress when onboarding CTA is tapped', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(() => {
+        fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
+      }).not.toThrow();
     });
   });
 });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { ScrollView, Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import MoneyHeader from '../../components/MoneyHeader';
@@ -29,6 +30,7 @@ import { MUSD_MAINNET_ASSET_FOR_DETAILS } from '../../../../Views/Homepage/Secti
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import AppConstants from '../../../../../core/AppConstants';
 import NavigationService from '../../../../../core/NavigationService';
+import { selectIsCardholder } from '../../../../../selectors/cardController';
 
 const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
 
@@ -55,8 +57,11 @@ const MoneyHomeView = () => {
   const { tokens: conversionTokens } = useMusdConversionTokens();
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
 
+  const isCardholder = useSelector(selectIsCardholder);
+
   const homeState = getMoneyHomeState(allTransactions.length);
   const isMilestone = homeState === 'milestone' || homeState === 'filled';
+  const isCardUnlinked = isMilestone && isCardholder;
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -70,6 +75,7 @@ const MoneyHomeView = () => {
   const handleApyInfoPress = displayUnderConstructionAlert;
   const handleProjectedEarningsPress = displayUnderConstructionAlert;
   const handleGetNowPress = displayUnderConstructionAlert;
+  const handleLinkCardPress = displayUnderConstructionAlert;
   const handleMusdRowPress = useCallback(() => {
     NavigationService.navigation.navigate('Asset', {
       ...MUSD_MAINNET_ASSET_FOR_DETAILS,
@@ -130,6 +136,7 @@ const MoneyHomeView = () => {
         />
         <MoneyOnboardingCard
           currentStep={isMilestone ? 2 : 1}
+          variant={isCardUnlinked ? 'link-card' : 'get-card'}
           onCtaPress={isMilestone ? handleCardPress : handleAddPress}
         />
         <Divider />
@@ -175,8 +182,10 @@ const MoneyHomeView = () => {
           </>
         )}
         <MoneyMetaMaskCard
+          mode={isCardUnlinked ? 'link' : 'upsell'}
           onGetNowPress={handleGetNowPress}
           onHeaderPress={handleHeaderPress}
+          onLinkPress={handleLinkCardPress}
         />
         <Divider />
         {isMilestone && (

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -104,12 +104,25 @@ const MoneyHomeView = () => {
     showMoneyActivityUnderConstructionAlert();
   }, []);
 
-  let onboardingCtaPress = handleAddPress;
-  if (isCardUnlinked) {
-    onboardingCtaPress = handleLinkCardPress;
-  } else if (isMilestone) {
-    onboardingCtaPress = handleCardPress;
-  }
+  const handleOnboardingCtaPress = useCallback(() => {
+    if (isCardUnlinked) {
+      handleLinkCardPress();
+      return;
+    }
+
+    if (isMilestone) {
+      handleCardPress();
+      return;
+    }
+
+    handleAddPress();
+  }, [
+    isCardUnlinked,
+    isMilestone,
+    handleLinkCardPress,
+    handleCardPress,
+    handleAddPress,
+  ]);
 
   // TODO: Remove before launch
   // Useful for testing how zero and non-zero APYs are handled quickly.
@@ -144,7 +157,7 @@ const MoneyHomeView = () => {
         <MoneyOnboardingCard
           currentStep={isMilestone ? 2 : 1}
           variant={isCardUnlinked ? 'link-card' : 'get-card'}
-          onCtaPress={onboardingCtaPress}
+          onCtaPress={handleOnboardingCtaPress}
         />
         <Divider />
         <MoneyEarnings onProjectedPress={handleProjectedEarningsPress} />

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -104,6 +104,13 @@ const MoneyHomeView = () => {
     showMoneyActivityUnderConstructionAlert();
   }, []);
 
+  let onboardingCtaPress = handleAddPress;
+  if (isCardUnlinked) {
+    onboardingCtaPress = handleLinkCardPress;
+  } else if (isMilestone) {
+    onboardingCtaPress = handleCardPress;
+  }
+
   // TODO: Remove before launch
   // Useful for testing how zero and non-zero APYs are handled quickly.
   const DEV_APY = __DEV__ ? 4 : vaultApyQuery.data?.apy;
@@ -137,7 +144,7 @@ const MoneyHomeView = () => {
         <MoneyOnboardingCard
           currentStep={isMilestone ? 2 : 1}
           variant={isCardUnlinked ? 'link-card' : 'get-card'}
-          onCtaPress={isMilestone ? handleCardPress : handleAddPress}
+          onCtaPress={onboardingCtaPress}
         />
         <Divider />
         <MoneyEarnings onProjectedPress={handleProjectedEarningsPress} />

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -206,6 +206,7 @@ const MoneyHomeView = () => {
           onGetNowPress={handleGetNowPress}
           onHeaderPress={handleHeaderPress}
           onLinkPress={handleLinkCardPress}
+          apy={DEV_APY}
         />
         <Divider />
         {isMilestone && (

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -65,4 +65,98 @@ describe('MoneyMetaMaskCard', () => {
 
     expect(mockGetNow).toHaveBeenCalledWith('metal');
   });
+
+  describe('link mode', () => {
+    it('renders link subtitle instead of upsell subtitle', () => {
+      const { getByText, queryByText } = render(
+        <MoneyMetaMaskCard mode="link" />,
+      );
+
+      expect(
+        getByText(strings('money.metamask_card.link_subtitle')),
+      ).toBeOnTheScreen();
+      expect(
+        queryByText(strings('money.metamask_card.subtitle')),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders card image in link mode', () => {
+      const { getByTestId } = render(<MoneyMetaMaskCard mode="link" />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_CARD_IMAGE),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders cashback and APY bullets', () => {
+      const { getByTestId } = render(<MoneyMetaMaskCard mode="link" />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_BULLET_CASHBACK),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_BULLET_APY),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders "Link card" button', () => {
+      const { getByTestId } = render(<MoneyMetaMaskCard mode="link" />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides virtual and metal card rows in link mode', () => {
+      const { queryByTestId } = render(<MoneyMetaMaskCard mode="link" />);
+
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
+      ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('calls onLinkPress when "Link card" button is pressed', () => {
+      const mockLink = jest.fn();
+      const { getByTestId } = render(
+        <MoneyMetaMaskCard mode="link" onLinkPress={mockLink} />,
+      );
+
+      fireEvent.press(getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON));
+      expect(mockLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onHeaderPress when section header is tapped in link mode', () => {
+      const mockHeader = jest.fn();
+      const { getByText } = render(
+        <MoneyMetaMaskCard mode="link" onHeaderPress={mockHeader} />,
+      );
+
+      fireEvent.press(getByText(strings('money.metamask_card.title')));
+      expect(mockHeader).toHaveBeenCalled();
+    });
+  });
+
+  describe('upsell mode (default)', () => {
+    it('renders virtual and metal card rows', () => {
+      const { getByTestId } = render(<MoneyMetaMaskCard />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render link mode elements', () => {
+      const { queryByTestId } = render(<MoneyMetaMaskCard />);
+
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -89,7 +89,7 @@ describe('MoneyMetaMaskCard', () => {
     });
 
     it('renders cashback and APY bullets', () => {
-      const { getByTestId } = render(<MoneyMetaMaskCard mode="link" />);
+      const { getByTestId } = render(<MoneyMetaMaskCard mode="link" apy={5} />);
 
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.LINK_BULLET_CASHBACK),

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -128,13 +128,21 @@ describe('MoneyMetaMaskCard', () => {
       expect(mockLink).toHaveBeenCalledTimes(1);
     });
 
+    it('renders link-specific section title', () => {
+      const { getByText } = render(<MoneyMetaMaskCard mode="link" />);
+
+      expect(
+        getByText(strings('money.metamask_card.link_title')),
+      ).toBeOnTheScreen();
+    });
+
     it('calls onHeaderPress when section header is tapped in link mode', () => {
       const mockHeader = jest.fn();
       const { getByText } = render(
         <MoneyMetaMaskCard mode="link" onHeaderPress={mockHeader} />,
       );
 
-      fireEvent.press(getByText(strings('money.metamask_card.title')));
+      fireEvent.press(getByText(strings('money.metamask_card.link_title')));
       expect(mockHeader).toHaveBeenCalled();
     });
   });

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.testIds.ts
@@ -2,4 +2,10 @@ export const MoneyMetaMaskCardTestIds = {
   CONTAINER: 'money-metamask-card-container',
   VIRTUAL_CARD_ROW: 'money-metamask-card-virtual-card-row',
   METAL_CARD_ROW: 'money-metamask-card-metal-card-row',
+  LINK_CONTAINER: 'money-metamask-card-link-container',
+  LINK_SUBTITLE: 'money-metamask-card-link-subtitle',
+  LINK_CARD_IMAGE: 'money-metamask-card-link-card-image',
+  LINK_BULLET_CASHBACK: 'money-metamask-card-link-bullet-cashback',
+  LINK_BULLET_APY: 'money-metamask-card-link-bullet-apy',
+  LINK_BUTTON: 'money-metamask-card-link-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -9,6 +9,10 @@ import {
   ButtonSize,
   ButtonVariant,
   FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -22,8 +26,12 @@ import mmCardRegular from '../../../../../images/mm_card_regular.png';
 import mmCardMetal from '../../../../../images/mm_card_metal.png';
 
 interface MoneyMetaMaskCardProps {
+  /** 'upsell' (default): virtual/metal card rows. 'link': card-linking CTA layout. */
+  mode?: 'upsell' | 'link';
   onGetNowPress?: (cardType: string) => void;
   onHeaderPress?: () => void;
+  /** Called when the "Link card" button is pressed (link mode only). */
+  onLinkPress?: () => void;
 }
 
 const CardRow = ({
@@ -78,9 +86,75 @@ const CardRow = ({
   </Box>
 );
 
+const LinkContent = ({ onLinkPress }: { onLinkPress: () => void }) => (
+  <Box twClassName="gap-3">
+    <Text
+      variant={TextVariant.BodySm}
+      color={TextColor.TextAlternative}
+      testID={MoneyMetaMaskCardTestIds.LINK_SUBTITLE}
+    >
+      {strings('money.metamask_card.link_subtitle')}
+    </Text>
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      twClassName="gap-4"
+      testID={MoneyMetaMaskCardTestIds.LINK_CONTAINER}
+    >
+      <Image
+        source={mmCardMetal}
+        style={styles.cardImage}
+        testID={MoneyMetaMaskCardTestIds.LINK_CARD_IMAGE}
+      />
+      <Box twClassName="gap-2 flex-1 justify-center">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-1"
+          testID={MoneyMetaMaskCardTestIds.LINK_BULLET_CASHBACK}
+        >
+          <Icon
+            name={IconName.Check}
+            size={IconSize.Sm}
+            color={IconColor.SuccessDefault}
+          />
+          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+            {strings('money.metamask_card.link_bullet_cashback')}
+          </Text>
+        </Box>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-1"
+          testID={MoneyMetaMaskCardTestIds.LINK_BULLET_APY}
+        >
+          <Icon
+            name={IconName.Check}
+            size={IconSize.Sm}
+            color={IconColor.SuccessDefault}
+          />
+          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+            {strings('money.metamask_card.link_bullet_apy')}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+    <Button
+      variant={ButtonVariant.Secondary}
+      size={ButtonSize.Lg}
+      isFullWidth
+      onPress={onLinkPress}
+      testID={MoneyMetaMaskCardTestIds.LINK_BUTTON}
+    >
+      {strings('money.metamask_card.link_card')}
+    </Button>
+  </Box>
+);
+
 const MoneyMetaMaskCard = ({
+  mode = 'upsell',
   onGetNowPress = () => undefined,
   onHeaderPress,
+  onLinkPress,
 }: MoneyMetaMaskCardProps) => {
   const handleVirtualPress = useCallback(
     () => onGetNowPress('virtual'),
@@ -90,6 +164,7 @@ const MoneyMetaMaskCard = ({
     () => onGetNowPress('metal'),
     [onGetNowPress],
   );
+  const handleLinkPress = useCallback(() => onLinkPress?.(), [onLinkPress]);
 
   return (
     <Box
@@ -100,30 +175,33 @@ const MoneyMetaMaskCard = ({
         title={strings('money.metamask_card.title')}
         onPress={onHeaderPress}
       />
-
-      <Text
-        variant={TextVariant.BodyMd}
-        fontWeight={FontWeight.Regular}
-        color={TextColor.TextAlternative}
-      >
-        {strings('money.metamask_card.subtitle')}
-      </Text>
-
-      <CardRow
-        imageSource={mmCardRegular}
-        cardName={strings('money.metamask_card.virtual_card')}
-        cashbackPercentage="1"
-        onPress={handleVirtualPress}
-        testID={MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW}
-      />
-
-      <CardRow
-        imageSource={mmCardMetal}
-        cardName={strings('money.metamask_card.metal_card')}
-        cashbackPercentage="3"
-        onPress={handleMetalPress}
-        testID={MoneyMetaMaskCardTestIds.METAL_CARD_ROW}
-      />
+      {mode === 'link' ? (
+        <LinkContent onLinkPress={handleLinkPress} />
+      ) : (
+        <>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Regular}
+            color={TextColor.TextAlternative}
+          >
+            {strings('money.metamask_card.subtitle')}
+          </Text>
+          <CardRow
+            imageSource={mmCardRegular}
+            cardName={strings('money.metamask_card.virtual_card')}
+            cashbackPercentage="1"
+            onPress={handleVirtualPress}
+            testID={MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW}
+          />
+          <CardRow
+            imageSource={mmCardMetal}
+            cardName={strings('money.metamask_card.metal_card')}
+            cashbackPercentage="3"
+            onPress={handleMetalPress}
+            testID={MoneyMetaMaskCardTestIds.METAL_CARD_ROW}
+          />
+        </>
+      )}
     </Box>
   );
 };

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -32,6 +32,8 @@ interface MoneyMetaMaskCardProps {
   onHeaderPress?: () => void;
   /** Called when the "Link card" button is pressed (link mode only). */
   onLinkPress?: () => void;
+  /** Current APY value displayed in the link mode bullet. */
+  apy?: number;
 }
 
 const CardRow = ({
@@ -108,7 +110,13 @@ const CheckBullet = ({ text, testID }: { text: string; testID: string }) => (
   </Box>
 );
 
-const LinkContent = ({ onLinkPress }: { onLinkPress: () => void }) => (
+const LinkContent = ({
+  onLinkPress,
+  apy,
+}: {
+  onLinkPress: () => void;
+  apy?: number;
+}) => (
   <Box twClassName="gap-3">
     <Text
       variant={TextVariant.BodySm}
@@ -133,7 +141,9 @@ const LinkContent = ({ onLinkPress }: { onLinkPress: () => void }) => (
           testID={MoneyMetaMaskCardTestIds.LINK_BULLET_CASHBACK}
         />
         <CheckBullet
-          text={strings('money.metamask_card.link_bullet_apy')}
+          text={strings('money.metamask_card.link_bullet_apy', {
+            apy: apy ?? 4,
+          })}
           testID={MoneyMetaMaskCardTestIds.LINK_BULLET_APY}
         />
       </Box>
@@ -155,6 +165,7 @@ const MoneyMetaMaskCard = ({
   onGetNowPress = () => undefined,
   onHeaderPress,
   onLinkPress,
+  apy,
 }: MoneyMetaMaskCardProps) => {
   const handleVirtualPress = useCallback(
     () => onGetNowPress('virtual'),
@@ -180,7 +191,7 @@ const MoneyMetaMaskCard = ({
         onPress={onHeaderPress}
       />
       {mode === 'link' ? (
-        <LinkContent onLinkPress={handleLinkPress} />
+        <LinkContent onLinkPress={handleLinkPress} apy={apy} />
       ) : (
         <>
           <Text

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -86,6 +86,28 @@ const CardRow = ({
   </Box>
 );
 
+const CheckBullet = ({ text, testID }: { text: string; testID: string }) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="gap-1"
+    testID={testID}
+  >
+    <Icon
+      name={IconName.Check}
+      size={IconSize.Sm}
+      color={IconColor.SuccessDefault}
+    />
+    <Text
+      variant={TextVariant.BodySm}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.SuccessDefault}
+    >
+      {text}
+    </Text>
+  </Box>
+);
+
 const LinkContent = ({ onLinkPress }: { onLinkPress: () => void }) => (
   <Box twClassName="gap-3">
     <Text
@@ -106,36 +128,14 @@ const LinkContent = ({ onLinkPress }: { onLinkPress: () => void }) => (
         testID={MoneyMetaMaskCardTestIds.LINK_CARD_IMAGE}
       />
       <Box twClassName="gap-2 flex-1 justify-center">
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-1"
+        <CheckBullet
+          text={strings('money.metamask_card.link_bullet_cashback')}
           testID={MoneyMetaMaskCardTestIds.LINK_BULLET_CASHBACK}
-        >
-          <Icon
-            name={IconName.Check}
-            size={IconSize.Sm}
-            color={IconColor.SuccessDefault}
-          />
-          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-            {strings('money.metamask_card.link_bullet_cashback')}
-          </Text>
-        </Box>
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-1"
+        />
+        <CheckBullet
+          text={strings('money.metamask_card.link_bullet_apy')}
           testID={MoneyMetaMaskCardTestIds.LINK_BULLET_APY}
-        >
-          <Icon
-            name={IconName.Check}
-            size={IconSize.Sm}
-            color={IconColor.SuccessDefault}
-          />
-          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-            {strings('money.metamask_card.link_bullet_apy')}
-          </Text>
-        </Box>
+        />
       </Box>
     </Box>
     <Button
@@ -172,7 +172,11 @@ const MoneyMetaMaskCard = ({
       testID={MoneyMetaMaskCardTestIds.CONTAINER}
     >
       <MoneySectionHeader
-        title={strings('money.metamask_card.title')}
+        title={strings(
+          mode === 'link'
+            ? 'money.metamask_card.link_title'
+            : 'money.metamask_card.title',
+        )}
         onPress={onHeaderPress}
       />
       {mode === 'link' ? (

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -99,4 +99,76 @@ describe('MoneyOnboardingCard', () => {
       getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON),
     ).toHaveTextContent(strings('money.onboarding.step2_cta'));
   });
+
+  describe('link-card variant', () => {
+    it('renders link card title when variant is link-card and step is 2', () => {
+      const { getByTestId } = render(
+        <MoneyOnboardingCard currentStep={2} variant="link-card" />,
+      );
+
+      expect(getByTestId(MoneyOnboardingCardTestIds.TITLE)).toHaveTextContent(
+        strings('money.onboarding.link_card_title'),
+      );
+    });
+
+    it('renders link card CTA when variant is link-card and step is 2', () => {
+      const { getByTestId } = render(
+        <MoneyOnboardingCard currentStep={2} variant="link-card" />,
+      );
+
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON),
+      ).toHaveTextContent(strings('money.onboarding.link_card_cta'));
+    });
+
+    it('renders benefits bullets when variant is link-card and step is 2', () => {
+      const { getByTestId } = render(
+        <MoneyOnboardingCard currentStep={2} variant="link-card" />,
+      );
+
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.BULLET_CASHBACK),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.BULLET_APY),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render benefits bullets for get-card variant', () => {
+      const { queryByTestId } = render(
+        <MoneyOnboardingCard currentStep={2} variant="get-card" />,
+      );
+
+      expect(
+        queryByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('does not render benefits bullets for step 1 even with link-card variant', () => {
+      const { queryByTestId } = render(
+        <MoneyOnboardingCard currentStep={1} variant="link-card" />,
+      );
+
+      expect(
+        queryByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('calls onCtaPress when link card CTA is tapped', () => {
+      const mockCta = jest.fn();
+      const { getByTestId } = render(
+        <MoneyOnboardingCard
+          currentStep={2}
+          variant="link-card"
+          onCtaPress={mockCta}
+        />,
+      );
+
+      fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
+      expect(mockCta).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -111,6 +111,16 @@ describe('MoneyOnboardingCard', () => {
       );
     });
 
+    it('renders link card description when variant is link-card and step is 2', () => {
+      const { getByTestId } = render(
+        <MoneyOnboardingCard currentStep={2} variant="link-card" />,
+      );
+
+      expect(
+        getByTestId(MoneyOnboardingCardTestIds.DESCRIPTION),
+      ).toHaveTextContent(strings('money.onboarding.link_card_description'));
+    });
+
     it('renders link card CTA when variant is link-card and step is 2', () => {
       const { getByTestId } = render(
         <MoneyOnboardingCard currentStep={2} variant="link-card" />,
@@ -121,40 +131,14 @@ describe('MoneyOnboardingCard', () => {
       ).toHaveTextContent(strings('money.onboarding.link_card_cta'));
     });
 
-    it('renders benefits bullets when variant is link-card and step is 2', () => {
+    it('falls back to get-card content for step 1 even with link-card variant', () => {
       const { getByTestId } = render(
-        <MoneyOnboardingCard currentStep={2} variant="link-card" />,
-      );
-
-      expect(
-        getByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyOnboardingCardTestIds.BULLET_CASHBACK),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyOnboardingCardTestIds.BULLET_APY),
-      ).toBeOnTheScreen();
-    });
-
-    it('does not render benefits bullets for get-card variant', () => {
-      const { queryByTestId } = render(
-        <MoneyOnboardingCard currentStep={2} variant="get-card" />,
-      );
-
-      expect(
-        queryByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
-      ).not.toBeOnTheScreen();
-    });
-
-    it('does not render benefits bullets for step 1 even with link-card variant', () => {
-      const { queryByTestId } = render(
         <MoneyOnboardingCard currentStep={1} variant="link-card" />,
       );
 
-      expect(
-        queryByTestId(MoneyOnboardingCardTestIds.BENEFITS_CONTAINER),
-      ).not.toBeOnTheScreen();
+      expect(getByTestId(MoneyOnboardingCardTestIds.TITLE)).toHaveTextContent(
+        strings('money.onboarding.title'),
+      );
     });
 
     it('calls onCtaPress when link card CTA is tapped', () => {

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
@@ -6,4 +6,7 @@ export const MoneyOnboardingCardTestIds = {
   TITLE: 'money-onboarding-card-title',
   DESCRIPTION: 'money-onboarding-card-description',
   CTA_BUTTON: 'money-onboarding-card-cta-button',
+  BENEFITS_CONTAINER: 'money-onboarding-card-benefits-container',
+  BULLET_CASHBACK: 'money-onboarding-card-bullet-cashback',
+  BULLET_APY: 'money-onboarding-card-bullet-apy',
 } as const;

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.testIds.ts
@@ -6,7 +6,4 @@ export const MoneyOnboardingCardTestIds = {
   TITLE: 'money-onboarding-card-title',
   DESCRIPTION: 'money-onboarding-card-description',
   CTA_BUTTON: 'money-onboarding-card-cta-button',
-  BENEFITS_CONTAINER: 'money-onboarding-card-benefits-container',
-  BULLET_CASHBACK: 'money-onboarding-card-bullet-cashback',
-  BULLET_APY: 'money-onboarding-card-bullet-apy',
 } as const;

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   Box,
   BoxAlignItems,
-  BoxFlexDirection,
   BoxJustifyContent,
   Button,
   ButtonSize,
@@ -42,7 +41,7 @@ interface MoneyOnboardingCardProps {
   totalSteps?: number;
   /**
    * Controls step 2 content: 'get-card' (default) shows card acquisition,
-   * 'link-card' shows card linking with benefits bullets.
+   * 'link-card' shows card linking messaging.
    */
   variant?: 'get-card' | 'link-card';
 }
@@ -65,24 +64,6 @@ const STEP_2_LINK_CARD = {
   description: 'money.onboarding.link_card_description',
   cta: 'money.onboarding.link_card_cta',
 } as const;
-
-const BenefitBullet = ({ text, testID }: { text: string; testID: string }) => (
-  <Box
-    flexDirection={BoxFlexDirection.Row}
-    alignItems={BoxAlignItems.Center}
-    twClassName="gap-1"
-    testID={testID}
-  >
-    <Icon
-      name={IconName.Check}
-      size={IconSize.Sm}
-      color={IconColor.SuccessDefault}
-    />
-    <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-      {text}
-    </Text>
-  </Box>
-);
 
 const MoneyOnboardingCard = ({
   onCtaPress,
@@ -149,32 +130,8 @@ const MoneyOnboardingCard = ({
             testID={MoneyOnboardingCardTestIds.DESCRIPTION}
           >
             {strings(content.description)}
-            {isLinkCard && (
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {strings('money.onboarding.link_card_description_highlight')}
-                {strings('money.onboarding.link_card_description_suffix')}
-              </Text>
-            )}
           </Text>
         </Box>
-        {isLinkCard && (
-          <Box
-            twClassName="gap-2"
-            testID={MoneyOnboardingCardTestIds.BENEFITS_CONTAINER}
-          >
-            <BenefitBullet
-              text={strings('money.onboarding.link_card_bullet_cashback')}
-              testID={MoneyOnboardingCardTestIds.BULLET_CASHBACK}
-            />
-            <BenefitBullet
-              text={strings('money.onboarding.link_card_bullet_apy')}
-              testID={MoneyOnboardingCardTestIds.BULLET_APY}
-            />
-          </Box>
-        )}
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Box,
   BoxAlignItems,
+  BoxFlexDirection,
   BoxJustifyContent,
   Button,
   ButtonSize,
@@ -39,6 +40,11 @@ interface MoneyOnboardingCardProps {
    * Total number of onboarding steps. Defaults to 2.
    */
   totalSteps?: number;
+  /**
+   * Controls step 2 content: 'get-card' (default) shows card acquisition,
+   * 'link-card' shows card linking with benefits bullets.
+   */
+  variant?: 'get-card' | 'link-card';
 }
 
 const STEP_CONTENT = {
@@ -54,14 +60,42 @@ const STEP_CONTENT = {
   },
 } as const;
 
+const STEP_2_LINK_CARD = {
+  title: 'money.onboarding.link_card_title',
+  description: 'money.onboarding.link_card_description',
+  cta: 'money.onboarding.link_card_cta',
+} as const;
+
+const BenefitBullet = ({ text, testID }: { text: string; testID: string }) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="gap-1"
+    testID={testID}
+  >
+    <Icon
+      name={IconName.Check}
+      size={IconSize.Sm}
+      color={IconColor.SuccessDefault}
+    />
+    <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+      {text}
+    </Text>
+  </Box>
+);
+
 const MoneyOnboardingCard = ({
   onCtaPress,
   onAddPress,
   currentStep = 1,
   totalSteps = 2,
+  variant = 'get-card',
 }: MoneyOnboardingCardProps) => {
-  const content =
-    STEP_CONTENT[currentStep as keyof typeof STEP_CONTENT] ?? STEP_CONTENT[1];
+  const isLinkCard = variant === 'link-card' && currentStep === 2;
+  const content = isLinkCard
+    ? STEP_2_LINK_CARD
+    : (STEP_CONTENT[currentStep as keyof typeof STEP_CONTENT] ??
+      STEP_CONTENT[1]);
   const handleCtaPress = onCtaPress ?? onAddPress ?? NOOP;
 
   return (
@@ -115,8 +149,32 @@ const MoneyOnboardingCard = ({
             testID={MoneyOnboardingCardTestIds.DESCRIPTION}
           >
             {strings(content.description)}
+            {isLinkCard && (
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings('money.onboarding.link_card_description_highlight')}
+                {strings('money.onboarding.link_card_description_suffix')}
+              </Text>
+            )}
           </Text>
         </Box>
+        {isLinkCard && (
+          <Box
+            twClassName="gap-2"
+            testID={MoneyOnboardingCardTestIds.BENEFITS_CONTAINER}
+          >
+            <BenefitBullet
+              text={strings('money.onboarding.link_card_bullet_cashback')}
+              testID={MoneyOnboardingCardTestIds.BULLET_CASHBACK}
+            />
+            <BenefitBullet
+              text={strings('money.onboarding.link_card_bullet_apy')}
+              testID={MoneyOnboardingCardTestIds.BULLET_APY}
+            />
+          </Box>
+        )}
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6321,12 +6321,8 @@
       "step2_description": "Spend your Money balance while it earns, anywhere Mastercard is accepted.",
       "step2_cta": "Get card",
       "link_card_title": "Link your MetaMask Card",
-      "link_card_description": "Spend your Money balance with your MetaMask Card and get ",
-      "link_card_description_highlight": "1-3% cashback",
-      "link_card_description_suffix": ".",
-      "link_card_cta": "Link card",
-      "link_card_bullet_cashback": "Get 1-3% cashback",
-      "link_card_bullet_apy": "Earn 4% APY on your balance"
+      "link_card_description": "Spend your balance while it earns, anywhere Mastercard is accepted.",
+      "link_card_cta": "Link card"
     },
     "action": {
       "add": "Add",
@@ -6361,9 +6357,10 @@
       "metal_card": "Metal card",
       "cashback": "{{percentage}}% cashback",
       "get_now": "Get now",
-      "link_subtitle": "Link your card to unlock all the benefits of your Money account.",
-      "link_bullet_cashback": "Get 1-3% cashback",
-      "link_bullet_apy": "Earn 4% APY on your balance",
+      "link_title": "Link MetaMask Card",
+      "link_subtitle": "Spend your Money balance and earn.",
+      "link_bullet_cashback": "Up to 3% cash back",
+      "link_bullet_apy": "Up to 4% APY",
       "link_card": "Link card"
     },
     "what_you_get": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6360,7 +6360,11 @@
       "virtual_card": "Virtual card",
       "metal_card": "Metal card",
       "cashback": "{{percentage}}% cashback",
-      "get_now": "Get now"
+      "get_now": "Get now",
+      "link_subtitle": "Link your card to unlock all the benefits of your Money account.",
+      "link_bullet_cashback": "Get 1-3% cashback",
+      "link_bullet_apy": "Earn 4% APY on your balance",
+      "link_card": "Link card"
     },
     "what_you_get": {
       "title": "What you get",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6360,7 +6360,7 @@
       "link_title": "Link MetaMask Card",
       "link_subtitle": "Spend your Money balance and earn.",
       "link_bullet_cashback": "Up to 3% cash back",
-      "link_bullet_apy": "Up to 4% APY",
+      "link_bullet_apy": "Up to {{apy}}% APY",
       "link_card": "Link card"
     },
     "what_you_get": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6319,7 +6319,14 @@
       "add": "Add",
       "step2_title": "Get your MetaMask Card",
       "step2_description": "Spend your Money balance while it earns, anywhere Mastercard is accepted.",
-      "step2_cta": "Get card"
+      "step2_cta": "Get card",
+      "link_card_title": "Link your MetaMask Card",
+      "link_card_description": "Spend your Money balance with your MetaMask Card and get ",
+      "link_card_description_highlight": "1-3% cashback",
+      "link_card_description_suffix": ".",
+      "link_card_cta": "Link card",
+      "link_card_bullet_cashback": "Get 1-3% cashback",
+      "link_card_bullet_apy": "Earn 4% APY on your balance"
     },
     "action": {
       "add": "Add",


### PR DESCRIPTION
## **Description**

Implements the Money Account homepage "card linking" state — displayed when a user has deposited funds and has an unlinked MetaMask Card. This state encourages card linking with benefits messaging.

**Subtasks implemented:**

- **MUSD-610**: Updated the "Step 2 of 2" `MoneyOnboardingCard` with a `variant` prop (`'get-card'` | `'link-card'`). The link-card variant shows "Link your MetaMask Card" title, cashback description, benefits bullets (checkmark icons with cashback and APY text), and a "Link card" CTA button.
- **MUSD-611**: Added a `mode` prop (`'upsell'` | `'link'`) to `MoneyMetaMaskCard`. Link mode replaces the virtual/metal card rows with a card-linking layout: metal card thumbnail, benefits bullets, and a full-width "Link card" button.
- **MUSD-612**: Wired the card-unlinked state in `MoneyHomeView` using the `selectIsCardholder` Redux selector. When `isMilestone && isCardholder`, both `MoneyOnboardingCard` and `MoneyMetaMaskCard` switch to their link-card variants. Verified all 6 reused sections (balance, action pills, earnings, activity, condensed cards, potential earnings) render correctly in the new state.

**Card linking CTA handlers** are currently stubbed with `displayUnderConstructionAlert` — they will be wired to the card linking flow when MUSD-489 lands.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-602

## **Manual testing steps**

```gherkin
Feature: Money Account card linking homepage state

  Scenario: user sees card linking prompt when they have an unlinked card
    Given user has a Money Account with balance > $0.00
    And user has ordered/received a MetaMask Card (isCardholder = true)
    And card is NOT linked to Money Account

    When user navigates to Money home screen
    Then the "Step 2 of 2" card shows "Link your MetaMask Card" title
    And benefits bullets show "Get 1-3% cashback" and "Earn 4% APY on your balance"
    And CTA button reads "Link card"
    And MetaMask Card section shows card linking layout instead of virtual/metal card rows
    And all other sections (balance, earnings, activity, condensed cards) display correctly

  Scenario: user without a card sees standard milestone state
    Given user has a Money Account with balance > $0.00
    And user does NOT have a MetaMask Card (isCardholder = false)

    When user navigates to Money home screen
    Then the "Step 2 of 2" card shows "Get your MetaMask Card" title
    And MetaMask Card section shows virtual/metal card rows with "Get now" buttons
```

## **Screenshots/Recordings**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/66162bfd-36db-4c4a-b2c1-0bc12884ad4d" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/79b1b757-571e-4ae6-bda7-b49243cae31e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state changes: new rendering variants and CTA routing based on `selectIsCardholder`, with handlers still stubbed to under-construction alerts.
> 
> **Overview**
> Adds a new **“card-unlinked”** homepage state on `MoneyHomeView` when the user is in a milestone/filled state and `selectIsCardholder` is true, switching the onboarding CTA to a **link-card** flow.
> 
> Extends `MoneyOnboardingCard` with a `variant` to swap step-2 copy/CTA for card linking, and extends `MoneyMetaMaskCard` with a `mode="link"` layout (benefit bullets + “Link card” button, plus APY display) instead of the virtual/metal upsell rows.
> 
> Updates English i18n strings and expands unit tests to cover the new variants/mode and CTA press behavior across empty/milestone/card-unlinked states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a8d8ea9f9c7b31c8c1b42ee9d98d92c3619d19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->