### PR TITLE
Add wallet connect tron

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -206,6 +206,10 @@ jest.mock('../Snaps/utils', () => ({
   handleSnapRequest: jest.fn().mockResolvedValue('snap-result'),
 }));
 
+jest.mock('../SnapKeyring/TronWalletSnap', () => ({
+  TRON_WALLET_SNAP_ID: 'npm:@metamask/tron-wallet-snap',
+}));
+
 jest.mock('../RPCMethods/lib/ethereum-chain-utils', () => ({
   findExistingNetwork: jest.fn().mockImplementation((chainId) => {
     const networkClientId = `network-client-id-${chainId}`;
@@ -1235,6 +1239,303 @@ describe('WalletConnect2Session', () => {
 
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
+    });
+
+    describe('Tron namespace', () => {
+      it('routes tron_signTransaction to Tron Snap', async () => {
+        const requestId = Math.floor(Math.random() * 1000000);
+        const request: WalletKitTypes.SessionRequest = {
+          id: requestId,
+          topic: mockSession.topic,
+          params: {
+            request: {
+              method: 'tron_signTransaction',
+              params: [
+                {
+                  address: 'TTestAddress',
+                  transaction: {
+                    raw_data_hex: '0xabc',
+                    type: 'TransferContract',
+                  },
+                },
+              ],
+            },
+            chainId: 'tron:728126428' as CaipChainId,
+          },
+          verifyContext: {
+            verified: {
+              origin: 'https://sunswap.com',
+              validation: 'UNKNOWN',
+              verifyUrl: '',
+            },
+          },
+        };
+
+        const approveRequestSpy = jest
+          .spyOn(session, 'approveRequest')
+          .mockResolvedValue(undefined);
+
+        session.setDeeplink(false);
+        (session as any).topicByRequestId[requestId] = mockSession.topic;
+        await session.handleRequest(request);
+
+        expect(
+          jest.requireMock('../Engine/Engine').default.controllerMessenger.call,
+        ).toHaveBeenCalledWith(
+          'MultichainRoutingService:handleRequest',
+          expect.objectContaining({
+            origin: 'metamask',
+            scope: 'tron:728126428',
+            request: expect.objectContaining({
+              method: 'signTransaction',
+              params: {
+                address: 'TTestAddress',
+                transaction: {
+                  rawDataHex: '0xabc',
+                  type: 'TransferContract',
+                },
+              },
+            }),
+          }),
+        );
+        expect(approveRequestSpy).toHaveBeenCalledWith({
+          id: requestId + '',
+          result: 'snap-result',
+        });
+      });
+
+      it('merges Tron signature-only Snap result into original transaction', async () => {
+        const requestId = Math.floor(Math.random() * 1000000);
+        jest
+          .requireMock('../Engine/Engine')
+          .default.controllerMessenger.call.mockResolvedValueOnce({
+            signature: '0xsignature',
+          });
+        const request: WalletKitTypes.SessionRequest = {
+          id: requestId,
+          topic: mockSession.topic,
+          params: {
+            request: {
+              method: 'tron_signTransaction',
+              params: [
+                {
+                  address: 'TTestAddress',
+                  transaction: {
+                    transaction: {
+                      raw_data_hex: '0xabc',
+                      txID: 'tx-123',
+                      visible: false,
+                    },
+                  },
+                },
+              ],
+            },
+            chainId: 'tron:728126428' as CaipChainId,
+          },
+          verifyContext: {
+            verified: {
+              origin: 'https://sunswap.com',
+              validation: 'UNKNOWN',
+              verifyUrl: '',
+            },
+          },
+        };
+
+        const approveRequestSpy = jest
+          .spyOn(session, 'approveRequest')
+          .mockResolvedValue(undefined);
+
+        session.setDeeplink(false);
+        (session as any).topicByRequestId[requestId] = mockSession.topic;
+        await session.handleRequest(request);
+
+        expect(approveRequestSpy).toHaveBeenCalledWith({
+          id: requestId + '',
+          result: {
+            raw_data_hex: '0xabc',
+            txID: 'tx-123',
+            visible: false,
+            signature: ['0xsignature'],
+          },
+        });
+      });
+
+      it('marks tron_signTransaction for redirect before routing to Snap', async () => {
+        const requestId = Math.floor(Math.random() * 1000000);
+        const request: WalletKitTypes.SessionRequest = {
+          id: requestId,
+          topic: mockSession.topic,
+          params: {
+            request: {
+              method: 'tron_signTransaction',
+              params: [],
+            },
+            chainId: 'tron:728126428' as CaipChainId,
+          },
+          verifyContext: {
+            verified: {
+              origin: 'https://sunswap.com',
+              validation: 'UNKNOWN',
+              verifyUrl: '',
+            },
+          },
+        };
+
+        jest.spyOn(session, 'approveRequest').mockResolvedValue(undefined);
+
+        session.setDeeplink(false);
+        (session as any).topicByRequestId[requestId] = mockSession.topic;
+
+        // Intercept routeToSnap to capture the redirect state at routing time
+        let redirectStateAtRouting: boolean | undefined;
+        const routeToSnapSpy = jest
+          .spyOn(session as any, 'routeToSnap')
+          .mockImplementation(async () => {
+            redirectStateAtRouting = (session as any).requestsToRedirect[
+              requestId
+            ];
+          });
+
+        await session.handleRequest(request);
+
+        expect(redirectStateAtRouting).toBe(true);
+        routeToSnapSpy.mockRestore();
+      });
+
+      it('rejects Tron Snap request and calls rejectRequest on error', async () => {
+        const requestId = Math.floor(Math.random() * 1000000);
+        const snapError = new Error('Snap rejected');
+        jest
+          .requireMock('../Engine/Engine')
+          .default.controllerMessenger.call.mockRejectedValueOnce(snapError);
+
+        const request: WalletKitTypes.SessionRequest = {
+          id: requestId,
+          topic: mockSession.topic,
+          params: {
+            request: {
+              method: 'tron_signMessage',
+              params: ['hello'],
+            },
+            chainId: 'tron:728126428' as CaipChainId,
+          },
+          verifyContext: {
+            verified: {
+              origin: 'https://sunswap.com',
+              validation: 'UNKNOWN',
+              verifyUrl: '',
+            },
+          },
+        };
+
+        const rejectRequestSpy = jest
+          .spyOn(session, 'rejectRequest')
+          .mockResolvedValue(undefined);
+
+        session.setDeeplink(false);
+        (session as any).topicByRequestId[requestId] = mockSession.topic;
+        await session.handleRequest(request);
+
+        expect(rejectRequestSpy).toHaveBeenCalledWith({
+          id: requestId + '',
+          error: snapError,
+        });
+      });
+
+      it('getAllowedChainIds returns chains from all namespaces including non-EVM', () => {
+        session.session = {
+          ...mockSession,
+          namespaces: {
+            [KnownCaipNamespace.Eip155]: {
+              chains: ['eip155:1', 'eip155:137'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+              accounts: [],
+            },
+            [KnownCaipNamespace.Tron]: {
+              chains: ['tron:728126428'],
+              methods: ['tron_signTransaction'],
+              events: [],
+              accounts: [],
+            },
+          },
+        } as any;
+
+        const chainIds = session.getAllowedChainIds;
+        expect(chainIds).toContain('eip155:1');
+        expect(chainIds).toContain('eip155:137');
+        expect(chainIds).toContain('tron:728126428');
+        expect(chainIds).toHaveLength(3);
+      });
+
+      it('normalizes missing namespace chains from account prefixes', () => {
+        const sessionWithMissingChains = {
+          ...mockSession,
+          namespaces: {
+            [KnownCaipNamespace.Tron]: {
+              methods: ['tron_signTransaction'],
+              events: [],
+              accounts: ['tron:728126428:TJ4ExampleAddress'],
+            },
+            [KnownCaipNamespace.Eip155]: {
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+              accounts: ['eip155:1:0x123'],
+            },
+          },
+        } as any;
+
+        const normalizedSession = new WalletConnect2Session({
+          web3Wallet: mockClient,
+          session: sessionWithMissingChains,
+          channelId: 'test-channel',
+          deeplink: true,
+          navigation: mockNavigation,
+        });
+
+        const chainIds = normalizedSession.getAllowedChainIds;
+        expect(chainIds).toContain('tron:728126428');
+        expect(chainIds).toContain('eip155:1');
+      });
+
+      it('merges requested optional tron chains into updated session namespaces', async () => {
+        session.session = {
+          ...mockSession,
+          optionalNamespaces: {
+            [KnownCaipNamespace.Tron]: {
+              chains: ['tron:0x94a9059e'],
+              methods: ['tron_signTransaction', 'tron_signMessage'],
+              events: [],
+            },
+          },
+          namespaces: {
+            [KnownCaipNamespace.Eip155]: {
+              chains: ['eip155:1'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged', 'accountsChanged'],
+              accounts: ['eip155:1:0x123'],
+            },
+            [KnownCaipNamespace.Tron]: {
+              chains: ['tron:728126428', 'tron:0x2b6653dc'],
+              methods: ['tron_signTransaction', 'tron_signMessage'],
+              events: [],
+              accounts: ['tron:728126428:TENH9XL11i2qyDQUEvXsYf51aY2ALnEXeG'],
+            },
+          },
+        } as any;
+
+        const mockUpdateSession = jest
+          .spyOn(mockClient, 'updateSession')
+          .mockResolvedValue({ acknowledged: () => Promise.resolve() });
+
+        await session.updateSession({ chainId: 1, accounts: ['0x123'] });
+
+        const updateCall = mockUpdateSession.mock.calls.find(
+          ([payload]) => payload?.topic === mockSession.topic,
+        )?.[0];
+        const tronChains = updateCall?.namespaces?.tron?.chains ?? [];
+        expect(tronChains).toEqual(expect.arrayContaining(['tron:0x94a9059e']));
+      });
     });
 
     it('handles eth_signTypedData_v3 correctly with valid chainId that it has permissions for', async () => {

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -911,6 +911,143 @@ describe('WC2Manager', () => {
   });
 
   describe('WC2Manager session proposal handling', () => {
+    describe('Tron namespace', () => {
+      it('injects tron namespace with chains requested in optional namespaces', async () => {
+        (
+          Engine.context.AccountsController as unknown as {
+            listAccounts: jest.Mock;
+          }
+        ).listAccounts = jest.fn().mockReturnValue([]);
+
+        const mockSessionProposal = {
+          id: 1,
+          params: {
+            id: 1,
+            pairingTopic: 'test-pairing',
+            proposer: {
+              publicKey: 'test-public-key',
+              metadata: {
+                name: 'Test App',
+                description: 'Test App',
+                url: 'https://example.com',
+                icons: ['https://example.com/icon.png'],
+              },
+            },
+            requiredNamespaces: {
+              eip155: {
+                chains: ['eip155:1'],
+                methods: ['eth_sendTransaction'],
+                events: ['chainChanged'],
+              },
+            },
+            optionalNamespaces: {
+              tron: {
+                chains: ['tron:0x94a9059e'],
+                methods: ['tron_signTransaction'],
+                events: [],
+              },
+            },
+            expiryTimestamp: 10000000,
+            relays: [{ protocol: 'irn' }],
+          },
+        };
+
+        await manager.onSessionProposal(mockSessionProposal as any);
+
+        expect(mockApproveSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            namespaces: expect.objectContaining({
+              tron: expect.objectContaining({
+                chains: expect.arrayContaining(['tron:0x94a9059e']),
+              }),
+            }),
+          }),
+        );
+      });
+
+      it('preserves tron accounts from scoped permissions when AccountsController filter returns empty', async () => {
+        (
+          Engine.context.AccountsController as unknown as {
+            listAccounts: jest.Mock;
+          }
+        ).listAccounts = jest.fn().mockReturnValue([]);
+
+        // The tron adapter reads permitted Tron accounts directly from the
+        // CAIP-25 caveat. Simulate that a Tron account was previously granted
+        // for this channel even though the AccountsController keyring filter
+        // returns nothing (e.g. keyring not yet re-registered on cold start).
+        (
+          Engine.context.PermissionController.getCaveat as jest.Mock
+        ).mockImplementationOnce(() => ({
+          type: 'caip25',
+          value: {
+            requiredScopes: {},
+            optionalScopes: {
+              'eip155:1': {
+                accounts: [
+                  'eip155:1:0x1234567890abcdef1234567890abcdef12345678',
+                ],
+              },
+              'tron:728126428': {
+                accounts: ['tron:728126428:TENH9XL11i2qyDQUEvXsYf51aY2ALnEXeG'],
+              },
+            },
+            sessionProperties: {},
+            isMultichainOrigin: false,
+          },
+        }));
+
+        const mockSessionProposal = {
+          id: 1,
+          params: {
+            id: 1,
+            pairingTopic: 'test-pairing',
+            proposer: {
+              publicKey: 'test-public-key',
+              metadata: {
+                name: 'Test App',
+                description: 'Test App',
+                url: 'https://example.com',
+                icons: ['https://example.com/icon.png'],
+              },
+            },
+            requiredNamespaces: {
+              eip155: {
+                chains: ['eip155:1'],
+                methods: ['eth_sendTransaction'],
+                events: ['chainChanged'],
+              },
+            },
+            optionalNamespaces: {
+              tron: {
+                chains: ['tron:0x94a9059e'],
+                methods: ['tron_signTransaction'],
+                events: [],
+              },
+            },
+            expiryTimestamp: 10000000,
+            relays: [{ protocol: 'irn' }],
+          },
+        };
+
+        await manager.onSessionProposal(mockSessionProposal as any);
+
+        const approveCall = mockApproveSession.mock.calls.find(
+          (call) => call[0]?.namespaces?.tron,
+        );
+        expect(approveCall).toBeDefined();
+        const approvedTron = approveCall[0].namespaces.tron;
+        expect(approvedTron.accounts).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(
+              /^tron:[^:]+:TENH9XL11i2qyDQUEvXsYf51aY2ALnEXeG$/,
+            ),
+          ]),
+        );
+        expect(approvedTron.accounts.length).toBeGreaterThan(0);
+      });
+    });
+
     it('adds wallet namespace alias when proposal requests wallet:eip155', async () => {
       const mockSessionProposal = {
         id: 1,
@@ -933,7 +1070,13 @@ describe('WC2Manager', () => {
               events: [],
             },
           },
-          optionalNamespaces: {},
+          optionalNamespaces: {
+            tron: {
+              chains: ['tron:0x94a9059e'],
+              methods: ['tron_signTransaction'],
+              events: [],
+            },
+          },
           expiryTimestamp: 10000000,
           relays: [{ protocol: 'irn' }],
         },

--- a/app/core/WalletConnect/multichain/emission.test.ts
+++ b/app/core/WalletConnect/multichain/emission.test.ts
@@ -28,6 +28,28 @@ describe('getChainChangedEmission', () => {
     ).toEqual({ chainId: 'eip155:1', data: '0x1' });
   });
 
+  it('prefers tron (priority 10) over eip155 (priority 0)', () => {
+    expect(
+      getChainChangedEmission({
+        namespaces: {
+          eip155: {
+            chains: ['eip155:1'],
+            methods: [],
+            events: [],
+            accounts: [],
+          },
+          tron: {
+            chains: ['tron:0x2b6653dc'],
+            methods: [],
+            events: [],
+            accounts: [],
+          },
+        },
+        ...fallback,
+      }),
+    ).toEqual({ chainId: 'tron:0x2b6653dc', data: 'tron:0x2b6653dc' });
+  });
+
   it('falls back to the first eip155 chain when no non-EVM namespace is present', () => {
     expect(
       getChainChangedEmission({

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -7,6 +7,9 @@
 import { KnownCaipNamespace } from '@metamask/utils';
 
 import { eip155Adapter } from './eip155';
+///: BEGIN:ONLY_INCLUDE_IF(tron)
+import { tronAdapter, tronRequestMapper, tronResponseMapper } from './tron';
+///: END:ONLY_INCLUDE_IF
 import type {
   ChainAdapter,
   RequestMapper,
@@ -25,7 +28,16 @@ interface ChainRegistration {
   responseMapper?: ResponseMapper;
 }
 
-const registrations: ChainRegistration[] = [{ adapter: eip155Adapter }];
+const registrations: ChainRegistration[] = [
+  { adapter: eip155Adapter },
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  {
+    adapter: tronAdapter,
+    requestMapper: tronRequestMapper,
+    responseMapper: tronResponseMapper,
+  },
+  ///: END:ONLY_INCLUDE_IF
+];
 
 const byNamespace = new Map<string, ChainRegistration>(
   registrations.map((r) => [r.adapter.namespace, r]),

--- a/app/core/WalletConnect/multichain/tron/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.test.ts
@@ -1,0 +1,155 @@
+jest.mock('../../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountsController: { listAccounts: jest.fn(() => []) },
+      PermissionController: { getCaveat: jest.fn(() => undefined) },
+    },
+  },
+}));
+
+jest.mock('../../../Permissions', () => ({
+  __esModule: true,
+  addPermittedAccounts: jest.fn(),
+  getPermittedAccounts: jest.fn(() => []),
+  getPermittedChains: jest.fn(async () => []),
+}));
+
+import { TrxAccountType, TrxScope } from '@metamask/keyring-api';
+import { addPermittedAccounts } from '../../../Permissions';
+import Engine from '../../../Engine';
+import { tronAdapter } from './adapter';
+
+const listAccountsMock = (
+  Engine as unknown as {
+    context: { AccountsController: { listAccounts: jest.Mock } };
+  }
+).context.AccountsController.listAccounts;
+const getCaveatMock = (
+  Engine as unknown as {
+    context: { PermissionController: { getCaveat: jest.Mock } };
+  }
+).context.PermissionController.getCaveat;
+const addPermittedAccountsMock = addPermittedAccounts as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  listAccountsMock.mockReturnValue([]);
+  getCaveatMock.mockReturnValue(undefined);
+});
+
+describe('tronAdapter.buildNamespace', () => {
+  it('echoes back exactly the Tron chain ids the dapp requested', async () => {
+    listAccountsMock.mockReturnValue([
+      { type: TrxAccountType.Eoa, address: 'TAddr1' },
+    ]);
+
+    const namespace = await tronAdapter.buildNamespace({
+      proposal: {
+        optionalNamespaces: {
+          tron: { chains: ['tron:0x94a9059e'] },
+        },
+      },
+      channelId: 'channel-1',
+    });
+
+    expect(namespace).toBeDefined();
+    expect(namespace?.chains).toEqual(['tron:0x94a9059e']);
+    expect(namespace?.accounts).toEqual(['tron:0x94a9059e:TAddr1']);
+    expect(namespace?.methods).toEqual(
+      expect.arrayContaining(['tron_signTransaction', 'tron_signMessage']),
+    );
+  });
+
+  it('prefers addresses already permitted via scoped caveat over AccountsController', async () => {
+    listAccountsMock.mockReturnValue([
+      { type: TrxAccountType.Eoa, address: 'TDiscovered' },
+    ]);
+    getCaveatMock.mockReturnValue({
+      value: {
+        requiredScopes: {},
+        optionalScopes: {
+          'tron:0x2b6653dc': {
+            accounts: ['tron:0x2b6653dc:TPermitted'],
+          },
+        },
+        sessionProperties: {},
+        isMultichainOrigin: true,
+      },
+    });
+
+    const namespace = await tronAdapter.buildNamespace({
+      proposal: {
+        optionalNamespaces: {
+          tron: { chains: ['tron:0x2b6653dc'] },
+        },
+      },
+      channelId: 'channel-1',
+    });
+
+    expect(namespace?.accounts).toEqual(['tron:0x2b6653dc:TPermitted']);
+  });
+
+  it('returns undefined when no Tron is requested and no Tron EOAs exist', async () => {
+    const namespace = await tronAdapter.buildNamespace({
+      proposal: {},
+      channelId: 'channel-1',
+    });
+    expect(namespace).toBeUndefined();
+  });
+
+  it('picks the fallback mainnet chain when no request but EOA exists', async () => {
+    listAccountsMock.mockReturnValue([
+      { type: TrxAccountType.Eoa, address: 'TAddr1' },
+    ]);
+
+    const namespace = await tronAdapter.buildNamespace({
+      proposal: {},
+      channelId: 'channel-1',
+    });
+
+    expect(namespace?.chains).toEqual([TrxScope.Mainnet]);
+    expect(namespace?.accounts).toEqual([`${TrxScope.Mainnet}:TAddr1`]);
+  });
+});
+
+describe('tronAdapter.normalizeCaipChainId', () => {
+  it('converts hex chain reference to decimal', () => {
+    expect(tronAdapter.normalizeCaipChainId?.('tron:0x2b6653dc')).toBe(
+      'tron:728126428',
+    );
+  });
+
+  it('returns decimal chain IDs unchanged', () => {
+    expect(tronAdapter.normalizeCaipChainId?.('tron:728126428')).toBe(
+      'tron:728126428',
+    );
+  });
+});
+
+describe('tronAdapter.onBeforeApprove', () => {
+  it('adds Tron EOA accounts to the channel permissions', async () => {
+    listAccountsMock.mockReturnValue([
+      { type: TrxAccountType.Eoa, address: 'TAddr1' },
+      { type: TrxAccountType.Eoa, address: 'TAddr2' },
+    ]);
+
+    await tronAdapter.onBeforeApprove?.({
+      proposal: {},
+      channelId: 'channel-42',
+    });
+
+    expect(addPermittedAccountsMock).toHaveBeenCalledWith('channel-42', [
+      `${TrxScope.Mainnet}:TAddr1`,
+      `${TrxScope.Mainnet}:TAddr2`,
+    ]);
+  });
+
+  it('does nothing when there are no Tron EOAs', async () => {
+    await tronAdapter.onBeforeApprove?.({
+      proposal: {},
+      channelId: 'channel-42',
+    });
+    expect(addPermittedAccountsMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/WalletConnect/multichain/tron/adapter.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.ts
@@ -1,0 +1,215 @@
+/**
+ * Tron chain adapter for WalletConnect.
+ *
+ * Owns the declarative session configuration (methods, events, redirect
+ * methods) and the permission / namespace-building logic needed during
+ * session proposal approval. Request mapping lives in `./request-mapper.ts`.
+ */
+
+import {
+  Caip25CaveatType,
+  Caip25CaveatValue,
+  Caip25EndowmentPermissionName,
+  getCaipAccountIdsFromCaip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { TrxAccountType, TrxScope } from '@metamask/keyring-api';
+import { KnownCaipNamespace, type CaipAccountId } from '@metamask/utils';
+
+import Engine from '../../../Engine';
+import { addPermittedAccounts } from '../../../Permissions';
+import DevLogger from '../../../SDKConnect/utils/DevLogger';
+import type { ChainAdapter, NamespaceConfig, ProposalLike } from '../types';
+
+/** WalletConnect methods the wallet exposes for the Tron namespace. */
+const METHODS: string[] = ['tron_signTransaction', 'tron_signMessage'];
+
+/** WalletConnect events the wallet may emit for the Tron namespace. */
+const EVENTS: string[] = [];
+
+/** Methods that should redirect the user back to the dapp after confirmation. */
+const REDIRECT_METHODS: string[] = ['tron_signTransaction', 'tron_signMessage'];
+
+/** CAIP-2 prefix for Tron chain IDs. */
+const TRON_PREFIX = `${KnownCaipNamespace.Tron}:` as const;
+
+/** Default Tron chain used when the dapp doesn't specify one. */
+const FALLBACK_TRON_CHAIN = TrxScope.Mainnet;
+
+/**
+ * List all Tron EOA addresses currently managed by the wallet.
+ *
+ * @returns An array of base58-encoded Tron addresses.
+ */
+const listTronEoaAddresses = (): string[] => {
+  try {
+    return Engine.context.AccountsController.listAccounts()
+      .filter(
+        (account: { type: string }) => account.type === TrxAccountType.Eoa,
+      )
+      .map((account: { address: string }) => account.address);
+  } catch (err) {
+    DevLogger.log('[wc][tron] listTronEoaAddresses failed', err);
+    return [];
+  }
+};
+
+/**
+ * Collect every Tron CAIP-2 chain ID requested by the dapp proposal.
+ * Checks both `requiredNamespaces` and `optionalNamespaces`, including
+ * bare chain references that start with the `tron:` prefix.
+ *
+ * @param proposal - The WalletConnect session proposal.
+ * @returns Deduplicated array of requested Tron chain IDs.
+ */
+const getRequestedTronChainIds = (proposal: ProposalLike): string[] => {
+  const requestedInRequired =
+    proposal.requiredNamespaces?.[KnownCaipNamespace.Tron]?.chains ?? [];
+  const requestedInOptional =
+    proposal.optionalNamespaces?.[KnownCaipNamespace.Tron]?.chains ?? [];
+  const bareTronChains = [
+    ...Object.values(proposal.requiredNamespaces ?? {}).flatMap(
+      (ns) => ns?.chains ?? [],
+    ),
+    ...Object.values(proposal.optionalNamespaces ?? {}).flatMap(
+      (ns) => ns?.chains ?? [],
+    ),
+  ].filter((chain) => chain.startsWith(TRON_PREFIX));
+
+  return Array.from(
+    new Set([
+      ...requestedInRequired,
+      ...requestedInOptional,
+      ...bareTronChains,
+    ]),
+  );
+};
+
+/**
+ * Read Tron accounts already permitted for this WalletConnect channel from
+ * the CAIP-25 caveat stored in the PermissionController.
+ *
+ * @param channelId - The WalletConnect channel / pairing topic ID.
+ * @returns Array of CAIP-10 Tron account IDs.
+ */
+const getPermittedTronAccountsFromCaveat = (
+  channelId: string,
+): CaipAccountId[] => {
+  const caveat = Engine.context.PermissionController?.getCaveat?.(
+    channelId,
+    Caip25EndowmentPermissionName,
+    Caip25CaveatType,
+  );
+  if (!caveat) {
+    return [];
+  }
+
+  return getCaipAccountIdsFromCaip25CaveatValue(
+    caveat.value as Caip25CaveatValue,
+  ).filter((account) => account.startsWith(TRON_PREFIX)) as CaipAccountId[];
+};
+
+/**
+ * Tron adapter for WalletConnect multichain sessions.
+ *
+ * Handles namespace building and permission seeding during session proposal
+ * approval. Request/response mapping is handled separately by
+ * `tronRequestMapper` / `tronResponseMapper`.
+ */
+export const tronAdapter: ChainAdapter = {
+  namespace: KnownCaipNamespace.Tron,
+  methods: METHODS,
+  events: EVENTS,
+  redirectMethods: REDIRECT_METHODS,
+  emissionPriority: 10,
+
+  /**
+   * Normalize Tron CAIP-2 chain IDs from hex to decimal format.
+   * Some dapps send `tron:0x2b6653dc` instead of `tron:728126428`.
+   */
+  normalizeCaipChainId(caipChainId: string): string {
+    const chainRef = caipChainId.slice(TRON_PREFIX.length);
+    if (chainRef.startsWith('0x')) {
+      const decimalRef = parseInt(chainRef, 16);
+      const normalized = `${TRON_PREFIX}${decimalRef}`;
+      DevLogger.log('[wc][tron] normalize inbound chainId hex->dec', {
+        input: caipChainId,
+        output: normalized,
+      });
+      return normalized;
+    }
+    return caipChainId;
+  },
+
+  /**
+   * Seed Tron EOA accounts into the CAIP-25 caveat before session approval.
+   * This ensures Tron authorization is visible alongside EVM when the
+   * proposal handler reads scoped permissions.
+   *
+   * @param params - Contains the WC channel ID.
+   */
+  async onBeforeApprove({ channelId }) {
+    const tronAddresses = listTronEoaAddresses();
+    if (tronAddresses.length === 0) {
+      return;
+    }
+    try {
+      const tronCaipAccountIds = tronAddresses.map(
+        (address) => `${FALLBACK_TRON_CHAIN}:${address}` as CaipAccountId,
+      );
+      addPermittedAccounts(channelId, tronCaipAccountIds);
+    } catch (err) {
+      DevLogger.log('[wc][tron] onBeforeApprove addPermittedAccounts failed', {
+        err,
+      });
+    }
+  },
+
+  /**
+   * Build the Tron namespace slice for a WalletConnect session.
+   *
+   * Echoes back exactly the CAIP chain IDs the dapp requested (dapp Tron
+   * adapters crash on mismatches). Falls back to mainnet when no chains
+   * are requested. Returns `undefined` if neither chains nor accounts
+   * are available.
+   *
+   * @param params - Contains the proposal and WC channel ID.
+   * @returns The namespace config or `undefined`.
+   */
+  async buildNamespace({
+    proposal,
+    channelId,
+  }): Promise<NamespaceConfig | undefined> {
+    const requestedChains = getRequestedTronChainIds(proposal);
+
+    const hasTronRequest = requestedChains.length > 0;
+    const tronChains = hasTronRequest
+      ? Array.from(new Set(requestedChains))
+      : [FALLBACK_TRON_CHAIN];
+
+    const permittedAccounts = getPermittedTronAccountsFromCaveat(channelId);
+    const permittedAddresses = Array.from(
+      new Set(
+        permittedAccounts
+          .map((account) => account.split(':').slice(2).join(':'))
+          .filter(Boolean),
+      ),
+    );
+
+    const fallbackAddresses =
+      permittedAddresses.length > 0 ? [] : listTronEoaAddresses();
+
+    const addresses = Array.from(
+      new Set([...permittedAddresses, ...fallbackAddresses]),
+    );
+
+    if (!hasTronRequest && addresses.length === 0) {
+      return undefined;
+    }
+
+    const accounts = addresses.flatMap((address) =>
+      tronChains.map((chain) => `${chain}:${address}`),
+    );
+
+    return { chains: tronChains, methods: METHODS, events: EVENTS, accounts };
+  },
+};

--- a/app/core/WalletConnect/multichain/tron/index.ts
+++ b/app/core/WalletConnect/multichain/tron/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Tron multichain module for WalletConnect.
+ *
+ * Re-exports the chain adapter (session config + permissions) and the
+ * request/response mappers (WC ↔ CAIP translation) as a single entry point.
+ */
+
+export { tronAdapter } from './adapter';
+export { tronRequestMapper, tronResponseMapper } from './request-mapper';
+export {
+  extractTronRawDataHex,
+  extractTronType,
+  normalizeSignTransactionResult,
+} from './utils';

--- a/app/core/WalletConnect/multichain/tron/request-mapper.test.ts
+++ b/app/core/WalletConnect/multichain/tron/request-mapper.test.ts
@@ -1,0 +1,103 @@
+import { tronRequestMapper, tronResponseMapper } from './request-mapper';
+
+describe('tronRequestMapper', () => {
+  it('maps tron_signMessage to canonical signMessage with address and message', () => {
+    expect(
+      tronRequestMapper({
+        method: 'tron_signMessage',
+        params: [{ address: 'TAddr', message: '0x1234' }],
+      }),
+    ).toEqual({
+      method: 'signMessage',
+      params: { address: 'TAddr', message: '0x1234' },
+    });
+  });
+
+  it('maps tron_signTransaction extracting raw_data_hex and type', () => {
+    expect(
+      tronRequestMapper({
+        method: 'tron_signTransaction',
+        params: [
+          {
+            address: 'TAddr',
+            transaction: {
+              raw_data_hex: '0xabc',
+              type: 'TransferContract',
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      method: 'signTransaction',
+      params: {
+        address: 'TAddr',
+        transaction: { rawDataHex: '0xabc', type: 'TransferContract' },
+      },
+    });
+  });
+
+  it('maps tron_sendTransaction and tron_getBalance to canonical names', () => {
+    expect(
+      tronRequestMapper({ method: 'tron_sendTransaction', params: [] }),
+    ).toEqual({ method: 'sendTransaction', params: [] });
+    expect(
+      tronRequestMapper({ method: 'tron_getBalance', params: [] }),
+    ).toEqual({
+      method: 'getBalance',
+      params: [],
+    });
+  });
+
+  it('returns the request unchanged for unknown methods', () => {
+    expect(
+      tronRequestMapper({ method: 'some_other_method', params: [1] }),
+    ).toEqual({
+      method: 'some_other_method',
+      params: [1],
+    });
+  });
+});
+
+describe('tronResponseMapper', () => {
+  it('wraps a bare signature result into the legacy transaction+signature shape', () => {
+    const wrapped = tronResponseMapper({
+      method: 'tron_signTransaction',
+      params: [
+        {
+          transaction: {
+            transaction: { raw_data_hex: '0xabc', type: 'TransferContract' },
+          },
+        },
+      ],
+      result: { signature: '0xdeadbeef' },
+    });
+
+    expect(wrapped).toEqual({
+      raw_data_hex: '0xabc',
+      type: 'TransferContract',
+      signature: ['0xdeadbeef'],
+    });
+  });
+
+  it('leaves a fully-shaped (txID-bearing) result alone', () => {
+    const result = { txID: '0xabc', signature: ['0xdef'] };
+    expect(
+      tronResponseMapper({
+        method: 'tron_signTransaction',
+        params: [{ transaction: { raw_data_hex: '0xabc' } }],
+        result,
+      }),
+    ).toBe(result);
+  });
+
+  it('passes through results for non-sign methods', () => {
+    const result = { balance: '123' };
+    expect(
+      tronResponseMapper({
+        method: 'tron_getBalance',
+        params: [],
+        result,
+      }),
+    ).toBe(result);
+  });
+});

--- a/app/core/WalletConnect/multichain/tron/request-mapper.ts
+++ b/app/core/WalletConnect/multichain/tron/request-mapper.ts
@@ -1,0 +1,116 @@
+/**
+ * WalletConnect ↔ CAIP request/response mapping for the Tron namespace.
+ *
+ * Translates dapp-facing WalletConnect methods (e.g. `tron_signTransaction`)
+ * into the Snap-facing CAIP methods (e.g. `signTransaction`) and normalizes
+ * the params/results between the two formats.
+ */
+
+import type { RequestMapper, ResponseMapper } from '../types';
+import {
+  extractTronRawDataHex,
+  extractTronType,
+  normalizeSignTransactionResult,
+} from './utils';
+
+/**
+ * Map a WalletConnect `tron_*` request into the shape expected by the Tron
+ * Snap's keyring handler. Strips the `tron_` prefix and normalizes params
+ * (e.g. extracts `rawDataHex` from the various dapp payload formats).
+ *
+ * @param request - The raw WalletConnect method and params.
+ * @returns The mapped method and params for the Snap.
+ */
+export const tronRequestMapper: RequestMapper = ({ method, params }) => {
+  const firstParam = Array.isArray(params)
+    ? params.length > 0
+      ? params[0]
+      : undefined
+    : params && typeof params === 'object'
+      ? params
+      : undefined;
+
+  if (method === 'tron_signMessage') {
+    const mappedParams: Record<string, string> = {};
+    const address =
+      firstParam && typeof firstParam === 'object' && 'address' in firstParam
+        ? firstParam.address
+        : undefined;
+    const message =
+      firstParam && typeof firstParam === 'object' && 'message' in firstParam
+        ? firstParam.message
+        : undefined;
+    if (typeof address === 'string') {
+      mappedParams.address = address;
+    }
+    if (typeof message === 'string') {
+      mappedParams.message = message;
+    }
+    return { method: 'signMessage', params: mappedParams };
+  }
+
+  if (method === 'tron_signTransaction') {
+    const transactionContainer =
+      firstParam &&
+      typeof firstParam === 'object' &&
+      'transaction' in firstParam
+        ? (firstParam as Record<string, unknown>).transaction
+        : firstParam;
+
+    const rawDataHex = extractTronRawDataHex(
+      firstParam ?? transactionContainer,
+    );
+    const type = extractTronType(firstParam ?? transactionContainer);
+
+    const mappedTransaction: Record<string, string> = {};
+    if (typeof rawDataHex === 'string') {
+      mappedTransaction.rawDataHex = rawDataHex;
+    }
+    if (typeof type === 'string') {
+      mappedTransaction.type = type;
+    }
+
+    const mappedParams: {
+      address?: string;
+      transaction: Record<string, string>;
+    } = { transaction: mappedTransaction };
+    const address =
+      firstParam && typeof firstParam === 'object' && 'address' in firstParam
+        ? firstParam.address
+        : undefined;
+    if (typeof address === 'string') {
+      mappedParams.address = address;
+    }
+
+    return { method: 'signTransaction', params: mappedParams };
+  }
+
+  if (method === 'tron_sendTransaction') {
+    return { method: 'sendTransaction', params };
+  }
+
+  if (method === 'tron_getBalance') {
+    return { method: 'getBalance', params };
+  }
+
+  return { method, params };
+};
+
+/**
+ * Post-process a Snap result before the wallet responds to the dapp.
+ * For `tron_signTransaction`, re-assembles the response into the legacy
+ * shape dapps expect (original transaction body + `signature` array).
+ *
+ * @param params - The original WalletConnect method, params, and snap result.
+ * @returns The response to send back to the dapp via WalletConnect.
+ */
+export const tronResponseMapper: ResponseMapper = ({
+  method,
+  params,
+  result,
+}) => {
+  if (method === 'tron_signTransaction') {
+    return normalizeSignTransactionResult(params, result);
+  }
+  return result;
+};

--- a/app/core/WalletConnect/multichain/tron/utils.ts
+++ b/app/core/WalletConnect/multichain/tron/utils.ts
@@ -1,0 +1,148 @@
+/**
+ * Tron-specific data extraction and normalization helpers.
+ *
+ * These are pure functions that deal with the various shapes dapps send for
+ * Tron transactions and messages. They have no dependency on Engine,
+ * controllers, or WalletConnect — only raw data in, structured data out.
+ */
+
+/**
+ * Recursively extract the `rawDataHex` (or `raw_data_hex`) field from a
+ * Tron transaction payload. Dapps may nest the value under `transaction`,
+ * `tx`, or at the top level with either camelCase or snake_case keys.
+ *
+ * @param value - The raw transaction payload from a WalletConnect request.
+ * @returns The hex-encoded raw data string, or `undefined` if not found.
+ */
+export const extractTronRawDataHex = (value: unknown): string | undefined => {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as {
+    raw_data_hex?: unknown;
+    rawDataHex?: unknown;
+    transaction?: unknown;
+    tx?: unknown;
+  };
+
+  if (typeof candidate.raw_data_hex === 'string') {
+    return candidate.raw_data_hex;
+  }
+  if (typeof candidate.rawDataHex === 'string') {
+    return candidate.rawDataHex;
+  }
+  return (
+    extractTronRawDataHex(candidate.transaction) ??
+    extractTronRawDataHex(candidate.tx)
+  );
+};
+
+/**
+ * Recursively extract the transaction type from a Tron transaction payload.
+ * Checks the top-level `type` field first, then falls back to the first
+ * contract type in `raw_data.contract[0].type`, and finally recurses into
+ * nested `transaction` / `tx` wrappers.
+ *
+ * @param value - The raw transaction payload from a WalletConnect request.
+ * @returns The transaction type string, or `undefined` if not found.
+ */
+export const extractTronType = (value: unknown): string | undefined => {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as {
+    type?: unknown;
+    transaction?: unknown;
+    tx?: unknown;
+    raw_data?: { contract?: { type?: unknown }[] };
+  };
+
+  if (typeof candidate.type === 'string' && candidate.type.length > 0) {
+    return candidate.type;
+  }
+  const contractType = candidate.raw_data?.contract?.[0]?.type;
+  if (typeof contractType === 'string' && contractType.length > 0) {
+    return contractType;
+  }
+  return (
+    extractTronType(candidate.transaction) ?? extractTronType(candidate.tx)
+  );
+};
+
+/**
+ * Walk through the nested transaction wrappers dapps may send and return
+ * the innermost plain transaction object. Dapps may nest the body under
+ * `{ transaction: { transaction: { ... } } }` or `{ transaction: { ... } }`.
+ *
+ * @param params - The original WalletConnect request params.
+ * @returns The innermost transaction object, or `undefined`.
+ */
+const extractOriginalTransaction = (
+  params: unknown,
+): Record<string, unknown> | undefined => {
+  const firstParam = Array.isArray(params) ? params[0] : params;
+  const container =
+    typeof firstParam === 'object' && firstParam !== null
+      ? (firstParam as Record<string, unknown>).transaction
+      : undefined;
+
+  if (
+    typeof container !== 'object' ||
+    container === null ||
+    Array.isArray(container)
+  ) {
+    return undefined;
+  }
+
+  const inner = (container as Record<string, unknown>).transaction;
+  if (typeof inner === 'object' && inner !== null) {
+    return inner as Record<string, unknown>;
+  }
+
+  return container as Record<string, unknown>;
+};
+
+/**
+ * Normalize the signing result the Tron Snap returns into the legacy shape
+ * dapp Tron adapters expect: the original transaction body with a
+ * `signature` array appended.
+ *
+ * When the result already looks like a full transaction (has a `txID`
+ * field), it is returned unchanged.
+ *
+ * @param params - The original WalletConnect request params (pre-adaptation).
+ * @param result - The raw result returned by the Tron Snap.
+ * @returns The normalized result suitable for the WalletConnect response.
+ */
+export const normalizeSignTransactionResult = (
+  params: unknown,
+  result: unknown,
+): unknown => {
+  const originalTransaction = extractOriginalTransaction(params);
+
+  const resultObject =
+    typeof result === 'object' && result !== null && !Array.isArray(result)
+      ? (result as Record<string, unknown>)
+      : undefined;
+  const signatureValue = resultObject?.signature;
+  const normalizedSignature = Array.isArray(signatureValue)
+    ? signatureValue
+    : typeof signatureValue === 'string'
+      ? [signatureValue]
+      : undefined;
+
+  if (
+    originalTransaction &&
+    normalizedSignature &&
+    !(typeof resultObject?.txID === 'string')
+  ) {
+    return {
+      ...originalTransaction,
+      signature: normalizedSignature,
+    };
+  }
+
+  return result;
+};


### PR DESCRIPTION
## **Description**

Added Tron chain support for WalletConnect through a dedicated multichain Tron adapter layer, while also refactoring WalletConnect v2 session handling into chain-specific routing/adapters.  
This change separates generic namespace/session logic from chain-specific handling (EIP-155 and Tron), and includes follow-up fixes for delegated namespace key resolution and improved EIP-155 routing error capture.

## **Changelog**

CHANGELOG entry: Added Tron chain support for WalletConnect and multichain session routing.

## **Related issues**

Fixes: TBD (no confirmed linked issue provided)

## **Manual testing steps**

```gherkin
Feature: WalletConnect Tron chain support

  Scenario: user connects a WalletConnect session for supported chains
    Given the app is running with WalletConnect enabled
    And a dapp provides a valid WalletConnect v2 URI with supported namespaces

    When user approves the WalletConnect connection
    Then the session is established successfully
    And chain-specific routing is delegated via the multichain adapter layer

  Scenario: user interacts with WalletConnect requests mapped to Tron
    Given an active WalletConnect session includes Tron namespace support

    When user triggers a dapp action that requires Tron request mapping
    Then the request is routed through the Tron adapter/request mapper
    And the app returns a valid response or expected error

  Scenario: user connects with delegated namespace keys
    Given a WalletConnect proposal/session includes delegated namespace keys

    When user proceeds with the connection flow
    Then delegated namespace keys are resolved correctly
    And network/chain selection remains consistent

  Scenario: EIP-155 routing error is thrown during request handling
    Given a WalletConnect request is handled by EIP-155 routing
    And an internal error is thrown in the routing path

    When the request is processed
    Then error details are captured in the catch block for diagnostics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new non-EVM (Tron) WalletConnect routing path that affects session approval, request/response shaping, and `chainChanged` emission selection; issues could break signing flows or mis-handle scoped permissions for existing WC2 sessions.
> 
> **Overview**
> Adds **WalletConnect v2 Tron namespace support** through a new multichain adapter layer, wiring `tron_*` methods to the Tron Snap via `MultichainRoutingService:handleRequest` and handling redirect behavior for Tron signing.
> 
> Introduces a `tronAdapter` (namespace config, permission seeding via CAIP-25 caveats, hex→decimal CAIP chain normalization, emission priority) plus `tronRequestMapper`/`tronResponseMapper` utilities to translate WalletConnect request/response shapes (including signature-only result wrapping for `tron_signTransaction`).
> 
> Updates the multichain registry and emission logic/tests so non-EVM namespaces can be registered and preferred for `chainChanged`, and expands WalletConnect session/manager tests to cover Tron proposal approval, namespace normalization, session updates merging optional Tron chains, and error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa115098513e63dbc756d4c4b86ad06189367c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->