### PR TITLE
chore: display chain badge on position token avatars in trader profile

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -55,7 +55,7 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
         gap={4}
         twClassName="flex-1 min-w-0 mr-3"
       >
-        <PositionTokenAvatar position={position} />
+        <PositionTokenAvatar position={position} showChainBadge />
 
         <Box twClassName="flex-1 min-w-0">
           <Text

--- a/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.test.tsx
@@ -7,6 +7,8 @@ import {
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import PositionTokenAvatar from './PositionTokenAvatar';
 import type { Position } from '@metamask/social-controllers';
+import BadgeWrapper from '../../../../component-library/components/Badges/BadgeWrapper';
+import BadgeNetwork from '../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
 
 jest.mock('@metamask/design-system-react-native', () => ({
   ...jest.requireActual('@metamask/design-system-react-native'),
@@ -26,7 +28,30 @@ jest.mock('../utils/chainMapping', () => ({
   ),
 }));
 
+jest.mock(
+  '../../../../component-library/components/Badges/BadgeWrapper',
+  () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+    BadgePosition: { BottomRight: 'bottom-right' },
+  }),
+);
+
+jest.mock(
+  '../../../../component-library/components/Badges/Badge/variants/BadgeNetwork',
+  () => ({
+    __esModule: true,
+    default: jest.fn(() => null),
+  }),
+);
+
+jest.mock('../../../../util/networks', () => ({
+  getNetworkImageSource: jest.fn(() => ({ uri: 'network.png' })),
+}));
+
 const MockAvatarToken = AvatarToken as jest.Mock;
+const MockBadgeWrapper = BadgeWrapper as jest.Mock;
+const MockBadgeNetwork = BadgeNetwork as jest.Mock;
 
 const lastAvatarTokenProps = () =>
   MockAvatarToken.mock.calls[MockAvatarToken.mock.calls.length - 1][0] as {
@@ -212,6 +237,42 @@ describe('PositionTokenAvatar', () => {
 
     expect(lastAvatarTokenProps().src).toEqual({
       uri: 'https://static.cx.metamask.io/eip155:8453.png',
+    });
+  });
+
+  describe('showChainBadge', () => {
+    it('wraps the avatar in BadgeWrapper when showChainBadge is true and the chain resolves', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={basePosition} showChainBadge />,
+      );
+
+      expect(MockBadgeWrapper).toHaveBeenCalled();
+    });
+
+    it('passes a BadgeNetwork as the badgeElement when showChainBadge is true', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={basePosition} showChainBadge />,
+      );
+
+      const badgeElement = MockBadgeWrapper.mock.calls[0][0]
+        .badgeElement as React.ReactElement;
+      expect(badgeElement.type).toBe(MockBadgeNetwork);
+    });
+
+    it('does not wrap the avatar in BadgeWrapper when showChainBadge is false by default', () => {
+      renderWithProvider(<PositionTokenAvatar position={basePosition} />);
+
+      expect(MockBadgeWrapper).not.toHaveBeenCalled();
+    });
+
+    it('does not wrap the avatar in BadgeWrapper when the chain is unsupported', () => {
+      const position = { ...basePosition, chain: 'unsupported' };
+
+      renderWithProvider(
+        <PositionTokenAvatar position={position} showChainBadge />,
+      );
+
+      expect(MockBadgeWrapper).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.tsx
+++ b/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.tsx
@@ -6,10 +6,16 @@ import {
 import type { Position } from '@metamask/social-controllers';
 import { getAssetImageUrl } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import { chainNameToId } from '../utils/chainMapping';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../component-library/components/Badges/BadgeWrapper';
+import BadgeNetwork from '../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
+import { getNetworkImageSource } from '../../../../util/networks';
 
 export interface PositionTokenAvatarProps {
   position: Position;
   size?: AvatarTokenSize;
+  showChainBadge?: boolean;
 }
 
 type ImageSource = 'clicker' | 'metamask' | 'none';
@@ -23,12 +29,17 @@ type ImageSource = 'clicker' | 'metamask' | 'none';
 const PositionTokenAvatar: React.FC<PositionTokenAvatarProps> = ({
   position,
   size = AvatarTokenSize.Lg,
+  showChainBadge = false,
 }) => {
+  const caipChainId = useMemo(
+    () => chainNameToId(position.chain),
+    [position.chain],
+  );
+
   const metamaskUrl = useMemo(() => {
-    const chainId = chainNameToId(position.chain);
-    if (!chainId) return undefined;
-    return getAssetImageUrl(position.tokenAddress, chainId);
-  }, [position.chain, position.tokenAddress]);
+    if (!caipChainId) return undefined;
+    return getAssetImageUrl(position.tokenAddress, caipChainId);
+  }, [caipChainId, position.tokenAddress]);
 
   const initialSource = useMemo((): ImageSource => {
     if (position.tokenImageUrl) return 'clicker';
@@ -64,7 +75,7 @@ const PositionTokenAvatar: React.FC<PositionTokenAvatarProps> = ({
     });
   };
 
-  return (
+  const avatar = (
     <AvatarToken
       name={position.tokenSymbol}
       src={src}
@@ -75,6 +86,24 @@ const PositionTokenAvatar: React.FC<PositionTokenAvatarProps> = ({
       }}
     />
   );
+
+  if (showChainBadge && caipChainId) {
+    return (
+      <BadgeWrapper
+        badgePosition={BadgePosition.BottomRight}
+        badgeElement={
+          <BadgeNetwork
+            name={position.chain}
+            imageSource={getNetworkImageSource({ chainId: caipChainId })}
+          />
+        }
+      >
+        {avatar}
+      </BadgeWrapper>
+    );
+  }
+
+  return avatar;
 };
 
 export default PositionTokenAvatar;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adds a chain network icon to each token avatar in the Open and Closed position rows of the Trader Profile view. It reuses the existing `BadgeWrapper` + `BadgeNetwork` + `getNetworkImageSource` composition already present in the codebase.

<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-24 at 14 11 17" src="https://github.com/user-attachments/assets/c7f69c06-41c4-4435-b02b-3a8e479889d7" />
<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-24 at 14 12 17" src="https://github.com/user-attachments/assets/0cf1e0ce-c061-4ff5-97a2-2e6b058589e7" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit afa3ba12c1d7af8dec58d186df23caec529cfae2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->