### PR TITLE
fix(Rewards): RWDS-1212 fix musd logo not displayed

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
+++ b/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
@@ -26,7 +26,10 @@ import { BridgeToken } from '../../../../Bridge/types';
 import {
   MUSD_TOKEN,
   MUSD_TOKEN_ADDRESS,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../../Earn/constants/musd';
+import { getTokenIconUrl } from '../../../../Bridge/utils';
+import { CaipAssetType } from '@metamask/utils';
 import { getNativeSourceToken } from '../../../../Bridge/utils/tokenUtils';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -38,10 +41,14 @@ const BUY_MUSD_URL =
 
 const MUSD_DEST_TOKEN: BridgeToken = {
   address: MUSD_TOKEN_ADDRESS,
-  symbol: MUSD_TOKEN.symbol,
+  symbol: MUSD_TOKEN.symbol.toUpperCase(),
   name: MUSD_TOKEN.name,
   decimals: MUSD_TOKEN.decimals,
   chainId: '0x1',
+  image: getTokenIconUrl(
+    MUSD_TOKEN_ASSET_ID_BY_CHAIN['0x1'] as CaipAssetType,
+    false,
+  ),
 };
 
 const MusdCalculatorTab: React.FC = () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This fixes an issue where opening the mUSD swap flow from Rewards does not display the token logo

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed musd logo not displayed when opening musd swap from rewards

## **Related issues**

Fixes: #29042 

## **Manual testing steps**

```gherkin
Feature: mUSD swap flow from Rewards

  Scenario: User is on mobile app
    Given user is on the mUSD calculator page

    When user taps the swap button
    Then swap flow opens with the mUSD logo displayed on the destination asset
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ba81a629-02f4-4c6e-9c09-70fd52f3bd66

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI fix that only adjusts the `BridgeToken` metadata passed into the swap navigation (symbol casing and icon URL). Risk is limited to potentially incorrect asset-id/icon URL formatting affecting how the destination token is rendered.
> 
> **Overview**
> Fixes the Rewards → swap deeplink so the destination `mUSD` token renders with an icon by populating `MUSD_DEST_TOKEN.image` via `getTokenIconUrl` using `MUSD_TOKEN_ASSET_ID_BY_CHAIN`.
> 
> Also normalizes the destination token symbol to uppercase (`MUSD_TOKEN.symbol.toUpperCase()`), aligning with other token display expectations in the swap UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa04ea9121e3ee4f30ed9293cd1c588756638fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->