### PR TITLE
chore: leaderboard - abbreviate large token amounts in position rows

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -57,10 +57,10 @@ describe('PositionRow', () => {
     expect(screen.getAllByText('STARKBOT')[0]).toBeOnTheScreen();
   });
 
-  it('renders formatted token amount', () => {
+  it('renders formatted token amount abbreviated for large values', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
 
-    expect(screen.getByText('1,500,000,000 STARKBOT')).toBeOnTheScreen();
+    expect(screen.getByText('1.50B STARKBOT')).toBeOnTheScreen();
   });
 
   it('renders current value formatted as USD', () => {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -44,12 +44,16 @@ describe('formatTokenAmount', () => {
     expect(formatTokenAmount(1500000000000)).toBe('1.50T');
   });
 
-  it('caps decimals at 4 for small values below 1,000', () => {
+  it('caps decimals at 5 for small values below 1,000', () => {
     expect(formatTokenAmount(1.5)).toBe('1.5');
   });
 
-  it('caps decimals at 4 and strips trailing zeros for values below 1,000', () => {
-    expect(formatTokenAmount(1.23456789)).toBe('1.2346');
+  it('caps decimals at 5 and strips trailing zeros for values below 1,000', () => {
+    expect(formatTokenAmount(1.23456789)).toBe('1.23457');
+  });
+
+  it('correctly displays values just above the dust threshold', () => {
+    expect(formatTokenAmount(0.00003)).toBe('0.00003');
   });
 
   it('returns dust threshold string for very small positive values', () => {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -1,0 +1,115 @@
+import {
+  formatUsd,
+  formatTokenAmount,
+  formatPercent,
+  formatTradeDate,
+} from './formatters';
+
+describe('formatUsd', () => {
+  it('formats positive USD values with two decimal places', () => {
+    expect(formatUsd(1234.5)).toBe('$1,234.50');
+  });
+
+  it('formats negative USD values with a leading minus', () => {
+    expect(formatUsd(-150.5)).toBe('-$150.50');
+  });
+
+  it('formats zero as $0.00', () => {
+    expect(formatUsd(0)).toBe('$0.00');
+  });
+
+  it('returns an em dash for null', () => {
+    expect(formatUsd(null)).toBe('\u2014');
+  });
+
+  it('returns an em dash for undefined', () => {
+    expect(formatUsd(undefined)).toBe('\u2014');
+  });
+});
+
+describe('formatTokenAmount', () => {
+  it('abbreviates billions (e.g. 1.5B)', () => {
+    expect(formatTokenAmount(1500000000)).toBe('1.50B');
+  });
+
+  it('abbreviates millions (e.g. 216.65M)', () => {
+    expect(formatTokenAmount(216649924.26742363)).toBe('216.65M');
+  });
+
+  it('abbreviates thousands (e.g. 63.21K)', () => {
+    expect(formatTokenAmount(63213.6435416642)).toBe('63.21K');
+  });
+
+  it('abbreviates trillions (e.g. 1.50T)', () => {
+    expect(formatTokenAmount(1500000000000)).toBe('1.50T');
+  });
+
+  it('caps decimals at 4 for small values below 1,000', () => {
+    expect(formatTokenAmount(1.5)).toBe('1.5');
+  });
+
+  it('caps decimals at 4 and strips trailing zeros for values below 1,000', () => {
+    expect(formatTokenAmount(1.23456789)).toBe('1.2346');
+  });
+
+  it('returns dust threshold string for very small positive values', () => {
+    expect(formatTokenAmount(0.0000001)).toBe('< 0.00001');
+  });
+
+  it('returns 0 for zero input', () => {
+    expect(formatTokenAmount(0)).toBe('0');
+  });
+
+  it('returns 0 for NaN input', () => {
+    expect(formatTokenAmount(NaN)).toBe('0');
+  });
+
+  it('returns 0 for Infinity input', () => {
+    expect(formatTokenAmount(Infinity)).toBe('0');
+  });
+
+  it('handles negative values below 1,000', () => {
+    expect(formatTokenAmount(-500)).toBe('-500');
+  });
+
+  it('abbreviates large negative values', () => {
+    expect(formatTokenAmount(-1500000000)).toBe('-1.50B');
+  });
+});
+
+describe('formatPercent', () => {
+  it('formats positive percent with plus sign', () => {
+    expect(formatPercent(182)).toBe('+182%');
+  });
+
+  it('formats negative percent', () => {
+    expect(formatPercent(-25)).toBe('-25%');
+  });
+
+  it('formats zero percent with plus sign', () => {
+    expect(formatPercent(0)).toBe('+0%');
+  });
+
+  it('returns an em dash for null', () => {
+    expect(formatPercent(null)).toBe('\u2014');
+  });
+
+  it('returns an em dash for undefined', () => {
+    expect(formatPercent(undefined)).toBe('\u2014');
+  });
+});
+
+describe('formatTradeDate', () => {
+  it('formats a millisecond timestamp', () => {
+    const ms = 1744732800000; // a known fixed date
+    const result = formatTradeDate(ms);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('converts a seconds timestamp to milliseconds before formatting', () => {
+    const seconds = 1744732800; // same date in seconds
+    const ms = 1744732800000;
+    expect(formatTradeDate(seconds)).toBe(formatTradeDate(ms));
+  });
+});

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -2,9 +2,12 @@ import {
   formatPerpsFiat,
   formatPercentage,
   formatTransactionDate,
-  formatLargeNumber,
 } from '../../../UI/Perps/utils/formatUtils';
-import { formatAmountWithThreshold } from '../../../../util/number';
+import {
+  formatAmountWithThreshold,
+  localizeLargeNumber,
+} from '../../../../util/number';
+import { strings } from '../../../../../locales/i18n';
 
 const EM_DASH = '\u2014';
 
@@ -27,8 +30,14 @@ export function formatUsd(value: number | null | undefined): string {
  */
 export function formatTokenAmount(value: number): string {
   if (!Number.isFinite(value) || value === 0) return '0';
-  if (Math.abs(value) >= 1000) {
-    return formatLargeNumber(value, { decimals: 2, rawDecimals: 4 });
+  const absValue = Math.abs(value);
+  if (absValue >= 1000) {
+    const sign = value < 0 ? '-' : '';
+    const i18n = { t: (key: string) => strings(key) };
+    return (
+      sign +
+      localizeLargeNumber(i18n, absValue, { decimals: 2, includeK: true })
+    );
   }
   return String(formatAmountWithThreshold(value, 4));
 }

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -39,7 +39,7 @@ export function formatTokenAmount(value: number): string {
       localizeLargeNumber(i18n, absValue, { decimals: 2, includeK: true })
     );
   }
-  return String(formatAmountWithThreshold(value, 4));
+  return String(formatAmountWithThreshold(value, 5));
 }
 
 export function formatPercent(value: number | null | undefined): string {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -2,8 +2,9 @@ import {
   formatPerpsFiat,
   formatPercentage,
   formatTransactionDate,
+  formatLargeNumber,
 } from '../../../UI/Perps/utils/formatUtils';
-import formatNumber from '../../../../util/formatNumber';
+import { formatAmountWithThreshold } from '../../../../util/number';
 
 const EM_DASH = '\u2014';
 
@@ -18,8 +19,18 @@ export function formatUsd(value: number | null | undefined): string {
   return sign + formatPerpsFiat(Math.abs(value), { stripTrailingZeros: false });
 }
 
+/**
+ * Formats a raw token quantity for display in list rows.
+ * - Values >= 1,000 are abbreviated with K/M/B/T suffixes (e.g. 216.65M).
+ * - Smaller values are capped at 4 decimal places, with "< 0.00001" for dust.
+ * - Returns "0" for zero, NaN, or non-finite inputs.
+ */
 export function formatTokenAmount(value: number): string {
-  return formatNumber(value);
+  if (!Number.isFinite(value) || value === 0) return '0';
+  if (Math.abs(value) >= 1000) {
+    return formatLargeNumber(value, { decimals: 2, rawDecimals: 4 });
+  }
+  return String(formatAmountWithThreshold(value, 4));
 }
 
 export function formatPercent(value: number | null | undefined): string {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Token quantities in the Trader Profile position rows (216,649,924.26742363 ASTEROID) were rendered with full precision, making list rows noisy and hard to watch. Updated `formatTokenAmount` method to abbreviate values ≥ 1,000 using K/M/B/T suffixes (reusing the existing pattern in the app) and cap smaller values at 4 decimal places with a < 0.00001 floor, aligning with the market-data display convention already used in `AssetOverview`. 

<img height="850" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-24 at 11 55 22" src="https://github.com/user-attachments/assets/37f6c816-967d-4d84-b967-5e398963e6f8" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI formatting change limited to how token quantities are displayed in social leaderboard position rows, with broad unit tests added to catch edge cases.
> 
> **Overview**
> Updates `formatTokenAmount` used by Social Leaderboard position rows to **abbreviate values >= 1,000** with `K/M/B/T` suffixes (via `localizeLargeNumber`), while **handling dust/precision** for smaller values via `formatAmountWithThreshold` and returning `0` for non-finite inputs.
> 
> Adjusts the `PositionRow` test expectation for large balances and adds a dedicated `formatters.test.ts` suite covering USD, token amount, percent, and trade date formatting (including negative, null/undefined, dust threshold, and seconds-vs-ms timestamps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca4802817fa0f48d854dca2abe8e33e536834cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->