### PR TITLE
fix(ci): add retry logic for apt-get to prevent mirror desync failures

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -125,6 +125,7 @@ runs:
         retry_wait_seconds: 30
         on_retry_command: sudo apt-get clean
         command: |
+          set -euo pipefail
           sudo apt-get -o DPkg::Lock::Timeout=120 update
           sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             libpulse0 \

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -118,16 +118,19 @@ runs:
 
     - name: Install required emulator dependencies
       if: ${{ inputs.platform == 'android' && runner.os == 'Linux' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libpulse0 \
-          libglu1-mesa \
-          libnss3 \
-          libxss1
-
-        echo "✅ Linux dependencies installed successfully"
-      shell: bash
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 30
+        command: |
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+            libpulse0 \
+            libglu1-mesa \
+            libnss3 \
+            libxss1
+          echo "✅ Linux dependencies installed successfully"
 
     ## Android SDK Setup (SDK pre-installed in container)
 

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -120,9 +120,10 @@ runs:
       if: ${{ inputs.platform == 'android' && runner.os == 'Linux' }}
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
-        timeout_minutes: 5
+        timeout_minutes: 3
         max_attempts: 3
         retry_wait_seconds: 30
+        on_retry_command: sudo apt-get clean
         command: |
           sudo apt-get -o DPkg::Lock::Timeout=120 update
           sudo apt-get -o DPkg::Lock::Timeout=120 install -y \

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -20,10 +20,7 @@ jobs:
 
 
       - name: Setup GitHub CLI
-        run: |
-          sudo apt update
-          sudo apt install gh
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Create Draft Release
         run: ./scripts/create-release-draft.sh ${{ github.ref_name }} ${{ github.workspace }}


### PR DESCRIPTION
## **Description**

**Problem:** Ubuntu apt mirror desync failures account for **26% (~17 runs)** of the 64 Setup Environment CI failures on `main` over 30 days (Mar 16 – Apr 16, 2026). The failure signature is `apt-get update` failing with `File has unexpected size ... Mirror sync in progress?` when Ubuntu mirrors are mid-sync. Additionally, dpkg lock contention on Cirrus self-hosted runners caused ~2% (~1 run) of failures.

All failures are 100% transient network/infrastructure issues — zero are caused by missing packages, version conflicts, or configuration errors. See [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) for the full root cause analysis.

**Solution:**

1. **`setup-e2e-env/action.yml`** — Wrap `apt-get update` + `apt-get install` in `nick-fields/retry` (3 attempts, 30s wait, 3min timeout per attempt), matching the existing repo pattern already used 3 times in the same file. Add `-o DPkg::Lock::Timeout=120` to handle dpkg lock contention on Cirrus runners. Add `on_retry_command: sudo apt-get clean` to clear cached/corrupt package lists before each retry.

2. **`create-release-draft.yml`** — Remove unnecessary `apt update && apt install gh`. GitHub CLI (`gh`) is pre-installed on all `ubuntu-latest` runner images (v2.89.0 on both Ubuntu 22.04 and 24.04 per [actions/runner-images](https://github.com/actions/runner-images)).

**Data-backed design decisions:**
- Full "Set up E2E environment" composite action takes 99-160s (median 139s) across 15 samples from 5 recent runs. The apt step alone is ~5-15s in the happy path.
- `timeout_minutes: 3` per attempt — apt takes 5-15s normally; even with a 120s dpkg lock wait the worst case is ~135s. 3 min is 12-36x the happy path while avoiding a 5-min wait on true hangs.
- `retry_wait_seconds: 30` gives mirrors time to finish syncing (typically resolves in <60s).
- `on_retry_command: sudo apt-get clean` clears cached/corrupt package lists before each retry so `apt-get update` fetches fresh data from mirrors.
- `DPkg::Lock::Timeout=120` has zero cost when no lock contention exists (the normal case). Needed because Android E2E runs on Cirrus self-hosted runners (`ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg`) where background `unattended-upgrades` or `apt-daily` can hold the dpkg lock.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) (partial — addresses Ubuntu apt mirror desync and dpkg lock contention sub-causes)

## **Manual testing steps**

```gherkin
Feature: CI resilience for apt package installation

  Scenario: Android E2E setup completes successfully with retry logic
    Given a PR triggers Android E2E smoke tests on CI

    When the setup-e2e-env composite action runs on a Cirrus Linux runner
    Then the "Install required emulator dependencies" step uses nick-fields/retry
    And apt-get commands include DPkg::Lock::Timeout=120
    And transient apt mirror failures are retried up to 3 times with 30s wait

  Scenario: Release draft workflow no longer depends on apt
    Given a release tag triggers the create-release-draft workflow

    When the "Setup GitHub CLI" step runs
    Then it only runs gh auth login (no apt install)
    And the pre-installed gh CLI on ubuntu-latest is used directly
```

## **Screenshots/Recordings**

N/A — CI workflow changes only, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md). _(N/A — CI workflow YAML only, no application code changes)_
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable _(N/A — CI workflow configuration, validated by CI run on this PR)_
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable _(N/A — CI workflow YAML, no code)_
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main impact is altering how Android E2E Linux dependencies are installed and could affect runner setup if the retry wrapper is misconfigured.
> 
> **Overview**
> Improves Android E2E setup reliability by wrapping the Linux `apt-get update`/`install` step in `nick-fields/retry`, adding dpkg lock timeouts and cleanup on retry to better handle transient mirror/lock issues.
> 
> Simplifies `create-release-draft` by removing `apt`-based `gh` installation and only performing `gh auth login` before running the release draft script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ee232aabfacf6702b05ac2707dc5fa3017c827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->