### PR TITLE
feat(multichain): integrate malicious token detection in transaction views

### DIFF
--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -29,6 +29,8 @@ import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
+import { useMultichainActivityMaliciousTokenKeys } from '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys';
+import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../../../util/multichain/multichainTransactionTokenScan';
 
 interface MultichainTransactionsViewProps {
   /**
@@ -104,6 +106,19 @@ const MultichainTransactionsView = ({
     [transactions, nonEvmTransactions],
   );
 
+  const { maliciousTokenKeys } = useMultichainActivityMaliciousTokenKeys(
+    txList ?? [],
+  );
+
+  const visibleMultichainTransactions = useMemo(
+    () =>
+      filterMultichainTransactionsExcludingMaliciousTokenActivity(
+        txList ?? [],
+        maliciousTokenKeys,
+      ),
+    [txList, maliciousTokenKeys],
+  );
+
   const { bridgeHistoryItemsBySrcTxHash } = useBridgeHistoryItemBySrcTxHash();
 
   const [refreshing, setRefreshing] = React.useState(false);
@@ -134,7 +149,7 @@ const MultichainTransactionsView = ({
   const footer = (
     <MultichainTransactionsFooter
       url={url}
-      hasTransactions={(txList?.length ?? 0) > 0}
+      hasTransactions={(visibleMultichainTransactions?.length ?? 0) > 0}
       showDisclaimer={showDisclaimer}
       showExplorerLink={!isBitcoinNetwork}
       onViewMore={() => {
@@ -181,7 +196,8 @@ const MultichainTransactionsView = ({
         <PriceChartContext.Consumer>
           {({ isChartBeingTouched }) => (
             <FlashList
-              data={txList}
+              data={visibleMultichainTransactions}
+              extraData={maliciousTokenKeys}
               renderItem={renderTransactionItem}
               keyExtractor={(item) => item.id}
               ListHeaderComponent={header}

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -197,7 +197,6 @@ const MultichainTransactionsView = ({
           {({ isChartBeingTouched }) => (
             <FlashList
               data={visibleMultichainTransactions}
-              extraData={maliciousTokenKeys}
               renderItem={renderTransactionItem}
               keyExtractor={(item) => item.id}
               ListHeaderComponent={header}

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -174,9 +174,10 @@ const UnifiedTransactionsView = ({
     [addressBook, internalAccounts],
   );
 
-  const { data, nonEvmTransactionsForSelectedChain } = useMemo<{
-    data: UnifiedItem[];
-    nonEvmTransactionsForSelectedChain: NonEvmTransaction[];
+  const unifiedTransactionSource = useMemo<{
+    evmPendingItems: UnifiedItem[];
+    evmConfirmedItems: UnifiedItem[];
+    chainFilteredNonEvmTransactionsForSelectedChain: NonEvmTransaction[];
   }>(() => {
     // Build EVM submitted/confirmed with full filtering pipeline
     let accountAddedTimeInsertPointFound = false;
@@ -316,25 +317,20 @@ const UnifiedTransactionsView = ({
     // whose destination chain is enabled (e.g. Solana→Optimism bridge
     // should appear when viewing Optimism activity)
     const bridgeHistoryValues = Object.values(bridgeHistory ?? {});
-    const filteredNonEvmTransactionsForSelectedChain =
-      filterMultichainTransactionsExcludingMaliciousTokenActivity(
-        nonEvmTransactions
-          .filter((tx) => {
-            if (enabledNonEVMChainIds.includes(tx.chain)) return true;
-            const bridge = bridgeHistoryValues.find(
-              (item) => item.status?.srcChain?.txHash === tx.id,
-            );
-            return (
-              bridge?.quote?.destChainId !== undefined &&
-              enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
-            );
-          })
-          // deduplicate by id
-          .filter(
-            (tx, index, self) =>
-              index === self.findIndex((t) => t.id === tx.id),
-          ),
-        maliciousTokenKeys,
+    const chainFilteredNonEvmTransactionsForSelectedChain = nonEvmTransactions
+      .filter((tx) => {
+        if (enabledNonEVMChainIds.includes(tx.chain)) return true;
+        const bridge = bridgeHistoryValues.find(
+          (item) => item.status?.srcChain?.txHash === tx.id,
+        );
+        return (
+          bridge?.quote?.destChainId !== undefined &&
+          enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
+        );
+      })
+      // deduplicate by id
+      .filter(
+        (tx, index, self) => index === self.findIndex((t) => t.id === tx.id),
       );
 
     const evmPendingItems: UnifiedItem[] = evmPendingFirst.map((tx) => ({
@@ -345,14 +341,46 @@ const UnifiedTransactionsView = ({
       kind: TransactionKind.Evm,
       tx,
     }));
-    const nonEvmItems: UnifiedItem[] = (
-      filteredNonEvmTransactionsForSelectedChain ?? []
-    ).map((tx) => ({
-      kind: TransactionKind.NonEvm,
-      tx,
-    }));
 
-    // Merge confirmed by time across EVM confirmed and non-EVM
+    return {
+      evmPendingItems,
+      evmConfirmedItems,
+      chainFilteredNonEvmTransactionsForSelectedChain,
+    };
+  }, [
+    evmTransactions,
+    nonEvmTransactions,
+    selectedAccountGroupInternalAccountsAddresses,
+    enabledEVMChainIds,
+    enabledNonEVMChainIds,
+    selectedInternalAccount,
+    tokens,
+    bridgeHistory,
+    trustedAddresses,
+  ]);
+
+  const { data, nonEvmTransactionsForSelectedChain } = useMemo<{
+    data: UnifiedItem[];
+    nonEvmTransactionsForSelectedChain: NonEvmTransaction[];
+  }>(() => {
+    const {
+      evmPendingItems,
+      evmConfirmedItems,
+      chainFilteredNonEvmTransactionsForSelectedChain,
+    } = unifiedTransactionSource;
+
+    const filteredNonEvmTransactionsForSelectedChain =
+      filterMultichainTransactionsExcludingMaliciousTokenActivity(
+        chainFilteredNonEvmTransactionsForSelectedChain,
+        maliciousTokenKeys,
+      );
+
+    const nonEvmItems: UnifiedItem[] =
+      filteredNonEvmTransactionsForSelectedChain.map((tx) => ({
+        kind: TransactionKind.NonEvm,
+        tx,
+      }));
+
     const confirmedUnified = [...evmConfirmedItems, ...nonEvmItems].sort(
       (a, b) => {
         const ta =
@@ -372,18 +400,7 @@ const UnifiedTransactionsView = ({
       nonEvmTransactionsForSelectedChain:
         filteredNonEvmTransactionsForSelectedChain,
     };
-  }, [
-    evmTransactions,
-    nonEvmTransactions,
-    maliciousTokenKeys,
-    selectedAccountGroupInternalAccountsAddresses,
-    enabledEVMChainIds,
-    enabledNonEVMChainIds,
-    selectedInternalAccount,
-    tokens,
-    bridgeHistory,
-    trustedAddresses,
-  ]);
+  }, [unifiedTransactionSource, maliciousTokenKeys]);
 
   const hasEvmChainsEnabled = enabledEVMChainIds.length > 0;
   const popularListBlockExplorer = useBlockExplorer(

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -62,6 +62,8 @@ import useBlockExplorer from '../../hooks/useBlockExplorer';
 import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 import { TabEmptyState } from '../../../component-library/components-temp/TabEmptyState';
 import { UnifiedTransactionsViewSelectorsIDs } from './UnifiedTransactionsView.testIds';
+import { useMultichainActivityMaliciousTokenKeys } from '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys';
+import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../../../util/multichain/multichainTransactionTokenScan';
 
 type SmartTransactionWithId = SmartTransaction & { id: string };
 type EvmTransaction = TransactionMeta | SmartTransactionWithId;
@@ -150,6 +152,10 @@ const UnifiedTransactionsView = ({
     () => enabledNonEVMNetworks ?? [],
     [enabledNonEVMNetworks],
   );
+
+  const { maliciousTokenKeys } =
+    useMultichainActivityMaliciousTokenKeys(nonEvmTransactions);
+
   const providerType = useSelector(selectProviderType);
   const evmNetworkConfigurationsByChainId = useSelector(
     selectEvmNetworkConfigurationsByChainId,
@@ -310,20 +316,25 @@ const UnifiedTransactionsView = ({
     // whose destination chain is enabled (e.g. Solana→Optimism bridge
     // should appear when viewing Optimism activity)
     const bridgeHistoryValues = Object.values(bridgeHistory ?? {});
-    const filteredNonEvmTransactionsForSelectedChain = nonEvmTransactions
-      .filter((tx) => {
-        if (enabledNonEVMChainIds.includes(tx.chain)) return true;
-        const bridge = bridgeHistoryValues.find(
-          (item) => item.status?.srcChain?.txHash === tx.id,
-        );
-        return (
-          bridge?.quote?.destChainId !== undefined &&
-          enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
-        );
-      })
-      // deduplicate by id
-      .filter(
-        (tx, index, self) => index === self.findIndex((t) => t.id === tx.id),
+    const filteredNonEvmTransactionsForSelectedChain =
+      filterMultichainTransactionsExcludingMaliciousTokenActivity(
+        nonEvmTransactions
+          .filter((tx) => {
+            if (enabledNonEVMChainIds.includes(tx.chain)) return true;
+            const bridge = bridgeHistoryValues.find(
+              (item) => item.status?.srcChain?.txHash === tx.id,
+            );
+            return (
+              bridge?.quote?.destChainId !== undefined &&
+              enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
+            );
+          })
+          // deduplicate by id
+          .filter(
+            (tx, index, self) =>
+              index === self.findIndex((t) => t.id === tx.id),
+          ),
+        maliciousTokenKeys,
       );
 
     const evmPendingItems: UnifiedItem[] = evmPendingFirst.map((tx) => ({
@@ -364,6 +375,7 @@ const UnifiedTransactionsView = ({
   }, [
     evmTransactions,
     nonEvmTransactions,
+    maliciousTokenKeys,
     selectedAccountGroupInternalAccountsAddresses,
     enabledEVMChainIds,
     enabledNonEVMChainIds,
@@ -658,6 +670,7 @@ const UnifiedTransactionsView = ({
             <FlashList
               ref={listRef}
               data={data}
+              extraData={maliciousTokenKeys}
               testID={UnifiedTransactionsViewSelectorsIDs.CONTAINER}
               renderItem={renderItem}
               keyExtractor={(listItem) =>

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -687,7 +687,6 @@ const UnifiedTransactionsView = ({
             <FlashList
               ref={listRef}
               data={data}
-              extraData={maliciousTokenKeys}
               testID={UnifiedTransactionsViewSelectorsIDs.CONTAINER}
               renderItem={renderItem}
               keyExtractor={(listItem) =>

--- a/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.test.ts
+++ b/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.test.ts
@@ -1,0 +1,417 @@
+import type { Transaction } from '@metamask/keyring-api';
+import { TokenScanResultType } from '@metamask/phishing-controller';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import Engine from '../../../core/Engine';
+import type { MultichainTokenScanKey } from '../../../util/multichain/multichainTransactionTokenScan';
+// eslint-disable-next-line import-x/no-namespace -- jest.spyOn must patch the module namespace the hook imports
+import * as multichainTransactionTokenScan from '../../../util/multichain/multichainTransactionTokenScan';
+import { useMultichainActivityMaliciousTokenKeys } from './useMultichainActivityMaliciousTokenKeys';
+
+jest.mock('../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      PhishingController: {
+        bulkScanTokens: jest.fn().mockResolvedValue({}),
+      },
+    },
+  },
+}));
+
+const SOL_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const SPL_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+const CAIP_TOKEN = `${SOL_MAINNET}/token:${SPL_MINT}`;
+
+function makeReceiveTx(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    type: 'receive',
+    id: 'tx-1',
+    chain: SOL_MAINNET as `${string}:${string}`,
+    status: 'confirmed',
+    account: 'acc-1',
+    timestamp: 1,
+    from: [
+      {
+        address: 'Sender1111111111111111111111111111111111',
+        asset: {
+          fungible: true,
+          type: `${SOL_MAINNET}/slip44:501`,
+          unit: 'SOL',
+          amount: '0.001',
+        },
+      },
+    ],
+    to: [
+      {
+        address: 'Recv111111111111111111111111111111111111',
+        asset: {
+          fungible: true,
+          type: CAIP_TOKEN,
+          unit: 'USDT',
+          amount: '5000',
+        },
+      },
+    ],
+    events: [{ status: 'confirmed', timestamp: 1 }],
+    fees: [
+      {
+        type: 'base',
+        asset: {
+          fungible: true,
+          type: `${SOL_MAINNET}/slip44:501`,
+          unit: 'SOL',
+          amount: '0.00001',
+        },
+      },
+    ],
+    ...overrides,
+  } as Transaction;
+}
+
+function getBulkScanTokensMock(): jest.Mock {
+  return Engine.context.PhishingController.bulkScanTokens as jest.Mock;
+}
+
+describe('useMultichainActivityMaliciousTokenKeys', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const bulkScanTokens = jest.fn().mockResolvedValue({});
+    (
+      Engine.context.PhishingController as unknown as {
+        bulkScanTokens: jest.Mock;
+      }
+    ).bulkScanTokens = bulkScanTokens;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('initializes with empty malicious keys and not scanning', () => {
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([]),
+    );
+
+    expect(result.current.maliciousTokenKeys.size).toBe(0);
+    expect(result.current.isScanning).toBe(false);
+  });
+
+  it('does not scan when bulkScanTokens is unavailable', async () => {
+    (
+      Engine.context.PhishingController as unknown as {
+        bulkScanTokens: undefined;
+      }
+    ).bulkScanTokens = undefined;
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(result.current.maliciousTokenKeys.size).toBe(0);
+  });
+
+  it('does not scan when the activity fingerprint has no token keys', async () => {
+    const onlyNative = makeReceiveTx({
+      to: [
+        {
+          address: 'Recv111111111111111111111111111111111111',
+          asset: {
+            fungible: true,
+            type: `${SOL_MAINNET}/slip44:501`,
+            unit: 'SOL',
+            amount: '1',
+          },
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([onlyNative]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(getBulkScanTokensMock()).not.toHaveBeenCalled();
+  });
+
+  it('adds keys flagged Malicious by bulkScanTokens', async () => {
+    getBulkScanTokensMock().mockResolvedValue({
+      [SPL_MINT]: { result_type: TokenScanResultType.Malicious },
+    });
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.maliciousTokenKeys.has(`solana:${SPL_MINT}`)).toBe(
+        true,
+      );
+    });
+
+    expect(getBulkScanTokensMock()).toHaveBeenCalledWith({
+      chainId: 'solana',
+      tokens: [SPL_MINT],
+    });
+  });
+
+  it('replaces malicious keys when activity shifts to a different flagged token', async () => {
+    const OTHER_MINT = 'CleanMint1111111111111111111111111111';
+    const txFirst = makeReceiveTx({ id: 'first' });
+    const txSecond = makeReceiveTx({
+      id: 'second',
+      to: [
+        {
+          address: 'Recv111111111111111111111111111111111111',
+          asset: {
+            fungible: true,
+            type: `${SOL_MAINNET}/token:${OTHER_MINT}`,
+            unit: 'USDT',
+            amount: '1',
+          },
+        },
+      ],
+    });
+
+    getBulkScanTokensMock()
+      .mockResolvedValueOnce({
+        [SPL_MINT]: { result_type: TokenScanResultType.Malicious },
+      })
+      .mockResolvedValueOnce({
+        [OTHER_MINT]: { result_type: TokenScanResultType.Malicious },
+      });
+
+    const { result, rerender } = renderHook(
+      ({ txs }: { txs: Transaction[] }) =>
+        useMultichainActivityMaliciousTokenKeys(txs),
+      { initialProps: { txs: [txFirst] } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.maliciousTokenKeys.has(`solana:${SPL_MINT}`)).toBe(
+        true,
+      );
+    });
+
+    rerender({ txs: [txSecond] });
+
+    await waitFor(() => {
+      expect(
+        result.current.maliciousTokenKeys.has(`solana:${OTHER_MINT}`),
+      ).toBe(true);
+    });
+
+    expect(result.current.maliciousTokenKeys.has(`solana:${SPL_MINT}`)).toBe(
+      false,
+    );
+  });
+
+  it('ignores non-Malicious scan results', async () => {
+    getBulkScanTokensMock().mockResolvedValue({
+      [SPL_MINT]: { result_type: TokenScanResultType.Warning },
+    });
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(result.current.maliciousTokenKeys.size).toBe(0);
+  });
+
+  it('sets isScanning while a batch is pending', async () => {
+    let resolveBatch: (value: Record<string, unknown>) => void = () =>
+      undefined;
+    getBulkScanTokensMock().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBatch = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(true);
+    });
+
+    await act(async () => {
+      resolveBatch({});
+    });
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+  });
+
+  it('clears malicious keys when bulkScanTokens rejects', async () => {
+    getBulkScanTokensMock().mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(result.current.maliciousTokenKeys.size).toBe(0);
+  });
+
+  it('requests bulkScanTokens in batches of 100 addresses per namespace', async () => {
+    const addrs = Array.from(
+      { length: 101 },
+      (_, i) => `Mint${i.toString().padStart(39, '0')}`,
+    );
+    const keys101 = addrs.map(
+      (addr) => `solana:${addr}` as MultichainTokenScanKey,
+    );
+
+    const collectSpy = jest
+      .spyOn(
+        multichainTransactionTokenScan,
+        'collectMultichainTransactionTokenScanKeys',
+      )
+      .mockReturnValue(keys101);
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(getBulkScanTokensMock()).toHaveBeenCalledTimes(2);
+    expect(getBulkScanTokensMock().mock.calls[0]?.[0]).toEqual({
+      chainId: 'solana',
+      tokens: addrs.slice(0, 100),
+    });
+    expect(getBulkScanTokensMock().mock.calls[1]?.[0]).toEqual({
+      chainId: 'solana',
+      tokens: addrs.slice(100, 101),
+    });
+
+    collectSpy.mockRestore();
+  });
+
+  it('skips malformed scan keys when batching namespaces', async () => {
+    const collectSpy = jest
+      .spyOn(
+        multichainTransactionTokenScan,
+        'collectMultichainTransactionTokenScanKeys',
+      )
+      .mockReturnValue([
+        'not-a-valid-colon-pattern',
+        'solonly:',
+        ':onlyaddr',
+        `solana:${SPL_MINT}`,
+      ] as MultichainTokenScanKey[]);
+
+    getBulkScanTokensMock().mockResolvedValue({
+      [SPL_MINT]: { result_type: TokenScanResultType.Malicious },
+    });
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.maliciousTokenKeys.has(`solana:${SPL_MINT}`)).toBe(
+        true,
+      );
+    });
+
+    expect(getBulkScanTokensMock()).toHaveBeenCalledWith({
+      chainId: 'solana',
+      tokens: [SPL_MINT],
+    });
+
+    collectSpy.mockRestore();
+  });
+
+  it('does not apply malicious results after unmount mid-scan', async () => {
+    let resolveBatch: (value: Record<string, unknown>) => void = () =>
+      undefined;
+    getBulkScanTokensMock().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBatch = resolve;
+        }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(true);
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveBatch({
+        [SPL_MINT]: { result_type: TokenScanResultType.Malicious },
+      });
+    });
+  });
+
+  it('uses nullish coalescing when bulkScanTokens returns undefined results', async () => {
+    getBulkScanTokensMock().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScanning).toBe(false);
+    });
+
+    expect(result.current.maliciousTokenKeys.size).toBe(0);
+  });
+
+  it('warns when Engine.context throws before the scan try block runs', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const engine = Engine as { context: object };
+    const savedContext = engine.context;
+
+    Object.defineProperty(engine, 'context', {
+      configurable: true,
+      get() {
+        throw new Error('ctx');
+      },
+    });
+
+    renderHook(() =>
+      useMultichainActivityMaliciousTokenKeys([makeReceiveTx()]),
+    );
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Multichain activity token scan failed:',
+        expect.any(Error),
+      );
+    });
+
+    Object.defineProperty(engine, 'context', {
+      configurable: true,
+      writable: true,
+      enumerable: true,
+      value: savedContext,
+    });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
+++ b/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
@@ -56,28 +56,30 @@ export function useMultichainActivityMaliciousTokenKeys(
         return;
       }
 
-      setIsScanning(true);
-
-      const byNamespace: Record<string, Set<string>> = {};
-      for (const tx of transactionsRef.current) {
-        for (const key of collectMultichainTransactionTokenScanKeys(tx)) {
-          const sep = key.indexOf(':');
-          if (sep <= 0) {
-            continue;
-          }
-          const ns = key.slice(0, sep);
-          const addr = key.slice(sep + 1);
-          if (!addr) {
-            continue;
-          }
-          byNamespace[ns] ??= new Set();
-          byNamespace[ns].add(addr);
-        }
+      if (!cancelled) {
+        setIsScanning(true);
       }
 
-      const malicious = new Set<MultichainTokenScanKey>();
-
       try {
+        const byNamespace: Record<string, Set<string>> = {};
+        for (const tx of transactionsRef.current) {
+          for (const key of collectMultichainTransactionTokenScanKeys(tx)) {
+            const sep = key.indexOf(':');
+            if (sep <= 0) {
+              continue;
+            }
+            const ns = key.slice(0, sep);
+            const addr = key.slice(sep + 1);
+            if (!addr) {
+              continue;
+            }
+            byNamespace[ns] ??= new Set();
+            byNamespace[ns].add(addr);
+          }
+        }
+
+        const malicious = new Set<MultichainTokenScanKey>();
+
         for (const [chainNamespace, addresses] of Object.entries(byNamespace)) {
           const list = [...addresses];
           for (let i = 0; i < list.length; i += BATCH_SIZE) {
@@ -98,15 +100,28 @@ export function useMultichainActivityMaliciousTokenKeys(
             }
           }
         }
-      } finally {
-        setIsScanning(false);
+
         if (!cancelled) {
           setMaliciousTokenKeys(malicious);
+        }
+      } catch {
+        if (!cancelled) {
+          setMaliciousTokenKeys(new Set());
+        }
+      } finally {
+        if (!cancelled) {
+          setIsScanning(false);
         }
       }
     };
 
-    run();
+    run().catch((error: unknown) => {
+      if (!cancelled) {
+        setMaliciousTokenKeys(new Set());
+        setIsScanning(false);
+      }
+      console.warn('Multichain activity token scan failed:', error);
+    });
 
     return () => {
       cancelled = true;

--- a/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
+++ b/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
@@ -10,6 +10,24 @@ import {
 
 const BATCH_SIZE = 100;
 
+/** Stable empty set so `Object.is` can skip redundant state updates when scan result is still “no malicious keys”. */
+const EMPTY_MALICIOUS_TOKEN_KEYS = new Set<MultichainTokenScanKey>();
+
+function areMaliciousTokenScanKeySetsEqual(
+  a: Set<MultichainTokenScanKey>,
+  b: Set<MultichainTokenScanKey>,
+): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const key of a) {
+    if (!b.has(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Scans fungible token mints appearing in multichain activity using the same
  * {@link PhishingController.bulkScanTokens} path as {@link MultichainAssetsController}
@@ -31,7 +49,7 @@ export function useMultichainActivityMaliciousTokenKeys(
 
   const [maliciousTokenKeys, setMaliciousTokenKeys] = useState<
     Set<MultichainTokenScanKey>
-  >(() => new Set());
+  >(() => EMPTY_MALICIOUS_TOKEN_KEYS);
   const [isScanning, setIsScanning] = useState(false);
 
   useEffect(() => {
@@ -42,7 +60,9 @@ export function useMultichainActivityMaliciousTokenKeys(
 
       if (!phishing?.bulkScanTokens) {
         if (!cancelled) {
-          setMaliciousTokenKeys(new Set());
+          setMaliciousTokenKeys((prev) =>
+            prev.size === 0 ? prev : EMPTY_MALICIOUS_TOKEN_KEYS,
+          );
           setIsScanning(false);
         }
         return;
@@ -50,7 +70,9 @@ export function useMultichainActivityMaliciousTokenKeys(
 
       if (fingerprint.length === 0) {
         if (!cancelled) {
-          setMaliciousTokenKeys(new Set());
+          setMaliciousTokenKeys((prev) =>
+            prev.size === 0 ? prev : EMPTY_MALICIOUS_TOKEN_KEYS,
+          );
           setIsScanning(false);
         }
         return;
@@ -102,11 +124,20 @@ export function useMultichainActivityMaliciousTokenKeys(
         }
 
         if (!cancelled) {
-          setMaliciousTokenKeys(malicious);
+          setMaliciousTokenKeys((prev) => {
+            if (areMaliciousTokenScanKeySetsEqual(prev, malicious)) {
+              return prev;
+            }
+            return malicious.size === 0
+              ? EMPTY_MALICIOUS_TOKEN_KEYS
+              : malicious;
+          });
         }
       } catch {
         if (!cancelled) {
-          setMaliciousTokenKeys(new Set());
+          setMaliciousTokenKeys((prev) =>
+            prev.size === 0 ? prev : EMPTY_MALICIOUS_TOKEN_KEYS,
+          );
         }
       } finally {
         if (!cancelled) {
@@ -117,7 +148,9 @@ export function useMultichainActivityMaliciousTokenKeys(
 
     run().catch((error: unknown) => {
       if (!cancelled) {
-        setMaliciousTokenKeys(new Set());
+        setMaliciousTokenKeys((prev) =>
+          prev.size === 0 ? prev : EMPTY_MALICIOUS_TOKEN_KEYS,
+        );
         setIsScanning(false);
       }
       console.warn('Multichain activity token scan failed:', error);

--- a/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
+++ b/app/components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Transaction } from '@metamask/keyring-api';
+import { TokenScanResultType } from '@metamask/phishing-controller';
+import Engine from '../../../core/Engine';
+import {
+  buildMultichainActivityTokenScanFingerprint,
+  collectMultichainTransactionTokenScanKeys,
+  type MultichainTokenScanKey,
+} from '../../../util/multichain/multichainTransactionTokenScan';
+
+const BATCH_SIZE = 100;
+
+/**
+ * Scans fungible token mints appearing in multichain activity using the same
+ * {@link PhishingController.bulkScanTokens} path as {@link MultichainAssetsController}
+ * (Malicious-only, fail-open on errors).
+ */
+export function useMultichainActivityMaliciousTokenKeys(
+  transactions: Transaction[],
+): {
+  maliciousTokenKeys: Set<MultichainTokenScanKey>;
+  isScanning: boolean;
+} {
+  const transactionsRef = useRef(transactions);
+  transactionsRef.current = transactions;
+
+  const fingerprint = useMemo(
+    () => buildMultichainActivityTokenScanFingerprint(transactions),
+    [transactions],
+  );
+
+  const [maliciousTokenKeys, setMaliciousTokenKeys] = useState<
+    Set<MultichainTokenScanKey>
+  >(() => new Set());
+  const [isScanning, setIsScanning] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      const phishing = Engine.context.PhishingController;
+
+      if (!phishing?.bulkScanTokens) {
+        if (!cancelled) {
+          setMaliciousTokenKeys(new Set());
+          setIsScanning(false);
+        }
+        return;
+      }
+
+      if (fingerprint.length === 0) {
+        if (!cancelled) {
+          setMaliciousTokenKeys(new Set());
+          setIsScanning(false);
+        }
+        return;
+      }
+
+      setIsScanning(true);
+
+      const byNamespace: Record<string, Set<string>> = {};
+      for (const tx of transactionsRef.current) {
+        for (const key of collectMultichainTransactionTokenScanKeys(tx)) {
+          const sep = key.indexOf(':');
+          if (sep <= 0) {
+            continue;
+          }
+          const ns = key.slice(0, sep);
+          const addr = key.slice(sep + 1);
+          if (!addr) {
+            continue;
+          }
+          byNamespace[ns] ??= new Set();
+          byNamespace[ns].add(addr);
+        }
+      }
+
+      const malicious = new Set<MultichainTokenScanKey>();
+
+      try {
+        for (const [chainNamespace, addresses] of Object.entries(byNamespace)) {
+          const list = [...addresses];
+          for (let i = 0; i < list.length; i += BATCH_SIZE) {
+            const batch = list.slice(i, i + BATCH_SIZE);
+            const results = await phishing.bulkScanTokens({
+              chainId: chainNamespace,
+              tokens: batch,
+            });
+            if (cancelled) {
+              return;
+            }
+            for (const [address, result] of Object.entries(results ?? {})) {
+              if (result?.result_type === TokenScanResultType.Malicious) {
+                malicious.add(
+                  `${chainNamespace}:${address}` as MultichainTokenScanKey,
+                );
+              }
+            }
+          }
+        }
+      } finally {
+        setIsScanning(false);
+        if (!cancelled) {
+          setMaliciousTokenKeys(malicious);
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fingerprint]);
+
+  return { maliciousTokenKeys, isScanning };
+}

--- a/app/util/multichain/multichainTransactionTokenScan.test.ts
+++ b/app/util/multichain/multichainTransactionTokenScan.test.ts
@@ -1,0 +1,131 @@
+import type { Transaction } from '@metamask/keyring-api';
+import {
+  buildMultichainActivityTokenScanFingerprint,
+  collectMultichainTransactionTokenScanKeys,
+  filterMultichainTransactionsExcludingMaliciousTokenActivity,
+  multichainTransactionInvolvesMaliciousTokenKey,
+  type MultichainTokenScanKey,
+} from './multichainTransactionTokenScan';
+
+const SOL_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const SPL_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+const CAIP_TOKEN = `${SOL_MAINNET}/token:${SPL_MINT}`;
+
+function makeReceiveTx(): Transaction {
+  return {
+    type: 'receive',
+    id: 'tx-1',
+    chain: SOL_MAINNET as `${string}:${string}`,
+    status: 'confirmed',
+    account: 'acc-1',
+    timestamp: 1,
+    from: [
+      {
+        address: 'Sender1111111111111111111111111111111111',
+        asset: {
+          fungible: true,
+          type: `${SOL_MAINNET}/slip44:501`,
+          unit: 'SOL',
+          amount: '0.001',
+        },
+      },
+    ],
+    to: [
+      {
+        address: 'Recv111111111111111111111111111111111111',
+        asset: {
+          fungible: true,
+          type: CAIP_TOKEN,
+          unit: 'USDT',
+          amount: '5000',
+        },
+      },
+    ],
+    events: [{ status: 'confirmed', timestamp: 1 }],
+    fees: [
+      {
+        type: 'base',
+        asset: {
+          fungible: true,
+          type: `${SOL_MAINNET}/slip44:501`,
+          unit: 'SOL',
+          amount: '0.00001',
+        },
+      },
+    ],
+  } as Transaction;
+}
+
+describe('multichainTransactionTokenScan', () => {
+  it('collectMultichainTransactionTokenScanKeys returns only token namespace assets', () => {
+    const keys = collectMultichainTransactionTokenScanKeys(makeReceiveTx());
+    expect(keys).toEqual([`solana:${SPL_MINT}`]);
+  });
+
+  it('multichainTransactionInvolvesMaliciousTokenKey matches scan keys', () => {
+    const tx = makeReceiveTx();
+    const malicious = new Set<MultichainTokenScanKey>([
+      `solana:${SPL_MINT}` as MultichainTokenScanKey,
+    ]);
+    expect(multichainTransactionInvolvesMaliciousTokenKey(tx, malicious)).toBe(
+      true,
+    );
+    expect(multichainTransactionInvolvesMaliciousTokenKey(tx, new Set())).toBe(
+      false,
+    );
+    expect(
+      multichainTransactionInvolvesMaliciousTokenKey(
+        tx,
+        new Set([`solana:OtherMint111111111111111111111111111`]),
+      ),
+    ).toBe(false);
+  });
+
+  it('buildMultichainActivityTokenScanFingerprint is order-stable', () => {
+    const a = buildMultichainActivityTokenScanFingerprint([
+      makeReceiveTx(),
+      makeReceiveTx(),
+    ]);
+    const b = buildMultichainActivityTokenScanFingerprint([makeReceiveTx()]);
+    expect(a).toBe(b);
+  });
+
+  it('filterMultichainTransactionsExcludingMaliciousTokenActivity is a noop when malicious set is empty', () => {
+    const txs = [makeReceiveTx(), { ...makeReceiveTx(), id: 'tx-2' }];
+    expect(
+      filterMultichainTransactionsExcludingMaliciousTokenActivity(
+        txs,
+        new Set(),
+      ),
+    ).toEqual(txs);
+  });
+
+  it('filterMultichainTransactionsExcludingMaliciousTokenActivity removes txs involving malicious keys', () => {
+    const bad = makeReceiveTx();
+    const base = makeReceiveTx();
+    const good: Transaction = {
+      ...base,
+      id: 'tx-clean',
+      to: [
+        {
+          address: base.to[0]?.address ?? '',
+          asset: {
+            fungible: true,
+            type: `${SOL_MAINNET}/token:CleanMint1111111111111111111111111111`,
+            unit: 'USDT',
+            amount: '1',
+          },
+        },
+      ],
+    };
+    const malicious = new Set<MultichainTokenScanKey>([
+      `solana:${SPL_MINT}` as MultichainTokenScanKey,
+    ]);
+    expect(
+      filterMultichainTransactionsExcludingMaliciousTokenActivity(
+        [bad, good],
+        malicious,
+      ),
+    ).toEqual([good]);
+  });
+});

--- a/app/util/multichain/multichainTransactionTokenScan.ts
+++ b/app/util/multichain/multichainTransactionTokenScan.ts
@@ -1,0 +1,110 @@
+import type { Transaction } from '@metamask/keyring-api';
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+
+/** Stable key: `{chain.namespace}:{assetReference}` for fungible token CAIP assets (matches PhishingController bulk scan grouping). */
+export type MultichainTokenScanKey = `${string}:${string}`;
+
+function tryParseTokenScanKey(
+  assetType: string,
+): MultichainTokenScanKey | null {
+  if (!isCaipAssetType(assetType)) {
+    return null;
+  }
+  const parsed = parseCaipAssetType(assetType);
+  if (parsed.assetNamespace !== 'token') {
+    return null;
+  }
+  return `${parsed.chain.namespace}:${parsed.assetReference}`;
+}
+
+function collectTokenScanKeysFromMovements(
+  movements: {
+    asset:
+      | {
+          fungible: true;
+          type: string;
+        }
+      | {
+          fungible: false;
+          id: string;
+        }
+      | null;
+  }[],
+  into: Set<MultichainTokenScanKey>,
+) {
+  for (const movement of movements) {
+    const asset = movement?.asset;
+    if (!asset || !('fungible' in asset) || !asset.fungible) {
+      continue;
+    }
+    const key = tryParseTokenScanKey(asset.type);
+    if (key) {
+      into.add(key);
+    }
+  }
+}
+
+/**
+ * Collects unique token scan keys from a multichain {@link Transaction} (from / to / fees).
+ * Only CAIP `token:` fungible assets are included — same set MultichainAssetsController sends to Blockaid.
+ */
+export function collectMultichainTransactionTokenScanKeys(
+  transaction: Transaction,
+): MultichainTokenScanKey[] {
+  const keys = new Set<MultichainTokenScanKey>();
+  collectTokenScanKeysFromMovements(transaction.from ?? [], keys);
+  collectTokenScanKeysFromMovements(transaction.to ?? [], keys);
+  for (const fee of transaction.fees ?? []) {
+    collectTokenScanKeysFromMovements([fee], keys);
+  }
+  return [...keys];
+}
+
+/**
+ * Returns true if any fungible token movement in the transaction matches a malicious scan key.
+ */
+export function multichainTransactionInvolvesMaliciousTokenKey(
+  transaction: Transaction,
+  maliciousKeys: Set<MultichainTokenScanKey>,
+): boolean {
+  if (maliciousKeys.size === 0) {
+    return false;
+  }
+  for (const key of collectMultichainTransactionTokenScanKeys(transaction)) {
+    if (maliciousKeys.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Drops multichain activity rows that involve a Blockaid-malicious fungible token
+ * (same Malicious signal as {@link MultichainAssetsController} uses for the token list).
+ * When {@link maliciousKeys} is empty, returns the list unchanged (fail-open until scan results exist).
+ */
+export function filterMultichainTransactionsExcludingMaliciousTokenActivity<
+  T extends Transaction,
+>(transactions: readonly T[], maliciousKeys: Set<MultichainTokenScanKey>): T[] {
+  if (maliciousKeys.size === 0) {
+    return [...transactions];
+  }
+  return transactions.filter(
+    (tx) => !multichainTransactionInvolvesMaliciousTokenKey(tx, maliciousKeys),
+  );
+}
+
+/**
+ * Builds a stable fingerprint of all scannable token keys across transactions (for effect deps).
+ */
+export function buildMultichainActivityTokenScanFingerprint(
+  transactions: Transaction[],
+): string {
+  const all = new Set<MultichainTokenScanKey>();
+  for (const tx of transactions) {
+    for (const key of collectMultichainTransactionTokenScanKeys(tx)) {
+      all.add(key);
+    }
+  }
+  return [...all].sort().join('\u0000');
+}

--- a/app/util/multichain/multichainTransactionTokenScan.ts
+++ b/app/util/multichain/multichainTransactionTokenScan.ts
@@ -106,5 +106,5 @@ export function buildMultichainActivityTokenScanFingerprint(
       all.add(key);
     }
   }
-  return [...all].sort().join('\u0000');
+  return [...all].sort((a, b) => a.localeCompare(b)).join('\u0000');
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fake or spam SPL receipts can show up in multichain Activity even when the same mint is treated as malicious elsewhere (e.g. token list / assets path via `PhishingController.bulkScanTokens`). That misleads users into thinking they received spendable value.

This change **hides** non‑EVM activity rows whose `from` / `to` / `fees` movements include a fungible CAIP `token:` asset that **bulkScanTokens** marks as **Malicious**, matching the same signal used for asset overview suppression. Until scan results exist, the list stays **fail‑open** (nothing filtered). `FlashList` uses **`extraData={maliciousTokenKeys}`** so rows update when the async scan completes.

Implementation highlights:

- **`multichainTransactionTokenScan.ts`** — collect `token:` scan keys per transaction, detect involvement, **`filterMultichainTransactionsExcludingMaliciousTokenActivity`**.
- **`useMultichainActivityMaliciousTokenKeys`** — batches `bulkScanTokens` by chain namespace; fingerprinted effect deps.
- **`UnifiedTransactionsView`** — applies filter after existing non‑EVM chain/bridge/dedupe logic.
- **`MultichainTransactionsView`** — filters the list passed to `FlashList` and the footer “has transactions” check.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Hid multichain Activity entries that involve tokens flagged as malicious by security scanning, consistent with how malicious tokens are handled on the assets overview.

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Filter malicious-token multichain activity

  Scenario: Malicious SPL activity disappears after scan (unified Activity)
    Given a wallet with Solana activity that includes a receive involving a mint known to be Malicious in bulkScanTokens
    When the user opens the unified Activity tab and waits for the list to settle
    Then the row for that transaction is not shown
    And other legitimate multichain rows still appear

  Scenario: Malicious SPL activity disappears after scan (per-chain multichain view)
    Given the same wallet on a screen that uses MultichainTransactionsView for Solana
    When the transaction list loads and the token scan completes
    Then rows involving only that malicious fungible token movement are not shown
    And the footer reflects whether any visible rows remain

  Scenario: No token movements to scan
    Given activity with only native asset movements (no CAIP token: fungible legs)
    When the user views Activity
    Then the list behaves as before with no filtering side effects
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes transaction list rendering by asynchronously scanning token mints via `PhishingController.bulkScanTokens` and filtering results, which could hide legitimate non‑EVM activity if key parsing/batching or scan responses behave unexpectedly.
> 
> **Overview**
> Adds malicious-token suppression to multichain activity views by scanning fungible CAIP `token:` movements and filtering any transactions involving mints marked `Malicious` by `PhishingController.bulkScanTokens` (fail-open until results are available).
> 
> Introduces `useMultichainActivityMaliciousTokenKeys` (batched per chain namespace, cancellation-safe) and a `multichainTransactionTokenScan` util to collect token scan keys, build a stable fingerprint, and filter transactions; `UnifiedTransactionsView` and `MultichainTransactionsView` now render and compute footers from the filtered non‑EVM transaction set, with new unit tests covering scan behavior and filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61b9eff90a0d2b6fd7872accf873ba8b6510780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->