### PR TITLE
fix(ci): add retry logic for Foundry installation

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -230,23 +230,30 @@ runs:
         YARN_ENABLE_GLOBAL_CACHE: 'true'
 
     - name: Install Foundry
-      shell: bash
-      env:
-        FOUNDRY_VERSION: ${{ inputs.foundry-version }}
-      run: |
-        echo "Installing Foundry via foundryup..."
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      with:
+        timeout_minutes: 3
+        max_attempts: 3
+        retry_wait_seconds: 30
+        on_retry_command: |
+          FOUNDRY_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/.foundry"
+          rm -rf "$FOUNDRY_DIR"
+          echo "🧹 Cleaned up partial Foundry installation"
+        command: |
+          set -euo pipefail
+          echo "Installing Foundry via foundryup..."
 
-        export FOUNDRY_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/.foundry"
-        export FOUNDRY_BIN="$FOUNDRY_DIR/bin"
+          export FOUNDRY_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/.foundry"
+          export FOUNDRY_BIN="$FOUNDRY_DIR/bin"
 
-        mkdir -p "$FOUNDRY_BIN"
+          mkdir -p "$FOUNDRY_BIN"
 
-        curl -sL https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup -o "$FOUNDRY_BIN/foundryup"
-        chmod +x "$FOUNDRY_BIN/foundryup"
+          curl -sL https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup -o "$FOUNDRY_BIN/foundryup"
+          chmod +x "$FOUNDRY_BIN/foundryup"
 
-        echo "$FOUNDRY_BIN" >> "$GITHUB_PATH"
+          echo "$FOUNDRY_BIN" >> "$GITHUB_PATH"
 
-        "$FOUNDRY_BIN/foundryup" -i "$FOUNDRY_VERSION"
+          "$FOUNDRY_BIN/foundryup" -i "${{ inputs.foundry-version }}"
 
     ## iOS Setup ##
 


### PR DESCRIPTION
## **Description**

**Problem:** Foundry download failures account for **16% (~10 runs)** of the 64 Setup Environment CI failures on `main` over 30 days (Mar 16 – Apr 16, 2026). The failure modes include `curl: (35) Recv failure: Connection reset by peer`, corrupt tar archives, and malformed URLs. The current implementation has **zero retry logic** — a single `curl` or `foundryup` failure kills the entire step.

See [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) for the full root cause analysis.

**Solution:**

Wrap the Foundry installation step in `nick-fields/retry` (3 attempts, 30s wait, 3min timeout per attempt), matching the existing repo pattern already used for Corepack, Yarn, and CocoaPods in the same file.

**Key details:**
- `set -euo pipefail` at the top of the command block to ensure failures propagate correctly (learned from [bugbot review on PR #29236](https://github.com/MetaMask/metamask-mobile/pull/29236))
- `on_retry_command` cleans up partial/corrupt Foundry downloads (`rm -rf $FOUNDRY_DIR`) before each retry — addresses the "corrupt tar" failure mode
- `timeout_minutes: 3` per attempt — Foundry download + install typically takes seconds
- `GITHUB_PATH` modification (`echo "$FOUNDRY_BIN" >> "$GITHUB_PATH"`) works correctly inside `nick-fields/retry` since it's a file-based mechanism
- Replaced `env: FOUNDRY_VERSION` with inline `${{ inputs.foundry-version }}` expression since `uses:` steps in composite actions resolve inputs at parse time

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) (partial — addresses Foundry download failure sub-cause)

## **Manual testing steps**

```gherkin
Feature: CI resilience for Foundry installation

  Scenario: Foundry install completes successfully with retry logic
    Given a PR triggers E2E tests on CI

    When the setup-e2e-env composite action runs
    Then the "Install Foundry" step uses nick-fields/retry
    And transient curl/foundryup failures are retried up to 3 times with 30s wait
    And partial downloads are cleaned up before each retry

  Scenario: Foundry binaries are available to subsequent steps
    Given the "Install Foundry" step succeeds via nick-fields/retry

    When subsequent steps reference forge or cast
    Then the binaries are found on PATH via GITHUB_PATH
```

## **Screenshots/Recordings**

N/A — CI workflow changes only, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md). _(N/A — CI workflow YAML only, no application code changes)_
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable _(N/A — CI workflow configuration, validated by CI run on this PR)_
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable _(N/A — CI workflow YAML, no code)_
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds retries and cleanup around Foundry installation; main risk is masking persistent install issues or increasing setup time slightly on repeated failures.
> 
> **Overview**
> Improves CI resilience by wrapping the `Install Foundry` step in `.github/actions/setup-e2e-env/action.yml` with `nick-fields/retry` (3 attempts, 30s backoff, 3-minute timeout).
> 
> Each retry now *cleans up* the Foundry directory to avoid partial/corrupt installs, and the install command is hardened with `set -euo pipefail` while directly using `${{ inputs.foundry-version }}` for the requested version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959916f5e4fa6f96f5700c0d366392bbfc569e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->