### PR TITLE
refactor(networks): enhance NetworkDetailsView with improved RPC and block explorer handling cp-7.74.0

### DIFF
--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { strings } from '../../../../../locales/i18n';
 import { IconColor } from '../../../../component-library/components/Icons/Icon';
 import { NetworkDetailsViewSelectorsIDs } from './NetworkDetailsView.testIds';
@@ -140,6 +140,7 @@ const createMockFormHook = (overrides: Record<string, unknown> = {}) => ({
   onBlockExplorerSelect: jest.fn(),
   onBlockExplorerUrlDelete: jest.fn(),
   setValidationCallback: jest.fn(),
+  commitBaselineFromFormState: jest.fn(),
   onNameFocused: jest.fn(),
   onNameBlur: jest.fn(),
   onSymbolFocused: jest.fn(),
@@ -174,6 +175,7 @@ const createMockValidation = () => ({
   validateSymbol: jest.fn(),
   validateName: jest.fn(),
   validateRpcAndChainId: jest.fn(),
+  validateNewRpcEndpointForSheet: jest.fn().mockResolvedValue({ ok: true }),
   disabledByChainId: jest.fn(() => false),
   disabledByName: jest.fn(() => false),
   disabledBySymbol: jest.fn(() => false),
@@ -187,7 +189,7 @@ const createMockValidation = () => ({
 });
 
 const createMockOperations = () => ({
-  saveNetwork: jest.fn(),
+  saveNetwork: jest.fn().mockResolvedValue(true),
   removeNetwork: jest.fn(),
   goToNetworkEdit: jest.fn(),
 });
@@ -877,7 +879,9 @@ describe('NetworkDetailsView', () => {
       });
     });
 
-    it('calls onRpcItemAdd when add RPC button is pressed in modal', () => {
+    it('calls onRpcItemAdd when add RPC button is pressed in modal', async () => {
+      const val = createMockValidation();
+      mockValidation.mockReturnValue(val);
       const form = editFormWithRpcModal2();
       mockFormHook.mockReturnValue(form);
 
@@ -886,11 +890,18 @@ describe('NetworkDetailsView', () => {
       const addButtons = getAllByTestId(
         NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON,
       );
-      fireEvent.press(addButtons[0]);
-      expect(form.onRpcItemAdd).toHaveBeenCalledWith(
-        'https://new-rpc.example.com',
-        'New RPC',
-      );
+      await act(async () => {
+        fireEvent.press(addButtons[0]);
+      });
+      await waitFor(() => {
+        expect(val.validateNewRpcEndpointForSheet).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(form.onRpcItemAdd).toHaveBeenCalledWith(
+          'https://new-rpc.example.com',
+          'New RPC',
+        );
+      });
     });
   });
 
@@ -926,7 +937,7 @@ describe('NetworkDetailsView', () => {
       });
     });
 
-    it('calls onBlockExplorerItemAdd when add button is pressed in modal', () => {
+    it('calls onBlockExplorerItemAdd when add button is pressed in modal', async () => {
       const form = editFormWithBlockExplorerModal2();
       mockFormHook.mockReturnValue(form);
 
@@ -935,10 +946,14 @@ describe('NetworkDetailsView', () => {
       const addButtons = getAllByTestId(
         NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER,
       );
-      fireEvent.press(addButtons[0]);
-      expect(form.onBlockExplorerItemAdd).toHaveBeenCalledWith(
-        'https://new-scan.example.com',
-      );
+      await act(async () => {
+        fireEvent.press(addButtons[0]);
+      });
+      await waitFor(() => {
+        expect(form.onBlockExplorerItemAdd).toHaveBeenCalledWith(
+          'https://new-scan.example.com',
+        );
+      });
     });
   });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.testIds.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.testIds.ts
@@ -13,6 +13,9 @@ export const NetworkDetailsViewSelectorsIDs = {
   ICON_BUTTON_RPC: 'network-details-view-rpc-dropdown',
   ICON_BUTTON_BLOCK_EXPLORER: 'network-details-view-block-explorer-dropdown',
   ADD_RPC_BUTTON: 'network-details-view-add-rpc-button',
+  RPC_SHEET_SUBMIT_ERROR: 'network-details-view-rpc-sheet-submit-error',
+  BLOCK_EXPLORER_SHEET_SUBMIT_ERROR:
+    'network-details-view-block-explorer-sheet-submit-error',
   RPC_NAME_INPUT: 'network-details-view-rpc-name-input',
   REMOVE_NETWORK_BUTTON: 'network-details-view-remove-network-button',
   USE_THIS_NETWORK_BUTTON: 'network-details-view-use-this-network-button',

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -119,7 +119,7 @@ const NetworkDetailsView = () => {
     validation.disabledBySymbol(formHook.form);
 
   // Latest form + deps for sheet persist. Reassigned every render; async persist reads
-  // `persistSheetCtxRef.current` inside `runPersist` so data is never "initial render" stale.
+  // `persistSheetCtxRef.current` at invoke time so data is never "initial render" stale.
   const persistSheetCtxRef = useRef({
     form: formHook.form,
     enableAction: formHook.enableAction,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -163,9 +163,8 @@ const NetworkDetailsView = () => {
   ]);
 
   /**
-   * Persist after RPC / block-explorer sheet mutations.
-   * Default path uses double rAF until React commits setState. When passing
-   * committedFormSnapshot (RPC sheet add after async validation), persist runs immediately.
+   * Persist after RPC / block-explorer sheet mutations. Callers pass the committed
+   * `NetworkFormState` snapshot produced by the same pure transforms as the form hook.
    *
    * Intentionally `[]` deps: the callback must stay referentially stable for sheet children,
    * and always reads fresh `form` / `operations` / `validation` via `persistSheetCtxRef.current`
@@ -173,23 +172,23 @@ const NetworkDetailsView = () => {
    */
   const schedulePersistAfterUrlSheetMutation = useCallback(
     async (
-      committedFormSnapshot?: NetworkFormState,
+      committedFormSnapshot: NetworkFormState,
       persistOptions?: UrlSheetPersistOptions,
     ): Promise<boolean> => {
-      const runPersist = async (
-        snapshot?: NetworkFormState,
-        opts?: UrlSheetPersistOptions,
-      ): Promise<boolean> => {
-        const ctx = persistSheetCtxRef.current;
-        const formSnapshot = snapshot ?? ctx.form;
-        if (formSnapshot.addMode) {
-          return false;
-        }
-        const saved = await ctx.operations.saveNetwork(formSnapshot, {
+      const ctx = persistSheetCtxRef.current;
+      if (committedFormSnapshot.addMode) {
+        return false;
+      }
+      try {
+        const saved = await ctx.operations.saveNetwork(committedFormSnapshot, {
           enableAction: ctx.enableAction,
-          disabledByChainId: ctx.validation.disabledByChainId(formSnapshot),
-          disabledByName: ctx.validation.disabledByName(formSnapshot),
-          disabledBySymbol: ctx.validation.disabledBySymbol(formSnapshot),
+          disabledByChainId: ctx.validation.disabledByChainId(
+            committedFormSnapshot,
+          ),
+          disabledByName: ctx.validation.disabledByName(committedFormSnapshot),
+          disabledBySymbol: ctx.validation.disabledBySymbol(
+            committedFormSnapshot,
+          ),
           isCustomMainnet: ctx.isCustomMainnet,
           shouldNetworkSwitchPopToWallet: ctx.shouldNetworkSwitchPopToWallet,
           trackRpcUpdateFromBanner: ctx.trackRpcUpdateFromBanner,
@@ -198,31 +197,15 @@ const NetworkDetailsView = () => {
           bypassEnableActionGuard: true,
           bypassFormDisabledGuards: true,
           skipChainIdSubmitValidation:
-            opts?.skipChainIdSubmitValidation === true,
+            persistOptions?.skipChainIdSubmitValidation === true,
         });
         if (saved === true) {
-          ctx.commitBaselineFromFormState(formSnapshot);
+          ctx.commitBaselineFromFormState(committedFormSnapshot);
         }
         return saved === true;
-      };
-
-      if (committedFormSnapshot !== undefined) {
-        return runPersist(committedFormSnapshot, persistOptions).catch(
-          () => false,
-        );
+      } catch {
+        return false;
       }
-
-      return new Promise<boolean>((resolve) => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            runPersist(undefined, persistOptions)
-              .then(resolve)
-              .catch(() => {
-                resolve(false);
-              });
-          });
-        });
-      });
     },
     [],
   );

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx
@@ -67,7 +67,11 @@ import BlockExplorerSection, {
 
 import { NetworkDetailsViewSelectorsIDs } from './NetworkDetailsView.testIds';
 import createStyles from './NetworkDetailsView.styles';
-import type { NetworkDetailsViewParams } from './NetworkDetailsView.types';
+import type {
+  NetworkDetailsViewParams,
+  NetworkFormState,
+  UrlSheetPersistOptions,
+} from './NetworkDetailsView.types';
 
 type NetworkDetailsRouteParams = RouteProp<
   { AddNetworkForm: NetworkDetailsViewParams },
@@ -106,12 +110,36 @@ const NetworkDetailsView = () => {
     });
   }, [formHook, validation]);
 
+  // `editable` only locks name/symbol fields — RPC & block explorer lists still change;
+  // Save / sheet persist must run when those lists diverge from the last saved baseline.
   const isActionDisabled =
     !formHook.enableAction ||
-    formHook.form.editable === false ||
     validation.disabledByChainId(formHook.form) ||
     validation.disabledByName(formHook.form) ||
     validation.disabledBySymbol(formHook.form);
+
+  // Latest form + deps for sheet persist. Reassigned every render; async persist reads
+  // `persistSheetCtxRef.current` inside `runPersist` so data is never "initial render" stale.
+  const persistSheetCtxRef = useRef({
+    form: formHook.form,
+    enableAction: formHook.enableAction,
+    validation,
+    operations,
+    isCustomMainnet,
+    shouldNetworkSwitchPopToWallet,
+    trackRpcUpdateFromBanner,
+    commitBaselineFromFormState: formHook.commitBaselineFromFormState,
+  });
+  persistSheetCtxRef.current = {
+    form: formHook.form,
+    enableAction: formHook.enableAction,
+    validation,
+    operations,
+    isCustomMainnet,
+    shouldNetworkSwitchPopToWallet,
+    trackRpcUpdateFromBanner,
+    commitBaselineFromFormState: formHook.commitBaselineFromFormState,
+  };
 
   const handleSave = useCallback(async () => {
     await operations.saveNetwork(formHook.form, {
@@ -133,6 +161,71 @@ const NetworkDetailsView = () => {
     shouldNetworkSwitchPopToWallet,
     trackRpcUpdateFromBanner,
   ]);
+
+  /**
+   * Persist after RPC / block-explorer sheet mutations.
+   * Default path uses double rAF until React commits setState. When passing
+   * committedFormSnapshot (RPC sheet add after async validation), persist runs immediately.
+   *
+   * Intentionally `[]` deps: the callback must stay referentially stable for sheet children,
+   * and always reads fresh `form` / `operations` / `validation` via `persistSheetCtxRef.current`
+   * at invoke time (ref is updated synchronously each render above).
+   */
+  const schedulePersistAfterUrlSheetMutation = useCallback(
+    async (
+      committedFormSnapshot?: NetworkFormState,
+      persistOptions?: UrlSheetPersistOptions,
+    ): Promise<boolean> => {
+      const runPersist = async (
+        snapshot?: NetworkFormState,
+        opts?: UrlSheetPersistOptions,
+      ): Promise<boolean> => {
+        const ctx = persistSheetCtxRef.current;
+        const formSnapshot = snapshot ?? ctx.form;
+        if (formSnapshot.addMode) {
+          return false;
+        }
+        const saved = await ctx.operations.saveNetwork(formSnapshot, {
+          enableAction: ctx.enableAction,
+          disabledByChainId: ctx.validation.disabledByChainId(formSnapshot),
+          disabledByName: ctx.validation.disabledByName(formSnapshot),
+          disabledBySymbol: ctx.validation.disabledBySymbol(formSnapshot),
+          isCustomMainnet: ctx.isCustomMainnet,
+          shouldNetworkSwitchPopToWallet: ctx.shouldNetworkSwitchPopToWallet,
+          trackRpcUpdateFromBanner: ctx.trackRpcUpdateFromBanner,
+          validateChainIdOnSubmit: ctx.validation.validateChainIdOnSubmit,
+          skipPostSaveNavigation: true,
+          bypassEnableActionGuard: true,
+          bypassFormDisabledGuards: true,
+          skipChainIdSubmitValidation:
+            opts?.skipChainIdSubmitValidation === true,
+        });
+        if (saved === true) {
+          ctx.commitBaselineFromFormState(formSnapshot);
+        }
+        return saved === true;
+      };
+
+      if (committedFormSnapshot !== undefined) {
+        return runPersist(committedFormSnapshot, persistOptions).catch(
+          () => false,
+        );
+      }
+
+      return new Promise<boolean>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            runPersist(undefined, persistOptions)
+              .then(resolve)
+              .catch(() => {
+                resolve(false);
+              });
+          });
+        });
+      });
+    },
+    [],
+  );
 
   const handleValidateChainId = useCallback(() => {
     validation.validateChainId(formHook.form);
@@ -317,12 +410,14 @@ const NetworkDetailsView = () => {
             styles={styles}
             themeAppearance={themeAppearance}
             placeholderTextColor={placeholderTextColor}
+            onUrlSheetMutationCommitted={schedulePersistAfterUrlSheetMutation}
           />
           <BlockExplorerModals
             formHook={formHook}
             styles={styles}
             themeAppearance={themeAppearance}
             placeholderTextColor={placeholderTextColor}
+            onUrlSheetMutationCommitted={schedulePersistAfterUrlSheetMutation}
           />
         </>
       )}

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
@@ -51,6 +51,12 @@ export interface NetworkFormState {
   addMode: boolean;
 }
 
+/** Options when auto-persisting after RPC / block explorer sheet commits. */
+export interface UrlSheetPersistOptions {
+  /** Skip redundant eth_chainId check (e.g. RPC sheet add after sheet validation). */
+  skipChainIdSubmitValidation?: boolean;
+}
+
 /** Validation warnings displayed under form fields. */
 export interface ValidationState {
   warningRpcUrl: string | undefined;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
@@ -53,7 +53,11 @@ export interface NetworkFormState {
 
 /** Options when auto-persisting after RPC / block explorer sheet commits. */
 export interface UrlSheetPersistOptions {
-  /** Skip redundant eth_chainId check (e.g. RPC sheet add after sheet validation). */
+  /**
+   * Skip `eth_chainId` vs form chain-id check on save.
+   * Use after RPC-sheet validation already proved the endpoint, or for block-explorer-only
+   * edits where RPC / chain-id correctness is unchanged.
+   */
   skipChainIdSubmitValidation?: boolean;
 }
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
@@ -59,12 +59,13 @@ export interface UrlSheetPersistOptions {
 
 /**
  * Persists RPC / block explorer sheet mutations to the network store.
+ * `committedFormSnapshot` is the post-mutation form state (same pure transforms as the hook).
  * Return `true` so the sheet applies the local form mutation; return `false` to show an
  * error and leave the form unchanged. Must be a boolean (sync or async) — not `void`, so
  * callers cannot accidentally hit the failure path by omitting a return value.
  */
 export type UrlSheetMutationCommittedHandler = (
-  committedFormSnapshot?: NetworkFormState,
+  committedFormSnapshot: NetworkFormState,
   persistOptions?: UrlSheetPersistOptions,
 ) => boolean | Promise<boolean>;
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.types.ts
@@ -57,6 +57,17 @@ export interface UrlSheetPersistOptions {
   skipChainIdSubmitValidation?: boolean;
 }
 
+/**
+ * Persists RPC / block explorer sheet mutations to the network store.
+ * Return `true` so the sheet applies the local form mutation; return `false` to show an
+ * error and leave the form unchanged. Must be a boolean (sync or async) — not `void`, so
+ * callers cannot accidentally hit the failure path by omitting a return value.
+ */
+export type UrlSheetMutationCommittedHandler = (
+  committedFormSnapshot?: NetworkFormState,
+  persistOptions?: UrlSheetPersistOptions,
+) => boolean | Promise<boolean>;
+
 /** Validation warnings displayed under form fields. */
 export interface ValidationState {
   warningRpcUrl: string | undefined;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
@@ -231,6 +231,26 @@ describe('NetworkDetailsView.utils', () => {
           .blockExplorerUrls,
       ).toEqual(['https://b.com']);
     });
+
+    it('repoints blockExplorerUrl when deleted url was selected', () => {
+      const prev = {
+        blockExplorerUrls: ['https://a.com', 'https://b.com'],
+        blockExplorerUrl: 'https://a.com',
+      } as NetworkFormState;
+      const next = removeBlockExplorerUrlFromFormState(prev, 'https://a.com');
+      expect(next.blockExplorerUrls).toEqual(['https://b.com']);
+      expect(next.blockExplorerUrl).toBe('https://b.com');
+    });
+
+    it('clears blockExplorerUrl when deleting the last explorer', () => {
+      const prev = {
+        blockExplorerUrls: ['https://a.com'],
+        blockExplorerUrl: 'https://a.com',
+      } as NetworkFormState;
+      const next = removeBlockExplorerUrlFromFormState(prev, 'https://a.com');
+      expect(next.blockExplorerUrls).toEqual([]);
+      expect(next.blockExplorerUrl).toBeUndefined();
+    });
   });
 
   describe('networkFormBaselineSnapshot', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
@@ -1,8 +1,16 @@
+import { RpcEndpointType } from '@metamask/network-controller';
 import {
+  appendBlockExplorerItemToFormState,
+  appendRpcItemToFormState,
+  applyBlockExplorerSelectionToFormState,
+  applyRpcSelectionToFormState,
   formatNetworkRpcUrl,
-  templateInfuraRpc,
   getDefaultBlockExplorerUrl,
+  removeBlockExplorerUrlFromFormState,
+  removeRpcUrlFromFormState,
+  templateInfuraRpc,
 } from './NetworkDetailsView.utils';
+import type { NetworkFormState } from './NetworkDetailsView.types';
 
 jest.mock('../../../../util/stripProtocol', () => (url: string | undefined) => {
   if (!url) return undefined;
@@ -95,6 +103,132 @@ describe('NetworkDetailsView.utils', () => {
       expect(
         getDefaultBlockExplorerUrl('0xdeadbeef', 'unknown-type'),
       ).toBeUndefined();
+    });
+  });
+
+  describe('appendRpcItemToFormState', () => {
+    const editFormFixture = (): NetworkFormState =>
+      ({
+        rpcUrl: 'https://existing.com',
+        failoverRpcUrls: ['https://failover.com'],
+        rpcName: 'Old',
+        rpcUrlForm: 'typed',
+        rpcNameForm: 'typedName',
+        rpcUrls: [
+          {
+            url: 'https://existing.com',
+            name: 'Old',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+        blockExplorerUrls: [],
+        selectedRpcEndpointIndex: 0,
+        blockExplorerUrl: undefined,
+        blockExplorerUrlForm: undefined,
+        nickname: 'Net',
+        chainId: '0x1',
+        ticker: 'ETH',
+        editable: true,
+        addMode: false,
+      }) as NetworkFormState;
+
+    it('appends endpoint, selects it, clears sheet fields and failover', () => {
+      const prev = editFormFixture();
+      const next = appendRpcItemToFormState(prev, 'https://new.com', 'New');
+
+      expect(next.rpcUrls).toHaveLength(2);
+      expect(next.rpcUrls[1]).toEqual({
+        url: 'https://new.com',
+        name: 'New',
+        type: RpcEndpointType.Custom,
+      });
+      expect(next.rpcUrl).toBe('https://new.com');
+      expect(next.rpcName).toBe('New');
+      expect(next.failoverRpcUrls).toBeUndefined();
+      expect(next.rpcUrlForm).toBe('');
+      expect(next.rpcNameForm).toBe('');
+    });
+
+    it('returns prev when url is empty', () => {
+      const prev = editFormFixture();
+      expect(appendRpcItemToFormState(prev, '', 'x')).toBe(prev);
+    });
+  });
+
+  describe('applyRpcSelectionToFormState', () => {
+    it('uses type when name is empty', () => {
+      const prev = {
+        rpcUrl: 'https://a.com',
+        rpcUrls: [
+          { url: 'https://a.com', name: 'A', type: RpcEndpointType.Custom },
+        ],
+        rpcName: 'A',
+        failoverRpcUrls: undefined,
+      } as NetworkFormState;
+      const next = applyRpcSelectionToFormState(
+        prev,
+        'https://b.com',
+        ['https://f.com'],
+        '',
+        'Custom',
+      );
+      expect(next.rpcUrl).toBe('https://b.com');
+      expect(next.rpcName).toBe('Custom');
+      expect(next.failoverRpcUrls).toEqual(['https://f.com']);
+    });
+  });
+
+  describe('removeRpcUrlFromFormState', () => {
+    it('repoints selection to first endpoint when current is removed', () => {
+      const prev = {
+        rpcUrl: 'https://b.com',
+        rpcName: 'B',
+        rpcUrls: [
+          { url: 'https://a.com', name: 'A', type: RpcEndpointType.Custom },
+          { url: 'https://b.com', name: 'B', type: RpcEndpointType.Custom },
+        ],
+      } as NetworkFormState;
+      const next = removeRpcUrlFromFormState(prev, 'https://b.com');
+      expect(next.rpcUrls).toHaveLength(1);
+      expect(next.rpcUrl).toBe('https://a.com');
+      expect(next.rpcName).toBe('A');
+    });
+  });
+
+  describe('appendBlockExplorerItemToFormState', () => {
+    it('appends url and sets selection', () => {
+      const prev = {
+        blockExplorerUrls: [],
+        blockExplorerUrl: undefined,
+      } as unknown as NetworkFormState;
+      const next = appendBlockExplorerItemToFormState(prev, 'https://scan.com');
+      expect(next.blockExplorerUrls).toEqual(['https://scan.com']);
+      expect(next.blockExplorerUrl).toBe('https://scan.com');
+    });
+  });
+
+  describe('applyBlockExplorerSelectionToFormState', () => {
+    it('sets blockExplorerUrl', () => {
+      const prev = {
+        blockExplorerUrls: ['https://a.com'],
+        blockExplorerUrl: 'https://a.com',
+      } as NetworkFormState;
+      expect(
+        applyBlockExplorerSelectionToFormState(prev, 'https://b.com')
+          .blockExplorerUrl,
+      ).toBe('https://b.com');
+    });
+  });
+
+  describe('removeBlockExplorerUrlFromFormState', () => {
+    it('removes matching url', () => {
+      const prev = {
+        blockExplorerUrls: ['https://a.com', 'https://b.com'],
+      } as NetworkFormState;
+      expect(
+        removeBlockExplorerUrlFromFormState(prev, 'https://a.com')
+          .blockExplorerUrls,
+      ).toEqual(['https://b.com']);
     });
   });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
@@ -194,6 +194,26 @@ describe('NetworkDetailsView.utils', () => {
       expect(next.rpcUrl).toBe('https://a.com');
       expect(next.rpcName).toBe('A');
     });
+
+    it('clears rpcUrl and rpcName when deleting the last endpoint while it was selected', () => {
+      const prev = {
+        rpcUrl: 'https://only.com',
+        rpcName: 'Only',
+        failoverRpcUrls: ['https://fail.com'],
+        rpcUrls: [
+          {
+            url: 'https://only.com',
+            name: 'Only',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      } as NetworkFormState;
+      const next = removeRpcUrlFromFormState(prev, 'https://only.com');
+      expect(next.rpcUrls).toEqual([]);
+      expect(next.rpcUrl).toBeUndefined();
+      expect(next.rpcName).toBeUndefined();
+      expect(next.failoverRpcUrls).toBeUndefined();
+    });
   });
 
   describe('appendBlockExplorerItemToFormState', () => {
@@ -308,6 +328,15 @@ describe('NetworkDetailsView.utils', () => {
         blockExplorerUrls: ['https://b.io'],
         blockExplorerUrl: 'https://a.io',
       });
+
+      expect(networkFormBaselineSnapshot(a)).not.toBe(
+        networkFormBaselineSnapshot(b),
+      );
+    });
+
+    it('differs when nickname and ticker shift across former string boundary', () => {
+      const a = minimalForm({ nickname: 'Net', ticker: 'ABC' });
+      const b = minimalForm({ nickname: 'NetA', ticker: 'BC' });
 
       expect(networkFormBaselineSnapshot(a)).not.toBe(
         networkFormBaselineSnapshot(b),

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.test.ts
@@ -6,6 +6,7 @@ import {
   applyRpcSelectionToFormState,
   formatNetworkRpcUrl,
   getDefaultBlockExplorerUrl,
+  networkFormBaselineSnapshot,
   removeBlockExplorerUrlFromFormState,
   removeRpcUrlFromFormState,
   templateInfuraRpc,
@@ -229,6 +230,68 @@ describe('NetworkDetailsView.utils', () => {
         removeBlockExplorerUrlFromFormState(prev, 'https://a.com')
           .blockExplorerUrls,
       ).toEqual(['https://b.com']);
+    });
+  });
+
+  describe('networkFormBaselineSnapshot', () => {
+    const minimalForm = (
+      overrides: Partial<NetworkFormState> = {},
+    ): NetworkFormState =>
+      ({
+        rpcUrl: 'https://rpc.example.com',
+        failoverRpcUrls: undefined,
+        rpcName: 'R',
+        rpcUrlForm: '',
+        rpcNameForm: '',
+        rpcUrls: [
+          {
+            url: 'https://rpc.example.com',
+            name: 'SameName',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+        blockExplorerUrls: ['https://a.io'],
+        selectedRpcEndpointIndex: 0,
+        blockExplorerUrl: 'https://a.io',
+        blockExplorerUrlForm: undefined,
+        nickname: 'Net',
+        chainId: '0x1',
+        ticker: 'ETH',
+        editable: true,
+        addMode: false,
+        ...overrides,
+      }) as NetworkFormState;
+
+    it('differs when only an RPC endpoint display name changes', () => {
+      const a = minimalForm();
+      const b = minimalForm({
+        rpcUrls: [
+          {
+            url: 'https://rpc.example.com',
+            name: 'Renamed',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      });
+
+      expect(networkFormBaselineSnapshot(a)).not.toBe(
+        networkFormBaselineSnapshot(b),
+      );
+    });
+
+    it('differs when a block explorer URL entry changes', () => {
+      const a = minimalForm({
+        blockExplorerUrls: ['https://a.io'],
+        blockExplorerUrl: 'https://a.io',
+      });
+      const b = minimalForm({
+        blockExplorerUrls: ['https://b.io'],
+        blockExplorerUrl: 'https://a.io',
+      });
+
+      expect(networkFormBaselineSnapshot(a)).not.toBe(
+        networkFormBaselineSnapshot(b),
+      );
     });
   });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
@@ -130,9 +130,16 @@ export function removeBlockExplorerUrlFromFormState(
   prev: NetworkFormState,
   url: string,
 ): NetworkFormState {
+  const updated = prev.blockExplorerUrls.filter((u) => u !== url);
+  const wasSelected = prev.blockExplorerUrl === url;
   return {
     ...prev,
-    blockExplorerUrls: prev.blockExplorerUrls.filter((u) => u !== url),
+    blockExplorerUrls: updated,
+    ...(wasSelected
+      ? {
+          blockExplorerUrl: updated.length > 0 ? updated[0] : undefined,
+        }
+      : {}),
   };
 }
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
@@ -10,6 +10,29 @@ import type { NetworkFormState, RpcEndpoint } from './NetworkDetailsView.types';
 export const formatNetworkRpcUrl = (rpcUrl: string): string =>
   stripProtocol(stripKeyFromInfuraUrl(rpcUrl) ?? rpcUrl) ?? rpcUrl;
 
+/**
+ * Stable snapshot of form fields for dirty detection vs the last committed baseline.
+ * Uses `JSON.stringify` for `rpcUrls`, `blockExplorerUrls`, and `failoverRpcUrls` so
+ * in-place content changes register (not `String([object])` collisions).
+ */
+export function networkFormBaselineSnapshot(prev: NetworkFormState): string {
+  const failoverKey =
+    prev.failoverRpcUrls === undefined
+      ? ''
+      : JSON.stringify(prev.failoverRpcUrls);
+  return (
+    (prev.rpcUrl ?? '') +
+    failoverKey +
+    (prev.blockExplorerUrl ?? '') +
+    (prev.nickname ?? '') +
+    (prev.chainId ?? '') +
+    (prev.ticker ?? '') +
+    String(prev.editable) +
+    JSON.stringify(prev.rpcUrls ?? []) +
+    JSON.stringify(prev.blockExplorerUrls ?? [])
+  );
+}
+
 /** Next form state after appending a custom RPC (same transform as `onRpcItemAdd`). */
 export function appendRpcItemToFormState(
   prev: NetworkFormState,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
@@ -12,25 +12,21 @@ export const formatNetworkRpcUrl = (rpcUrl: string): string =>
 
 /**
  * Stable snapshot of form fields for dirty detection vs the last committed baseline.
- * Uses `JSON.stringify` for `rpcUrls`, `blockExplorerUrls`, and `failoverRpcUrls` so
- * in-place content changes register (not `String([object])` collisions).
+ * One `JSON.stringify` over a fixed-order tuple so field boundaries cannot alias (e.g.
+ * nickname+ticker edits that would collide when naive-concatenating strings).
  */
 export function networkFormBaselineSnapshot(prev: NetworkFormState): string {
-  const failoverKey =
-    prev.failoverRpcUrls === undefined
-      ? ''
-      : JSON.stringify(prev.failoverRpcUrls);
-  return (
-    (prev.rpcUrl ?? '') +
-    failoverKey +
-    (prev.blockExplorerUrl ?? '') +
-    (prev.nickname ?? '') +
-    (prev.chainId ?? '') +
-    (prev.ticker ?? '') +
-    String(prev.editable) +
-    JSON.stringify(prev.rpcUrls ?? []) +
-    JSON.stringify(prev.blockExplorerUrls ?? [])
-  );
+  return JSON.stringify([
+    prev.rpcUrl ?? null,
+    prev.failoverRpcUrls ?? null,
+    prev.blockExplorerUrl ?? null,
+    prev.nickname ?? null,
+    prev.chainId ?? null,
+    prev.ticker ?? null,
+    prev.editable ?? null,
+    prev.rpcUrls ?? [],
+    prev.blockExplorerUrls ?? [],
+  ]);
 }
 
 /** Next form state after appending a custom RPC (same transform as `onRpcItemAdd`). */
@@ -82,16 +78,27 @@ export function removeRpcUrlFromFormState(
 ): NetworkFormState {
   const updated = prev.rpcUrls.filter((rpc) => rpc.url !== url);
   const isCurrentRpc = prev.rpcUrl === url;
+  if (isCurrentRpc && updated.length > 0) {
+    return {
+      ...prev,
+      rpcUrls: updated,
+      rpcUrl: updated[0].url,
+      failoverRpcUrls: updated[0].failoverUrls,
+      rpcName: updated[0].name,
+    };
+  }
+  if (isCurrentRpc && updated.length === 0) {
+    return {
+      ...prev,
+      rpcUrls: updated,
+      rpcUrl: undefined,
+      rpcName: undefined,
+      failoverRpcUrls: undefined,
+    };
+  }
   return {
     ...prev,
     rpcUrls: updated,
-    ...(isCurrentRpc && updated.length > 0
-      ? {
-          rpcUrl: updated[0].url,
-          failoverRpcUrls: updated[0].failoverUrls,
-          rpcName: updated[0].name,
-        }
-      : {}),
   };
 }
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.utils.ts
@@ -1,12 +1,117 @@
 import { PopularList } from '../../../../util/networks/customNetworks';
 import { BlockExplorerUrl } from '@metamask/controller-utils';
+import { RpcEndpointType } from '@metamask/network-controller';
 import stripProtocol from '../../../../util/stripProtocol';
 import stripKeyFromInfuraUrl from '../../../../util/stripKeyFromInfuraUrl';
 
 import { infuraProjectId } from './NetworkDetailsView.constants';
+import type { NetworkFormState, RpcEndpoint } from './NetworkDetailsView.types';
 
 export const formatNetworkRpcUrl = (rpcUrl: string): string =>
   stripProtocol(stripKeyFromInfuraUrl(rpcUrl) ?? rpcUrl) ?? rpcUrl;
+
+/** Next form state after appending a custom RPC (same transform as `onRpcItemAdd`). */
+export function appendRpcItemToFormState(
+  prev: NetworkFormState,
+  url: string,
+  name: string,
+): NetworkFormState {
+  if (!url) {
+    return prev;
+  }
+  const newRpcUrl: RpcEndpoint = {
+    url,
+    name: name ?? '',
+    type: RpcEndpointType.Custom,
+  };
+  return {
+    ...prev,
+    rpcUrls: [...prev.rpcUrls, newRpcUrl],
+    rpcUrl: newRpcUrl.url,
+    failoverRpcUrls: undefined,
+    rpcName: newRpcUrl.name,
+    rpcUrlForm: '',
+    rpcNameForm: '',
+  };
+}
+
+/** Next form state after selecting an RPC endpoint (same transform as `onRpcUrlChangeWithName`). */
+export function applyRpcSelectionToFormState(
+  prev: NetworkFormState,
+  url: string,
+  failoverUrls: string[] | undefined,
+  name: string,
+  type: string,
+): NetworkFormState {
+  const nameToUse = name || type;
+  return {
+    ...prev,
+    rpcName: nameToUse,
+    rpcUrl: url,
+    failoverRpcUrls: failoverUrls,
+  };
+}
+
+/** Next form state after removing an RPC URL from the list (same transform as `onRpcUrlDelete`). */
+export function removeRpcUrlFromFormState(
+  prev: NetworkFormState,
+  url: string,
+): NetworkFormState {
+  const updated = prev.rpcUrls.filter((rpc) => rpc.url !== url);
+  const isCurrentRpc = prev.rpcUrl === url;
+  return {
+    ...prev,
+    rpcUrls: updated,
+    ...(isCurrentRpc && updated.length > 0
+      ? {
+          rpcUrl: updated[0].url,
+          failoverRpcUrls: updated[0].failoverUrls,
+          rpcName: updated[0].name,
+        }
+      : {}),
+  };
+}
+
+/** Next form state after adding a block explorer URL (same transform as `onBlockExplorerItemAdd`). */
+export function appendBlockExplorerItemToFormState(
+  prev: NetworkFormState,
+  url: string,
+): NetworkFormState {
+  if (!url) {
+    return prev;
+  }
+  if (prev.blockExplorerUrls.includes(url)) {
+    return prev;
+  }
+  return {
+    ...prev,
+    blockExplorerUrls: [...prev.blockExplorerUrls, url],
+    blockExplorerUrl: url,
+    blockExplorerUrlForm: undefined,
+  };
+}
+
+/** Next form state after selecting a block explorer URL (same transform as `onBlockExplorerSelect`). */
+export function applyBlockExplorerSelectionToFormState(
+  prev: NetworkFormState,
+  url: string,
+): NetworkFormState {
+  return {
+    ...prev,
+    blockExplorerUrl: url,
+  };
+}
+
+/** Next form state after removing a block explorer URL (same transform as `onBlockExplorerUrlDelete`). */
+export function removeBlockExplorerUrlFromFormState(
+  prev: NetworkFormState,
+  url: string,
+): NetworkFormState {
+  return {
+    ...prev,
+    blockExplorerUrls: prev.blockExplorerUrls.filter((u) => u !== url),
+  };
+}
 
 /**
  * Replace the Infura project ID placeholder with the actual key.

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.test.tsx
@@ -218,6 +218,10 @@ describe('BlockExplorerModals', () => {
     await waitFor(() => {
       expect(onUrlSheetMutationCommitted).toHaveBeenCalled();
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onBlockExplorerItemAdd).toHaveBeenCalledWith(
       'https://new-scan.example.com',
     );
@@ -252,6 +256,10 @@ describe('BlockExplorerModals', () => {
         strings('app_settings.url_sheet_network_update_failed'),
       );
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onBlockExplorerItemAdd).not.toHaveBeenCalled();
   });
 
@@ -292,13 +300,15 @@ describe('BlockExplorerModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(true);
+
     const { getByText } = render(
       <BlockExplorerModals
         formHook={formHook}
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(true)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -311,6 +321,10 @@ describe('BlockExplorerModals', () => {
         'https://scan2.example.com',
       );
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
   });
 
   it('shows sheet error and skips onBlockExplorerSelect when persist returns false', async () => {
@@ -325,13 +339,15 @@ describe('BlockExplorerModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
     const { getByText, getByTestId } = render(
       <BlockExplorerModals
         formHook={formHook}
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -346,6 +362,10 @@ describe('BlockExplorerModals', () => {
         ),
       ).toBeOnTheScreen();
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onBlockExplorerSelect).not.toHaveBeenCalled();
   });
 
@@ -361,13 +381,15 @@ describe('BlockExplorerModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
     const { getAllByTestId, getByTestId } = render(
       <BlockExplorerModals
         formHook={formHook}
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -382,6 +404,10 @@ describe('BlockExplorerModals', () => {
         ),
       ).toBeOnTheScreen();
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onBlockExplorerUrlDelete).not.toHaveBeenCalled();
   });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.test.tsx
@@ -1,0 +1,387 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { mockTheme } from '../../../../../util/theme';
+import createStyles from '../NetworkDetailsView.styles';
+import { BUTTON_TEST_ID } from '../../../../../component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.constants';
+import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
+import type { NetworkFormState } from '../NetworkDetailsView.types';
+import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
+import BlockExplorerSection, {
+  BlockExplorerModals,
+} from './BlockExplorerSection';
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const Rn = jest.requireActual('react-native');
+    const R = jest.requireActual('react');
+    return {
+      __esModule: true,
+      default: R.forwardRef(
+        (
+          { children }: { children: React.ReactNode },
+          _ref: React.Ref<unknown>,
+        ) => <Rn.View>{children}</Rn.View>,
+      ),
+      BottomSheetRef: {},
+    };
+  },
+);
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheetHeader',
+  () => {
+    const Rn = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({ children }: { children: React.ReactNode }) => (
+        <Rn.Text>{children}</Rn.Text>
+      ),
+    };
+  },
+);
+
+const styles = createStyles({ theme: mockTheme });
+const placeholderTextColor = mockTheme.colors.text.muted;
+
+const baseEditForm: NetworkFormState = {
+  rpcUrl: 'https://rpc.example.com',
+  failoverRpcUrls: undefined,
+  rpcName: 'RPC',
+  rpcUrlForm: '',
+  rpcNameForm: '',
+  rpcUrls: [{ url: 'https://rpc.example.com', name: 'RPC', type: 'custom' }],
+  blockExplorerUrls: ['https://scan1.example.com'],
+  selectedRpcEndpointIndex: 0,
+  blockExplorerUrl: 'https://scan1.example.com',
+  blockExplorerUrlForm: 'https://new-scan.example.com',
+  nickname: 'TestNet',
+  chainId: '0x2a',
+  ticker: 'TST',
+  editable: true,
+  addMode: false,
+};
+
+function createBlockExplorerModalFormHook(
+  overrides: Partial<{
+    form: Partial<NetworkFormState>;
+    showMultiBlockExplorerAddModal: boolean;
+    blockExplorerModalShowForm: boolean;
+  }> = {},
+): UseNetworkFormReturn {
+  const form: NetworkFormState = {
+    ...baseEditForm,
+    ...overrides.form,
+    blockExplorerUrls:
+      overrides.form?.blockExplorerUrls ?? baseEditForm.blockExplorerUrls,
+  };
+
+  return {
+    form,
+    enableAction: false,
+    focus: {
+      isNameFieldFocused: false,
+      isSymbolFieldFocused: false,
+      isRpcUrlFieldFocused: false,
+      isChainIdFieldFocused: false,
+    },
+    modals: {
+      showMultiRpcAddModal: false,
+      rpcModalShowForm: false,
+      showMultiBlockExplorerAddModal:
+        overrides.showMultiBlockExplorerAddModal ?? true,
+      blockExplorerModalShowForm: overrides.blockExplorerModalShowForm ?? true,
+      showWarningModal: false,
+    },
+    isAnyModalVisible: true,
+    inputRpcURL: { current: null },
+    inputNameRpcURL: { current: null },
+    inputChainId: { current: null },
+    inputSymbol: { current: null },
+    inputBlockExplorerURL: { current: null },
+    onNicknameChange: jest.fn(),
+    onChainIDChange: jest.fn(),
+    onTickerChange: jest.fn(),
+    autoFillNameField: jest.fn(),
+    autoFillSymbolField: jest.fn(),
+    onRpcUrlAdd: jest.fn(),
+    onRpcNameAdd: jest.fn(),
+    onRpcItemAdd: jest.fn(),
+    onRpcUrlChangeWithName: jest.fn(),
+    onRpcUrlDelete: jest.fn(),
+    onBlockExplorerItemAdd: jest.fn(),
+    onBlockExplorerUrlChange: jest.fn(),
+    onBlockExplorerSelect: jest.fn(),
+    onBlockExplorerUrlDelete: jest.fn(),
+    setValidationCallback: jest.fn(),
+    commitBaselineFromFormState: jest.fn(),
+    onNameFocused: jest.fn(),
+    onNameBlur: jest.fn(),
+    onSymbolFocused: jest.fn(),
+    onSymbolBlur: jest.fn(),
+    onRpcUrlFocused: jest.fn(),
+    onRpcUrlBlur: jest.fn(),
+    onChainIdFocused: jest.fn(),
+    onChainIdBlur: jest.fn(),
+    jumpToRpcURL: jest.fn(),
+    jumpToChainId: jest.fn(),
+    jumpToSymbol: jest.fn(),
+    jumpBlockExplorerURL: jest.fn(),
+    openRpcModal: jest.fn(),
+    closeRpcModal: jest.fn(),
+    setRpcModalShowForm: jest.fn(),
+    openBlockExplorerModal: jest.fn(),
+    closeBlockExplorerModal: jest.fn(),
+    setBlockExplorerModalShowForm: jest.fn(),
+    toggleWarningModal: jest.fn(),
+  } as UseNetworkFormReturn;
+}
+
+describe('BlockExplorerSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders block explorer text field in add mode', () => {
+    const formHook = createBlockExplorerModalFormHook({
+      form: {
+        addMode: true,
+        blockExplorerUrlForm: '',
+        blockExplorerUrls: [],
+        blockExplorerUrl: undefined,
+      },
+      showMultiBlockExplorerAddModal: false,
+      blockExplorerModalShowForm: false,
+    });
+
+    const { getByTestId } = render(
+      <BlockExplorerSection
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_INPUT),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders block explorer selector in edit mode', () => {
+    const formHook = createBlockExplorerModalFormHook({
+      showMultiBlockExplorerAddModal: false,
+      blockExplorerModalShowForm: false,
+    });
+
+    const { getByTestId } = render(
+      <BlockExplorerSection
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.ICON_BUTTON_BLOCK_EXPLORER),
+    ).toBeOnTheScreen();
+  });
+});
+
+describe('BlockExplorerModals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onBlockExplorerItemAdd when add submit runs and persist succeeds', async () => {
+    const formHook = createBlockExplorerModalFormHook();
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(true);
+
+    const { getAllByTestId } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(onUrlSheetMutationCommitted).toHaveBeenCalled();
+    });
+    expect(formHook.onBlockExplorerItemAdd).toHaveBeenCalledWith(
+      'https://new-scan.example.com',
+    );
+  });
+
+  it('shows sheet error and skips onBlockExplorerItemAdd when persist returns false', async () => {
+    const formHook = createBlockExplorerModalFormHook();
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
+    const { getAllByTestId, getByTestId } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(
+          NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_SHEET_SUBMIT_ERROR,
+        ),
+      ).toHaveTextContent(
+        strings('app_settings.url_sheet_network_update_failed'),
+      );
+    });
+    expect(formHook.onBlockExplorerItemAdd).not.toHaveBeenCalled();
+  });
+
+  it('calls onBlockExplorerItemAdd when onUrlSheetMutationCommitted is omitted', async () => {
+    const formHook = createBlockExplorerModalFormHook();
+
+    const { getAllByTestId } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(formHook.onBlockExplorerItemAdd).toHaveBeenCalledWith(
+        'https://new-scan.example.com',
+      );
+    });
+  });
+
+  it('calls onBlockExplorerSelect after choosing an explorer URL when persist succeeds', async () => {
+    const formHook = createBlockExplorerModalFormHook({
+      form: {
+        ...baseEditForm,
+        blockExplorerUrls: [
+          'https://scan1.example.com',
+          'https://scan2.example.com',
+        ],
+        blockExplorerUrl: 'https://scan1.example.com',
+      },
+    });
+
+    const { getByText } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('https://scan2.example.com'));
+    });
+
+    await waitFor(() => {
+      expect(formHook.onBlockExplorerSelect).toHaveBeenCalledWith(
+        'https://scan2.example.com',
+      );
+    });
+  });
+
+  it('shows sheet error and skips onBlockExplorerSelect when persist returns false', async () => {
+    const formHook = createBlockExplorerModalFormHook({
+      form: {
+        ...baseEditForm,
+        blockExplorerUrls: [
+          'https://scan1.example.com',
+          'https://scan2.example.com',
+        ],
+        blockExplorerUrl: 'https://scan1.example.com',
+      },
+    });
+
+    const { getByText, getByTestId } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('https://scan2.example.com'));
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(
+          NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_SHEET_SUBMIT_ERROR,
+        ),
+      ).toBeOnTheScreen();
+    });
+    expect(formHook.onBlockExplorerSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows sheet error and skips onBlockExplorerUrlDelete when persist returns false', async () => {
+    const formHook = createBlockExplorerModalFormHook({
+      form: {
+        ...baseEditForm,
+        blockExplorerUrls: [
+          'https://scan1.example.com',
+          'https://scan2.example.com',
+        ],
+        blockExplorerUrl: 'https://scan1.example.com',
+      },
+    });
+
+    const { getAllByTestId, getByTestId } = render(
+      <BlockExplorerModals
+        formHook={formHook}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getAllByTestId(BUTTON_TEST_ID)[0]);
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(
+          NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_SHEET_SUBMIT_ERROR,
+        ),
+      ).toBeOnTheScreen();
+    });
+    expect(formHook.onBlockExplorerUrlDelete).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
 import { Animated as RNAnimated, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import isUrl from 'is-url';
@@ -28,6 +28,15 @@ import { AvatarVariant } from '../../../../../component-library/components/Avata
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import SelectField from './SelectField';
 import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
+import {
+  appendBlockExplorerItemToFormState,
+  applyBlockExplorerSelectionToFormState,
+  removeBlockExplorerUrlFromFormState,
+} from '../NetworkDetailsView.utils';
+import type {
+  NetworkFormState,
+  UrlSheetPersistOptions,
+} from '../NetworkDetailsView.types';
 import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
 import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
 
@@ -38,6 +47,11 @@ interface BlockExplorerSectionProps {
   styles: NetworkDetailsStyles;
   themeAppearance: 'light' | 'dark' | 'default';
   placeholderTextColor: string;
+  /** Invoked after add / select / delete explorer URL is applied in edit mode (persists to network store). */
+  onUrlSheetMutationCommitted?: (
+    committedFormSnapshot?: NetworkFormState,
+    persistOptions?: UrlSheetPersistOptions,
+  ) => void | Promise<boolean>;
 }
 
 const BlockExplorerSection: React.FC<BlockExplorerSectionProps> = ({
@@ -94,13 +108,15 @@ const BlockExplorerSection: React.FC<BlockExplorerSectionProps> = ({
 interface BlockExplorerListItemProps {
   url: string;
   isSelected: boolean;
-  onSelect: (url: string) => void;
-  onDelete: (url: string) => void;
+  onSelect: (url: string) => void | Promise<void>;
+  onDelete: (url: string) => void | Promise<void>;
 }
 
 const BlockExplorerListItem: React.FC<BlockExplorerListItemProps> = React.memo(
   ({ url, isSelected, onSelect, onDelete }) => {
-    const handlePress = useCallback(() => onSelect(url), [onSelect, url]);
+    const handlePress = useCallback(async () => {
+      await onSelect(url);
+    }, [onSelect, url]);
     const handleDelete = useCallback(() => onDelete(url), [onDelete, url]);
 
     return (
@@ -130,6 +146,7 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
   styles,
   themeAppearance,
   placeholderTextColor,
+  onUrlSheetMutationCommitted,
 }) => {
   const {
     form: { blockExplorerUrl, blockExplorerUrls, blockExplorerUrlForm },
@@ -148,6 +165,14 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
 
   const sheetRef = useRef<BottomSheetRef>(null);
   const hadListWhenFormOpened = useRef(false);
+  const latestFormRef = useRef(formHook.form);
+  latestFormRef.current = formHook.form;
+
+  const [blockExplorerSheetError, setBlockExplorerSheetError] = useState<
+    string | undefined
+  >(undefined);
+  const [isBlockExplorerSheetSubmitting, setIsBlockExplorerSheetSubmitting] =
+    useState(false);
 
   const { onContentLayout, contentWrapperStyle, toggleButtonStyle } =
     useExpandableFormAnimation(showForm);
@@ -160,16 +185,58 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showForm]);
 
+  useEffect(() => {
+    if (showMultiBlockExplorerAddModal) {
+      setBlockExplorerSheetError(undefined);
+      setIsBlockExplorerSheetSubmitting(false);
+    }
+  }, [showMultiBlockExplorerAddModal]);
+
+  useEffect(() => {
+    setBlockExplorerSheetError(undefined);
+  }, [blockExplorerUrlForm]);
+
   const handleDismiss = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
   }, []);
 
   const handleSelectAndDismiss = useCallback(
-    (url: string) => {
+    async (url: string) => {
+      setBlockExplorerSheetError(undefined);
+      const nextForm = applyBlockExplorerSelectionToFormState(
+        latestFormRef.current,
+        url,
+      );
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setBlockExplorerSheetError(
+          strings('app_settings.url_sheet_network_update_failed'),
+        );
+        return;
+      }
       onBlockExplorerSelect(url);
       handleDismiss();
     },
-    [onBlockExplorerSelect, handleDismiss],
+    [onBlockExplorerSelect, handleDismiss, onUrlSheetMutationCommitted],
+  );
+
+  const onBlockExplorerUrlDeletePersisted = useCallback(
+    async (url: string) => {
+      setBlockExplorerSheetError(undefined);
+      const nextForm = removeBlockExplorerUrlFromFormState(
+        latestFormRef.current,
+        url,
+      );
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setBlockExplorerSheetError(
+          strings('app_settings.url_sheet_network_update_failed'),
+        );
+        return;
+      }
+      onBlockExplorerUrlDelete(url);
+    },
+    [onBlockExplorerUrlDelete, onUrlSheetMutationCommitted],
   );
 
   const handleBack = () => {
@@ -180,19 +247,37 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
     }
   };
 
-  const handleFormSubmit = () => {
+  const handleFormSubmit = async () => {
     if (
       !blockExplorerUrlForm ||
       !isUrl(blockExplorerUrlForm) ||
-      blockExplorerUrls.includes(blockExplorerUrlForm)
+      blockExplorerUrls.includes(blockExplorerUrlForm) ||
+      isBlockExplorerSheetSubmitting
     ) {
       return;
     }
-    onBlockExplorerItemAdd(blockExplorerUrlForm);
-    if (hadListWhenFormOpened.current) {
-      setShowForm(false);
-    } else {
-      handleDismiss();
+    setBlockExplorerSheetError(undefined);
+    setIsBlockExplorerSheetSubmitting(true);
+    try {
+      const nextForm = appendBlockExplorerItemToFormState(
+        latestFormRef.current,
+        blockExplorerUrlForm,
+      );
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setBlockExplorerSheetError(
+          strings('app_settings.url_sheet_network_update_failed'),
+        );
+        return;
+      }
+      onBlockExplorerItemAdd(blockExplorerUrlForm);
+      if (hadListWhenFormOpened.current) {
+        setShowForm(false);
+      } else {
+        handleDismiss();
+      }
+    } finally {
+      setIsBlockExplorerSheetSubmitting(false);
     }
   };
 
@@ -228,12 +313,26 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
                   url={url}
                   isSelected={blockExplorerUrl === url}
                   onSelect={handleSelectAndDismiss}
-                  onDelete={onBlockExplorerUrlDelete}
+                  onDelete={onBlockExplorerUrlDeletePersisted}
                 />
               </React.Fragment>
             ))}
           </Box>
         )}
+
+        {blockExplorerSheetError ? (
+          <Box twClassName="mx-4 mt-2">
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-error-default"
+              testID={
+                NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_SHEET_SUBMIT_ERROR
+              }
+            >
+              {blockExplorerSheetError}
+            </Text>
+          </Box>
+        ) : null}
 
         {/* Form — always mounted, height-animated to drive sheet resize */}
         <RNAnimated.View style={contentWrapperStyle}>
@@ -242,46 +341,53 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
             onLayout={onContentLayout}
             pointerEvents={showForm ? 'auto' : 'none'}
           >
-            <Box twClassName="mx-4 mt-4 p-4 gap-4 rounded-xl bg-background-muted">
-              <Box twClassName="gap-1">
-                <Label>
-                  {strings('app_settings.network_block_explorer_label')}
-                </Label>
-                <TextField
-                  ref={inputBlockExplorerURL}
-                  autoCapitalize="none"
-                  value={blockExplorerUrlForm}
-                  autoCorrect={false}
-                  onChangeText={onBlockExplorerUrlChange}
-                  placeholder={strings(
-                    'app_settings.network_block_explorer_placeholder',
+            <View
+              pointerEvents={isBlockExplorerSheetSubmitting ? 'none' : 'auto'}
+            >
+              <Box twClassName="mx-4 mt-4 p-4 gap-4 rounded-xl bg-background-muted">
+                <Box twClassName="gap-1">
+                  <Label>
+                    {strings('app_settings.network_block_explorer_label')}
+                  </Label>
+                  <TextField
+                    ref={inputBlockExplorerURL}
+                    autoCapitalize="none"
+                    value={blockExplorerUrlForm}
+                    autoCorrect={false}
+                    onChangeText={onBlockExplorerUrlChange}
+                    placeholder={strings(
+                      'app_settings.network_block_explorer_placeholder',
+                    )}
+                    testID={NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_INPUT}
+                    placeholderTextColor={placeholderTextColor}
+                    onSubmitEditing={handleFormSubmit}
+                    keyboardAppearance={themeAppearance}
+                    isError={hasInvalidUrl}
+                  />
+                  {hasInvalidUrl && (
+                    <Text
+                      variant={TextVariant.BodySm}
+                      twClassName="text-error-default"
+                    >
+                      {strings('app_settings.invalid_block_explorer_url')}
+                    </Text>
                   )}
-                  testID={NetworkDetailsViewSelectorsIDs.BLOCK_EXPLORER_INPUT}
-                  placeholderTextColor={placeholderTextColor}
-                  onSubmitEditing={handleFormSubmit}
-                  keyboardAppearance={themeAppearance}
-                  isError={hasInvalidUrl}
+                </Box>
+                <ButtonPrimary
+                  label={strings('app_settings.add_block_explorer_url')}
+                  testID={NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER}
+                  size={ButtonSize.Lg}
+                  onPress={handleFormSubmit}
+                  width={ButtonWidthTypes.Full}
+                  loading={isBlockExplorerSheetSubmitting}
+                  isDisabled={
+                    !blockExplorerUrlForm ||
+                    !isUrl(blockExplorerUrlForm) ||
+                    isBlockExplorerSheetSubmitting
+                  }
                 />
-                {hasInvalidUrl && (
-                  <Text
-                    variant={TextVariant.BodySm}
-                    twClassName="text-error-default"
-                  >
-                    {strings('app_settings.invalid_block_explorer_url')}
-                  </Text>
-                )}
               </Box>
-              <ButtonPrimary
-                label={strings('app_settings.add_block_explorer_url')}
-                testID={NetworkDetailsViewSelectorsIDs.ADD_BLOCK_EXPLORER}
-                size={ButtonSize.Lg}
-                onPress={handleFormSubmit}
-                width={ButtonWidthTypes.Full}
-                isDisabled={
-                  !blockExplorerUrlForm || !isUrl(blockExplorerUrlForm)
-                }
-              />
-            </Box>
+            </View>
           </View>
         </RNAnimated.View>
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
@@ -33,7 +33,15 @@ import {
   applyBlockExplorerSelectionToFormState,
   removeBlockExplorerUrlFromFormState,
 } from '../NetworkDetailsView.utils';
-import type { UrlSheetMutationCommittedHandler } from '../NetworkDetailsView.types';
+import type {
+  UrlSheetMutationCommittedHandler,
+  UrlSheetPersistOptions,
+} from '../NetworkDetailsView.types';
+
+/** Block explorer list edits do not change RPC / chain-id pairing — skip eth_chainId on persist. */
+const BLOCK_EXPLORER_SHEET_PERSIST_OPTS: UrlSheetPersistOptions = {
+  skipChainIdSubmitValidation: true,
+};
 import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
 import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
 
@@ -203,7 +211,10 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
         latestFormRef.current,
         url,
       );
-      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      const persisted = await onUrlSheetMutationCommitted?.(
+        nextForm,
+        BLOCK_EXPLORER_SHEET_PERSIST_OPTS,
+      );
       if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
         setBlockExplorerSheetError(
           strings('app_settings.url_sheet_network_update_failed'),
@@ -223,7 +234,10 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
         latestFormRef.current,
         url,
       );
-      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      const persisted = await onUrlSheetMutationCommitted?.(
+        nextForm,
+        BLOCK_EXPLORER_SHEET_PERSIST_OPTS,
+      );
       if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
         setBlockExplorerSheetError(
           strings('app_settings.url_sheet_network_update_failed'),
@@ -259,7 +273,10 @@ const BlockExplorerModals: React.FC<BlockExplorerSectionProps> = ({
         latestFormRef.current,
         blockExplorerUrlForm,
       );
-      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      const persisted = await onUrlSheetMutationCommitted?.(
+        nextForm,
+        BLOCK_EXPLORER_SHEET_PERSIST_OPTS,
+      );
       if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
         setBlockExplorerSheetError(
           strings('app_settings.url_sheet_network_update_failed'),

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
@@ -33,10 +33,7 @@ import {
   applyBlockExplorerSelectionToFormState,
   removeBlockExplorerUrlFromFormState,
 } from '../NetworkDetailsView.utils';
-import type {
-  NetworkFormState,
-  UrlSheetPersistOptions,
-} from '../NetworkDetailsView.types';
+import type { UrlSheetMutationCommittedHandler } from '../NetworkDetailsView.types';
 import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
 import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
 
@@ -47,11 +44,8 @@ interface BlockExplorerSectionProps {
   styles: NetworkDetailsStyles;
   themeAppearance: 'light' | 'dark' | 'default';
   placeholderTextColor: string;
-  /** Invoked after add / select / delete explorer URL is applied in edit mode (persists to network store). */
-  onUrlSheetMutationCommitted?: (
-    committedFormSnapshot?: NetworkFormState,
-    persistOptions?: UrlSheetPersistOptions,
-  ) => void | Promise<boolean>;
+  /** Invoked after add / select / delete explorer URL is applied in edit mode (persists to network store). Must return whether persist succeeded. */
+  onUrlSheetMutationCommitted?: UrlSheetMutationCommittedHandler;
 }
 
 const BlockExplorerSection: React.FC<BlockExplorerSectionProps> = ({
@@ -117,7 +111,9 @@ const BlockExplorerListItem: React.FC<BlockExplorerListItemProps> = React.memo(
     const handlePress = useCallback(async () => {
       await onSelect(url);
     }, [onSelect, url]);
-    const handleDelete = useCallback(() => onDelete(url), [onDelete, url]);
+    const handleDelete = useCallback(async () => {
+      await onDelete(url);
+    }, [onDelete, url]);
 
     return (
       <Cell

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx
@@ -37,16 +37,15 @@ import type {
   UrlSheetMutationCommittedHandler,
   UrlSheetPersistOptions,
 } from '../NetworkDetailsView.types';
+import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
+import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
 
 /** Block explorer list edits do not change RPC / chain-id pairing — skip eth_chainId on persist. */
 const BLOCK_EXPLORER_SHEET_PERSIST_OPTS: UrlSheetPersistOptions = {
   skipChainIdSubmitValidation: true,
 };
-import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
-import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
 
 const FORM_INNER_STYLE = { position: 'absolute' as const, left: 0, right: 0 };
-
 interface BlockExplorerSectionProps {
   formHook: UseNetworkFormReturn;
   styles: NetworkDetailsStyles;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.test.tsx
@@ -1,0 +1,515 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { BUTTON_TEST_ID } from '../../../../../component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.constants';
+import { mockTheme } from '../../../../../util/theme';
+import createStyles from '../NetworkDetailsView.styles';
+import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
+import type { NetworkFormState } from '../NetworkDetailsView.types';
+import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
+import type { UseNetworkValidationReturn } from '../hooks/useNetworkValidation';
+import RpcEndpointSection, { RpcEndpointModals } from './RpcEndpointSection';
+
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { log: jest.fn() },
+}));
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const Rn = jest.requireActual('react-native');
+    const R = jest.requireActual('react');
+    return {
+      __esModule: true,
+      default: R.forwardRef(
+        (
+          { children }: { children: React.ReactNode },
+          _ref: React.Ref<unknown>,
+        ) => <Rn.View>{children}</Rn.View>,
+      ),
+      BottomSheetRef: {},
+    };
+  },
+);
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheetHeader',
+  () => {
+    const Rn = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({ children }: { children: React.ReactNode }) => (
+        <Rn.Text>{children}</Rn.Text>
+      ),
+    };
+  },
+);
+
+const styles = createStyles({ theme: mockTheme });
+const placeholderTextColor = mockTheme.colors.text.muted;
+
+const baseEditForm: NetworkFormState = {
+  rpcUrl: 'https://rpc1.example.com',
+  failoverRpcUrls: undefined,
+  rpcName: 'RPC One',
+  rpcUrlForm: 'https://new-rpc.example.com',
+  rpcNameForm: 'New RPC',
+  rpcUrls: [
+    {
+      url: 'https://rpc1.example.com',
+      name: 'RPC One',
+      type: RpcEndpointType.Custom,
+    },
+  ],
+  blockExplorerUrls: [],
+  selectedRpcEndpointIndex: 0,
+  blockExplorerUrl: undefined,
+  blockExplorerUrlForm: undefined,
+  nickname: 'TestNet',
+  chainId: '0x2a',
+  ticker: 'TST',
+  editable: true,
+  addMode: false,
+};
+
+function createRpcModalFormHook(
+  overrides: Partial<{
+    form: Partial<NetworkFormState>;
+    showMultiRpcAddModal: boolean;
+    rpcModalShowForm: boolean;
+  }> = {},
+): UseNetworkFormReturn {
+  const form: NetworkFormState = {
+    ...baseEditForm,
+    ...overrides.form,
+    rpcUrls: overrides.form?.rpcUrls ?? baseEditForm.rpcUrls,
+  };
+
+  return {
+    form,
+    enableAction: false,
+    focus: {
+      isNameFieldFocused: false,
+      isSymbolFieldFocused: false,
+      isRpcUrlFieldFocused: false,
+      isChainIdFieldFocused: false,
+    },
+    modals: {
+      showMultiRpcAddModal: overrides.showMultiRpcAddModal ?? true,
+      rpcModalShowForm: overrides.rpcModalShowForm ?? true,
+      showMultiBlockExplorerAddModal: false,
+      blockExplorerModalShowForm: false,
+      showWarningModal: false,
+    },
+    isAnyModalVisible: true,
+    inputRpcURL: { current: null },
+    inputNameRpcURL: { current: null },
+    inputChainId: { current: null },
+    inputSymbol: { current: null },
+    inputBlockExplorerURL: { current: null },
+    onNicknameChange: jest.fn(),
+    onChainIDChange: jest.fn(),
+    onTickerChange: jest.fn(),
+    autoFillNameField: jest.fn(),
+    autoFillSymbolField: jest.fn(),
+    onRpcUrlAdd: jest.fn(),
+    onRpcNameAdd: jest.fn(),
+    onRpcItemAdd: jest.fn(),
+    onRpcUrlChangeWithName: jest.fn(),
+    onRpcUrlDelete: jest.fn(),
+    onBlockExplorerItemAdd: jest.fn(),
+    onBlockExplorerUrlChange: jest.fn(),
+    onBlockExplorerSelect: jest.fn(),
+    onBlockExplorerUrlDelete: jest.fn(),
+    setValidationCallback: jest.fn(),
+    commitBaselineFromFormState: jest.fn(),
+    onNameFocused: jest.fn(),
+    onNameBlur: jest.fn(),
+    onSymbolFocused: jest.fn(),
+    onSymbolBlur: jest.fn(),
+    onRpcUrlFocused: jest.fn(),
+    onRpcUrlBlur: jest.fn(),
+    onChainIdFocused: jest.fn(),
+    onChainIdBlur: jest.fn(),
+    jumpToRpcURL: jest.fn(),
+    jumpToChainId: jest.fn(),
+    jumpToSymbol: jest.fn(),
+    jumpBlockExplorerURL: jest.fn(),
+    openRpcModal: jest.fn(),
+    closeRpcModal: jest.fn(),
+    setRpcModalShowForm: jest.fn(),
+    openBlockExplorerModal: jest.fn(),
+    closeBlockExplorerModal: jest.fn(),
+    setBlockExplorerModalShowForm: jest.fn(),
+    toggleWarningModal: jest.fn(),
+  } as UseNetworkFormReturn;
+}
+
+function createRpcValidation(
+  overrides: Partial<{
+    validateNewRpcEndpointForSheet: UseNetworkValidationReturn['validateNewRpcEndpointForSheet'];
+    validatedRpcURL: boolean;
+    warningRpcUrl: string | undefined;
+  }> = {},
+): UseNetworkValidationReturn {
+  return {
+    warningRpcUrl: overrides.warningRpcUrl,
+    warningChainId: undefined,
+    warningSymbol: undefined,
+    warningName: undefined,
+    validatedRpcURL: overrides.validatedRpcURL ?? true,
+    validatedChainId: true,
+    validatedSymbol: true,
+    validateChainId: jest.fn(),
+    validateChainIdOnSubmit: jest.fn().mockResolvedValue(true),
+    validateSymbol: jest.fn(),
+    validateName: jest.fn(),
+    validateRpcAndChainId: jest.fn(),
+    validateNewRpcEndpointForSheet:
+      overrides.validateNewRpcEndpointForSheet ??
+      jest.fn().mockResolvedValue({ ok: true }),
+    disabledByChainId: jest.fn(() => false),
+    disabledByName: jest.fn(() => false),
+    disabledBySymbol: jest.fn(() => false),
+    checkIfChainIdExists: jest.fn(() => false),
+    checkIfNetworkExists: jest.fn().mockResolvedValue([]),
+    checkIfRpcUrlExists: jest.fn().mockResolvedValue([]),
+    setWarningRpcUrl: jest.fn(),
+    setWarningChainId: jest.fn(),
+    onRpcUrlValidationChange: jest.fn(),
+    networkList: null,
+  } as UseNetworkValidationReturn;
+}
+
+describe('RpcEndpointSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders inline RPC form fields in add mode', () => {
+    const formHook = createRpcModalFormHook({
+      form: { addMode: true, rpcUrlForm: '', rpcNameForm: '', rpcUrls: [] },
+      showMultiRpcAddModal: false,
+      rpcModalShowForm: false,
+    });
+
+    const { getByTestId } = render(
+      <RpcEndpointSection
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.RPC_URL_INPUT),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders RPC selector in edit mode', () => {
+    const formHook = createRpcModalFormHook({
+      showMultiRpcAddModal: false,
+      rpcModalShowForm: false,
+    });
+
+    const { getByTestId } = render(
+      <RpcEndpointSection
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    expect(
+      getByTestId(NetworkDetailsViewSelectorsIDs.ICON_BUTTON_RPC),
+    ).toBeOnTheScreen();
+  });
+});
+
+describe('RpcEndpointModals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onRpcItemAdd after sheet validation when persist succeeds', async () => {
+    const validateNewRpcEndpointForSheet = jest
+      .fn()
+      .mockResolvedValue({ ok: true });
+    const formHook = createRpcModalFormHook();
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(true);
+
+    const { getAllByTestId } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation({ validateNewRpcEndpointForSheet })}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
+      />,
+    );
+
+    const addButtons = getAllByTestId(
+      NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON,
+    );
+
+    await act(async () => {
+      fireEvent.press(addButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(validateNewRpcEndpointForSheet).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onUrlSheetMutationCommitted).toHaveBeenCalled();
+    });
+    expect(formHook.onRpcItemAdd).toHaveBeenCalledWith(
+      'https://new-rpc.example.com',
+      'New RPC',
+    );
+  });
+
+  it('shows RPC sheet error and skips onRpcItemAdd when persist returns false', async () => {
+    const formHook = createRpcModalFormHook();
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
+    const { getAllByTestId, getByTestId } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(NetworkDetailsViewSelectorsIDs.RPC_SHEET_SUBMIT_ERROR),
+      ).toHaveTextContent(
+        strings('app_settings.rpc_sheet_network_update_failed'),
+      );
+    });
+    expect(formHook.onRpcItemAdd).not.toHaveBeenCalled();
+  });
+
+  it('shows validation message and skips persist when sheet validation fails', async () => {
+    const formHook = createRpcModalFormHook();
+    const onUrlSheetMutationCommitted = jest.fn();
+    const validateNewRpcEndpointForSheet = jest.fn().mockResolvedValue({
+      ok: false,
+      message: 'Sheet validation failed',
+    });
+
+    const { getAllByTestId, getByText } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation({ validateNewRpcEndpointForSheet })}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(getByText('Sheet validation failed')).toBeOnTheScreen();
+    });
+    expect(onUrlSheetMutationCommitted).not.toHaveBeenCalled();
+    expect(formHook.onRpcItemAdd).not.toHaveBeenCalled();
+  });
+
+  it('calls onRpcItemAdd when onUrlSheetMutationCommitted is omitted', async () => {
+    const formHook = createRpcModalFormHook();
+
+    const { getAllByTestId } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(
+        getAllByTestId(NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON)[0],
+      );
+    });
+
+    await waitFor(() => {
+      expect(formHook.onRpcItemAdd).toHaveBeenCalledWith(
+        'https://new-rpc.example.com',
+        'New RPC',
+      );
+    });
+  });
+
+  it('calls onRpcUrlChangeWithName after selecting another RPC when persist succeeds', async () => {
+    const formHook = createRpcModalFormHook({
+      form: {
+        rpcUrl: 'https://rpc1.example.com',
+        rpcUrls: [
+          {
+            url: 'https://rpc1.example.com',
+            name: 'RPC One',
+            type: RpcEndpointType.Custom,
+          },
+          {
+            url: 'https://rpc2.example.com',
+            name: 'RPC Two',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      },
+    });
+
+    const { getByText } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('RPC Two'));
+    });
+
+    await waitFor(() => {
+      expect(formHook.onRpcUrlChangeWithName).toHaveBeenCalledWith(
+        'https://rpc2.example.com',
+        undefined,
+        'RPC Two',
+        RpcEndpointType.Custom,
+      );
+    });
+  });
+
+  it('shows sheet error and skips onRpcUrlChangeWithName when persist returns false', async () => {
+    const formHook = createRpcModalFormHook({
+      form: {
+        rpcUrl: 'https://rpc1.example.com',
+        rpcUrls: [
+          {
+            url: 'https://rpc1.example.com',
+            name: 'RPC One',
+            type: RpcEndpointType.Custom,
+          },
+          {
+            url: 'https://rpc2.example.com',
+            name: 'RPC Two',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      },
+    });
+
+    const { getByText, getByTestId } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('RPC Two'));
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(NetworkDetailsViewSelectorsIDs.RPC_SHEET_SUBMIT_ERROR),
+      ).toHaveTextContent(
+        strings('app_settings.url_sheet_network_update_failed'),
+      );
+    });
+    expect(formHook.onRpcUrlChangeWithName).not.toHaveBeenCalled();
+  });
+
+  it('shows sheet error and skips onRpcUrlDelete when persist returns false', async () => {
+    const formHook = createRpcModalFormHook({
+      form: {
+        rpcUrl: 'https://rpc1.example.com',
+        rpcUrls: [
+          {
+            url: 'https://rpc1.example.com',
+            name: 'RPC One',
+            type: RpcEndpointType.Custom,
+          },
+          {
+            url: 'https://rpc2.example.com',
+            name: 'RPC Two',
+            type: RpcEndpointType.Custom,
+          },
+        ],
+      },
+    });
+
+    const { getAllByTestId, getByTestId } = render(
+      <RpcEndpointModals
+        formHook={formHook}
+        validation={createRpcValidation()}
+        onValidationSuccess={jest.fn()}
+        isRpcFailoverEnabled={false}
+        styles={styles}
+        themeAppearance="light"
+        placeholderTextColor={placeholderTextColor}
+        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getAllByTestId(BUTTON_TEST_ID)[0]);
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(NetworkDetailsViewSelectorsIDs.RPC_SHEET_SUBMIT_ERROR),
+      ).toBeOnTheScreen();
+    });
+    expect(formHook.onRpcUrlDelete).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.test.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.test.tsx
@@ -275,6 +275,10 @@ describe('RpcEndpointModals', () => {
     await waitFor(() => {
       expect(onUrlSheetMutationCommitted).toHaveBeenCalled();
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onRpcItemAdd).toHaveBeenCalledWith(
       'https://new-rpc.example.com',
       'New RPC',
@@ -311,6 +315,10 @@ describe('RpcEndpointModals', () => {
         strings('app_settings.rpc_sheet_network_update_failed'),
       );
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onRpcItemAdd).not.toHaveBeenCalled();
   });
 
@@ -396,6 +404,8 @@ describe('RpcEndpointModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(true);
+
     const { getByText } = render(
       <RpcEndpointModals
         formHook={formHook}
@@ -405,7 +415,7 @@ describe('RpcEndpointModals', () => {
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(true)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -421,6 +431,10 @@ describe('RpcEndpointModals', () => {
         RpcEndpointType.Custom,
       );
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
   });
 
   it('shows sheet error and skips onRpcUrlChangeWithName when persist returns false', async () => {
@@ -442,6 +456,8 @@ describe('RpcEndpointModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
     const { getByText, getByTestId } = render(
       <RpcEndpointModals
         formHook={formHook}
@@ -451,7 +467,7 @@ describe('RpcEndpointModals', () => {
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -466,6 +482,10 @@ describe('RpcEndpointModals', () => {
         strings('app_settings.url_sheet_network_update_failed'),
       );
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onRpcUrlChangeWithName).not.toHaveBeenCalled();
   });
 
@@ -488,6 +508,8 @@ describe('RpcEndpointModals', () => {
       },
     });
 
+    const onUrlSheetMutationCommitted = jest.fn().mockResolvedValue(false);
+
     const { getAllByTestId, getByTestId } = render(
       <RpcEndpointModals
         formHook={formHook}
@@ -497,7 +519,7 @@ describe('RpcEndpointModals', () => {
         styles={styles}
         themeAppearance="light"
         placeholderTextColor={placeholderTextColor}
-        onUrlSheetMutationCommitted={jest.fn().mockResolvedValue(false)}
+        onUrlSheetMutationCommitted={onUrlSheetMutationCommitted}
       />,
     );
 
@@ -510,6 +532,10 @@ describe('RpcEndpointModals', () => {
         getByTestId(NetworkDetailsViewSelectorsIDs.RPC_SHEET_SUBMIT_ERROR),
       ).toBeOnTheScreen();
     });
+    expect(onUrlSheetMutationCommitted).toHaveBeenCalledWith(
+      expect.any(Object),
+      { skipChainIdSubmitValidation: true },
+    );
     expect(formHook.onRpcUrlDelete).not.toHaveBeenCalled();
   });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -397,7 +397,9 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
         name,
         type,
       );
-      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm, {
+        skipChainIdSubmitValidation: true,
+      });
       if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
         setRpcSheetSubmitError(
           strings('app_settings.url_sheet_network_update_failed'),
@@ -414,7 +416,9 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
     async (url: string) => {
       setRpcSheetSubmitError(undefined);
       const nextForm = removeRpcUrlFromFormState(latestFormRef.current, url);
-      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm, {
+        skipChainIdSubmitValidation: true,
+      });
       if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
         setRpcSheetSubmitError(
           strings('app_settings.url_sheet_network_update_failed'),

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -38,9 +38,8 @@ import {
   removeRpcUrlFromFormState,
 } from '../NetworkDetailsView.utils';
 import type {
-  NetworkFormState,
   RpcEndpoint,
-  UrlSheetPersistOptions,
+  UrlSheetMutationCommittedHandler,
 } from '../NetworkDetailsView.types';
 import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
 import type { UseNetworkValidationReturn } from '../hooks/useNetworkValidation';
@@ -56,11 +55,8 @@ interface RpcEndpointSectionProps {
   styles: NetworkDetailsStyles;
   themeAppearance: 'light' | 'dark' | 'default';
   placeholderTextColor: string;
-  /** Invoked to persist RPC / explorer edits; RPC add passes a form snapshot and returns success. */
-  onUrlSheetMutationCommitted?: (
-    committedFormSnapshot?: NetworkFormState,
-    persistOptions?: UrlSheetPersistOptions,
-  ) => void | Promise<boolean>;
+  /** Invoked to persist RPC / explorer edits; RPC add passes a form snapshot. Must return whether persist succeeded. */
+  onUrlSheetMutationCommitted?: UrlSheetMutationCommittedHandler;
 }
 
 const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
@@ -211,7 +207,9 @@ const RpcListItem: React.FC<RpcListItemProps> = React.memo(
       await onSelect(url, failoverUrls, name ?? '', type);
     }, [onSelect, url, failoverUrls, name, type]);
 
-    const handleDelete = useCallback(() => onDelete(url), [onDelete, url]);
+    const handleDelete = useCallback(async () => {
+      await onDelete(url);
+    }, [onDelete, url]);
 
     return (
       <Cell

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
 import { Animated as RNAnimated, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import {
@@ -31,8 +31,17 @@ import { IconName } from '../../../../../component-library/components/Icons/Icon
 import RpcFormFields from './RpcFormFields';
 import SelectField from './SelectField';
 import { NetworkDetailsViewSelectorsIDs } from '../NetworkDetailsView.testIds';
-import { formatNetworkRpcUrl } from '../NetworkDetailsView.utils';
-import type { RpcEndpoint } from '../NetworkDetailsView.types';
+import {
+  appendRpcItemToFormState,
+  applyRpcSelectionToFormState,
+  formatNetworkRpcUrl,
+  removeRpcUrlFromFormState,
+} from '../NetworkDetailsView.utils';
+import type {
+  NetworkFormState,
+  RpcEndpoint,
+  UrlSheetPersistOptions,
+} from '../NetworkDetailsView.types';
 import type { UseNetworkFormReturn } from '../hooks/useNetworkForm';
 import type { UseNetworkValidationReturn } from '../hooks/useNetworkValidation';
 import type { NetworkDetailsStyles } from '../NetworkDetailsView.styles';
@@ -47,6 +56,11 @@ interface RpcEndpointSectionProps {
   styles: NetworkDetailsStyles;
   themeAppearance: 'light' | 'dark' | 'default';
   placeholderTextColor: string;
+  /** Invoked to persist RPC / explorer edits; RPC add passes a form snapshot and returns success. */
+  onUrlSheetMutationCommitted?: (
+    committedFormSnapshot?: NetworkFormState,
+    persistOptions?: UrlSheetPersistOptions,
+  ) => void | Promise<boolean>;
 }
 
 const RpcEndpointSection: React.FC<RpcEndpointSectionProps> = ({
@@ -176,9 +190,8 @@ interface RpcListItemProps {
     failoverUrls: string[] | undefined,
     name: string,
     type: string,
-  ) => void;
-  onDelete: (url: string) => void;
-  onDismiss: () => void;
+  ) => void | Promise<void>;
+  onDelete: (url: string) => void | Promise<void>;
   styles: NetworkDetailsStyles;
 }
 
@@ -189,16 +202,14 @@ const RpcListItem: React.FC<RpcListItemProps> = React.memo(
     isRpcFailoverEnabled,
     onSelect,
     onDelete,
-    onDismiss,
     styles,
   }) => {
     const { url, failoverUrls, name, type } = endpoint;
     const formattedName = type === 'infura' ? 'Infura' : name;
 
-    const handleSelect = useCallback(() => {
-      onSelect(url, failoverUrls, name ?? '', type);
-      onDismiss();
-    }, [onSelect, onDismiss, url, failoverUrls, name, type]);
+    const handleSelect = useCallback(async () => {
+      await onSelect(url, failoverUrls, name ?? '', type);
+    }, [onSelect, url, failoverUrls, name, type]);
 
     const handleDelete = useCallback(() => onDelete(url), [onDelete, url]);
 
@@ -252,9 +263,10 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
   styles,
   themeAppearance,
   placeholderTextColor,
+  onUrlSheetMutationCommitted,
 }) => {
   const {
-    form: { rpcUrl, rpcUrls, rpcUrlForm, rpcNameForm },
+    form: { rpcUrl, rpcUrls, rpcUrlForm, rpcNameForm, chainId },
     inputRpcURL,
     inputNameRpcURL,
     closeRpcModal,
@@ -274,13 +286,19 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
   const {
     warningRpcUrl,
     validatedRpcURL,
-    checkIfNetworkExists,
-    checkIfRpcUrlExists,
+    validateNewRpcEndpointForSheet,
     onRpcUrlValidationChange,
   } = validation;
 
+  const [rpcSheetSubmitError, setRpcSheetSubmitError] = useState<
+    string | undefined
+  >(undefined);
+  const [isRpcSheetSubmitting, setIsRpcSheetSubmitting] = useState(false);
+
   const sheetRef = useRef<BottomSheetRef>(null);
   const hadListWhenFormOpened = useRef(false);
+  const latestFormRef = useRef(formHook.form);
+  latestFormRef.current = formHook.form;
 
   const { onContentLayout, contentWrapperStyle, toggleButtonStyle } =
     useExpandableFormAnimation(showForm);
@@ -292,6 +310,17 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
     // rpcUrls.length intentionally excluded — only snapshot on form open
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showForm]);
+
+  useEffect(() => {
+    if (showMultiRpcAddModal) {
+      setRpcSheetSubmitError(undefined);
+      setIsRpcSheetSubmitting(false);
+    }
+  }, [showMultiRpcAddModal]);
+
+  useEffect(() => {
+    setRpcSheetSubmitError(undefined);
+  }, [rpcUrlForm]);
 
   const handleDismiss = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -305,14 +334,99 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
     }
   };
 
-  const handleFormSubmit = () => {
-    onRpcItemAdd(rpcUrlForm, rpcNameForm);
-    if (hadListWhenFormOpened.current) {
-      setShowForm(false);
-    } else {
-      handleDismiss();
+  const handleFormSubmit = async () => {
+    if (
+      !rpcUrlForm ||
+      !validatedRpcURL ||
+      !!warningRpcUrl ||
+      isRpcSheetSubmitting
+    ) {
+      return;
+    }
+
+    setRpcSheetSubmitError(undefined);
+    setIsRpcSheetSubmitting(true);
+    try {
+      const existingUrls = rpcUrls.map((e) => e.url);
+      const result = await validateNewRpcEndpointForSheet(
+        rpcUrlForm,
+        chainId ?? '',
+        existingUrls,
+      );
+      if (!result.ok) {
+        setRpcSheetSubmitError(result.message);
+        return;
+      }
+
+      const nextForm = appendRpcItemToFormState(
+        latestFormRef.current,
+        rpcUrlForm,
+        rpcNameForm,
+      );
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm, {
+        skipChainIdSubmitValidation: true,
+      });
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setRpcSheetSubmitError(
+          strings('app_settings.rpc_sheet_network_update_failed'),
+        );
+        return;
+      }
+
+      onRpcItemAdd(rpcUrlForm, rpcNameForm);
+      if (hadListWhenFormOpened.current) {
+        setShowForm(false);
+      } else {
+        handleDismiss();
+      }
+    } finally {
+      setIsRpcSheetSubmitting(false);
     }
   };
+
+  const onRpcUrlChangeWithNamePersisted = useCallback(
+    async (
+      url: string,
+      failoverUrls: string[] | undefined,
+      name: string,
+      type: string,
+    ) => {
+      setRpcSheetSubmitError(undefined);
+      const nextForm = applyRpcSelectionToFormState(
+        latestFormRef.current,
+        url,
+        failoverUrls,
+        name,
+        type,
+      );
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setRpcSheetSubmitError(
+          strings('app_settings.url_sheet_network_update_failed'),
+        );
+        return;
+      }
+      onRpcUrlChangeWithName(url, failoverUrls, name, type);
+      handleDismiss();
+    },
+    [onRpcUrlChangeWithName, onUrlSheetMutationCommitted, handleDismiss],
+  );
+
+  const onRpcUrlDeletePersisted = useCallback(
+    async (url: string) => {
+      setRpcSheetSubmitError(undefined);
+      const nextForm = removeRpcUrlFromFormState(latestFormRef.current, url);
+      const persisted = await onUrlSheetMutationCommitted?.(nextForm);
+      if (onUrlSheetMutationCommitted !== undefined && persisted !== true) {
+        setRpcSheetSubmitError(
+          strings('app_settings.url_sheet_network_update_failed'),
+        );
+        return;
+      }
+      onRpcUrlDelete(url);
+    },
+    [onRpcUrlDelete, onUrlSheetMutationCommitted],
+  );
 
   const handleShowForm = () => setShowForm(true);
 
@@ -341,15 +455,26 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
                   endpoint={endpoint}
                   isSelected={rpcUrl === endpoint.url}
                   isRpcFailoverEnabled={isRpcFailoverEnabled}
-                  onSelect={onRpcUrlChangeWithName}
-                  onDelete={onRpcUrlDelete}
-                  onDismiss={handleDismiss}
+                  onSelect={onRpcUrlChangeWithNamePersisted}
+                  onDelete={onRpcUrlDeletePersisted}
                   styles={styles}
                 />
               </React.Fragment>
             ))}
           </Box>
         )}
+
+        {rpcSheetSubmitError ? (
+          <Box twClassName="mx-4 mt-2">
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-error-default"
+              testID={NetworkDetailsViewSelectorsIDs.RPC_SHEET_SUBMIT_ERROR}
+            >
+              {rpcSheetSubmitError}
+            </Text>
+          </Box>
+        ) : null}
 
         {/* Form — always mounted, height-animated to drive sheet resize */}
         <RNAnimated.View style={contentWrapperStyle}>
@@ -358,36 +483,44 @@ const RpcEndpointModals: React.FC<RpcEndpointSectionProps> = ({
             onLayout={onContentLayout}
             pointerEvents={showForm ? 'auto' : 'none'}
           >
-            <Box twClassName="mx-4 mt-4 p-4 gap-4 rounded-xl bg-background-muted">
-              <RpcFormFields
-                inputRpcURL={inputRpcURL}
-                inputNameRpcURL={inputNameRpcURL}
-                rpcUrlForm={rpcUrlForm}
-                rpcNameForm={rpcNameForm}
-                isRpcUrlFieldFocused={isRpcUrlFieldFocused}
-                warningRpcUrl={warningRpcUrl}
-                onRpcUrlAdd={onRpcUrlAdd}
-                onRpcNameAdd={onRpcNameAdd}
-                onRpcUrlFocused={onRpcUrlFocused}
-                onRpcUrlBlur={onRpcUrlBlur}
-                jumpToChainId={jumpToChainId}
-                checkIfNetworkExists={checkIfNetworkExists}
-                checkIfRpcUrlExists={checkIfRpcUrlExists}
-                onValidationSuccess={onValidationSuccess}
-                onRpcUrlValidationChange={onRpcUrlValidationChange}
-                styles={styles}
-                themeAppearance={themeAppearance}
-                placeholderTextColor={placeholderTextColor}
-              />
-              <ButtonPrimary
-                label={strings('app_settings.add_rpc_url')}
-                size={ButtonSize.Lg}
-                onPress={handleFormSubmit}
-                width={ButtonWidthTypes.Full}
-                isDisabled={!rpcUrlForm || !validatedRpcURL || !!warningRpcUrl}
-                testID={NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON}
-              />
-            </Box>
+            <View pointerEvents={isRpcSheetSubmitting ? 'none' : 'auto'}>
+              <Box twClassName="mx-4 mt-4 p-4 gap-4 rounded-xl bg-background-muted">
+                <RpcFormFields
+                  inputRpcURL={inputRpcURL}
+                  inputNameRpcURL={inputNameRpcURL}
+                  rpcUrlForm={rpcUrlForm}
+                  rpcNameForm={rpcNameForm}
+                  isRpcUrlFieldFocused={isRpcUrlFieldFocused}
+                  warningRpcUrl={warningRpcUrl}
+                  onRpcUrlAdd={onRpcUrlAdd}
+                  onRpcNameAdd={onRpcNameAdd}
+                  onRpcUrlFocused={onRpcUrlFocused}
+                  onRpcUrlBlur={onRpcUrlBlur}
+                  jumpToChainId={jumpToChainId}
+                  checkIfNetworkExists={validation.checkIfNetworkExists}
+                  checkIfRpcUrlExists={validation.checkIfRpcUrlExists}
+                  onValidationSuccess={onValidationSuccess}
+                  onRpcUrlValidationChange={onRpcUrlValidationChange}
+                  styles={styles}
+                  themeAppearance={themeAppearance}
+                  placeholderTextColor={placeholderTextColor}
+                />
+                <ButtonPrimary
+                  label={strings('app_settings.add_rpc_url')}
+                  size={ButtonSize.Lg}
+                  onPress={handleFormSubmit}
+                  width={ButtonWidthTypes.Full}
+                  loading={isRpcSheetSubmitting}
+                  isDisabled={
+                    !rpcUrlForm ||
+                    !validatedRpcURL ||
+                    !!warningRpcUrl ||
+                    isRpcSheetSubmitting
+                  }
+                  testID={NetworkDetailsViewSelectorsIDs.ADD_RPC_BUTTON}
+                />
+              </Box>
+            </View>
           </View>
         </RNAnimated.View>
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { RpcEndpointType } from '@metamask/network-controller';
+import { appendRpcItemToFormState } from '../NetworkDetailsView.utils';
 import { useNetworkForm } from './useNetworkForm';
 
 jest.mock('react-redux', () => ({
@@ -214,6 +215,37 @@ describe('useNetworkForm', () => {
       expect(result.current.form.rpcUrls.length).toBeGreaterThan(1);
       expect(result.current.form.rpcUrl).toBe('https://new.example.com');
       expect(result.current.form.rpcName).toBe('New RPC');
+    });
+
+    it('does not re-enable Save after commitBaseline then onRpcItemAdd (sheet persist order)', () => {
+      const customConfigs = {
+        '0x89': {
+          chainId: '0x89',
+          name: 'Polygon',
+          nativeCurrency: 'MATIC',
+          rpcEndpoints: [{ url: 'https://polygon-rpc.com', type: 'custom' }],
+          defaultRpcEndpointIndex: 0,
+          blockExplorerUrls: [],
+        },
+      };
+      mockUseSelector.mockReturnValue(customConfigs);
+
+      const { result } = renderHook(() =>
+        useNetworkForm({ network: 'https://polygon-rpc.com' }),
+      );
+
+      const nextForm = appendRpcItemToFormState(
+        result.current.form,
+        'https://extra-rpc.example.com',
+        'Extra',
+      );
+
+      act(() => {
+        result.current.commitBaselineFromFormState(nextForm);
+        result.current.onRpcItemAdd('https://extra-rpc.example.com', 'Extra');
+      });
+
+      expect(result.current.enableAction).toBe(false);
     });
 
     it('does not add empty RPC item', () => {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.test.ts
@@ -13,6 +13,9 @@ jest.mock('../NetworkDetailsView.constants', () => ({
 }));
 
 jest.mock('../NetworkDetailsView.utils', () => ({
+  ...jest.requireActual<typeof import('../NetworkDetailsView.utils')>(
+    '../NetworkDetailsView.utils',
+  ),
   getDefaultBlockExplorerUrl: jest.fn(() => 'https://etherscan.io'),
 }));
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
@@ -16,6 +16,7 @@ import {
   applyBlockExplorerSelectionToFormState,
   applyRpcSelectionToFormState,
   getDefaultBlockExplorerUrl,
+  networkFormBaselineSnapshot,
   removeBlockExplorerUrlFromFormState,
   removeRpcUrlFromFormState,
 } from '../NetworkDetailsView.utils';
@@ -57,21 +58,6 @@ function getRpcEndpointName(
   if (!endpoint) return undefined;
   if (endpoint.type === RpcEndpointType.Infura) return 'Infura';
   return 'name' in endpoint ? endpoint.name : undefined;
-}
-
-/** Snapshot string used to detect unsaved edits vs the last baseline. */
-function baselineSnapshotFromForm(prev: NetworkFormState): string {
-  return (
-    (prev.rpcUrl ?? '') +
-    String(prev.failoverRpcUrls) +
-    (prev.blockExplorerUrl ?? '') +
-    (prev.nickname ?? '') +
-    (prev.chainId ?? '') +
-    (prev.ticker ?? '') +
-    String(prev.editable) +
-    String(prev.rpcUrls) +
-    String(prev.blockExplorerUrls)
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +154,7 @@ export const useNetworkForm = (
   // ---- Helpers -------------------------------------------------------------
   const getCurrentState = useCallback(() => {
     setForm((prev) => {
-      const actual = baselineSnapshotFromForm(prev);
+      const actual = networkFormBaselineSnapshot(prev);
 
       setEnableAction(actual !== initialBaselineStrRef.current);
       return prev; // no mutation
@@ -177,7 +163,7 @@ export const useNetworkForm = (
 
   const commitBaselineFromFormState = useCallback(
     (formState: NetworkFormState) => {
-      initialBaselineStrRef.current = baselineSnapshotFromForm(formState);
+      initialBaselineStrRef.current = networkFormBaselineSnapshot(formState);
       setEnableAction(false);
     },
     [],
@@ -291,7 +277,7 @@ export const useNetworkForm = (
         addMode: false,
       };
 
-      initialBaselineStrRef.current = baselineSnapshotFromForm(nextForm);
+      initialBaselineStrRef.current = networkFormBaselineSnapshot(nextForm);
       setForm(nextForm);
     } else {
       // --- Add mode --------------------------------------------------------

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
@@ -154,9 +154,8 @@ export const useNetworkForm = (
 
   // ---- Derived / tracking state -------------------------------------------
   const [enableAction, setEnableAction] = useState(false);
-  const [initialStateStr, setInitialStateStr] = useState<string | undefined>(
-    undefined,
-  );
+  /** Last-saved baseline for dirty detection; ref (not state) so `getCurrentState` never closes over a stale string after `commitBaselineFromFormState`. */
+  const initialBaselineStrRef = useRef<string | undefined>(undefined);
 
   // Allows the parent to register a callback we invoke after
   // certain form changes (e.g. chainId change, rpc change).
@@ -171,14 +170,14 @@ export const useNetworkForm = (
     setForm((prev) => {
       const actual = baselineSnapshotFromForm(prev);
 
-      setEnableAction(actual !== initialStateStr);
+      setEnableAction(actual !== initialBaselineStrRef.current);
       return prev; // no mutation
     });
-  }, [initialStateStr]);
+  }, []);
 
   const commitBaselineFromFormState = useCallback(
     (formState: NetworkFormState) => {
-      setInitialStateStr(baselineSnapshotFromForm(formState));
+      initialBaselineStrRef.current = baselineSnapshotFromForm(formState);
       setEnableAction(false);
     },
     [],
@@ -292,7 +291,7 @@ export const useNetworkForm = (
         addMode: false,
       };
 
-      setInitialStateStr(baselineSnapshotFromForm(nextForm));
+      initialBaselineStrRef.current = baselineSnapshotFromForm(nextForm);
       setForm(nextForm);
     } else {
       // --- Add mode --------------------------------------------------------

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts
@@ -10,7 +10,15 @@ type NetworkRpcEndpoint = NetworkConfiguration['rpcEndpoints'][number];
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import Networks from '../../../../../util/networks';
 import { allNetworks } from '../NetworkDetailsView.constants';
-import { getDefaultBlockExplorerUrl } from '../NetworkDetailsView.utils';
+import {
+  appendBlockExplorerItemToFormState,
+  appendRpcItemToFormState,
+  applyBlockExplorerSelectionToFormState,
+  applyRpcSelectionToFormState,
+  getDefaultBlockExplorerUrl,
+  removeBlockExplorerUrlFromFormState,
+  removeRpcUrlFromFormState,
+} from '../NetworkDetailsView.utils';
 import type {
   NetworkDetailsViewParams,
   NetworkFormState,
@@ -51,6 +59,21 @@ function getRpcEndpointName(
   return 'name' in endpoint ? endpoint.name : undefined;
 }
 
+/** Snapshot string used to detect unsaved edits vs the last baseline. */
+function baselineSnapshotFromForm(prev: NetworkFormState): string {
+  return (
+    (prev.rpcUrl ?? '') +
+    String(prev.failoverRpcUrls) +
+    (prev.blockExplorerUrl ?? '') +
+    (prev.nickname ?? '') +
+    (prev.chainId ?? '') +
+    (prev.ticker ?? '') +
+    String(prev.editable) +
+    String(prev.rpcUrls) +
+    String(prev.blockExplorerUrls)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Hook return type
 // ---------------------------------------------------------------------------
@@ -87,6 +110,9 @@ export interface UseNetworkFormReturn
 
   // Register a callback invoked after form changes that require re-validation
   setValidationCallback: (cb: (() => void) | null) => void;
+
+  /** After a successful persist, treat the given form snapshot as the new dirty baseline. */
+  commitBaselineFromFormState: (formState: NetworkFormState) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,21 +169,20 @@ export const useNetworkForm = (
   // ---- Helpers -------------------------------------------------------------
   const getCurrentState = useCallback(() => {
     setForm((prev) => {
-      const actual =
-        (prev.rpcUrl ?? '') +
-        String(prev.failoverRpcUrls) +
-        (prev.blockExplorerUrl ?? '') +
-        (prev.nickname ?? '') +
-        (prev.chainId ?? '') +
-        (prev.ticker ?? '') +
-        String(prev.editable) +
-        String(prev.rpcUrls) +
-        String(prev.blockExplorerUrls);
+      const actual = baselineSnapshotFromForm(prev);
 
       setEnableAction(actual !== initialStateStr);
       return prev; // no mutation
     });
   }, [initialStateStr]);
+
+  const commitBaselineFromFormState = useCallback(
+    (formState: NetworkFormState) => {
+      setInitialStateStr(baselineSnapshotFromForm(formState));
+      setEnableAction(false);
+    },
+    [],
+  );
 
   // ---- Initialization (componentDidMount equivalent) -----------------------
   useEffect(() => {
@@ -249,19 +274,7 @@ export const useNetworkForm = (
       const selectedRpcEndpointIndex =
         networkConfiguration?.defaultRpcEndpointIndex ?? 0;
 
-      const stateSnapshot =
-        (rpcUrl ?? '') +
-        String(failoverRpcUrls) +
-        (blockExplorerUrl ?? '') +
-        (nickname ?? '') +
-        (chainId ?? '') +
-        (ticker ?? '') +
-        String(editable) +
-        String(rpcUrls) +
-        String(blockExplorerUrls);
-
-      setInitialStateStr(stateSnapshot);
-      setForm({
+      const nextForm: NetworkFormState = {
         rpcUrl,
         failoverRpcUrls,
         rpcName,
@@ -277,7 +290,10 @@ export const useNetworkForm = (
         ticker,
         editable,
         addMode: false,
-      });
+      };
+
+      setInitialStateStr(baselineSnapshotFromForm(nextForm));
+      setForm(nextForm);
     } else {
       // --- Add mode --------------------------------------------------------
       const prefill = params?.prefill;
@@ -418,21 +434,9 @@ export const useNetworkForm = (
   const onRpcItemAdd = useCallback(
     (url: string, name: string) => {
       if (!url) return;
-      const newRpcUrl: RpcEndpoint = {
-        url,
-        name: name ?? '',
-        type: RpcEndpointType.Custom,
-      };
-      setForm((prev) => ({
-        ...prev,
-        rpcUrls: [...prev.rpcUrls, newRpcUrl],
-        rpcUrl: newRpcUrl.url,
-        failoverRpcUrls: undefined,
-        rpcName: newRpcUrl.name,
-        rpcUrlForm: '',
-        rpcNameForm: '',
-      }));
+      setForm((prev) => appendRpcItemToFormState(prev, url, name));
       getCurrentState();
+      requestValidation.current?.();
     },
     [getCurrentState],
   );
@@ -444,13 +448,9 @@ export const useNetworkForm = (
       name: string,
       type: string,
     ) => {
-      const nameToUse = name || type;
-      setForm((prev) => ({
-        ...prev,
-        rpcName: nameToUse,
-        rpcUrl: url,
-        failoverRpcUrls: failoverUrls,
-      }));
+      setForm((prev) =>
+        applyRpcSelectionToFormState(prev, url, failoverUrls, name, type),
+      );
       getCurrentState();
       requestValidation.current?.();
     },
@@ -459,21 +459,7 @@ export const useNetworkForm = (
 
   const onRpcUrlDelete = useCallback(
     (url: string) => {
-      setForm((prev) => {
-        const updated = prev.rpcUrls.filter((rpc) => rpc.url !== url);
-        const isCurrentRpc = prev.rpcUrl === url;
-        return {
-          ...prev,
-          rpcUrls: updated,
-          ...(isCurrentRpc && updated.length > 0
-            ? {
-                rpcUrl: updated[0].url,
-                failoverRpcUrls: updated[0].failoverUrls,
-                rpcName: updated[0].name,
-              }
-            : {}),
-        };
-      });
+      setForm((prev) => removeRpcUrlFromFormState(prev, url));
       getCurrentState();
       requestValidation.current?.();
     },
@@ -484,16 +470,9 @@ export const useNetworkForm = (
   const onBlockExplorerItemAdd = useCallback(
     (url: string) => {
       if (!url) return;
-      setForm((prev) => {
-        if (prev.blockExplorerUrls.includes(url)) return prev;
-        return {
-          ...prev,
-          blockExplorerUrls: [...prev.blockExplorerUrls, url],
-          blockExplorerUrl: url,
-          blockExplorerUrlForm: undefined,
-        };
-      });
+      setForm((prev) => appendBlockExplorerItemToFormState(prev, url));
       getCurrentState();
+      requestValidation.current?.();
     },
     [getCurrentState],
   );
@@ -522,21 +501,16 @@ export const useNetworkForm = (
 
   const onBlockExplorerSelect = useCallback(
     (url: string) => {
-      setForm((prev) => ({
-        ...prev,
-        blockExplorerUrl: url,
-      }));
+      setForm((prev) => applyBlockExplorerSelectionToFormState(prev, url));
       getCurrentState();
+      requestValidation.current?.();
     },
     [getCurrentState],
   );
 
   const onBlockExplorerUrlDelete = useCallback(
     (url: string) => {
-      setForm((prev) => ({
-        ...prev,
-        blockExplorerUrls: prev.blockExplorerUrls.filter((u) => u !== url),
-      }));
+      setForm((prev) => removeBlockExplorerUrlFromFormState(prev, url));
       getCurrentState();
       requestValidation.current?.();
     },
@@ -563,5 +537,6 @@ export const useNetworkForm = (
     onBlockExplorerSelect,
     onBlockExplorerUrlDelete,
     setValidationCallback,
+    commitBaselineFromFormState,
   };
 };

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -487,6 +487,139 @@ describe('useNetworkOperations', () => {
       expect(mockAddNetwork).not.toHaveBeenCalled();
     });
 
+    it('does not navigate when skipPostSaveNavigation is true', async () => {
+      setupExistingNetwork();
+
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Test RPC',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+          },
+        );
+      });
+
+      expect(mockUpdateNetwork).toHaveBeenCalled();
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('skips validateChainIdOnSubmit when skipChainIdSubmitValidation is true', async () => {
+      setupExistingNetwork();
+
+      const validateChainIdOnSubmit = jest.fn().mockResolvedValue(false);
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Test RPC',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            validateChainIdOnSubmit,
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+            bypassEnableActionGuard: true,
+            bypassFormDisabledGuards: true,
+            skipChainIdSubmitValidation: true,
+          },
+        );
+      });
+
+      expect(validateChainIdOnSubmit).not.toHaveBeenCalled();
+      expect(mockUpdateNetwork).toHaveBeenCalled();
+    });
+
+    it('persists when bypassEnableActionGuard is true even if enableAction is false', async () => {
+      setupExistingNetwork();
+
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Test RPC',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            enableAction: false,
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+            bypassEnableActionGuard: true,
+          },
+        );
+      });
+
+      expect(mockUpdateNetwork).toHaveBeenCalled();
+    });
+
+    it('persists when bypassFormDisabledGuards is true despite disabledByChainId', async () => {
+      setupExistingNetwork();
+
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Test RPC',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            disabledByChainId: true,
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+            bypassEnableActionGuard: true,
+            bypassFormDisabledGuards: true,
+          },
+        );
+      });
+
+      expect(mockUpdateNetwork).toHaveBeenCalled();
+    });
+
     it('passes options with indexRpc when form rpcUrl is not in rpcUrls list', async () => {
       setupExistingNetwork();
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -251,7 +251,7 @@ describe('useNetworkOperations', () => {
 
     const { result } = renderHook(() => useNetworkOperations());
 
-    let saved: boolean;
+    let saved = false;
     await act(async () => {
       saved = await result.current.saveNetwork(baseForm, {
         ...defaultSaveOpts(),
@@ -285,7 +285,7 @@ describe('useNetworkOperations', () => {
 
     const { result } = renderHook(() => useNetworkOperations());
 
-    let saved: boolean;
+    let saved = false;
     await act(async () => {
       saved = await result.current.saveNetwork(
         {

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -246,6 +246,68 @@ describe('useNetworkOperations', () => {
     expect(mockGoBack).toHaveBeenCalled();
   });
 
+  it('returns false and skips token filter and enableNetwork when addNetwork rejects', async () => {
+    mockAddNetwork.mockRejectedValueOnce(new Error('persist failed'));
+
+    const { result } = renderHook(() => useNetworkOperations());
+
+    let saved: boolean;
+    await act(async () => {
+      saved = await result.current.saveNetwork(baseForm, {
+        ...defaultSaveOpts(),
+        shouldNetworkSwitchPopToWallet: false,
+      });
+    });
+
+    expect(saved).toBe(false);
+    expect(mockAddNetwork).toHaveBeenCalled();
+    expect(mockSetTokenNetworkFilter).not.toHaveBeenCalled();
+    expect(mockEnableNetwork).not.toHaveBeenCalled();
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('returns false and skips token filter and enableNetwork when updateNetwork rejects', async () => {
+    mockUpdateNetwork.mockRejectedValueOnce(new Error('update failed'));
+    setupSelectors({
+      networkConfigurations: {
+        '0x2a': {
+          chainId: '0x2a',
+          rpcEndpoints: [
+            { url: 'https://rpc.example.com', name: 'R', type: 'Custom' },
+          ],
+          defaultRpcEndpointIndex: 0,
+          name: 'Test',
+          nativeCurrency: 'TST',
+          blockExplorerUrls: [],
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useNetworkOperations());
+
+    let saved: boolean;
+    await act(async () => {
+      saved = await result.current.saveNetwork(
+        {
+          ...baseForm,
+          addMode: false,
+          rpcUrls: [
+            { url: 'https://rpc.example.com', name: 'R', type: 'Custom' },
+          ],
+        },
+        {
+          ...defaultSaveOpts(),
+          shouldNetworkSwitchPopToWallet: false,
+        },
+      );
+    });
+
+    expect(saved).toBe(false);
+    expect(mockUpdateNetwork).toHaveBeenCalled();
+    expect(mockSetTokenNetworkFilter).not.toHaveBeenCalled();
+    expect(mockEnableNetwork).not.toHaveBeenCalled();
+  });
+
   it('navigates to WalletView when shouldNetworkSwitchPopToWallet is true', async () => {
     const { result } = renderHook(() => useNetworkOperations());
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -450,6 +450,45 @@ describe('useNetworkOperations', () => {
       });
     };
 
+    it('uses stored network name when form nickname is empty in edit mode', async () => {
+      setupExistingNetwork();
+
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            nickname: '',
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Test RPC',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+            bypassEnableActionGuard: true,
+            bypassFormDisabledGuards: true,
+          },
+        );
+      });
+
+      expect(mockUpdateNetwork).toHaveBeenCalledWith(
+        existingChainId,
+        expect.objectContaining({
+          name: 'OldNet',
+        }),
+        expect.anything(),
+      );
+    });
+
     it('calls updateNetwork for an existing network', async () => {
       setupExistingNetwork();
 
@@ -620,7 +659,7 @@ describe('useNetworkOperations', () => {
       expect(mockUpdateNetwork).toHaveBeenCalled();
     });
 
-    it('passes options with indexRpc when form rpcUrl is not in rpcUrls list', async () => {
+    it('omits replacementSelectedRpcEndpointIndex when selected RPC is not in list', async () => {
       setupExistingNetwork();
 
       const { result } = renderHook(() => useNetworkOperations());
@@ -645,9 +684,51 @@ describe('useNetworkOperations', () => {
         expect.objectContaining({
           defaultRpcEndpointIndex: -1,
         }),
+        undefined,
+      );
+    });
+
+    it('matches selected RPC index when URL differs only by trailing slash', async () => {
+      setupExistingNetwork();
+
+      const { result } = renderHook(() => useNetworkOperations());
+
+      await act(async () => {
+        await result.current.saveNetwork(
+          {
+            ...baseForm,
+            chainId: '42',
+            addMode: false,
+            rpcUrl: 'https://linea-rpc.publicnode.com',
+            rpcUrls: [
+              {
+                url: 'https://rpc.example.com/',
+                name: 'Old',
+                type: 'Custom',
+              },
+              {
+                url: 'https://linea-rpc.publicnode.com/',
+                name: 'PublicNode',
+                type: 'Custom',
+              },
+            ],
+          },
+          {
+            ...defaultSaveOpts(),
+            shouldNetworkSwitchPopToWallet: false,
+            skipPostSaveNavigation: true,
+            bypassEnableActionGuard: true,
+            bypassFormDisabledGuards: true,
+          },
+        );
+      });
+
+      expect(mockUpdateNetwork).toHaveBeenCalledWith(
+        existingChainId,
         expect.objectContaining({
-          replacementSelectedRpcEndpointIndex: -1,
+          defaultRpcEndpointIndex: 1,
         }),
+        { replacementSelectedRpcEndpointIndex: 1 },
       );
     });
 

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
@@ -125,7 +125,21 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
 
       const hexChainId = chainId as Hex;
       const existingNetwork = networkConfigurations[hexChainId];
-      const indexRpc = rpcUrls.findIndex((r) => r.url === correctedRpcUrl);
+
+      const stripTrailingSlashFromUrl = (value: string) =>
+        value.replace(/\/$/, '');
+
+      const rpcUrlsReferToSameEndpoint = (a: string, b: string) =>
+        a === b ||
+        stripTrailingSlashFromUrl(a) === stripTrailingSlashFromUrl(b);
+
+      const endpointMatchesSelectedRpc = (endpointUrl: string) =>
+        rpcUrlsReferToSameEndpoint(endpointUrl, rpcUrl) ||
+        rpcUrlsReferToSameEndpoint(endpointUrl, correctedRpcUrl);
+
+      const indexRpc = rpcUrls.findIndex((r) =>
+        endpointMatchesSelectedRpc(r.url),
+      );
       const blockExplorerIndex = blockExplorerUrls.findIndex(
         (u) => u === blockExplorerUrl,
       );
@@ -134,25 +148,29 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         blockExplorerUrls,
         chainId: hexChainId,
         rpcEndpoints: rpcUrls.map((r) =>
-          r.url === rpcUrl ? { ...r, url: correctedRpcUrl } : r,
+          endpointMatchesSelectedRpc(r.url)
+            ? { ...r, url: correctedRpcUrl }
+            : r,
         ),
         nativeCurrency: ticker,
         name: nickname,
-        defaultRpcEndpointIndex:
-          indexRpc !== -1
-            ? indexRpc
-            : rpcUrls.findIndex((r) => r.url === rpcUrl),
+        defaultRpcEndpointIndex: indexRpc,
         defaultBlockExplorerUrlIndex:
           blockExplorerIndex !== -1 ? blockExplorerIndex : undefined,
       };
+
+      const updateOptions =
+        existingNetwork != null &&
+        existingNetwork.chainId === hexChainId &&
+        indexRpc >= 0
+          ? { replacementSelectedRpcEndpointIndex: indexRpc }
+          : undefined;
 
       if (!isNetworkNew && existingNetwork) {
         await NetworkController.updateNetwork(
           existingNetwork.chainId,
           networkConfig as unknown as UpdateNetworkFields,
-          existingNetwork.chainId === hexChainId
-            ? { replacementSelectedRpcEndpointIndex: indexRpc }
-            : undefined,
+          updateOptions,
         );
 
         if (trackRpcUpdateFromBanner) {
@@ -269,7 +287,22 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
 
       const ticker = form.ticker ? form.ticker.toUpperCase() : undefined;
 
-      if (!stateChainId || !rpcUrl || !nickname?.trim()) {
+      if (!stateChainId || !rpcUrl) {
+        return false;
+      }
+
+      const formChainId = stateChainId.trim().toLowerCase();
+      let chainId = formChainId;
+      if (!chainId.startsWith('0x')) {
+        chainId = `0x${parseInt(chainId, 10).toString(16)}`;
+      }
+
+      const existingNetwork = networkConfigurations[chainId as Hex];
+      let resolvedNickname = nickname?.trim() ?? '';
+      if (!resolvedNickname && !addMode && existingNetwork?.name) {
+        resolvedNickname = existingNetwork.name.trim();
+      }
+      if (!resolvedNickname) {
         return false;
       }
 
@@ -279,12 +312,6 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
             (cfg) => cfg.chainId === toHex(stateChainId),
           )
         : false;
-
-      const formChainId = stateChainId.trim().toLowerCase();
-      let chainId = formChainId;
-      if (!chainId.startsWith('0x')) {
-        chainId = `0x${parseInt(chainId, 10).toString(16)}`;
-      }
 
       if (
         !skipChainIdSubmitValidation &&
@@ -307,20 +334,24 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       const { NetworkEnablementController } = Engine.context;
       NetworkEnablementController.enableNetwork(chainId as Hex);
 
-      await handleNetworkUpdate({
-        rpcUrl,
-        chainId,
-        nickname: nickname ?? '',
-        ticker: ticker ?? '',
-        blockExplorerUrl,
-        blockExplorerUrls,
-        rpcUrls,
-        isNetworkNew,
-        isCustomMainnet,
-        shouldNetworkSwitchPopToWallet,
-        trackRpcUpdateFromBanner,
-        skipPostSaveNavigation,
-      });
+      try {
+        await handleNetworkUpdate({
+          rpcUrl,
+          chainId,
+          nickname: resolvedNickname,
+          ticker: ticker ?? '',
+          blockExplorerUrl,
+          blockExplorerUrls,
+          rpcUrls,
+          isNetworkNew,
+          isCustomMainnet,
+          shouldNetworkSwitchPopToWallet,
+          trackRpcUpdateFromBanner,
+          skipPostSaveNavigation,
+        });
+      } catch (error) {
+        return false;
+      }
       return true;
     },
     [

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
@@ -55,8 +55,21 @@ export interface UseNetworkOperationsReturn {
         parsedChainId: string,
         rpcUrl: string,
       ) => Promise<boolean>;
+      /** Persist without navigating (e.g. RPC / block explorer bottom sheet). */
+      skipPostSaveNavigation?: boolean;
+      /** Persist even when enableAction is false (paired with a confirmed URL-list edit). */
+      bypassEnableActionGuard?: boolean;
+      /**
+       * Skip disabledBy* checks (sheet persist only). Built-in edit can leave stale
+       * warningChainId while name/chain/symbol are locked; submit RPC check still runs.
+       */
+      bypassFormDisabledGuards?: boolean;
+      /**
+       * Skip eth_chainId submit check (RPC bottom sheet already validated this URL).
+       */
+      skipChainIdSubmitValidation?: boolean;
     },
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   /** Remove the current network and navigate back. */
   removeNetwork: (chainId: string) => Promise<void>;
   /** Navigate to the edit screen for the current network. */
@@ -87,6 +100,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       isCustomMainnet,
       shouldNetworkSwitchPopToWallet,
       trackRpcUpdateFromBanner,
+      skipPostSaveNavigation,
     }: {
       rpcUrl: string;
       chainId: string;
@@ -99,6 +113,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       isCustomMainnet: boolean;
       shouldNetworkSwitchPopToWallet: boolean;
       trackRpcUpdateFromBanner: boolean;
+      skipPostSaveNavigation?: boolean;
     }) => {
       const { NetworkController } = Engine.context;
 
@@ -174,12 +189,14 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         addTraitsToUser(addItemToChainIdList(networkConfig.chainId));
       }
 
-      if (isCustomMainnet) {
-        navigation.navigate('OptinMetrics');
-      } else if (shouldNetworkSwitchPopToWallet) {
-        navigation.navigate('WalletView');
-      } else {
-        navigation.goBack();
+      if (!skipPostSaveNavigation) {
+        if (isCustomMainnet) {
+          navigation.navigate('OptinMetrics');
+        } else if (shouldNetworkSwitchPopToWallet) {
+          navigation.navigate('WalletView');
+        } else {
+          navigation.goBack();
+        }
       }
     },
     [
@@ -208,6 +225,10 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
           parsedChainId: string,
           rpcUrl: string,
         ) => Promise<boolean>;
+        skipPostSaveNavigation?: boolean;
+        bypassEnableActionGuard?: boolean;
+        bypassFormDisabledGuards?: boolean;
+        skipChainIdSubmitValidation?: boolean;
       },
     ) => {
       const {
@@ -219,15 +240,21 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         shouldNetworkSwitchPopToWallet,
         trackRpcUpdateFromBanner,
         validateChainIdOnSubmit,
+        skipPostSaveNavigation = false,
+        bypassEnableActionGuard = false,
+        bypassFormDisabledGuards = false,
+        skipChainIdSubmitValidation = false,
       } = params;
 
+      if (!bypassEnableActionGuard && !enableAction) {
+        return false;
+      }
+
       if (
-        !enableAction ||
-        disabledByChainId ||
-        disabledByName ||
-        disabledBySymbol
+        !bypassFormDisabledGuards &&
+        (disabledByChainId || disabledByName || disabledBySymbol)
       ) {
-        return;
+        return false;
       }
 
       const {
@@ -242,7 +269,9 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
 
       const ticker = form.ticker ? form.ticker.toUpperCase() : undefined;
 
-      if (!stateChainId || !rpcUrl || !nickname?.trim()) return;
+      if (!stateChainId || !rpcUrl || !nickname?.trim()) {
+        return false;
+      }
 
       // Check if network with this chainId already exists
       const isNetworkNew = addMode
@@ -257,8 +286,11 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         chainId = `0x${parseInt(chainId, 10).toString(16)}`;
       }
 
-      if (!(await validateChainIdOnSubmit(formChainId, chainId, rpcUrl))) {
-        return;
+      if (
+        !skipChainIdSubmitValidation &&
+        !(await validateChainIdOnSubmit(formChainId, chainId, rpcUrl))
+      ) {
+        return false;
       }
 
       // Update token network filter
@@ -287,7 +319,9 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         isCustomMainnet,
         shouldNetworkSwitchPopToWallet,
         trackRpcUpdateFromBanner,
+        skipPostSaveNavigation,
       });
+      return true;
     },
     [
       networkConfigurations,

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
@@ -320,20 +320,6 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         return false;
       }
 
-      // Update token network filter
-      const { PreferencesController } = Engine.context;
-      if (!isAllNetworks) {
-        PreferencesController.setTokenNetworkFilter({ [chainId]: true });
-      } else {
-        PreferencesController.setTokenNetworkFilter({
-          ...tokenNetworkFilter,
-          [chainId]: true,
-        });
-      }
-
-      const { NetworkEnablementController } = Engine.context;
-      NetworkEnablementController.enableNetwork(chainId as Hex);
-
       try {
         await handleNetworkUpdate({
           rpcUrl,
@@ -349,7 +335,20 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
           trackRpcUpdateFromBanner,
           skipPostSaveNavigation,
         });
-      } catch (error) {
+
+        const { PreferencesController } = Engine.context;
+        if (!isAllNetworks) {
+          PreferencesController.setTokenNetworkFilter({ [chainId]: true });
+        } else {
+          PreferencesController.setTokenNetworkFilter({
+            ...tokenNetworkFilter,
+            [chainId]: true,
+          });
+        }
+
+        const { NetworkEnablementController } = Engine.context;
+        NetworkEnablementController.enableNetwork(chainId as Hex);
+      } catch {
         return false;
       }
       return true;

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.test.ts
@@ -648,4 +648,55 @@ describe('useNetworkValidation', () => {
       expect(result.current.warningSymbol).toBeUndefined();
     });
   });
+
+  describe('validateNewRpcEndpointForSheet', () => {
+    const { jsonRpcRequest } = jest.requireMock(
+      '../../../../../util/jsonRpcRequest',
+    ) as { jsonRpcRequest: jest.Mock };
+
+    it('rejects empty url', async () => {
+      const { result } = renderHook(() => useNetworkValidation());
+      const r = await result.current.validateNewRpcEndpointForSheet(
+        '',
+        '0x2a',
+        [],
+      );
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects duplicate url already in form list', async () => {
+      const { result } = renderHook(() => useNetworkValidation());
+      const r = await result.current.validateNewRpcEndpointForSheet(
+        'https://rpc.example.com',
+        '0x2a',
+        ['https://rpc.example.com/'],
+      );
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects when endpoint returns different chain id', async () => {
+      jsonRpcRequest.mockResolvedValueOnce('0x1');
+      const { result } = renderHook(() => useNetworkValidation());
+      const r = await result.current.validateNewRpcEndpointForSheet(
+        'https://rpc.example.com',
+        '0x2a',
+        [],
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('resolves ok when endpoint chain matches', async () => {
+      jsonRpcRequest.mockResolvedValueOnce('0x2a');
+      const { result } = renderHook(() => useNetworkValidation());
+      const r = await result.current.validateNewRpcEndpointForSheet(
+        'https://rpc.example.com',
+        '0x2a',
+        [],
+      );
+      expect(r).toEqual({ ok: true });
+    });
+  });
 });

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.ts
@@ -3,14 +3,18 @@ import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import { isSafeChainId, toHex } from '@metamask/controller-utils';
 import type { NetworkConfiguration } from '@metamask/network-controller';
+import URLParse from 'url-parse';
+import { isWebUri } from 'valid-url';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { selectUseSafeChainsListValidation } from '../../../../../selectors/preferencesController';
 import { jsonRpcRequest } from '../../../../../util/jsonRpcRequest';
 import { isPrefixedFormattedHexString } from '../../../../../util/number';
 import {
+  isPrivateConnection,
   isValidNetworkName,
   isWhitelistedSymbol,
 } from '../../../../../util/networks';
+import { compareSanitizedUrl } from '../../../../../util/sanitizeUrl';
 import { regex } from '../../../../../util/regex';
 import Logger from '../../../../../util/Logger';
 import AppConstants from '../../../../../core/AppConstants';
@@ -22,6 +26,58 @@ import type {
   NetworkFormState,
   ValidationState,
 } from '../NetworkDetailsView.types';
+
+/**
+ * Returns an error message if the RPC does not return eth_chainId matching the network,
+ * or if the endpoint cannot be reached. Shared by save submit and RPC bottom sheet add.
+ */
+async function getRpcEndpointChainIdMatchErrorMessage(
+  rpcUrl: string,
+  formChainId: string,
+  parsedChainId: string,
+): Promise<string | undefined> {
+  let endpointChainId: string | undefined;
+  let providerError: unknown;
+
+  try {
+    endpointChainId = await jsonRpcRequest(
+      templateInfuraRpc(rpcUrl),
+      'eth_chainId',
+    );
+  } catch (err) {
+    Logger.error(
+      err as Error,
+      'Failed to fetch the chainId from the endpoint.',
+    );
+    providerError = err;
+  }
+
+  if (providerError || typeof endpointChainId !== 'string') {
+    return strings('app_settings.failed_to_fetch_chain_id');
+  }
+
+  if (parsedChainId !== endpointChainId) {
+    let displayEndpointId = endpointChainId;
+    if (!formChainId.startsWith('0x')) {
+      try {
+        const endpointChainIdNumber = new BigNumber(endpointChainId, 16);
+        if (endpointChainIdNumber.isNaN()) {
+          throw new Error('Invalid endpointChainId');
+        }
+        displayEndpointId = endpointChainIdNumber.toString(10);
+      } catch (err) {
+        Logger.error(err as Error, {
+          endpointChainId,
+          message: 'Failed to convert endpoint chain ID to decimal',
+        });
+      }
+    }
+    return strings('app_settings.endpoint_returned_different_chain_id', {
+      chainIdReturned: displayEndpointId,
+    });
+  }
+  return undefined;
+}
 
 export interface UseNetworkValidationReturn extends ValidationState {
   validateChainId: (form: NetworkFormState) => Promise<void>;
@@ -39,6 +95,12 @@ export interface UseNetworkValidationReturn extends ValidationState {
     chainToMatch?: SafeChain | null,
   ) => void;
   validateRpcAndChainId: (form: NetworkFormState) => void;
+  /** Full RPC checks for add-RPC bottom sheet (RpcUrlInput rules + eth_chainId). */
+  validateNewRpcEndpointForSheet: (
+    rpcUrl: string,
+    stateChainId: string,
+    existingFormRpcUrls: string[],
+  ) => Promise<{ ok: true } | { ok: false; message: string }>;
   disabledByChainId: (form: NetworkFormState) => boolean;
   disabledByName: (form: NetworkFormState) => boolean;
   disabledBySymbol: (form: NetworkFormState) => boolean;
@@ -215,46 +277,11 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
       parsedChainId: string,
       rpcUrl: string,
     ): Promise<boolean> => {
-      let errorMessage: string | undefined;
-      let endpointChainId: string | undefined;
-      let providerError: unknown;
-
-      try {
-        endpointChainId = await jsonRpcRequest(
-          templateInfuraRpc(rpcUrl),
-          'eth_chainId',
-        );
-      } catch (err) {
-        Logger.error(
-          err as Error,
-          'Failed to fetch the chainId from the endpoint.',
-        );
-        providerError = err;
-      }
-
-      if (providerError || typeof endpointChainId !== 'string') {
-        errorMessage = strings('app_settings.failed_to_fetch_chain_id');
-      } else if (parsedChainId !== endpointChainId) {
-        if (!formChainId.startsWith('0x')) {
-          try {
-            const endpointChainIdNumber = new BigNumber(endpointChainId, 16);
-            if (endpointChainIdNumber.isNaN()) {
-              throw new Error('Invalid endpointChainId');
-            }
-            endpointChainId = endpointChainIdNumber.toString(10);
-          } catch (err) {
-            Logger.error(err as Error, {
-              endpointChainId,
-              message: 'Failed to convert endpoint chain ID to decimal',
-            });
-          }
-        }
-        errorMessage = strings(
-          'app_settings.endpoint_returned_different_chain_id',
-          { chainIdReturned: endpointChainId },
-        );
-      }
-
+      const errorMessage = await getRpcEndpointChainIdMatchErrorMessage(
+        rpcUrl,
+        formChainId,
+        parsedChainId,
+      );
       if (errorMessage) {
         setWarningChainId(errorMessage);
         return false;
@@ -262,6 +289,84 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
       return true;
     },
     [],
+  );
+
+  const validateNewRpcEndpointForSheet = useCallback(
+    async (
+      rpcUrl: string,
+      stateChainId: string,
+      existingFormRpcUrls: string[],
+    ): Promise<{ ok: true } | { ok: false; message: string }> => {
+      const trimmed = rpcUrl.trim();
+      if (!trimmed) {
+        return { ok: false, message: strings('app_settings.required') };
+      }
+
+      if (!stateChainId?.trim()) {
+        return {
+          ok: false,
+          message: strings('app_settings.chain_id_required'),
+        };
+      }
+
+      for (const existing of existingFormRpcUrls) {
+        if (compareSanitizedUrl(trimmed, existing)) {
+          return {
+            ok: false,
+            message: strings('app_settings.invalid_rpc_url'),
+          };
+        }
+      }
+
+      if (!isWebUri(trimmed)) {
+        const appendedRpc = `http://${trimmed}`;
+        if (isWebUri(appendedRpc)) {
+          return {
+            ok: false,
+            message: strings('app_settings.invalid_rpc_prefix'),
+          };
+        }
+        return { ok: false, message: strings('app_settings.invalid_rpc_url') };
+      }
+
+      const isRpcExists = await checkIfRpcUrlExists(trimmed);
+      if (isRpcExists.length > 0) {
+        return { ok: false, message: strings('app_settings.invalid_rpc_url') };
+      }
+
+      const isNetworkExists = await checkIfNetworkExists(trimmed);
+      if (isNetworkExists.length > 0) {
+        return {
+          ok: false,
+          message: strings('app_settings.url_associated_to_another_chain_id'),
+        };
+      }
+
+      const url = new URLParse(trimmed);
+      if (!isPrivateConnection(url.hostname) && url.protocol === 'http:') {
+        return {
+          ok: false,
+          message: strings('app_settings.invalid_rpc_prefix'),
+        };
+      }
+
+      const formChainId = stateChainId.trim().toLowerCase();
+      let parsedChainId = formChainId;
+      if (!parsedChainId.startsWith('0x')) {
+        parsedChainId = `0x${parseInt(parsedChainId, 10).toString(16)}`;
+      }
+
+      const chainErr = await getRpcEndpointChainIdMatchErrorMessage(
+        trimmed,
+        formChainId,
+        parsedChainId,
+      );
+      if (chainErr) {
+        return { ok: false, message: chainErr };
+      }
+      return { ok: true };
+    },
+    [checkIfNetworkExists, checkIfRpcUrlExists],
   );
 
   // ---- Symbol validation --------------------------------------------------
@@ -375,6 +480,7 @@ export const useNetworkValidation = (): UseNetworkValidationReturn => {
     validateSymbol,
     validateName,
     validateRpcAndChainId,
+    validateNewRpcEndpointForSheet,
     disabledByChainId,
     disabledByName,
     disabledBySymbol,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3198,6 +3198,8 @@
     "network_delete": "If you delete this network, you will need to add it again to view your assets in this network",
     "networks_default_cta": "Use this network",
     "add_rpc_url": "Add RPC URL",
+    "rpc_sheet_network_update_failed": "Couldn't save this RPC URL. Check your connection and try again.",
+    "url_sheet_network_update_failed": "Couldn't save changes. Check your connection and try again.",
     "add_block_explorer_url": "Add block explorer URL",
     "networks_desc": "Add and edit custom RPC networks",
     "networks_enabled": "Enabled Networks",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

**Reason:** Editing RPC endpoints or block explorers from the network details bottom sheets could leave the in-app form out of sync with what was actually saved. Saving from the main screen was also incorrectly blocked when `editable === false` (e.g. built-in networks) even though RPC / explorer lists are still mutable. Fire-and-forget `saveNetwork` calls from sheet actions could fail silently or race with sheet dismissal.

**Solution:**

- After RPC / block explorer sheet mutations, the screen schedules `saveNetwork` with options that skip post-save navigation, bypass `enableAction` / form-disabled guards where appropriate, and commit a new dirty baseline via `commitBaselineFromFormState` on success.
- RPC sheet **add** runs async `validateNewRpcEndpointForSheet` first, then persists using a committed form snapshot and `skipChainIdSubmitValidation: true` so the redundant submit-time chain-id check is not double-run. Other sheet persists pass an explicit snapshot without that flag so submit validation still runs when needed.
- RPC **select** / **delete** and block explorer **add** / **select** / **delete** build the next form state with shared pure helpers (`appendRpcItemToFormState`, `applyRpcSelectionToFormState`, `removeRpcUrlFromFormState`, block explorer equivalents), `await` persist, then apply the form hook update only after success; failures surface inline errors and loading states.
- `useNetworkForm` uses the same helpers so snapshots match runtime `setForm` behavior. Tests were updated (`act` / `waitFor` around async sheet actions) plus unit coverage for the new utils.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed custom network RPC and block explorer changes from the network details bottom sheets so they persist reliably, including for networks with locked name/chain/symbol fields, and added clearer error feedback when a sheet save fails.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/28643

## **Manual testing steps**

```gherkin
Feature: Network details — RPC and block explorer bottom sheets

  Scenario: Add RPC from sheet persists without main Save
    Given the user opens Settings > Networks and edits an existing custom network
    When they open the RPC bottom sheet, enter a valid new RPC URL and name, and confirm add
    Then the new RPC appears in the list, the sheet closes or returns to the list as before, and switching away and back shows the RPC still present

  Scenario: RPC sheet add shows error when validation fails
    Given the user is on the add-RPC form inside the RPC bottom sheet
    When they submit an RPC URL that fails sheet validation (e.g. wrong chain or duplicate per product rules)
    Then an inline error is shown and the RPC is not added until the issue is resolved

  Scenario: Select another RPC from the sheet persists
    Given a network has multiple RPC endpoints and the RPC sheet is open
    When the user selects a different endpoint in the list
    Then the sheet dismisses on success and the active RPC reflects the selection after reopening network details

  Scenario: Delete RPC from the sheet persists
    Given a network has more than one RPC and the RPC sheet is open
    When the user deletes a non-selected RPC (or deletes the selected one per product rules)
    Then the list updates and the change survives leaving and re-entering the screen

  Scenario: Add block explorer from sheet persists
    Given the user edits a network and opens the block explorer bottom sheet
    When they enter a valid new explorer URL and tap add
    Then the explorer is selected and the change persists without relying on the main Save button alone

  Scenario: Select or delete block explorer from sheet
    Given the network has multiple block explorer URLs in the sheet
    When the user selects another explorer or deletes one
    Then the UI updates and persisted state matches after revisiting the screen

  Scenario: Built-in network with locked fields can still persist RPC / explorer list edits
    Given a network where name/chain/symbol fields are not editable but RPC/explorer lists are
    When the user changes RPC or block explorer URLs from the sheets
    Then changes persist and the main Save button state matches whether other fields still have unsaved edits
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/5cfed7ea-e0a8-431e-b726-12580e1d3899


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies network save/persist flow and validation around RPC endpoints, including new bypass/skip flags and async sheet persistence, which can affect whether network changes are correctly saved or navigation occurs.
> 
> **Overview**
> Fixes network edit bottom sheets so **RPC and block explorer add/select/delete now persist immediately and reliably** (instead of being fire-and-forget), with loading + inline error messaging when persistence fails.
> 
> Adds a stable `UrlSheetMutationCommittedHandler` path: `NetworkDetailsView` schedules `saveNetwork` after sheet mutations (no navigation, bypasses `enableAction`/disabled guards, optionally skips chain-id submit validation) and commits a new dirty baseline on success so the main Save button stays in sync.
> 
> Refactors form dirty detection and URL-list mutations into shared pure utils (`append*/apply*/remove*` + `networkFormBaselineSnapshot`), updates `useNetworkForm` to use them, hardens `useNetworkOperations.saveNetwork` to return `boolean` and handle failures, and introduces `validateNewRpcEndpointForSheet` for RPC-sheet-specific validation (duplicates, URL rules, and `eth_chainId` match). Tests are expanded/updated for the new async flows and helpers, and new i18n strings are added for sheet save failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd51e0e2f6f9f1c64080aeafc8d9927a28a4e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->