### PR TITLE
chore(rewards): no date in campaign tile for upcoming

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -161,7 +161,7 @@ describe('CampaignTile', () => {
       );
     });
 
-    it('renders date label for upcoming campaign', () => {
+    it('does not render date label for upcoming campaign', () => {
       (getCampaignStatusInfo as jest.Mock).mockReturnValue({
         status: 'upcoming',
         statusLabel: 'Coming soon',
@@ -170,11 +170,9 @@ describe('CampaignTile', () => {
       });
       const campaign = createTestCampaign();
 
-      const { getByTestId } = render(<CampaignTile campaign={campaign} />);
+      const { queryByTestId } = render(<CampaignTile campaign={campaign} />);
 
-      expect(getByTestId('campaign-tile-date-info')).toHaveTextContent(
-        'Starts June 1',
-      );
+      expect(queryByTestId('campaign-tile-date-info')).toBeNull();
     });
 
     it('renders date label for complete campaign', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.tsx
@@ -149,21 +149,25 @@ const CampaignTile: React.FC<CampaignTileProps> = ({ campaign, onPress }) => {
                 {statusLabel}
               </Text>
             )}
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.OverlayInverse}
-              fontWeight={FontWeight.Medium}
-            >
-              •
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.OverlayInverse}
-              fontWeight={FontWeight.Medium}
-              testID="campaign-tile-date-info"
-            >
-              {dateLabel}
-            </Text>
+            {campaignStatus !== 'upcoming' && (
+              <>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.OverlayInverse}
+                  fontWeight={FontWeight.Medium}
+                >
+                  •
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.OverlayInverse}
+                  fontWeight={FontWeight.Medium}
+                  testID="campaign-tile-date-info"
+                >
+                  {dateLabel}
+                </Text>
+              </>
+            )}
           </Box>
 
           <Text


### PR DESCRIPTION
## **Description**

Don't show a date in the campaign card is the status is upcoming

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally hides existing text; main risk is small visual regression if other statuses were expected to show the date separator/label.
> 
> **Overview**
> **Upcoming reward campaigns no longer show a date line in the campaign tile.** `CampaignTile` now conditionally renders the date separator and `dateLabel` only when `campaignStatus !== 'upcoming'`.
> 
> Tests were updated to assert that the `campaign-tile-date-info` element is *not* rendered for upcoming campaigns (while still present for active/complete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a2d8990434ba529ded139447100b3209e04b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->