### PR TITLE
fix: Use development profile for main dev environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,6 +369,49 @@ jobs:
           aws-secret-name: ${{ needs.prepare.outputs.signing_aws_secret }}
           android-keystore-path: ${{ needs.prepare.outputs.signing_android_keystore_path }}
 
+      # Temporary: iOS signing from GitHub Environment secrets (no AWS).
+      # Bridges main-dev until signing is fully migrated to AWS. Remove this step once it uses AWS-based signing.
+      - name: Configure iOS signing from GitHub secrets
+        if: matrix.platform == 'ios' && inputs.build_name == 'main-dev'
+        run: |
+          echo "📦 Configuring iOS code signing for dev builds..."
+
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          PROFILE_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          CERT_PW="${IOS_SIGNING_KEYSTORE_PASSWORD}"
+
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            echo "🧹 Removing existing keychain..."
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+
+          echo "$IOS_SIGNING_KEYSTORE" | base64 --decode > "$CERT_PATH"
+          echo "$IOS_SIGNING_PROFILE" | base64 --decode > "$PROFILE_PATH"
+          echo "✅ Decoded .p12 and provisioning profile"
+
+          security create-keychain -p "$CERT_PW" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$CERT_PW" "$KEYCHAIN_PATH"
+
+          echo "🔐 Importing certificate..."
+          if ! security import "$CERT_PATH" -P "$CERT_PW" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"; then
+            echo "❌ Failed to import certificate."
+            exit 1
+          fi
+          echo "✅ Certificate imported"
+
+          security set-key-partition-list -S apple-tool:,apple: -k "$CERT_PW" "$KEYCHAIN_PATH" 2>/dev/null || true
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+          echo "✅ Installed provisioning profile"
+
+          # Add keychain to search list (codesign searches this; default-keychain alone is insufficient)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
+          security default-keychain -s "$KEYCHAIN_PATH"
+          echo "✅ Keychain added to search list and set as default"
+
       # iOS: Configure Node path for Xcode build scripts (React Native Codegen)
       - name: Configure Node path for Xcode
         if: matrix.platform == 'ios'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,8 @@ jobs:
           echo "✅ Installed provisioning profile"
 
           # Add keychain to search list (codesign searches this; default-keychain alone is insufficient)
-          # shellcheck disable=SC2046 -- word splitting is intentional; security list-keychains -s expects separate args
+          # Word splitting is intentional; security list-keychains -s expects separate args
+          # shellcheck disable=SC2046
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
           security default-keychain -s "$KEYCHAIN_PATH"
           echo "✅ Keychain added to search list and set as default"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,8 @@ jobs:
           echo "✅ Installed provisioning profile"
 
           # Add keychain to search list (codesign searches this; default-keychain alone is insufficient)
-          security list-keychains -d user -s "$KEYCHAIN_PATH" "$(security list-keychains -d user | tr -d '"' | xargs)"
+          # shellcheck disable=SC2046 -- word splitting is intentional; security list-keychains -s expects separate args
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
           security default-keychain -s "$KEYCHAIN_PATH"
           echo "✅ Keychain added to search list and set as default"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,7 @@ jobs:
           echo "✅ Installed provisioning profile"
 
           # Add keychain to search list (codesign searches this; default-keychain alone is insufficient)
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "$(security list-keychains -d user | tr -d '"' | xargs)"
           security default-keychain -s "$KEYCHAIN_PATH"
           echo "✅ Keychain added to search list and set as default"
 

--- a/builds.yml
+++ b/builds.yml
@@ -285,7 +285,7 @@ builds:
   # Local development / Expo development build (simulator .app + optional device IPA when IS_DEVICE_BUILD)
   main-dev:
     github_environment: build-exp
-    signing: *signing_uat
+    # signing: *signing_uat  # Temporarily using GitHub secrets for iOS signing; restore when migrated to AWS
     env:
       <<: *public_envs
       METAMASK_ENVIRONMENT: 'dev'
@@ -306,7 +306,12 @@ builds:
       IS_DEVICE_BUILD: 'true'
       CONFIGURATION: 'Debug'
       DEV_OAUTH_CONFIG: 'true'
-    secrets: *secrets
+    # secrets: *secrets  # Temporarily overridden to include iOS signing secrets; restore when migrated to AWS
+    secrets:
+      <<: *secrets
+      IOS_SIGNING_KEYSTORE: 'IOS_SIGNING_KEYSTORE'
+      IOS_SIGNING_KEYSTORE_PASSWORD: 'IOS_SIGNING_KEYSTORE_PASSWORD'
+      IOS_SIGNING_PROFILE: 'IOS_SIGNING_PROFILE'
     code_fencing: *code_fencing_main
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

It was discovered that we're still using UAT signing configuration for main-dev builds, which is incorrect. It should be using a development profile. Since we have not yet set up a development profile in AWS, this PR temporarily routes main-dev to use github environments instead. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1776699450350369

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI code-signing behavior and secret sources for `main-dev` iOS builds, which can break build/release outputs if misconfigured. Scope is limited to the `main-dev` workflow path and does not affect prod/rc signing via AWS.
> 
> **Overview**
> Updates `main-dev` to stop using UAT AWS signing config and instead **temporarily sign iOS builds using GitHub Environment secrets** until dev signing is migrated to AWS.
> 
> Adds a `build.yml` step that, for `ios` + `main-dev` only, decodes a base64 `.p12` and provisioning profile from secrets, creates/imports them into a temporary keychain, and installs the provisioning profile. `builds.yml` is adjusted to omit the `main-dev` AWS `signing` block and to include the new iOS signing secret mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083bee93b4cbc3a704c9da7c7f25726c70d27f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->