### PR TITLE
fix: stop hardcoding transaction pay strategy

### DIFF
--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
@@ -91,4 +91,12 @@ describe('Transaction Pay Controller Init', () => {
 
     expect(state).toBe(MOCK_TRANSACTION_PAY_CONTROLLER_STATE);
   });
+
+  it('does not override strategy selection in mobile init', () => {
+    const getStrategy = testConstructorOption('getStrategy');
+    const getStrategies = testConstructorOption('getStrategies');
+
+    expect(getStrategy).toBeUndefined();
+    expect(getStrategies).toBeUndefined();
+  });
 });

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -3,9 +3,7 @@ import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
   TransactionPayControllerMessenger,
-  TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
-import { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
 
@@ -20,7 +18,6 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
     const transactionPayController = new TransactionPayController({
       getDelegationTransaction: ({ transaction }) =>
         getDelegationTransaction(initMessenger, transaction),
-      getStrategy,
       messenger: controllerMessenger,
       state: persistedState.TransactionPayController,
     });
@@ -34,7 +31,3 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
     throw error;
   }
 };
-
-function getStrategy(_transaction: TransactionMeta): TransactionPayStrategy {
-  return TransactionPayStrategy.Relay;
-}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This removes the mobile-specific `TransactionPayController` strategy override that always forced Relay.

With this change, strategy selection is left to the controller configuration instead of being hardcoded in mobile init, so fallback and provider routing can be decided by the controller itself.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

No issue: internal transaction-pay strategy selection cleanup.

## **Manual testing steps**

```gherkin
Feature: Transaction pay strategy selection

  Scenario: mobile init does not override transaction pay strategy
    Given the repository is on this branch
    When I run `yarn jest app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts`
    Then the test suite should pass
    And the regression test should confirm `getStrategy` and `getStrategies` are undefined
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `TransactionPayController` selects its payment strategy by removing the mobile init override, which could alter transaction routing/fallback behavior at runtime. Scope is small but touches transaction payment execution paths.
> 
> **Overview**
> Stops hardcoding the `TransactionPayController` strategy in `transaction-pay-controller-init.ts` by removing the `getStrategy` override that always forced `Relay`, leaving strategy selection to the controller’s own configuration.
> 
> Adds a regression test ensuring mobile init does **not** pass `getStrategy`/`getStrategies` into the controller constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4efc556d583da64be802f314017d3fbc471542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->