### PR TITLE
chore: use DS svg icons in token details chart

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
+++ b/app/components/UI/Charts/AdvancedChart/TimeRangeSelector.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { Dimensions, Pressable } from 'react-native';
-import Svg, { Path } from 'react-native-svg';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -9,40 +8,15 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react-native';
-import { IconSize } from '../../../../component-library/components/Icons/Icon';
 import { useTheme } from '../../../../util/theme';
 import { ChartType } from './AdvancedChart.types';
 import { TOKEN_OVERVIEW_TIME_RANGE_ROW_HEIGHT } from '../../AssetOverview/Price/tokenOverviewChart.constants';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-
-const CandlestickIcon = ({
-  color,
-  size,
-}: {
-  color: string;
-  size: IconSize;
-}) => (
-  <Svg width={size} height={size} viewBox="0 0 14 16" fill="none">
-    <Path d="M4 0H2V2H0V14H2V16H4V14H6V2H4V0ZM4 12H2V4H4V12Z" fill={color} />
-    <Path
-      d="M14 4H12V0H10V4H8V11H10V16H12V11H14V4ZM12 9H10V6H12V9Z"
-      fill={color}
-    />
-  </Svg>
-);
-
-const LineChartIcon = ({ color, size }: { color: string; size: IconSize }) => (
-  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M3 16.5L9 10L13 16L21 6.5"
-      stroke={color}
-      strokeWidth={2.04}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </Svg>
-);
 
 export type TimeRange = '1H' | '1D' | '1W' | '1M' | '1Y';
 
@@ -177,14 +151,16 @@ const TimeRangeSelector: React.FC<TimeRangeSelectorProps> = ({
               }
             >
               {chartType === ChartType.Candles ? (
-                <LineChartIcon
-                  color={colors.text.alternative}
-                  size={IconSize.Md}
+                <Icon
+                  name={IconName.TrendUp}
+                  size={IconSize.Lg}
+                  color={IconColor.IconAlternative}
                 />
               ) : (
-                <CandlestickIcon
-                  color={colors.text.alternative}
-                  size={IconSize.Sm}
+                <Icon
+                  name={IconName.Candlestick}
+                  size={IconSize.Lg}
+                  color={IconColor.IconAlternative}
                 />
               )}
             </Pressable>


### PR DESCRIPTION


## **Description**

PR to use DS icons instead of custom SVG icons for chart.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/184afbb6-2462-4140-a793-a112cf0e03fe


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d8f65547-b6b3-4883-926f-18598d2751ef




## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the chart type toggle’s custom SVG icons for design-system `Icon` components; behavior and data flow are unchanged.
> 
> **Overview**
> Updates the token details chart `TimeRangeSelector` to **remove custom `react-native-svg` candlestick/line icons** and instead render the design-system `Icon` (`IconName.TrendUp` / `IconName.Candlestick`) for the chart type toggle.
> 
> This simplifies icon rendering by relying on DS-provided sizing/color tokens (`IconSize`, `IconColor`) rather than inline SVG paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a710363306e6fa0e133b2d5fea674fb2055a6231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->