### PR TITLE
fix(perps): create a private userFills subscription for account subsc…

### DIFF
--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -4047,6 +4047,100 @@ describe('HyperLiquidSubscriptionService', () => {
 
       expect(accountSpotRefreshSubscription.unsubscribe).toHaveBeenCalled();
     });
+
+    it('ignores stale fills callbacks after switching accounts', async () => {
+      mockSpotClearinghouseState.mockResolvedValue({
+        balances: [{ coin: 'USDC', total: '100', hold: '0' }],
+      });
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        availableToTradeBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      let firstUserFillsCallback: ((data: any) => void) | undefined;
+      let secondUserFillsCallback: ((data: any) => void) | undefined;
+      let resolveFirstUnsubscribe: (() => void) | undefined;
+      const firstSubscription = {
+        unsubscribe: jest.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveFirstUnsubscribe = resolve;
+            }),
+        ),
+      };
+      const secondSubscription = {
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockWalletService.getUserAddressWithDefault.mockImplementation(
+        async (accountId?: CaipAccountId) =>
+          (accountId === 'eip155:1:0x456' ? '0x456' : '0x123') as Hex,
+      );
+
+      mockSubscriptionClient.userFills.mockImplementation(
+        (params: { user: string }, callback: any) => {
+          if (params.user === '0x123') {
+            firstUserFillsCallback = callback;
+            return Promise.resolve(firstSubscription);
+          }
+
+          secondUserFillsCallback = callback;
+          return Promise.resolve(secondSubscription);
+        },
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const mockCallback = jest.fn();
+      const unsubscribeFirst = singleDexService.subscribeToAccount({
+        accountId: 'eip155:1:0x123',
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+      expect(firstUserFillsCallback).toBeDefined();
+
+      unsubscribeFirst();
+
+      const unsubscribeSecond = singleDexService.subscribeToAccount({
+        accountId: 'eip155:1:0x456',
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+      expect(secondUserFillsCallback).toBeDefined();
+
+      mockSpotClearinghouseState.mockClear();
+      mockCallback.mockClear();
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      firstUserFillsCallback!({
+        isSnapshot: false,
+        fills: [{ oid: 12345, coin: 'BTC', side: 'B', sz: '0.1', px: '50000' }],
+      });
+
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.runAllTimersAsync();
+
+      expect(mockSpotClearinghouseState).not.toHaveBeenCalled();
+      expect(mockCallback).not.toHaveBeenCalled();
+
+      resolveFirstUnsubscribe?.();
+      await Promise.resolve();
+
+      unsubscribeSecond();
+      expect(secondSubscription.unsubscribe).toHaveBeenCalled();
+    });
   });
 
   describe('aggregateAccountStates - returnOnEquity calculation', () => {
@@ -4363,6 +4457,42 @@ describe('HyperLiquidSubscriptionService', () => {
 
       // Verify allMids was not called
       expect(mockSubscriptionClient.allMids).not.toHaveBeenCalled();
+    });
+
+    it('restores the internal account spot refresh fills subscription when account subscribers exist', async () => {
+      const firstSpotRefreshSubscription = {
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+      const secondSpotRefreshSubscription = {
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockSubscriptionClient.userFills
+        .mockResolvedValueOnce(firstSpotRefreshSubscription)
+        .mockResolvedValueOnce(secondSpotRefreshSubscription);
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockSubscriptionClient.userFills).toHaveBeenCalledTimes(1);
+
+      await singleDexService.restoreSubscriptions();
+
+      expect(firstSpotRefreshSubscription.unsubscribe).toHaveBeenCalled();
+      expect(mockSubscriptionClient.userFills).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
+      expect(secondSpotRefreshSubscription.unsubscribe).toHaveBeenCalled();
     });
 
     // TODO: Refactor to test restoreSubscriptions through public disconnect/reconnect API

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3839,6 +3839,214 @@ describe('HyperLiquidSubscriptionService', () => {
 
       unsubscribe();
     });
+
+    it('refreshes spot-backed availableToTradeBalance after streaming fills', async () => {
+      mockSpotClearinghouseState
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '0' }],
+        })
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '3' }],
+        });
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        availableToTradeBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      let userFillsCallback: ((data: any) => void) | undefined;
+      mockSubscriptionClient.userFills.mockImplementation(
+        (_params: any, callback: any) => {
+          userFillsCallback = callback;
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const mockCallback = jest.fn();
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      expect(mockCallback.mock.calls.at(-1)[0].availableToTradeBalance).toBe(
+        '150',
+      );
+
+      mockCallback.mockClear();
+      expect(userFillsCallback).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      userFillsCallback!({
+        isSnapshot: false,
+        fills: [{ oid: 12345, coin: 'BTC', side: 'B', sz: '0.1', px: '50000' }],
+      });
+
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.runAllTimersAsync();
+
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(2);
+      expect(mockCallback).toHaveBeenCalled();
+      expect(mockCallback.mock.calls.at(-1)[0].availableToTradeBalance).toBe(
+        '147',
+      );
+
+      unsubscribe();
+    });
+
+    it('does not refresh spot state on userFills snapshot events', async () => {
+      mockSpotClearinghouseState.mockResolvedValue({
+        balances: [{ coin: 'USDC', total: '100', hold: '0' }],
+      });
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        availableToTradeBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      let userFillsCallback: ((data: any) => void) | undefined;
+      mockSubscriptionClient.userFills.mockImplementation(
+        (_params: any, callback: any) => {
+          userFillsCallback = callback;
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(userFillsCallback).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      userFillsCallback!({
+        isSnapshot: true,
+        fills: [{ oid: 12345, coin: 'BTC', side: 'B', sz: '0.1', px: '50000' }],
+      });
+
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.runAllTimersAsync();
+
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+    });
+
+    it('coalesces multiple streaming fills into one spot refresh', async () => {
+      mockSpotClearinghouseState
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '0' }],
+        })
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '3' }],
+        });
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        availableToTradeBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      let userFillsCallback: ((data: any) => void) | undefined;
+      mockSubscriptionClient.userFills.mockImplementation(
+        (_params: any, callback: any) => {
+          userFillsCallback = callback;
+          return Promise.resolve({
+            unsubscribe: jest.fn().mockResolvedValue(undefined),
+          });
+        },
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(userFillsCallback).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      userFillsCallback!({
+        isSnapshot: false,
+        fills: [{ oid: 12345, coin: 'BTC', side: 'B', sz: '0.1', px: '50000' }],
+      });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      userFillsCallback!({
+        isSnapshot: false,
+        fills: [{ oid: 12346, coin: 'BTC', side: 'S', sz: '0.1', px: '50010' }],
+      });
+
+      await jest.advanceTimersByTimeAsync(250);
+      await jest.runAllTimersAsync();
+
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
+    });
+
+    it('cleans up the internal spot refresh fill subscription when account subscribers end', async () => {
+      const accountSpotRefreshSubscription = {
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockSubscriptionClient.userFills.mockImplementation(
+        (_params: any, _callback: any) =>
+          Promise.resolve(accountSpotRefreshSubscription),
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+
+      unsubscribe();
+
+      expect(accountSpotRefreshSubscription.unsubscribe).toHaveBeenCalled();
+    });
   });
 
   describe('aggregateAccountStates - returnOnEquity calculation', () => {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -58,6 +58,8 @@ import { calculateOpenInterestUSD } from '../utils/marketDataTransform';
  * Implements singleton subscription architecture with reference counting
  */
 export class HyperLiquidSubscriptionService {
+  static readonly #accountSpotRefreshDebounceMs = 250;
+
   // Service dependencies
   readonly #clientService: HyperLiquidClientService;
 
@@ -136,6 +138,14 @@ export class HyperLiquidSubscriptionService {
 
   // Order fill subscriptions keyed by accountId (normalized: undefined -> 'default')
   readonly #orderFillSubscriptions = new Map<string, ISubscription>();
+
+  #accountSpotRefreshSubscription?: ISubscription;
+
+  #accountSpotRefreshSubscriptionPromise?: Promise<void>;
+
+  #accountSpotRefreshUserAddress?: string;
+
+  #accountSpotRefreshTimeout?: ReturnType<typeof setTimeout>;
 
   readonly #symbolSubscriberCounts = new Map<string, number>();
 
@@ -1024,7 +1034,17 @@ export class HyperLiquidSubscriptionService {
     const userAddress =
       await this.#walletService.getUserAddressWithDefault(accountId);
 
+    await this.#queueSpotStateRefreshForUser(userAddress);
+  }
+
+  async #queueSpotStateRefreshForUser(
+    userAddress: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    const force = options?.force ?? false;
+
     if (
+      !force &&
       this.#cachedSpotState &&
       this.#cachedSpotStateUserAddress === userAddress
     ) {
@@ -1035,6 +1055,7 @@ export class HyperLiquidSubscriptionService {
     // A pending fetch for a different user is stale after an account switch —
     // start a fresh fetch; the stale one will self-discard via generation check.
     if (
+      !force &&
       this.#spotStatePromise &&
       this.#spotStatePromiseUserAddress === userAddress
     ) {
@@ -1103,6 +1124,117 @@ export class HyperLiquidSubscriptionService {
         this.#getErrorContext('refreshSpotState'),
       );
     }
+  }
+
+  #scheduleAccountSpotRefresh(userAddress: string): void {
+    if (this.#accountSubscriberCount === 0) {
+      return;
+    }
+
+    if (this.#accountSpotRefreshTimeout) {
+      clearTimeout(this.#accountSpotRefreshTimeout);
+    }
+
+    this.#accountSpotRefreshTimeout = setTimeout(() => {
+      this.#accountSpotRefreshTimeout = undefined;
+      this.#queueSpotStateRefreshForUser(userAddress, { force: true }).catch(
+        (error) => {
+          this.#logErrorUnlessClearing(
+            ensureError(
+              error,
+              'HyperLiquidSubscriptionService.scheduleAccountSpotRefresh',
+            ),
+            this.#getErrorContext('scheduleAccountSpotRefresh'),
+          );
+        },
+      );
+    }, HyperLiquidSubscriptionService.#accountSpotRefreshDebounceMs);
+  }
+
+  async #ensureAccountSpotRefreshSubscription(
+    accountId?: CaipAccountId,
+  ): Promise<void> {
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    if (
+      this.#accountSpotRefreshSubscription &&
+      this.#accountSpotRefreshUserAddress === userAddress
+    ) {
+      return;
+    }
+
+    if (
+      this.#accountSpotRefreshSubscriptionPromise &&
+      this.#accountSpotRefreshUserAddress === userAddress
+    ) {
+      await this.#accountSpotRefreshSubscriptionPromise;
+      return;
+    }
+
+    this.#cleanupAccountSpotRefreshSubscription();
+
+    const promise = this.#createAccountSpotRefreshSubscription(userAddress);
+    this.#accountSpotRefreshSubscriptionPromise = promise;
+    this.#accountSpotRefreshUserAddress = userAddress;
+
+    try {
+      await promise;
+    } finally {
+      if (this.#accountSpotRefreshSubscriptionPromise === promise) {
+        this.#accountSpotRefreshSubscriptionPromise = undefined;
+      }
+    }
+  }
+
+  async #createAccountSpotRefreshSubscription(
+    userAddress: string,
+  ): Promise<void> {
+    const subscriptionClient = this.#clientService.getSubscriptionClient();
+    if (!subscriptionClient) {
+      await this.#clientService.ensureSubscriptionClient(
+        this.#walletService.createWalletAdapter(),
+      );
+      return this.#createAccountSpotRefreshSubscription(userAddress);
+    }
+
+    const subscription = await subscriptionClient.userFills(
+      { user: userAddress },
+      (data: UserFillsWsEvent) => {
+        const { isSnapshot } = data as { isSnapshot?: boolean };
+        if (isSnapshot !== false) {
+          return;
+        }
+
+        this.#scheduleAccountSpotRefresh(userAddress);
+      },
+    );
+
+    this.#accountSpotRefreshSubscription = subscription;
+    return undefined;
+  }
+
+  #cleanupAccountSpotRefreshSubscription(): void {
+    if (this.#accountSpotRefreshTimeout) {
+      clearTimeout(this.#accountSpotRefreshTimeout);
+      this.#accountSpotRefreshTimeout = undefined;
+    }
+
+    if (this.#accountSpotRefreshSubscription) {
+      this.#accountSpotRefreshSubscription.unsubscribe().catch((error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(
+            error,
+            'HyperLiquidSubscriptionService.cleanupAccountSpotRefreshSubscription',
+          ),
+          this.#getErrorContext('cleanupAccountSpotRefreshSubscription'),
+        );
+      });
+    }
+
+    this.#accountSpotRefreshSubscription = undefined;
+    this.#accountSpotRefreshSubscriptionPromise = undefined;
+    this.#accountSpotRefreshUserAddress = undefined;
   }
 
   /**
@@ -2395,6 +2527,13 @@ export class HyperLiquidSubscriptionService {
       );
     });
 
+    this.#ensureAccountSpotRefreshSubscription(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureAccountSpotRefresh'),
+      );
+    });
+
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
       this.#logErrorUnlessClearing(
@@ -2406,6 +2545,9 @@ export class HyperLiquidSubscriptionService {
     return () => {
       unsubscribe();
       this.#accountSubscriberCount -= 1;
+      if (this.#accountSubscriberCount === 0) {
+        this.#cleanupAccountSpotRefreshSubscription();
+      }
       this.#cleanupSharedWebData3ISubscription();
     };
   }
@@ -3610,6 +3752,11 @@ export class HyperLiquidSubscriptionService {
       );
     }
 
+    if (this.#accountSubscriberCount > 0) {
+      this.#cleanupAccountSpotRefreshSubscription();
+      await this.#ensureAccountSpotRefreshSubscription();
+    }
+
     // Re-establish user data subscriptions if there are user data subscribers
     if (
       this.#positionSubscribers.size > 0 ||
@@ -3785,6 +3932,7 @@ export class HyperLiquidSubscriptionService {
       });
     });
     this.#orderFillSubscriptions.clear();
+    this.#cleanupAccountSpotRefreshSubscription();
 
     // Clear cached data
     this.#cachedPriceData = null;

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -145,6 +145,8 @@ export class HyperLiquidSubscriptionService {
 
   #accountSpotRefreshUserAddress?: string;
 
+  #accountSpotRefreshSubscriptionGeneration = 0;
+
   #accountSpotRefreshTimeout?: ReturnType<typeof setTimeout>;
 
   readonly #symbolSubscriberCounts = new Map<string, number>();
@@ -1174,7 +1176,12 @@ export class HyperLiquidSubscriptionService {
 
     this.#cleanupAccountSpotRefreshSubscription();
 
-    const promise = this.#createAccountSpotRefreshSubscription(userAddress);
+    const subscriptionGeneration =
+      this.#accountSpotRefreshSubscriptionGeneration;
+    const promise = this.#createAccountSpotRefreshSubscription(
+      userAddress,
+      subscriptionGeneration,
+    );
     this.#accountSpotRefreshSubscriptionPromise = promise;
     this.#accountSpotRefreshUserAddress = userAddress;
 
@@ -1189,18 +1196,32 @@ export class HyperLiquidSubscriptionService {
 
   async #createAccountSpotRefreshSubscription(
     userAddress: string,
+    subscriptionGeneration: number,
   ): Promise<void> {
-    const subscriptionClient = this.#clientService.getSubscriptionClient();
+    let subscriptionClient = this.#clientService.getSubscriptionClient();
     if (!subscriptionClient) {
       await this.#clientService.ensureSubscriptionClient(
         this.#walletService.createWalletAdapter(),
       );
-      return this.#createAccountSpotRefreshSubscription(userAddress);
+      subscriptionClient = this.#clientService.getSubscriptionClient();
+      if (!subscriptionClient) {
+        throw new Error(
+          'HyperLiquidSubscriptionService.createAccountSpotRefreshSubscription: subscription client unavailable after ensureSubscriptionClient',
+        );
+      }
     }
 
     const subscription = await subscriptionClient.userFills(
       { user: userAddress },
       (data: UserFillsWsEvent) => {
+        if (
+          this.#accountSpotRefreshSubscriptionGeneration !==
+            subscriptionGeneration ||
+          this.#accountSpotRefreshUserAddress !== userAddress
+        ) {
+          return;
+        }
+
         const { isSnapshot } = data as { isSnapshot?: boolean };
         if (isSnapshot !== false) {
           return;
@@ -1209,6 +1230,25 @@ export class HyperLiquidSubscriptionService {
         this.#scheduleAccountSpotRefresh(userAddress);
       },
     );
+
+    if (
+      this.#accountSpotRefreshSubscriptionGeneration !==
+        subscriptionGeneration ||
+      this.#accountSpotRefreshUserAddress !== userAddress
+    ) {
+      await subscription.unsubscribe().catch((error) => {
+        this.#logErrorUnlessClearing(
+          ensureError(
+            error,
+            'HyperLiquidSubscriptionService.createAccountSpotRefreshSubscription.unsubscribeStale',
+          ),
+          this.#getErrorContext(
+            'createAccountSpotRefreshSubscription.unsubscribeStale',
+          ),
+        );
+      });
+      return undefined;
+    }
 
     this.#accountSpotRefreshSubscription = subscription;
     return undefined;
@@ -1220,8 +1260,11 @@ export class HyperLiquidSubscriptionService {
       this.#accountSpotRefreshTimeout = undefined;
     }
 
-    if (this.#accountSpotRefreshSubscription) {
-      this.#accountSpotRefreshSubscription.unsubscribe().catch((error) => {
+    this.#accountSpotRefreshSubscriptionGeneration += 1;
+
+    const subscription = this.#accountSpotRefreshSubscription;
+    if (subscription) {
+      subscription.unsubscribe().catch((error) => {
         this.#logErrorUnlessClearing(
           ensureError(
             error,


### PR DESCRIPTION
…ribers

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR builds on perps/fix-avail-balance-order-entry by fixing the remaining live-update gap for HyperLiquid availableToTradeBalance. The balance math was already corrected on the base branch, but spot-backed available-to-trade was still not reacting live after a user opened or closed a position because cached spotClearinghouseState was not being refreshed after fills.

The solution is to refresh spot state from HyperLiquidSubscriptionService using a private fill-driven path.

The service now listens to userFills while account subscribers exist, debounces a forced spot refresh on non-snapshot fills, and re-emits account state only when the recomputed hash changes.

This keeps REST volume much lower than refreshing on every account stream update, which is important for HyperLiquid 429 risk.

The PR also hardens that new path by making the internal fills subscription lifecycle safe across reconnects and account switches, and adds focused regression coverage for fill-triggered refresh, snapshot suppression, coalescing, reconnect restore, stale callback ignore, and cleanup.

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
