### PR TITLE
fix(ci): add transient network error message to yarn install retry

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -224,6 +224,7 @@ runs:
         timeout_minutes: 15
         max_attempts: 3
         retry_wait_seconds: 30
+        on_retry_command: echo "⚠️ yarn install failed — likely a transient network issue on the self-hosted runner. Retrying..."
         command: yarn install --immutable
       env:
         NODE_OPTIONS: --max-old-space-size=4096


### PR DESCRIPTION
## **Description**

**Problem:** When `yarn install --immutable` fails during E2E setup on self-hosted Cirrus runners, the CI logs don't clearly indicate the root cause. Investigation of [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) showed that the "GitHub download timeout" sub-cause (12%, ~8 runs) is already covered by existing retry logic (15min timeout, 3 attempts, 30s wait). The remaining failures are infrastructure-level network stalls where all 3 attempts fail during the same outage window.

**Investigation data:**

Examined 4 failed jobs from the ticket's date range (Mar 16 – Apr 16):

| Job ID | What timed out | Actual root cause |
|--------|----------------|-------------------|
| 71654463922 | `apt-get update` stuck on slow mirror | apt mirror desync (covered by PR #29236) |
| 71649993955 | `yarn install` during Fetch step | Yarn fetch stuck — network completely stalled >15min |
| 71646989579 | `yarn install` during Link step | Action timeout — yarn succeeded (26s) but composite action timed out |
| 71644136736 | Large file download (81% then timeout) | Generic slow network on self-hosted runner |

**Timing data (GitHub Actions API):**

Normal yarn install takes 55-96s (well within the 15min timeout):

| Period | Runner | Samples | Min | Max | Avg | Median |
|--------|--------|---------|-----|-----|-----|--------|
| Apr 16 (failure day) | Cirrus (E2E setup) | 9 | 81s | 127s | 103s | 106s |
| Apr 22-23 (recent) | Cirrus (E2E setup) | 15 | 99s | 160s | 136s | 139s |
| Apr 16 (failure day) | GitHub-hosted (CI) | 10 | 55s | 70s | 65s | 66s |
| Apr 22-23 (recent) | GitHub-hosted (CI) | 10 | 56s | 96s | 68s | 68s |

**Solution:**

Add `on_retry_command` to the existing yarn install retry step to log a clear message when retries trigger, indicating the failure is likely a transient network issue on the self-hosted runner. This helps with triage — when someone investigates a CI failure, the logs immediately show it's a known infra-level issue, not a code problem.

No timeout changes needed — 15min per attempt with 3 retries is adequate. The failures that slip through are complete network stalls that no reasonable timeout increase would fix.

**Recommendation:** When these network stall failures recur on Cirrus runners, consider raising it with Cirrus Labs. The failure pattern (complete network stall >15min on `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg` and `ghcr.io/cirruslabs/macos-runner:tahoe`) suggests an infra-level issue on their side.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3580](https://consensyssoftware.atlassian.net/browse/INFRA-3580) (partial — addresses GitHub download timeout sub-cause with observability improvement)

## **Manual testing steps**

```gherkin
Feature: CI observability for yarn install failures

  Scenario: Yarn install retry logs transient network message
    Given a PR triggers E2E tests on a Cirrus self-hosted runner

    When yarn install --immutable fails due to a network issue
    Then the retry logs show "yarn install failed — likely a transient network issue on the self-hosted runner"
    And the step retries up to 3 times with 30s wait
```

## **Screenshots/Recordings**

N/A — CI workflow changes only, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md). _(N/A — CI workflow YAML only, no application code changes)_
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable _(N/A — CI workflow configuration, validated by CI run on this PR)_
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable _(N/A — CI workflow YAML, no code)_
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-3580]: https://consensyssoftware.atlassian.net/browse/INFRA-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds an informational log message during retries without altering install commands, timeouts, or retry behavior.
> 
> **Overview**
> Improves CI observability in the `setup-e2e-env` composite action by adding an `on_retry_command` message to the existing `yarn install --immutable` retry step.
> 
> When `yarn install` retries, logs now explicitly call out likely transient self-hosted runner network issues, aiding failure triage without changing execution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cf612a6ceb759c1f4fec31a262e7236a931f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->