### PR TITLE
feat(MUSD-473): Add money choice bottom sheet

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -15,6 +15,7 @@ import { MoneyWhatYouGetTestIds } from '../../components/MoneyWhatYouGet/MoneyWh
 import { MoneyFooterTestIds } from '../../components/MoneyFooter/MoneyFooter.testIds';
 import { MoneyActivityListTestIds } from '../../components/MoneyActivityList/MoneyActivityList.testIds';
 import { MoneyCondensedInfoCardsTestIds } from '../../components/MoneyCondensedInfoCards/MoneyCondensedInfoCards.testIds';
+import { MoneyMusdTokenRowTestIds } from '../../components/MoneyMusdTokenRow/MoneyMusdTokenRow.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import MOCK_MONEY_TRANSACTIONS from '../../constants/mockActivityData';
@@ -241,6 +242,17 @@ describe('MoneyHomeView', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ACTIVITY);
   });
 
+  it.each([
+    ['action row Add', MoneyActionButtonRowTestIds.ADD_BUTTON],
+    ['footer Add money', MoneyFooterTestIds.ADD_MONEY_BUTTON],
+  ])('opens the Add money sheet from the %s button', (_label, testId) => {
+    const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+    fireEvent.press(getByTestId(testId));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ADD_MONEY_SHEET);
+  });
+
   describe('milestone state (1-9 transactions)', () => {
     beforeEach(() => {
       mockUseMoneyAccountTransactions.mockReturnValue({
@@ -334,6 +346,17 @@ describe('MoneyHomeView', () => {
     it('renders expanded WhatYouGet section', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(getByTestId(MoneyWhatYouGetTestIds.CONTAINER)).toBeOnTheScreen();
+    });
+
+    it.each([
+      ['onboarding card CTA', MoneyOnboardingCardTestIds.CTA_BUTTON],
+      ['mUSD row Add', MoneyMusdTokenRowTestIds.ADD_BUTTON],
+    ])('opens the Add money sheet from the %s button', (_label, testId) => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      fireEvent.press(getByTestId(testId));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ADD_MONEY_SHEET);
     });
   });
 });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -68,7 +68,9 @@ const MoneyHomeView = () => {
   // // eslint-disable-next-line no-alert
   const handleMenuPress = displayUnderConstructionAlert;
 
-  const handleAddPress = displayUnderConstructionAlert;
+  const handleAddPress = useCallback(() => {
+    navigation.navigate(Routes.MONEY.ADD_MONEY_SHEET as never);
+  }, [navigation]);
   const handleTransferPress = displayUnderConstructionAlert;
   const handleCardPress = displayUnderConstructionAlert;
   const handleApyInfoPress = displayUnderConstructionAlert;
@@ -88,7 +90,7 @@ const MoneyHomeView = () => {
   const handleLearnMorePress = useCallback(() => {
     Linking.openURL(AppConstants.URLS.MUSD_LEARN_MORE);
   }, []);
-  const handleAddMoneyPress = displayUnderConstructionAlert;
+  const handleAddMoneyPress = handleAddPress;
   const handleHowItWorksHeaderPress = useCallback(() => {
     navigation.navigate(Routes.MONEY.HOW_IT_WORKS as never);
   }, [navigation]);

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
@@ -1,0 +1,11 @@
+import { Theme } from '@metamask/design-tokens';
+import { StyleSheet } from 'react-native';
+
+export const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    iconContainer: {
+      padding: 8,
+      borderRadius: 8,
+      backgroundColor: theme.colors.primary.muted,
+    },
+  });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
@@ -3,9 +3,18 @@ import { StyleSheet } from 'react-native';
 
 export const createStyles = (theme: Theme) =>
   StyleSheet.create({
-    iconContainer: {
-      padding: 8,
-      borderRadius: 8,
-      backgroundColor: theme.colors.primary.muted,
+    disabledRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 16,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      backgroundColor: theme.colors.background.default,
+    },
+    disabledRowContent: {
+      flex: 1,
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      gap: 4,
     },
   });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
@@ -3,13 +3,17 @@ import { StyleSheet } from 'react-native';
 
 export const createStyles = (theme: Theme) =>
   StyleSheet.create({
-    disabledRow: {
+    list: {
+      paddingBottom: 16,
+      backgroundColor: theme.colors.background.default,
+    },
+    row: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: 16,
       paddingHorizontal: 16,
-      paddingVertical: 12,
-      backgroundColor: theme.colors.background.default,
+      paddingVertical: 8,
+      minHeight: 59,
     },
     disabledRowContent: {
       flex: 1,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
@@ -21,4 +21,7 @@ export const createStyles = (theme: Theme) =>
       alignItems: 'flex-start',
       gap: 4,
     },
+    comingSoonTag: {
+      borderRadius: 8,
+    },
   });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MoneyAddMoneySheet from './MoneyAddMoneySheet';
+import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
+import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
+import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
+import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
+import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+
+const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
+const mockInitiateCustomConversion = jest.fn().mockResolvedValue(undefined);
+const mockGetPaymentTokenForSelectedNetwork = jest.fn();
+const mockGoToBuy = jest.fn();
+
+jest.mock('../../../Earn/hooks/useMusdConversion', () => ({
+  useMusdConversion: jest.fn(),
+}));
+
+jest.mock('../../../Earn/hooks/useMusdConversionFlowData', () => ({
+  useMusdConversionFlowData: jest.fn(),
+}));
+
+jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    const MockBottomSheet = forwardRef(
+      (
+        { children, testID }: { children: React.ReactNode; testID?: string },
+        ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+      ) => {
+        useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: mockOnCloseBottomSheet,
+        }));
+        return <View testID={testID}>{children}</View>;
+      },
+    );
+    return { __esModule: true, default: MockBottomSheet };
+  },
+);
+
+const mockPaymentToken = {
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const,
+  chainId: '0x1' as const,
+};
+
+describe('MoneyAddMoneySheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useMusdConversion as jest.Mock).mockReturnValue({
+      initiateCustomConversion: mockInitiateCustomConversion,
+    });
+    (useMusdConversionFlowData as jest.Mock).mockReturnValue({
+      getPaymentTokenForSelectedNetwork: mockGetPaymentTokenForSelectedNetwork,
+    });
+    (useRampNavigation as jest.Mock).mockReturnValue({
+      goToBuy: mockGoToBuy,
+    });
+    mockGetPaymentTokenForSelectedNetwork.mockReturnValue(mockPaymentToken);
+  });
+
+  it('renders both options', () => {
+    const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(getByText('Convert tokens')).toBeOnTheScreen();
+    expect(getByText('Buy with fiat')).toBeOnTheScreen();
+  });
+
+  it('navigates to the Ramps buy flow when Buy with fiat is pressed', () => {
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.BUY_WITH_FIAT_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
+  });
+
+  it('initiates mUSD conversion when Convert tokens is pressed', () => {
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockInitiateCustomConversion).toHaveBeenCalledWith({
+      preferredPaymentToken: mockPaymentToken,
+      navigationOverride: MUSD_CONVERSION_NAVIGATION_OVERRIDE.QUICK_CONVERT,
+    });
+  });
+
+  it('closes the sheet without initiating conversion when no payment token is available', () => {
+    mockGetPaymentTokenForSelectedNetwork.mockReturnValue(null);
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -7,6 +7,7 @@ import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 
 const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
 const mockInitiateCustomConversion = jest.fn().mockResolvedValue(undefined);
@@ -23,6 +24,11 @@ jest.mock('../../../Earn/hooks/useMusdConversionFlowData', () => ({
 
 jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
+}));
+
+jest.mock('../../hooks/useMoneyAccountBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
 }));
 
 jest.mock(
@@ -63,32 +69,52 @@ describe('MoneyAddMoneySheet', () => {
     (useRampNavigation as jest.Mock).mockReturnValue({
       goToBuy: mockGoToBuy,
     });
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      musdFiatFormatted: '$1,203.89',
+    });
     mockGetPaymentTokenForSelectedNetwork.mockReturnValue(mockPaymentToken);
   });
 
-  it('renders both options', () => {
-    const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
+  it('renders all four options', () => {
+    const { getByText, getByTestId } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
 
-    expect(getByText('Convert tokens')).toBeOnTheScreen();
-    expect(getByText('Buy with fiat')).toBeOnTheScreen();
+    expect(getByText('Convert crypto')).toBeOnTheScreen();
+    expect(getByText('Deposit funds')).toBeOnTheScreen();
+    expect(getByText('Move your $1,203.89 mUSD')).toBeOnTheScreen();
+    expect(getByText('Receive from external wallet')).toBeOnTheScreen();
+    expect(getByText('Coming soon')).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW),
+    ).toBeOnTheScreen();
   });
 
-  it('navigates to the Ramps buy flow when Buy with fiat is pressed', () => {
+  it('falls back to the no-amount copy when the mUSD balance is unavailable', () => {
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      musdFiatFormatted: undefined,
+    });
+    const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(getByText('Move your mUSD')).toBeOnTheScreen();
+  });
+
+  it('navigates to the Ramps buy flow when Deposit funds is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 
     fireEvent.press(
-      getByTestId(MoneyAddMoneySheetTestIds.BUY_WITH_FIAT_OPTION),
+      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(mockGoToBuy).toHaveBeenCalledTimes(1);
   });
 
-  it('initiates mUSD conversion when Convert tokens is pressed', () => {
+  it('initiates mUSD conversion when Convert crypto is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 
     fireEvent.press(
-      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION),
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
@@ -103,10 +129,20 @@ describe('MoneyAddMoneySheet', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 
     fireEvent.press(
-      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION),
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
+  });
+
+  it('closes the sheet when Move mUSD is pressed (interim, no flow wired yet)', () => {
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
+    expect(mockGoToBuy).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -99,6 +99,15 @@ describe('MoneyAddMoneySheet', () => {
     expect(getByText('Move your mUSD')).toBeOnTheScreen();
   });
 
+  it('normalizes a US$ locale prefix to a plain $ in the move mUSD row', () => {
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      musdFiatFormatted: 'US$1,203.89',
+    });
+    const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(getByText('Move your $1,203.89 mUSD')).toBeOnTheScreen();
+  });
+
   it('navigates to the Ramps buy flow when Deposit funds is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -7,7 +7,7 @@ import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
-import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 
 const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
 const mockInitiateCustomConversion = jest.fn().mockResolvedValue(undefined);
@@ -26,9 +26,8 @@ jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
 }));
 
-jest.mock('../../hooks/useMoneyAccountBalance', () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
+  useMusdBalance: jest.fn(),
 }));
 
 jest.mock(
@@ -69,8 +68,8 @@ describe('MoneyAddMoneySheet', () => {
     (useRampNavigation as jest.Mock).mockReturnValue({
       goToBuy: mockGoToBuy,
     });
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      musdFiatFormatted: '$1,203.89',
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregatedFormatted: '$1,203.89',
     });
     mockGetPaymentTokenForSelectedNetwork.mockReturnValue(mockPaymentToken);
   });
@@ -91,8 +90,8 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('falls back to the no-amount copy when the mUSD balance is unavailable', () => {
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      musdFiatFormatted: undefined,
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregatedFormatted: undefined,
     });
     const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 
@@ -100,8 +99,8 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('normalizes a US$ locale prefix to a plain $ in the move mUSD row', () => {
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      musdFiatFormatted: 'US$1,203.89',
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregatedFormatted: 'US$1,203.89',
     });
     const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.testIds.ts
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.testIds.ts
@@ -1,0 +1,5 @@
+export const MoneyAddMoneySheetTestIds = {
+  CONTAINER: 'money-add-money-sheet',
+  CONVERT_TOKENS_OPTION: 'money-add-money-sheet-convert-tokens',
+  BUY_WITH_FIAT_OPTION: 'money-add-money-sheet-buy-with-fiat',
+};

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.testIds.ts
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.testIds.ts
@@ -1,5 +1,7 @@
 export const MoneyAddMoneySheetTestIds = {
   CONTAINER: 'money-add-money-sheet',
-  CONVERT_TOKENS_OPTION: 'money-add-money-sheet-convert-tokens',
-  BUY_WITH_FIAT_OPTION: 'money-add-money-sheet-buy-with-fiat',
+  CONVERT_CRYPTO_OPTION: 'money-add-money-sheet-convert-crypto',
+  DEPOSIT_FUNDS_OPTION: 'money-add-money-sheet-deposit-funds',
+  MOVE_MUSD_OPTION: 'money-add-money-sheet-move-musd',
+  RECEIVE_EXTERNAL_ROW: 'money-add-money-sheet-receive-external',
 };

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { View } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
+import { TouchableOpacity, View } from 'react-native';
 import {
   Icon,
   IconName,
@@ -15,8 +14,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
-import ListItemColumn from '../../../../../component-library/components/List/ListItemColumn';
 import Tag from '../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
@@ -96,7 +93,7 @@ const MoneyAddMoneySheet: React.FC = () => {
     },
     {
       label: strings('money.add_money_sheet.deposit_funds'),
-      icon: IconName.Money,
+      icon: IconName.AttachMoney,
       onPress: handleDepositFunds,
       testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
     },
@@ -124,42 +121,40 @@ const MoneyAddMoneySheet: React.FC = () => {
           {strings('money.add_money_sheet.title')}
         </Text>
       </BottomSheetHeader>
-      <FlatList
-        scrollEnabled={false}
-        data={options}
-        renderItem={({ item }) => (
-          <ListItemSelect onPress={item.onPress} testID={item.testID}>
-            <ListItemColumn>
-              <Icon
-                name={item.icon}
-                size={IconSize.Lg}
-                color={IconColor.IconDefault}
-              />
-            </ListItemColumn>
-            <ListItemColumn>
-              <Text variant={TextVariant.BodyMDMedium}>{item.label}</Text>
-            </ListItemColumn>
-          </ListItemSelect>
-        )}
-        keyExtractor={(item) => item.testID}
-      />
-      <View
-        style={styles.disabledRow}
-        testID={MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW}
-      >
-        <Icon
-          name={IconName.Received}
-          size={IconSize.Lg}
-          color={IconColor.IconMuted}
-        />
-        <View style={styles.disabledRowContent}>
-          <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+      <View style={styles.list}>
+        {options.map((item) => (
+          <TouchableOpacity
+            key={item.testID}
+            onPress={item.onPress}
+            style={styles.row}
+            testID={item.testID}
           >
-            {strings('money.add_money_sheet.receive_external')}
-          </Text>
-          <Tag label={strings('money.add_money_sheet.coming_soon')} />
+            <Icon
+              name={item.icon}
+              size={IconSize.Lg}
+              color={IconColor.IconDefault}
+            />
+            <Text variant={TextVariant.BodyMDMedium}>{item.label}</Text>
+          </TouchableOpacity>
+        ))}
+        <View
+          style={styles.row}
+          testID={MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW}
+        >
+          <Icon
+            name={IconName.Received}
+            size={IconSize.Lg}
+            color={IconColor.IconMuted}
+          />
+          <View style={styles.disabledRowContent}>
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Alternative}
+            >
+              {strings('money.add_money_sheet.receive_external')}
+            </Text>
+            <Tag label={strings('money.add_money_sheet.coming_soon')} />
+          </View>
         </View>
       </View>
     </BottomSheet>

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -155,7 +155,10 @@ const MoneyAddMoneySheet: React.FC = () => {
             >
               {strings('money.add_money_sheet.receive_external')}
             </Text>
-            <Tag label={strings('money.add_money_sheet.coming_soon')} />
+            <Tag
+              label={strings('money.add_money_sheet.coming_soon')}
+              style={styles.comingSoonTag}
+            />
           </View>
         </View>
       </View>

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -148,7 +148,7 @@ const MoneyAddMoneySheet: React.FC = () => {
         testID={MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW}
       >
         <Icon
-          name={IconName.ArrowDown}
+          name={IconName.Received}
           size={IconSize.Lg}
           color={IconColor.IconMuted}
         />

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useRef } from 'react';
+import { View } from 'react-native';
+import { FlatList } from 'react-native-gesture-handler';
+import {
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+  Label,
+} from '@metamask/design-system-react-native';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
+import ListItemColumn from '../../../../../component-library/components/List/ListItemColumn';
+import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
+import Logger from '../../../../../util/Logger';
+import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
+import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
+import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
+import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import { createStyles } from './MoneyAddMoneySheet.styles';
+import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
+
+const MoneyAddMoneySheet: React.FC = () => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const theme = useTheme();
+  const styles = createStyles(theme);
+
+  const { initiateCustomConversion } = useMusdConversion();
+  const { getPaymentTokenForSelectedNetwork } = useMusdConversionFlowData();
+  const { goToBuy } = useRampNavigation();
+
+  const closeAndNavigate = useCallback((navigateFn: () => void) => {
+    sheetRef.current?.onCloseBottomSheet(navigateFn);
+  }, []);
+
+  // TODO(MUSD-478/MUSD-516): Replace with the MM Pay "Add money" amount-entry
+  // screen (Figma 2547:8887) once that screen lands. Interim: the existing
+  // mUSD quick-convert token list.
+  const handleConvertTokens = useCallback(() => {
+    const paymentToken = getPaymentTokenForSelectedNetwork();
+    if (!paymentToken) {
+      Logger.error(new Error('[MoneyAddMoneySheet] payment token missing'));
+      sheetRef.current?.onCloseBottomSheet();
+      return;
+    }
+    closeAndNavigate(() => {
+      initiateCustomConversion({
+        preferredPaymentToken: paymentToken,
+        navigationOverride: MUSD_CONVERSION_NAVIGATION_OVERRIDE.QUICK_CONVERT,
+      }).catch((error) => {
+        Logger.error(error as Error, '[MoneyAddMoneySheet] conversion failed');
+      });
+    });
+  }, [
+    closeAndNavigate,
+    getPaymentTokenForSelectedNetwork,
+    initiateCustomConversion,
+  ]);
+
+  // TODO(MUSD-479): Route to the Ramps "Add funds" amount-entry screen
+  // (Figma 2547:8780) once that screen lands. Interim: the unified
+  // smart-routed Buy flow.
+  const handleBuyWithFiat = useCallback(() => {
+    closeAndNavigate(() => {
+      goToBuy();
+    });
+  }, [closeAndNavigate, goToBuy]);
+
+  const options = [
+    {
+      label: strings('money.add_money_sheet.convert_tokens'),
+      description: strings('money.add_money_sheet.convert_tokens_description'),
+      icon: IconName.SwapHorizontal,
+      onPress: handleConvertTokens,
+      testID: MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION,
+    },
+    {
+      label: strings('money.add_money_sheet.buy_with_fiat'),
+      description: strings('money.add_money_sheet.buy_with_fiat_description'),
+      icon: IconName.Card,
+      onPress: handleBuyWithFiat,
+      testID: MoneyAddMoneySheetTestIds.BUY_WITH_FIAT_OPTION,
+    },
+  ];
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack
+      testID={MoneyAddMoneySheetTestIds.CONTAINER}
+      keyboardAvoidingViewEnabled={false}
+    >
+      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+        <Text variant={TextVariant.HeadingSM}>
+          {strings('money.add_money_sheet.title')}
+        </Text>
+      </BottomSheetHeader>
+      <FlatList
+        scrollEnabled={false}
+        data={options}
+        renderItem={({ item }) => (
+          <ListItemSelect onPress={item.onPress} testID={item.testID}>
+            <ListItemColumn>
+              <View style={styles.iconContainer}>
+                <Icon
+                  name={item.icon}
+                  size={IconSize.Md}
+                  color={IconColor.PrimaryDefault}
+                />
+              </View>
+            </ListItemColumn>
+            <ListItemColumn>
+              <Label>{item.label}</Label>
+              <Text
+                variant={TextVariant.BodySM}
+                color={theme.colors.text.alternative}
+              >
+                {item.description}
+              </Text>
+            </ListItemColumn>
+          </ListItemSelect>
+        )}
+        keyExtractor={(item) => item.label}
+      />
+    </BottomSheet>
+  );
+};
+
+export default MoneyAddMoneySheet;

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -6,7 +6,6 @@ import {
   IconName,
   IconSize,
   IconColor,
-  Label,
 } from '@metamask/design-system-react-native';
 import BottomSheet, {
   BottomSheetRef,
@@ -14,12 +13,15 @@ import BottomSheet, {
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import Text, {
   TextVariant,
+  TextColor,
 } from '../../../../../component-library/components/Texts/Text';
 import ListItemSelect from '../../../../../component-library/components/List/ListItemSelect';
 import ListItemColumn from '../../../../../component-library/components/List/ListItemColumn';
+import Tag from '../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
 import Logger from '../../../../../util/Logger';
+import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
@@ -27,11 +29,19 @@ import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
 import { createStyles } from './MoneyAddMoneySheet.styles';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 
+interface Option {
+  label: string;
+  icon: IconName;
+  onPress: () => void;
+  testID: string;
+}
+
 const MoneyAddMoneySheet: React.FC = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const theme = useTheme();
   const styles = createStyles(theme);
 
+  const { musdFiatFormatted } = useMoneyAccountBalance();
   const { initiateCustomConversion } = useMusdConversion();
   const { getPaymentTokenForSelectedNetwork } = useMusdConversionFlowData();
   const { goToBuy } = useRampNavigation();
@@ -40,10 +50,9 @@ const MoneyAddMoneySheet: React.FC = () => {
     sheetRef.current?.onCloseBottomSheet(navigateFn);
   }, []);
 
-  // TODO(MUSD-478/MUSD-516): Replace with the MM Pay "Add money" amount-entry
-  // screen (Figma 2547:8887) once that screen lands. Interim: the existing
-  // mUSD quick-convert token list.
-  const handleConvertTokens = useCallback(() => {
+  // TODO(MUSD-478/MUSD-516): point to the MM Pay "Add money" amount-entry
+  // screen (Figma 2547:8887). Interim: existing mUSD quick-convert token list.
+  const handleConvertCrypto = useCallback(() => {
     const paymentToken = getPaymentTokenForSelectedNetwork();
     if (!paymentToken) {
       Logger.error(new Error('[MoneyAddMoneySheet] payment token missing'));
@@ -64,29 +73,42 @@ const MoneyAddMoneySheet: React.FC = () => {
     initiateCustomConversion,
   ]);
 
-  // TODO(MUSD-479): Route to the Ramps "Add funds" amount-entry screen
-  // (Figma 2547:8780) once that screen lands. Interim: the unified
-  // smart-routed Buy flow.
-  const handleBuyWithFiat = useCallback(() => {
+  // TODO(MUSD-479): point to the Ramps "Add funds" amount-entry screen
+  // (Figma 2547:8780). Interim: unified smart-routed Buy flow.
+  const handleDepositFunds = useCallback(() => {
     closeAndNavigate(() => {
       goToBuy();
     });
   }, [closeAndNavigate, goToBuy]);
 
-  const options = [
+  // TODO: wire to the "move external mUSD → Money Account" flow once the
+  // dedicated ticket lands. Interim: close sheet.
+  const handleMoveMusd = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const options: Option[] = [
     {
-      label: strings('money.add_money_sheet.convert_tokens'),
-      description: strings('money.add_money_sheet.convert_tokens_description'),
-      icon: IconName.SwapHorizontal,
-      onPress: handleConvertTokens,
-      testID: MoneyAddMoneySheetTestIds.CONVERT_TOKENS_OPTION,
+      label: strings('money.add_money_sheet.convert_crypto'),
+      icon: IconName.Refresh,
+      onPress: handleConvertCrypto,
+      testID: MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
     },
     {
-      label: strings('money.add_money_sheet.buy_with_fiat'),
-      description: strings('money.add_money_sheet.buy_with_fiat_description'),
-      icon: IconName.Card,
-      onPress: handleBuyWithFiat,
-      testID: MoneyAddMoneySheetTestIds.BUY_WITH_FIAT_OPTION,
+      label: strings('money.add_money_sheet.deposit_funds'),
+      icon: IconName.Money,
+      onPress: handleDepositFunds,
+      testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+    },
+    {
+      label: musdFiatFormatted
+        ? strings('money.add_money_sheet.move_musd', {
+            amount: musdFiatFormatted,
+          })
+        : strings('money.add_money_sheet.move_musd_no_amount'),
+      icon: IconName.Add,
+      onPress: handleMoveMusd,
+      testID: MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
     },
   ];
 
@@ -108,27 +130,38 @@ const MoneyAddMoneySheet: React.FC = () => {
         renderItem={({ item }) => (
           <ListItemSelect onPress={item.onPress} testID={item.testID}>
             <ListItemColumn>
-              <View style={styles.iconContainer}>
-                <Icon
-                  name={item.icon}
-                  size={IconSize.Md}
-                  color={IconColor.PrimaryDefault}
-                />
-              </View>
+              <Icon
+                name={item.icon}
+                size={IconSize.Lg}
+                color={IconColor.IconDefault}
+              />
             </ListItemColumn>
             <ListItemColumn>
-              <Label>{item.label}</Label>
-              <Text
-                variant={TextVariant.BodySM}
-                color={theme.colors.text.alternative}
-              >
-                {item.description}
-              </Text>
+              <Text variant={TextVariant.BodyMDMedium}>{item.label}</Text>
             </ListItemColumn>
           </ListItemSelect>
         )}
-        keyExtractor={(item) => item.label}
+        keyExtractor={(item) => item.testID}
       />
+      <View
+        style={styles.disabledRow}
+        testID={MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW}
+      >
+        <Icon
+          name={IconName.ArrowDown}
+          size={IconSize.Lg}
+          color={IconColor.IconMuted}
+        />
+        <View style={styles.disabledRowContent}>
+          <Text
+            variant={TextVariant.BodyMDMedium}
+            color={TextColor.Alternative}
+          >
+            {strings('money.add_money_sheet.receive_external')}
+          </Text>
+          <Tag label={strings('money.add_money_sheet.coming_soon')} />
+        </View>
+      </View>
     </BottomSheet>
   );
 };

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -17,7 +17,7 @@ import Tag from '../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
 import Logger from '../../../../../util/Logger';
-import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMusdConversion } from '../../../Earn/hooks/useMusdConversion';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
 import { MUSD_CONVERSION_NAVIGATION_OVERRIDE } from '../../../Earn/types/musd.types';
@@ -37,10 +37,15 @@ const MoneyAddMoneySheet: React.FC = () => {
   const theme = useTheme();
   const styles = createStyles(theme);
 
-  const { musdFiatFormatted } = useMoneyAccountBalance();
+  // The Move row shows the user's mUSD held in external wallet accounts
+  // (what can be moved INTO the Money Account), not the Money Account balance.
+  const { fiatBalanceAggregatedFormatted } = useMusdBalance();
   // Figma 3027:12190 renders the amount as "$1,203.89" (plain USD symbol).
   // The hook formats in the user locale and may prefix "US$" — normalize.
-  const musdAmountForLabel = musdFiatFormatted?.replace(/^US\$/, '$');
+  const musdAmountForLabel = fiatBalanceAggregatedFormatted?.replace(
+    /^US\$/,
+    '$',
+  );
   const { initiateCustomConversion } = useMusdConversion();
   const { getPaymentTokenForSelectedNetwork } = useMusdConversionFlowData();
   const { goToBuy } = useRampNavigation();

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -37,11 +37,7 @@ const MoneyAddMoneySheet: React.FC = () => {
   const theme = useTheme();
   const styles = createStyles(theme);
 
-  // The Move row shows the user's mUSD held in external wallet accounts
-  // (what can be moved INTO the Money Account), not the Money Account balance.
   const { fiatBalanceAggregatedFormatted } = useMusdBalance();
-  // Figma 3027:12190 renders the amount as "$1,203.89" (plain USD symbol).
-  // The hook formats in the user locale and may prefix "US$" — normalize.
   const musdAmountForLabel = fiatBalanceAggregatedFormatted?.replace(
     /^US\$/,
     '$',

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useRef } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import {
-  Icon,
+import Icon, {
   IconName,
   IconSize,
   IconColor,
-} from '@metamask/design-system-react-native';
+} from '../../../../../component-library/components/Icons/Icon';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -132,7 +131,7 @@ const MoneyAddMoneySheet: React.FC = () => {
             <Icon
               name={item.icon}
               size={IconSize.Lg}
-              color={IconColor.IconDefault}
+              color={IconColor.Default}
             />
             <Text variant={TextVariant.BodyMDMedium}>{item.label}</Text>
           </TouchableOpacity>
@@ -142,9 +141,9 @@ const MoneyAddMoneySheet: React.FC = () => {
           testID={MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW}
         >
           <Icon
-            name={IconName.Received}
+            name={IconName.Arrow2Down}
             size={IconSize.Lg}
-            color={IconColor.IconMuted}
+            color={IconColor.Muted}
           />
           <View style={styles.disabledRowContent}>
             <Text

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -38,6 +38,9 @@ const MoneyAddMoneySheet: React.FC = () => {
   const styles = createStyles(theme);
 
   const { musdFiatFormatted } = useMoneyAccountBalance();
+  // Figma 3027:12190 renders the amount as "$1,203.89" (plain USD symbol).
+  // The hook formats in the user locale and may prefix "US$" — normalize.
+  const musdAmountForLabel = musdFiatFormatted?.replace(/^US\$/, '$');
   const { initiateCustomConversion } = useMusdConversion();
   const { getPaymentTokenForSelectedNetwork } = useMusdConversionFlowData();
   const { goToBuy } = useRampNavigation();
@@ -97,9 +100,9 @@ const MoneyAddMoneySheet: React.FC = () => {
       testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
     },
     {
-      label: musdFiatFormatted
+      label: musdAmountForLabel
         ? strings('money.add_money_sheet.move_musd', {
-            amount: musdFiatFormatted,
+            amount: musdAmountForLabel,
           })
         : strings('money.add_money_sheet.move_musd_no_amount'),
       icon: IconName.Add,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/index.ts
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MoneyAddMoneySheet';
+export { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';

--- a/app/components/UI/Money/routes/index.test.tsx
+++ b/app/components/UI/Money/routes/index.test.tsx
@@ -55,14 +55,19 @@ jest.mock('../Views/MoneyActivityView', () => () => (
   <MockView testID="mock-money-activity-view" />
 ));
 
+jest.mock('../components/MoneyAddMoneySheet', () => () => (
+  <MockView testID="mock-money-add-money-sheet" />
+));
+
 describe('MoneyScreenStack', () => {
-  it('registers Money home and activity screens', () => {
+  it('registers Money home, activity, and add-money sheet screens', () => {
     const { getByTestId } = renderWithProvider(<MoneyScreenStack />, {
       theme: themeWithCustomBackground,
     });
 
     expect(getByTestId('money-screen-MoneyHome')).toBeOnTheScreen();
     expect(getByTestId('money-screen-MoneyActivity')).toBeOnTheScreen();
+    expect(getByTestId('money-screen-MoneyAddMoneySheet')).toBeOnTheScreen();
   });
 
   it('sets stack card background from theme to avoid flash during inner navigation', () => {

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import Routes from '../../../../constants/navigation/Routes';
+import { clearStackNavigatorOptions } from '../../../../constants/navigation/clearStackNavigatorOptions';
 import { useTheme } from '../../../../util/theme';
 import MoneyHomeView from '../Views/MoneyHomeView';
 import MoneyActivityView from '../Views/MoneyActivityView';
 import MoneyHowItWorksView from '../Views/MoneyHowItWorksView';
+import MoneyAddMoneySheet from '../components/MoneyAddMoneySheet';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
 import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 
@@ -29,6 +31,11 @@ const MoneyScreenStack = () => {
       <Stack.Screen
         name={Routes.MONEY.HOW_IT_WORKS}
         component={MoneyHowItWorksView}
+      />
+      <Stack.Screen
+        name={Routes.MONEY.ADD_MONEY_SHEET}
+        component={MoneyAddMoneySheet}
+        options={clearStackNavigatorOptions}
       />
       <Stack.Screen
         name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -419,6 +419,7 @@ const Routes = {
     HOME: 'MoneyHome',
     ACTIVITY: 'MoneyActivity',
     HOW_IT_WORKS: 'MoneyHowItWorks',
+    ADD_MONEY_SHEET: 'MoneyAddMoneySheet',
   },
   FULL_SCREEN_CONFIRMATIONS: {
     REDESIGNED_CONFIRMATIONS: 'RedesignedConfirmations',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6442,10 +6442,12 @@
     },
     "add_money_sheet": {
       "title": "Add money",
-      "convert_tokens": "Convert tokens",
-      "convert_tokens_description": "Use crypto you already have",
-      "buy_with_fiat": "Buy with fiat",
-      "buy_with_fiat_description": "Use debit or credit card"
+      "convert_crypto": "Convert crypto",
+      "deposit_funds": "Deposit funds",
+      "move_musd": "Move your {{amount}} mUSD",
+      "move_musd_no_amount": "Move your mUSD",
+      "receive_external": "Receive from external wallet",
+      "coming_soon": "Coming soon"
     },
     "activity": {
       "title": "Activity",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6440,6 +6440,13 @@
     "footer": {
       "add_money": "Add money"
     },
+    "add_money_sheet": {
+      "title": "Add money",
+      "convert_tokens": "Convert tokens",
+      "convert_tokens_description": "Use crypto you already have",
+      "buy_with_fiat": "Buy with fiat",
+      "buy_with_fiat_description": "Use debit or credit card"
+    },
     "activity": {
       "title": "Activity",
       "view_all": "View all",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Tapping the "Add" action pill on the Money Account homepage previously triggered an under-construction alert. This PR ties the pill (and the three other "Add money" entry points on the homepage — the onboarding-card CTA in step 1, the mUSD token row, and the full-width footer button) to a single new bottom sheet, `MoneyAddMoneySheet`, which presents the four deposit paths from Figma `3027:12190`:

1. **Convert crypto** — initiates the existing mUSD quick-convert flow as an interim. `TODO(MUSD-478/MUSD-516)` is left inline so the owning team can swap in the dedicated MM Pay amount-entry screen (Figma `2547:8887`) when it lands.
2. **Deposit funds** — routes through `useRampNavigation().goToBuy()` (unified smart-routed Ramps entry). `TODO(MUSD-479)` marks the final Ramps "Add funds" amount-entry screen (Figma `2547:8780`) swap.
3. **Move your {{amount}} mUSD** — displays the user's aggregated mUSD fiat balance held in EOA wallet accounts across Mainnet + Linea (sourced from `useMusdBalance().fiatBalanceAggregatedFormatted`, locale-normalized from `US$` → `$` to match Figma). Currently closes the sheet as an interim; the move-external-mUSD-to-Money-Account flow is tracked separately.
4. **Receive from external wallet** — rendered as a disabled row with a "Coming soon" tag per Figma.

This also covers MUSD-252: the full-width "Add money" footer button now calls the same handler as the "Add" pill (`handleAddMoneyPress = handleAddPress`), so both reach the same sheet.

The sheet component follows the existing bottom-sheet pattern (see `app/components/UI/Card/components/AddFundsBottomSheet`). Rows are custom `TouchableOpacity` layouts (flat 24px icon + single-line label, 8/16 padding, 59px min-height) rather than `ListItemSelect` to match the Figma row spec exactly. Icons come from the app-level `component-library` set (MMDS lacked the `Arrow2Down` glyph needed for the Receive row).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added an "Add money" bottom sheet to the Money Account homepage offering Convert crypto, Deposit funds, Move mUSD, and Receive from external wallet options; wired the "Add" header pill, onboarding CTA, mUSD row Add button, and full-width "Add money" footer to it.

## **Related issues**

Fixes: [MUSD-473](https://consensyssoftware.atlassian.net/browse/MUSD-473), [MUSD-252](https://consensyssoftware.atlassian.net/browse/MUSD-252)

## **Manual testing steps**

```gherkin
Feature: Add money bottom sheet on Money Account homepage

  Scenario: user taps the Add action pill in the header row
    Given the user is on the Money Account homepage
    When the user taps the "Add" pill in the header action row
    Then the "Add money" bottom sheet is presented with four rows: Convert crypto, Deposit funds, Move your {amount} mUSD, and Receive from external wallet (with a "Coming soon" tag)

  Scenario: user taps the Add money footer button (MUSD-252)
    Given the user is on the Money Account homepage
    When the user taps the full-width "Add money" button at the bottom of the screen
    Then the same "Add money" bottom sheet is presented

  Scenario: user taps the onboarding CTA in empty state
    Given the Money Account has zero transactions
    And the onboarding card is showing step 1
    When the user taps the step-1 CTA button
    Then the "Add money" bottom sheet is presented

  Scenario: user taps the Add button in the mUSD token row
    Given the Money Account has zero transactions
    And the mUSD token row is visible below the How it works section
    When the user taps the row's "Add" button
    Then the "Add money" bottom sheet is presented

  Scenario: user selects Convert crypto
    Given the "Add money" bottom sheet is open
    When the user taps "Convert crypto"
    Then the sheet closes and the existing mUSD quick-convert flow is launched

  Scenario: user selects Deposit funds
    Given the "Add money" bottom sheet is open
    When the user taps "Deposit funds"
    Then the sheet closes and the unified Ramps Buy flow is launched

  Scenario: user sees aggregated mUSD in the Move row
    Given the user holds mUSD on Mainnet or Linea in a regular wallet account
    When the user opens the "Add money" bottom sheet
    Then the Move row reads "Move your ${amount} mUSD" using the aggregated fiat value

  Scenario: Receive from external wallet is disabled
    Given the "Add money" bottom sheet is open
    When the user views the Receive from external wallet row
    Then the row appears muted with a "Coming soon" tag and does not respond to taps
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Tapping "Add" (pill / onboarding / mUSD row / footer) presents an under-construction alert.

### **After**

<!-- [screenshots/recordings] -->

Tapping any of the four Add money entry points opens the bottom sheet from Figma `3027:12190`.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-473]: https://consensyssoftware.atlassian.net/browse/MUSD-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new navigation route and bottom-sheet entry point that triggers Ramp buy and mUSD conversion flows, so regressions could break funding/conversion navigation from the Money homepage.
> 
> **Overview**
> Adds a new `MoneyAddMoneySheet` bottom sheet route (`Routes.MONEY.ADD_MONEY_SHEET`) to present multiple “add money” paths from the Money home experience.
> 
> Updates `MoneyHomeView` so all existing Add-money entry points (action row Add, onboarding CTA, mUSD row Add, and footer Add money) navigate to this sheet instead of showing an under-construction alert.
> 
> Implements the sheet UI and wiring: **Convert crypto** starts the mUSD quick-convert flow (with payment-token guard + logging), **Deposit funds** launches the Ramp buy flow, **Move mUSD** currently just closes, and **Receive from external wallet** is shown as a disabled “Coming soon” row. Adds/updates tests for the new navigation and sheet behaviors, plus new i18n strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f2802ecfce55b27ae66d245d09b32a6bf5e99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->