### PR TITLE
feat(ramp): bypass order-processing redirect in headless flows (Phase 6)

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -55,6 +55,11 @@ jest.mock('../../utils/v2OrderToast', () => ({
   showV2OrderToast: jest.fn(),
 }));
 
+jest.mock('../../headless/sessionRegistry', () => ({
+  getSession: jest.fn(),
+  closeSession: jest.fn(),
+}));
+
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
   log: jest.fn(),
@@ -605,6 +610,186 @@ describe('Checkout', () => {
         'https://provider.example.com/next-hop',
         Logger,
       );
+    });
+  });
+
+  describe('headless session flow', () => {
+    const mockGetSession = jest.requireMock('../../headless/sessionRegistry')
+      .getSession as jest.Mock;
+    const mockCloseSession = jest.requireMock('../../headless/sessionRegistry')
+      .closeSession as jest.Mock;
+    const showV2OrderToastMock = jest.requireMock('../../utils/v2OrderToast')
+      .showV2OrderToast as jest.Mock;
+
+    const mockOrder = {
+      providerOrderId: 'headless-order-1',
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.5',
+      status: 'Pending',
+    };
+
+    const callbackFlowParams = {
+      url: 'https://provider.example.com/checkout',
+      providerName: 'Test Provider',
+      providerCode: 'moonpay',
+      walletAddress: '0xdeadbeef',
+      headlessSessionId: 'hs-1',
+    };
+
+    let mockParentPop: jest.Mock;
+
+    beforeEach(() => {
+      mockGetSession.mockReset();
+      mockCloseSession.mockReset();
+      mockParentPop = jest.fn();
+      mockNavigation.getParent.mockReturnValue({ pop: mockParentPop });
+      mockGetOrderFromCallback.mockResolvedValue(mockOrder);
+      mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+    });
+
+    it('fires onOrderCreated, closes the session, and pops the ramp stack when a live session is present', async () => {
+      const onOrderCreated = jest.fn();
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(onOrderCreated).toHaveBeenCalledWith('headless-order-1');
+      });
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      expect(mockNavigation.reset).not.toHaveBeenCalled();
+      expect(showV2OrderToastMock).not.toHaveBeenCalled();
+    });
+
+    it('still adds the order to Redux and dispatches protect-wallet when headless', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(mockAddOrder).toHaveBeenCalledWith(mockOrder);
+      });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'PROTECT_WALLET_MODAL_VISIBLE',
+      });
+    });
+
+    it('swallows consumer onOrderCreated errors and still closes + pops', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger') as {
+        error: jest.Mock;
+      };
+      const throwingCallback = jest.fn(() => {
+        throw new Error('consumer bug');
+      });
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: throwingCallback,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(throwingCallback).toHaveBeenCalled();
+      });
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        'UnifiedCheckout: onOrderCreated callback threw',
+      );
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+    });
+
+    it('falls back to the regular reset + toast when session id is present but session is missing from registry', async () => {
+      mockGetSession.mockReturnValue(undefined);
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(showV2OrderToastMock).toHaveBeenCalledWith(
+          expect.objectContaining({ orderId: 'headless-order-1' }),
+        );
+      });
+      expect(mockNavigation.reset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          routes: [
+            expect.objectContaining({
+              params: expect.objectContaining({
+                orderId: 'headless-order-1',
+              }),
+            }),
+          ],
+        }),
+      );
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(mockParentPop).not.toHaveBeenCalled();
+    });
+
+    it('takes the regular non-headless path when headlessSessionId is absent', async () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test Provider',
+        providerCode: 'moonpay',
+        walletAddress: '0xdeadbeef',
+      });
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(mockNavigation.reset).toHaveBeenCalled();
+      });
+      expect(showV2OrderToastMock).toHaveBeenCalled();
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(mockParentPop).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -27,6 +27,7 @@ import {
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
 import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
+import { closeSession, getSession } from '../../headless/sessionRegistry';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './Checkout.styles';
 import Device from '../../../../../util/device';
@@ -56,6 +57,14 @@ interface CheckoutParams {
   providerType?: FIAT_ORDER_PROVIDERS;
   /** Optional callback invoked on navigation state changes after URL de-duplication (e.g. redirect URLs). */
   onNavigationStateChange?: (navState: { url: string }) => void;
+  /**
+   * When set, Checkout is participating in a headless buy session. On
+   * successful callback the screen fires the session's `onOrderCreated`
+   * callback, closes the session, and pops the ramp stack instead of
+   * resetting to `RAMPS_ORDER_DETAILS`. The `showV2OrderToast` surface is
+   * also suppressed — headless consumers drive their own UI.
+   */
+  headlessSessionId?: string;
 }
 
 export const createCheckoutNavDetails = createNavigationDetails<CheckoutParams>(
@@ -87,6 +96,7 @@ const Checkout = () => {
     network,
     userAgent,
     onNavigationStateChange,
+    headlessSessionId,
   } = params ?? {};
   const effectiveOrderId = (orderIdParam ?? customOrderId)?.trim() || null;
 
@@ -178,6 +188,26 @@ const Checkout = () => {
         addOrder(rampsOrder);
         dispatch(protectWalletModalVisible());
 
+        // Headless mode: hand the orderId to the consumer, close the
+        // session, and unwind out of the ramp stack so the caller regains
+        // foreground. Skip the toast + RAMPS_ORDER_DETAILS reset — both
+        // are user-facing UI the headless consumer didn't ask for.
+        const session = getSession(headlessSessionId);
+        if (headlessSessionId && session) {
+          try {
+            session.callbacks.onOrderCreated(rampsOrder.providerOrderId);
+          } catch (callbackError) {
+            Logger.error(
+              callbackError as Error,
+              'UnifiedCheckout: onOrderCreated callback threw',
+            );
+          }
+          closeSession(headlessSessionId, { reason: 'completed' });
+          // @ts-expect-error navigation prop mismatch
+          navigation.getParent()?.pop();
+          return;
+        }
+
         if (isV2Enabled) {
           showV2OrderToast({
             orderId: rampsOrder.providerOrderId,
@@ -217,6 +247,7 @@ const Checkout = () => {
       getOrderFromCallback,
       isV2Enabled,
       params?.cryptocurrency,
+      headlessSessionId,
     ],
   );
 

--- a/app/components/UI/Ramp/headless/PLAN.md
+++ b/app/components/UI/Ramp/headless/PLAN.md
@@ -13,7 +13,7 @@
 - [x] **Phase 4c** — Make `useContinueWithQuote` headless-ready — extend `ContinueWithQuoteContext` with optional overrides so callers without controller state (the Host) can drive it from a `Quote`
 - [x] **Phase 5 (revised)** — Quote-first headless start path — `startHeadlessBuy({ quote, redirectUrl? })` creates a session carrying the quote, navigates to Headless Host, Host calls `continueWithQuote(quote, ctx)` and re-orchestrates after auth loops
 - [ ] **Phase 5b (deferred)** — `startHeadlessBuy({ assetId, amount, paymentMethodId, providerId? })` "open BuildQuote / Host fetches quotes" mode — picked up after the quote-first path is stable
-- [ ] **Phase 6** — Bypass order-processing redirect in Transak/aggregator routing when headless; fire `onOrderCreated` and end session
+- [x] **Phase 6** — Bypass order-processing redirect in Transak/aggregator routing when headless; fire `onOrderCreated` and end session
 - [ ] **Phase 7** — Extract UI-coupled error/limit surfacing; route errors through `onError` as typed `HeadlessBuyError`
 - [ ] **Phase 8** — Cancellation + `onClose` semantics (including user-dismissed detection)
 - [ ] **Phase 9** — Expose `getOrder` / `refreshOrder` from hook and show in playground

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -328,6 +328,7 @@ export function useContinueWithQuote(
             currency: effectiveCurrency,
             cryptocurrency: effectiveCryptoSymbol,
             orderId: buyWidget.orderId?.trim() || undefined,
+            headlessSessionId: ctx.headlessSessionId,
           }),
         );
       } catch (error) {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -4,13 +4,21 @@ import { useTransakRouting } from './useTransakRouting';
 
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
+const mockParentPop = jest.fn();
+const mockGetParent = jest.fn(() => ({ pop: mockParentPop }));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
     reset: mockReset,
+    getParent: mockGetParent,
   }),
+}));
+
+jest.mock('../headless/sessionRegistry', () => ({
+  getSession: jest.fn(),
+  closeSession: jest.fn(),
 }));
 
 const MOCK_WALLET_ADDRESS = '0xabcdef1234567890';
@@ -1255,6 +1263,215 @@ describe('useTransakRouting', () => {
         }),
       );
       expect(mockAddOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('headless session flow', () => {
+    const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+      .getSession as jest.Mock;
+    const mockCloseSession = jest.requireMock('../headless/sessionRegistry')
+      .closeSession as jest.Mock;
+    const mockShowV2OrderToast = jest.requireMock('../utils/v2OrderToast')
+      .showV2OrderToast as jest.Mock;
+
+    const HEADLESS_CONFIG = {
+      baseRoute: 'RampHeadlessHost',
+      baseRouteParams: { headlessSessionId: 'hs-1' },
+    };
+
+    const depositOrder = {
+      id: 'order-hs',
+      providerOrderId: 'order-hs',
+      provider: 'transak-native',
+      walletAddress: MOCK_WALLET_ADDRESS,
+      paymentDetails: {},
+    };
+
+    const refreshedOrder = {
+      providerOrderId: 'order-hs',
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.05',
+      status: 'Pending',
+      fiatAmount: 100,
+      exchangeRate: 2000,
+      networkFees: 0,
+      partnerFees: 0,
+      totalFeesFiat: 0,
+      paymentMethod: { id: 'card' },
+      network: { chainId: '1', name: 'Ethereum' },
+      fiatCurrency: { symbol: 'USD' },
+    };
+
+    const runApprovedFlowHeadless = async () => {
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+      mockGetUserLimits.mockResolvedValue({
+        remaining: { '1': 10000, '30': 50000, '365': 200000 },
+      });
+      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
+      mockGeneratePaymentWidgetUrl.mockReturnValue(
+        'https://payment.example.com',
+      );
+
+      const { result } = renderHook(() => useTransakRouting(HEADLESS_CONFIG));
+
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+
+      return capturedHandleNavigationStateChange;
+    };
+
+    beforeEach(() => {
+      mockGetSession.mockReset();
+      mockCloseSession.mockReset();
+      mockParentPop.mockReset();
+      mockGetOrder.mockResolvedValue(depositOrder);
+      mockRefreshOrder.mockResolvedValue(refreshedOrder);
+    });
+
+    it('fires onOrderCreated, closes the session, and pops the ramp stack when a live session is present', async () => {
+      const onOrderCreated = jest.fn();
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(onOrderCreated).toHaveBeenCalledWith('order-hs');
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          routes: [expect.objectContaining({ name: 'RampsOrderDetails' })],
+        }),
+      );
+      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
+    });
+
+    it('still adds the order and tracks the transaction event when headless', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockAddOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ providerOrderId: 'order-hs' }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_TRANSACTION_CONFIRMED',
+        expect.objectContaining({ ramp_type: 'DEPOSIT' }),
+      );
+    });
+
+    it('swallows consumer onOrderCreated errors and still closes + pops', async () => {
+      const Logger = jest.requireMock('../../../../util/Logger');
+      const mockLoggerError = Logger.error as jest.Mock;
+      const throwingCallback = jest.fn(() => {
+        throw new Error('consumer bug');
+      });
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: throwingCallback,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(throwingCallback).toHaveBeenCalled();
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.any(Error),
+        'useTransakRouting: onOrderCreated callback threw',
+      );
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+    });
+
+    it('falls back to the regular order-details reset + toast when session id is present but session is missing from registry', async () => {
+      mockGetSession.mockReturnValue(undefined);
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockShowV2OrderToast).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: 'order-hs' }),
+      );
+      expect(mockReset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: 0,
+          routes: [
+            expect.objectContaining({
+              params: expect.objectContaining({ orderId: 'order-hs' }),
+            }),
+          ],
+        }),
+      );
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(mockParentPop).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -4,13 +4,21 @@ import { useTransakRouting } from './useTransakRouting';
 
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
+const mockParentPop = jest.fn();
+const mockGetParent = jest.fn(() => ({ pop: mockParentPop }));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
     reset: mockReset,
+    getParent: mockGetParent,
   }),
+}));
+
+jest.mock('../headless/sessionRegistry', () => ({
+  getSession: jest.fn(),
+  closeSession: jest.fn(),
 }));
 
 const MOCK_WALLET_ADDRESS = '0xabcdef1234567890';
@@ -1373,6 +1381,215 @@ describe('useTransakRouting', () => {
         }),
       );
       expect(mockAddOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('headless session flow', () => {
+    const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+      .getSession as jest.Mock;
+    const mockCloseSession = jest.requireMock('../headless/sessionRegistry')
+      .closeSession as jest.Mock;
+    const mockShowV2OrderToast = jest.requireMock('../utils/v2OrderToast')
+      .showV2OrderToast as jest.Mock;
+
+    const HEADLESS_CONFIG = {
+      baseRoute: 'RampHeadlessHost',
+      baseRouteParams: { headlessSessionId: 'hs-1' },
+    };
+
+    const depositOrder = {
+      id: 'order-hs',
+      providerOrderId: 'order-hs',
+      provider: 'transak-native',
+      walletAddress: MOCK_WALLET_ADDRESS,
+      paymentDetails: {},
+    };
+
+    const refreshedOrder = {
+      providerOrderId: 'order-hs',
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.05',
+      status: 'Pending',
+      fiatAmount: 100,
+      exchangeRate: 2000,
+      networkFees: 0,
+      partnerFees: 0,
+      totalFeesFiat: 0,
+      paymentMethod: { id: 'card' },
+      network: { chainId: '1', name: 'Ethereum' },
+      fiatCurrency: { symbol: 'USD' },
+    };
+
+    const runApprovedFlowHeadless = async () => {
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+      mockGetUserLimits.mockResolvedValue({
+        remaining: { '1': 10000, '30': 50000, '365': 200000 },
+      });
+      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
+      mockGeneratePaymentWidgetUrl.mockReturnValue(
+        'https://payment.example.com',
+      );
+
+      const { result } = renderHook(() => useTransakRouting(HEADLESS_CONFIG));
+
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+
+      return capturedHandleNavigationStateChange;
+    };
+
+    beforeEach(() => {
+      mockGetSession.mockReset();
+      mockCloseSession.mockReset();
+      mockParentPop.mockReset();
+      mockGetOrder.mockResolvedValue(depositOrder);
+      mockRefreshOrder.mockResolvedValue(refreshedOrder);
+    });
+
+    it('fires onOrderCreated, closes the session, and pops the ramp stack when a live session is present', async () => {
+      const onOrderCreated = jest.fn();
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(onOrderCreated).toHaveBeenCalledWith('order-hs');
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          routes: [expect.objectContaining({ name: 'RampsOrderDetails' })],
+        }),
+      );
+      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
+    });
+
+    it('still adds the order and tracks the transaction event when headless', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockAddOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ providerOrderId: 'order-hs' }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_TRANSACTION_CONFIRMED',
+        expect.objectContaining({ ramp_type: 'DEPOSIT' }),
+      );
+    });
+
+    it('swallows consumer onOrderCreated errors and still closes + pops', async () => {
+      const Logger = jest.requireMock('../../../../util/Logger');
+      const mockLoggerError = Logger.error as jest.Mock;
+      const throwingCallback = jest.fn(() => {
+        throw new Error('consumer bug');
+      });
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: throwingCallback,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(throwingCallback).toHaveBeenCalled();
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.any(Error),
+        'useTransakRouting: onOrderCreated callback threw',
+      );
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+    });
+
+    it('falls back to the regular order-details reset + toast when session id is present but session is missing from registry', async () => {
+      mockGetSession.mockReturnValue(undefined);
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockShowV2OrderToast).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: 'order-hs' }),
+      );
+      expect(mockReset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: 0,
+          routes: [
+            expect.objectContaining({
+              params: expect.objectContaining({ orderId: 'order-hs' }),
+            }),
+          ],
+        }),
+      );
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(mockParentPop).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -27,6 +27,7 @@ import useRampAccountAddress from './useRampAccountAddress';
 import { isHttpUnauthorized } from '../utils/isHttpUnauthorized';
 import { parseUserFacingError } from '../utils/parseUserFacingError';
 import { useRampsOrders } from './useRampsOrders';
+import { closeSession, getSession } from '../headless/sessionRegistry';
 
 interface RampStackParamList {
   RampVerifyIdentity: { quote: TransakBuyQuote };
@@ -86,6 +87,14 @@ interface UseTransakRoutingConfig {
 export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const baseRoute = config?.baseRoute;
   const baseRouteParams = config?.baseRouteParams;
+  // Headless-mode marker extracted from the caller's config. When the
+  // Host wires `baseRouteParams: { headlessSessionId }` through, this
+  // lets post-checkout success paths hand the orderId to the session's
+  // `onOrderCreated` callback and unwind the ramp stack instead of
+  // resetting to `RAMPS_ORDER_DETAILS`.
+  const headlessSessionId = (
+    baseRouteParams as { headlessSessionId?: string } | undefined
+  )?.headlessSessionId;
   // Composes the stack base entry used by `navigation.reset` calls below.
   // - When the caller didn't override `baseRoute`, we keep BuildQuote as the
   //   base and merge the per-call `amount` (so the input is pre-filled when
@@ -264,6 +273,26 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
 
   const navigateToOrderProcessingCallback = useCallback(
     ({ orderId }: { orderId: string }) => {
+      // Headless mode: fire `onOrderCreated`, close the session, and pop
+      // out of the ramp stack so the caller regains foreground. The
+      // consumer drives post-order UI themselves — no RAMPS_ORDER_DETAILS.
+      const session = getSession(headlessSessionId);
+      if (headlessSessionId && session) {
+        try {
+          session.callbacks.onOrderCreated(orderId);
+        } catch (callbackError) {
+          Logger.error(
+            callbackError as Error,
+            'useTransakRouting: onOrderCreated callback threw',
+          );
+        }
+        closeSession(headlessSessionId, { reason: 'completed' });
+        // @ts-expect-error `pop` exists on the parent stack navigator at
+        // runtime but is not surfaced on the generic `NavigationProp`
+        // type returned by `getParent()`.
+        navigation.getParent()?.pop();
+        return;
+      }
       navigation.reset({
         index: 0,
         routes: [
@@ -274,7 +303,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         ],
       });
     },
-    [navigation],
+    [navigation, headlessSessionId],
   );
 
   const navigateToAdditionalVerificationCallback = useCallback(
@@ -343,12 +372,18 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           paymentDetails: depositOrder.paymentDetails,
         });
 
-        showV2OrderToast({
-          orderId: rampsOrder.providerOrderId,
-          cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
-          cryptoAmount: rampsOrder.cryptoAmount,
-          status: rampsOrder.status,
-        });
+        // Suppress the toast when a headless session is driving this
+        // flow — the consumer handles its own notification UI. Keep
+        // `addOrder` and the analytics event in both modes so Redux
+        // state + telemetry parity is preserved.
+        if (!getSession(headlessSessionId)) {
+          showV2OrderToast({
+            orderId: rampsOrder.providerOrderId,
+            cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
+            cryptoAmount: rampsOrder.cryptoAmount,
+            status: rampsOrder.status,
+          });
+        }
 
         navigateToOrderProcessingCallback({
           orderId: rampsOrder.providerOrderId,
@@ -387,6 +422,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       navigateToOrderProcessingCallback,
       regionIsoCode,
       trackEvent,
+      headlessSessionId,
     ],
   );
 

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -28,6 +28,7 @@ import useRampAccountAddress from './useRampAccountAddress';
 import { isHttpUnauthorized } from '../utils/isHttpUnauthorized';
 import { parseUserFacingError } from '../utils/parseUserFacingError';
 import { useRampsOrders } from './useRampsOrders';
+import { closeSession, getSession } from '../headless/sessionRegistry';
 
 interface RampStackParamList {
   /** `baseRouteParams` (e.g. `headlessSessionId`) are merged onto this route in resets — see `navigateToVerifyIdentityCallback`. */
@@ -99,6 +100,14 @@ interface UseTransakRoutingConfig {
 export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const baseRoute = config?.baseRoute;
   const baseRouteParams = config?.baseRouteParams;
+  // Headless-mode marker extracted from the caller's config. When the
+  // Host wires `baseRouteParams: { headlessSessionId }` through, this
+  // lets post-checkout success paths hand the orderId to the session's
+  // `onOrderCreated` callback and unwind the ramp stack instead of
+  // resetting to `RAMPS_ORDER_DETAILS`.
+  const headlessSessionId = (
+    baseRouteParams as { headlessSessionId?: string } | undefined
+  )?.headlessSessionId;
   // Composes the stack base entry used by `navigation.reset` calls below.
   // - When the caller didn't override `baseRoute`, we keep BuildQuote as the
   //   base and merge the per-call `amount` (so the input is pre-filled when
@@ -287,6 +296,26 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
 
   const navigateToOrderProcessingCallback = useCallback(
     ({ orderId }: { orderId: string }) => {
+      // Headless mode: fire `onOrderCreated`, close the session, and pop
+      // out of the ramp stack so the caller regains foreground. The
+      // consumer drives post-order UI themselves — no RAMPS_ORDER_DETAILS.
+      const session = getSession(headlessSessionId);
+      if (headlessSessionId && session) {
+        try {
+          session.callbacks.onOrderCreated(orderId);
+        } catch (callbackError) {
+          Logger.error(
+            callbackError as Error,
+            'useTransakRouting: onOrderCreated callback threw',
+          );
+        }
+        closeSession(headlessSessionId, { reason: 'completed' });
+        // @ts-expect-error `pop` exists on the parent stack navigator at
+        // runtime but is not surfaced on the generic `NavigationProp`
+        // type returned by `getParent()`.
+        navigation.getParent()?.pop();
+        return;
+      }
       navigation.reset({
         index: 0,
         routes: [
@@ -297,7 +326,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         ],
       });
     },
-    [navigation],
+    [navigation, headlessSessionId],
   );
 
   const navigateToAdditionalVerificationCallback = useCallback(
@@ -366,12 +395,18 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           paymentDetails: depositOrder.paymentDetails,
         });
 
-        showV2OrderToast({
-          orderId: rampsOrder.providerOrderId,
-          cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
-          cryptoAmount: rampsOrder.cryptoAmount,
-          status: rampsOrder.status,
-        });
+        // Suppress the toast when a headless session is driving this
+        // flow — the consumer handles its own notification UI. Keep
+        // `addOrder` and the analytics event in both modes so Redux
+        // state + telemetry parity is preserved.
+        if (!getSession(headlessSessionId)) {
+          showV2OrderToast({
+            orderId: rampsOrder.providerOrderId,
+            cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
+            cryptoAmount: rampsOrder.cryptoAmount,
+            status: rampsOrder.status,
+          });
+        }
 
         navigateToOrderProcessingCallback({
           orderId: rampsOrder.providerOrderId,
@@ -410,6 +445,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       navigateToOrderProcessingCallback,
       regionIsoCode,
       trackEvent,
+      headlessSessionId,
     ],
   );
 


### PR DESCRIPTION
## **Description**

This PR closes **Phase 6** of the incremental **Unified Buy (v2) headless buy** plan (`app/components/UI/Ramp/headless/PLAN.md`): when a flow produces an orderId under a live headless session, the consumer's `onOrderCreated` callback fires and the ramp stack unwinds — no more redirect to `RAMPS_ORDER_DETAILS`, no `showV2OrderToast` the consumer didn't ask for.

**Reason**

- Phase 5 ([#29338](https://github.com/MetaMask/metamask-mobile/pull/29338)) introduced the Headless Host and quote-first session API, but the flow still ended on `RAMPS_ORDER_DETAILS` with a toast — there was no way for external UIs to know an order was created. Phase 6 closes the loop so consumers can actually react to completion.

**What changed**

- **`app/components/UI/Ramp/Views/Checkout/Checkout.tsx`** — adds `headlessSessionId` to `CheckoutParams`. When the widget callback URL resolves and `getSession(headlessSessionId)` returns a live session, the screen fires `session.callbacks.onOrderCreated(orderId)`, calls `closeSession(id, { reason: 'completed' })`, and pops the parent stack. `addOrder` and `protectWalletModalVisible` still dispatch so Redux stays consistent; `showV2OrderToast` is suppressed. Non-headless behavior is unchanged.
- **`app/components/UI/Ramp/hooks/useTransakRouting.ts`** — extracts `headlessSessionId` from `config.baseRouteParams` (already threaded by the Host via Phase 5's parameterization) and applies the same branching inside `navigateToOrderProcessingCallback`. `handleNavigationStateChange`'s toast is suppressed when the session is live; `addOrder` + `trackEvent` keep firing so Redux + analytics parity are preserved.
- **`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`** — threads `ctx.headlessSessionId` into `createCheckoutNavDetails` so the v2 Checkout screen can see it on the aggregator/widget branch.
- **Error safety** — consumer `onOrderCreated` errors are caught and logged via `Logger.error`; the session still closes and the stack still pops, so a consumer-side bug can never break the flow.
- **`PLAN.md`** — Phase 6 ticked.

**References**

- **Stacked on Phase 5**: [#29338](https://github.com/MetaMask/metamask-mobile/pull/29338) (Headless Host + quote-first start). **This PR's base is `poc/headless-buy-phase-5`**; when #29338 merges, GitHub will auto-retarget the base to `main` so the final diff is Phase 6-only.
- Continues from **Phase 4** merged to `main`: [#29213](https://github.com/MetaMask/metamask-mobile/pull/29213) (`useContinueWithQuote` extraction).

**Tests**

- New `headless session flow` describe block in `app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx` (5 cases): live-session success, `addOrder` + `protectWalletModalVisible` side-effect preservation, consumer `onOrderCreated` error swallow, missing-session fallback, absent-`headlessSessionId` unchanged path.
- New `headless session flow` describe block in `app/components/UI/Ramp/hooks/useTransakRouting.test.ts` (4 cases): the same shape exercised through the Transak native callback path.
- Regressed green locally: `sessionRegistry.test.ts`, `useContinueWithQuote.test.ts`, `HeadlessHost.test.tsx`. **101/101** pass across the five suites.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: _No GitHub issue — incremental POC on branch `poc/headless-buy-phase-6`._

Continuity: [#29338](https://github.com/MetaMask/metamask-mobile/pull/29338) (Phase 5 — Headless Host + quote-first start). [#29213](https://github.com/MetaMask/metamask-mobile/pull/29213) (Phase 4 — `useContinueWithQuote`).

## **Manual testing steps**

```gherkin
Feature: Headless Buy Phase 6 (onOrderCreated + stack unwind on order success)

  Scenario: Aggregator order success fires onOrderCreated and pops out of the ramp stack
    Given the app is an internal build and I am signed in
    And I open Settings → Fiat on-ramp → Headless Buy playground
    When I fetch quotes, tap "Start headless buy" on an aggregator (e.g. MoonPay) quote
    And I complete a sandbox order inside the Checkout WebView
    Then the playground event log should show `onOrderCreated(orderId)` followed by `onClose({ reason: 'completed' })`
    And the app should return to the playground (no RAMPS_ORDER_DETAILS flash, no toast)

  Scenario: Native Transak order success fires onOrderCreated and pops out of the ramp stack
    Given I am on the playground with a Transak native quote selected
    When I complete the native OTP + KYC + webview flow through to order creation
    Then the event log should show `onOrderCreated(orderId)` and `onClose({ reason: 'completed' })`
    And I should be returned to the playground

  Scenario: Non-headless Buy flow is unchanged
    Given I open Wallet → Buy through the regular flow
    When I complete an aggregator order
    Then the order-details screen should render with the usual toast
    And no headless callback should fire

  Scenario: Missing session falls back gracefully
    Given a headless order is produced after the session has been cancelled
    When the success callback resolves
    Then the flow falls back to the regular reset + toast (no dangling state)
```

## **Screenshots/Recordings**

### **Before**

N/A — Phase 6 wires the existing callback contract; no UI changes.

### **After**

MoonPay succeeds (similar to Phase)

Can't provide a video for Transak since Transak KYC keeps asking me to submit a live selfie for my iOS simulator (even though my purchase amount is under $30)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes success-path navigation and notification behavior in checkout/order routing, which could affect user flow completion if session detection or parent stack popping is wrong; covered by new unit tests but still touches core ramp navigation paths.
> 
> **Overview**
> Headless buy flows now short-circuit the usual post-checkout UX: when `Checkout` or `useTransakRouting` detects a live `headlessSessionId`, it calls the session’s `onOrderCreated(orderId)`, closes the session, and pops the ramp stack instead of resetting to `RAMPS_ORDER_DETAILS` and showing the V2 order toast.
> 
> `useContinueWithQuote` now forwards `headlessSessionId` into `Checkout` navigation so aggregator/widget checkouts can participate in this behavior, and the headless plan doc marks Phase 6 complete. Comprehensive unit tests were added to cover live-session success, callback error swallowing + logging, toast suppression, and fallback to the non-headless path when the session is missing/absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740efe3c5dea61818a2d2755b996af2c358f6632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
