### PR TITLE
chore: adds navigation to trader profile from notifications follow list

### DIFF
--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
@@ -21,10 +21,11 @@ import type {
 // ---------------------------------------------------------------------------
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
 }));
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
@@ -479,6 +480,21 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(toggleTraderNotification).toHaveBeenCalledWith('trader-1');
+    });
+
+    it('navigates to the trader profile when a trader username is pressed', () => {
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.TRADER_PRESS('trader-1'),
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith('TraderProfileView', {
+        traderId: 'trader-1',
+        traderName: 'dutchiono',
+      });
     });
 
     it('calls setEnabled when the global toggle is pressed', () => {

--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.testIds.ts
@@ -13,4 +13,6 @@ export const NotificationPreferencesViewSelectorsIDs = {
     `notification-preferences-view-trader-toggle-${traderId}`,
   TRADER_ROW: (traderId: string) =>
     `notification-preferences-view-trader-row-${traderId}`,
+  TRADER_PRESS: (traderId: string) =>
+    `notification-preferences-view-trader-press-${traderId}`,
 };

--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -28,6 +28,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
+import Routes from '../../../../constants/navigation/Routes';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { NotificationPreferencesViewSelectorsIDs } from './NotificationPreferencesView.testIds';
 import {
   useNotificationPreferences,
@@ -131,6 +133,7 @@ interface TraderNotificationRowProps {
   isEnabled: boolean;
   isDisabled: boolean;
   onToggle: (traderId: string) => void;
+  onPress: (traderId: string, username: string) => void;
 }
 
 const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
@@ -140,6 +143,7 @@ const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
   isEnabled,
   isDisabled,
   onToggle,
+  onPress,
 }) => {
   const tw = useTailwind();
   const { colors, brandColors } = useTheme();
@@ -152,11 +156,11 @@ const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
       twClassName={`px-4 py-3${isDisabled ? ' opacity-50' : ''}`}
       testID={NotificationPreferencesViewSelectorsIDs.TRADER_ROW(traderId)}
     >
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        gap={3}
-        twClassName="flex-1 min-w-0 mr-3"
+      <TouchableOpacity
+        onPress={() => onPress(traderId, username)}
+        accessibilityRole="button"
+        style={tw.style('flex-row items-center gap-3 flex-1 min-w-0 mr-3')}
+        testID={NotificationPreferencesViewSelectorsIDs.TRADER_PRESS(traderId)}
       >
         {avatarUri ? (
           <Image
@@ -182,7 +186,7 @@ const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
         >
           {username}
         </Text>
-      </Box>
+      </TouchableOpacity>
 
       <Switch
         value={isEnabled}
@@ -244,7 +248,7 @@ const formatThreshold = (
  * through `AuthenticatedUserStorageService` (via `useNotificationPreferences`).
  */
 const NotificationPreferencesView = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const tw = useTailwind();
   const { colors, brandColors } = useTheme();
   const isEnabled = useSelector(selectSocialLeaderboardEnabled);
@@ -269,6 +273,16 @@ const NotificationPreferencesView = () => {
   const handleBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
+
+  const handleTraderPress = useCallback(
+    (traderId: string, traderName: string) => {
+      navigation.navigate(Routes.SOCIAL_LEADERBOARD.PROFILE, {
+        traderId,
+        traderName,
+      });
+    },
+    [navigation],
+  );
 
   // On a cold (re)entry the GET is in flight, `preferences` falls back to
   // defaults (`enabled: false`), and binding that straight into the Switch
@@ -442,6 +456,7 @@ const NotificationPreferencesView = () => {
               isEnabled={isTraderNotificationEnabled(trader.id)}
               isDisabled={globalOff}
               onToggle={toggleTraderNotification}
+              onPress={handleTraderPress}
             />
           ))
         )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adds navigation from the "Traders you follow" list in `NotificationPreferencesView` to the corresponding `TraderProfileView`. Tapping the avatar or username on a trader row navigates to its profile, mirroring the pattern already used in `TopTradersView`.

https://github.com/user-attachments/assets/d6495097-a0f0-43dd-831e-ba6d68ae1c4e


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation change that adds a new tap target and route params; main risk is mismatched route/param typing or unintended touch interactions in the trader row.
> 
> **Overview**
> Adds **tap-to-navigate** behavior to the "Traders you follow" rows in `NotificationPreferencesView`: pressing a trader’s avatar/username now routes to `Routes.SOCIAL_LEADERBOARD.PROFILE` with `traderId` and `traderName`.
> 
> Updates testIDs to include `TRADER_PRESS` and extends the existing Jest test to assert `navigation.navigate('TraderProfileView', { traderId, traderName })` is called when a trader row is pressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8033ec3629b1fcc336900e5d2f6bdba0af3468cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->