### PR TITLE
chore(rewards): hide pending/ineligible indicators and market value on completed Ondo campaign

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -1505,6 +1505,62 @@ describe('OndoCampaignDetailsView', () => {
     });
   });
 
+  describe('positions section visibility', () => {
+    it('hides the positions section when campaign is complete, even if opted in with positions', () => {
+      const lastMonth = new Date();
+      lastMonth.setMonth(lastMonth.getMonth() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [
+          createTestCampaign({
+            startDate: lastMonth.toISOString(),
+            endDate: yesterday.toISOString(),
+          }),
+        ],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
+        refetch: jest.fn(),
+      });
+      const { queryByTestId } = render(<OndoCampaignDetailsView />);
+      expect(queryByTestId('ondo-campaign-portfolio')).toBeNull();
+    });
+
+    it('shows the positions section when campaign is active, opted in with positions', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        ...hookDefaults,
+        campaigns: [createTestCampaign()],
+      });
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        portfolio: { positions: [{}], summary: {}, computedAt: '' } as never,
+        isLoading: false,
+        hasError: false,
+        hasFetched: true,
+        refetch: jest.fn(),
+      });
+      const { getByTestId } = render(<OndoCampaignDetailsView />);
+      expect(getByTestId('ondo-campaign-portfolio')).toBeDefined();
+    });
+  });
+
   describe('portfolio and leaderboard navigation', () => {
     const setupOptedInWithPositions = () => {
       mockUseRewardCampaigns.mockReturnValue({

--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.tsx
@@ -277,7 +277,8 @@ const OndoCampaignDetailsView: React.FC = () => {
         !hasPositions &&
         getCampaignStatus(campaign) === 'active',
       showStatsSummarySection: hasPositions,
-      showPortfolioSection: isOptedIn && hasPositions,
+      showPortfolioSection:
+        isOptedIn && hasPositions && getCampaignStatus(campaign) !== 'complete',
       showLeaderboardSection: true,
     };
   }, [campaign, isOptedIn, hasPositions]);
@@ -523,6 +524,9 @@ const OndoCampaignDetailsView: React.FC = () => {
                       currentUserReferralCode={referralCode}
                       userPosition={leaderboardUserPosition}
                       campaignId={effectiveCampaignId}
+                      isCampaignComplete={
+                        getCampaignStatus(campaign) === 'complete'
+                      }
                     />
                   </Box>
                 </>

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -666,6 +666,54 @@ describe('OndoCampaignStatsView', () => {
     expect(getByText('$12,000.00')).toBeDefined();
   });
 
+  it('hides market value label when campaign is complete', () => {
+    mockGetCampaignStatus.mockReturnValue('complete');
+    mockRewardsState.campaigns = [createTestCampaign()];
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: {
+        positions: [],
+        summary: {
+          totalCurrentValue: '12000',
+          totalBookValue: '11000',
+          totalUsdDeposited: '11000',
+          netDeposit: '10500',
+          totalCashedOut: '0',
+          portfolioPnl: '1000',
+          portfolioPnlPercent: '0.09',
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { queryByText } = render(<OndoCampaignStatsView />);
+    expect(
+      queryByText('rewards.ondo_campaign_stats.label_market_value'),
+    ).toBeNull();
+  });
+
+  it('shows market value label when campaign is active', () => {
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: {
+        positions: [],
+        summary: {
+          totalCurrentValue: '12000',
+          totalBookValue: '11000',
+          totalUsdDeposited: '11000',
+          netDeposit: '10500',
+          totalCashedOut: '0',
+          portfolioPnl: '1000',
+          portfolioPnlPercent: '0.09',
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { getByText } = render(<OndoCampaignStatsView />);
+    expect(
+      getByText('rewards.ondo_campaign_stats.label_market_value'),
+    ).toBeDefined();
+  });
+
   it('shows pending tag when position is not qualified', () => {
     mockUseGetOndoLeaderboardPosition.mockReturnValue({
       ...positionDefaults,
@@ -854,6 +902,25 @@ describe('OndoCampaignStatsView', () => {
       const { queryByText } = render(<OndoCampaignStatsView />);
       expect(
         queryByText('rewards.ondo_campaign_leaderboard.ineligible'),
+      ).toBeNull();
+    });
+
+    it('does not show pending tag when campaign is complete even if position is not qualified', () => {
+      mockGetCampaignStatus.mockReturnValue('complete');
+      mockRewardsState.campaigns = [createTestCampaign()];
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: makePendingPosition(),
+      });
+      const { queryByText } = render(<OndoCampaignStatsView />);
+      expect(
+        queryByText('rewards.ondo_campaign_leaderboard.pending'),
       ).toBeNull();
     });
   });

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -799,6 +799,66 @@ describe('OndoCampaignStatsView', () => {
     ).toBeDefined();
   });
 
+  describe('completed campaign portfolio display', () => {
+    const setupComplete = () => {
+      mockGetCampaignStatus.mockReturnValue('complete');
+      mockRewardsState.campaigns = [createTestCampaign()];
+      mockUseGetCampaignParticipantStatus.mockReturnValue({
+        status: { optedIn: true, participantCount: 1 },
+        isLoading: false,
+        hasError: false,
+        refetch: jest.fn(),
+      });
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: makeQualifiedPosition({ rank: 5 }),
+      });
+      mockUseGetOndoPortfolioPosition.mockReturnValue({
+        ...portfolioDefaults,
+        portfolio: {
+          positions: [],
+          summary: {
+            totalCurrentValue: '12000',
+            totalBookValue: '11000',
+            totalUsdDeposited: '11000',
+            netDeposit: '10500',
+            totalCashedOut: '250',
+            portfolioPnl: '1000',
+            portfolioPnlPercent: '0.09',
+          },
+          computedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+    };
+
+    it('shows only rate of return and hides net inflow when campaign is complete', () => {
+      setupComplete();
+      const { getByText, queryByText } = render(<OndoCampaignStatsView />);
+      expect(
+        getByText('rewards.ondo_campaign_stats.label_return'),
+      ).toBeDefined();
+      expect(
+        queryByText('rewards.ondo_campaign_stats.label_net_inflow'),
+      ).toBeNull();
+    });
+
+    it('hides outflow when campaign is complete', () => {
+      setupComplete();
+      const { queryByText } = render(<OndoCampaignStatsView />);
+      expect(
+        queryByText('rewards.ondo_campaign_stats.label_outflow'),
+      ).toBeNull();
+    });
+
+    it('hides days held when campaign is complete', () => {
+      setupComplete();
+      const { queryByText } = render(<OndoCampaignStatsView />);
+      expect(
+        queryByText('rewards.ondo_campaign_stats.label_days_held'),
+      ).toBeNull();
+    });
+  });
+
   describe('ineligible state', () => {
     const makeIneligibleCampaign = (): CampaignDto => {
       const now = new Date();

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -265,32 +265,38 @@ const OndoCampaignStatsView: React.FC = () => {
             </Box>
 
             {/* Net inflow | Outflow (or Days held when no outflow) */}
-            <Box flexDirection={BoxFlexDirection.Row}>
-              <StatCell
-                label={strings('rewards.ondo_campaign_stats.label_net_inflow')}
-                value={netInflowValue}
-                isLoading={portfolioLoading}
-                suffix={isQualified ? <CheckIcon /> : undefined}
-              />
-              {hasCashedOut ? (
+            {!isCampaignComplete && (
+              <Box flexDirection={BoxFlexDirection.Row}>
                 <StatCell
-                  label={strings('rewards.ondo_campaign_stats.label_outflow')}
-                  value={outflowValue}
+                  label={strings(
+                    'rewards.ondo_campaign_stats.label_net_inflow',
+                  )}
+                  value={netInflowValue}
                   isLoading={portfolioLoading}
-                />
-              ) : (
-                <StatCell
-                  label={strings('rewards.ondo_campaign_stats.label_days_held')}
-                  value={daysHeldValue}
-                  isLoading={leaderboardLoading}
-                  valueColor={TextColor.TextDefault}
                   suffix={isQualified ? <CheckIcon /> : undefined}
                 />
-              )}
-            </Box>
+                {hasCashedOut ? (
+                  <StatCell
+                    label={strings('rewards.ondo_campaign_stats.label_outflow')}
+                    value={outflowValue}
+                    isLoading={portfolioLoading}
+                  />
+                ) : (
+                  <StatCell
+                    label={strings(
+                      'rewards.ondo_campaign_stats.label_days_held',
+                    )}
+                    value={daysHeldValue}
+                    isLoading={leaderboardLoading}
+                    valueColor={TextColor.TextDefault}
+                    suffix={isQualified ? <CheckIcon /> : undefined}
+                  />
+                )}
+              </Box>
+            )}
 
             {/* Days held (when outflow row present) */}
-            {hasCashedOut && (
+            {!isCampaignComplete && hasCashedOut && (
               <Box flexDirection={BoxFlexDirection.Row}>
                 <StatCell
                   label={strings('rewards.ondo_campaign_stats.label_days_held')}

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -230,9 +230,9 @@ const OndoCampaignStatsView: React.FC = () => {
               rank={rankValue}
               tier={tierValue}
               isLoading={leaderboardLoading}
-              isPending={isPending}
+              isPending={!isCampaignComplete && isPending}
               isQualified={isQualified}
-              isIneligible={isIneligible}
+              isIneligible={!isCampaignComplete && isIneligible}
             />
           </Box>
 
@@ -252,14 +252,16 @@ const OndoCampaignStatsView: React.FC = () => {
                 isLoading={portfolioLoading}
                 valueColor={returnColor}
               />
-              <StatCell
-                label={strings(
-                  'rewards.ondo_campaign_stats.label_market_value',
-                )}
-                value={marketValue}
-                isLoading={portfolioLoading}
-                valueColor={returnColor}
-              />
+              {!isCampaignComplete && (
+                <StatCell
+                  label={strings(
+                    'rewards.ondo_campaign_stats.label_market_value',
+                  )}
+                  value={marketValue}
+                  isLoading={portfolioLoading}
+                  valueColor={returnColor}
+                />
+              )}
             </Box>
 
             {/* Net inflow | Outflow (or Days held when no outflow) */}

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.test.tsx
@@ -358,4 +358,61 @@ describe('OndoLeaderboardView', () => {
       expect.objectContaining({ defaultTier: 'MID' }),
     );
   });
+
+  describe('isCampaignComplete behavior', () => {
+    const completeCampaign = {
+      ...mockCampaign,
+      startDate: '2024-01-01T00:00:00Z',
+      endDate: '2024-01-02T00:00:00Z',
+    };
+
+    const pendingPosition = {
+      rank: 8,
+      projectedTier: 'STARTER',
+      qualified: false,
+      qualifiedDays: 3,
+      totalInTier: 100,
+      rateOfReturn: 0.05,
+      currentUsdValue: 5000,
+      totalUsdDeposited: 4000,
+      netDeposit: 3500,
+      neighbors: [],
+      computedAt: '2024-01-01T00:00:00Z',
+    };
+
+    it('does not show Pending tag when campaign is complete and position is not qualified', () => {
+      mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+        selector({
+          rewards: { referralCode: null, campaigns: [completeCampaign] },
+        }),
+      );
+      mockUseGetOndoLeaderboardPosition.mockReturnValue({
+        ...positionDefaults,
+        position: pendingPosition,
+      });
+      const { queryByText } = render(<OndoLeaderboardView />);
+      expect(
+        queryByText('rewards.ondo_campaign_leaderboard.pending'),
+      ).toBeNull();
+    });
+
+    it('passes isCampaignComplete=true to OndoLeaderboard when campaign is complete', () => {
+      mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+        selector({
+          rewards: { referralCode: null, campaigns: [completeCampaign] },
+        }),
+      );
+      render(<OndoLeaderboardView />);
+      expect(mockOndoLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({ isCampaignComplete: true }),
+      );
+    });
+
+    it('passes isCampaignComplete=false to OndoLeaderboard when campaign is active', () => {
+      render(<OndoLeaderboardView />);
+      expect(mockOndoLeaderboard).toHaveBeenCalledWith(
+        expect.objectContaining({ isCampaignComplete: false }),
+      );
+    });
+  });
 });

--- a/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/OndoLeaderboardView.tsx
@@ -23,6 +23,7 @@ import { useGetCampaignParticipantStatus } from '../hooks/useGetCampaignParticip
 import { getCurrentPrize } from '../components/Campaigns/OndoPrizePool';
 import { formatPercentChange, formatUsd } from '../utils/formatUtils';
 import { isCampaignIneligible } from '../utils/ondoCampaignConstants';
+import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import {
@@ -72,6 +73,9 @@ const OndoLeaderboardView: React.FC = () => {
 
   const { deposits, isLoading: isDepositsLoading } =
     useGetOndoCampaignDeposits(campaignId);
+
+  const isCampaignComplete =
+    campaign != null && getCampaignStatus(campaign) === 'complete';
 
   const isPending = position != null && !position.qualified;
   const isQualified = position != null && position.qualified;
@@ -168,9 +172,9 @@ const OndoLeaderboardView: React.FC = () => {
                   rank={rankValue}
                   tier={tierValue}
                   isLoading={isPositionLoading}
-                  isPending={isPending}
+                  isPending={!isCampaignComplete && isPending}
                   isQualified={isQualified}
-                  isIneligible={isIneligible}
+                  isIneligible={!isCampaignComplete && isIneligible}
                   showReturn
                   returnValue={returnValue}
                   returnColor={returnColor}
@@ -197,6 +201,7 @@ const OndoLeaderboardView: React.FC = () => {
               currentUserReferralCode={referralCode}
               userPosition={leaderboardUserPosition}
               campaignId={campaignId}
+              isCampaignComplete={isCampaignComplete}
             />
           </Box>
         </ScrollView>

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.test.tsx
@@ -621,6 +621,33 @@ describe('CampaignStatsSummary', () => {
 
   // ── Campaign complete state ───────────────────────────────────────
 
+  it('hides IneligibleTag from rank cell suffix when isCampaignComplete=true', () => {
+    const { queryByTestId } = render(
+      <CampaignStatsSummary {...baseProps} isIneligible isCampaignComplete />,
+    );
+    expect(
+      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.INELIGIBLE_TAG),
+    ).toBeNull();
+  });
+
+  it('hides PendingTag from rank cell suffix when isCampaignComplete=true and position is pending', () => {
+    const pendingPosition: CampaignLeaderboardPositionDto = {
+      ...MOCK_POSITION,
+      qualified: false,
+      qualifiedDays: 3,
+    };
+    const { queryByTestId } = render(
+      <CampaignStatsSummary
+        {...baseProps}
+        leaderboardPosition={pendingPosition}
+        isCampaignComplete
+      />,
+    );
+    expect(
+      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.PENDING_TAG),
+    ).toBeNull();
+  });
+
   it('hides qualified card when isCampaignComplete=true', () => {
     const { queryByText } = render(
       <CampaignStatsSummary
@@ -656,6 +683,24 @@ describe('CampaignStatsSummary', () => {
       />,
     );
     expect(queryByText('Qualify for this rank')).toBeNull();
+  });
+
+  it('hides market value cell when isCampaignComplete=true', () => {
+    const { queryByTestId } = render(
+      <CampaignStatsSummary {...baseProps} isCampaignComplete />,
+    );
+    expect(
+      queryByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE),
+    ).toBeNull();
+  });
+
+  it('shows market value cell when isCampaignComplete=false', () => {
+    const { getByTestId } = render(
+      <CampaignStatsSummary {...baseProps} isCampaignComplete={false} />,
+    );
+    expect(
+      getByTestId(CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE),
+    ).toBeDefined();
   });
 
   it('shows outcome banner when isCampaignComplete=true and outcome is provided', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignStatsSummary.tsx
@@ -193,11 +193,11 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
           isLoading={leaderboardLoading}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.RANK}
           suffix={
-            isIneligible ? (
+            !isCampaignComplete && isIneligible ? (
               <IneligibleTag
                 testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.INELIGIBLE_TAG}
               />
-            ) : isPending ? (
+            ) : !isCampaignComplete && isPending ? (
               <PendingTag
                 testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.PENDING_TAG}
               />
@@ -228,13 +228,15 @@ const CampaignStatsSummary: React.FC<CampaignStatsSummaryProps> = ({
           valueColor={returnColor}
           testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.RETURN}
         />
-        <StatCell
-          label={strings('rewards.ondo_campaign_stats.label_market_value')}
-          value={marketValue}
-          isLoading={portfolioLoading}
-          valueColor={returnColor}
-          testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE}
-        />
+        {!isCampaignComplete && (
+          <StatCell
+            label={strings('rewards.ondo_campaign_stats.label_market_value')}
+            value={marketValue}
+            isLoading={portfolioLoading}
+            valueColor={returnColor}
+            testID={CAMPAIGN_STATS_SUMMARY_TEST_IDS.MARKET_VALUE}
+          />
+        )}
       </Box>
 
       {/* Outcome banner (campaign ended) */}

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
@@ -680,6 +680,29 @@ describe('OndoLeaderboard', () => {
         queryByTestId(CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG),
       ).toBeNull();
     });
+
+    it('does not render Pending tag when isCampaignComplete is true, even if entry is not qualified and is current user', () => {
+      const entries = [
+        createMockEntry({
+          rank: 1,
+          referralCode: 'MYCODE',
+          qualified: false,
+          qualifiedDays: 3,
+        }),
+      ];
+      const { queryByTestId } = render(
+        <OndoLeaderboard
+          {...defaultProps}
+          entries={entries}
+          currentUserReferralCode="MYCODE"
+          isCampaignComplete
+        />,
+      );
+
+      expect(
+        queryByTestId(CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG),
+      ).toBeNull();
+    });
   });
 
   describe('rate of return formatting', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
@@ -69,6 +69,7 @@ interface CampaignLeaderboardProps {
   userPosition?: UserPosition | null;
   /** Campaign ID used for analytics tracking. */
   campaignId?: string;
+  isCampaignComplete?: boolean;
 }
 
 /**
@@ -78,7 +79,13 @@ const LeaderboardEntryRow: React.FC<{
   entry: CampaignLeaderboardEntry;
   isCurrentUser?: boolean;
   showCrown?: boolean;
-}> = ({ entry, isCurrentUser = false, showCrown = false }) => {
+  isCampaignComplete?: boolean;
+}> = ({
+  entry,
+  isCurrentUser = false,
+  showCrown = false,
+  isCampaignComplete = false,
+}) => {
   const isPositiveReturn = entry.rateOfReturn >= 0;
   const textColor = isCurrentUser
     ? isPositiveReturn
@@ -122,7 +129,7 @@ const LeaderboardEntryRow: React.FC<{
             <CrownIcon name="crown" width={14} height={14} />
           )}
         </Box>
-        {isCurrentUser && isPending && (
+        {isCurrentUser && isPending && !isCampaignComplete && (
           <PendingTag testID={CAMPAIGN_LEADERBOARD_TEST_IDS.PENDING_TAG} />
         )}
       </Box>
@@ -210,6 +217,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
   maxEntries,
   userPosition,
   campaignId,
+  isCampaignComplete = false,
 }) => {
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -370,6 +378,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
               entry={entry}
               isCurrentUser={isCurrentUser(entry)}
               showCrown={!isPreview}
+              isCampaignComplete={isCampaignComplete}
             />
           ))}
           {showSplitView && userPosition && (
@@ -381,6 +390,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
                   entry={entry}
                   isCurrentUser={isCurrentUser(entry)}
                   showCrown={!isPreview}
+                  isCampaignComplete={isCampaignComplete}
                 />
               ))}
             </>


### PR DESCRIPTION
## Summary

- Hide portfolio section in `OndoCampaignDetailsView` when campaign is complete
- Suppress ineligible/pending status tags across leaderboard and stats views when campaign is complete
- Hide market value stat cell in `OndoCampaignStatsView` and `CampaignStatsSummary` when campaign is complete
- Pass `isCampaignComplete` flag through to `OndoLeaderboard` and `LeaderboardEntryRow` to suppress the pending tag for the current user
- Hide days held, cashed out, .. (except rate of return) on stats page

## CHANGELOG entry

CHANGELOG entry: null

## Screenshots/Recordings

- When campaign is still active

<img width="324" height="663" alt="image" src="https://github.com/user-attachments/assets/ee9c99c7-07d0-4905-9233-8dea845478ab" />

<img width="324" height="663" alt="image" src="https://github.com/user-attachments/assets/8d191acb-cce4-468d-812f-36953c5334ac" />


- When campaign has closed

<img width="315" height="647" alt="image" src="https://github.com/user-attachments/assets/18cd32c2-6b99-4e74-a378-23a442addd0c" />

<img width="317" height="538" alt="image" src="https://github.com/user-attachments/assets/1ca70315-7ae8-4017-849e-ab3d775a9db4" />



---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5a70bbb54fd8e1e40b399fabaf55261f71be3dc6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->