### PR TITLE
chore: Combine Snaps build flags

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_FLOW = 'snap-install-flow';
 export const SNAP_INSTALL_OK = 'snap-install-ok';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 import Device from '../../../util/device';

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useEffect, useState } from 'react';
 import ApprovalModal from '../ApprovalModal';
 import useApprovalRequest, {
@@ -8,13 +8,9 @@ import { ApprovalTypes } from '../../../core/RPCMethods/RPCMethodMiddleware';
 import { SnapInstallState } from './InstallSnapApproval.types';
 import {
   InstallSnapConnectionRequest,
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   InstallSnapError,
   InstallSnapPermissionsRequest,
   InstallSnapSuccess,
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 } from './components';
 import { useSelector } from 'react-redux';
 import { selectSnapsMetadata, getPermissions } from '../../../selectors/snaps';
@@ -33,13 +29,9 @@ const InstallSnapApproval = () => {
   const [installState, setInstallState] = useState<
     SnapInstallState | undefined
   >(undefined);
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
   const [installError, setInstallError] = useState<Error | undefined>(
     undefined,
   );
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   const {
     approvalRequest,
     onConfirm: rawOnConfirm,
@@ -114,9 +106,6 @@ const InstallSnapApproval = () => {
 
   if (!approvalRequest) return null;
 
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
-
   const onPermissionsConfirm = async () => {
     try {
       await onConfirm(undefined, {
@@ -130,7 +119,7 @@ const InstallSnapApproval = () => {
     }
   };
   ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 
   if (!approvalRequest || installState === undefined) return null;
 
@@ -161,8 +150,6 @@ const InstallSnapApproval = () => {
             onCancel={onReject}
           />
         );
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
       case SnapInstallState.AcceptPermissions:
         return (
           <InstallSnapPermissionsRequest
@@ -184,7 +171,7 @@ const InstallSnapApproval = () => {
           />
         );
       ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       default:
         return null;
     }

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 interface InstallSnapFlowProps {
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_CONNECTION_REQUEST =
   'snap-install-connection-request';
 export const SNAP_INSTALL_CANCEL = 'snap-install-cancel';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { InstallSnapFlowProps } from '../../InstallSnapApproval.types';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 import InstallSnapConnectionRequest from './InstallSnapConnectionRequest';
 

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_INSTALL_ERROR = 'snap-install-error';
 export default SNAP_INSTALL_ERROR;
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import InstallSnapError from './InstallSnapError';
-
-export { InstallSnapError };
+export { InstallSnapError } from './InstallSnapError';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
@@ -1,4 +1,4 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-export { InstallSnapError } from './InstallSnapError';
+export { default as InstallSnapError } from './InstallSnapError';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/test/InstallSnapError.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/test/InstallSnapError.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import InstallSnapError from '../InstallSnapError';
@@ -63,4 +62,3 @@ describe('InstallSnapError', () => {
     expect(getByText('Installation failed')).toBeTruthy();
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_CANCEL = 'snap-install-cancel';
 export const SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE =
   'snap-install-connection-permissions-request-approve';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import InstallSnapPermissionsRequest from './InstallSnapPermissionsRequest';
-
-export { InstallSnapPermissionsRequest };
+export { default as InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/test/InstallSnapPermissionsRequest.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/test/InstallSnapPermissionsRequest.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import InstallSnapPermissionsRequest from '../InstallSnapPermissionsRequest';
@@ -59,4 +58,3 @@ describe('InstallSnapPermissionsRequest', () => {
     expect(permissionCells).toHaveLength(3);
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_INSTALL_SUCCESS = 'snap-install-success';
 export default SNAP_INSTALL_SUCCESS;
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import InstallSnapSuccess from './InstallSnapSuccess';
-
-export { InstallSnapSuccess };
+export { default as InstallSnapSuccess } from './InstallSnapSuccess';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/test/InstallSnapSuccess.test.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/test/InstallSnapSuccess.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import InstallSnapSuccess from '../InstallSnapSuccess';
@@ -47,4 +46,3 @@ describe('InstallSnapSuccess', () => {
     expect(getByText(expectedSnapName)).toBeTruthy();
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/index.ts
@@ -1,18 +1,7 @@
 /* eslint-disable import-x/prefer-default-export */
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
-import { InstallSnapConnectionRequest } from './InstallSnapConnectionRequest';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
-import { InstallSnapSuccess } from './InstallSnapSuccess';
-import { InstallSnapError } from './InstallSnapError';
-import { InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
-///: END:ONLY_INCLUDE_IF
-
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
-export { InstallSnapPermissionsRequest };
-export { InstallSnapError };
-export { InstallSnapSuccess };
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
-export { InstallSnapConnectionRequest };
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
+export { InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
+export { InstallSnapError } from './InstallSnapError';
+export { InstallSnapSuccess } from './InstallSnapSuccess';
+export { InstallSnapConnectionRequest } from './InstallSnapConnectionRequest';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/index.ts
@@ -1,3 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export { default } from './InstallSnapApproval';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -74,7 +74,7 @@ import DepositOrderDetails from '../../UI/Ramp/Deposit/Views/DepositOrderDetails
 import ProcessingInfoModal from '../../UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal';
 import SendTransaction from '../../UI/Ramp/Aggregator/Views/SendTransaction';
 import TabBar from '../../../component-library/components/Navigation/TabBar';
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
 import { SnapSettings } from '../../Views/Snaps/SnapSettings';
 ///: END:ONLY_INCLUDE_IF
@@ -411,7 +411,7 @@ const ExploreHome = () => {
   );
 };
 
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SnapsSettingsStack = () => (
   <Stack.Navigator>
     <Stack.Screen
@@ -617,7 +617,8 @@ const SettingsFlow = () => {
         options={{ headerShown: false }}
       />
       {
-        ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+        // TODO: Hide with runtime FF
       }
       <Stack.Screen
         name={Routes.SNAPS.SNAPS_SETTINGS_LIST}

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -77,6 +77,7 @@ import TabBar from '../../../component-library/components/Navigation/TabBar';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
 import { SnapSettings } from '../../Views/Snaps/SnapSettings';
+import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
 ///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
 import { clearStackNavigatorOptionsWithTransitionAnimation } from '../../../constants/navigation/clearStackNavigatorOptions';
@@ -618,13 +619,14 @@ const SettingsFlow = () => {
       />
       {
         ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-        // TODO: Hide with runtime FF
       }
-      <Stack.Screen
-        name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
-        component={SnapsSettingsStack}
-        options={{ headerShown: false }}
-      />
+      {CAN_INSTALL_THIRD_PARTY_SNAPS && (
+        <Stack.Screen
+          name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
+          component={SnapsSettingsStack}
+          options={{ headerShown: false }}
+        />
+      )}
       {
         ///: END:ONLY_INCLUDE_IF
       }

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -24,7 +24,7 @@ import { ConfirmRoot } from '../../../components/Views/confirmations/components/
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import { STX_NO_HASH_ERROR } from '../../../util/smart-transactions/smart-publish-hook';
 
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import InstallSnapApproval from '../../Approvals/InstallSnapApproval';
 import SnapDialogApproval from '../../Snaps/SnapDialogApproval/SnapDialogApproval';
 ///: END:ONLY_INCLUDE_IF
@@ -145,7 +145,7 @@ const RootRPCMethodsUI = (props) => {
       <FlowLoaderModal />
       <TemplateConfirmationModal />
       {
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       }
       <InstallSnapApproval />
       <SnapDialogApproval />

--- a/app/components/Snaps/SnapAvatar/SnapAvatar.styles.ts
+++ b/app/components/Snaps/SnapAvatar/SnapAvatar.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 

--- a/app/components/Snaps/SnapAvatar/SnapAvatar.tsx
+++ b/app/components/Snaps/SnapAvatar/SnapAvatar.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { useSelector } from 'react-redux';
 import AvatarFavicon from '../../../component-library/components/Avatars/Avatar/variants/AvatarFavicon';

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../hooks/useStyles';

--- a/app/components/Snaps/SnapDialogApproval/index.ts
+++ b/app/components/Snaps/SnapDialogApproval/index.ts
@@ -1,3 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export { default } from './SnapDialogApproval';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { isValidUrl } from '@metamask/snaps-utils';
 import React from 'react';
 import { StyleProp, View, ViewStyle, ImageStyle } from 'react-native';

--- a/app/components/Snaps/SnapUILink/SnapUILink.tsx
+++ b/app/components/Snaps/SnapUILink/SnapUILink.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import {
   Text,

--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -16,7 +16,7 @@ import ControllersGate from '../../Nav/ControllersGate';
 import { isTest } from '../../../util/test/utils';
 import { FeatureFlagOverrideProvider } from '../../../contexts/FeatureFlagOverrideContext';
 import { ScreenOrientationService } from '../../../core/ScreenOrientation';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsExecutionWebView } from '../../../lib/snaps';
 ///: END:ONLY_INCLUDE_IF
 import { ReducedMotionConfig, ReduceMotion } from 'react-native-reanimated';
@@ -75,7 +75,7 @@ const Root = ({ foxCode }: RootProps) => {
         <PersistGate persistor={persistor}>
           <ErrorBoundary view="Root">
             {
-              ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+              ///: BEGIN:ONLY_INCLUDE_IF(snaps)
               // NOTE: This must be mounted before Engine initialization since Engine interacts with SnapsExecutionWebView
               <SnapsExecutionWebView />
               ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -12,6 +12,7 @@ import { Colors } from '../../../util/theme/models';
 import { SettingsViewSelectorsIDs } from './SettingsView.testIds';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { createSnapsSettingsListNavDetails } from '../Snaps/SnapsSettingsList/SnapsSettingsList';
+import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
 ///: END:ONLY_INCLUDE_IF
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
@@ -164,14 +165,15 @@ const Settings = () => {
         )}
         {
           ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-          // TODO: Hide with runtime FF
         }
-        <SettingsDrawer
-          title={strings('app_settings.snaps.title')}
-          description={strings('app_settings.snaps.description')}
-          onPress={onPressSnaps}
-          testID={SettingsViewSelectorsIDs.SNAPS}
-        />
+        {CAN_INSTALL_THIRD_PARTY_SNAPS && (
+          <SettingsDrawer
+            title={strings('app_settings.snaps.title')}
+            description={strings('app_settings.snaps.description')}
+            onPress={onPressSnaps}
+            testID={SettingsViewSelectorsIDs.SNAPS}
+          />
+        )}
         {
           ///: END:ONLY_INCLUDE_IF
         }

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '../../../util/theme';
 import Routes from '../../../constants/navigation/Routes';
 import { Colors } from '../../../util/theme/models';
 import { SettingsViewSelectorsIDs } from './SettingsView.testIds';
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { createSnapsSettingsListNavDetails } from '../Snaps/SnapsSettingsList/SnapsSettingsList';
 ///: END:ONLY_INCLUDE_IF
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
@@ -105,7 +105,7 @@ const Settings = () => {
     navigation.navigate(Routes.FEATURE_FLAG_OVERRIDE);
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   const onPressSnaps = () => {
     navigation.navigate(...createSnapsSettingsListNavDetails());
   };
@@ -163,7 +163,8 @@ const Settings = () => {
           />
         )}
         {
-          ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+          ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+          // TODO: Hide with runtime FF
         }
         <SettingsDrawer
           title={strings('app_settings.snaps.title')}

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export const SNAP_SETTINGS_SCROLLVIEW = 'snap-settings-scrollview';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps,keyring-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps,keyring-snaps)
 import React, { useCallback, useEffect, useState } from 'react';
 import { View, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';

--- a/app/components/Views/Snaps/SnapSettings/index.ts
+++ b/app/components/Views/Snaps/SnapSettings/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapSettings from './SnapSettings';
-
-export { SnapSettings };
+export { default as SnapSettings } from './SnapSettings';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.styles.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../util/theme/models';
 

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useEffect } from 'react';
 import { View, ScrollView } from 'react-native';
 import { useSelector } from 'react-redux';

--- a/app/components/Views/Snaps/SnapsSettingsList/index.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapsSettingsList from './SnapsSettingsList';
-
-export { SnapsSettingsList };
+export { default as SnapsSettingsList } from './SnapsSettingsList';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DESCRIPTION_TITLE = 'snap-description-title';
 export const SNAP_DESCRIPTION = 'snap-description';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {

--- a/app/components/Views/Snaps/components/SnapDescription/index.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapDescription from './SnapDescription';
-
-export { SnapDescription };
+export { default as SnapDescription } from './SnapDescription';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/test/SnapDescription.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import SnapDescription from '../SnapDescription';
@@ -21,4 +20,3 @@ describe('SnapDescription', () => {
     expect(description.props.children).toBe('Test snap description');
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DETAILS_CELL = 'snap-details-cell';
 export const SNAP_DETAILS_SWITCH = 'snap-details-switch';
 export const SNAP_DETAILS_INSTALL_ORIGIN = 'snap-details-install-origin';

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck - Snaps team directory
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useMemo, useState } from 'react';
 import { View, Switch } from 'react-native';
 

--- a/app/components/Views/Snaps/components/SnapDetails/index.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapDetails from './SnapDetails';
-
-export { SnapDetails };
+export { default as SnapDetails } from './SnapDetails';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.constants.ts
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_ElEMENT = 'snap-element';
 export default SNAP_ElEMENT;
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.styles.ts
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Cell, {

--- a/app/components/Views/Snaps/components/SnapElement/index.ts
+++ b/app/components/Views/Snaps/components/SnapElement/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapElement from './SnapElement';
-
-export { SnapElement };
+export { default as SnapElement } from './SnapElement';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.constants.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_PERMISSIONS_DATE = 'snap-permissions-date';
 export const SNAP_PERMISSION_CELL = 'snap-permission-cell';
 export const SNAP_PERMISSIONS_TITLE = 'snap-permissions-title';

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../../../hooks/useStyles';

--- a/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapPermissionCell from './SnapPermissionCell';
-
-export { SnapPermissionCell };
+export { default as SnapPermissionCell } from './SnapPermissionCell';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.contants.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.contants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_PERMISSIONS = 'snap-permissions';
 export default SNAP_PERMISSIONS;
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 /**

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck - Snaps team directory
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import slip44 from '@metamask/slip44';

--- a/app/components/Views/Snaps/components/SnapPermissions/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapPermissions from './SnapPermissions';
-
-export { SnapPermissions };
+export { SnapPermissions } from './SnapPermissions';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/index.ts
@@ -1,4 +1,4 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-export { SnapPermissions } from './SnapPermissions';
+export { default as SnapPermissions } from './SnapPermissions';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_VERSION_BADGE = 'snap-version-badge';
 export const SNAP_VERSION_BADGE_VALUE = 'snap-version-badge-value';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {

--- a/app/components/Views/Snaps/components/SnapVersionTag/index.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
-import SnapVersionBadge from './SnapVersionTag';
-
-export { SnapVersionBadge };
+export { default as SnapVersionBadge } from './SnapVersionTag';
 ///: END:ONLY_INCLUDE_IF

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -439,7 +439,7 @@ const Routes = {
     PRIVATE_KEY_LIST: 'MultichainPrivateKeyList',
     ACCOUNT_CELL_ACTIONS: 'MultichainAccountActions',
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SNAPS: {
     SNAPS_SETTINGS_LIST: 'SnapsSettingsList',
     SNAP_SETTINGS: 'SnapSettings',

--- a/app/constants/snaps.ts
+++ b/app/constants/snaps.ts
@@ -1,6 +1,9 @@
 /* eslint-disable import-x/prefer-default-export */
 import type { SupportedCurve } from '@metamask/key-tree';
 
+export const CAN_INSTALL_THIRD_PARTY_SNAPS =
+  process.env.METAMASK_BUILD_TYPE === 'flask';
+
 export type SnapsDerivationPathType = ['m', ...string[]];
 
 export interface SnapsDerivationPath {

--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -25,7 +25,7 @@ import RemotePort from './RemotePort';
 import WalletConnectPort from './WalletConnectPort';
 import Port from './Port';
 import { store } from '../../store';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { rpcErrors } from '@metamask/rpc-errors';
 import snapMethodMiddlewareBuilder from '../Snaps/SnapsMethodMiddleware';
 ///: END:ONLY_INCLUDE_IF
@@ -638,7 +638,7 @@ export class BackgroundBridge extends EventEmitter {
     // Sentry tracing middleware
     engine.push(createTracingMiddleware());
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     // These Snaps RPC methods are disabled in WalletConnect and SDK for now
     if (this.isMMSDK || this.isWalletConnect) {
       engine.push((req, _res, next, end) => {
@@ -652,7 +652,7 @@ export class BackgroundBridge extends EventEmitter {
     }
     ///: END:ONLY_INCLUDE_IF
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     // The Snaps middleware is disabled in WalletConnect and SDK for now.
     if (!this.isMMSDK && !this.isWalletConnect) {
       engine.push(

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -2,7 +2,7 @@
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 import { samplePetnamesControllerInit } from '../../features/SampleFeature/controllers/sample-petnames-controller-init';
 ///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   AppState,
   AppStateStatus,
@@ -14,7 +14,7 @@ import { AccountsController } from '@metamask/accounts-controller';
 import {
   KeyringController,
   KeyringControllerState,
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   KeyringTypes,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-controller';
@@ -29,7 +29,7 @@ import {
   type CaveatSpecificationConstraint,
   PermissionController,
   type PermissionSpecificationConstraint,
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SubjectMetadataController,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
@@ -51,7 +51,7 @@ import Logger from '../../util/Logger';
 import { isZero } from '../../util/lodash';
 import { initializeRpcProviderDomains } from '../../util/rpc-domain-utils';
 
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { notificationServicesControllerInit } from './controllers/notifications/notification-services-controller-init';
 import { notificationServicesPushControllerInit } from './controllers/notifications/notification-services-push-controller-init';
 ///: END:ONLY_INCLUDE_IF
@@ -93,7 +93,7 @@ import { multichainAccountServiceInit } from './controllers/multichain-account-s
 import { snapKeyringBuilderInit } from './controllers/snap-keyring/snap-keyring-builder-init';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
 ///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   cronjobControllerInit,
   executionServiceInit,
@@ -139,7 +139,7 @@ import type { GatorPermissionsController } from '@metamask/gator-permissions-con
 import { DelegationControllerInit } from './controllers/delegation/delegation-controller-init';
 import { selectedNetworkControllerInit } from './controllers/selected-network-controller-init';
 import { permissionControllerInit } from './controllers/permission-controller-init';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { subjectMetadataControllerInit } from './controllers/subject-metadata-controller-init';
 ///: END:ONLY_INCLUDE_IF
 import { PreferencesController } from '@metamask/preferences-controller';
@@ -222,7 +222,7 @@ export class Engine {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   lastIncomingTxBlockInfo: any;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   /**
    * The app state event listener.
    * This is used to handle app state changes in snaps lifecycle hooks.
@@ -302,7 +302,7 @@ export class Engine {
         ///: END:ONLY_INCLUDE_IF
         KeyringController: keyringControllerInit,
         PermissionController: permissionControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         SubjectMetadataController: subjectMetadataControllerInit,
         ///: END:ONLY_INCLUDE_IF
         AccountTreeController: accountTreeControllerInit,
@@ -339,7 +339,7 @@ export class Engine {
         BridgeStatusController: bridgeStatusControllerInit,
         NftController: nftControllerInit,
         NftDetectionController: nftDetectionControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         ExecutionService: executionServiceInit,
         CronjobController: cronjobControllerInit,
         SnapRegistryController: snapRegistryControllerInit,
@@ -477,7 +477,7 @@ export class Engine {
       messengerClientsByName.NftDetectionController;
     const networkController = messengerClientsByName.NetworkController;
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     const cronjobController = messengerClientsByName.CronjobController;
     const executionService = messengerClientsByName.ExecutionService;
     const snapController = messengerClientsByName.SnapController;
@@ -529,7 +529,7 @@ export class Engine {
       captureException(error);
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     snapController.init();
     cronjobController.init();
     // Notification Setup
@@ -568,7 +568,7 @@ export class Engine {
       SelectedNetworkController: selectedNetworkController,
       SignatureController: signatureController,
       LoggingController: loggingController,
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       CronjobController: cronjobController,
       ExecutionService: executionService,
       SnapController: snapController,
@@ -680,7 +680,7 @@ export class Engine {
       },
     );
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     this.controllerMessenger.subscribe(
       `${snapController.name}:snapTerminated`,
       (truncatedSnap) => {
@@ -1155,7 +1155,7 @@ export class Engine {
       TokenRatesController,
       PermissionController,
       // SelectedNetworkController,
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       SnapController,
       ///: END:ONLY_INCLUDE_IF
       LoggingController,
@@ -1163,7 +1163,7 @@ export class Engine {
 
     // Remove all permissions.
     PermissionController?.clearState?.();
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     await SnapController.clearState();
     ///: END:ONLY_INCLUDE_IF
 
@@ -1194,7 +1194,7 @@ export class Engine {
   removeAllListeners() {
     this.controllerMessenger.clearSubscriptions();
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     this.appStateListener?.remove();
     ///: END:ONLY_INCLUDE_IF
 
@@ -1399,7 +1399,7 @@ export default {
       ClientController,
       SocialController,
       ComplianceController,
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       AuthenticationController,
       CronjobController,
       NotificationServicesController,
@@ -1473,7 +1473,7 @@ export default {
       CardController: CardController.state,
       ClientController: ClientController.state,
       ComplianceController: ComplianceController.state,
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       AuthenticationController: AuthenticationController.state,
       CronjobController: CronjobController.state,
       NotificationServicesController: NotificationServicesController.state,

--- a/app/core/Engine/constants.ts
+++ b/app/core/Engine/constants.ts
@@ -58,7 +58,7 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   'TransactionController:stateChange',
   'TransactionPayController:stateChange',
   'MultichainNetworkController:stateChange',
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   'SnapController:stateChange',
   'SnapRegistryController:stateChange',
   'SubjectMetadataController:stateChange',

--- a/app/core/Engine/controllers/permission-controller-init.ts
+++ b/app/core/Engine/controllers/permission-controller-init.ts
@@ -11,7 +11,7 @@ import {
   getPermissionSpecifications,
   unrestrictedMethods,
 } from '../../Permissions/specifications';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { getSnapPermissionSpecifications } from '../../Snaps/permissions/specifications';
 ///: END:ONLY_INCLUDE_IF
 import { CaipChainId } from '@metamask/utils';
@@ -36,7 +36,7 @@ export const permissionControllerInit: MessengerClientInitFunction<
   persistedState,
   getMessengerClient,
 }) => {
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   const keyringController = getMessengerClient('KeyringController');
   ///: END:ONLY_INCLUDE_IF
 
@@ -64,7 +64,7 @@ export const permissionControllerInit: MessengerClientInitFunction<
     }),
     permissionSpecifications: {
       ...getPermissionSpecifications(),
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       ...getSnapPermissionSpecifications(initMessenger, {
         addNewKeyring: keyringController.addNewKeyring.bind(keyringController),
       }),

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../../actions/onboarding';
 import { SagaIterator } from 'redux-saga';
 import { getMnemonicSeed } from '../../../Snaps/permissions/utils';
+import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../../constants/snaps';
 
 /**
  * Initialize the Snap controller.
@@ -48,7 +49,7 @@ export const snapControllerInit: MessengerClientInitFunction<
   SnapControllerInitMessenger
 > = ({ initMessenger, controllerMessenger, persistedState }) => {
   const requireAllowlist = process.env.METAMASK_BUILD_TYPE !== 'flask';
-  const disableSnapInstallation = process.env.METAMASK_BUILD_TYPE !== 'flask';
+  const disableSnapInstallation = !CAN_INSTALL_THIRD_PARTY_SNAPS;
   const allowLocalSnaps = process.env.METAMASK_BUILD_TYPE === 'flask';
   const autoUpdatePreinstalledSnaps = true;
 

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -17,7 +17,7 @@ import {
   getBackendWebSocketServiceInitMessenger,
   getAccountActivityServiceMessenger,
 } from './core-backend';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   getCronjobControllerMessenger,
   getExecutionServiceMessenger,
@@ -272,7 +272,7 @@ export const MESSENGER_FACTORIES = {
     getMessenger: getDeFiPositionsControllerMessenger,
     getInitMessenger: getDeFiPositionsControllerInitMessenger,
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   AuthenticationController: {
     getMessenger: getAuthenticationControllerMessenger,
     getInitMessenger: noop,

--- a/app/core/Engine/messengers/permission-controller-messenger.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.ts
@@ -44,7 +44,7 @@ export function getPermissionControllerMessenger(rootMessenger: RootMessenger) {
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
       'ApprovalController:rejectRequest',
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       'SnapController:getPermittedSnaps',
       'SnapController:installSnaps',
       'SubjectMetadataController:getSubjectMetadata',

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -167,14 +167,14 @@ import {
   PermissionControllerActions,
   PermissionControllerEvents,
   PermissionControllerState,
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SubjectMetadataController,
   SubjectMetadataControllerActions,
   SubjectMetadataControllerEvents,
   SubjectMetadataControllerState,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   SnapController,
   ExecutionService,
@@ -225,7 +225,7 @@ import {
   type SmartTransactionsControllerEvents,
   SmartTransactionsControllerState,
 } from '@metamask/smart-transactions-controller';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   AuthenticationController,
   UserStorageController,
@@ -489,7 +489,7 @@ type OptionalControllers = Pick<
 type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
 type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];
 
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // TODO: Abstract this into controller utils for SnapsController
 type SnapsGlobalActions =
   | SnapControllerActions
@@ -524,7 +524,7 @@ type GlobalActions =
   | SignatureControllerActions
   | LoggingControllerActions
   | AnalyticsControllerActions
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | SnapsGlobalActions
   | SnapInterfaceControllerActions
   | AuthenticationController.Actions
@@ -609,7 +609,7 @@ type GlobalEvents =
   | NetworkControllerEvents
   | NetworkEnablementControllerEvents
   | PermissionControllerEvents
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | SnapsGlobalEvents
   | SnapInterfaceControllerEvents
   | AuthenticationController.Events
@@ -753,7 +753,7 @@ export type MessengerClients = {
   SmartTransactionsController: SmartTransactionsController;
   SignatureController: SignatureController;
   StorageService: StorageService;
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   ExecutionService: ExecutionService;
   SnapController: SnapController;
   SnapRegistryController: SnapRegistryController;
@@ -842,7 +842,7 @@ export type EngineState = {
   GasFeeController: GasFeeState;
   TokensController: TokensControllerState;
   DeFiPositionsController: DeFiPositionsControllerState;
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SnapController: PersistedSnapControllerState;
   SnapRegistryController: SnapRegistryControllerState;
   SubjectMetadataController: SubjectMetadataControllerState;
@@ -925,7 +925,7 @@ export type MessengerClientsToInitialize =
   | 'AssetsContractController'
   | 'AssetsController'
   | 'ConnectivityController'
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | 'AuthenticationController'
   | 'CronjobController'
   | 'ExecutionService'

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -623,7 +623,7 @@ export interface RootStackParamList extends ParamListBase {
   MultichainAddressList: MultichainAddressListParams | undefined;
   MultichainPrivateKeyList: PrivateKeyListParams | undefined;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Snaps routes
   SnapsSettingsList: undefined;
   SnapSettings: SnapSettingsParams | undefined;

--- a/app/core/Permissions/constants.ts
+++ b/app/core/Permissions/constants.ts
@@ -5,7 +5,7 @@ export const CaveatTypes = Object.freeze({
 
 export const RestrictedMethods = Object.freeze({
   eth_accounts: 'eth_accounts',
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Snap Specific Restricted Methods
   snap_notify: 'snap_notify',
   snap_dialog: 'snap_dialog',

--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   caveatSpecifications as snapsCaveatsSpecifications,
   endowmentCaveatSpecifications as snapsEndowmentCaveatSpecifications,
@@ -68,7 +68,7 @@ export const getCaveatSpecifications = ({
     isNonEvmScopeSupported,
     getNonEvmAccountAddresses,
   }),
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   ...snapsCaveatsSpecifications,
   ...snapsEndowmentCaveatSpecifications,
   ///: END:ONLY_INCLUDE_IF
@@ -163,7 +163,7 @@ export const unrestrictedMethods = Object.freeze([
   'wallet_sendCalls',
   'wallet_getCallsStatus',
   'wallet_getCapabilities',
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   'wallet_getAllSnaps',
   'wallet_getSnaps',
   'wallet_requestSnaps',

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -76,7 +76,7 @@ export enum ApprovalTypes {
   RESULT_ERROR = 'result_error',
   RESULT_SUCCESS = 'result_success',
   SMART_TRANSACTION_STATUS = 'smart_transaction_status',
-  ///: BEGIN:ONLY_INCLUDE_IF(external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   INSTALL_SNAP = 'wallet_installSnap',
   UPDATE_SNAP = 'wallet_updateSnap',
   SNAP_DIALOG = 'snap_dialog',

--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { createSnapsMethodMiddleware } from '@metamask/snaps-rpc-methods';
 import {
   RequestedPermissions,

--- a/app/core/Snaps/index.ts
+++ b/app/core/Snaps/index.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import SnapBridge from './SnapBridge';
 import {
   ExcludedSnapPermissions,

--- a/app/core/Snaps/location/index.ts
+++ b/app/core/Snaps/location/index.ts
@@ -1,3 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export * from './location';
 ///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/location.ts
+++ b/app/core/Snaps/location/location.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { NpmLocation } from './npm';
 import {
   HttpLocation,

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/prefer-default-export */
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { VirtualFile } from '@metamask/snaps-utils';
 import { assert, getErrorMessage } from '@metamask/utils';
 import { NativeModules } from 'react-native';

--- a/app/core/Snaps/permissions/permissions.ts
+++ b/app/core/Snaps/permissions/permissions.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // TODO: Figure out which permissions should be disabled at this point
 export const ExcludedSnapPermissions = Object.freeze({
   eth_accounts:

--- a/app/core/Snaps/permissions/specifications.ts
+++ b/app/core/Snaps/permissions/specifications.ts
@@ -237,7 +237,7 @@ export const getSnapPermissionSpecifications = (
     ...buildSnapRestrictedMethodSpecifications(
       Object.keys(ExcludedSnapPermissions),
       {
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         ...snapRestrictedMethods,
         ///: END:ONLY_INCLUDE_IF
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import { WebViewMessageEvent, WebView } from '@metamask/react-native-webview';

--- a/app/lib/snaps/index.ts
+++ b/app/lib/snaps/index.ts
@@ -1,3 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export * from './SnapsExecutionWebView';
 ///: END:ONLY_INCLUDE_IF

--- a/app/lib/snaps/styles.ts
+++ b/app/lib/snaps/styles.ts
@@ -1,4 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable react-native/no-color-literals */
 import { StyleSheet } from 'react-native';
 

--- a/app/selectors/types.ts
+++ b/app/selectors/types.ts
@@ -18,7 +18,7 @@ import { GasFeeController } from '@metamask/gas-fee-controller';
 import { ApprovalControllerState } from '@metamask/approval-controller';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { AccountTreeControllerState } from '@metamask/account-tree-controller';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapController } from '@metamask/snaps-controllers';
 ///: END:ONLY_INCLUDE_IF
 
@@ -38,7 +38,7 @@ export interface EngineState {
       TokenBalancesController: TokenBalancesControllerState;
       TokenRatesController: TokenRatesControllerState;
       TransactionController: TransactionControllerState;
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       SnapController: SnapController;
       ///: END:ONLY_INCLUDE_IF
       GasFeeController: GasFeeController;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -272,7 +272,7 @@ export function* handleDeeplinkSaga() {
   }
 }
 
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /**
  * Handles updating the Snaps registry when the user has booted the app and is onboarded
  */
@@ -350,7 +350,7 @@ export function* rootSaga() {
   yield fork(backfillSocialLoginMarketingConsentSaga);
 
   yield fork(promptIosGoogleWarningSheetSaga);
-  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   yield fork(handleSnapsRegistry);
   ///: END:ONLY_INCLUDE_IF
 }

--- a/builds.yml
+++ b/builds.yml
@@ -129,7 +129,7 @@ _signing_flask_uat: &signing_flask_uat
 
 # Main code fencing features
 _code_fencing_main: &code_fencing_main
-  - preinstalled-snaps
+  - snaps
   - keyring-snaps
   - multi-srp
   - solana
@@ -139,7 +139,7 @@ _code_fencing_main: &code_fencing_main
 # Beta code fencing features (main + beta feature)
 _code_fencing_beta: &code_fencing_beta
   - beta
-  - preinstalled-snaps
+  - snaps
   - keyring-snaps
   - multi-srp
   - solana
@@ -148,7 +148,7 @@ _code_fencing_beta: &code_fencing_beta
 
 # Experimental code fencing features (main + experimental)
 _code_fencing_experimental: &code_fencing_experimental
-  - preinstalled-snaps
+  - snaps
   - keyring-snaps
   - multi-srp
   - solana
@@ -159,8 +159,7 @@ _code_fencing_experimental: &code_fencing_experimental
 # Flask code fencing features (includes experimental)
 _code_fencing_flask: &code_fencing_flask
   - flask
-  - preinstalled-snaps
-  - external-snaps
+  - snaps
   - keyring-snaps
   - multi-srp
   - solana

--- a/metro.transform.js
+++ b/metro.transform.js
@@ -16,8 +16,7 @@ const fileExtsToScan = ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx'];
 // All available features that can be used in code fences
 const availableFeatures = new Set([
   'flask',
-  'preinstalled-snaps',
-  'external-snaps',
+  'snaps',
   'beta',
   'keyring-snaps',
   'multi-srp',
@@ -30,7 +29,7 @@ const availableFeatures = new Set([
 
 // Legacy (main) hardcoded feature sets — used when CODE_FENCING_FEATURES is not set (e.g. Bitrise / local)
 const mainFeatureSet = new Set([
-  'preinstalled-snaps',
+  'snaps',
   'keyring-snaps',
   'multi-srp',
   'solana',
@@ -39,7 +38,7 @@ const mainFeatureSet = new Set([
 ]);
 const betaFeatureSet = new Set([
   'beta',
-  'preinstalled-snaps',
+  'snaps',
   'keyring-snaps',
   'multi-srp',
   'solana',
@@ -48,8 +47,7 @@ const betaFeatureSet = new Set([
 ]);
 const flaskFeatureSet = new Set([
   'flask',
-  'preinstalled-snaps',
-  'external-snaps',
+  'snaps',
   'keyring-snaps',
   'multi-srp',
   'bitcoin',

--- a/scripts/verify-build-config.js
+++ b/scripts/verify-build-config.js
@@ -84,7 +84,7 @@ const SECRETS_TO_VERIFY = [
 // Expected code fencing features per build type
 const EXPECTED_CODE_FENCING = {
   main: [
-    'preinstalled-snaps',
+    'snaps',
     'keyring-snaps',
     'multi-srp',
     'solana',
@@ -93,8 +93,7 @@ const EXPECTED_CODE_FENCING = {
   ],
   flask: [
     'flask',
-    'preinstalled-snaps',
-    'external-snaps',
+    'snaps',
     'keyring-snaps',
     'multi-srp',
     'solana',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Combine the `preinstalled-snaps` and `external-snaps` build flags into one `snaps` flag. The separation was originally meant to exclude sensitive installation logic used for external Snaps. At this point, this logic is already used in production to support preinstalled Snaps and as such mostly unfinished components were currently excluded. These components won't be visible in production though.

External Snaps are still unable to be installed unless the build is configured with build type Flask.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-984

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build-time feature gating and navigation/engine wiring for Snaps, which could unintentionally include or exclude Snaps middleware and screens in certain build configurations. Runtime behavior is additionally gated by `CAN_INSTALL_THIRD_PARTY_SNAPS`, but misconfiguration could affect Snap approvals or settings availability.
> 
> **Overview**
> **Unifies Snaps feature gating** by replacing the separate `preinstalled-snaps`/`external-snaps` code fences with a single `snaps` flag across approvals, UI components, routes, engine wiring, and build tooling (`builds.yml`, `metro.transform.js`, `verify-build-config.js`).
> 
> **Adds an explicit runtime gate for third‑party Snaps UI** via `CAN_INSTALL_THIRD_PARTY_SNAPS` (Flask-only), and uses it to conditionally register the Snaps settings stack and Settings entry, while aligning Snap controller initialization to use the same constant for `disableSnapInstallation`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f921f861112e362097db2865f509329a9351a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->