### PR TITLE
feat(predict): support multi-market sports events via parent/child event fetching

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -78,10 +78,12 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
 
   const { data: activePositions = [] } = usePredictPositions({
     marketId: market.id,
+    childMarketIds: market.childMarketIds,
     claimable: false,
   });
   const { data: claimablePositions = [] } = usePredictPositions({
     marketId: market.id,
+    childMarketIds: market.childMarketIds,
     claimable: true,
   });
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -36,6 +36,7 @@ interface CapturedCard {
     variant: string;
     teamColor?: string;
   }[];
+  buttonLayout?: string;
   lines?: number[];
   selectedLine?: number;
   testID?: string;
@@ -47,6 +48,7 @@ interface MockCardProps {
   title: string;
   subtitle?: string;
   buttons: PredictSportOutcomeButton[];
+  buttonLayout?: string;
   lines?: number[];
   selectedLine?: number;
   onSelectLine?: (line: number, index: number) => void;
@@ -66,6 +68,7 @@ jest.mock('../PredictSportOutcomeCard', () => {
         variant: b.variant,
         teamColor: b.teamColor,
       })),
+      buttonLayout: props.buttonLayout,
       lines: props.lines,
       selectedLine: props.selectedLine,
       testID: props.testID,
@@ -843,6 +846,379 @@ describe('PredictGameOutcomesTab', () => {
         getByTestId(PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.OUTCOMES_CONTENT),
       ).toBeOnTheScreen();
       expect(mockCapturedCards).toHaveLength(0);
+    });
+  });
+
+  describe('moneyline subgroup rendering', () => {
+    it('renders stacked card for moneyline subgroup with multiple outcomes sorted by threshold', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-2',
+          groupItemThreshold: 2,
+          groupItemTitle: 'Away Win',
+          volume: 3000,
+          tokens: [createToken({ shortTitle: 'AWY', price: 0.25 })],
+        }),
+        createOutcome({
+          id: 'ml-0',
+          groupItemThreshold: 0,
+          groupItemTitle: 'Home Win',
+          volume: 5000,
+          tokens: [createToken({ shortTitle: 'HOM', price: 0.55 })],
+        }),
+        createOutcome({
+          id: 'ml-1',
+          groupItemThreshold: 1,
+          groupItemTitle: 'Draw',
+          volume: 2000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.2 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards).toHaveLength(1);
+      expect(mockCapturedCards[0].buttonLayout).toBe('stacked');
+      expect(mockCapturedCards[0].buttons[0].label).toBe('HOM');
+      expect(mockCapturedCards[0].buttons[1].label).toBe('Draw');
+      expect(mockCapturedCards[0].buttons[2].label).toBe('AWY');
+    });
+
+    it('sums volumes from all outcomes for moneyline subgroup subtitle', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-a',
+          groupItemThreshold: 0,
+          volume: 10000,
+          tokens: [createToken({ shortTitle: 'TA', price: 0.6 })],
+        }),
+        createOutcome({
+          id: 'ml-b',
+          groupItemThreshold: 1,
+          volume: 20000,
+          tokens: [createToken({ shortTitle: 'TB', price: 0.4 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].subtitle).toBe('$30k Vol');
+    });
+
+    it('builds moneyline buttons with correct prices and variants', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-h',
+          groupItemThreshold: 0,
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'TA', price: 0.45 })],
+        }),
+        createOutcome({
+          id: 'ml-d',
+          groupItemThreshold: 1,
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.3 })],
+        }),
+        createOutcome({
+          id: 'ml-a',
+          groupItemThreshold: 2,
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'TB', price: 0.25 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].price).toBe(45);
+      expect(mockCapturedCards[0].buttons[0].variant).toBe('yes');
+      expect(mockCapturedCards[0].buttons[1].price).toBe(30);
+      expect(mockCapturedCards[0].buttons[1].variant).toBe('draw');
+      expect(mockCapturedCards[0].buttons[2].price).toBe(25);
+      expect(mockCapturedCards[0].buttons[2].variant).toBe('no');
+    });
+
+    it('calls onBuyPress with correct outcome and token for moneyline button', () => {
+      const tokenA = createToken({ id: 'tok-a', shortTitle: 'TA', price: 0.6 });
+      const tokenB = createToken({ id: 'tok-b', shortTitle: 'TB', price: 0.4 });
+      const outcomeA = createOutcome({
+        id: 'ml-a',
+        groupItemThreshold: 0,
+        volume: 1000,
+        tokens: [tokenA],
+      });
+      const outcomeB = createOutcome({
+        id: 'ml-b',
+        groupItemThreshold: 1,
+        volume: 1000,
+        tokens: [tokenB],
+      });
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes: [outcomeA, outcomeB] }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      const { getByTestId } = render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      fireEvent(getByTestId('game_lines-moneyline-0-btn-1'), 'touchEnd');
+
+      expect(mockOnBuyPress).toHaveBeenCalledWith(outcomeB, tokenB);
+    });
+  });
+
+  describe('moneyline sorting without thresholds', () => {
+    it('places home team first, draw middle, away last when game is provided', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-draw',
+          groupItemTitle: 'Draw',
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.2 })],
+        }),
+        createOutcome({
+          id: 'ml-away',
+          groupItemTitle: 'Away Win',
+          volume: 2000,
+          tokens: [createToken({ shortTitle: 'TB', price: 0.3 })],
+        }),
+        createOutcome({
+          id: 'ml-home',
+          groupItemTitle: 'Home Win',
+          volume: 3000,
+          tokens: [createToken({ shortTitle: 'TA', price: 0.5 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].label).toBe('TA');
+      expect(mockCapturedCards[0].buttons[1].label).toBe('Draw');
+      expect(mockCapturedCards[0].buttons[2].label).toBe('TB');
+    });
+
+    it('places draw second when no game is provided and no thresholds', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-draw',
+          groupItemTitle: 'Draw',
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.2 })],
+        }),
+        createOutcome({
+          id: 'ml-first',
+          groupItemTitle: 'Team X',
+          volume: 2000,
+          tokens: [createToken({ shortTitle: 'TX', price: 0.4 })],
+        }),
+        createOutcome({
+          id: 'ml-second',
+          groupItemTitle: 'Team Y',
+          volume: 3000,
+          tokens: [createToken({ shortTitle: 'TY', price: 0.4 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={undefined}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].label).toBe('TX');
+      expect(mockCapturedCards[0].buttons[1].label).toBe('Draw');
+      expect(mockCapturedCards[0].buttons[2].label).toBe('TY');
+    });
+
+    it('preserves original order when draw is present but fewer than 2 non-draw outcomes', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-draw',
+          groupItemTitle: 'Draw',
+          volume: 1000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.5 })],
+        }),
+        createOutcome({
+          id: 'ml-only',
+          groupItemTitle: 'Team X',
+          volume: 2000,
+          tokens: [createToken({ shortTitle: 'TX', price: 0.5 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].label).toBe('Draw');
+      expect(mockCapturedCards[0].buttons[1].label).toBe('TX');
+    });
+  });
+
+  describe('flat outcomes moneyline rendering', () => {
+    it('renders single stacked card for moneyline-like group without subgroups', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'hr-1',
+          sportsMarketType: 'soccer_halftime_result',
+          groupItemTitle: 'Home',
+          volume: 4000,
+          tokens: [createToken({ shortTitle: 'HOM', price: 0.5 })],
+        }),
+        createOutcome({
+          id: 'hr-2',
+          sportsMarketType: 'soccer_halftime_result',
+          groupItemTitle: 'Away',
+          volume: 6000,
+          tokens: [createToken({ shortTitle: 'AWY', price: 0.3 })],
+        }),
+        createOutcome({
+          id: 'hr-3',
+          sportsMarketType: 'soccer_halftime_result',
+          groupItemTitle: 'Draw',
+          volume: 5000,
+          tokens: [createToken({ shortTitle: 'Draw', price: 0.2 })],
+        }),
+      ];
+      const groups = [createGroup({ key: 'halftime', outcomes })];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="halftime"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards).toHaveLength(1);
+      expect(mockCapturedCards[0].buttonLayout).toBe('stacked');
+      expect(mockCapturedCards[0].testID).toBe('halftime-moneyline');
+      expect(mockCapturedCards[0].subtitle).toBe('$15k Vol');
+    });
+
+    it('renders individual cards when flat group has only one outcome with moneyline type', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'hr-single',
+          sportsMarketType: 'soccer_halftime_result',
+          volume: 4000,
+          tokens: [createToken({ shortTitle: 'HOM', price: 0.5 })],
+        }),
+      ];
+      const groups = [createGroup({ key: 'halftime', outcomes })];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="halftime"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards).toHaveLength(1);
+      expect(mockCapturedCards[0].buttonLayout).toBeUndefined();
+    });
+  });
+
+  describe('formatOutcomeCardTitle edge cases', () => {
+    it('strips O/U suffix when title has colon but no player pattern match', () => {
+      const outcome = createOutcome({
+        id: 'o-colon-ou',
+        groupItemTitle: 'Total: O/U 2.5',
+      });
+      const groups = [createGroup({ key: 'totals', outcomes: [outcome] })];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="totals"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].title).toBe('Total');
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -49,7 +49,7 @@ interface MockCardProps {
   buttons: PredictSportOutcomeButton[];
   lines?: number[];
   selectedLine?: number;
-  onSelectLine?: (line: number) => void;
+  onSelectLine?: (line: number, index: number) => void;
   testID?: string;
 }
 
@@ -83,11 +83,11 @@ jest.mock('../PredictSportOutcomeCard', () => {
           />
         ))}
         {props.lines &&
-          props.lines.map((line: number) => (
+          props.lines.map((line: number, lineIdx: number) => (
             <View
-              key={line}
-              testID={`${props.testID}-line-${line}`}
-              onTouchEnd={() => props.onSelectLine?.(line)}
+              key={`${lineIdx}-${line}`}
+              testID={`${props.testID}-line-${lineIdx}-${line}`}
+              onTouchEnd={() => props.onSelectLine?.(line, lineIdx)}
               accessibilityHint={
                 line === props.selectedLine ? 'selected' : 'unselected'
               }
@@ -777,7 +777,7 @@ describe('PredictGameOutcomesTab', () => {
         />,
       );
 
-      expect(mockCapturedCards[0].selectedLine).toBe(7.5);
+      expect(mockCapturedCards[0].selectedLine).toBe(3.5);
     });
 
     it('switches displayed outcome when line is selected', () => {
@@ -822,7 +822,7 @@ describe('PredictGameOutcomesTab', () => {
       expect(mockCapturedCards[0].buttons[0].price).toBe(60);
 
       mockCapturedCards = [];
-      fireEvent(getByTestId('game_lines-spreads-0-line-7.5'), 'touchEnd');
+      fireEvent(getByTestId('game_lines-spreads-0-line-1-7.5'), 'touchEnd');
 
       expect(mockCapturedCards[0].buttons[0].price).toBe(80);
     });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -1011,6 +1011,48 @@ describe('PredictGameOutcomesTab', () => {
 
       expect(mockOnBuyPress).toHaveBeenCalledWith(outcomeB, tokenB);
     });
+
+    it('skips outcomes without tokens when building moneyline buttons', () => {
+      const outcomes = [
+        createOutcome({
+          id: 'ml-home',
+          groupItemThreshold: 0,
+          groupItemTitle: 'Home Win',
+          tokens: [createToken({ shortTitle: 'HOM', price: 0.55 })],
+        }),
+        createOutcome({
+          id: 'ml-empty',
+          groupItemThreshold: 1,
+          groupItemTitle: 'Draw',
+          tokens: [],
+        }),
+        createOutcome({
+          id: 'ml-away',
+          groupItemThreshold: 2,
+          groupItemTitle: 'Away Win',
+          tokens: [createToken({ shortTitle: 'AWY', price: 0.45 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons).toHaveLength(2);
+      expect(mockCapturedCards[0].buttons[0].label).toBe('HOM');
+      expect(mockCapturedCards[0].buttons[1].label).toBe('AWY');
+    });
   });
 
   describe('moneyline sorting without thresholds', () => {

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -11,10 +11,9 @@ import PredictSportOutcomeCard, {
   type PredictSportOutcomeButton,
 } from '../PredictSportOutcomeCard';
 import { formatVolume } from '../../utils/format';
+import { isMoneylineLikeMarketType } from '../../constants/sports';
 import { strings } from '../../../../../../locales/i18n';
 import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from './PredictGameDetailsContent.testIds';
-
-const noop = () => undefined;
 
 const I18N_PREFIX = 'predict.sports_market_types';
 
@@ -47,8 +46,6 @@ const formatOutcomeCardTitle = (outcome: PredictOutcome): string => {
   return raw;
 };
 
-import { isMoneylineLikeMarketType } from '../../constants/sports';
-
 const getTeamColor = (
   tokenTitle: string,
   game?: PredictMarketGame,
@@ -71,7 +68,7 @@ const getButtonVariant = (
 
 const buildButtons = (
   outcome: PredictOutcome,
-  onBuyPress?: BuyHandler,
+  onBuyPress: BuyHandler,
   game?: PredictMarketGame,
   sportsMarketType?: string,
 ): PredictSportOutcomeButton[] => {
@@ -79,7 +76,7 @@ const buildButtons = (
   return outcome.tokens.map((token, index) => ({
     label: token.shortTitle ?? token.title,
     price: Math.round(token.price * 100),
-    onPress: onBuyPress ? () => onBuyPress(outcome, token) : noop,
+    onPress: () => onBuyPress(outcome, token),
     variant: getButtonVariant(index, outcome.tokens.length, moneyline),
     teamColor: moneyline
       ? getTeamColor(token.shortTitle ?? token.title, game)
@@ -101,7 +98,7 @@ const SimpleOutcomeCard = memo(
   }: {
     outcome: PredictOutcome;
     title: string;
-    onBuyPress?: BuyHandler;
+    onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     sportsMarketType?: string;
     testID: string;
@@ -128,7 +125,7 @@ const LineOutcomeCard = memo(
   }: {
     outcomes: PredictOutcome[];
     title: string;
-    onBuyPress?: BuyHandler;
+    onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     sportsMarketType?: string;
     testID: string;
@@ -225,7 +222,7 @@ const sortMoneylineOutcomes = (
 
 const buildMoneylineButtons = (
   outcomes: PredictOutcome[],
-  onBuyPress?: BuyHandler,
+  onBuyPress: BuyHandler,
   game?: PredictMarketGame,
 ): PredictSportOutcomeButton[] => {
   const sorted = sortMoneylineOutcomes(outcomes, game);
@@ -234,7 +231,7 @@ const buildMoneylineButtons = (
     return {
       label: yesToken.shortTitle ?? yesToken.title,
       price: Math.round(yesToken.price * 100),
-      onPress: onBuyPress ? () => onBuyPress(outcome, yesToken) : noop,
+      onPress: () => onBuyPress(outcome, yesToken),
       variant: getButtonVariant(i, sorted.length, true),
       teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
     };
@@ -255,7 +252,7 @@ const SubgroupCards = memo(
     index,
   }: {
     subgroup: PredictOutcomeGroup;
-    onBuyPress?: BuyHandler;
+    onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     groupKey: string;
     index: number;
@@ -313,7 +310,7 @@ const OutcomesContent = memo(
     game,
   }: {
     group: PredictOutcomeGroup;
-    onBuyPress?: BuyHandler;
+    onBuyPress: BuyHandler;
     game?: PredictMarketGame;
   }) => {
     if (group.subgroups && group.subgroups.length > 0) {
@@ -334,7 +331,11 @@ const OutcomesContent = memo(
     }
 
     const firstType = group.outcomes[0]?.sportsMarketType;
-    if (isMoneylineLikeMarketType(firstType) && group.outcomes.length > 1) {
+    if (
+      firstType &&
+      isMoneylineLikeMarketType(firstType) &&
+      group.outcomes.length > 1
+    ) {
       return (
         <PredictSportOutcomeCard
           title={getSportsMarketTypeLabel(firstType)}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import type {
   PredictMarketGame,
@@ -47,8 +47,7 @@ const formatOutcomeCardTitle = (outcome: PredictOutcome): string => {
   return raw;
 };
 
-const isMoneylineType = (type?: string): boolean =>
-  type === 'moneyline' || type === 'first_half_moneyline';
+import { isMoneylineLikeMarketType } from '../../constants/sports';
 
 const getTeamColor = (
   tokenTitle: string,
@@ -76,7 +75,7 @@ const buildButtons = (
   game?: PredictMarketGame,
   sportsMarketType?: string,
 ): PredictSportOutcomeButton[] => {
-  const moneyline = isMoneylineType(sportsMarketType);
+  const moneyline = isMoneylineLikeMarketType(sportsMarketType);
   return outcome.tokens.map((token, index) => ({
     label: token.shortTitle ?? token.title,
     price: Math.round(token.price * 100),
@@ -134,24 +133,40 @@ const LineOutcomeCard = memo(
     sportsMarketType?: string;
     testID: string;
   }) => {
-    const lines = useMemo(
+    const lineIndices = useMemo(
       () =>
         outcomes
-          .map((o) => o.line)
-          .filter((l): l is number => l != null)
-          .sort((a, b) => a - b),
+          .map((o, i) => (o.line != null ? i : -1))
+          .filter((i) => i !== -1)
+          .sort((a, b) => {
+            const lineA = outcomes[a].line ?? 0;
+            const lineB = outcomes[b].line ?? 0;
+            return lineA - lineB;
+          }),
       [outcomes],
     );
 
-    const [selectedLine, setSelectedLine] = useState(outcomes[0]?.line);
+    const lines = useMemo(
+      () => lineIndices.map((i) => Math.abs(outcomes[i].line ?? 0)),
+      [lineIndices, outcomes],
+    );
+
+    const [selectedIdx, setSelectedIdx] = useState(0);
 
     useEffect(() => {
-      setSelectedLine(outcomes[0]?.line);
+      setSelectedIdx(0);
     }, [outcomes]);
 
+    const handleSelectLine = useCallback(
+      (_line: number, indexInLines: number) => {
+        setSelectedIdx(indexInLines);
+      },
+      [],
+    );
+
     const selectedOutcome = useMemo(
-      () => outcomes.find((o) => o.line === selectedLine) ?? outcomes[0],
-      [outcomes, selectedLine],
+      () => outcomes[lineIndices[selectedIdx]] ?? outcomes[0],
+      [outcomes, lineIndices, selectedIdx],
     );
 
     return (
@@ -165,8 +180,9 @@ const LineOutcomeCard = memo(
           sportsMarketType,
         )}
         lines={lines}
-        selectedLine={selectedLine}
-        onSelectLine={setSelectedLine}
+        selectedLine={lines[selectedIdx]}
+        selectedIndex={selectedIdx}
+        onSelectLine={handleSelectLine}
         testID={testID}
       />
     );
@@ -174,6 +190,61 @@ const LineOutcomeCard = memo(
 );
 
 LineOutcomeCard.displayName = 'LineOutcomeCard';
+
+const isDrawOutcome = (outcome: PredictOutcome): boolean =>
+  outcome.groupItemTitle?.toLowerCase().startsWith('draw') ?? false;
+
+const sortMoneylineOutcomes = (
+  outcomes: PredictOutcome[],
+  game?: PredictMarketGame,
+): PredictOutcome[] => {
+  const hasThresholds = outcomes.some((o) => o.groupItemThreshold != null);
+  if (hasThresholds) {
+    return [...outcomes].sort(
+      (a, b) => (a.groupItemThreshold ?? 0) - (b.groupItemThreshold ?? 0),
+    );
+  }
+
+  const draw = outcomes.find(isDrawOutcome);
+  const nonDraw = outcomes.filter((o) => !isDrawOutcome(o));
+  if (!draw || nonDraw.length < 2) {
+    return [...outcomes];
+  }
+
+  if (game) {
+    const homeAbbr = game.homeTeam.abbreviation;
+    const home = nonDraw.find((o) => o.tokens[0]?.shortTitle === homeAbbr);
+    const away = nonDraw.find((o) => o !== home);
+    if (home && away) {
+      return [home, draw, away];
+    }
+  }
+
+  return [nonDraw[0], draw, ...nonDraw.slice(1)];
+};
+
+const buildMoneylineButtons = (
+  outcomes: PredictOutcome[],
+  onBuyPress?: BuyHandler,
+  game?: PredictMarketGame,
+): PredictSportOutcomeButton[] => {
+  const sorted = sortMoneylineOutcomes(outcomes, game);
+  return sorted.map((outcome, i) => {
+    const yesToken = outcome.tokens[0];
+    return {
+      label: yesToken.shortTitle ?? yesToken.title,
+      price: Math.round(yesToken.price * 100),
+      onPress: onBuyPress ? () => onBuyPress(outcome, yesToken) : noop,
+      variant: getButtonVariant(i, sorted.length, true),
+      teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
+    };
+  });
+};
+
+const buildMoneylineSubtitle = (outcomes: PredictOutcome[]): string => {
+  const totalVolume = outcomes.reduce((sum, o) => sum + o.volume, 0);
+  return `$${formatVolume(totalVolume)} Vol`;
+};
 
 const SubgroupCards = memo(
   ({
@@ -191,6 +262,21 @@ const SubgroupCards = memo(
   }) => {
     const title = getSportsMarketTypeLabel(subgroup.key);
     const testID = `${groupKey}-${subgroup.key}-${index}`;
+
+    if (
+      isMoneylineLikeMarketType(subgroup.key) &&
+      subgroup.outcomes.length > 1
+    ) {
+      return (
+        <PredictSportOutcomeCard
+          title={title}
+          subtitle={buildMoneylineSubtitle(subgroup.outcomes)}
+          buttons={buildMoneylineButtons(subgroup.outcomes, onBuyPress, game)}
+          buttonLayout="stacked"
+          testID={testID}
+        />
+      );
+    }
 
     if (subgroup.outcomes.length === 1) {
       return (
@@ -244,6 +330,19 @@ const OutcomesContent = memo(
             />
           ))}
         </>
+      );
+    }
+
+    const firstType = group.outcomes[0]?.sportsMarketType;
+    if (isMoneylineLikeMarketType(firstType) && group.outcomes.length > 1) {
+      return (
+        <PredictSportOutcomeCard
+          title={getSportsMarketTypeLabel(firstType)}
+          subtitle={buildMoneylineSubtitle(group.outcomes)}
+          buttons={buildMoneylineButtons(group.outcomes, onBuyPress, game)}
+          buttonLayout="stacked"
+          testID={`${group.key}-moneyline`}
+        />
       );
     }
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -229,22 +229,16 @@ const buildMoneylineButtons = (
     (outcome) => outcome.tokens[0] !== undefined,
   );
 
-  return sortedWithTokens.flatMap((outcome, i) => {
+  return sortedWithTokens.map((outcome, i) => {
     const yesToken = outcome.tokens[0];
 
-    if (!yesToken) {
-      return [];
-    }
-
-    return [
-      {
-        label: yesToken.shortTitle ?? yesToken.title,
-        price: Math.round(yesToken.price * 100),
-        onPress: () => onBuyPress(outcome, yesToken),
-        variant: getButtonVariant(i, sortedWithTokens.length, true),
-        teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
-      },
-    ];
+    return {
+      label: yesToken.shortTitle ?? yesToken.title,
+      price: Math.round(yesToken.price * 100),
+      onPress: () => onBuyPress(outcome, yesToken),
+      variant: getButtonVariant(i, sortedWithTokens.length, true),
+      teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
+    };
   });
 };
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -217,7 +217,10 @@ const sortMoneylineOutcomes = (
     }
   }
 
-  return [nonDraw[0], draw, ...nonDraw.slice(1)];
+  const sorted = [...nonDraw].sort((a, b) =>
+    (a.groupItemTitle ?? '').localeCompare(b.groupItemTitle ?? ''),
+  );
+  return [sorted[0], draw, ...sorted.slice(1)];
 };
 
 const buildMoneylineButtons = (

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -267,6 +267,15 @@ const SubgroupCards = memo(
     const title = getSportsMarketTypeLabel(subgroup.key);
     const testID = `${groupKey}-${subgroup.key}-${index}`;
 
+    const subtitle = useMemo(
+      () => buildMoneylineSubtitle(subgroup.outcomes),
+      [subgroup.outcomes],
+    );
+    const buttons = useMemo(
+      () => buildMoneylineButtons(subgroup.outcomes, onBuyPress, game),
+      [subgroup.outcomes, onBuyPress, game],
+    );
+
     if (
       isMoneylineLikeMarketType(subgroup.key) &&
       subgroup.outcomes.length > 1
@@ -274,8 +283,8 @@ const SubgroupCards = memo(
       return (
         <PredictSportOutcomeCard
           title={title}
-          subtitle={buildMoneylineSubtitle(subgroup.outcomes)}
-          buttons={buildMoneylineButtons(subgroup.outcomes, onBuyPress, game)}
+          subtitle={subtitle}
+          buttons={buttons}
           buttonLayout="stacked"
           testID={testID}
         />
@@ -320,6 +329,15 @@ const OutcomesContent = memo(
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
   }) => {
+    const subtitle = useMemo(
+      () => buildMoneylineSubtitle(group.outcomes),
+      [group.outcomes],
+    );
+    const buttons = useMemo(
+      () => buildMoneylineButtons(group.outcomes, onBuyPress, game),
+      [group.outcomes, onBuyPress, game],
+    );
+
     if (group.subgroups && group.subgroups.length > 0) {
       return (
         <>
@@ -346,8 +364,8 @@ const OutcomesContent = memo(
       return (
         <PredictSportOutcomeCard
           title={getSportsMarketTypeLabel(firstType)}
-          subtitle={buildMoneylineSubtitle(group.outcomes)}
-          buttons={buildMoneylineButtons(group.outcomes, onBuyPress, game)}
+          subtitle={subtitle}
+          buttons={buttons}
           buttonLayout="stacked"
           testID={`${group.key}-moneyline`}
         />

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -225,16 +225,26 @@ const buildMoneylineButtons = (
   onBuyPress: BuyHandler,
   game?: PredictMarketGame,
 ): PredictSportOutcomeButton[] => {
-  const sorted = sortMoneylineOutcomes(outcomes, game);
-  return sorted.map((outcome, i) => {
+  const sortedWithTokens = sortMoneylineOutcomes(outcomes, game).filter(
+    (outcome) => outcome.tokens[0] !== undefined,
+  );
+
+  return sortedWithTokens.flatMap((outcome, i) => {
     const yesToken = outcome.tokens[0];
-    return {
-      label: yesToken.shortTitle ?? yesToken.title,
-      price: Math.round(yesToken.price * 100),
-      onPress: () => onBuyPress(outcome, yesToken),
-      variant: getButtonVariant(i, sorted.length, true),
-      teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
-    };
+
+    if (!yesToken) {
+      return [];
+    }
+
+    return [
+      {
+        label: yesToken.shortTitle ?? yesToken.title,
+        price: Math.round(yesToken.price * 100),
+        onPress: () => onBuyPress(outcome, yesToken),
+        variant: getButtonVariant(i, sortedWithTokens.length, true),
+        teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
+      },
+    ];
   });
 };
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -250,6 +250,43 @@ const buildMoneylineSubtitle = (outcomes: PredictOutcome[]): string => {
   return `$${formatVolume(totalVolume)} Vol`;
 };
 
+const MoneylineCard = memo(
+  ({
+    outcomes,
+    onBuyPress,
+    game,
+    title,
+    testID,
+  }: {
+    outcomes: PredictOutcome[];
+    onBuyPress: BuyHandler;
+    game?: PredictMarketGame;
+    title: string;
+    testID: string;
+  }) => {
+    const subtitle = useMemo(
+      () => buildMoneylineSubtitle(outcomes),
+      [outcomes],
+    );
+    const buttons = useMemo(
+      () => buildMoneylineButtons(outcomes, onBuyPress, game),
+      [outcomes, onBuyPress, game],
+    );
+
+    return (
+      <PredictSportOutcomeCard
+        title={title}
+        subtitle={subtitle}
+        buttons={buttons}
+        buttonLayout="stacked"
+        testID={testID}
+      />
+    );
+  },
+);
+
+MoneylineCard.displayName = 'MoneylineCard';
+
 const SubgroupCards = memo(
   ({
     subgroup,
@@ -267,25 +304,16 @@ const SubgroupCards = memo(
     const title = getSportsMarketTypeLabel(subgroup.key);
     const testID = `${groupKey}-${subgroup.key}-${index}`;
 
-    const subtitle = useMemo(
-      () => buildMoneylineSubtitle(subgroup.outcomes),
-      [subgroup.outcomes],
-    );
-    const buttons = useMemo(
-      () => buildMoneylineButtons(subgroup.outcomes, onBuyPress, game),
-      [subgroup.outcomes, onBuyPress, game],
-    );
-
     if (
       isMoneylineLikeMarketType(subgroup.key) &&
       subgroup.outcomes.length > 1
     ) {
       return (
-        <PredictSportOutcomeCard
+        <MoneylineCard
+          outcomes={subgroup.outcomes}
+          onBuyPress={onBuyPress}
+          game={game}
           title={title}
-          subtitle={subtitle}
-          buttons={buttons}
-          buttonLayout="stacked"
           testID={testID}
         />
       );
@@ -329,15 +357,6 @@ const OutcomesContent = memo(
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
   }) => {
-    const subtitle = useMemo(
-      () => buildMoneylineSubtitle(group.outcomes),
-      [group.outcomes],
-    );
-    const buttons = useMemo(
-      () => buildMoneylineButtons(group.outcomes, onBuyPress, game),
-      [group.outcomes, onBuyPress, game],
-    );
-
     if (group.subgroups && group.subgroups.length > 0) {
       return (
         <>
@@ -362,11 +381,11 @@ const OutcomesContent = memo(
       group.outcomes.length > 1
     ) {
       return (
-        <PredictSportOutcomeCard
+        <MoneylineCard
+          outcomes={group.outcomes}
+          onBuyPress={onBuyPress}
+          game={game}
           title={getSportsMarketTypeLabel(firstType)}
-          subtitle={subtitle}
-          buttons={buttons}
-          buttonLayout="stacked"
           testID={`${group.key}-moneyline`}
         />
       );

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -44,7 +44,8 @@ const IDS = PREDICT_SPORT_LINE_SELECTOR_TEST_IDS;
 
 const arrowLeftId = `${TEST_ID}-${IDS.ARROW_LEFT}`;
 const arrowRightId = `${TEST_ID}-${IDS.ARROW_RIGHT}`;
-const lineId = (value: number) => `${TEST_ID}-${IDS.LINE_PREFIX}${value}`;
+const lineId = (index: number, value: number) =>
+  `${TEST_ID}-${IDS.LINE_PREFIX}${index}-${value}`;
 
 describe('PredictSportLineSelector', () => {
   const defaultProps = {
@@ -86,7 +87,7 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByText('4.5'));
 
-    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(4.5);
+    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(4.5, 1);
   });
 
   it('calls onSelectLine with previous line when left arrow is tapped', () => {
@@ -96,7 +97,7 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByTestId(arrowLeftId));
 
-    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(4.5);
+    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(4.5, 1);
   });
 
   it('calls onSelectLine with next line when right arrow is tapped', () => {
@@ -106,7 +107,7 @@ describe('PredictSportLineSelector', () => {
 
     fireEvent.press(getByTestId(arrowRightId));
 
-    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(5.5);
+    expect(defaultProps.onSelectLine).toHaveBeenCalledWith(5.5, 3);
   });
 
   it('disables left arrow when first line is selected', () => {
@@ -142,8 +143,8 @@ describe('PredictSportLineSelector', () => {
     expect(getByTestId(arrowLeftId)).toBeOnTheScreen();
     expect(getByTestId(arrowRightId)).toBeOnTheScreen();
 
-    defaultProps.lines.forEach((line) => {
-      expect(getByTestId(lineId(line))).toBeOnTheScreen();
+    defaultProps.lines.forEach((line, index) => {
+      expect(getByTestId(lineId(index, line))).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -27,7 +27,8 @@ import { PREDICT_SPORT_LINE_SELECTOR_TEST_IDS } from './PredictSportLineSelector
 interface PredictSportLineSelectorProps {
   lines: number[];
   selectedLine: number;
-  onSelectLine: (line: number) => void;
+  selectedIndex?: number;
+  onSelectLine: (line: number, index: number) => void;
   testID?: string;
 }
 
@@ -38,6 +39,7 @@ const ANIMATION_DURATION = 250;
 const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
   lines,
   selectedLine,
+  selectedIndex: selectedIndexProp,
   onSelectLine,
   testID,
 }) => {
@@ -45,7 +47,8 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
   const translateX = useSharedValue(0);
   const containerWidth = useSharedValue(0);
 
-  const selectedIndex = Math.max(0, lines.indexOf(selectedLine));
+  const selectedIndex =
+    selectedIndexProp ?? Math.max(0, lines.indexOf(selectedLine));
   const isFirstSelected = selectedIndex <= 0;
   const isLastSelected = selectedIndex >= lines.length - 1;
 
@@ -82,22 +85,24 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
   }));
 
   const selectWithHaptics = useCallback(
-    (line: number) => {
+    (line: number, index: number) => {
       impactAsync(ImpactFeedbackStyle.Light);
-      onSelectLine(line);
+      onSelectLine(line, index);
     },
     [onSelectLine],
   );
 
   const handlePrevious = () => {
     if (!isFirstSelected) {
-      selectWithHaptics(lines[selectedIndex - 1]);
+      const prevIdx = selectedIndex - 1;
+      selectWithHaptics(lines[prevIdx], prevIdx);
     }
   };
 
   const handleNext = () => {
     if (!isLastSelected) {
-      selectWithHaptics(lines[selectedIndex + 1]);
+      const nextIdx = selectedIndex + 1;
+      selectWithHaptics(lines[nextIdx], nextIdx);
     }
   };
 
@@ -150,13 +155,13 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
       >
         <Box onLayout={handleLayout}>
           <Animated.View style={animatedStyle}>
-            {lines.map((line) => {
-              const isSelected = line === selectedLine;
+            {lines.map((line, index) => {
+              const isSelected = index === selectedIndex;
               return (
                 <Pressable
-                  key={line}
-                  onPress={() => selectWithHaptics(line)}
-                  testID={`${baseTestID}-${PREDICT_SPORT_LINE_SELECTOR_TEST_IDS.LINE_PREFIX}${line}`}
+                  key={`${index}-${line}`}
+                  onPress={() => selectWithHaptics(line, index)}
+                  testID={`${baseTestID}-${PREDICT_SPORT_LINE_SELECTOR_TEST_IDS.LINE_PREFIX}${index}-${line}`}
                   style={({ pressed }) =>
                     tw.style(
                       'items-center justify-center py-2',

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -159,7 +159,7 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
               const isSelected = index === selectedIndex;
               return (
                 <Pressable
-                  key={`${index}-${line}`}
+                  key={`line-${line}`}
                   onPress={() => selectWithHaptics(line, index)}
                   testID={`${baseTestID}-${PREDICT_SPORT_LINE_SELECTOR_TEST_IDS.LINE_PREFIX}${index}-${line}`}
                   style={({ pressed }) =>

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -159,7 +159,7 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
               const isSelected = index === selectedIndex;
               return (
                 <Pressable
-                  key={`line-${line}`}
+                  key={`line-${index}-${line}`}
                   onPress={() => selectWithHaptics(line, index)}
                   testID={`${baseTestID}-${PREDICT_SPORT_LINE_SELECTOR_TEST_IDS.LINE_PREFIX}${index}-${line}`}
                   style={({ pressed }) =>

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
@@ -27,7 +27,9 @@ interface PredictSportOutcomeCardProps {
   buttons: PredictSportOutcomeButton[];
   lines?: number[];
   selectedLine?: number;
-  onSelectLine?: (line: number) => void;
+  selectedIndex?: number;
+  onSelectLine?: (line: number, index: number) => void;
+  buttonLayout?: 'inline' | 'stacked';
   disabled?: boolean;
   testID?: string;
 }
@@ -38,7 +40,9 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
   buttons,
   lines,
   selectedLine,
+  selectedIndex,
   onSelectLine,
+  buttonLayout = 'inline',
   disabled = false,
   testID = PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER,
 }) => {
@@ -86,7 +90,7 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
               variant={button.variant}
               teamColor={button.teamColor}
               disabled={disabled}
-              layout="inline"
+              layout={buttonLayout}
               testID={`${testID}-button-${index}`}
             />
           </Box>
@@ -98,6 +102,7 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
           <PredictSportLineSelector
             lines={lines}
             selectedLine={selectedLine}
+            selectedIndex={selectedIndex}
             onSelectLine={onSelectLine}
             testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.LINE_SELECTOR}
           />

--- a/app/components/UI/Predict/constants/sports.test.ts
+++ b/app/components/UI/Predict/constants/sports.test.ts
@@ -1,0 +1,51 @@
+import { MONEYLINE_MARKET_TYPES, isMoneylineLikeMarketType } from './sports';
+
+describe('MONEYLINE_MARKET_TYPES', () => {
+  it('contains exactly 3 entries', () => {
+    expect(MONEYLINE_MARKET_TYPES.size).toBe(3);
+  });
+
+  it('contains moneyline', () => {
+    expect(MONEYLINE_MARKET_TYPES.has('moneyline')).toBe(true);
+  });
+
+  it('contains first_half_moneyline', () => {
+    expect(MONEYLINE_MARKET_TYPES.has('first_half_moneyline')).toBe(true);
+  });
+
+  it('contains soccer_halftime_result', () => {
+    expect(MONEYLINE_MARKET_TYPES.has('soccer_halftime_result')).toBe(true);
+  });
+});
+
+describe('isMoneylineLikeMarketType', () => {
+  it('returns true for moneyline', () => {
+    const result = isMoneylineLikeMarketType('moneyline');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for first_half_moneyline', () => {
+    const result = isMoneylineLikeMarketType('first_half_moneyline');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for soccer_halftime_result', () => {
+    const result = isMoneylineLikeMarketType('soccer_halftime_result');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false for spreads', () => {
+    const result = isMoneylineLikeMarketType('spreads');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    const result = isMoneylineLikeMarketType(undefined);
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/components/UI/Predict/constants/sports.test.ts
+++ b/app/components/UI/Predict/constants/sports.test.ts
@@ -37,6 +37,12 @@ describe('isMoneylineLikeMarketType', () => {
     expect(result).toBe(true);
   });
 
+  it('returns true for mixed-case moneyline values', () => {
+    expect(isMoneylineLikeMarketType('Moneyline')).toBe(true);
+    expect(isMoneylineLikeMarketType('FIRST_HALF_MONEYLINE')).toBe(true);
+    expect(isMoneylineLikeMarketType('Soccer_Halftime_Result')).toBe(true);
+  });
+
   it('returns false for spreads', () => {
     const result = isMoneylineLikeMarketType('spreads');
 

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -102,3 +102,12 @@ const DRAW_CAPABLE_LEAGUES: ReadonlySet<PredictSportsLeague> = new Set([
 
 export const isDrawCapableLeague = (league: PredictSportsLeague): boolean =>
   DRAW_CAPABLE_LEAGUES.has(league);
+
+export const MONEYLINE_MARKET_TYPES = new Set([
+  'moneyline',
+  'first_half_moneyline',
+  'soccer_halftime_result',
+]);
+
+export const isMoneylineLikeMarketType = (type?: string): boolean =>
+  type !== undefined && MONEYLINE_MARKET_TYPES.has(type);

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -110,4 +110,4 @@ export const MONEYLINE_MARKET_TYPES = new Set([
 ]);
 
 export const isMoneylineLikeMarketType = (type?: string): boolean =>
-  type !== undefined && MONEYLINE_MARKET_TYPES.has(type);
+  type !== undefined && MONEYLINE_MARKET_TYPES.has(type.toLowerCase());

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -103,7 +103,7 @@ const DRAW_CAPABLE_LEAGUES: ReadonlySet<PredictSportsLeague> = new Set([
 export const isDrawCapableLeague = (league: PredictSportsLeague): boolean =>
   DRAW_CAPABLE_LEAGUES.has(league);
 
-export const MONEYLINE_MARKET_TYPES = new Set([
+export const MONEYLINE_MARKET_TYPES: ReadonlySet<string> = new Set([
   'moneyline',
   'first_half_moneyline',
   'soccer_halftime_result',

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -271,4 +271,104 @@ describe('usePredictPositions', () => {
 
     expect(result.current.data).toEqual([claimableTargetMarket]);
   });
+
+  describe('childMarketIds filtering', () => {
+    it('filters positions by childMarketIds when provided', async () => {
+      const { Wrapper } = createWrapper();
+      const parentPosition = createPosition('parent-1', {
+        marketId: 'parent-1',
+      });
+      const child1Position = createPosition('child-1', {
+        marketId: 'child-1',
+      });
+      const child2Position = createPosition('child-2', {
+        marketId: 'child-2',
+      });
+      const unrelatedPosition = createPosition('unrelated-3', {
+        marketId: 'unrelated-3',
+      });
+      mockGetPositions.mockResolvedValue([
+        parentPosition,
+        child1Position,
+        child2Position,
+        unrelatedPosition,
+      ]);
+
+      const { result } = renderHook(
+        () =>
+          usePredictPositions({
+            marketId: 'parent-1',
+            childMarketIds: ['parent-1', 'child-1', 'child-2'],
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual([
+        parentPosition,
+        child1Position,
+        child2Position,
+      ]);
+    });
+
+    it('falls back to marketId filtering when childMarketIds is empty', async () => {
+      const { Wrapper } = createWrapper();
+      const parentPosition = createPosition('parent-1', {
+        marketId: 'parent-1',
+      });
+      const childPosition = createPosition('child-1', {
+        marketId: 'child-1',
+      });
+      mockGetPositions.mockResolvedValue([parentPosition, childPosition]);
+
+      const { result } = renderHook(
+        () =>
+          usePredictPositions({
+            marketId: 'parent-1',
+            childMarketIds: [],
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual([parentPosition]);
+    });
+
+    it('falls back to marketId filtering when childMarketIds is undefined', async () => {
+      const { Wrapper } = createWrapper();
+      const parentPosition = createPosition('parent-1', {
+        marketId: 'parent-1',
+      });
+      const childPosition = createPosition('child-1', {
+        marketId: 'child-1',
+      });
+      mockGetPositions.mockResolvedValue([parentPosition, childPosition]);
+
+      const { result } = renderHook(
+        () =>
+          usePredictPositions({
+            marketId: 'parent-1',
+          }),
+        {
+          wrapper: Wrapper,
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toEqual([parentPosition]);
+    });
+  });
 });

--- a/app/components/UI/Predict/hooks/usePredictPositions.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.ts
@@ -14,9 +14,14 @@ interface UsePredictPositionsOptions {
   refetchInterval?: number | false;
   claimable?: boolean;
   marketId?: string;
+  childMarketIds?: string[];
 }
 
-function buildSelect(claimable?: boolean, marketId?: string) {
+function buildSelect(
+  claimable?: boolean,
+  marketId?: string,
+  childMarketIds?: string[],
+) {
   return (data: PredictPosition[]) => {
     let result = data;
 
@@ -27,7 +32,12 @@ function buildSelect(claimable?: boolean, marketId?: string) {
     }
 
     if (marketId) {
-      result = result.filter((p) => p.marketId === marketId);
+      if (childMarketIds && childMarketIds.length > 0) {
+        const validIds = new Set(childMarketIds);
+        result = result.filter((p) => validIds.has(p.marketId));
+      } else {
+        result = result.filter((p) => p.marketId === marketId);
+      }
     }
 
     return result;
@@ -35,7 +45,13 @@ function buildSelect(claimable?: boolean, marketId?: string) {
 }
 
 export function usePredictPositions(options: UsePredictPositionsOptions = {}) {
-  const { enabled = true, refetchInterval, claimable, marketId } = options;
+  const {
+    enabled = true,
+    refetchInterval,
+    claimable,
+    marketId,
+    childMarketIds,
+  } = options;
 
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
   // Subscribe to account group changes so the hook re-renders when the user switches accounts
@@ -64,6 +80,6 @@ export function usePredictPositions(options: UsePredictPositionsOptions = {}) {
     refetchInterval: hasOptimistic
       ? OPTIMISTIC_POLL_INTERVAL
       : (refetchInterval ?? false),
-    select: buildSelect(claimable, marketId),
+    select: buildSelect(claimable, marketId, childMarketIds),
   });
 }

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -49,6 +49,7 @@ import type { PredictFeatureFlags } from '../../types/flags';
 import { submitProtocolClobOrder } from './protocol/transport';
 import {
   extractNeededTeamsFromEvents,
+  getEventLeague,
   isLiveSportsEvent,
 } from '../../utils/gameParser';
 import { OrderPreview, PlaceOrderParams } from '../types';
@@ -67,6 +68,7 @@ import { PERMIT2_ADDRESS } from './safe/constants';
 import {
   createApiKey,
   encodeClaim,
+  fetchChildEventsFromGammaApi,
   getBalance,
   getRawBalance,
   getContractConfig,
@@ -77,6 +79,7 @@ import {
   getMarketDetailsFromGammaApi,
   getOrderTypedData,
   getPolymarketEndpoints,
+  mergeChildEventsIntoParent,
   parsePolymarketEvents,
   parsePolymarketPositions,
   previewOrder,
@@ -131,6 +134,8 @@ jest.mock('./utils', () => {
     createApiKey: jest.fn(),
     submitClobOrder: jest.fn(),
     getMarketPositions: jest.fn(),
+    fetchChildEventsFromGammaApi: jest.fn(),
+    mergeChildEventsIntoParent: jest.fn(),
     getBalance: jest.fn(),
     getRawBalance: jest.fn(),
     previewOrder: jest.fn(),
@@ -267,6 +272,10 @@ const mockGetBalance = getBalance as jest.Mock;
 const mockGetRawBalance = getRawBalance as jest.Mock;
 const mockSubmitProtocolClobOrder = submitProtocolClobOrder as jest.Mock;
 const mockIsLiveSportsEvent = isLiveSportsEvent as jest.Mock;
+const mockGetEventLeague = getEventLeague as jest.Mock;
+const mockFetchChildEventsFromGammaApi =
+  fetchChildEventsFromGammaApi as jest.Mock;
+const mockMergeChildEventsIntoParent = mergeChildEventsIntoParent as jest.Mock;
 const mockExtractNeededTeamsFromEvents =
   extractNeededTeamsFromEvents as jest.Mock;
 
@@ -3434,6 +3443,126 @@ describe('PolymarketProvider', () => {
       await expect(
         provider.getMarketDetails({ marketId: 'market-1' }),
       ).rejects.toThrow('Failed to parse market details');
+    });
+
+    describe('child event fetching', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      const parentEvent = { id: 'market-1', question: 'Who wins the game?' };
+      const childEvent1 = { id: 'child-1', question: 'Total points?' };
+      const childEvent2 = { id: 'child-2', question: 'First scorer?' };
+      const mergedEvent = {
+        id: 'market-1',
+        question: 'Who wins the game?',
+        markets: [
+          { outcome: 'Team A', price: 0.6 },
+          { outcome: 'Team B', price: 0.4 },
+          { outcome: 'Over', price: 0.5 },
+          { outcome: 'Under', price: 0.5 },
+        ],
+      };
+
+      it('fetches and merges child events for sports event with extended league', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
+        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue('nfl');
+        mockFetchChildEventsFromGammaApi.mockResolvedValue([
+          parentEvent,
+          childEvent1,
+          childEvent2,
+        ]);
+        mockMergeChildEventsIntoParent.mockReturnValue(mergedEvent);
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        await provider.getMarketDetails({ marketId: 'market-1' });
+
+        expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
+          parentEventId: 'market-1',
+        });
+        expect(mockMergeChildEventsIntoParent).toHaveBeenCalledWith([
+          parentEvent,
+          childEvent1,
+          childEvent2,
+        ]);
+        expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+          [mergedEvent],
+          expect.objectContaining({ category: 'trending' }),
+        );
+      });
+
+      it('does not fetch child events for non-sports event', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
+        mockIsLiveSportsEvent.mockReturnValue(false);
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        await provider.getMarketDetails({ marketId: 'market-1' });
+
+        expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
+      });
+
+      it('does not fetch child events when league not in extendedSportsMarketsLeagues', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
+        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue('nba');
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        await provider.getMarketDetails({ marketId: 'market-1' });
+
+        expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
+      });
+
+      it('falls back to parent event when child fetch fails', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
+        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue('nfl');
+        mockFetchChildEventsFromGammaApi.mockRejectedValue(
+          new Error('Network error'),
+        );
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        const result = await provider.getMarketDetails({
+          marketId: 'market-1',
+        });
+
+        expect(result).toEqual(mockParsedMarket);
+        expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+          [parentEvent],
+          expect.objectContaining({ category: 'trending' }),
+        );
+      });
+
+      it('does not fetch child events when getEventLeague returns null', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
+        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue(null);
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        await provider.getMarketDetails({ marketId: 'market-1' });
+
+        expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -278,6 +278,20 @@ const mockFetchChildEventsFromGammaApi =
 const mockMergeChildEventsIntoParent = mergeChildEventsIntoParent as jest.Mock;
 const mockExtractNeededTeamsFromEvents =
   extractNeededTeamsFromEvents as jest.Mock;
+const { getEventLeague: actualGetEventLeague } = jest.requireActual(
+  '../../utils/gameParser',
+);
+
+mockIsLiveSportsEvent.mockImplementation(
+  (
+    event: Parameters<typeof getEventLeague>[0],
+    enabledLeagues: string[],
+    extendedSportsMarketsLeagues: string[] = [],
+  ) => {
+    const league = mockGetEventLeague(event, extendedSportsMarketsLeagues);
+    return league !== null && enabledLeagues.includes(league);
+  },
+);
 
 describe('PolymarketProvider', () => {
   const originalBuilderCode = process.env.MM_PREDICT_BUILDER_CODE;
@@ -3361,6 +3375,12 @@ describe('PolymarketProvider', () => {
   });
 
   describe('getMarketDetails', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetEventLeague.mockReturnValue(null);
+      mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
+    });
+
     const mockEvent = {
       id: 'market-1',
       question: 'Will it rain tomorrow?',
@@ -3380,7 +3400,7 @@ describe('PolymarketProvider', () => {
 
     it('get market details successfully', async () => {
       const provider = createProvider({ liveSportsLeagues: ['nfl'] });
-      mockIsLiveSportsEvent.mockReturnValueOnce(true);
+      mockGetEventLeague.mockReturnValueOnce('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -3448,13 +3468,36 @@ describe('PolymarketProvider', () => {
     describe('child event fetching', () => {
       beforeEach(() => {
         jest.clearAllMocks();
+        mockGetEventLeague.mockReturnValue(null);
+        mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
       });
 
-      const parentEvent = { id: 'market-1', question: 'Who wins the game?' };
-      const childEvent1 = { id: 'child-1', question: 'Total points?' };
-      const childEvent2 = { id: 'child-2', question: 'First scorer?' };
+      const parentEvent = {
+        id: 'game-1',
+        slug: 'nfl-kc-buf-2026-01-01',
+        question: 'Who wins the game?',
+        tags: [{ slug: 'games' }, { slug: 'nfl' }],
+      };
+      const requestedChildEvent = {
+        id: 'child-player-props',
+        slug: 'nfl-kc-buf-2026-01-01-player-props',
+        parentEventId: 'game-1',
+        question: 'Player props?',
+        tags: [{ slug: 'games' }, { slug: 'nfl' }],
+        teams: [{ league: 'nfl' }, { league: 'nfl' }],
+      };
+      const childEvent1 = {
+        id: 'child-player-props',
+        slug: 'nfl-kc-buf-2026-01-01-player-props',
+        question: 'Player props?',
+      };
+      const childEvent2 = {
+        id: 'child-halftime',
+        slug: 'nfl-kc-buf-2026-01-01-halftime-result',
+        question: 'Halftime result?',
+      };
       const mergedEvent = {
-        id: 'market-1',
+        id: 'game-1',
         question: 'Who wins the game?',
         markets: [
           { outcome: 'Team A', price: 0.6 },
@@ -3464,14 +3507,19 @@ describe('PolymarketProvider', () => {
         ],
       };
 
-      it('fetches and merges child events for sports event with extended league', async () => {
+      it('promotes suffixed child events to their parent when the parent is an extended sports game', async () => {
         const provider = createProvider({
           liveSportsLeagues: ['nfl'],
           extendedSportsMarketsLeagues: ['nfl'],
         });
-        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
-        mockIsLiveSportsEvent.mockReturnValue(true);
-        mockGetEventLeague.mockReturnValue('nfl');
+        mockGetEventLeague.mockImplementation(actualGetEventLeague);
+        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
+          Promise.resolve(
+            marketId === requestedChildEvent.id
+              ? requestedChildEvent
+              : parentEvent,
+          ),
+        );
         mockFetchChildEventsFromGammaApi.mockResolvedValue([
           parentEvent,
           childEvent1,
@@ -3480,10 +3528,17 @@ describe('PolymarketProvider', () => {
         mockMergeChildEventsIntoParent.mockReturnValue(mergedEvent);
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
-        await provider.getMarketDetails({ marketId: 'market-1' });
+        await provider.getMarketDetails({ marketId: requestedChildEvent.id });
+
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(1, {
+          marketId: requestedChildEvent.id,
+        });
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(2, {
+          marketId: 'game-1',
+        });
 
         expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
-          parentEventId: 'market-1',
+          parentEventId: 'game-1',
         });
         expect(mockMergeChildEventsIntoParent).toHaveBeenCalledWith([
           parentEvent,
@@ -3502,7 +3557,6 @@ describe('PolymarketProvider', () => {
           extendedSportsMarketsLeagues: ['nfl'],
         });
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
-        mockIsLiveSportsEvent.mockReturnValue(false);
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
         await provider.getMarketDetails({ marketId: 'market-1' });
@@ -3510,19 +3564,28 @@ describe('PolymarketProvider', () => {
         expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
       });
 
-      it('does not fetch child events when league not in extendedSportsMarketsLeagues', async () => {
+      it('keeps the requested child event when the parent league is not extended', async () => {
         const provider = createProvider({
           liveSportsLeagues: ['nfl'],
-          extendedSportsMarketsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: [],
         });
-        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
-        mockIsLiveSportsEvent.mockReturnValue(true);
-        mockGetEventLeague.mockReturnValue('nba');
+        mockGetEventLeague.mockImplementation(actualGetEventLeague);
+        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
+          Promise.resolve(
+            marketId === requestedChildEvent.id
+              ? requestedChildEvent
+              : parentEvent,
+          ),
+        );
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
-        await provider.getMarketDetails({ marketId: 'market-1' });
+        await provider.getMarketDetails({ marketId: requestedChildEvent.id });
 
         expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
+        expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+          [requestedChildEvent],
+          expect.objectContaining({ category: 'trending' }),
+        );
       });
 
       it('falls back to parent event when child fetch fails', async () => {
@@ -3530,16 +3593,21 @@ describe('PolymarketProvider', () => {
           liveSportsLeagues: ['nfl'],
           extendedSportsMarketsLeagues: ['nfl'],
         });
-        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
-        mockIsLiveSportsEvent.mockReturnValue(true);
-        mockGetEventLeague.mockReturnValue('nfl');
+        mockGetEventLeague.mockImplementation(actualGetEventLeague);
+        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
+          Promise.resolve(
+            marketId === requestedChildEvent.id
+              ? requestedChildEvent
+              : parentEvent,
+          ),
+        );
         mockFetchChildEventsFromGammaApi.mockRejectedValue(
           new Error('Network error'),
         );
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
         const result = await provider.getMarketDetails({
-          marketId: 'market-1',
+          marketId: requestedChildEvent.id,
         });
 
         expect(result).toEqual(mockParsedMarket);
@@ -3555,7 +3623,6 @@ describe('PolymarketProvider', () => {
           extendedSportsMarketsLeagues: ['nfl'],
         });
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
-        mockIsLiveSportsEvent.mockReturnValue(true);
         mockGetEventLeague.mockReturnValue(null);
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
@@ -8250,7 +8317,7 @@ describe('PolymarketProvider', () => {
     describe('getMarketDetails', () => {
       it('applies GameCache overlay to fetched market details when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
-        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = {
           id: 'market-1',
           slug: 'sea-vs-den-2024-01-15',
@@ -8280,7 +8347,7 @@ describe('PolymarketProvider', () => {
 
       it('returns market with cached game data overlay applied when event is a sports event', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
-        mockIsLiveSportsEvent.mockReturnValue(true);
+        mockGetEventLeague.mockReturnValue('nfl');
         const mockEvent = {
           id: 'market-1',
           slug: 'sea-vs-den-2024-01-15',
@@ -8312,7 +8379,7 @@ describe('PolymarketProvider', () => {
 
       it('skips GameCache overlay when event is not a sports event despite leagues being enabled', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
-        mockIsLiveSportsEvent.mockReturnValue(false);
+        mockGetEventLeague.mockReturnValue(null);
         const mockEvent = { id: 'market-1', question: 'Will BTC hit 100k?' };
         const parsedMarket = { id: 'market-1', title: 'Will BTC hit 100k?' };
         mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
@@ -8329,7 +8396,7 @@ describe('PolymarketProvider', () => {
 
       it('throws error when parsing fails without calling GameCache overlay', async () => {
         const provider = createProvider({ liveSportsLeagues: ['nfl'] });
-        mockIsLiveSportsEvent.mockReturnValueOnce(true);
+        mockGetEventLeague.mockReturnValueOnce('nfl');
         mockGetMarketDetailsFromGammaApi.mockResolvedValue({});
         mockParsePolymarketEvents.mockReturnValue([]);
 
@@ -8763,7 +8830,7 @@ describe('PolymarketProvider', () => {
         extendedSportsMarketsLeagues: leagues,
       });
       const mockEvent = { id: 'market-1', question: 'Test?' };
-      mockIsLiveSportsEvent.mockReturnValue(true);
+      mockGetEventLeague.mockReturnValue('nfl');
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
       mockParsePolymarketEvents.mockReturnValue([

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -3617,6 +3617,52 @@ describe('PolymarketProvider', () => {
         );
       });
 
+      it('falls back to the requested event when parent fetch fails and still resolves child markets', async () => {
+        const provider = createProvider({
+          liveSportsLeagues: ['nfl'],
+          extendedSportsMarketsLeagues: ['nfl'],
+        });
+        const parentFetchError = new Error('Parent fetch failed');
+        mockGetEventLeague.mockImplementation(actualGetEventLeague);
+        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
+          marketId === requestedChildEvent.id
+            ? Promise.resolve(requestedChildEvent)
+            : Promise.reject(parentFetchError),
+        );
+        mockFetchChildEventsFromGammaApi.mockResolvedValue([
+          parentEvent,
+          childEvent1,
+          childEvent2,
+        ]);
+        mockMergeChildEventsIntoParent.mockReturnValue(mergedEvent);
+        mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
+
+        await provider.getMarketDetails({ marketId: requestedChildEvent.id });
+
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(1, {
+          marketId: requestedChildEvent.id,
+        });
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(2, {
+          marketId: 'game-1',
+        });
+        expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
+          parentEventId: 'game-1',
+        });
+        expect(mockMergeChildEventsIntoParent).toHaveBeenCalledWith([
+          parentEvent,
+          childEvent1,
+          childEvent2,
+        ]);
+        expect(DevLogger.log).toHaveBeenCalledWith(
+          'Failed to fetch parent event, using requested event only:',
+          parentFetchError,
+        );
+        expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
+          [mergedEvent],
+          expect.objectContaining({ category: 'trending' }),
+        );
+      });
+
       it('does not fetch child events when getEventLeague returns null', async () => {
         const provider = createProvider({
           liveSportsLeagues: ['nfl'],
@@ -8830,7 +8876,7 @@ describe('PolymarketProvider', () => {
         extendedSportsMarketsLeagues: leagues,
       });
       const mockEvent = { id: 'market-1', question: 'Test?' };
-      mockGetEventLeague.mockReturnValue('nfl');
+      mockGetEventLeague.mockReturnValue(null);
       mockGetMarketDetailsFromGammaApi.mockResolvedValue(mockEvent);
       mockExtractNeededTeamsFromEvents.mockReturnValue(new Map());
       mockParsePolymarketEvents.mockReturnValue([
@@ -8840,7 +8886,7 @@ describe('PolymarketProvider', () => {
       await provider.getMarketDetails({ marketId: 'market-1' });
 
       expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
-        [mockEvent],
+        expect.anything(),
         expect.objectContaining({ extendedSportsMarketsLeagues: leagues }),
       );
     });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -3513,13 +3513,7 @@ describe('PolymarketProvider', () => {
           extendedSportsMarketsLeagues: ['nfl'],
         });
         mockGetEventLeague.mockImplementation(actualGetEventLeague);
-        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
-          Promise.resolve(
-            marketId === requestedChildEvent.id
-              ? requestedChildEvent
-              : parentEvent,
-          ),
-        );
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(requestedChildEvent);
         mockFetchChildEventsFromGammaApi.mockResolvedValue([
           parentEvent,
           childEvent1,
@@ -3530,11 +3524,9 @@ describe('PolymarketProvider', () => {
 
         await provider.getMarketDetails({ marketId: requestedChildEvent.id });
 
-        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(1, {
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenCalledTimes(1);
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenCalledWith({
           marketId: requestedChildEvent.id,
-        });
-        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(2, {
-          marketId: 'game-1',
         });
 
         expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
@@ -3588,19 +3580,13 @@ describe('PolymarketProvider', () => {
         );
       });
 
-      it('falls back to parent event when child fetch fails', async () => {
+      it('falls back to the requested event when child fetch fails', async () => {
         const provider = createProvider({
           liveSportsLeagues: ['nfl'],
           extendedSportsMarketsLeagues: ['nfl'],
         });
         mockGetEventLeague.mockImplementation(actualGetEventLeague);
-        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
-          Promise.resolve(
-            marketId === requestedChildEvent.id
-              ? requestedChildEvent
-              : parentEvent,
-          ),
-        );
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(requestedChildEvent);
         mockFetchChildEventsFromGammaApi.mockRejectedValue(
           new Error('Network error'),
         );
@@ -3612,23 +3598,18 @@ describe('PolymarketProvider', () => {
 
         expect(result).toEqual(mockParsedMarket);
         expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
-          [parentEvent],
+          [requestedChildEvent],
           expect.objectContaining({ category: 'trending' }),
         );
       });
 
-      it('falls back to the requested event when parent fetch fails and still resolves child markets', async () => {
+      it('uses event.id to fetch children when the event has no parentEventId', async () => {
         const provider = createProvider({
           liveSportsLeagues: ['nfl'],
           extendedSportsMarketsLeagues: ['nfl'],
         });
-        const parentFetchError = new Error('Parent fetch failed');
         mockGetEventLeague.mockImplementation(actualGetEventLeague);
-        mockGetMarketDetailsFromGammaApi.mockImplementation(({ marketId }) =>
-          marketId === requestedChildEvent.id
-            ? Promise.resolve(requestedChildEvent)
-            : Promise.reject(parentFetchError),
-        );
+        mockGetMarketDetailsFromGammaApi.mockResolvedValue(parentEvent);
         mockFetchChildEventsFromGammaApi.mockResolvedValue([
           parentEvent,
           childEvent1,
@@ -3637,14 +3618,9 @@ describe('PolymarketProvider', () => {
         mockMergeChildEventsIntoParent.mockReturnValue(mergedEvent);
         mockParsePolymarketEvents.mockReturnValue([mockParsedMarket]);
 
-        await provider.getMarketDetails({ marketId: requestedChildEvent.id });
+        await provider.getMarketDetails({ marketId: parentEvent.id });
 
-        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(1, {
-          marketId: requestedChildEvent.id,
-        });
-        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenNthCalledWith(2, {
-          marketId: 'game-1',
-        });
+        expect(mockGetMarketDetailsFromGammaApi).toHaveBeenCalledTimes(1);
         expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
           parentEventId: 'game-1',
         });
@@ -3653,10 +3629,6 @@ describe('PolymarketProvider', () => {
           childEvent1,
           childEvent2,
         ]);
-        expect(DevLogger.log).toHaveBeenCalledWith(
-          'Failed to fetch parent event, using requested event only:',
-          parentFetchError,
-        );
         expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
           [mergedEvent],
           expect.objectContaining({ category: 'trending' }),

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -685,9 +685,17 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      const event = await getMarketDetailsFromGammaApi({
+      let event = await getMarketDetailsFromGammaApi({
         marketId,
       });
+
+      let resolvedMarketId = marketId;
+      if (event.parentEventId) {
+        resolvedMarketId = event.parentEventId;
+        event = await getMarketDetailsFromGammaApi({
+          marketId: resolvedMarketId,
+        });
+      }
 
       const supportedLeagues = this.#getSupportedLeagues();
       const liveSportsEnabled = supportedLeagues.length > 0;
@@ -695,14 +703,16 @@ export class PolymarketProvider implements PredictProvider {
         liveSportsEnabled && isLiveSportsEvent(event, supportedLeagues);
 
       let mergedEvent = event;
+      let childMarketIds: string[] | undefined;
       if (isSportsEvent) {
         const league = getEventLeague(event);
         if (league && this.#hasExtendedMarketsForLeague(league)) {
           try {
             const allEvents = await fetchChildEventsFromGammaApi({
-              parentEventId: marketId,
+              parentEventId: resolvedMarketId,
             });
             mergedEvent = mergeChildEventsIntoParent(allEvents);
+            childMarketIds = allEvents.map((e) => e.id);
           } catch (childFetchError) {
             DevLogger.log(
               'Failed to fetch child events, using parent only:',
@@ -724,6 +734,10 @@ export class PolymarketProvider implements PredictProvider {
 
       if (!parsedMarket) {
         throw new Error('Failed to parse market details');
+      }
+
+      if (childMarketIds) {
+        parsedMarket.childMarketIds = childMarketIds;
       }
 
       const result = isSportsEvent

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -194,10 +194,6 @@ export class PolymarketProvider implements PredictProvider {
     return this.#getFeatureFlags().extendedSportsMarketsLeagues;
   }
 
-  #hasExtendedMarketsForLeague(league: string): boolean {
-    return this.#getExtendedSportsMarketsLeagues().includes(league);
-  }
-
   #createTeamLookup(
     enabled: boolean,
   ):
@@ -231,6 +227,64 @@ export class PolymarketProvider implements PredictProvider {
         TeamsCache.getInstance().ensureTeamsLoaded(league, abbreviations),
       ),
     );
+  }
+
+  /**
+   * Extended sports positions can point to child events like player props or
+   * halftime markets, but the details view should resolve back to the parent
+   * game and merge the child markets into that game when the league supports it.
+   */
+  async #resolveSportMarketFromPolymarket({
+    event,
+    marketId,
+    extendedSportsMarketsLeagues,
+  }: {
+    event: PolymarketApiEvent;
+    marketId: string;
+    extendedSportsMarketsLeagues: string[];
+  }): Promise<{
+    resolvedEvent: PolymarketApiEvent;
+    childMarketIds?: string[];
+  }> {
+    const eventLeague = getEventLeague(event, extendedSportsMarketsLeagues);
+    if (!eventLeague || !extendedSportsMarketsLeagues.includes(eventLeague)) {
+      return { resolvedEvent: event };
+    }
+
+    let resolvedEvent = event;
+    let resolvedMarketId = marketId;
+
+    if (event.parentEventId) {
+      resolvedMarketId = String(event.parentEventId);
+      try {
+        resolvedEvent = await getMarketDetailsFromGammaApi({
+          marketId: resolvedMarketId,
+        });
+      } catch (parentFetchError) {
+        DevLogger.log(
+          'Failed to fetch parent event, using requested event only:',
+          parentFetchError,
+        );
+      }
+    }
+
+    try {
+      const allEvents = await fetchChildEventsFromGammaApi({
+        parentEventId: resolvedMarketId,
+      });
+      return {
+        resolvedEvent: mergeChildEventsIntoParent(allEvents),
+        childMarketIds: allEvents.map(
+          (resolvedChildEvent) => resolvedChildEvent.id,
+        ),
+      };
+    } catch (childFetchError) {
+      DevLogger.log(
+        'Failed to fetch child events, using resolved event only:',
+        childFetchError,
+      );
+      return { resolvedEvent };
+    }
   }
 
   /**
@@ -685,7 +739,7 @@ export class PolymarketProvider implements PredictProvider {
     }
 
     try {
-      let event = await getMarketDetailsFromGammaApi({
+      const event = await getMarketDetailsFromGammaApi({
         marketId,
       });
 
@@ -704,38 +758,14 @@ export class PolymarketProvider implements PredictProvider {
       let mergedEvent = event;
       let childMarketIds: string[] | undefined;
       if (isSportsEvent) {
-        const eventLeague = getEventLeague(event, extendedSportsMarketsLeagues);
-        if (eventLeague && this.#hasExtendedMarketsForLeague(eventLeague)) {
-          let resolvedMarketId = marketId;
-          // If event has parentEventId, we fetch parent data instead of the requested event
-          if (event.parentEventId) {
-            resolvedMarketId = String(event.parentEventId);
-            try {
-              event = await getMarketDetailsFromGammaApi({
-                marketId: resolvedMarketId,
-              });
-              mergedEvent = event;
-            } catch (parentFetchError) {
-              DevLogger.log(
-                'Failed to fetch parent event, using requested event only:',
-                parentFetchError,
-              );
-            }
-          }
-
-          try {
-            const allEvents = await fetchChildEventsFromGammaApi({
-              parentEventId: resolvedMarketId,
-            });
-            mergedEvent = mergeChildEventsIntoParent(allEvents);
-            childMarketIds = allEvents.map((e) => e.id);
-          } catch (childFetchError) {
-            DevLogger.log(
-              'Failed to fetch child events, using parent only:',
-              childFetchError,
-            );
-          }
-        }
+        const resolvedSportMarket =
+          await this.#resolveSportMarketFromPolymarket({
+            event,
+            marketId,
+            extendedSportsMarketsLeagues,
+          });
+        mergedEvent = resolvedSportMarket.resolvedEvent;
+        childMarketIds = resolvedSportMarket.childMarketIds;
 
         await this.#ensureTeamsLoadedForEvents([mergedEvent], supportedLeagues);
       }

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -689,14 +689,6 @@ export class PolymarketProvider implements PredictProvider {
         marketId,
       });
 
-      let resolvedMarketId = marketId;
-      if (event.parentEventId) {
-        resolvedMarketId = event.parentEventId;
-        event = await getMarketDetailsFromGammaApi({
-          marketId: resolvedMarketId,
-        });
-      }
-
       const supportedLeagues = this.#getSupportedLeagues();
       const liveSportsEnabled = supportedLeagues.length > 0;
       const isSportsEvent =
@@ -707,6 +699,14 @@ export class PolymarketProvider implements PredictProvider {
       if (isSportsEvent) {
         const league = getEventLeague(event);
         if (league && this.#hasExtendedMarketsForLeague(league)) {
+          let resolvedMarketId = marketId;
+          if (event.parentEventId) {
+            resolvedMarketId = event.parentEventId;
+            event = await getMarketDetailsFromGammaApi({
+              marketId: resolvedMarketId,
+            });
+          }
+
           try {
             const allEvents = await fetchChildEventsFromGammaApi({
               parentEventId: resolvedMarketId,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -96,7 +96,9 @@ import {
   getBalance,
   getContractConfig,
   getL2Headers,
+  fetchChildEventsFromGammaApi,
   getMarketDetailsFromGammaApi,
+  mergeChildEventsIntoParent,
   getOrderTypedData,
   getPolymarketEndpoints,
   parsePolymarketActivity,
@@ -108,6 +110,7 @@ import {
 import { PredictFeatureFlags } from '../../types/flags';
 import {
   extractNeededTeamsFromEvents,
+  getEventLeague,
   isLiveSportsEvent,
 } from '../../utils/gameParser';
 import { GameCache } from './GameCache';
@@ -691,13 +694,29 @@ export class PolymarketProvider implements PredictProvider {
       const isSportsEvent =
         liveSportsEnabled && isLiveSportsEvent(event, supportedLeagues);
 
+      let mergedEvent = event;
       if (isSportsEvent) {
-        await this.#ensureTeamsLoadedForEvents([event], supportedLeagues);
+        const league = getEventLeague(event);
+        if (league && this.#hasExtendedMarketsForLeague(league)) {
+          try {
+            const allEvents = await fetchChildEventsFromGammaApi({
+              parentEventId: marketId,
+            });
+            mergedEvent = mergeChildEventsIntoParent(allEvents);
+          } catch (childFetchError) {
+            DevLogger.log(
+              'Failed to fetch child events, using parent only:',
+              childFetchError,
+            );
+          }
+        }
+
+        await this.#ensureTeamsLoadedForEvents([mergedEvent], supportedLeagues);
       }
 
       const teamLookup = this.#createTeamLookup(isSportsEvent);
 
-      const [parsedMarket] = parsePolymarketEvents([event], {
+      const [parsedMarket] = parsePolymarketEvents([mergedEvent], {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
         extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -691,20 +691,36 @@ export class PolymarketProvider implements PredictProvider {
 
       const supportedLeagues = this.#getSupportedLeagues();
       const liveSportsEnabled = supportedLeagues.length > 0;
+      const extendedSportsMarketsLeagues =
+        this.#getExtendedSportsMarketsLeagues();
       const isSportsEvent =
-        liveSportsEnabled && isLiveSportsEvent(event, supportedLeagues);
+        liveSportsEnabled &&
+        isLiveSportsEvent(
+          event,
+          supportedLeagues,
+          extendedSportsMarketsLeagues,
+        );
 
       let mergedEvent = event;
       let childMarketIds: string[] | undefined;
       if (isSportsEvent) {
-        const league = getEventLeague(event);
-        if (league && this.#hasExtendedMarketsForLeague(league)) {
+        const eventLeague = getEventLeague(event, extendedSportsMarketsLeagues);
+        if (eventLeague && this.#hasExtendedMarketsForLeague(eventLeague)) {
           let resolvedMarketId = marketId;
+          // If event has parentEventId, we fetch parent data instead of the requested event
           if (event.parentEventId) {
-            resolvedMarketId = event.parentEventId;
-            event = await getMarketDetailsFromGammaApi({
-              marketId: resolvedMarketId,
-            });
+            resolvedMarketId = String(event.parentEventId);
+            try {
+              event = await getMarketDetailsFromGammaApi({
+                marketId: resolvedMarketId,
+              });
+              mergedEvent = event;
+            } catch (parentFetchError) {
+              DevLogger.log(
+                'Failed to fetch parent event, using requested event only:',
+                parentFetchError,
+              );
+            }
           }
 
           try {
@@ -729,7 +745,7 @@ export class PolymarketProvider implements PredictProvider {
       const [parsedMarket] = parsePolymarketEvents([mergedEvent], {
         category: PolymarketProvider.FALLBACK_CATEGORY,
         teamLookup,
-        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
+        extendedSportsMarketsLeagues,
       });
 
       if (!parsedMarket) {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -236,11 +236,9 @@ export class PolymarketProvider implements PredictProvider {
    */
   async #resolveSportMarketFromPolymarket({
     event,
-    marketId,
     extendedSportsMarketsLeagues,
   }: {
     event: PolymarketApiEvent;
-    marketId: string;
     extendedSportsMarketsLeagues: string[];
   }): Promise<{
     resolvedEvent: PolymarketApiEvent;
@@ -251,26 +249,11 @@ export class PolymarketProvider implements PredictProvider {
       return { resolvedEvent: event };
     }
 
-    let resolvedEvent = event;
-    let resolvedMarketId = marketId;
-
-    if (event.parentEventId) {
-      resolvedMarketId = String(event.parentEventId);
-      try {
-        resolvedEvent = await getMarketDetailsFromGammaApi({
-          marketId: resolvedMarketId,
-        });
-      } catch (parentFetchError) {
-        DevLogger.log(
-          'Failed to fetch parent event, using requested event only:',
-          parentFetchError,
-        );
-      }
-    }
+    const resolvedEventId = event.parentEventId ?? event.id;
 
     try {
       const allEvents = await fetchChildEventsFromGammaApi({
-        parentEventId: resolvedMarketId,
+        parentEventId: resolvedEventId,
       });
       return {
         resolvedEvent: mergeChildEventsIntoParent(allEvents),
@@ -283,7 +266,7 @@ export class PolymarketProvider implements PredictProvider {
         'Failed to fetch child events, using resolved event only:',
         childFetchError,
       );
-      return { resolvedEvent };
+      return { resolvedEvent: event };
     }
   }
 
@@ -761,7 +744,6 @@ export class PolymarketProvider implements PredictProvider {
         const resolvedSportMarket =
           await this.#resolveSportMarketFromPolymarket({
             event,
-            marketId,
             extendedSportsMarketsLeagues,
           });
         mergedEvent = resolvedSportMarket.resolvedEvent;

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -782,13 +782,13 @@ export class PolymarketProvider implements PredictProvider {
         throw new Error('Failed to parse market details');
       }
 
-      if (childMarketIds) {
-        parsedMarket.childMarketIds = childMarketIds;
-      }
-
       const result = isSportsEvent
         ? GameCache.getInstance().overlayOnMarket(parsedMarket)
         : parsedMarket;
+
+      if (childMarketIds) {
+        result.childMarketIds = childMarketIds;
+      }
 
       return result;
     } catch (error) {

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -180,6 +180,7 @@ export interface PolymarketApiEvent {
   series: PolymarketApiSeries[];
   markets: PolymarketApiMarket[];
   tags: PolymarketApiTag[];
+  teams?: PolymarketApiTeam[];
   liquidity: number;
   volume: number;
   sortBy?: 'price' | 'ascending' | 'descending';
@@ -191,7 +192,7 @@ export interface PolymarketApiEvent {
   period?: PredictGamePeriod;
   live?: boolean;
   ended?: boolean;
-  parentEventId?: string;
+  parentEventId?: string | number;
 }
 
 export interface PolymarketApiActivity {
@@ -363,6 +364,7 @@ export interface PolymarketApiTeam {
   abbreviation: string;
   color: string;
   alias: string;
+  league?: string;
 }
 
 export interface PolymarketApiGameEvent {

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -191,6 +191,7 @@ export interface PolymarketApiEvent {
   period?: PredictGamePeriod;
   live?: boolean;
   ended?: boolean;
+  parentEventId?: string;
 }
 
 export interface PolymarketApiActivity {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -2599,6 +2599,25 @@ describe('polymarket utils', () => {
         expect(result.tokens[1].shortTitle).toBe('SEA');
       });
 
+      it('resolves negRisk moneyline shortTitles with mixed-case market type', () => {
+        const game = createGameData();
+        const market = createMarket({
+          negRisk: true,
+          sportsMarketType: 'Moneyline',
+          groupItemTitle: 'Denver Broncos',
+          outcomes: '["Yes", "No"]',
+          clobTokenIds: '["token-1", "token-2"]',
+          outcomePrices: '["0.6", "0.4"]',
+        });
+        const event = createTestEvent();
+
+        const result = parsePolymarketMarket(market, event, game);
+
+        expect(result.tokens[0].title).toBe('Denver Broncos');
+        expect(result.tokens[0].shortTitle).toBe('DEN');
+        expect(result.tokens[1].shortTitle).toBe('SEA');
+      });
+
       it('skips negRisk shortTitles for draw markets', () => {
         const game = createGameData();
         const market = createMarket({

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -82,6 +82,8 @@ import {
   sortMarketsByField,
   sortMarkets,
   parsePolymarketMarket,
+  fetchChildEventsFromGammaApi,
+  mergeChildEventsIntoParent,
 } from './utils';
 
 // Mock external dependencies
@@ -5285,6 +5287,215 @@ describe('polymarket utils', () => {
       const result = parsePolymarketEvents([event], mockCategory);
 
       expect(result[0].series).toEqual(firstSeries);
+    });
+  });
+
+  describe('fetchChildEventsFromGammaApi', () => {
+    const buildMockApiEvent = (
+      overrides: Partial<PolymarketApiEvent> = {},
+    ): PolymarketApiEvent => ({
+      id: 'event-1',
+      slug: 'test-event',
+      title: 'Test Event',
+      description: 'A test event',
+      icon: 'https://example.com/icon.png',
+      closed: false,
+      series: [],
+      markets: [],
+      tags: [],
+      liquidity: 500000,
+      volume: 1000000,
+      ...overrides,
+    });
+
+    it('returns array of events on success', async () => {
+      const events = [
+        buildMockApiEvent({ id: 'parent-1', title: 'Parent' }),
+        buildMockApiEvent({ id: 'child-1', title: 'Child' }),
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(events),
+      });
+
+      const result = await fetchChildEventsFromGammaApi({
+        parentEventId: 'parent-1',
+      });
+
+      expect(result).toEqual(events);
+      expect(result).toHaveLength(2);
+    });
+
+    it('throws on non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn(),
+      });
+
+      await expect(
+        fetchChildEventsFromGammaApi({ parentEventId: 'parent-1' }),
+      ).rejects.toThrow('Failed to fetch child events');
+    });
+
+    it('calls correct URL with parent_event_id and include_children params', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue([]),
+      });
+
+      await fetchChildEventsFromGammaApi({ parentEventId: 'abc-123' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gamma-api.polymarket.com/events?parent_event_id=abc-123&include_children=true',
+      );
+    });
+  });
+
+  describe('mergeChildEventsIntoParent', () => {
+    const buildMarket = (
+      overrides: Partial<PolymarketApiMarket> = {},
+    ): PolymarketApiMarket => ({
+      conditionId: 'cond-default',
+      question: 'Default question?',
+      description: 'Default description',
+      icon: 'https://example.com/icon.png',
+      image: 'https://example.com/image.png',
+      groupItemTitle: 'Default',
+      status: 'open',
+      volumeNum: 100,
+      liquidity: 50,
+      negRisk: false,
+      clobTokenIds: '["tok-a","tok-b"]',
+      outcomes: '["Yes","No"]',
+      outcomePrices: '["0.5","0.5"]',
+      closed: false,
+      active: true,
+      resolvedBy: '0x0000000000000000000000000000000000000000',
+      orderPriceMinTickSize: 0.01,
+      umaResolutionStatus: 'unresolved',
+      ...overrides,
+    });
+
+    const buildEvent = (
+      overrides: Partial<PolymarketApiEvent> = {},
+    ): PolymarketApiEvent => ({
+      id: 'evt-default',
+      slug: 'default-event',
+      title: 'Default Event',
+      description: 'Default description',
+      icon: 'https://example.com/icon.png',
+      closed: false,
+      series: [],
+      markets: [],
+      tags: [],
+      liquidity: 500000,
+      volume: 1000000,
+      ...overrides,
+    });
+
+    it('merges parent and children markets into single event', () => {
+      const parentMarket = buildMarket({ conditionId: 'parent-mkt' });
+      const childMarket1 = buildMarket({ conditionId: 'child-mkt-1' });
+      const childMarket2 = buildMarket({ conditionId: 'child-mkt-2' });
+      const parent = buildEvent({
+        id: 'parent-1',
+        markets: [parentMarket],
+      });
+      const child1 = buildEvent({
+        id: 'child-1',
+        markets: [childMarket1],
+      });
+      const child2 = buildEvent({
+        id: 'child-2',
+        markets: [childMarket2],
+      });
+
+      const result = mergeChildEventsIntoParent([parent, child1, child2]);
+
+      expect(result.markets).toHaveLength(3);
+      expect(result.markets[0].conditionId).toBe('parent-mkt');
+      expect(result.markets[1].conditionId).toBe('child-mkt-1');
+      expect(result.markets[2].conditionId).toBe('child-mkt-2');
+    });
+
+    it('returns parent as-is when no children', () => {
+      const parentMarket = buildMarket({ conditionId: 'solo-mkt' });
+      const parent = buildEvent({
+        id: 'solo-parent',
+        title: 'Solo Parent',
+        markets: [parentMarket],
+      });
+
+      const result = mergeChildEventsIntoParent([parent]);
+
+      expect(result).toBe(parent);
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0].conditionId).toBe('solo-mkt');
+    });
+
+    it('throws on empty array', () => {
+      expect(() => mergeChildEventsIntoParent([])).toThrow(
+        'No events to merge',
+      );
+    });
+
+    it('preserves parent metadata (id, slug, title)', () => {
+      const parent = buildEvent({
+        id: 'parent-id',
+        slug: 'parent-slug',
+        title: 'Parent Title',
+        markets: [buildMarket()],
+      });
+      const child = buildEvent({
+        id: 'child-id',
+        slug: 'child-slug',
+        title: 'Child Title',
+        markets: [buildMarket({ conditionId: 'child-cond' })],
+      });
+
+      const result = mergeChildEventsIntoParent([parent, child]);
+
+      expect(result.id).toBe('parent-id');
+      expect(result.slug).toBe('parent-slug');
+      expect(result.title).toBe('Parent Title');
+    });
+
+    it('handles children with empty markets arrays', () => {
+      const parentMarket = buildMarket({ conditionId: 'parent-mkt' });
+      const parent = buildEvent({
+        id: 'parent-1',
+        markets: [parentMarket],
+      });
+      const childNoMarkets = buildEvent({
+        id: 'child-empty',
+        markets: [],
+      });
+
+      const result = mergeChildEventsIntoParent([parent, childNoMarkets]);
+
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0].conditionId).toBe('parent-mkt');
+    });
+
+    it('does not duplicate parent markets', () => {
+      const parentMarket = buildMarket({ conditionId: 'parent-mkt' });
+      const childMarket = buildMarket({ conditionId: 'child-mkt' });
+      const parent = buildEvent({
+        id: 'parent-1',
+        markets: [parentMarket],
+      });
+      const child = buildEvent({
+        id: 'child-1',
+        markets: [childMarket],
+      });
+
+      const result = mergeChildEventsIntoParent([parent, child]);
+
+      const parentMarketCount = result.markets.filter(
+        (m) => m.conditionId === 'parent-mkt',
+      ).length;
+      expect(parentMarketCount).toBe(1);
+      expect(result.markets).toHaveLength(2);
     });
   });
 });

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -5496,6 +5496,27 @@ describe('polymarket utils', () => {
       expect(result.markets[0].conditionId).toBe('parent-mkt');
     });
 
+    it('identifies parent by missing parentEventId when parent is not first', () => {
+      const childMarket = buildMarket({ conditionId: 'child-mkt' });
+      const parentMarket = buildMarket({ conditionId: 'parent-mkt' });
+      const child = buildEvent({
+        id: 'child-1',
+        parentEventId: 'parent-1',
+        markets: [childMarket],
+      });
+      const parent = buildEvent({
+        id: 'parent-1',
+        markets: [parentMarket],
+      });
+
+      const result = mergeChildEventsIntoParent([child, parent]);
+
+      expect(result.id).toBe('parent-1');
+      expect(result.markets).toHaveLength(2);
+      expect(result.markets[0].conditionId).toBe('parent-mkt');
+      expect(result.markets[1].conditionId).toBe('child-mkt');
+    });
+
     it('does not duplicate parent markets', () => {
       const parentMarket = buildMarket({ conditionId: 'parent-mkt' });
       const childMarket = buildMarket({ conditionId: 'child-mkt' });

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -996,7 +996,7 @@ export const parsePolymarketEvents = (
   const parsedMarkets: PredictMarket[] = events.map(
     (event: PolymarketApiEvent) => {
       const tags = Array.isArray(event.tags) ? event.tags : [];
-      const eventLeague = getEventLeague(event);
+      const eventLeague = getEventLeague(event, extendedSportsMarketsLeagues);
 
       const predictTeamLookup: TeamLookup | undefined = teamLookup
         ? (league, abbr) => {
@@ -1336,7 +1336,7 @@ export const getMarketDetailsFromGammaApi = async ({
 export const fetchChildEventsFromGammaApi = async ({
   parentEventId,
 }: {
-  parentEventId: string;
+  parentEventId: string | number;
 }): Promise<PolymarketApiEvent[]> => {
   const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
   const response = await fetch(

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -633,6 +633,7 @@ export const isMoneylineMarket = (market: PolymarketApiMarket): boolean =>
 
 const isMoneylineLikeMarket = (market: PolymarketApiMarket): boolean =>
   isMoneylineLikeMarketType(market.sportsMarketType);
+
 /**
  * Sort markets within a sports market type group by liquidity + volume (descending)
  */

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -31,6 +31,7 @@ import {
 } from '../../utils/gameParser';
 import {
   isDrawCapableLeague,
+  isMoneylineLikeMarketType,
   SUPPORTED_SPORTS_LEAGUES,
 } from '../../constants/sports';
 import type {
@@ -629,6 +630,9 @@ export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
 
 export const isMoneylineMarket = (market: PolymarketApiMarket): boolean =>
   market.sportsMarketType?.toLowerCase() === 'moneyline';
+
+const isMoneylineLikeMarket = (market: PolymarketApiMarket): boolean =>
+  isMoneylineLikeMarketType(market.sportsMarketType);
 /**
  * Sort markets within a sports market type group by liquidity + volume (descending)
  */
@@ -750,7 +754,11 @@ const sortOutcomeTokens = (
 const getNegRiskYesTokenTitle = (
   market: PolymarketApiMarket,
 ): string | undefined => {
-  if (!market.negRisk || !isMoneylineMarket(market) || !market.groupItemTitle) {
+  if (
+    !market.negRisk ||
+    !isMoneylineLikeMarket(market) ||
+    !market.groupItemTitle
+  ) {
     return undefined;
   }
   return market.groupItemTitle.toLowerCase().startsWith('draw')
@@ -762,7 +770,11 @@ const resolveNegRiskShortTitles = (
   market: PolymarketApiMarket,
   game: PredictMarketGame,
 ): { yesShort?: string; noShort?: string } => {
-  if (!market.negRisk || !isMoneylineMarket(market) || !market.groupItemTitle) {
+  if (
+    !market.negRisk ||
+    !isMoneylineLikeMarket(market) ||
+    !market.groupItemTitle
+  ) {
     return {};
   }
 
@@ -1318,6 +1330,45 @@ export const getMarketDetailsFromGammaApi = async ({
 
   const responseData = await response.json();
   return responseData as PolymarketApiEvent;
+};
+
+export const fetchChildEventsFromGammaApi = async ({
+  parentEventId,
+}: {
+  parentEventId: string;
+}): Promise<PolymarketApiEvent[]> => {
+  const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
+  const response = await fetch(
+    `${GAMMA_API_ENDPOINT}/events?parent_event_id=${parentEventId}&include_children=true`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch child events');
+  }
+
+  const responseData = await response.json();
+  return responseData as PolymarketApiEvent[];
+};
+
+export const mergeChildEventsIntoParent = (
+  events: PolymarketApiEvent[],
+): PolymarketApiEvent => {
+  if (events.length === 0) {
+    throw new Error('No events to merge');
+  }
+
+  const [parent, ...children] = events;
+
+  if (children.length === 0) {
+    return parent;
+  }
+
+  const childMarkets = children.flatMap((child) => child.markets ?? []);
+
+  return {
+    ...parent,
+    markets: [...(parent.markets ?? []), ...childMarkets],
+  };
 };
 
 export const getPredictPositionStatus = ({

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -628,9 +628,6 @@ export function buildOutcomeGroups(
 export const isSpreadMarket = (market: PolymarketApiMarket): boolean =>
   market.sportsMarketType?.toLowerCase().includes('spread') ?? false;
 
-export const isMoneylineMarket = (market: PolymarketApiMarket): boolean =>
-  market.sportsMarketType?.toLowerCase() === 'moneyline';
-
 const isMoneylineLikeMarket = (market: PolymarketApiMarket): boolean =>
   isMoneylineLikeMarketType(market.sportsMarketType);
 
@@ -653,7 +650,7 @@ const formatMarketGroupItemTitle = (market: PolymarketApiMarket): string => {
     return market.groupItemTitle.replace(/-(?=\d)/, '');
   }
 
-  if (isMoneylineMarket(market)) {
+  if (isMoneylineLikeMarket(market)) {
     return market.groupItemTitle || market.question;
   }
   return market.groupItemTitle;

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1355,7 +1355,8 @@ export const mergeChildEventsIntoParent = (
     throw new Error('No events to merge');
   }
 
-  const [parent, ...children] = events;
+  const parent = events.find((e) => !e.parentEventId) ?? events[0];
+  const children = events.filter((e) => e !== parent);
 
   if (children.length === 0) {
     return parent;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -115,6 +115,7 @@ export type PredictMarket = {
   volume: number;
   game?: PredictMarketGame;
   series?: PredictSeries;
+  childMarketIds?: string[];
 };
 
 export type PredictSeries = {

--- a/app/components/UI/Predict/utils/gameParser.test.ts
+++ b/app/components/UI/Predict/utils/gameParser.test.ts
@@ -88,6 +88,52 @@ describe('gameParser', () => {
       expect(result).toBeNull();
     });
 
+    it('returns league for suffixed child events when extended markets are enabled and teams match the league', () => {
+      const event = createMockEvent({
+        slug: 'epl-ful-ast-2026-04-25-player-props',
+        tags: [
+          { id: '1', label: 'Premier League', slug: 'premier-league' },
+          { id: '2', label: 'Games', slug: 'games' },
+        ],
+        teams: [
+          createMockApiTeam({ id: 'team-1', league: 'epl' }),
+          createMockApiTeam({
+            id: 'team-2',
+            abbreviation: 'AST',
+            alias: 'Villa',
+            league: 'epl',
+          }),
+        ],
+      });
+
+      const result = getEventLeague(event, ['epl']);
+
+      expect(result).toBe('epl');
+    });
+
+    it('returns null for suffixed child events when extended markets are disabled', () => {
+      const event = createMockEvent({
+        slug: 'epl-ful-ast-2026-04-25-player-props',
+        tags: [
+          { id: '1', label: 'Premier League', slug: 'premier-league' },
+          { id: '2', label: 'Games', slug: 'games' },
+        ],
+        teams: [
+          createMockApiTeam({ id: 'team-1', league: 'epl' }),
+          createMockApiTeam({
+            id: 'team-2',
+            abbreviation: 'AST',
+            alias: 'Villa',
+            league: 'epl',
+          }),
+        ],
+      });
+
+      const result = getEventLeague(event);
+
+      expect(result).toBeNull();
+    });
+
     it('returns null when tags is not an array', () => {
       const event = createMockEvent({
         tags: undefined as unknown as [],
@@ -125,6 +171,29 @@ describe('gameParser', () => {
       const result = isLiveSportsEvent(event, ['nfl']);
 
       expect(result).toBe(false);
+    });
+
+    it('returns true for suffixed child events when the league is enabled for extended markets', () => {
+      const event = createMockEvent({
+        slug: 'epl-ful-ast-2026-04-25-player-props',
+        tags: [
+          { id: '1', label: 'Premier League', slug: 'premier-league' },
+          { id: '2', label: 'Games', slug: 'games' },
+        ],
+        teams: [
+          createMockApiTeam({ id: 'team-1', league: 'epl' }),
+          createMockApiTeam({
+            id: 'team-2',
+            abbreviation: 'AST',
+            alias: 'Villa',
+            league: 'epl',
+          }),
+        ],
+      });
+
+      const result = isLiveSportsEvent(event, ['epl'], ['epl']);
+
+      expect(result).toBe(true);
     });
   });
 

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -220,8 +220,17 @@ export interface ParsedGameSlug {
   dateString: string;
 }
 
+const hasTeamsMatchingLeague = (
+  event: PolymarketApiEvent,
+  league: PredictSportsLeague,
+): boolean => {
+  const teams = Array.isArray(event.teams) ? event.teams : [];
+  return teams.length > 0 && teams.every((team) => team.league === league);
+};
+
 export function getEventLeague(
   event: PolymarketApiEvent,
+  extendedSportsMarketsLeagues: string[] = [],
 ): PredictSportsLeague | null {
   const tags = Array.isArray(event.tags) ? event.tags : [];
   const hasGamesTag = tags.some((tag) => tag.slug === 'games');
@@ -238,6 +247,15 @@ export function getEventLeague(
     if (hasLeagueTag && hasValidSlug) {
       return league;
     }
+
+    const canInferFromTeams =
+      hasLeagueTag &&
+      extendedSportsMarketsLeagues.includes(league) &&
+      hasTeamsMatchingLeague(event, league);
+
+    if (canInferFromTeams) {
+      return league;
+    }
   }
 
   return null;
@@ -246,8 +264,9 @@ export function getEventLeague(
 export function isLiveSportsEvent(
   event: PolymarketApiEvent,
   enabledLeagues: PredictSportsLeague[],
+  extendedSportsMarketsLeagues: string[] = [],
 ): boolean {
-  const league = getEventLeague(event);
+  const league = getEventLeague(event, extendedSportsMarketsLeagues);
   return league !== null && enabledLeagues.includes(league);
 }
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -3664,6 +3664,33 @@ describe('PredictMarketDetails', () => {
       expect(screen.getByText('NFL: Team A vs Team B')).toBeOnTheScreen();
     });
 
+    it('threads childMarketIds to usePredictPositions for both active and claimable queries', () => {
+      const marketWithChildren = createMockMarket({
+        childMarketIds: ['child-1', 'child-2'],
+      });
+
+      setupPredictMarketDetailsTest(marketWithChildren);
+
+      const { usePredictPositions } = jest.requireMock(
+        '../../hooks/usePredictPositions',
+      );
+
+      const calls = usePredictPositions.mock.calls;
+      const activeCall = calls.find(
+        ([args]: [{ claimable: boolean }]) => !args.claimable,
+      );
+      const claimableCall = calls.find(
+        ([args]: [{ claimable: boolean }]) => args.claimable,
+      );
+
+      expect(activeCall[0]).toEqual(
+        expect.objectContaining({ childMarketIds: ['child-1', 'child-2'] }),
+      );
+      expect(claimableCall[0]).toEqual(
+        expect.objectContaining({ childMarketIds: ['child-1', 'child-2'] }),
+      );
+    });
+
     it('renders regular market details when market has no game property', () => {
       const regularMarket = createMockMarket({
         title: 'Will Bitcoin reach $100k?',

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -126,6 +126,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     refetch: refetchActivePositions,
   } = usePredictPositions({
     marketId: resolvedMarketId,
+    childMarketIds: market?.childMarketIds,
     claimable: false,
     enabled: !isMarketLoading && Boolean(resolvedMarketId),
   });
@@ -137,6 +138,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     refetch: refetchClaimablePositions,
   } = usePredictPositions({
     marketId: resolvedMarketId,
+    childMarketIds: market?.childMarketIds,
     claimable: true,
     enabled: !isMarketLoading && Boolean(resolvedMarketId),
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Soccer events on Polymarket have additional market types (spreads, totals, halftime result, exact score, player props) that live in separate child events under a parent event. Previously, only moneyline markets from the parent event were shown.

This PR extends the Polymarket provider to fetch child events via the Gamma API's `parent_event_id` endpoint and merge all markets into a single unified view, matching Polymarket's own sports event experience.

### What changed

**Provider layer — child event fetching & merging:**
- Added `fetchChildEventsFromGammaApi()` — calls `/events?parent_event_id={id}&include_children=true`
- Added `mergeChildEventsIntoParent()` — pure function that combines all children's markets into the parent event
- Modified `getMarketDetails()` to sequentially fetch child events for sports events in `extendedSportsMarketsLeagues`, with graceful fallback on failure
- Added `parentEventId` detection — when navigating to a child event directly (e.g., from a position), automatically re-fetches the parent for the full merged view

**UI layer — moneyline-style rendering for multi-outcome groups:**
- Moneyline and halftime result groups now render as a single card with one button per outcome (home/draw/away), using stacked layout to prevent overflow
- Added `MONEYLINE_MARKET_TYPES` constant in `constants/sports.ts` (shared between provider and UI)
- Extended `isMoneylineLikeMarketType()` to cover `moneyline`, `first_half_moneyline`, and `soccer_halftime_result` — enables proper team/draw token labels for all moneyline-like markets

**UI layer — line selector for spreads/totals:**
- Changed line selector to index-based selection (instead of line-value-based) so duplicate line values (two teams at the same spread) are independently selectable
- Added `selectedIndex` prop threading through `PredictSportOutcomeCard` → `PredictSportLineSelector`
- Lines display as absolute values (no negative sign), matching Polymarket

**Positions support:**
- Added `childMarketIds?: string[]` to `PredictMarket` — tracks all event IDs from the parent + children response
- Updated `usePredictPositions` to filter positions by any ID in the child set (not just the parent), so positions from spreads/totals/halftime events appear on the parent detail page

### Files changed (15 files, +614 / -49)

| Area | File | Change |
|------|------|--------|
| Provider | `providers/polymarket/utils.ts` | `fetchChildEventsFromGammaApi`, `mergeChildEventsIntoParent`, `isMoneylineLikeMarket` for token label resolution |
| Provider | `providers/polymarket/PolymarketProvider.ts` | `getMarketDetails` — child fetch, merge, parentEventId redirect, childMarketIds |
| Provider | `providers/polymarket/types.ts` | `parentEventId` on `PolymarketApiEvent` |
| Types | `types/index.ts` | `childMarketIds` on `PredictMarket` |
| Constants | `constants/sports.ts` | `MONEYLINE_MARKET_TYPES`, `isMoneylineLikeMarketType` |
| UI | `PredictGameOutcomesTab.tsx` | Moneyline card rendering, draw sorting, index-based line selector |
| UI | `PredictSportLineSelector.tsx` | Index-based selection, `selectedIndex` prop |
| UI | `PredictSportOutcomeCard.tsx` | `buttonLayout` and `selectedIndex` props |
| UI | `PredictGameDetailsContent.tsx` | Pass `childMarketIds` to positions hook |
| UI | `PredictMarketDetails.tsx` | Pass `childMarketIds` to positions hook |
| Hook | `usePredictPositions.ts` | Filter by parent OR child market IDs |
| Tests | `utils.test.ts` | 9 tests for fetch/merge functions |
| Tests | `PolymarketProvider.test.ts` | 5 tests for child event integration |
| Tests | `PredictGameOutcomesTab.test.tsx` | Updated for index-based line selection |
| Tests | `PredictSportLineSelector.test.tsx` | Updated for index-based API |

## **Changelog**

CHANGELOG entry: Added support for additional sports market types (spreads, totals, halftime result, exact score, player props) on prediction market event detail screens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-812

## **Manual testing steps**

```gherkin
Feature: Sports multi-market event display

  Scenario: user views a soccer event with multiple market types
    Given the user is on the Predict tab
    And a soccer event (e.g., EPL game) is visible in the feed

    When user taps on the soccer event
    Then the event detail screen shows chip tabs: Game Lines, Goalscorers, Exact Score, Halftime, Corners
    And the Moneyline card shows 3 stacked buttons (Home, Draw, Away) with team colors
    And the Spreads card shows a line selector with selectable lines and both team buttons
    And the Halftime Result card shows 3 stacked buttons (Home, Draw, Away) matching moneyline layout

  Scenario: user navigates line selector for spreads
    Given the user is on a soccer event detail screen
    And the Outcomes tab is active with Game Lines chip selected

    When user taps the left/right arrows on the Spreads line selector
    Then the line changes and the spread buttons update to show the selected line's outcomes
    And each duplicate line value is independently selectable

  Scenario: user sees positions from child event markets
    Given the user has bought a spread or totals outcome on a soccer event

    When user navigates to the parent soccer event detail screen
    Then the Positions tab shows the spread/totals position alongside moneyline positions

  Scenario: user navigates to market detail from a child event position
    Given the user has a position on a spread market (child event)

    When user taps on that position from the home screen
    Then the app navigates to the parent event detail screen with all market types visible
    And not to the child event alone

  Scenario: non-sports events are unaffected
    Given the user is viewing a crypto or politics prediction market

    When user taps on the event
    Then the event detail screen renders exactly as before with no extra API calls
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Polymarket Gamma API calls and changes market-detail resolution/merging logic, plus updates outcome rendering and positions filtering; issues here could hide markets/positions or mis-order/price selections in the details view.
> 
> **Overview**
> Enables **multi-market sports event** support by resolving Polymarket markets to a parent event and merging in child-event markets when the league is configured for extended sports markets. `PolymarketProvider.getMarketDetails` now optionally fetches child events via a new Gamma API helper, merges markets, and surfaces `childMarketIds` on the returned `PredictMarket`.
> 
> Updates the details UI to **include positions from child markets** by threading `childMarketIds` into `usePredictPositions` and filtering positions against that ID set.
> 
> Improves outcomes rendering for sports: moneyline-like groups (including `soccer_halftime_result`) can render as a single **stacked-button** card with deterministic sorting and combined volume, and the line selector is now **index-based** (with `selectedIndex` propagated) to handle duplicate line values; corresponding constants and tests were added/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e91b0d390ff2712418121be4d9eb070aa9a16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->