### PR TITLE
feat(perps/agentic): caption screenshots via per-file note sidecar

### DIFF
--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -389,12 +389,18 @@ if [ "$PLAT" = "ios" ]; then
   if [ -z "$BOOTED" ]; then
     $CHECK_ONLY && fail "Simulator $SIM_LABEL is not booted"
     echo "  Booting $SIM_LABEL..."
+    # Open Simulator.app first so the daemon binds a UI window when the device boots.
+    open -a Simulator 2>/dev/null || true
     xcrun simctl boot "$SIM_TARGET" 2>/dev/null || true
-    sleep 3
-    # Verify it actually booted
-    BOOTED=$(xcrun simctl list devices | grep "$SIM_LABEL" | grep "Booted" || true)
+    # Cold boot transitions Shutdown -> Booting -> Booted; poll up to 60s.
+    BOOTED=""
+    for _ in $(seq 1 60); do
+      BOOTED=$(xcrun simctl list devices | grep "$SIM_LABEL" | grep "Booted" || true)
+      [ -n "$BOOTED" ] && break
+      sleep 1
+    done
     if [ -z "$BOOTED" ]; then
-      fail "Failed to boot simulator $SIM_LABEL"
+      fail "Failed to boot simulator $SIM_LABEL within 60s"
     fi
     ok "Simulator booted: $SIM_LABEL"
   else
@@ -444,6 +450,8 @@ if [ "$PLAT" = "ios" ]; then
     set +e
     eval "$EXPO_CMD" >"$BUILD_LOG" 2>&1 &
     EXPO_PID=$!
+    # Drop the bg job from bash's jobs table so kill_tree's SIGTERM doesn't print "Terminated: 15".
+    disown "$EXPO_PID" 2>/dev/null || true
 
     watch_log "$BUILD_LOG" "$EXPO_PID" 3 &
     WATCH_PID=$!

--- a/scripts/perps/agentic/schemas/flow.schema.json
+++ b/scripts/perps/agentic/schemas/flow.schema.json
@@ -259,8 +259,14 @@
         {
           "if": { "properties": { "action": { "const": "screenshot" } } },
           "then": {
+            "required": ["filename", "note"],
             "properties": {
-              "filename": { "type": "string", "description": "Screenshot label." }
+              "filename": { "type": "string", "minLength": 1, "description": "Screenshot label." },
+              "note": {
+                "type": "string",
+                "minLength": 3,
+                "description": "State-specific caption describing what the screenshot proves (e.g. 'AC1: Recent Activity skeleton with 3 shimmer rows'). Required to keep caption-confidence HIGH."
+              }
             }
           }
         },

--- a/scripts/perps/agentic/schemas/flow.schema.json
+++ b/scripts/perps/agentic/schemas/flow.schema.json
@@ -11,6 +11,10 @@
       "type": "string",
       "description": "Human-readable title. May contain {{param}} template tokens that resolve at runtime."
     },
+    "schema_version": {
+      "type": ["string", "number"],
+      "description": "Opt-in strict-validation marker. Set to 1 to require fields like screenshot `note`. Recipes without this field (legacy/demo) only get console warnings instead of validation errors. Bump in future versions when adopting additional strict rules."
+    },
     "pr": {
       "type": ["string", "number"],
       "description": "Associated PR number (informational)."
@@ -259,13 +263,13 @@
         {
           "if": { "properties": { "action": { "const": "screenshot" } } },
           "then": {
-            "required": ["filename", "note"],
+            "required": ["filename"],
             "properties": {
               "filename": { "type": "string", "minLength": 1, "description": "Screenshot label." },
               "note": {
                 "type": "string",
                 "minLength": 3,
-                "description": "State-specific caption describing what the screenshot proves (e.g. 'AC1: Recent Activity skeleton with 3 shimmer rows'). Required to keep caption-confidence HIGH."
+                "description": "State-specific caption describing what the screenshot proves (e.g. 'AC1: Recent Activity skeleton with 3 shimmer rows'). Required when top-level schema_version is set (>= 1). Recipes without schema_version (legacy) only get a console warning."
               }
             }
           }

--- a/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
+++ b/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
@@ -1,5 +1,6 @@
 {
   "title": "Rapid market switching — validates candles load and no rate-limit/abort errors across BTC→ETH→SOL→HYPE→BTC→ETH",
+  "schema_version": 1,
   "inputs": {
     "screenshot_filename": {
       "type": "string",

--- a/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
+++ b/scripts/perps/agentic/teams/perps/flows/candle-rapid-switch.json
@@ -160,6 +160,7 @@
         "screenshot-chart": {
           "action": "screenshot",
           "filename": "{{screenshot_filename}}",
+          "note": "Final ETH market detail after rapid BTC→ETH→SOL→HYPE→BTC→ETH switch — proves chart loads on the last symbol without rate-limit/abort errors",
           "next": "back-6"
         },
         "back-6": {

--- a/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
+++ b/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
@@ -82,6 +82,7 @@
           "screenshot-market-list": {
             "action": "screenshot",
             "filename": "tat3016-{{phaseLabel}}-market-list.png",
+            "note": "PerpsMarketListView available-balance text in {{phaseLabel}} phase — must reflect availableToTradeBalance (gates Long/Add-Funds CTA)",
             "next": "nav-withdraw"
           },
           "nav-withdraw": {
@@ -121,6 +122,7 @@
           "screenshot-withdraw": {
             "action": "screenshot",
             "filename": "tat3016-{{phaseLabel}}-withdraw.png",
+            "note": "PerpsWithdraw available-balance text in {{phaseLabel}} phase — must show availableBalance only, never the spot-fold amount (TAT-3016 hotfix invariant)",
             "next": "nav-market-details"
           },
           "nav-market-details": {
@@ -172,6 +174,7 @@
           "screenshot-order-form": {
             "action": "screenshot",
             "filename": "tat3016-{{phaseLabel}}-order-form.png",
+            "note": "BTC order form in {{phaseLabel}} phase — pay-with should default to Perps balance when availableToTradeBalance > 0; place-order button mounted",
             "next": "back-to-wallet"
           },
           "back-to-wallet": {

--- a/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
+++ b/scripts/perps/agentic/teams/perps/flows/hl-balance-validation.json
@@ -1,5 +1,6 @@
 {
     "title": "HL balance validation — phase={{phaseLabel}} expectedMode={{expectedMode}}",
+    "schema_version": 1,
     "description": "Captures and asserts the three balance readouts the TAT-3016 hotfix touches: (1) PerpsController.state.accountState (availableBalance vs availableToTradeBalance), (2) PerpsMarketDetails balance text (perps-market-available-balance-text — gates order-entry Long/Add-Funds CTA), (3) PerpsWithdraw balance text (perps-withdraw-available-balance-text — must show availableBalance only, never the spot fold). Screenshots per screen tagged with phaseLabel for reviewer before/after comparison. Fold invariant (trade >= avail) is asserted unconditionally. expectedMode='unified' additionally asserts the fold amount is non-trivial when spot USDC is present; expectedMode='standard' asserts withdrawable==availableBalance (no leak from fold into the withdrawable path).",
     "inputs": {
       "expectedMode": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-add-funds.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-add-funds.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perf — Perps add funds flow timing",
+  "schema_version": 1,
   "description": "Mirrors performance/login/perps-add-funds.spec.ts. Ensures tutorial is completed via setup, then navigates to Perps, opens Add Funds, and types amount. Teardown navigates back to PerpsHome.",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-add-funds.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-add-funds.json
@@ -54,6 +54,7 @@
         "screenshot-amount": {
           "action": "screenshot",
           "filename": "evidence-perf-add-funds.png",
+          "note": "Perf benchmark: deposit screen reached with $2 entered — captures end of timed nav-to-amount path",
           "next": "done"
         },
         "done": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-position-management.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-position-management.json
@@ -36,6 +36,7 @@
         "screenshot-open": {
           "action": "screenshot",
           "filename": "evidence-perf-btc-open.png",
+          "note": "Perf benchmark: BTC long opened — captured before close timer starts",
           "next": "close-position"
         },
         "close-position": {
@@ -54,6 +55,7 @@
         "screenshot-closed": {
           "action": "screenshot",
           "filename": "evidence-perf-btc-closed.png",
+          "note": "Perf benchmark: BTC position closed — getPositions empty, end of timed open-then-close path",
           "next": "done"
         },
         "done": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-position-management.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perf-position-management.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perf — Perps position open and close BTC",
+  "schema_version": 1,
   "description": "Mirrors performance/login/perps-position-management.spec.ts. Opens a BTC long position and closes it. Performance spec measures timing with 40x leverage; recipe uses default leverage via trade-open-market flow.",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-add-funds.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-add-funds.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps Add Funds — navigate to deposit screen and enter amount",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-add-funds.spec.ts. Navigates to Perps, taps Add Funds, and enters amount via keypad. Detox spec also confirms deposit via mock server; recipe validates the UI flow up to amount entry (deposit execution requires E2E mock infrastructure).",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-add-funds.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-add-funds.json
@@ -33,6 +33,7 @@
         "screenshot-perps-home": {
           "action": "screenshot",
           "filename": "evidence-perps-home.png",
+          "note": "PerpsHomeView loaded with Add Funds CTA visible — entry point for deposit flow",
           "next": "press-add-funds"
         },
         "press-add-funds": {
@@ -59,6 +60,7 @@
         "screenshot-amount-entered": {
           "action": "screenshot",
           "filename": "evidence-deposit-amount.png",
+          "note": "Deposit screen with $80 entered via keypad — UI flow up to amount confirmation (deposit execution requires E2E mock)",
           "next": "done"
         },
         "done": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-limit-long-fill.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-limit-long-fill.json
@@ -35,6 +35,7 @@
         "screenshot-order": {
           "action": "screenshot",
           "filename": "evidence-limit-order-placed.png",
+          "note": "ETH limit long order placed at mid price — order present in PerpsController.getOpenOrders pre-fill",
           "next": "verify-order-or-fill"
         },
         "verify-order-or-fill": {
@@ -58,6 +59,7 @@
         "screenshot-filled": {
           "action": "screenshot",
           "filename": "evidence-limit-order-filled.png",
+          "note": "ETH limit order filled — position now in PerpsController.getPositions, order removed from open orders",
           "next": "cleanup"
         },
         "cleanup": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-limit-long-fill.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-limit-long-fill.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps Limit Long Fill — limit long ETH at Mid, verify order and fill",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-limit-long-fill.spec.ts. Creates an ETH limit long at mid price via controller API, verifies the order appears, then waits for fill. Uses order-limit-place-controller flow (bypasses UI deposit path broken in dev mode).",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-no-funds-tutorial.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-no-funds-tutorial.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps No Funds Tutorial — walk through onboarding tutorial",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-no-funds-tutorial.spec.ts. Resets first-time-user state and navigates to Perps. If tutorial shows, walks through 6 continue steps. If user already onboarded (funded account), verifies market list is visible. Teardown marks tutorial completed and navigates to PerpsHome for clean state.",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-no-funds-tutorial.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-no-funds-tutorial.json
@@ -92,11 +92,13 @@
         "screenshot-tutorial-complete": {
           "action": "screenshot",
           "filename": "evidence-tutorial-complete.png",
+          "note": "Onboarding tutorial completed — final continue button dismissed and market list ready",
           "next": "verify-market-view"
         },
         "screenshot-already-onboarded": {
           "action": "screenshot",
           "filename": "evidence-already-onboarded.png",
+          "note": "Already-onboarded path — tutorial skipped, market list visible directly",
           "next": "verify-market-view"
         },
         "verify-market-view": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-liquidation.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-liquidation.json
@@ -50,6 +50,7 @@
         "screenshot-position": {
           "action": "screenshot",
           "filename": "evidence-position-open-for-liquidation.png",
+          "note": "ETH long position open on PerpsMarketDetails with close button visible — liquidation precondition (price-trigger requires E2E mock)",
           "next": "cleanup"
         },
         "cleanup": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-liquidation.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-liquidation.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps Position Liquidation — open long ETH, verify position exists",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-position-liquidation.spec.ts. Opens a long ETH position and verifies it exists. Detox spec pushes price to trigger liquidation via commandQueueServer; recipe validates position open (liquidation trigger requires E2E mock infrastructure for price manipulation).",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-stop-loss.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-stop-loss.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps Position Stop Loss — open long ETH with SL, verify SL set",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-position-stop-loss.spec.ts. Opens a long ETH position, sets a stop loss via tpsl-create flow. Detox spec uses custom SL price (2300) and pushes price to trigger; recipe uses SL preset and verifies SL is set (price trigger requires E2E mock).",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-stop-loss.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position-stop-loss.json
@@ -49,6 +49,7 @@
         "screenshot-sl-set": {
           "action": "screenshot",
           "filename": "evidence-stop-loss-set.png",
+          "note": "ETH long position with stopLossPrice attached via tpsl-create — SL trigger live (price-based liquidation requires E2E mock)",
           "next": "cleanup"
         },
         "cleanup": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position.json
@@ -36,6 +36,7 @@
         "screenshot-position-open": {
           "action": "screenshot",
           "filename": "evidence-position-open.png",
+          "note": "ETH long market position opened — appears in PerpsController.getPositions before TP/SL is attached",
           "next": "create-tpsl"
         },
         "create-tpsl": {
@@ -67,6 +68,7 @@
         "screenshot-closed": {
           "action": "screenshot",
           "filename": "evidence-position-closed.png",
+          "note": "ETH position closed — getPositions no longer returns ETH after trade-close-position completes",
           "next": "done"
         },
         "done": {

--- a/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position.json
+++ b/scripts/perps/agentic/teams/perps/recipes/benchmark/perps-position.json
@@ -1,5 +1,6 @@
 {
   "title": "Benchmark: Perps Position — open long ETH with TP, close position",
+  "schema_version": 1,
   "description": "Mirrors smoke/perps/perps-position.spec.ts. Opens a long ETH position, sets TP/SL, then closes it. Detox spec sets custom TP during order; recipe uses tpsl-create flow after position open (equivalent coverage, reuses existing flow).",
   "validate": {
     "workflow": {

--- a/scripts/perps/agentic/validate-flow-schema.js
+++ b/scripts/perps/agentic/validate-flow-schema.js
@@ -62,6 +62,9 @@ function validateActionShape(node, issues) {
     case 'switch_provider':
       requireFields(node, ['provider'], issues);
       break;
+    case 'screenshot':
+      requireFields(node, ['filename', 'note'], issues);
+      break;
     case 'log_watch':
       if (!(node.watch_for?.length || node.must_not_appear?.length)) {
         issues.push(

--- a/scripts/perps/agentic/validate-flow-schema.js
+++ b/scripts/perps/agentic/validate-flow-schema.js
@@ -25,6 +25,13 @@ const {
 
 const MUST_ASSERT = new Set(['eval_sync', 'eval_async', 'eval_ref']);
 const HOOK_ONLY_ACTIONS = new Set([...EXECUTABLE_ACTIONS]);
+const CURRENT_SCHEMA_VERSION = 1;
+
+function parseSchemaVersion(value) {
+  if (value == null || value === '') return 0;
+  const num = Number.parseInt(String(value), 10);
+  return Number.isFinite(num) && num >= 0 ? num : 0;
+}
 
 function requireFields(node, fields, issues) {
   fields.forEach((field) => {
@@ -34,7 +41,8 @@ function requireFields(node, fields, issues) {
   });
 }
 
-function validateActionShape(node, issues) {
+function validateActionShape(node, issues, context = {}) {
+  const { schemaVersion = 1, fileLabel = '?' } = context;
   switch (node.action) {
     case 'navigate':
       requireFields(node, ['target'], issues);
@@ -62,9 +70,23 @@ function validateActionShape(node, issues) {
     case 'switch_provider':
       requireFields(node, ['provider'], issues);
       break;
-    case 'screenshot':
-      requireFields(node, ['filename', 'note'], issues);
+    case 'screenshot': {
+      requireFields(node, ['filename'], issues);
+      const note = typeof node.note === 'string' ? node.note.trim() : '';
+      const noteOk = note.length >= 3;
+      if (!noteOk) {
+        if (schemaVersion >= 1) {
+          issues.push(
+            `  [${node.id || '?'}] action="screenshot" requires "note" (>= 3 chars) at schema_version ${schemaVersion}`
+          );
+        } else {
+          console.warn(
+            `  warning [${fileLabel}] [${node.id || '?'}] screenshot missing "note" — caption will fall back to filename. Add a note, then declare top-level "schema_version": ${CURRENT_SCHEMA_VERSION} to opt into strict validation.`
+          );
+        }
+      }
       break;
+    }
     case 'log_watch':
       if (!(node.watch_for?.length || node.must_not_appear?.length)) {
         issues.push(
@@ -168,7 +190,7 @@ function validateReference(node, appRoot, defaultTeam, issues) {
   }
 }
 
-function validateNodeCommon(node, issues) {
+function validateNodeCommon(node, issues, context = {}) {
   const action = node.action || '';
   const id = node.id || '?';
 
@@ -185,10 +207,10 @@ function validateNodeCommon(node, issues) {
     issues.push(`  [${id}] save_as must be a non-empty string`);
   }
 
-  validateActionShape(node, issues);
+  validateActionShape(node, issues, context);
 }
 
-function validateHookSection(sectionName, steps, appRoot, defaultTeam, issues, seenIds) {
+function validateHookSection(sectionName, steps, appRoot, defaultTeam, issues, seenIds, context = {}) {
   steps.forEach((step, index) => {
     const node = {
       ...step,
@@ -211,12 +233,12 @@ function validateHookSection(sectionName, steps, appRoot, defaultTeam, issues, s
       return;
     }
 
-    validateNodeCommon(node, issues);
+    validateNodeCommon(node, issues, context);
     validateReference(node, appRoot, defaultTeam, issues);
   });
 }
 
-function validateWorkflowNodes(normalizedDocument, appRoot, defaultTeam, issues, seenIds) {
+function validateWorkflowNodes(normalizedDocument, appRoot, defaultTeam, issues, seenIds, context = {}) {
   const workflow = normalizedDocument.workflow;
 
   if (!workflow.entry) {
@@ -250,7 +272,7 @@ function validateWorkflowNodes(normalizedDocument, appRoot, defaultTeam, issues,
       issues.push(`  [${nodeId}] control nodes cannot use when/unless guards`);
     }
 
-    validateNodeCommon(node, issues);
+    validateNodeCommon(node, issues, context);
     validateReference(node, appRoot, defaultTeam, issues);
 
     if (node.action === 'end') {
@@ -307,6 +329,13 @@ function validateScenario(filePath, registry) {
   }
 
   const seenIds = new Set();
+  const schemaVersion = parseSchemaVersion(document.schema_version);
+  if (schemaVersion > CURRENT_SCHEMA_VERSION) {
+    issues.push(
+      `  [schema_version] declared "${document.schema_version}" exceeds validator's known max (${CURRENT_SCHEMA_VERSION}). Update validator or fix the recipe.`
+    );
+  }
+  const context = { schemaVersion, fileLabel: path.basename(filePath) };
 
   validatePreConditions(normalizedDocument.hooks.pre_conditions || [], registry, issues);
   validateHookSection(
@@ -315,7 +344,8 @@ function validateScenario(filePath, registry) {
     appRoot,
     defaultTeam,
     issues,
-    seenIds
+    seenIds,
+    context
   );
   validateHookSection(
     'teardown',
@@ -323,9 +353,10 @@ function validateScenario(filePath, registry) {
     appRoot,
     defaultTeam,
     issues,
-    seenIds
+    seenIds,
+    context
   );
-  validateWorkflowNodes(normalizedDocument, appRoot, defaultTeam, issues, seenIds);
+  validateWorkflowNodes(normalizedDocument, appRoot, defaultTeam, issues, seenIds, context);
 
   const inputs = document.inputs || {};
   const inputKeys = new Set(Object.keys(inputs));

--- a/scripts/perps/agentic/validate-recipe.js
+++ b/scripts/perps/agentic/validate-recipe.js
@@ -1338,6 +1338,12 @@ async function runExecutableNode(node, context, options = {}) {
     if (screenshotPath && artifacts && fs.existsSync(screenshotPath)) {
       const dest = path.join(artifacts.screenshotsDir, path.basename(screenshotPath));
       fs.copyFileSync(screenshotPath, dest);
+      if (typeof node.note === 'string' && node.note.trim().length > 0) {
+        fs.writeFileSync(
+          `${dest}.json`,
+          `${JSON.stringify({ note: node.note, nodeId: node.id }, null, 2)}\n`,
+        );
+      }
     }
 
     stats.passed += 1;


### PR DESCRIPTION
## **Description**

Two changes to the agentic recipe pipeline plus an iOS preflight fix:

- **`schema_version` opt-in marker** — recipes/flows that declare top-level `schema_version: 1` get strict validation. Legacy recipes (no field) only emit a console warning when missing newly-required fields, so older demos keep passing. Future strict rules ratchet through new versions instead of breaking everything at once.
- **Screenshot caption sidecar** — `screenshot` steps gain a `note` field describing what the capture proves (e.g. `"AC1: Recent Activity skeleton with 3 shimmer rows"`). The runner writes a `<file>.png.json` sidecar alongside each PNG carrying `{ note, nodeId }` so a downstream HUD/review surface can render captions instead of bare filenames. Required at `schema_version >= 1`; warned (not blocked) for legacy recipes.
- **Backfill** — 7 benchmark recipes, 2 shared flows, and 1 tutorial recipe declare `schema_version: 1` and carry notes on every screenshot.
- **iOS preflight reliability** (`scripts/perps/agentic/preflight.sh`) — opens `Simulator.app` explicitly, polls boot state up to 60s, and disowns the Expo build PID to suppress noisy SIGTERM termination messages.

The JSON schema's `if/then/required` is documentation only; `validate-flow-schema.js` is the real gate.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: schema_version-gated screenshot captions

  Scenario: legacy recipe (no schema_version) keeps running
    Given a recipe with screenshot steps and no schema_version
    When the user runs validate-flow-schema.js
    Then the validator warns about missing "note" but exits 0

  Scenario: opt-in strict at schema_version 1
    Given a recipe declares "schema_version": 1
      And a screenshot step is missing "note"
    When the user runs validate-flow-schema.js
    Then the validator reports an error and exits non-zero

  Scenario: caption sidecar artifact
    Given a recipe with screenshot { filename, note } steps
    When the user runs validate-recipe.sh
    Then each captured PNG has a sibling <file>.png.json containing { note, nodeId }
```

## **Screenshots/Recordings**

N/A — internal tooling change (recipe schema + validator + runner + iOS preflight). No app UI affected.

### **Before**

<!-- screenshot files copied with no caption metadata; missing-note recipes silently passed schema validation -->

### **After**

<!-- captured PNGs ship a `<file>.png.json` sidecar with note + nodeId; strict validation gated on opt-in `schema_version` so legacy demos still run -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.