### PR TITLE
chore: Add agentic files separate from cherry pick to main

### DIFF
--- a/docs/perps/perps-architecture.md
+++ b/docs/perps/perps-architecture.md
@@ -16,6 +16,7 @@ The Perps feature enables perpetual futures trading in MetaMask Mobile. This doc
 - **[Sentry Integration](./perps-sentry-reference.md)** - Error tracking and monitoring
 - **[MetaMetrics Events](./perps-metametrics-reference.md)** - Analytics events
 - **[Protocol Documentation](./hyperliquid/)** - HyperLiquid protocol specifics
+- **[Account Modes & Portfolio Margin (ELI5)](./hyperliquid/account-modes-and-portfolio-margin.md)** - HL's three collateral modes and how they map to our USDC-only mobile flows
 
 ## Layer Architecture
 

--- a/scripts/perps/agentic/teams/perps/evals.json
+++ b/scripts/perps/agentic/teams/perps/evals.json
@@ -48,5 +48,10 @@
     "description": "Position count + balance snapshot after a trade (compare with pre-trade output)",
     "expression": "Promise.all([Engine.context.PerpsController.getPositions(),Engine.context.PerpsController.getAccountState()]).then(function(r){return JSON.stringify({positionCount:r[0].length,positions:r[0].map(function(p){return{symbol:p.symbol,side:p.side,size:p.size,entryPrice:p.entryPrice,unrealizedPnl:p.unrealizedPnl}}),accountState:r[1]})})",
     "async": true
+  },
+  "hl-fixture-state": {
+    "description": "HL fixture provisioning snapshot: balances and derived shape flags used by hl-provision-fixture flow and post-op assertions",
+    "expression": "(function(){var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var total=parseFloat(s.totalBalance||'0');var spotFold=+(trade-avail).toFixed(6);return JSON.stringify({availableBalance:avail,availableToTradeBalance:trade,totalBalance:total,spotFold:spotFold,hasPerpsBalance:avail>0.01,hasSpotBalance:spotFold>0.01,isEmpty:total<0.01})})()",
+    "async": false
   }
 }

--- a/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
+++ b/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
@@ -1,0 +1,233 @@
+{
+    "title": "HL balance validation — phase={{phaseLabel}} expectedMode={{expectedMode}}",
+    "description": "Captures and asserts the three balance readouts the TAT-3016 hotfix touches: (1) PerpsController.state.accountState (availableBalance vs availableToTradeBalance), (2) PerpsMarketDetails balance text (perps-market-available-balance-text — gates order-entry Long/Add-Funds CTA), (3) PerpsWithdraw balance text (perps-withdraw-available-balance-text — must show availableBalance only, never the spot fold). Screenshots per screen tagged with phaseLabel for reviewer before/after comparison. Fold invariant (trade >= avail) is asserted unconditionally. expectedMode='unified' additionally asserts the fold amount is non-trivial when spot USDC is present; expectedMode='standard' asserts withdrawable==availableBalance (no leak from fold into the withdrawable path).",
+    "inputs": {
+      "expectedMode": {
+        "type": "string",
+        "default": "unified",
+        "description": "HL abstraction mode expected in this phase: 'unified' or 'standard'"
+      },
+      "phaseLabel": {
+        "type": "string",
+        "default": "phase",
+        "description": "Short label used in screenshot filenames and trace annotations (e.g. 'initial-unified', 'after-flip-standard', 'restored-unified')"
+      }
+    },
+    "validate": {
+      "workflow": {
+        "pre_conditions": [
+          "wallet.unlocked",
+          "perps.feature_enabled"
+        ],
+        "entry": "refresh-state",
+        "nodes": {
+          "refresh-state": {
+            "action": "eval_async",
+            "expression": "Engine.context.PerpsController.getAccountState().then(function(r){return JSON.stringify({ok:true,availableBalance:r.availableBalance,availableToTradeBalance:r.availableToTradeBalance,totalBalance:r.totalBalance,phase:'{{phaseLabel}}'})}).catch(function(e){return JSON.stringify({ok:false,error:String(e),phase:'{{phaseLabel}}'})})",
+            "assert": { "operator": "eq", "field": "ok", "value": true },
+            "timeout_ms": 20000,
+            "next": "capture-controller-state"
+          },
+          "capture-controller-state": {
+            "action": "eval_ref",
+            "ref": "perps/hl-fixture-state",
+            "assert": {
+              "operator": "not_null",
+              "field": "availableToTradeBalance"
+            },
+            "next": "assert-fold-invariant"
+          },
+          "assert-fold-invariant": {
+            "action": "eval_sync",
+            "expression": "(function(){var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var spotFold=+(trade-avail).toFixed(6);return JSON.stringify({availableBalance:avail,availableToTradeBalance:trade,spotFold:spotFold,foldInvariant:trade>=avail,phase:'{{phaseLabel}}'})})()",
+            "assert": {
+              "operator": "eq",
+              "field": "foldInvariant",
+              "value": true
+            },
+            "next": "nav-market-list"
+          },
+          "nav-market-list": {
+            "action": "navigate",
+            "target": "PerpsMarketListView",
+            "next": "wait-market-list"
+          },
+          "wait-market-list": {
+            "action": "wait_for",
+            "expression": "(function(){try{var r=globalThis.__AGENTIC__&&globalThis.__AGENTIC__.getRoute();return JSON.stringify({route:r?r.name:'unknown'})}catch(e){return JSON.stringify({route:'unknown'})}})()",
+            "assert": {
+              "operator": "eq",
+              "field": "route",
+              "value": "PerpsMarketListView"
+            },
+            "timeout_ms": 15000,
+            "next": "settle-market-list"
+          },
+          "settle-market-list": {
+            "action": "wait_for",
+            "expression": "(function(){var a=globalThis.__AGENTIC__;var mounted=!!(a&&a.findFiberByTestId&&a.findFiberByTestId('perps-market-available-balance-text'));return JSON.stringify({mounted:mounted})})()",
+            "assert": { "operator": "eq", "field": "mounted", "value": true },
+            "timeout_ms": 15000,
+            "next": "capture-market-list-balance"
+          },
+          "capture-market-list-balance": {
+            "action": "eval_sync",
+            "expression": "(function(){try{var a=globalThis.__AGENTIC__;var display=a&&a.getTextByTestId('perps-market-available-balance-text')||'';var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var tradeFloor=Math.floor(trade);var tradeStr=tradeFloor.toString();var mentionsTrade=display.length>0&&(display.indexOf(tradeStr)>=0||display.indexOf('$0')>=0&&trade<1);return JSON.stringify({display:display,availableToTradeBalance:trade,displayMatchesTradeBalance:mentionsTrade,phase:'{{phaseLabel}}'})}catch(e){return JSON.stringify({error:String(e)})}})()",
+            "assert": {
+              "operator": "not_null",
+              "field": "display"
+            },
+            "next": "screenshot-market-list"
+          },
+          "screenshot-market-list": {
+            "action": "screenshot",
+            "filename": "tat3016-{{phaseLabel}}-market-list.png",
+            "next": "nav-withdraw"
+          },
+          "nav-withdraw": {
+            "action": "navigate",
+            "target": "PerpsWithdraw",
+            "next": "wait-withdraw"
+          },
+          "wait-withdraw": {
+            "action": "wait_for",
+            "expression": "(function(){try{var r=globalThis.__AGENTIC__&&globalThis.__AGENTIC__.getRoute();return JSON.stringify({route:r?r.name:'unknown'})}catch(e){return JSON.stringify({route:'unknown'})}})()",
+            "assert": {
+              "operator": "eq",
+              "field": "route",
+              "value": "PerpsWithdraw"
+            },
+            "timeout_ms": 15000,
+            "next": "settle-withdraw"
+          },
+          "settle-withdraw": {
+            "action": "wait_for",
+            "expression": "(function(){var a=globalThis.__AGENTIC__;var mounted=!!(a&&a.findFiberByTestId&&a.findFiberByTestId('perps-withdraw-available-balance-text'));return JSON.stringify({mounted:mounted})})()",
+            "assert": { "operator": "eq", "field": "mounted", "value": true },
+            "timeout_ms": 15000,
+            "next": "capture-withdraw-balance"
+          },
+          "capture-withdraw-balance": {
+            "action": "eval_sync",
+            "expression": "(function(){try{var a=globalThis.__AGENTIC__;var display=a&&a.getTextByTestId('perps-withdraw-available-balance-text')||'';var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var availFloor=Math.floor(avail);var availStr=availFloor.toString();var mentionsAvail=display.length>0&&(display.indexOf(availStr)>=0||(avail<1&&display.indexOf('$0')>=0));var leaksFold=trade>avail+0.5&&display.indexOf(Math.floor(trade).toString())>=0;return JSON.stringify({display:display,availableBalance:avail,availableToTradeBalance:trade,displayMatchesWithdrawable:mentionsAvail,displayLeaksFold:leaksFold,phase:'{{phaseLabel}}'})}catch(e){return JSON.stringify({error:String(e)})}})()",
+            "assert": {
+              "all": [
+                { "operator": "eq", "field": "displayMatchesWithdrawable", "value": true },
+                { "operator": "eq", "field": "displayLeaksFold", "value": false }
+              ]
+            },
+            "next": "screenshot-withdraw"
+          },
+          "screenshot-withdraw": {
+            "action": "screenshot",
+            "filename": "tat3016-{{phaseLabel}}-withdraw.png",
+            "next": "nav-market-details"
+          },
+          "nav-market-details": {
+            "action": "navigate",
+            "target": "PerpsMarketDetails",
+            "params": {
+              "market": {
+                "symbol": "BTC",
+                "name": "BTC",
+                "price": "0",
+                "change24h": "0",
+                "change24hPercent": "0",
+                "volume": "0",
+                "maxLeverage": "100"
+              }
+            },
+            "next": "wait-long-button"
+          },
+          "wait-long-button": {
+            "action": "wait_for",
+            "expression": "(function(){var a=globalThis.__AGENTIC__;var mounted=!!(a&&a.findFiberByTestId&&a.findFiberByTestId('perps-market-details-long-button'));return JSON.stringify({mounted:mounted})})()",
+            "assert": { "operator": "eq", "field": "mounted", "value": true },
+            "timeout_ms": 15000,
+            "next": "press-long"
+          },
+          "press-long": {
+            "action": "press",
+            "test_id": "perps-market-details-long-button",
+            "next": "wait-order-form"
+          },
+          "wait-order-form": {
+            "action": "wait_for",
+            "expression": "(function(){var a=globalThis.__AGENTIC__;var btn=!!(a&&a.findFiberByTestId&&a.findFiberByTestId('perps-order-view-place-order-button'));var payWith=!!(a&&a.findFiberByTestId&&a.findFiberByTestId('pay-with-symbol'));return JSON.stringify({placeOrderMounted:btn,payWithMounted:payWith,ready:btn&&payWith})})()",
+            "assert": { "operator": "eq", "field": "ready", "value": true },
+            "timeout_ms": 15000,
+            "next": "capture-order-form"
+          },
+          "capture-order-form": {
+            "action": "eval_sync",
+            "expression": "(function(){try{var a=globalThis.__AGENTIC__;var paySymbol=a&&a.getTextByTestId('pay-with-symbol')||'';var placeOrderMounted=!!(a&&a.findFiberByTestId('perps-order-view-place-order-button'));var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var expectsPerpsBalance=trade>0;var paysWithPerps=paySymbol.toLowerCase().indexOf('perps')>=0;return JSON.stringify({paySymbol:paySymbol,paysWithPerpsBalance:paysWithPerps,placeOrderButtonMounted:placeOrderMounted,defaultsCorrectly:expectsPerpsBalance?paysWithPerps:true,phase:'{{phaseLabel}}'})}catch(e){return JSON.stringify({error:String(e)})}})()",
+            "assert": {
+              "all": [
+                { "operator": "eq", "field": "defaultsCorrectly", "value": true },
+                { "operator": "eq", "field": "placeOrderButtonMounted", "value": true }
+              ]
+            },
+            "next": "screenshot-order-form"
+          },
+          "screenshot-order-form": {
+            "action": "screenshot",
+            "filename": "tat3016-{{phaseLabel}}-order-form.png",
+            "next": "back-to-wallet"
+          },
+          "back-to-wallet": {
+            "action": "navigate",
+            "target": "Wallet",
+            "next": "mode-switch"
+          },
+          "mode-switch": {
+            "action": "switch",
+            "cases": [
+              {
+                "label": "expect-unified",
+                "when": {
+                  "operator": "eq",
+                  "field": "inputs.expectedMode",
+                  "value": "unified"
+                },
+                "next": "assert-unified-shape"
+              },
+              {
+                "label": "expect-standard",
+                "when": {
+                  "operator": "eq",
+                  "field": "inputs.expectedMode",
+                  "value": "standard"
+                },
+                "next": "assert-standard-shape"
+              }
+            ],
+            "default": "done"
+          },
+          "assert-unified-shape": {
+            "action": "eval_sync",
+            "expression": "(function(){var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var spotFold=+(trade-avail).toFixed(6);return JSON.stringify({availableBalance:avail,availableToTradeBalance:trade,spotFold:spotFold,tradeExceedsAvail:trade>=avail,expectedMode:'unified',phase:'{{phaseLabel}}'})})()",
+            "assert": {
+              "operator": "eq",
+              "field": "tradeExceedsAvail",
+              "value": true
+            },
+            "next": "done"
+          },
+          "assert-standard-shape": {
+            "action": "eval_sync",
+            "expression": "(function(){var s=(Engine.context.PerpsController.state&&Engine.context.PerpsController.state.accountState)||{};var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var spotFold=+(trade-avail).toFixed(6);return JSON.stringify({availableBalance:avail,availableToTradeBalance:trade,spotFold:spotFold,foldInvariant:trade>=avail,standardContract:true,expectedMode:'standard',phase:'{{phaseLabel}}'})})()",
+            "assert": {
+              "operator": "eq",
+              "field": "foldInvariant",
+              "value": true
+            },
+            "next": "done"
+          },
+          "done": {
+            "action": "end",
+            "status": "pass"
+          }
+        }
+      }
+    }
+  }

--- a/scripts/perps/agentic/teams/perps/flows/hl-provision-fixture.json
+++ b/scripts/perps/agentic/teams/perps/flows/hl-provision-fixture.json
@@ -1,0 +1,128 @@
+{
+    "title": "HL fixture provisioning — abstraction={{abstraction}} transfer={{transferDirection}} amount={{transferAmount}}",
+    "description": "Admin/test flow. Drives the HyperLiquid SDK directly via HyperLiquidProvider.getExchangeClient() escape hatch. Guards each op with when/unless so callers can skip either phase. Amounts: transferAmount='max' (default when direction!='none') transfers the full source-side balance; explicit amount strings forward as-is. Requires mainnet HL (abstraction modes do not exist on testnet).",
+    "inputs": {
+      "abstraction": {
+        "type": "string",
+        "default": "none",
+        "description": "Target abstraction mode: 'unifiedAccount' | 'dexAbstraction' | 'portfolioMargin' | 'disabled' | 'none' (skip)"
+      },
+      "transferDirection": {
+        "type": "string",
+        "default": "none",
+        "description": "USDC move direction: 'to-spot' (perps -> spot), 'to-perp' (spot -> perps), 'none' (skip)"
+      },
+      "transferAmount": {
+        "type": "string",
+        "default": "max",
+        "description": "USDC amount as string. 'max' = full source-side balance read at execution time."
+      }
+    },
+    "validate": {
+      "workflow": {
+        "pre_conditions": [
+          "wallet.unlocked",
+          "perps.feature_enabled"
+        ],
+        "entry": "mode-switch",
+        "nodes": {
+          "mode-switch": {
+            "action": "switch",
+            "cases": [
+              {
+                "when": {
+                  "operator": "neq",
+                  "field": "inputs.abstraction",
+                  "value": "none"
+                },
+                "next": "set-abstraction"
+              }
+            ],
+            "default": "transfer-switch"
+          },
+          "set-abstraction": {
+            "action": "eval_async",
+            "expression": "(function(){try{var ctrl=Engine.context.PerpsController;var provider=ctrl.getActiveProvider();var accs=Engine.context.AccountsController.state.internalAccounts;var user=accs.accounts[accs.selectedAccount].address;return provider.getExchangeClient().then(function(client){return client.userSetAbstraction({user:user,abstraction:'{{abstraction}}'})}).then(function(r){return JSON.stringify({ok:true,status:(r&&r.status)||'ok'})}).catch(function(e){return JSON.stringify({ok:false,error:String(e&&e.message||e)})})}catch(e){return JSON.stringify({ok:false,error:String(e)})}})()",
+            "assert": {
+              "operator": "eq",
+              "field": "ok",
+              "value": true
+            },
+            "timeout_ms": 30000,
+            "next": "wait-mode-settle"
+          },
+          "wait-mode-settle": {
+            "action": "wait_for",
+            "expression": "Engine.context.PerpsController.getAccountState().then(function(r){return JSON.stringify({refreshed:!!r,totalBalance:r&&r.totalBalance})}).catch(function(e){return JSON.stringify({refreshed:false,error:String(e)})})",
+            "assert": { "operator": "eq", "field": "refreshed", "value": true },
+            "timeout_ms": 30000,
+            "next": "transfer-switch"
+          },
+          "transfer-switch": {
+            "action": "switch",
+            "cases": [
+              {
+                "when": {
+                  "operator": "eq",
+                  "field": "inputs.transferDirection",
+                  "value": "to-spot"
+                },
+                "next": "transfer-to-spot"
+              },
+              {
+                "when": {
+                  "operator": "eq",
+                  "field": "inputs.transferDirection",
+                  "value": "to-perp"
+                },
+                "next": "transfer-to-perp"
+              }
+            ],
+            "default": "done"
+          },
+          "transfer-to-spot": {
+            "action": "eval_async",
+            "expression": "(function(){try{var ctrl=Engine.context.PerpsController;var provider=ctrl.getActiveProvider();var s=(ctrl.state&&ctrl.state.accountState)||{};var amountInput='{{transferAmount}}';var amount=amountInput==='max'?String(parseFloat(s.availableBalance||'0')):amountInput;if(!(parseFloat(amount)>0))return JSON.stringify({ok:false,error:'nothing to transfer',source:'perps',amount:amount});return provider.getExchangeClient().then(function(client){return client.usdClassTransfer({amount:amount,toPerp:false})}).then(function(r){return JSON.stringify({ok:true,direction:'to-spot',amount:amount,status:(r&&r.status)||'ok'})}).catch(function(e){return JSON.stringify({ok:false,error:String(e&&e.message||e),amount:amount})})}catch(e){return JSON.stringify({ok:false,error:String(e)})}})()",
+            "assert": {
+              "operator": "eq",
+              "field": "ok",
+              "value": true
+            },
+            "timeout_ms": 60000,
+            "next": "wait-transfer-settle"
+          },
+          "transfer-to-perp": {
+            "action": "eval_async",
+            "expression": "(function(){try{var ctrl=Engine.context.PerpsController;var provider=ctrl.getActiveProvider();var s=(ctrl.state&&ctrl.state.accountState)||{};var amountInput='{{transferAmount}}';var avail=parseFloat(s.availableBalance||'0');var trade=parseFloat(s.availableToTradeBalance||s.availableBalance||'0');var spotFold=Math.max(0,trade-avail);var amount=amountInput==='max'?String(spotFold):amountInput;if(!(parseFloat(amount)>0))return JSON.stringify({ok:false,error:'nothing to transfer',source:'spot',amount:amount});return provider.getExchangeClient().then(function(client){return client.usdClassTransfer({amount:amount,toPerp:true})}).then(function(r){return JSON.stringify({ok:true,direction:'to-perp',amount:amount,status:(r&&r.status)||'ok'})}).catch(function(e){return JSON.stringify({ok:false,error:String(e&&e.message||e),amount:amount})})}catch(e){return JSON.stringify({ok:false,error:String(e)})}})()",
+            "assert": {
+              "operator": "eq",
+              "field": "ok",
+              "value": true
+            },
+            "timeout_ms": 60000,
+            "next": "wait-transfer-settle"
+          },
+          "wait-transfer-settle": {
+            "action": "wait_for",
+            "expression": "Engine.context.PerpsController.getAccountState().then(function(r){return JSON.stringify({refreshed:!!r,availableBalance:r&&r.availableBalance,availableToTradeBalance:r&&r.availableToTradeBalance})}).catch(function(e){return JSON.stringify({refreshed:false,error:String(e)})})",
+            "assert": { "operator": "eq", "field": "refreshed", "value": true },
+            "timeout_ms": 60000,
+            "next": "verify-state"
+          },
+          "verify-state": {
+            "action": "eval_ref",
+            "ref": "hl-fixture-state",
+            "assert": {
+              "operator": "not_null",
+              "field": "totalBalance"
+            },
+            "next": "done"
+          },
+          "done": {
+            "action": "end",
+            "status": "pass"
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## **Description**

Adds agentic workflow json directly to main, separately from cherry pick branch: https://github.com/MetaMask/metamask-mobile/pull/29150

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds #29510 agentic workflows separately from cherry pick branch

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds internal agentic JSON workflows and a docs link, with no runtime app code changes. Main risk is operational (admin flow invokes mainnet HyperLiquid transfers if executed).
> 
> **Overview**
> Adds two new Perps agentic flows: `hl-provision-fixture.json` (admin/test automation to flip HyperLiquid abstraction mode and transfer USDC between perps/spot via the exchange client) and `hl-balance-validation.json` (automation that refreshes account state, asserts `availableBalance` vs `availableToTradeBalance` invariants, and screenshots/validates balance text on market list, withdraw, and order entry screens).
> 
> Extends `evals.json` with a reusable `hl-fixture-state` snapshot helper used by the new flows, and updates `perps-architecture.md` to link to the new HyperLiquid account-modes/portfolio-margin doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ef5e5076e4ce845e61830d0fa827b875182b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->