### PR TITLE
fix(perps): address bugbot findings on core sync

### DIFF
--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
@@ -24,9 +24,7 @@ import {
   type RawLedgerUpdate,
   type OrderParams,
   type AssetPosition,
-  type SpotBalance,
   type ClearinghouseStateResponse,
-  type SpotClearinghouseStateResponse,
   type PerpsUniverse,
   type FrontendOrder,
 } from '@metamask/perps-controller';
@@ -1082,89 +1080,6 @@ describe('hyperLiquidAdapter', () => {
         unrealizedPnl: '24.5', // 50.0 + (-25.5)
         returnOnEquity: '7.991673605328893', // Calculated from weighted return and margin
         totalBalance: '1000.5', // Perps only (no spot balance provided)
-      });
-    });
-
-    it('should convert account state with spot and perps', () => {
-      const perpsState: ClearinghouseStateResponse = {
-        crossMarginSummary: {
-          accountValue: '500.0',
-          totalMarginUsed: '150.0',
-          totalNtlPos: '500.0',
-          totalRawUsd: '500.0',
-        },
-        marginSummary: {
-          accountValue: '500.0',
-          totalNtlPos: '500.0',
-          totalRawUsd: '500.0',
-          totalMarginUsed: '150.0',
-        },
-        crossMaintenanceMarginUsed: '50.0',
-        time: Date.now(),
-        withdrawable: '350.0',
-        assetPositions: [
-          {
-            position: { unrealizedPnl: '100.0' },
-            type: 'perp',
-          } as unknown as AssetPosition,
-        ],
-      };
-
-      const spotState: SpotClearinghouseStateResponse = {
-        balances: [
-          { total: '200.0' },
-          { total: '300.5' },
-        ] as unknown as SpotBalance[],
-      };
-
-      const result = adaptAccountStateFromSDK(perpsState, spotState);
-
-      expect(result).toEqual({
-        availableBalance: '350.0',
-        availableToTradeBalance: '850.5', // withdrawable 350 + free spot 500.5 (hold = 0)
-        marginUsed: '150.0',
-        unrealizedPnl: '100',
-        returnOnEquity: '0',
-        totalBalance: '1000.5',
-      });
-    });
-
-    it('should handle missing spot balances', () => {
-      const perpsState: ClearinghouseStateResponse = {
-        crossMarginSummary: {
-          accountValue: '1000.0',
-          totalMarginUsed: '200.0',
-          totalNtlPos: '1000.0',
-          totalRawUsd: '1000.0',
-        },
-        marginSummary: {
-          accountValue: '1000.0',
-          totalNtlPos: '1000.0',
-          totalRawUsd: '1000.0',
-          totalMarginUsed: '200.0',
-        },
-        crossMaintenanceMarginUsed: '80.0',
-        time: Date.now(),
-        withdrawable: '800.0',
-        assetPositions: [],
-      };
-
-      const spotState: SpotClearinghouseStateResponse = {
-        balances: [
-          { total: undefined },
-          {} as SpotBalance, // no total field
-        ] as unknown as SpotBalance[],
-      };
-
-      const result = adaptAccountStateFromSDK(perpsState, spotState);
-
-      expect(result).toEqual({
-        availableBalance: '800.0',
-        availableToTradeBalance: '800', // withdrawable + 0 (no spot totals)
-        marginUsed: '200.0',
-        unrealizedPnl: '0',
-        returnOnEquity: '0',
-        totalBalance: '1000',
       });
     });
 

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1144,7 +1144,10 @@ export class HyperLiquidSubscriptionService {
             // its result instead of overwriting this fresher WS snapshot.
             this.#spotStateGeneration += 1;
             this.#cachedSpotState = event.spotState;
-            this.#cachedSpotStateUserAddress = event.user;
+            // Normalize to match REST path (stores lowercase) so the
+            // #ensureSpotState strict-equal check hits the cache regardless
+            // of whether HL returns a checksummed or lowercase user field.
+            this.#cachedSpotStateUserAddress = event.user.toLowerCase();
 
             if (this.#dexAccountCache.size > 0) {
               this.#aggregateAndNotifySubscribers();
@@ -1595,7 +1598,6 @@ export class HyperLiquidSubscriptionService {
               // Extract account data (webData2 provides clearinghouseState)
               const accountState: AccountState = adaptAccountStateFromSDK(
                 data.clearinghouseState,
-                undefined, // webData2 doesn't include spotState
               );
 
               // Store in caches (main DEX only)
@@ -1800,7 +1802,6 @@ export class HyperLiquidSubscriptionService {
             // Update account state
             const accountState: AccountState = adaptAccountStateFromSDK(
               data.clearinghouseState,
-              undefined,
             );
 
             // Update caches

--- a/app/controllers/perps/utils/hyperLiquidAdapter.ts
+++ b/app/controllers/perps/utils/hyperLiquidAdapter.ts
@@ -19,7 +19,6 @@ import type {
   AssetPosition,
   FrontendOrder,
   ClearinghouseStateResponse,
-  SpotClearinghouseStateResponse,
   MetaResponse,
   SDKOrderParams,
 } from '../types/hyperliquid-types';
@@ -255,9 +254,12 @@ export function adaptMarketFromSDK(
   };
 }
 
+// Perps-only account adapter. Spot balances are layered on afterwards by
+// addSpotBalanceToAccountState, which enforces the USDC-only policy via
+// SPOT_COLLATERAL_COINS. Keeping spot logic out of here preserves a single
+// source of truth for spot balance math.
 export function adaptAccountStateFromSDK(
   perpsState: ClearinghouseStateResponse,
-  spotState?: SpotClearinghouseStateResponse | null,
 ): AccountState {
   const { totalUnrealizedPnl, weightedReturnOnEquity } =
     perpsState.assetPositions.reduce(
@@ -288,30 +290,10 @@ export function adaptAccountStateFromSDK(
 
   const perpsBalance = parseFloat(perpsState.marginSummary.accountValue);
 
-  let spotBalance = 0;
-  let spotHold = 0;
-  if (spotState?.balances && Array.isArray(spotState.balances)) {
-    for (const balance of spotState.balances) {
-      spotBalance += parseFloat(balance.total ?? '0');
-      spotHold += parseFloat((balance as { hold?: string }).hold ?? '0');
-    }
-  }
-
-  // Subtract spotHold to avoid double-counting margin on Unified/PM:
-  // perpsBalance already includes the margin HL surfaces as spot.hold.
-  // Standard mode has spotHold = 0. See addSpotBalanceToAccountState.
-  const totalBalance = (spotBalance + perpsBalance - spotHold).toString();
-
-  const withdrawable = parseFloat(perpsState.withdrawable || '0');
-  const freeSpot = Math.max(0, spotBalance - spotHold);
-  const availableToTradeBalance = (
-    (Number.isFinite(withdrawable) ? withdrawable : 0) + freeSpot
-  ).toString();
-
   const accountState: AccountState = {
     availableBalance: perpsState.withdrawable || '0',
-    availableToTradeBalance,
-    totalBalance: totalBalance || '0',
+    availableToTradeBalance: perpsState.withdrawable || '0',
+    totalBalance: perpsBalance.toString() || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',
     returnOnEquity: totalReturnOnEquityPercentage || '0',


### PR DESCRIPTION
## **Description**

Addresses the two bugbot findings raised on the corresponding core sync PR ([MetaMask/core#8560](https://github.com/MetaMask/core/pull/8560)). Both issues are sourced from mobile — fix here first, then re-sync to core.

### 1. Dead spot branch in `adaptAccountStateFromSDK` (Medium)

`app/controllers/perps/utils/hyperLiquidAdapter.ts` — the exported function still advertised an optional `spotState` param and ran a spot branch that sums balances across **all** spot coins. Every current caller passes a single argument only; the live path layers spot balances afterwards via `addSpotBalanceToAccountState`, which restricts spot math to **USDC only** (`SPOT_COLLATERAL_COINS`).

The dormant branch is a future-caller trap: anyone wiring `spotState` in would silently get ALL-coins behavior, diverging from the USDC-only policy enforced elsewhere. Dropped the param, the branch, and the now-orphaned import.

### 2. Spot-state address casing causes redundant REST refetches (Low)

`app/controllers/perps/services/HyperLiquidSubscriptionService.ts` line 1147 — the spot-state WS callback filters `event.user` with `.toLowerCase()` but then stores the raw `event.user` in `#cachedSpotStateUserAddress`. The strict-equal check in `#ensureSpotState` (line 1032) compares that cached value against the wallet's lowercase address, so when HyperLiquid returns a checksummed address on the WS feed the cache check always misses and a redundant REST `spotClearinghouseState` fetch is triggered per `subscribeToAccount` call (it self-heals once REST rewrites the cache, but at a per-call cost until convergence).

Normalize at the store site to match the REST path's lowercase convention.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3066](https://consensyssoftware.atlassian.net/browse/TAT-3066)
Related: [MetaMask/core#8560](https://github.com/MetaMask/core/pull/8560) — re-sync to core once this lands.

## **Manual testing steps**

```gherkin
Feature: Perps account balance aggregation (unchanged behavior)

  Scenario: Unified-mode user opens perps with spot balance
    Given the user is on the Perps Home screen with an open position
    Then availableToTradeBalance, totalBalance, marginUsed render as before the change
    And the USDC-only spot policy continues to be applied by addSpotBalanceToAccountState

  Scenario: WS spotState event arrives with a checksummed address
    Given subscribeToAccount is active
    When HyperLiquid pushes a spotState WS event with a checksummed `event.user`
    Then subsequent #ensureSpotState calls skip the REST refetch (cache hit)
    And metro.log shows no redundant `refreshSpotState` fetches between account updates
```

## **Screenshots/Recordings**

No visual change. Fix is in controller/service layer; account balance values render identically.

### **Before**

N/A — code-level behavioral fixes, no UI surface.

### **After**

N/A — code-level behavioral fixes, no UI surface.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - Obsolete spot-branch tests removed alongside the dead code. The remaining 61 tests in `hyperLiquidAdapter.test.ts` still pass.
- [x] I've documented my code using JSDoc format if applicable
  - Added a short comment above `adaptAccountStateFromSDK` explaining why spot logic is intentionally excluded.
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Fix is perf-positive (removes a redundant REST fetch) and does not introduce new Sentry surfaces.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-3066]: https://consensyssoftware.atlassian.net/browse/TAT-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core perps account-balance adaptation and spot-state caching logic; mistakes could surface as incorrect balances or unnecessary network calls, but changes are small and covered by existing call patterns/tests.
> 
> **Overview**
> Fixes two perps core-sync issues.
> 
> `adaptAccountStateFromSDK` is now **perps-only**: it drops the optional `spotState` parameter and removes the dormant spot-balance summation branch, ensuring spot math is applied exclusively via `addSpotBalanceToAccountState` (USDC-only policy) and simplifying `availableToTradeBalance`/`totalBalance` to perps values.
> 
> Spot-state WebSocket handling now lowercases `event.user` when caching `#cachedSpotStateUserAddress`, preventing cache misses that previously triggered redundant REST `spotClearinghouseState` refetches when HL returned checksummed addresses. Related unit tests that covered the removed spot branch were deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c68052ccec878922a9909ee95306252a959ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->