### PR TITLE
feat(rewards): show ondo outcome toasts

### DIFF
--- a/app/components/UI/Rewards/Views/CampaignsView.test.tsx
+++ b/app/components/UI/Rewards/Views/CampaignsView.test.tsx
@@ -27,6 +27,14 @@ const mockUseRewardCampaigns = useRewardCampaigns as jest.MockedFunction<
   typeof useRewardCampaigns
 >;
 
+jest.mock('../hooks/useOndoOutcomeToast', () => ({
+  useOndoOutcomeToast: jest.fn(),
+}));
+import { useOndoOutcomeToast } from '../hooks/useOndoOutcomeToast';
+const mockUseOndoOutcomeToast = useOndoOutcomeToast as jest.MockedFunction<
+  typeof useOndoOutcomeToast
+>;
+
 jest.mock('../components/Campaigns/CampaignsGroup', () => {
   const ReactActual = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');
@@ -164,6 +172,7 @@ describe('CampaignsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRewardCampaigns.mockReturnValue(hookDefaults);
+    mockUseOndoOutcomeToast.mockReturnValue(undefined);
   });
 
   it('renders the header with the correct title', () => {
@@ -362,6 +371,13 @@ describe('CampaignsView', () => {
       const { queryByText } = render(<CampaignsView />);
 
       expect(queryByText('Refreshing...')).toBeNull();
+    });
+  });
+
+  describe('hook integration', () => {
+    it('calls useOndoOutcomeToast on render', () => {
+      render(<CampaignsView />);
+      expect(mockUseOndoOutcomeToast).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Rewards/Views/CampaignsView.tsx
+++ b/app/components/UI/Rewards/Views/CampaignsView.tsx
@@ -16,6 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
 import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useOndoOutcomeToast } from '../hooks/useOndoOutcomeToast';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants';
 import CampaignsGroup from '../components/Campaigns/CampaignsGroup';
@@ -30,6 +31,7 @@ import { strings } from '../../../../../locales/i18n';
 const CampaignsView: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
+  useOndoOutcomeToast();
   const { categorizedCampaigns, isLoading, hasError, fetchCampaigns } =
     useRewardCampaigns();
 

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -186,6 +186,10 @@ jest.mock('../hooks/useBulkLinkState', () => ({
   useBulkLinkState: jest.fn(),
 }));
 
+jest.mock('../hooks/useOndoOutcomeToast', () => ({
+  useOndoOutcomeToast: jest.fn(),
+}));
+
 // Import mocked hooks
 import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
 import { useRewardDashboardModals } from '../hooks/useRewardDashboardModals';

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -21,6 +21,7 @@ import {
   RewardsDashboardModalType,
 } from '../hooks/useRewardDashboardModals';
 import { useBulkLinkState } from '../hooks/useBulkLinkState';
+import { useOndoOutcomeToast } from '../hooks/useOndoOutcomeToast';
 import Toast from '../../../../component-library/components/Toast';
 import { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -42,6 +43,7 @@ const RewardsDashboard: React.FC = () => {
   const hasTrackedDashboardViewed = useRef(false);
 
   useTrackRewardsPageView({ page_type: 'home' });
+  useOndoOutcomeToast();
   const hideUnlinkedAccountsBanner = useSelector(
     selectHideUnlinkedAccountsBanner,
   );

--- a/app/components/UI/Rewards/hooks/useOndoOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useOndoOutcomeToast.test.ts
@@ -1,0 +1,559 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useContext } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { useOndoOutcomeToast } from './useOndoOutcomeToast';
+import { dismissCampaignOutcomeToast } from '../../../../reducers/rewards';
+import {
+  selectCampaigns,
+  selectDismissedCampaignOutcomeToasts,
+} from '../../../../reducers/rewards/selectors';
+import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { useOndoCampaignParticipantOutcome } from './useOndoCampaignParticipantOutcome';
+import {
+  CampaignType,
+  type OndoGmCampaignParticipantOutcomeDto,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+import Routes from '../../../../constants/navigation/Routes';
+import {
+  ToastVariants,
+  ButtonIconVariant,
+} from '../../../../component-library/components/Toast/Toast.types';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+  useCallback: jest.fn((fn) => fn),
+  useMemo: jest.fn((fn) => fn()),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('expo-haptics', () => ({
+  notificationAsync: jest.fn(),
+  NotificationFeedbackType: {
+    Success: 'success',
+    Warning: 'warning',
+    Error: 'error',
+  },
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string, params?: Record<string, string>) => {
+    if (params?.campaignName) return `${key}:${params.campaignName}`;
+    return key;
+  }),
+}));
+
+jest.mock('../../../../util/theme', () => {
+  const actual = jest.requireActual('../../../../util/theme');
+  return {
+    ...actual,
+    useAppThemeFromContext: () => actual.mockTheme,
+  };
+});
+
+jest.mock('../../../../reducers/rewards', () => ({
+  dismissCampaignOutcomeToast: jest.fn(),
+}));
+
+jest.mock('../../../../reducers/rewards/selectors', () => ({
+  selectCampaigns: jest.fn(),
+  selectDismissedCampaignOutcomeToasts: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/rewards', () => ({
+  selectRewardsSubscriptionId: jest.fn(),
+}));
+
+jest.mock('./useOndoCampaignParticipantOutcome', () => ({
+  useOndoCampaignParticipantOutcome: jest.fn(),
+}));
+
+const mockDispatch = jest.fn();
+const mockNavigate = jest.fn();
+const mockShowToast = jest.fn();
+const mockCloseToast = jest.fn();
+const mockToastRef = {
+  current: { showToast: mockShowToast, closeToast: mockCloseToast },
+};
+
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+  typeof useFocusEffect
+>;
+const mockUseNavigation = useNavigation as jest.MockedFunction<
+  typeof useNavigation
+>;
+const mockUseOndoCampaignParticipantOutcome =
+  useOndoCampaignParticipantOutcome as jest.MockedFunction<
+    typeof useOndoCampaignParticipantOutcome
+  >;
+const mockDismissCampaignOutcomeToast =
+  dismissCampaignOutcomeToast as jest.MockedFunction<
+    typeof dismissCampaignOutcomeToast
+  >;
+
+const SUBSCRIPTION_ID = 'sub-123';
+const CAMPAIGN_ID = 'campaign-456';
+const CAMPAIGN_NAME = 'Ondo Test Campaign';
+
+function makeParticipantOutcome(
+  options: Pick<OndoGmCampaignParticipantOutcomeDto, 'outcomeStatus'> & {
+    winnerVerificationCode?: string | null;
+    subscriptionId?: string;
+  },
+): OndoGmCampaignParticipantOutcomeDto {
+  return {
+    subscriptionId: options.subscriptionId ?? SUBSCRIPTION_ID,
+    outcomeStatus: options.outcomeStatus,
+    winnerVerificationCode: options.winnerVerificationCode,
+  };
+}
+
+const makeCompletedOndoCampaign = (
+  id = CAMPAIGN_ID,
+  endDate = '2025-01-01T00:00:00Z',
+) => ({
+  id,
+  name: CAMPAIGN_NAME,
+  type: CampaignType.ONDO_HOLDING,
+  endDate,
+  startDate: '2024-01-01T00:00:00Z',
+});
+
+function setupDefaults({
+  campaigns = [],
+  dismissed = {},
+  subscriptionId = SUBSCRIPTION_ID,
+  outcome = null,
+}: {
+  campaigns?: ReturnType<typeof makeCompletedOndoCampaign>[];
+  dismissed?: Record<string, boolean>;
+  subscriptionId?: string | null;
+  outcome?: OndoGmCampaignParticipantOutcomeDto | null;
+} = {}) {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectCampaigns) return campaigns;
+    if (selector === selectDismissedCampaignOutcomeToasts) return dismissed;
+    if (selector === selectRewardsSubscriptionId) return subscriptionId;
+    return undefined;
+  });
+  mockUseOndoCampaignParticipantOutcome.mockReturnValue({
+    outcome,
+    isLoading: false,
+    hasError: false,
+  });
+}
+
+describe('useOndoOutcomeToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockUseNavigation.mockReturnValue({ navigate: mockNavigate } as never);
+    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
+    mockUseFocusEffect.mockImplementation((cb) => {
+      cb();
+    });
+    mockDismissCampaignOutcomeToast.mockReturnValue({
+      type: 'rewards/dismissCampaignOutcomeToast',
+    } as never);
+  });
+
+  describe('targetCampaign selection', () => {
+    it('passes undefined to useOndoCampaignParticipantOutcome when no campaigns', () => {
+      setupDefaults({ campaigns: [] });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockUseOndoCampaignParticipantOutcome).toHaveBeenCalledWith(
+        undefined,
+      );
+    });
+
+    it('passes completed ONDO campaign id to useOndoCampaignParticipantOutcome', () => {
+      const campaign = makeCompletedOndoCampaign();
+      setupDefaults({ campaigns: [campaign] });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockUseOndoCampaignParticipantOutcome).toHaveBeenCalledWith(
+        CAMPAIGN_ID,
+      );
+    });
+
+    it('selects the most recently ended campaign when multiple exist', () => {
+      const older = makeCompletedOndoCampaign(
+        'campaign-old',
+        '2024-06-01T00:00:00Z',
+      );
+      const newer = makeCompletedOndoCampaign(
+        'campaign-new',
+        '2025-01-01T00:00:00Z',
+      );
+      setupDefaults({ campaigns: [older, newer] });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockUseOndoCampaignParticipantOutcome).toHaveBeenCalledWith(
+        'campaign-new',
+      );
+    });
+  });
+
+  describe('variant derivation', () => {
+    it('does not show toast when outcome is null', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: null,
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('derives winner_verify when outcome has verification code and is not finalized', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'WINNER-XYZ',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({ iconName: IconName.Star }),
+      );
+    });
+
+    it('derives participant_no_winner when outcome is finalized with no verification code', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: null,
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({ iconName: IconName.Info }),
+      );
+    });
+
+    it('does not show toast when outcome is finalized with a verification code', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: 'WINNER-XYZ',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('does not show toast when outcome is pending with no verification code', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: null,
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dismissal check', () => {
+    it('does not show toast when winner_verify toast was previously dismissed', () => {
+      const key = `${CAMPAIGN_ID}:${SUBSCRIPTION_ID}:winner_verify`;
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+        dismissed: { [key]: true },
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('does not show toast when participant_no_winner toast was previously dismissed', () => {
+      const key = `${CAMPAIGN_ID}:${SUBSCRIPTION_ID}:participant_no_winner`;
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: null,
+        }),
+        dismissed: { [key]: true },
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('shows toast when a different variant was dismissed', () => {
+      const key = `${CAMPAIGN_ID}:${SUBSCRIPTION_ID}:participant_no_winner`;
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+        dismissed: { [key]: true },
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).toHaveBeenCalled();
+    });
+  });
+
+  describe('toast configuration', () => {
+    it('shows winner_verify toast with correct config', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Star,
+          backgroundColor: 'transparent',
+          hasNoTimeout: true,
+          labelOptions: [
+            {
+              label: 'rewards.ondo_outcome_toast.winner_verify.title',
+              isBold: true,
+            },
+          ],
+          descriptionOptions: {
+            description: `rewards.ondo_outcome_toast.winner_verify.description:${CAMPAIGN_NAME}`,
+          },
+          linkButtonOptions: expect.objectContaining({
+            label: 'rewards.ondo_outcome_toast.winner_verify.cta',
+          }),
+          closeButtonOptions: expect.objectContaining({
+            variant: ButtonIconVariant.Icon,
+            iconName: IconName.Close,
+          }),
+        }),
+      );
+    });
+
+    it('shows participant_no_winner toast with correct config', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: null,
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Info,
+          backgroundColor: 'transparent',
+          hasNoTimeout: true,
+          labelOptions: [
+            {
+              label: 'rewards.ondo_outcome_toast.participant_no_winner.title',
+              isBold: true,
+            },
+          ],
+          descriptionOptions: {
+            description: `rewards.ondo_outcome_toast.participant_no_winner.description:${CAMPAIGN_NAME}`,
+          },
+          linkButtonOptions: expect.objectContaining({
+            label: 'rewards.ondo_outcome_toast.participant_no_winner.cta',
+          }),
+        }),
+      );
+    });
+
+    it('fires Success haptic for winner_verify', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(notificationAsync).toHaveBeenCalledWith(
+        NotificationFeedbackType.Success,
+      );
+    });
+
+    it('fires Warning haptic for participant_no_winner', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: null,
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(notificationAsync).toHaveBeenCalledWith(
+        NotificationFeedbackType.Warning,
+      );
+    });
+  });
+
+  describe('cleanup on blur', () => {
+    it('calls closeToast in the cleanup function when screen blurs', () => {
+      let cleanupFn: (() => void) | undefined;
+      mockUseFocusEffect.mockImplementation((cb) => {
+        const cleanup = cb();
+        if (typeof cleanup === 'function') cleanupFn = cleanup;
+      });
+
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      expect(cleanupFn).toBeDefined();
+      cleanupFn?.();
+      expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not return a cleanup function when variant is null', () => {
+      let cleanupFn: (() => void) | undefined;
+      mockUseFocusEffect.mockImplementation((cb) => {
+        const result = cb();
+        if (typeof result === 'function') cleanupFn = result;
+      });
+
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: null,
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      expect(cleanupFn).toBeUndefined();
+      expect(mockCloseToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleDismiss', () => {
+    it('dispatches dismissCampaignOutcomeToast and closes toast when close button is pressed', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      const closeButtonOptions =
+        mockShowToast.mock.calls[0][0].closeButtonOptions;
+      closeButtonOptions.onPress();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockDismissCampaignOutcomeToast.mock.results[0]?.value,
+      );
+      expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
+        campaignId: CAMPAIGN_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        variant: 'winner_verify',
+      });
+      expect(mockCloseToast).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCta', () => {
+    it('navigates to winning view and dismisses for winner_verify', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      const linkButtonOptions =
+        mockShowToast.mock.calls[0][0].linkButtonOptions;
+      linkButtonOptions.onPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.REWARDS_ONDO_CAMPAIGN_WINNING_VIEW,
+        { campaignId: CAMPAIGN_ID },
+      );
+      expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
+        campaignId: CAMPAIGN_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        variant: 'winner_verify',
+      });
+    });
+
+    it('navigates to campaign details view and dismisses for participant_no_winner', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'finalized',
+          winnerVerificationCode: null,
+        }),
+      });
+      renderHook(() => useOndoOutcomeToast());
+
+      const linkButtonOptions =
+        mockShowToast.mock.calls[0][0].linkButtonOptions;
+      linkButtonOptions.onPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW,
+        { campaignId: CAMPAIGN_ID },
+      );
+      expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
+        campaignId: CAMPAIGN_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        variant: 'participant_no_winner',
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('does not show toast when subscriptionId is missing', () => {
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+        subscriptionId: null,
+      });
+      renderHook(() => useOndoOutcomeToast());
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('handles null toastRef gracefully', () => {
+      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
+      setupDefaults({
+        campaigns: [makeCompletedOndoCampaign()],
+        outcome: makeParticipantOutcome({
+          outcomeStatus: 'pending',
+          winnerVerificationCode: 'CODE',
+        }),
+      });
+      expect(() => renderHook(() => useOndoOutcomeToast())).not.toThrow();
+    });
+  });
+});

--- a/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
@@ -1,0 +1,157 @@
+import { useCallback, useContext, useMemo } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useDispatch, useSelector } from 'react-redux';
+import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import Routes from '../../../../constants/navigation/Routes';
+import { strings } from '../../../../../locales/i18n';
+import { ToastContext } from '../../../../component-library/components/Toast';
+import {
+  ButtonIconVariant,
+  ToastVariants,
+} from '../../../../component-library/components/Toast/Toast.types';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { useAppThemeFromContext } from '../../../../util/theme';
+import { CampaignType } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
+import { dismissCampaignOutcomeToast } from '../../../../reducers/rewards';
+import {
+  selectCampaigns,
+  selectDismissedCampaignOutcomeToasts,
+} from '../../../../reducers/rewards/selectors';
+import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { useOndoCampaignParticipantOutcome } from './useOndoCampaignParticipantOutcome';
+
+export type OutcomeToastVariant = 'winner_verify' | 'participant_no_winner';
+
+export function useOndoOutcomeToast(): void {
+  const dispatch = useDispatch();
+  const { toastRef } = useContext(ToastContext);
+  const theme = useAppThemeFromContext();
+  const navigation = useNavigation();
+
+  const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const campaigns = useSelector(selectCampaigns);
+  const dismissed = useSelector(selectDismissedCampaignOutcomeToasts);
+
+  const targetCampaign = useMemo(() => {
+    const completed = campaigns
+      .filter(
+        (c) =>
+          c.type === CampaignType.ONDO_HOLDING &&
+          getCampaignStatus(c) === 'complete',
+      )
+      .sort(
+        (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime(),
+      );
+    return completed[0] ?? null;
+  }, [campaigns]);
+
+  const { outcome } = useOndoCampaignParticipantOutcome(targetCampaign?.id);
+
+  const variant = useMemo((): OutcomeToastVariant | null => {
+    if (!outcome) return null;
+    if (
+      outcome.winnerVerificationCode &&
+      outcome.outcomeStatus !== 'finalized'
+    ) {
+      return 'winner_verify';
+    }
+    if (
+      outcome.outcomeStatus === 'finalized' &&
+      !outcome.winnerVerificationCode
+    ) {
+      return 'participant_no_winner';
+    }
+    return null;
+  }, [outcome]);
+
+  const isDismissed = useMemo(() => {
+    if (!variant || !targetCampaign || !subscriptionId) return true;
+    const key = `${targetCampaign.id}:${subscriptionId}:${variant}`;
+    return dismissed[key] === true;
+  }, [variant, targetCampaign, subscriptionId, dismissed]);
+
+  const handleDismiss = useCallback(() => {
+    if (!variant || !targetCampaign || !subscriptionId) return;
+    dispatch(
+      dismissCampaignOutcomeToast({
+        campaignId: targetCampaign.id,
+        subscriptionId,
+        variant,
+      }),
+    );
+    toastRef?.current?.closeToast();
+  }, [variant, targetCampaign, subscriptionId, dispatch, toastRef]);
+
+  const handleCta = useCallback(() => {
+    if (!targetCampaign || !variant) return;
+    handleDismiss();
+    if (variant === 'winner_verify') {
+      navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_WINNING_VIEW, {
+        campaignId: targetCampaign.id,
+      });
+    } else {
+      navigation.navigate(Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW, {
+        campaignId: targetCampaign.id,
+      });
+    }
+  }, [variant, targetCampaign, handleDismiss, navigation]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!variant || isDismissed || !targetCampaign) return;
+
+      const isWinner = variant === 'winner_verify';
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        iconName: isWinner ? IconName.Star : IconName.Info,
+        iconColor: isWinner
+          ? theme.colors.warning.default
+          : theme.colors.icon.default,
+        backgroundColor: 'transparent',
+        hasNoTimeout: true,
+        labelOptions: [
+          {
+            label: strings(`rewards.ondo_outcome_toast.${variant}.title`),
+            isBold: true,
+          },
+        ],
+        descriptionOptions: {
+          description: strings(
+            `rewards.ondo_outcome_toast.${variant}.description`,
+            { campaignName: targetCampaign.name },
+          ),
+        },
+        linkButtonOptions: {
+          label: strings(`rewards.ondo_outcome_toast.${variant}.cta`),
+          onPress: handleCta,
+        },
+        closeButtonOptions: {
+          variant: ButtonIconVariant.Icon,
+          iconName: IconName.Close,
+          onPress: handleDismiss,
+        },
+      });
+      notificationAsync(
+        isWinner
+          ? NotificationFeedbackType.Success
+          : NotificationFeedbackType.Warning,
+      );
+
+      return () => {
+        toastRef?.current?.closeToast();
+      };
+    }, [
+      variant,
+      isDismissed,
+      targetCampaign,
+      toastRef,
+      theme.colors.warning.default,
+      theme.colors.icon.default,
+      handleCta,
+      handleDismiss,
+    ]),
+  );
+}
+
+export default useOndoOutcomeToast;

--- a/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useOndoOutcomeToast.ts
@@ -107,7 +107,7 @@ export function useOndoOutcomeToast(): void {
         iconName: isWinner ? IconName.Star : IconName.Info,
         iconColor: isWinner
           ? theme.colors.warning.default
-          : theme.colors.icon.default,
+          : theme.colors.success.default,
         backgroundColor: 'transparent',
         hasNoTimeout: true,
         labelOptions: [
@@ -147,7 +147,7 @@ export function useOndoOutcomeToast(): void {
       targetCampaign,
       toastRef,
       theme.colors.warning.default,
-      theme.colors.icon.default,
+      theme.colors.success.default,
       handleCta,
       handleDismiss,
     ]),

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -2079,6 +2079,7 @@ describe('rewardsReducer', () => {
         versionGuardLoading: false,
         versionGuardError: false,
         pendingDeeplink: null,
+        dismissedCampaignOutcomeToasts: {},
       };
       const action = resetRewardsState();
 
@@ -2254,6 +2255,7 @@ describe('rewardsReducer', () => {
             icon: 'Coin',
           },
         ],
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -2287,6 +2289,7 @@ describe('rewardsReducer', () => {
             buttonAction: { route: { root: 'PerpsRoot', screen: 'PerpsHome' } },
           },
         ],
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -2377,6 +2380,7 @@ describe('rewardsReducer', () => {
             hide: true,
           },
         ],
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -2445,6 +2449,7 @@ describe('rewardsReducer', () => {
         hideUnlinkedAccountsBanner: true,
         onboardingActiveStep: OnboardingStep.STEP_4, // This should NOT be persisted
         onboardingReferralCode: 'PERSISTED_REF', // This should NOT be persisted
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -2529,6 +2534,7 @@ describe('rewardsReducer', () => {
         ondoCampaignLeaderboardPositions: {
           'sub-1:campaign-1': mockPosition,
         },
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -2576,6 +2582,7 @@ describe('rewardsReducer', () => {
         ondoCampaignPortfolio: {
           'sub-1:campaign-1': persisted,
         },
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -4400,6 +4407,7 @@ describe('persist/REHYDRATE with bulk link state', () => {
         wasInterrupted: false,
         initialSubscriptionId: 'running-sub',
       },
+      dismissedCampaignOutcomeToasts: {},
     };
     const rehydrateAction = {
       type: 'persist/REHYDRATE',
@@ -4431,6 +4439,7 @@ describe('persist/REHYDRATE with bulk link state', () => {
         wasInterrupted: false,
         initialSubscriptionId: 'progress-sub',
       },
+      dismissedCampaignOutcomeToasts: {},
     };
     const rehydrateAction = {
       type: 'persist/REHYDRATE',
@@ -4460,6 +4469,7 @@ describe('persist/REHYDRATE with bulk link state', () => {
         wasInterrupted: false,
         initialSubscriptionId: 'validate-sub',
       },
+      dismissedCampaignOutcomeToasts: {},
     };
     const rehydrateAction = {
       type: 'persist/REHYDRATE',
@@ -4487,6 +4497,7 @@ describe('persist/REHYDRATE with bulk link state', () => {
         wasInterrupted: false,
         initialSubscriptionId: 'completed-sub',
       },
+      dismissedCampaignOutcomeToasts: {},
     };
     const rehydrateAction = {
       type: 'persist/REHYDRATE',
@@ -4515,6 +4526,7 @@ describe('persist/REHYDRATE with bulk link state', () => {
         wasInterrupted: false,
         initialSubscriptionId: 'old-sub',
       },
+      dismissedCampaignOutcomeToasts: {},
     };
     const rehydrateAction = {
       type: 'persist/REHYDRATE',
@@ -4592,6 +4604,7 @@ describe('setBenefits', () => {
     const stateWithBenefits: RewardsState = {
       ...initialState,
       benefits: mockBenefitsPayload.benefits,
+      dismissedCampaignOutcomeToasts: {},
     };
     const nextBenefitsPayload = {
       limit: 20,
@@ -4618,6 +4631,7 @@ describe('setBenefits', () => {
       benefitsError: true,
       campaignsLoading: true,
       activeTab: 'campaigns',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setBenefits(mockBenefitsPayload);
 
@@ -4644,6 +4658,7 @@ describe('setBenefitsLoading', () => {
     const stateWithLoading: RewardsState = {
       ...initialState,
       benefitsLoading: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setBenefitsLoading(false);
 
@@ -4666,6 +4681,7 @@ describe('setBenefitsError', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       benefitsError: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setBenefitsError(false);
 
@@ -4701,6 +4717,7 @@ describe('setCampaigns', () => {
     const stateWithCampaigns: RewardsState = {
       ...initialState,
       campaigns: [mockCampaign],
+      dismissedCampaignOutcomeToasts: {},
     };
     const newCampaign: CampaignDto = {
       ...mockCampaign,
@@ -4719,6 +4736,7 @@ describe('setCampaigns', () => {
     const stateWithCampaigns: RewardsState = {
       ...initialState,
       campaigns: [mockCampaign],
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaigns([]);
 
@@ -4732,6 +4750,7 @@ describe('setCampaigns', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       campaignsError: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaigns([mockCampaign]);
 
@@ -4756,6 +4775,7 @@ describe('setCampaignsLoading', () => {
       ...initialState,
       campaigns: [mockCampaign],
       campaignsLoading: false,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaignsLoading(true);
 
@@ -4768,6 +4788,7 @@ describe('setCampaignsLoading', () => {
     const stateWithLoading: RewardsState = {
       ...initialState,
       campaignsLoading: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaignsLoading(false);
 
@@ -4781,6 +4802,7 @@ describe('setCampaignsLoading', () => {
       ...initialState,
       campaigns: [mockCampaign],
       campaignsLoading: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaignsLoading(false);
 
@@ -4805,6 +4827,7 @@ describe('setCampaignsError', () => {
       ...initialState,
       campaignsError: true,
       campaignsHasLoaded: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaignsError(false);
 
@@ -4819,6 +4842,7 @@ describe('setCampaignsError', () => {
       ...initialState,
       campaignsError: true,
       campaignsHasLoaded: false,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setCampaignsError(false);
 
@@ -4870,6 +4894,7 @@ describe('setCampaignParticipantStatus', () => {
       campaignParticipantStatuses: {
         'sub-1:campaign-1': { optedIn: false, participantCount: 10 },
       },
+      dismissedCampaignOutcomeToasts: {},
     };
 
     const action = setCampaignParticipantStatus({
@@ -4935,6 +4960,7 @@ describe('setVersionGuardMinimumMobileVersion', () => {
     const stateWithVersion: RewardsState = {
       ...initialState,
       versionGuardMinimumMobileVersion: '7.29.0',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setVersionGuardMinimumMobileVersion('7.30.0');
 
@@ -4947,6 +4973,7 @@ describe('setVersionGuardMinimumMobileVersion', () => {
     const stateWithVersion: RewardsState = {
       ...initialState,
       versionGuardMinimumMobileVersion: '7.30.0',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setVersionGuardMinimumMobileVersion(null);
 
@@ -4979,6 +5006,7 @@ describe('setVersionGuardLoading', () => {
     const stateWithLoading: RewardsState = {
       ...initialState,
       versionGuardLoading: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setVersionGuardLoading(false);
 
@@ -5012,6 +5040,7 @@ describe('setVersionGuardError', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       versionGuardError: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setVersionGuardError(false);
 
@@ -5276,6 +5305,7 @@ describe('setOndoCampaignLeaderboard', () => {
     const stateWithSelectedTier: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardSelectedTier: 'MID',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboard(mockLeaderboard);
 
@@ -5288,6 +5318,7 @@ describe('setOndoCampaignLeaderboard', () => {
     const stateWithStaleSelection: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardSelectedTier: 'UPPER',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboard(mockLeaderboard);
 
@@ -5300,6 +5331,7 @@ describe('setOndoCampaignLeaderboard', () => {
     const stateWithLeaderboard: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboard: mockLeaderboard,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboard(null);
 
@@ -5312,6 +5344,7 @@ describe('setOndoCampaignLeaderboard', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardError: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboard(mockLeaderboard);
 
@@ -5335,6 +5368,7 @@ describe('setOndoCampaignLeaderboardLoading', () => {
       ...initialState,
       ondoCampaignLeaderboard: mockLeaderboard,
       ondoCampaignLeaderboardLoading: false,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboardLoading(true);
 
@@ -5347,6 +5381,7 @@ describe('setOndoCampaignLeaderboardLoading', () => {
     const stateWithLoading: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardLoading: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboardLoading(false);
 
@@ -5369,6 +5404,7 @@ describe('setOndoCampaignLeaderboardError', () => {
     const stateWithError: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardError: true,
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboardError(false);
 
@@ -5391,6 +5427,7 @@ describe('setOndoCampaignLeaderboardSelectedTier', () => {
     const stateWithSelectedTier: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardSelectedTier: 'STARTER',
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboardSelectedTier('UPPER');
 
@@ -5419,6 +5456,7 @@ describe('setOndoCampaignLeaderboardPosition', () => {
     const stateWithPosition: RewardsState = {
       ...initialState,
       ondoCampaignLeaderboardPositions: { 'sub-1:campaign-1': mockPosition },
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignLeaderboardPosition({
       subscriptionId: 'sub-1',
@@ -5483,6 +5521,7 @@ describe('setOndoCampaignPortfolioPosition', () => {
     const stateWithPortfolio: RewardsState = {
       ...initialState,
       ondoCampaignPortfolio: { 'sub-1:campaign-1': mockPortfolio },
+      dismissedCampaignOutcomeToasts: {},
     };
     const action = setOndoCampaignPortfolioPosition({
       subscriptionId: 'sub-1',

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -52,6 +52,7 @@ import rewardsReducer, {
   setVersionGuardMinimumMobileVersion,
   setVersionGuardLoading,
   setVersionGuardError,
+  dismissCampaignOutcomeToast,
   RewardsState,
 } from '.';
 import { OnboardingStep } from './types';
@@ -2199,6 +2200,7 @@ describe('rewardsReducer', () => {
         versionGuardLoading: false,
         versionGuardError: false,
         pendingDeeplink: null,
+        dismissedCampaignOutcomeToasts: {},
       };
       const rehydrateAction = {
         type: 'persist/REHYDRATE',
@@ -5608,5 +5610,122 @@ describe('ondoCampaignDeposits', () => {
     expect(state.ondoCampaignDeposits).toBeNull();
     expect(state.ondoCampaignDepositsLoading).toBe(false);
     expect(state.ondoCampaignDepositsError).toBe(false);
+  });
+
+  describe('dismissCampaignOutcomeToast', () => {
+    it('records winner_verify variant as dismissed', () => {
+      const state = rewardsReducer(
+        initialState,
+        dismissCampaignOutcomeToast({
+          campaignId: 'campaign-1',
+          subscriptionId: 'sub-1',
+          variant: 'winner_verify',
+        }),
+      );
+
+      expect(
+        state.dismissedCampaignOutcomeToasts['campaign-1:sub-1:winner_verify'],
+      ).toBe(true);
+    });
+
+    it('records participant_no_winner variant as dismissed', () => {
+      const state = rewardsReducer(
+        initialState,
+        dismissCampaignOutcomeToast({
+          campaignId: 'campaign-2',
+          subscriptionId: 'sub-2',
+          variant: 'participant_no_winner',
+        }),
+      );
+
+      expect(
+        state.dismissedCampaignOutcomeToasts[
+          'campaign-2:sub-2:participant_no_winner'
+        ],
+      ).toBe(true);
+    });
+
+    it('accumulates multiple dismissed toasts without overwriting existing ones', () => {
+      let state = rewardsReducer(
+        initialState,
+        dismissCampaignOutcomeToast({
+          campaignId: 'c1',
+          subscriptionId: 's1',
+          variant: 'winner_verify',
+        }),
+      );
+      state = rewardsReducer(
+        state,
+        dismissCampaignOutcomeToast({
+          campaignId: 'c2',
+          subscriptionId: 's2',
+          variant: 'participant_no_winner',
+        }),
+      );
+
+      expect(state.dismissedCampaignOutcomeToasts['c1:s1:winner_verify']).toBe(
+        true,
+      );
+      expect(
+        state.dismissedCampaignOutcomeToasts['c2:s2:participant_no_winner'],
+      ).toBe(true);
+    });
+
+    it('starts with empty dismissedCampaignOutcomeToasts in initial state', () => {
+      expect(initialState.dismissedCampaignOutcomeToasts).toEqual({});
+    });
+  });
+
+  describe('persist/REHYDRATE — dismissedCampaignOutcomeToasts', () => {
+    it('restores dismissedCampaignOutcomeToasts from persisted state', () => {
+      const persisted: RewardsState = {
+        ...initialState,
+        dismissedCampaignOutcomeToasts: {
+          'campaign-1:sub-1:winner_verify': true,
+        },
+      };
+
+      const state = rewardsReducer(initialState, {
+        type: 'persist/REHYDRATE',
+        payload: { rewards: persisted },
+      });
+
+      expect(state.dismissedCampaignOutcomeToasts).toEqual({
+        'campaign-1:sub-1:winner_verify': true,
+      });
+    });
+
+    it('defaults to empty object when dismissedCampaignOutcomeToasts is absent from persisted state', () => {
+      const persisted = { ...initialState } as Partial<RewardsState>;
+      delete persisted.dismissedCampaignOutcomeToasts;
+
+      const state = rewardsReducer(initialState, {
+        type: 'persist/REHYDRATE',
+        payload: { rewards: persisted },
+      });
+
+      expect(state.dismissedCampaignOutcomeToasts).toEqual({});
+    });
+  });
+
+  describe('setCandidateSubscriptionId — preserves dismissedCampaignOutcomeToasts', () => {
+    it('preserves dismissedCampaignOutcomeToasts when subscription ID changes', () => {
+      const stateWithDismissals: RewardsState = {
+        ...initialState,
+        candidateSubscriptionId: 'old-sub',
+        dismissedCampaignOutcomeToasts: {
+          'campaign-1:old-sub:winner_verify': true,
+        },
+      };
+
+      const state = rewardsReducer(
+        stateWithDismissals,
+        setCandidateSubscriptionId('new-sub'),
+      );
+
+      expect(state.dismissedCampaignOutcomeToasts).toEqual({
+        'campaign-1:old-sub:winner_verify': true,
+      });
+    });
   });
 });

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -168,6 +168,9 @@ export interface RewardsState {
   // Pending deeplink navigation intent, stored in Redux so it survives the
   // UnmountOnBlur remount of RewardsHome when navigating from outside the tab.
   pendingDeeplink: PendingDeeplink | null;
+
+  // Dismissed outcome toasts (keyed by `${campaignId}:${subscriptionId}:${variant}`)
+  dismissedCampaignOutcomeToasts: Record<string, boolean>;
 }
 
 /**
@@ -276,6 +279,8 @@ export const initialState: RewardsState = {
   ondoCampaignDepositsError: false,
 
   pendingDeeplink: null,
+
+  dismissedCampaignOutcomeToasts: {},
 };
 
 interface RehydrateAction extends Action<'persist/REHYDRATE'> {
@@ -438,6 +443,7 @@ const rewardsSlice = createSlice({
             state.hideCurrentAccountNotOptedInBanner,
           hideUnlinkedAccountsBanner: state.hideUnlinkedAccountsBanner,
           bulkLink: state.bulkLink,
+          dismissedCampaignOutcomeToasts: state.dismissedCampaignOutcomeToasts,
           versionGuardMinimumMobileVersion:
             state.versionGuardMinimumMobileVersion,
           versionGuardLoading: state.versionGuardLoading,
@@ -760,6 +766,18 @@ const rewardsSlice = createSlice({
     ) => {
       state.pendingDeeplink = action.payload;
     },
+
+    dismissCampaignOutcomeToast: (
+      state,
+      action: PayloadAction<{
+        campaignId: string;
+        subscriptionId: string;
+        variant: 'winner_verify' | 'participant_no_winner';
+      }>,
+    ) => {
+      const key = `${action.payload.campaignId}:${action.payload.subscriptionId}:${action.payload.variant}`;
+      state.dismissedCampaignOutcomeToasts[key] = true;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -813,6 +831,9 @@ const rewardsSlice = createSlice({
                 action.payload.rewards.hideUnlinkedAccountsBanner,
               hideCurrentAccountNotOptedInBanner:
                 action.payload.rewards.hideCurrentAccountNotOptedInBanner,
+
+              dismissedCampaignOutcomeToasts:
+                action.payload.rewards.dismissedCampaignOutcomeToasts ?? {},
 
               // Bulk link state - preserve interrupted status for resume capability
               bulkLink: {
@@ -897,6 +918,7 @@ export const {
   bulkLinkReset,
   bulkLinkResumed,
   setPendingDeeplink,
+  dismissCampaignOutcomeToast,
 } = rewardsSlice.actions;
 
 export default rewardsSlice.reducer;

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -70,6 +70,7 @@ import {
   selectOndoCampaignPortfolio,
   selectOndoCampaignPortfolioById,
   selectOndoCampaignActivityById,
+  selectDismissedCampaignOutcomeToasts,
 } from './selectors';
 // eslint-disable-next-line import-x/no-namespace
 import * as remoteFeatureFlagModule from '../../util/remoteFeatureFlag';
@@ -3816,6 +3817,42 @@ describe('Rewards selectors', () => {
       expect(
         selectOndoCampaignActivityById('sub-1', 'campaign-1')(state),
       ).toEqual(mockEntries);
+    });
+  });
+
+  describe('selectDismissedCampaignOutcomeToasts', () => {
+    it('returns empty object when no toasts have been dismissed', () => {
+      const state = createMockRootState({ dismissedCampaignOutcomeToasts: {} });
+      expect(selectDismissedCampaignOutcomeToasts(state)).toEqual({});
+    });
+
+    it('returns the dismissed toasts map', () => {
+      const dismissed = {
+        'campaign-1:sub-1:winner_verify': true,
+        'campaign-2:sub-1:participant_no_winner': true,
+      };
+      const state = createMockRootState({
+        dismissedCampaignOutcomeToasts: dismissed,
+      });
+      expect(selectDismissedCampaignOutcomeToasts(state)).toEqual(dismissed);
+    });
+
+    it('returns true for a dismissed toast key', () => {
+      const state = createMockRootState({
+        dismissedCampaignOutcomeToasts: {
+          'campaign-1:sub-1:winner_verify': true,
+        },
+      });
+      const result = selectDismissedCampaignOutcomeToasts(state);
+      expect(result['campaign-1:sub-1:winner_verify']).toBe(true);
+    });
+
+    it('returns undefined for a key that has not been dismissed', () => {
+      const state = createMockRootState({
+        dismissedCampaignOutcomeToasts: {},
+      });
+      const result = selectDismissedCampaignOutcomeToasts(state);
+      expect(result['campaign-1:sub-1:winner_verify']).toBeUndefined();
     });
   });
 });

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -307,3 +307,6 @@ export const selectOndoCampaignDepositsError = (state: RootState) =>
 
 export const selectPendingDeeplink = (state: RootState) =>
   state.rewards.pendingDeeplink;
+
+export const selectDismissedCampaignOutcomeToasts = (state: RootState) =>
+  state.rewards.dismissedCampaignOutcomeToasts;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8441,6 +8441,18 @@
         "title": "You're a confirmed winner!",
         "description": "Your reward is on its way — we'll be in touch shortly."
       }
+    },
+    "ondo_outcome_toast": {
+      "winner_verify": {
+        "title": "You won",
+        "description": "Claim your prize from the {{campaignName}}",
+        "cta": "View details"
+      },
+      "participant_no_winner": {
+        "title": "The results are in.",
+        "description": "See your ranking in the {{campaignName}}",
+        "cta": "View"
+      }
     }
   },
   "time": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8444,12 +8444,12 @@
     },
     "ondo_outcome_toast": {
       "winner_verify": {
-        "title": "You won",
+        "title": "You won 💰",
         "description": "Claim your prize from the {{campaignName}}",
         "cta": "View details"
       },
       "participant_no_winner": {
-        "title": "The results are in.",
+        "title": "The results are in. 🏅",
         "description": "See your ranking in the {{campaignName}}",
         "cta": "View"
       }

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -755,6 +755,7 @@
       "campaignsLoading": false,
       "candidateSubscriptionId": "pending",
       "currentTier": null,
+      "dismissedCampaignOutcomeToasts": {},
       "geoLocation": null,
       "hideCurrentAccountNotOptedInBanner": [],
       "hideUnlinkedAccountsBanner": false,


### PR DESCRIPTION
## **Description**

Shows a toast on the rewards home page or the campaign overview page if you're a potential winner with a verification code, or if you're a participant and we know that you're not a winner.

## **Changelog**

CHANGELOG entry: null

## **Screenshots/Recordings**

Showing toast for participant who didn't win once we know in the same tier for sure that there are 5 winners:

<img width="326" height="123" alt="image" src="https://github.com/user-attachments/assets/e3de243f-a123-495c-aedd-4035b9a608fe" />

<img width="304" height="558" alt="image" src="https://github.com/user-attachments/assets/7925af0e-48b3-407c-a2a6-d0db12884952" />

Showing a toast for winners with verification code but still in pending state.

<img width="304" height="558" alt="image" src="https://github.com/user-attachments/assets/97e5c31e-3fc5-471e-afc9-0f6cedc6ce55" />

<img width="304" height="558" alt="image" src="https://github.com/user-attachments/assets/e5b8cede-367e-4439-b350-8e57117a1657" />

- Dimissing the toast will cause it to not show up anymore in same session or cross session. 
- For non winners, it takes users to ondo details page;
- For winners with verification code but pending, it takes them to winner sheet.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new focus-driven toast + navigation side effect on key Rewards screens and persists new dismissal state in Redux, which could impact user-facing UX and state rehydration if mis-keyed or triggered unexpectedly.
> 
> **Overview**
> Adds `useOndoOutcomeToast`, which detects the most recently completed ONDO Holding campaign, derives an outcome variant from participant outcome data, and shows a persistent icon toast (with haptics) that deep-links to the winning or campaign details view.
> 
> Introduces Redux support for remembering dismissed outcome toasts via `dismissedCampaignOutcomeToasts` (new selector + `dismissCampaignOutcomeToast` action) and persists/rehydrates this map.
> 
> Wires the hook into `RewardsDashboard` and `CampaignsView`, updates fixtures/locales, and adds/extends unit tests covering toast behavior, dismissal, and integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa332938692d8ff05519c07e7ae5b9a76c19d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->