### PR TITLE
fix: tempo disable confirm button until gas autoselect

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -26,6 +26,7 @@ import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { emptySignatureControllerMock } from '../../__mocks__/controllers/signature-controller-mock';
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
+import { useIsGaslessLoading } from '../../hooks/gas/useIsGaslessLoading';
 
 const mockConfirmSpy = jest.fn();
 const mockRejectSpy = jest.fn();
@@ -78,6 +79,12 @@ jest.mock('../../hooks/ui/useFullScreenConfirmation', () => ({
   })),
 }));
 
+jest.mock('../../hooks/gas/useIsGaslessLoading', () => ({
+  useIsGaslessLoading: jest.fn(() => ({
+    isGaslessLoading: false,
+  })),
+}));
+
 const mockTrackAlertMetrics = jest.fn();
 
 (useConfirmationAlertMetrics as jest.Mock).mockReturnValue({
@@ -101,6 +108,7 @@ describe('Footer', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useIsGaslessLoadingMock = jest.mocked(useIsGaslessLoading);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -124,6 +132,7 @@ describe('Footer', () => {
     });
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: false });
   });
 
   it('should render correctly', () => {
@@ -228,9 +237,29 @@ describe('Footer', () => {
     ).toBe(true);
   });
 
-  it('disables confirm button if quotes are loading', () => {
+  it('disables confirm button if transaction pay is loading', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: false });
+    const state = merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      emptySignatureControllerMock,
+      { securityAlerts: { alerts: {} } },
+    );
 
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state,
+    });
+
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
+    ).toBe(true);
+  });
+
+  it('disables confirm button if gasless support is loading', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsGaslessLoadingMock.mockReturnValue({ isGaslessLoading: true });
     const state = merge(
       {},
       simpleSendTransactionControllerMock,

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -39,6 +39,7 @@ import { PredictClaimFooter } from '../predict-confirmations/predict-claim-foote
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useQRHardwareContext } from '../../context/qr-hardware-context';
+import { useIsGaslessLoading } from '../../hooks/gas/useIsGaslessLoading';
 
 const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.moneyAccountDeposit,
@@ -71,7 +72,7 @@ export const Footer = () => {
     TRANSFER_TRANSACTION_TYPES.includes(transactionType) &&
     transactionMetadata?.origin === MMM_ORIGIN;
   const isPayLoading = useIsTransactionPayLoading();
-
+  const { isGaslessLoading } = useIsGaslessLoading();
   const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
     useConfirmationContext();
 
@@ -158,7 +159,8 @@ export const Footer = () => {
     needsCameraPermission ||
     hasBlockingAlerts ||
     isTransactionValueUpdating ||
-    isPayLoading;
+    isPayLoading ||
+    isGaslessLoading;
 
   const buttons = [
     {

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -1,0 +1,209 @@
+import { GasFeeToken } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+import { useIsGaslessSupported } from './useIsGaslessSupported';
+import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { useIsGaslessLoading } from './useIsGaslessLoading';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+
+jest.mock('./useIsGaslessSupported');
+jest.mock('../useHasInsufficientBalance');
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../../../../selectors/preferencesController');
+
+const mockedUseIsGaslessSupported = jest.mocked(useIsGaslessSupported);
+const mockedUseHasInsufficientBalance = jest.mocked(useHasInsufficientBalance);
+const mockedUseTransactionMetadataRequest = jest.mocked(
+  useTransactionMetadataRequest,
+);
+const mockSelectUseTransactionSimulations = jest.mocked(
+  selectUseTransactionSimulations,
+);
+
+async function runHook({
+  simulationEnabled,
+  gaslessSupported,
+  insufficientBalance,
+  pending = false,
+  isSmartTransaction = true,
+  gasFeeTokens,
+  excludeNativeTokenForFee,
+  selectedGasFeeToken,
+}: {
+  simulationEnabled: boolean;
+  gaslessSupported: boolean;
+  insufficientBalance: boolean;
+  pending?: boolean;
+  isSmartTransaction?: boolean;
+  gasFeeTokens?: GasFeeToken[];
+  excludeNativeTokenForFee?: boolean;
+  selectedGasFeeToken?: Hex;
+}) {
+  mockedUseIsGaslessSupported.mockReturnValue({
+    isSupported: gaslessSupported,
+    isSmartTransaction,
+    pending,
+  });
+  mockedUseHasInsufficientBalance.mockReturnValue({
+    hasInsufficientBalance: insufficientBalance,
+    nativeCurrency: 'USD',
+  });
+  mockedUseTransactionMetadataRequest.mockReturnValue({
+    gasFeeTokens,
+    excludeNativeTokenForFee,
+    selectedGasFeeToken,
+  } as unknown as ReturnType<typeof useTransactionMetadataRequest>);
+  mockSelectUseTransactionSimulations.mockReturnValue(simulationEnabled);
+  const { result } = renderHookWithProvider(useIsGaslessLoading);
+  return result.current;
+}
+
+describe('useIsGaslessLoading', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true if pending', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      pending: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if simulation is disabled', async () => {
+    const result = await runHook({
+      simulationEnabled: false,
+      gaslessSupported: true,
+      insufficientBalance: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gasless is not supported', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: false,
+      insufficientBalance: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if there is no insufficient balance', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: false,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gas fee tokens are undefined (still loading)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: undefined, // this triggers loading
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if gas fee tokens are present', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens is an empty array', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [],
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present and dont match selectedGasFeeToken (non-reg)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gas fee tokens are present and dont match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if gas fee tokens are present AND match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [
+        { tokenAddress: '0x123' },
+        { tokenAddress: '0x789' },
+      ] as unknown as GasFeeToken[],
+      // Matches the first one
+      selectedGasFeeToken: '0x123',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present AND selectedGasFeeToken is undefined with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: undefined,
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens is empty array with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/app/components/Views/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,0 +1,62 @@
+import { useSelector } from 'react-redux';
+
+import { GasFeeToken } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { useIsGaslessSupported } from './useIsGaslessSupported';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
+
+// Chains with no native may have selectedGasFeeToken inconsistent with gasFeeTokens
+function hasWrongSelectedGasFeeToken({
+  gasFeeTokens,
+  selectedGasFeeToken,
+}: {
+  gasFeeTokens: GasFeeToken[];
+  selectedGasFeeToken?: Hex;
+}) {
+  return (
+    gasFeeTokens.length &&
+    selectedGasFeeToken &&
+    selectedGasFeeToken !== NATIVE_TOKEN_ADDRESS &&
+    !gasFeeTokens.some(
+      ({ tokenAddress }) =>
+        tokenAddress?.toLocaleLowerCase() ===
+        selectedGasFeeToken?.toLocaleLowerCase(),
+    )
+  );
+}
+
+export function useIsGaslessLoading() {
+  const transactionMeta = useTransactionMetadataRequest();
+
+  const { gasFeeTokens, excludeNativeTokenForFee, selectedGasFeeToken } =
+    transactionMeta ?? {};
+
+  const {
+    isSupported: isGaslessSupported,
+    pending: isGaslessSupportedPending,
+  } = useIsGaslessSupported();
+  const isSimulationEnabled = useSelector(selectUseTransactionSimulations);
+
+  const { hasInsufficientBalance } = useHasInsufficientBalance();
+
+  const isGaslessSupportedFinished =
+    !isGaslessSupportedPending && isGaslessSupported;
+
+  const hasNoNativeTokenAvailable =
+    excludeNativeTokenForFee || hasInsufficientBalance;
+
+  const isGaslessLoading = Boolean(
+    isSimulationEnabled &&
+      hasNoNativeTokenAvailable &&
+      (isGaslessSupportedPending || isGaslessSupportedFinished) &&
+      (!gasFeeTokens ||
+        (excludeNativeTokenForFee &&
+          hasWrongSelectedGasFeeToken({ gasFeeTokens, selectedGasFeeToken }))),
+  );
+
+  return { isGaslessLoading };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The goal of the change is to prevent a premature "enablement" for the Confirm button when a transaction is loading. There are pre-existing race conditions that allowed users to confirm a transaction before everything is fully loaded. Those conditions could make the tx skip gasless flows, falling back to native token for gas payment.

The impact is bigger on Tempo because using a native token is not an option (there is no native token on Tempo), which means that such race condition will always result in a failed tx (the tx won't be sent to the RPC or relayer). 

The changes solve the race conditions cases, as well as adds some extra conditions for the loading when on a chain that has no native token.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add new `isGaslessLoading` guard to Confirmation button - consistently with Extension.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-944?atlOrigin=eyJpIjoiYWFiY2U0NjU1ZjEzNGNmODlmOTZkNTQwNzM4N2MxMTUiLCJwIjoiaiJ9

## **Manual testing steps**

**Repeating instructions shared for Extension since Mobile flow will be very similar (just "tap" instead of click ;))**

- On Tempo mainnet, find `pathUSD` and click on "Send".
- Set amount to 0.01 and select the account to send to (any account).
- As soon as you clicked on the recipient account, start "spam clicking" on "Confirm" or the location where you know "Confirm" will appear.
- 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19a8535d-d73b-452b-98c2-d8471000fd48" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2846ad13-ba71-4101-b96b-74a86abdc7b7" />

What should be observed is that despite spam-clicking, it should not be possible to "Confirm" the transaction "too soon" and it should always succeed no matter how "early" you click on "Confirm".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation submit gating by disabling the Confirm button during gasless support/fee-token loading, which can affect the ability to send transactions if the loading conditions are wrong.
> 
> **Overview**
> Prevents premature transaction confirmation by adding a new `useIsGaslessLoading` guard that keeps the confirmation footer’s **Confirm** button disabled while gasless eligibility/fee-token data is still resolving (including chains that exclude native gas, e.g. Tempo).
> 
> Adds the `useIsGaslessLoading` hook (and unit tests) to derive loading from simulations enabled, gasless support pending/finished, insufficient/native-unavailable state, and missing or inconsistent `gasFeeTokens`/`selectedGasFeeToken`. Updates footer tests to cover both transaction-pay loading and the new gasless-loading disablement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1495a13136bceeef0f485513920ca6fdb01adbd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->