### PR TITLE
fix: hide big transaction fee on Perps withdraw when no quotes available cp-7.74.0

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -13,11 +13,14 @@ import { strings } from '../../../../../../locales/i18n';
 import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
+  useTransactionPayIsPostQuote,
   useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
 import {
   TransactionPayQuote,
+  TransactionPayRequiredToken,
   TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
 
@@ -50,6 +53,12 @@ describe('useNoPayTokenQuotesAlert', () => {
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
   );
+  const useTransactionPayIsPostQuoteMock = jest.mocked(
+    useTransactionPayIsPostQuote,
+  );
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -66,6 +75,8 @@ describe('useNoPayTokenQuotesAlert', () => {
     useTransactionPaySourceAmountsMock.mockReturnValue([
       {} as TransactionPaySourceAmount,
     ]);
+    useTransactionPayIsPostQuoteMock.mockReturnValue(false);
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
   });
 
@@ -136,5 +147,66 @@ describe('useNoPayTokenQuotesAlert', () => {
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
+  });
+
+  // Non-post-quote: `sourceAmount.targetTokenAddress` is a required-token
+  // address, so matching it against a `skipIfBalance` required token means the
+  // only required token is optional (gas) and no quote is needed.
+  it('returns no alerts when all source amounts target skipIfBalance required tokens (non-post-quote)', () => {
+    const optionalTokenAddress =
+      '0x0000000000000000000000000000000000000000' as Hex;
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {
+        targetTokenAddress: optionalTokenAddress,
+      } as TransactionPaySourceAmount,
+    ]);
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: optionalTokenAddress,
+        skipIfBalance: true,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  // Regression for #29297: perps withdraw $0.1 → ETH on Ethereum. The
+  // destination native token address (`0x0…0`) was false-matching the
+  // Arbitrum native gas required token (also `0x0…0`, `skipIfBalance: true`),
+  // making `isOptionalOnly` true and suppressing the "No quotes" alert, which
+  // let the UI render a huge bogus `targetNetwork` fee.
+  it('returns alert for post-quote even when sourceAmount target address false-matches a skipIfBalance required token', () => {
+    const nativeTokenAddress =
+      '0x0000000000000000000000000000000000000000' as Hex;
+
+    useTransactionPayIsPostQuoteMock.mockReturnValue(true);
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {
+        targetTokenAddress: nativeTokenAddress,
+      } as TransactionPaySourceAmount,
+    ]);
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: nativeTokenAddress,
+        chainId: '0xa4b1' as Hex,
+        skipIfBalance: true,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        key: AlertKeys.NoPayTokenQuotes,
+        severity: Severity.Danger,
+        isBlocking: true,
+      }),
+    ]);
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -7,6 +7,7 @@ import { strings } from '../../../../../../locales/i18n';
 import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
+  useTransactionPayIsPostQuote,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
@@ -19,6 +20,7 @@ export function useNoPayTokenQuotesAlert() {
   const isQuotesLoading = useIsTransactionPayLoading();
   const sourceAmounts = useTransactionPaySourceAmounts();
   const requiredTokens = useTransactionPayRequiredTokens();
+  const isPostQuote = useTransactionPayIsPostQuote();
 
   const fiatAmount = Number(fiatPayment?.amountFiat);
   const hasValidFiatAmount = Number.isFinite(fiatAmount) && fiatAmount > 0;
@@ -26,11 +28,20 @@ export function useNoPayTokenQuotesAlert() {
     fiatPayment?.selectedPaymentMethodId,
   );
 
-  const isOptionalOnly = (sourceAmounts ?? []).every(
-    (t) =>
-      requiredTokens?.find((rt) => rt.address === t.targetTokenAddress)
-        ?.skipIfBalance,
-  );
+  // For non-post-quote flows, sourceAmount.targetTokenAddress refers to a
+  // required token address, so matching against `requiredTokens` is valid.
+  // For post-quote flows (perps/predict/moneyAccount withdraw, musdConversion),
+  // sourceAmount.targetTokenAddress is the destination token address, so this
+  // lookup is meaningless and can false-match a skipped gas token across
+  // chains (e.g. destination native ETH `0x0…0` vs. Arbitrum native gas
+  // `0x0…0`). See issue #29297.
+  const isOptionalOnly =
+    !isPostQuote &&
+    (sourceAmounts ?? []).every(
+      (t) =>
+        requiredTokens?.find((rt) => rt.address === t.targetTokenAddress)
+          ?.skipIfBalance,
+    );
 
   const shouldShowNonFiatNoQuotesAlert =
     payToken &&


### PR DESCRIPTION
## **Description**

When no viable quote existed for a Perps withdraw (e.g. $0.1 → ETH on Ethereum), the confirmation still showed a big transaction fee and an enabled Withdraw button, letting the user submit into a failing transaction.

`useNoPayTokenQuotesAlert`'s `isOptionalOnly` check was matching the post-quote `sourceAmount.targetTokenAddress` (the destination token, e.g. native ETH `0x0…0`) against a `skipIfBalance` required token on a different chain (Arbitrum native gas, also `0x0…0`). That false match suppressed the `NoPayTokenQuotes` alert. `isOptionalOnly` is only meaningful for non-post-quote flows, so this PR bypasses it for post-quote. The existing `CustomAmountInfo` logic then hides the fee rows and shows the disabled "No quotes" button as designed.

## **Changelog**

CHANGELOG entry: Fixed Perps withdraw showing a transaction fee and enabled button when no route was available; the rows now hide and the button shows "No quotes".

## **Related issues**

Fixes: [#29297](https://github.com/MetaMask/metamask-mobile/issues/29297)

## **Manual testing steps**

~~~gherkin
Feature: Perps withdraw handles missing quotes

  Scenario: no viable quote for the amount
    Given user is on the Perps withdraw confirmation
    When user enters "0.1" and selects "ETH on Ethereum"
    And user presses Done
    Then "Transaction fee" and "You'll receive" rows are not shown
    And the primary button shows "No quotes" and is disabled

  Scenario: viable quote exists (regression)
    Given user is on the Perps withdraw confirmation
    When user enters a viable amount and selects any receive token
    And user presses Done
    Then "Transaction fee" and "You'll receive" rows are shown
    And the primary button shows "Withdraw" and is enabled
~~~

## **Screenshots/Recordings**

### **Before**
<img width="448" height="221" alt="image" src="https://github.com/user-attachments/assets/727d8f21-ce3a-41af-a90e-d30bcadc5c1b" />


### **After**
$0.1
<img width="460" height="220" alt="image" src="https://github.com/user-attachments/assets/05877a43-e94a-46ff-85d4-0ad7844fd622" />

$0.5
<img width="457" height="240" alt="image" src="https://github.com/user-attachments/assets/773271b5-a001-405b-b608-4c5fc6de9564" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes blocking alert logic in transaction confirmations for post-quote flows, which can affect whether users can proceed with withdrawals; risk is moderated by targeted condition and added tests.
> 
> **Overview**
> Fixes a false-negative in the `NoPayTokenQuotes` blocking alert for *post-quote* flows by bypassing the `isOptionalOnly` (skip-if-balance) suppression when `useTransactionPayIsPostQuote` is true, preventing cross-chain native-token address collisions (e.g., `0x0…0`) from hiding the no-quotes state.
> 
> Adds/updates unit tests to cover the non-post-quote optional-token case and a regression scenario where a post-quote destination token address would previously suppress the alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b1072bb2a9ecad7fc8c3f85f5d622082f5aec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->