### PR TITLE
feat: Support ENS v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "@metamask/earn-controller": "^12.0.0",
     "@metamask/eip-5792-middleware": "^2.0.0",
     "@metamask/eip1193-permission-middleware": "^1.0.2",
-    "@metamask/ens-resolver-snap": "^1.1.0",
+    "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^13.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^23.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,10 +8390,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ens-resolver-snap@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@metamask/ens-resolver-snap@npm:1.1.0"
-  checksum: 10/e7d636ae8934aa31e0b0ee916557e1911b37147d7a6eca74fbe3581df3652162104f190eddba6c5ae100166e79168855ac364393b57abfbc6f8bc82047d71082
+"@metamask/ens-resolver-snap@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@metamask/ens-resolver-snap@npm:1.2.0"
+  checksum: 10/abe07b3eaac4fa4daf5cf24041467183cc3d65975c77e80045e0eeb92c5bc78cd4c47c3980a35d33ed33dea92545ed3df5d7de387ee4bd7062848ccad30fd3db
   languageName: node
   linkType: hard
 
@@ -35841,7 +35841,7 @@ __metadata:
     "@metamask/earn-controller": "npm:^12.0.0"
     "@metamask/eip-5792-middleware": "npm:^2.0.0"
     "@metamask/eip1193-permission-middleware": "npm:^1.0.2"
-    "@metamask/ens-resolver-snap": "npm:^1.1.0"
+    "@metamask/ens-resolver-snap": "npm:^1.2.0"
     "@metamask/eslint-config-typescript": "npm:^13.0.0"
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^13.0.0"


### PR DESCRIPTION
## **Description**

Bump ENS Snap to the latest version which includes support for ENS v2.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for ENS v2

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a core ENS resolution dependency; behavior changes come from the upstream snap and could affect name lookups/resolution on supported networks. No in-repo logic changes beyond the dependency bump.
> 
> **Overview**
> Adds ENS v2 support by bumping `@metamask/ens-resolver-snap` from `^1.1.0` to `^1.2.0` and updating the corresponding `yarn.lock` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d612068ed18657fab33fa35b8587106873f274d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->