### PR TITLE
test: installs foundry with yarn instead of global install

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -41,10 +41,6 @@ inputs:
     description: JDK distribution to use (only for Android)
     required: false
     default: 'temurin'
-  foundry-version:
-    description: Foundry version to install
-    required: false
-    default: 'v0.3.0'
   android-avd-name:
     description: 'Name of AVD to create and boot (for Android)'
     required: false
@@ -231,22 +227,10 @@ runs:
 
     - name: Install Foundry
       shell: bash
-      env:
-        FOUNDRY_VERSION: ${{ inputs.foundry-version }}
       run: |
-        echo "Installing Foundry via foundryup..."
-
-        export FOUNDRY_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/.foundry"
-        export FOUNDRY_BIN="$FOUNDRY_DIR/bin"
-
-        mkdir -p "$FOUNDRY_BIN"
-
-        curl -sL https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup -o "$FOUNDRY_BIN/foundryup"
-        chmod +x "$FOUNDRY_BIN/foundryup"
-
-        echo "$FOUNDRY_BIN" >> "$GITHUB_PATH"
-
-        "$FOUNDRY_BIN/foundryup" -i "$FOUNDRY_VERSION"
+        echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
+        yarn install:foundryup
+        echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
     ## iOS Setup ##
 

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Restore .metamask folder (Foundry download cache for install:foundryup)
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
       - name: Setup Android Build Environment
         timeout-minutes: 15
         uses: ./.github/actions/setup-e2e-env
@@ -55,16 +61,6 @@ jobs:
           android-api-level: 36
           target: ${{ inputs.keystore_target }} # qa for taget=main and flask for target=flask
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache@v4
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
-
-      - name: Install Foundry if cache missed
-        if: steps.restore-metamask.outputs.cache-hit != 'true'
-        run: yarn install:foundryup
       - name: Setup project dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -96,6 +96,12 @@ jobs:
             ios/build
           key: ${{ runner.os }}-xcode-main-${{ env.XCODE_CACHE_VERSION }}-${{ hashFiles('ios/**/*.{h,m,mm,swift}', 'ios/**/Podfile.lock', 'yarn.lock') }}
 
+      - name: Restore .metamask folder (Foundry download cache for install:foundryup)
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
       # Install Node.js, Xcode tools, and other iOS development dependencies
       - name: Installing iOS Environment Setup
         timeout-minutes: 15
@@ -122,16 +128,6 @@ jobs:
       - name: Clean iOS plist files
         run: find ios -name "*.plist" -exec xattr -c {} \;
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache@v4
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
-
-      - name: Install Foundry if cache missed
-        if: steps.restore-metamask.outputs.cache-hit != 'true'
-        run: yarn install:foundryup
       # Run project setup with retry for better resilience
       - name: Setup project dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore .metamask folder
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
       - name: Set up E2E environment
         timeout-minutes: 15
         uses: ./.github/actions/setup-e2e-env

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -217,6 +217,12 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.BRANCH }}
 
+      - name: Restore .metamask folder (Foundry download cache for install:foundryup)
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
       - name: Set up E2E environment
         timeout-minutes: 15
         uses: ./.github/actions/setup-e2e-env


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
E2E setup was installing Anvil with the upstream foundryup script into the user’s Foundry directory and prepending that to PATH, while the repo pins Anvil through package.json and tests/seeder/anvil-manager.ts resolves node_modules/.bin/anvil when that file exists. In CI, the global install often “won” when the project-local binary was missing, so the chain did not always match local dev or the seeder’s resolved binary.

- `./.github/actions/setup-e2e-env`: Replace the global Foundry/curl foundryup step with yarn install:foundryup so the version and checksums come from the same package.json foundryup config as the rest of the project. Remove the foundry-version input; bump the toolchain by editing that config, not a workflow input. After install, add $GITHUB_WORKSPACE/node_modules/.bin to GITHUB_PATH so bare anvil on the runner matches the project binary.
- `build-android-e2e` / `build-ios-e2e`: Restore the .metamask cache before the composite E2E setup action (so mm-foundryup can reuse download cache when available) and remove the redundant “Install Foundry if cache missed” step now covered by the action.
- `run-e2e-workflow` / `update-e2e-fixtures`: Restore .metamask before setup-e2e-env for the same cache behavior. No foundry-version was passed in callers; no consumer updates are required for removed inputs.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1118

## **Manual testing steps**
N/A

## **Screenshots/Recordings**
N/A
<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI/E2E environment provisioning and PATH/caching behavior, which can break E2E runs if the Yarn-based Foundry install or cache assumptions are incorrect.
> 
> **Overview**
> E2E CI now installs Foundry via `yarn install:foundryup` inside the `setup-e2e-env` composite action (and adds `node_modules/.bin` to `GITHUB_PATH`), replacing the previous curl-based `foundryup` global install and removing the `foundry-version` action input.
> 
> The Android/iOS build, E2E run, and fixture-update workflows restore the `.metamask` cache *before* calling `setup-e2e-env`, and drop the extra “install Foundry if cache missed” steps since installation is handled centrally by the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d45f6428a8eaea18a693bce92d97082adb56f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->