### PR TITLE
feat: adds haptic feedback and checkmark to quickbuy

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
@@ -153,7 +153,6 @@ const buildHookResult = (
   hasError: false,
   hasValidAmount: false,
   isConfirmDisabled: true,
-  isConfirmLoading: false,
   getButtonLabel: () => 'social_leaderboard.trader_position.buy',
   handleClose: jest.fn(),
   handlePresetPress: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
@@ -153,6 +153,7 @@ const buildHookResult = (
   hasError: false,
   hasValidAmount: false,
   isConfirmDisabled: true,
+  confirmButtonState: 'idle',
   getButtonLabel: () => 'social_leaderboard.trader_position.buy',
   handleClose: jest.fn(),
   handlePresetPress: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
@@ -65,7 +65,7 @@ const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
     hasError,
     hasValidAmount,
     isConfirmDisabled,
-    isConfirmLoading,
+    confirmButtonState,
     getButtonLabel,
     handlePresetPress,
     handleAmountAreaPress,
@@ -114,7 +114,7 @@ const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
             hasRewardsError={hasRewardsError}
             rewardsAccountScope={rewardsAccountScope}
             isConfirmDisabled={isConfirmDisabled}
-            isConfirmLoading={isConfirmLoading}
+            confirmButtonState={confirmButtonState}
             getButtonLabel={getButtonLabel}
             onPresetPress={handlePresetPress}
             onConfirm={handleConfirm}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyConfirmButton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyConfirmButton.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+} from 'react-native';
+import Animated, {
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import { useTheme } from '../../../../../../util/theme';
+import Icon, {
+  IconName,
+  IconSize,
+} from '../../../../../../component-library/components/Icons/Icon';
+
+export type ConfirmButtonState = 'idle' | 'loading' | 'success';
+
+const styles = StyleSheet.create({
+  container: {
+    height: 48,
+    width: '100%',
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});
+
+interface QuickBuyConfirmButtonProps {
+  state: ConfirmButtonState;
+  label: string;
+  isDisabled: boolean;
+  onPress: () => void;
+  testID?: string;
+}
+
+const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
+  state,
+  label,
+  isDisabled,
+  onPress,
+  testID,
+}) => {
+  const { colors } = useTheme();
+  const checkScale = useSharedValue(0);
+
+  useEffect(() => {
+    checkScale.value =
+      state === 'success' ? withTiming(1, { duration: 200 }) : 0;
+  }, [state, checkScale]);
+
+  const checkmarkStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: checkScale.value }],
+  }));
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.container,
+        { backgroundColor: colors.primary.default },
+        state === 'idle' && isDisabled && styles.disabled,
+      ]}
+      onPress={onPress}
+      disabled={state !== 'idle' || isDisabled}
+      testID={testID}
+      activeOpacity={0.8}
+    >
+      {state === 'loading' && (
+        <ActivityIndicator size="small" color={colors.primary.inverse} />
+      )}
+      {state === 'success' && (
+        <Animated.View style={checkmarkStyle}>
+          <Icon
+            name={IconName.CheckBold}
+            size={IconSize.Lg}
+            color={colors.primary.inverse}
+          />
+        </Animated.View>
+      )}
+      {state === 'idle' && (
+        <Text style={[styles.label, { color: colors.primary.inverse }]}>
+          {label}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+export default QuickBuyConfirmButton;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.test.tsx
@@ -109,7 +109,7 @@ const defaultProps = {
   hasRewardsError: false,
   rewardsAccountScope: null,
   isConfirmDisabled: false,
-  isConfirmLoading: false,
+  confirmButtonState: 'idle' as const,
   getButtonLabel: () => 'social_leaderboard.trader_position.buy',
   onPresetPress: jest.fn(),
   onConfirm: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
@@ -14,6 +14,9 @@ import {
   AvatarToken,
   AvatarTokenSize,
 } from '@metamask/design-system-react-native';
+import QuickBuyConfirmButton, {
+  type ConfirmButtonState,
+} from './QuickBuyConfirmButton';
 import Icon, {
   IconName,
   IconSize,
@@ -55,7 +58,7 @@ interface QuickBuyFooterProps {
   hasRewardsError: boolean;
   rewardsAccountScope: InternalAccount | null;
   isConfirmDisabled: boolean;
-  isConfirmLoading: boolean;
+  confirmButtonState: ConfirmButtonState;
   getButtonLabel: () => string;
   onPresetPress: (preset: string) => void;
   onConfirm: () => Promise<void>;
@@ -80,7 +83,7 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
   hasRewardsError,
   rewardsAccountScope,
   isConfirmDisabled,
-  isConfirmLoading,
+  confirmButtonState,
   getButtonLabel,
   onPresetPress,
   onConfirm,
@@ -275,17 +278,13 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
       </Box>
 
       {/* Buy button */}
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonBaseSize.Lg}
-        isFullWidth
+      <QuickBuyConfirmButton
+        state={confirmButtonState}
+        label={getButtonLabel()}
         isDisabled={isConfirmDisabled}
-        isLoading={isConfirmLoading}
         onPress={onConfirm}
         testID="quick-buy-confirm-button"
-      >
-        {getButtonLabel()}
-      </Button>
+      />
     </Box>
   </Box>
 );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
@@ -387,7 +387,7 @@ describe('useQuickBuyBottomSheet', () => {
       });
 
       expect(result.current.isConfirmDisabled).toBe(true);
-      expect(result.current.isConfirmLoading).toBe(false);
+      expect(result.current.confirmButtonState).toBe('idle');
     });
 
     it('is disabled when a destination address is required but missing', () => {
@@ -410,7 +410,7 @@ describe('useQuickBuyBottomSheet', () => {
       });
 
       expect(result.current.isConfirmDisabled).toBe(true);
-      expect(result.current.isConfirmLoading).toBe(false);
+      expect(result.current.confirmButtonState).toBe('idle');
     });
 
     it('is enabled after quote loading settles for the entered amount', () => {
@@ -505,7 +505,7 @@ describe('useQuickBuyBottomSheet', () => {
       });
 
       expect(result.current.isConfirmDisabled).toBe(true);
-      expect(result.current.isConfirmLoading).toBe(true);
+      expect(result.current.confirmButtonState).toBe('loading');
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -252,7 +252,6 @@ export function useQuickBuyBottomSheet(
     try {
       dispatch(setIsSubmittingTx(true));
       await submitBridgeTx({ quoteResponse: activeQuote });
-      dispatch(setIsSubmittingTx(false));
       setTxPhase('success');
       notificationAsync(NotificationFeedbackType.Success);
       await new Promise((resolve) => setTimeout(resolve, 800));
@@ -260,8 +259,9 @@ export function useQuickBuyBottomSheet(
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     } catch (error) {
       console.error('Error submitting QuickBuy tx', error);
-      dispatch(setIsSubmittingTx(false));
       notificationAsync(NotificationFeedbackType.Error);
+    } finally {
+      dispatch(setIsSubmittingTx(false));
     }
   }, [
     activeQuote,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
 import { TextInput } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -72,7 +73,7 @@ export interface UseQuickBuyBottomSheetResult {
   hasError: boolean;
   hasValidAmount: boolean;
   isConfirmDisabled: boolean;
-  isConfirmLoading: boolean;
+  confirmButtonState: 'idle' | 'loading' | 'success';
   getButtonLabel: () => string;
   // handlers
   handleClose: () => void;
@@ -91,6 +92,7 @@ export function useQuickBuyBottomSheet(
   const navigation = useNavigation();
 
   const [usdAmount, setUsdAmount] = useState('');
+  const [txPhase, setTxPhase] = useState<'idle' | 'success'>('idle');
 
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
   const walletAddress = useSelector(selectSourceWalletAddress);
@@ -250,13 +252,16 @@ export function useQuickBuyBottomSheet(
     try {
       dispatch(setIsSubmittingTx(true));
       await submitBridgeTx({ quoteResponse: activeQuote });
+      dispatch(setIsSubmittingTx(false));
+      setTxPhase('success');
+      notificationAsync(NotificationFeedbackType.Success);
+      await new Promise((resolve) => setTimeout(resolve, 800));
       onClose();
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     } catch (error) {
       console.error('Error submitting QuickBuy tx', error);
-      // Keep sheet open on error
-    } finally {
       dispatch(setIsSubmittingTx(false));
+      notificationAsync(NotificationFeedbackType.Error);
     }
   }, [
     activeQuote,
@@ -345,6 +350,9 @@ export function useQuickBuyBottomSheet(
     isPendingQuoteRefresh ||
     (isQuoteLoading && !activeQuote && hasCompleteQuoteInputs);
 
+  const confirmButtonState: 'idle' | 'loading' | 'success' =
+    txPhase === 'success' ? 'success' : isConfirmLoading ? 'loading' : 'idle';
+
   const getButtonLabel = useCallback(() => {
     if (hasInsufficientBalance) return strings('bridge.insufficient_funds');
     if (hasSufficientGas === false) return strings('bridge.insufficient_gas');
@@ -381,7 +389,7 @@ export function useQuickBuyBottomSheet(
     hasError,
     hasValidAmount,
     isConfirmDisabled,
-    isConfirmLoading,
+    confirmButtonState,
     getButtonLabel,
     handleClose,
     handlePresetPress,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Refactor QuickBuy confirm button with blue color, animated spinner-to-checkmark transition, and haptic feedback.

- Replace generic `Button` with custom `QuickBuyConfirmButton` component
- Button is now blue (`colors.primary.default`) with 12px border radius, matching Figma design
- On transaction submission, show white spinner; on success, transition to checkmark icon with scale animation
- Add haptic feedback: `NotificationFeedbackType.Success` on tx success, `.Error` on failure (Perps pattern)
- Auto-close sheet 800ms after success state appears
- Update hook to track button state (`idle` | `loading` | `success`) instead of separate `isConfirmLoading` boolean



https://github.com/user-attachments/assets/be4de517-f7ef-41e4-ae7e-1f683f971d55


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the QuickBuy transaction submission UX (new success phase, delayed close, and haptic feedback) and replaces the design-system `Button` with a custom component, which could affect interaction/disabled states during bridging.
> 
> **Overview**
> Updates the QuickBuy confirm flow to use a custom `QuickBuyConfirmButton` that supports an `idle`/`loading`/`success` state, showing a spinner during submission and an animated checkmark on success.
> 
> Refactors `useQuickBuyBottomSheet` to expose `confirmButtonState` (replacing `isConfirmLoading`), trigger haptic feedback on success/error via `expo-haptics`, and delay sheet close by ~800ms after a successful submit before navigating to `Routes.TRANSACTIONS_VIEW`. Tests are updated to assert the new state model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b79d0c44c08dfe6736dfe7a4e86ace3963f0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->