### PR TITLE
chore: hide swaps asset security tag for now

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
@@ -1,0 +1,1 @@
+export const SHOW_TOKEN_WARNINGS = false;

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -12,6 +12,8 @@ import {
   TOKEN_RATE_UNDEFINED,
 } from '../../Tokens/constants';
 
+jest.mock('./TokenSelectorItem.config', () => ({ SHOW_TOKEN_WARNINGS: true }));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
 }));

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -62,6 +62,8 @@ import {
   IconSize,
 } from '@metamask/design-system-react-native';
 
+const SHOW_TOKEN_WARNINGS = false;
+
 const createStyles = ({
   theme,
   vars,
@@ -331,7 +333,9 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     ? ACCOUNT_TYPE_LABELS[token.accountType]
     : undefined;
 
-  const securityTag = getSecurityTag(token.securityData?.type);
+  const securityTag = SHOW_TOKEN_WARNINGS
+    ? getSecurityTag(token.securityData?.type)
+    : null;
 
   return (
     <Box

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -61,8 +61,7 @@ import {
   IconName,
   IconSize,
 } from '@metamask/design-system-react-native';
-
-const SHOW_TOKEN_WARNINGS = false;
+import { SHOW_TOKEN_WARNINGS } from './TokenSelectorItem.config';
 
 const createStyles = ({
   theme,


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Token security warning tags (Suspicious / Malicious) were being displayed inline on each token row in the Swaps/Bridge asset picker. These warnings are temporarily hidden while we develop the token warning banner and modal.

The change introduces a single local constant `SHOW_TOKEN_WARNINGS = false` in `TokenSelectorItem.tsx`. Setting it to `true` instantly re-enables the tags. No logic or data-fetching is removed — only the render path is gated.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Hid token warnings in Swaps asset picker temporarily

## **Related issues**

No issue: temporary UX decision to hide token security tags in the asset picker 

## **Manual testing steps**

```gherkin
Feature: Swaps asset picker token warnings

  Scenario: Token security tags are hidden in the asset picker
    Given the user has the Swaps/Bridge screen open
    When the user taps the source or destination token selector
    Then tokens with known security warnings (Suspicious or Malicious) should NOT display a warning tag
    And all other token row information (symbol, balance, network badge) should appear normally

  Scenario: Re-enabling warnings via the feature flag
    Given SHOW_TOKEN_WARNINGS is set to true in TokenSelectorItem.tsx
    When the user opens the asset picker
    Then tokens with security warnings should display the appropriate Suspicious or Malicious tag
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="598" height="1144" alt="Screenshot 2026-04-23 at 12 01 13 PM" src="https://github.com/user-attachments/assets/08239679-62c5-433f-bedd-c26027f88873" />


### **After**

<img width="598" height="1144" alt="Screenshot 2026-04-23 at 11 57 04 AM" src="https://github.com/user-attachments/assets/050132a6-f1e4-40f9-9f0e-7273e13ea6e3" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that gates rendering of the Suspicious/Malicious security tag in the Swaps/Bridge token selector; no token/security data fetching or logic is altered.
> 
> **Overview**
> Token security warning tags in the Swaps/Bridge asset picker are now **disabled by default** by gating `getSecurityTag(...)` behind a new `SHOW_TOKEN_WARNINGS` constant exported from `TokenSelectorItem.config.ts`.
> 
> Tests were updated to mock `SHOW_TOKEN_WARNINGS` as `true` so existing security-badge assertions continue to exercise the render path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92d7e1aa8511aef5e0713d43b66de812ce22fe1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->