### PR TITLE
chore: update follow button styling and add View More card to Top Traders carousel

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -130,7 +130,7 @@ const TopTradersSection = forwardRef<
           {!isLoading && traders.length > 0 && (
             <ViewMoreCard
               onPress={handleViewAll}
-              twClassName="w-[200px] self-stretch"
+              twClassName="w-[200px] h-[180px]"
               testID="top-traders-view-more-card"
             />
           )}

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -23,6 +23,7 @@ import useHomeViewedEvent, {
 import { TopTraderCard, TopTraderCardSkeleton } from './components';
 import { useTopTraders } from './hooks';
 import { useSectionPerformance } from '../../hooks/useSectionPerformance';
+import ViewMoreCard from '../../components/ViewMoreCard';
 
 const HOME_TRADER_LIMIT = 3;
 const SKELETON_KEYS = Array.from(
@@ -126,6 +127,13 @@ const TopTradersSection = forwardRef<
                   onTraderPress={handleTraderPress}
                 />
               ))}
+          {!isLoading && traders.length > 0 && (
+            <ViewMoreCard
+              onPress={handleViewAll}
+              twClassName="w-[200px] self-stretch"
+              testID="top-traders-view-more-card"
+            />
+          )}
         </ScrollView>
       </Box>
     </View>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -132,7 +132,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
       {/* Follow / Following button pinned to bottom */}
       <Button
         variant={
-          trader.isFollowing ? ButtonVariant.Primary : ButtonVariant.Secondary
+          trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
         size={ButtonSize.Sm}
         twClassName="self-center"

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
+import { lightTheme } from '@metamask/design-tokens';
 import {
   Box,
   Text,
@@ -135,7 +136,17 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
         size={ButtonSize.Sm}
-        twClassName="self-center"
+        isFullWidth
+        style={
+          trader.isFollowing
+            ? undefined
+            : { backgroundColor: lightTheme.colors.primary.default }
+        }
+        textProps={
+          trader.isFollowing
+            ? undefined
+            : { style: { color: lightTheme.colors.overlay.inverse } }
+        }
         onPress={() => onFollowPress(trader.id)}
       >
         {trader.isFollowing

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -151,7 +151,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
       {/* Follow / Following button */}
       <Button
         variant={
-          trader.isFollowing ? ButtonVariant.Primary : ButtonVariant.Secondary
+          trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
         size={ButtonSize.Sm}
         onPress={() => onFollowPress(trader.id)}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
+import { lightTheme } from '@metamask/design-tokens';
 import {
   Box,
   Text,
@@ -156,6 +157,16 @@ const TraderRow: React.FC<TraderRowProps> = ({
         size={ButtonSize.Sm}
         onPress={() => onFollowPress(trader.id)}
         twClassName="min-w-[96px]"
+        style={
+          trader.isFollowing
+            ? undefined
+            : { backgroundColor: lightTheme.colors.primary.default }
+        }
+        textProps={
+          trader.isFollowing
+            ? undefined
+            : { style: { color: lightTheme.colors.overlay.inverse } }
+        }
       >
         {trader.isFollowing
           ? strings('social_leaderboard.following')

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.testIds.ts
@@ -8,4 +8,5 @@ export const TraderProfileViewSelectorsIDs = {
   TAB_OPEN: 'trader-profile-tab-open',
   TAB_CLOSED: 'trader-profile-tab-closed',
   ERROR_BANNER: 'trader-profile-error-banner',
+  TWITTER_LINK: 'trader-profile-twitter-link',
 };

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -178,6 +178,7 @@ const TraderProfileView = () => {
               <ProfileHeader
                 profile={profile.profile}
                 followerCount={profile.followerCount}
+                twitterHandle={profile.socialHandles?.twitter}
               />
             )}
 
@@ -196,8 +197,8 @@ const TraderProfileView = () => {
                   <Button
                     variant={
                       isFollowing
-                        ? ButtonVariant.Primary
-                        : ButtonVariant.Secondary
+                        ? ButtonVariant.Secondary
+                        : ButtonVariant.Primary
                     }
                     isFullWidth
                     onPress={toggleFollow}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -25,6 +25,7 @@ import {
   Button,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
+import { lightTheme } from '@metamask/design-tokens';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
@@ -199,6 +200,22 @@ const TraderProfileView = () => {
                       isFollowing
                         ? ButtonVariant.Secondary
                         : ButtonVariant.Primary
+                    }
+                    style={
+                      isFollowing
+                        ? undefined
+                        : {
+                            backgroundColor: lightTheme.colors.primary.default,
+                          }
+                    }
+                    textProps={
+                      isFollowing
+                        ? undefined
+                        : {
+                            style: {
+                              color: lightTheme.colors.overlay.inverse,
+                            },
+                          }
                     }
                     isFullWidth
                     onPress={toggleFollow}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import ProfileHeader from './ProfileHeader';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 import type { TraderProfile } from '@metamask/social-controllers';
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  openURL: jest.fn(),
+  canOpenURL: jest.fn(),
+  getInitialURL: jest.fn(),
+}));
 
 const baseProfile: TraderProfile = {
   profileId: 'trader-1',
@@ -92,5 +101,63 @@ describe('ProfileHeader', () => {
     );
 
     expect(screen.getByText('D')).toBeOnTheScreen();
+  });
+
+  describe('X (Twitter) icon', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('renders the X icon link when twitterHandle is provided', () => {
+      renderWithProvider(
+        <ProfileHeader
+          profile={baseProfile}
+          followerCount={45}
+          twitterHandle="dutchiono"
+        />,
+      );
+      expect(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render the X icon link when twitterHandle is null', () => {
+      renderWithProvider(
+        <ProfileHeader
+          profile={baseProfile}
+          followerCount={45}
+          twitterHandle={null}
+        />,
+      );
+      expect(
+        screen.queryByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
+      ).toBeNull();
+    });
+
+    it('does not render the X icon link when twitterHandle is undefined', () => {
+      renderWithProvider(
+        <ProfileHeader profile={baseProfile} followerCount={45} />,
+      );
+      expect(
+        screen.queryByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
+      ).toBeNull();
+    });
+
+    it('calls Linking.openURL with the correct X URL when the icon is pressed', () => {
+      renderWithProvider(
+        <ProfileHeader
+          profile={baseProfile}
+          followerCount={45}
+          twitterHandle="dutchiono"
+        />,
+      );
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
+      );
+
+      expect(Linking.openURL).toHaveBeenCalledTimes(1);
+      expect(Linking.openURL).toHaveBeenCalledWith('https://x.com/dutchiono');
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Image } from 'react-native';
+import React, { useCallback } from 'react';
+import { Image, Linking, Pressable } from 'react-native';
 import {
   Box,
   Text,
@@ -10,6 +10,10 @@ import {
   BoxAlignItems,
   AvatarBase,
   AvatarBaseSize,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
@@ -21,13 +25,21 @@ const AVATAR_SIZE = 40;
 export interface ProfileHeaderProps {
   profile: TraderProfile;
   followerCount: number;
+  twitterHandle?: string | null;
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   profile,
   followerCount,
+  twitterHandle,
 }) => {
   const tw = useTailwind();
+
+  const handleTwitterPress = useCallback(() => {
+    if (twitterHandle) {
+      Linking.openURL(`https://x.com/${twitterHandle}`);
+    }
+  }, [twitterHandle]);
 
   return (
     <Box
@@ -53,14 +65,37 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
       )}
 
       <Box twClassName="flex-1 min-w-0">
-        <Text
-          variant={TextVariant.HeadingMd}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextDefault}
-          numberOfLines={1}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
         >
-          {profile.name}
-        </Text>
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            numberOfLines={1}
+            twClassName="flex-shrink"
+          >
+            {profile.name}
+          </Text>
+          {twitterHandle ? (
+            <Pressable
+              onPress={handleTwitterPress}
+              testID={TraderProfileViewSelectorsIDs.TWITTER_LINK}
+              accessibilityRole="link"
+              accessibilityLabel={strings(
+                'social_leaderboard.trader_profile.twitter_link',
+              )}
+            >
+              <Icon
+                name={IconName.X}
+                size={IconSize.Sm}
+                color={IconColor.IconDefault}
+              />
+            </Pressable>
+          ) : null}
+        </Box>
         <Text
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1044,7 +1044,8 @@
       "open": "Open",
       "closed": "Closed",
       "no_positions": "No positions yet",
-      "error_loading_profile": "Couldn't load profile"
+      "error_loading_profile": "Couldn't load profile",
+      "twitter_link": "View on X (Twitter)"
     },
     "trader_position": {
       "market_cap": "Market cap",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Updates the Follow button to use the correct blue background with white text across the homepage carousel, leaderboard list, and trader profile. Adds the X/Twitter icon to the trader profile header and appends a "View more" card to the Top Traders carousel linking to the leaderboard.

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-27 at 13 40 44" src="https://github.com/user-attachments/assets/f185a4f7-be9d-4d85-afc2-e8cc09f960be" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-27 at 13 40 29" src="https://github.com/user-attachments/assets/314f082c-d442-45a9-af86-963ff25f3002" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only updates, with the only behavioral change being opening an external `x.com` link from the trader profile header when a Twitter handle is present.
> 
> **Overview**
> Updates Social Leaderboard UI/UX across surfaces: the homepage Top Traders carousel now appends a `ViewMoreCard` that navigates to the full leaderboard, and Follow/Following buttons on the homepage cards, leaderboard rows, and trader profile are restyled to the correct primary blue/white treatment.
> 
> Enhances `TraderProfileView` by passing through `socialHandles.twitter` to `ProfileHeader`, which conditionally renders an X icon link that opens `https://x.com/{handle}` via `Linking.openURL`, with new test coverage and a new i18n string/`testID` for the link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2493356e60645f6e6bc56c0d6a516ae7aec116c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->