### PR TITLE
fix: Perps/refresh hl live account cache

### DIFF
--- a/app/components/UI/Perps/__mocks__/providerMocks.ts
+++ b/app/components/UI/Perps/__mocks__/providerMocks.ts
@@ -51,6 +51,7 @@ export const createMockHyperLiquidProvider =
       getOpenOrders: jest.fn(),
       subscribeToOrders: jest.fn(),
       subscribeToAccount: jest.fn(),
+      refreshLiveAccountState: jest.fn().mockResolvedValue(undefined),
       setUserFeeDiscount: jest.fn(),
       // WebSocket connection state methods
       getWebSocketConnectionState: jest.fn(),

--- a/app/controllers/perps/providers/AggregatedPerpsProvider.test.ts
+++ b/app/controllers/perps/providers/AggregatedPerpsProvider.test.ts
@@ -86,6 +86,7 @@ const createMockProvider = (providerId: string): jest.Mocked<PerpsProvider> => {
     subscribeToOrderFills: jest.fn().mockReturnValue(() => undefined),
     subscribeToOrders: jest.fn().mockReturnValue(() => undefined),
     subscribeToAccount: jest.fn().mockReturnValue(() => undefined),
+    refreshLiveAccountState: jest.fn().mockResolvedValue(undefined),
     subscribeToOICaps: jest.fn().mockReturnValue(() => undefined),
     subscribeToCandles: jest.fn().mockReturnValue(() => undefined),
     subscribeToOrderBook: jest.fn().mockReturnValue(() => undefined),
@@ -722,6 +723,12 @@ describe('AggregatedPerpsProvider', () => {
       aggregatedProvider.subscribeToAccount({ callback });
 
       expect(mockHLProvider.subscribeToAccount).toHaveBeenCalled();
+    });
+
+    it('delegates live account refresh to default provider', async () => {
+      await aggregatedProvider.refreshLiveAccountState();
+
+      expect(mockHLProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('delegates subscribeToOICaps to default provider', () => {

--- a/app/controllers/perps/providers/AggregatedPerpsProvider.ts
+++ b/app/controllers/perps/providers/AggregatedPerpsProvider.ts
@@ -600,6 +600,10 @@ export class AggregatedPerpsProvider implements PerpsProvider {
     return this.#getDefaultProvider().subscribeToAccount(params);
   }
 
+  async refreshLiveAccountState(): Promise<void> {
+    await this.#getDefaultProvider().refreshLiveAccountState?.();
+  }
+
   subscribeToOICaps(params: SubscribeOICapsParams): () => void {
     // Delegate to default provider
     return this.#getDefaultProvider().subscribeToOICaps(params);

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -7127,6 +7127,10 @@ export class HyperLiquidProvider implements PerpsProvider {
     return this.#subscriptionService.subscribeToAccount(params);
   }
 
+  async refreshLiveAccountState(): Promise<void> {
+    await this.#subscriptionService.refreshLiveAccountState();
+  }
+
   /**
    * Subscribe to open interest cap updates
    * Zero additional overhead - data extracted from existing webData2 subscription

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3839,6 +3839,91 @@ describe('HyperLiquidSubscriptionService', () => {
 
       unsubscribe();
     });
+
+    it('refreshes live account state with updated spot hold for active account subscribers', async () => {
+      mockSpotClearinghouseState
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '3' }],
+        })
+        .mockResolvedValueOnce({
+          balances: [{ coin: 'USDC', total: '100', hold: '7' }],
+        });
+
+      jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({
+        availableBalance: '50',
+        availableToTradeBalance: '50',
+        totalBalance: '200',
+        marginUsed: '10',
+        unrealizedPnl: '5',
+        returnOnEquity: '0.05',
+      }));
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const mockCallback = jest.fn();
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: mockCallback,
+      });
+
+      await jest.runAllTimersAsync();
+
+      expect(mockCallback).toHaveBeenCalled();
+      expect(mockCallback.mock.calls.at(-1)[0].availableToTradeBalance).toBe(
+        '147',
+      );
+
+      mockCallback.mockClear();
+
+      await singleDexService.refreshLiveAccountState();
+      await jest.runAllTimersAsync();
+
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(2);
+      expect(mockCallback).toHaveBeenCalled();
+      expect(mockCallback.mock.calls.at(-1)[0].availableToTradeBalance).toBe(
+        '143',
+      );
+
+      unsubscribe();
+    });
+
+    it('does not refresh live account state without active account subscribers', async () => {
+      await service.refreshLiveAccountState();
+
+      expect(mockSpotClearinghouseState).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh live account state before streamed account data is cached', async () => {
+      mockSubscriptionClient.webData2.mockImplementation(() =>
+        Promise.resolve({
+          unsubscribe: jest.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      const singleDexService = new HyperLiquidSubscriptionService(
+        mockClientService,
+        mockWalletService,
+        mockDeps,
+        false,
+      );
+
+      const unsubscribe = singleDexService.subscribeToAccount({
+        callback: jest.fn(),
+      });
+
+      await jest.runAllTimersAsync();
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(1);
+
+      await singleDexService.refreshLiveAccountState();
+
+      expect(mockSpotClearinghouseState).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+    });
   });
 
   describe('aggregateAccountStates - returnOnEquity calculation', () => {

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1024,7 +1024,17 @@ export class HyperLiquidSubscriptionService {
     const userAddress =
       await this.#walletService.getUserAddressWithDefault(accountId);
 
+    await this.#requestSpotStateRefresh(userAddress);
+  }
+
+  async #requestSpotStateRefresh(
+    userAddress: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    const { force = false } = options ?? {};
+
     if (
+      !force &&
       this.#cachedSpotState &&
       this.#cachedSpotStateUserAddress === userAddress
     ) {
@@ -1035,6 +1045,7 @@ export class HyperLiquidSubscriptionService {
     // A pending fetch for a different user is stale after an account switch —
     // start a fresh fetch; the stale one will self-discard via generation check.
     if (
+      !force &&
       this.#spotStatePromise &&
       this.#spotStatePromiseUserAddress === userAddress
     ) {
@@ -2408,6 +2419,22 @@ export class HyperLiquidSubscriptionService {
       this.#accountSubscriberCount -= 1;
       this.#cleanupSharedWebData3ISubscription();
     };
+  }
+
+  public async refreshLiveAccountState(
+    accountId?: CaipAccountId,
+  ): Promise<void> {
+    if (
+      this.#accountSubscriberCount === 0 ||
+      this.#dexAccountCache.size === 0
+    ) {
+      return;
+    }
+
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    await this.#requestSpotStateRefresh(userAddress, { force: true });
   }
 
   /**

--- a/app/controllers/perps/services/TradingService.test.ts
+++ b/app/controllers/perps/services/TradingService.test.ts
@@ -961,6 +961,7 @@ describe('TradingService', () => {
 
       expect(result).toEqual(mockResult);
       expect(mockProvider.cancelOrder).toHaveBeenCalledWith(cancelParams);
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('tracks analytics event when cancellation succeeds', async () => {
@@ -1053,6 +1054,7 @@ describe('TradingService', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe('Order already filled');
       expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalled();
+      expect(mockProvider.refreshLiveAccountState).not.toHaveBeenCalled();
     });
 
     it('handles provider exception during order cancel', async () => {
@@ -1076,6 +1078,28 @@ describe('TradingService', () => {
         expect.any(Object),
       );
       expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalled();
+    });
+
+    it('does not require refreshLiveAccountState to cancel orders successfully', async () => {
+      const cancelParams: CancelOrderParams = {
+        orderId: 'order-123',
+        symbol: 'BTC',
+      };
+      const mockResult = {
+        success: true,
+        orderId: 'order-123',
+      };
+
+      mockProvider.cancelOrder.mockResolvedValue(mockResult);
+      mockProvider.refreshLiveAccountState = undefined as never;
+
+      await expect(
+        tradingService.cancelOrder({
+          provider: mockProvider,
+          params: cancelParams,
+          context: mockContext,
+        }),
+      ).resolves.toEqual(mockResult);
     });
   });
 
@@ -1136,6 +1160,8 @@ describe('TradingService', () => {
       mockGetOpenOrders.mockResolvedValue(mockOrders);
       (mockProvider.cancelOrders as jest.Mock).mockResolvedValue({
         success: true,
+        successCount: 1,
+        failureCount: 0,
         results: [{ success: true, orderId: 'order-1' }],
       });
 
@@ -1150,6 +1176,7 @@ describe('TradingService', () => {
       expect(mockProvider.cancelOrders).toHaveBeenCalledWith([
         { symbol: 'BTC', orderId: 'order-1' },
       ]);
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('allows canceling TP/SL orders when specified by orderId', async () => {

--- a/app/controllers/perps/services/TradingService.test.ts
+++ b/app/controllers/perps/services/TradingService.test.ts
@@ -110,6 +110,7 @@ describe('TradingService', () => {
       expect(result).toEqual(mockOrderResult);
       expect(mockProvider.placeOrder).toHaveBeenCalledWith(orderParams);
       expect(mockProvider.setUserFeeDiscount).toHaveBeenCalledWith(undefined);
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('places order successfully with fee discount applied and cleared', async () => {
@@ -395,6 +396,58 @@ describe('TradingService', () => {
           status: 'failed',
         }),
       );
+    });
+
+    it('does not refresh live account state when order placement fails', async () => {
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+      };
+      const mockOrderResult: OrderResult = {
+        success: false,
+        error: 'Insufficient margin',
+      };
+
+      mockProvider.placeOrder.mockResolvedValue(mockOrderResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.placeOrder({
+        provider: mockProvider,
+        params: orderParams,
+        context: mockContext,
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockProvider.refreshLiveAccountState).not.toHaveBeenCalled();
+    });
+
+    it('does not require refreshLiveAccountState to place orders successfully', async () => {
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+      };
+      const mockOrderResult: OrderResult = {
+        success: true,
+        orderId: 'order-123',
+      };
+
+      mockProvider.placeOrder.mockResolvedValue(mockOrderResult);
+      mockProvider.refreshLiveAccountState = undefined as never;
+
+      await expect(
+        tradingService.placeOrder({
+          provider: mockProvider,
+          params: orderParams,
+          context: mockContext,
+          reportOrderToDataLake: mockReportOrderToDataLake,
+        }),
+      ).resolves.toEqual(mockOrderResult);
     });
 
     it('reports order to data lake on success (fire-and-forget)', async () => {
@@ -1304,6 +1357,7 @@ describe('TradingService', () => {
       expect(result).toEqual(mockResult);
       expect(mockProvider.closePosition).toHaveBeenCalledWith(params);
       expect(mockProvider.setUserFeeDiscount).toHaveBeenCalledWith(undefined);
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('closes position successfully with fee discount applied and cleared', async () => {
@@ -1506,6 +1560,8 @@ describe('TradingService', () => {
       mockGetPositions.mockResolvedValue(mockPositions);
       (mockProvider.closePositions as jest.Mock).mockResolvedValue({
         success: true,
+        successCount: 2,
+        failureCount: 0,
         results: [
           { success: true, orderId: 'close-1', symbol: 'BTC' },
           { success: true, orderId: 'close-2', symbol: 'ETH' },
@@ -1523,6 +1579,7 @@ describe('TradingService', () => {
 
       expect(result.success).toBe(true);
       expect(result.results).toHaveLength(2);
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('closes specific coins when provided', async () => {
@@ -1841,6 +1898,7 @@ describe('TradingService', () => {
         symbol: 'BTC',
         amount: '100',
       });
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('updates margin successfully when removing margin', async () => {
@@ -2004,6 +2062,7 @@ describe('TradingService', () => {
           size: '1',
         }),
       );
+      expect(mockProvider.refreshLiveAccountState).toHaveBeenCalled();
     });
 
     it('flips long position to short (isBuy=false)', async () => {

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -1658,6 +1658,9 @@ export class TradingService {
       if (operationResult?.success && operationResult.successCount > 0) {
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        // Only trigger one explicit refresh for the batch close path.
+        // The fallback path calls closePosition() per position, and each
+        // successful closePosition() already refreshes live account state.
         if (provider.closePositions) {
           this.#refreshLiveAccountStateInBackground(provider, 'closePositions');
         }

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -457,6 +457,7 @@ export class TradingService {
         // Invalidate standalone caches so external hooks (e.g., usePerpsPositionForAsset) refresh
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        this.#refreshLiveAccountStateInBackground(provider, 'placeOrder');
       } else {
         traceData = { success: false, error: result.error ?? 'Unknown error' };
       }
@@ -845,6 +846,24 @@ export class TradingService {
               operation: 'reportOrderToDataLake',
               symbol,
             },
+          },
+        },
+      );
+    });
+  }
+
+  #refreshLiveAccountStateInBackground(
+    provider: PerpsProvider,
+    operation: string,
+  ): void {
+    provider.refreshLiveAccountState?.().catch((refreshError) => {
+      this.#deps.logger.error(
+        ensureError(refreshError, 'TradingService.refreshLiveAccountState'),
+        {
+          tags: { feature: PERPS_CONSTANTS.FeatureName },
+          context: {
+            name: 'TradingService.refreshLiveAccountState',
+            data: { operation, provider: provider.protocolId },
           },
         },
       );
@@ -1414,6 +1433,7 @@ export class TradingService {
         // Invalidate standalone caches so external hooks (e.g., usePerpsPositionForAsset) refresh
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        this.#refreshLiveAccountStateInBackground(provider, 'closePosition');
       } else {
         traceData = { success: false, error: result.error ?? 'Unknown error' };
       }
@@ -1638,6 +1658,9 @@ export class TradingService {
       if (operationResult?.success && operationResult.successCount > 0) {
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        if (provider.closePositions) {
+          this.#refreshLiveAccountStateInBackground(provider, 'closePositions');
+        }
       }
 
       this.#deps.tracer.endTrace({
@@ -1866,6 +1889,7 @@ export class TradingService {
         // Invalidate standalone caches so external hooks refresh
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        this.#refreshLiveAccountStateInBackground(provider, 'updateMargin');
       }
 
       this.#deps.tracer.endTrace({
@@ -1997,6 +2021,7 @@ export class TradingService {
         // Invalidate standalone caches so external hooks refresh
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'positions' });
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        this.#refreshLiveAccountStateInBackground(provider, 'flipPosition');
       }
 
       this.#deps.tracer.endTrace({

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -856,7 +856,8 @@ export class TradingService {
     provider: PerpsProvider,
     operation: string,
   ): void {
-    provider.refreshLiveAccountState?.().catch((refreshError) => {
+    const refreshPromise = provider.refreshLiveAccountState?.();
+    refreshPromise?.catch((refreshError) => {
       this.#deps.logger.error(
         ensureError(refreshError, 'TradingService.refreshLiveAccountState'),
         {

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -1129,6 +1129,8 @@ export class TradingService {
           },
         );
 
+        this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        this.#refreshLiveAccountStateInBackground(provider, 'cancelOrder');
         traceData = { success: true, orderId: params.orderId };
       } else {
         // Track order cancel failed
@@ -1346,6 +1348,16 @@ export class TradingService {
         PerpsAnalyticsEvent.OrderCancelTransaction,
         batchCancelProps,
       );
+
+      if (operationResult?.success && operationResult.successCount > 0) {
+        this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
+        // Only trigger one explicit refresh for the batch cancel path.
+        // The fallback path calls cancelOrder() per order, and each
+        // successful cancelOrder() already refreshes live account state.
+        if (provider.cancelOrders) {
+          this.#refreshLiveAccountStateInBackground(provider, 'cancelOrders');
+        }
+      }
 
       this.#deps.tracer.endTrace({
         name: PerpsTraceNames.CancelOrder,

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1052,6 +1052,7 @@ export type PerpsProvider = {
   subscribeToOICaps(params: SubscribeOICapsParams): () => void;
   subscribeToCandles(params: SubscribeCandlesParams): () => void;
   subscribeToOrderBook(params: SubscribeOrderBookParams): () => void;
+  refreshLiveAccountState?(): Promise<void>;
 
   // Live data configuration
   setLiveDataConfig(config: Partial<LiveDataConfig>): void;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR builds on perps/fix-avail-balance-order-entry by fixing the remaining live-update gap for HyperLiquid availableToTradeBalance.

The parent branch corrected the balance math and UI usage, but after a successful trade or margin mutation the Perps home screen could still briefly show the right value and then get overwritten by stale streamed account data, because the live HyperLiquid account stream was still using cached spot state.

The solution is to refresh the existing streamed account path after successful trade mutations instead of adding new UI side refresh logic.

An optional refreshLiveAccountState() hook was added to the provider interface, implemented for HyperLiquid, and invoked by TradingService after successful order placement, close, flip, batch close, and margin updates.

On HyperLiquid, that forces a fresh spotClearinghouseState fetch and reuses the existing account aggregation/notification path, so subscribers receive an updated availableToTradeBalance from the live stream itself rather than a temporary one-off refresh.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-trade state update paths and HyperLiquid subscription caching; mistakes could cause missed/extra refreshes or stale balances in the UI. Changes are guarded (optional provider method, no-op when unsubscribed) and covered by unit tests.
> 
> **Overview**
> Fixes a stale-balance flicker by introducing optional `refreshLiveAccountState()` on `PerpsProvider`, implemented in `HyperLiquidProvider`/`HyperLiquidSubscriptionService` to forcibly refetch spot state and re-notify existing account subscribers.
> 
> `TradingService` now triggers this refresh (fire-and-forget with error logging) after **successful** `placeOrder`, `cancelOrder`/batch cancel, `closePosition`/batch close, `updateMargin`, and `flipPosition`, while keeping the behavior optional for providers that don’t implement it. Tests and mocks were updated to cover delegation via `AggregatedPerpsProvider` and to ensure refreshes only occur on successful mutations and only when streamed account data is already active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67be895a9b6785530d8cdfaa9bb1411184699b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->