### PR TITLE
ci(qa-stats): collect e2e_test_times per spec from JUnit artifacts

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -41,26 +41,12 @@
 import { readFile, writeFile, mkdir, readdir, access } from 'fs/promises';
 import { constants as fsConstants } from 'fs';
 import { execSync } from 'child_process';
-import { join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
 
-/**
- * When set, all GitHub API calls are bypassed and artifacts are read directly
- * from subdirectories of this folder. Each subdirectory name is treated as
- * the artifact name (e.g. `test-e2e-main-confirmations-android-smoke-1/junit.xml`).
- *
- * Used for local development and unit tests; production runs leave it unset.
- */
-const LOCAL_FIXTURES_DIR = process.env.LOCAL_QA_STATS_FIXTURES_DIR
-  ? resolve(process.env.LOCAL_QA_STATS_FIXTURES_DIR)
-  : null;
-
-if (!GITHUB_TOKEN && !LOCAL_FIXTURES_DIR) {
-  throw new Error('Missing required GITHUB_TOKEN env var (or LOCAL_QA_STATS_FIXTURES_DIR for local runs)');
-}
+if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
 
 // ---------------------------------------------------------------------------
@@ -125,10 +111,6 @@ async function getLatestCiRunId() {
 
 async function getRunId() {
   if (_runId) return _runId;
-  if (LOCAL_FIXTURES_DIR) {
-    _runId = 'local-fixtures';
-    return _runId;
-  }
   _runId = await getLatestCiRunId();
   return _runId;
 }
@@ -141,15 +123,6 @@ async function getRunId() {
  */
 async function getArtifactList() {
   if (_artifactList) return _artifactList;
-
-  if (LOCAL_FIXTURES_DIR) {
-    const entries = await readdir(LOCAL_FIXTURES_DIR, { withFileTypes: true });
-    _artifactList = entries
-      .filter((e) => e.isDirectory())
-      .map((e) => ({ name: e.name, archive_download_url: null }));
-    console.log(`[run] LOCAL_QA_STATS_FIXTURES_DIR set — using ${_artifactList.length} fixture artifact(s) from ${LOCAL_FIXTURES_DIR}`);
-    return _artifactList;
-  }
 
   const runId = await getRunId();
   const artifacts = [];
@@ -187,12 +160,6 @@ async function getArtifactList() {
  * @returns {Promise<string>} Path to the directory containing the extracted files
  */
 async function downloadArtifact(artifactName) {
-  if (LOCAL_FIXTURES_DIR) {
-    const localDir = join(LOCAL_FIXTURES_DIR, artifactName);
-    await access(localDir, fsConstants.F_OK);
-    return localDir;
-  }
-
   const artifacts = await getArtifactList();
   const artifact = artifacts.find((a) => a.name === artifactName);
   const runId = await getRunId();
@@ -1187,12 +1154,7 @@ async function main() {
     { namespace: 'e2e_test_times', collect: collectE2ETestTimes },
     { namespace: 'metametrics', collect: collectMetametricsQaStats },
     { namespace: 'performance', collect: collectPerformanceTestCounts },
-    // The feature-flag collector shells out to ts-node and depends on a full
-    // workspace install. Skip it in local fixture mode so the smoke test
-    // stays self-contained.
-    ...(LOCAL_FIXTURES_DIR
-      ? []
-      : [{ namespace: 'feature_flags', collect: collectFeatureFlagCoverage }]),
+    { namespace: 'feature_flags', collect: collectFeatureFlagCoverage },
   ];
 
   for (const { namespace, collect } of collectors) {
@@ -1211,14 +1173,7 @@ async function main() {
   console.log(`✅ QA stats written to ${outputPath}:`, stats);
 }
 
-// Only execute when run directly (e.g. `node collect-qa-stats.mjs`). When the
-// module is imported (unit tests), skip the side-effecting `main()` invocation.
-const isDirectInvocation =
-  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
-
-if (isDirectInvocation) {
-  main().catch((err) => {
-    console.error('\n❌ Unexpected error:', err);
-    process.exit(1);
-  });
-}
+main().catch((err) => {
+  console.error('\n❌ Unexpected error:', err);
+  process.exit(1);
+});

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -41,12 +41,26 @@
 import { readFile, writeFile, mkdir, readdir, access } from 'fs/promises';
 import { constants as fsConstants } from 'fs';
 import { execSync } from 'child_process';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-mobile';
 
-if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
+/**
+ * When set, all GitHub API calls are bypassed and artifacts are read directly
+ * from subdirectories of this folder. Each subdirectory name is treated as
+ * the artifact name (e.g. `test-e2e-main-confirmations-android-smoke-1/junit.xml`).
+ *
+ * Used for local development and unit tests; production runs leave it unset.
+ */
+const LOCAL_FIXTURES_DIR = process.env.LOCAL_QA_STATS_FIXTURES_DIR
+  ? resolve(process.env.LOCAL_QA_STATS_FIXTURES_DIR)
+  : null;
+
+if (!GITHUB_TOKEN && !LOCAL_FIXTURES_DIR) {
+  throw new Error('Missing required GITHUB_TOKEN env var (or LOCAL_QA_STATS_FIXTURES_DIR for local runs)');
+}
 
 
 // ---------------------------------------------------------------------------
@@ -111,6 +125,10 @@ async function getLatestCiRunId() {
 
 async function getRunId() {
   if (_runId) return _runId;
+  if (LOCAL_FIXTURES_DIR) {
+    _runId = 'local-fixtures';
+    return _runId;
+  }
   _runId = await getLatestCiRunId();
   return _runId;
 }
@@ -123,6 +141,15 @@ async function getRunId() {
  */
 async function getArtifactList() {
   if (_artifactList) return _artifactList;
+
+  if (LOCAL_FIXTURES_DIR) {
+    const entries = await readdir(LOCAL_FIXTURES_DIR, { withFileTypes: true });
+    _artifactList = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => ({ name: e.name, archive_download_url: null }));
+    console.log(`[run] LOCAL_QA_STATS_FIXTURES_DIR set — using ${_artifactList.length} fixture artifact(s) from ${LOCAL_FIXTURES_DIR}`);
+    return _artifactList;
+  }
 
   const runId = await getRunId();
   const artifacts = [];
@@ -160,6 +187,12 @@ async function getArtifactList() {
  * @returns {Promise<string>} Path to the directory containing the extracted files
  */
 async function downloadArtifact(artifactName) {
+  if (LOCAL_FIXTURES_DIR) {
+    const localDir = join(LOCAL_FIXTURES_DIR, artifactName);
+    await access(localDir, fsConstants.F_OK);
+    return localDir;
+  }
+
   const artifacts = await getArtifactList();
   const artifact = artifacts.find((a) => a.name === artifactName);
   const runId = await getRunId();
@@ -168,6 +201,19 @@ async function downloadArtifact(artifactName) {
     throw new Error(
       `Artifact "${artifactName}" not found in run ${runId}`,
     );
+  }
+
+  // Idempotent: if the artifact has already been downloaded and extracted in
+  // this process, reuse the existing directory (collectors may request the
+  // same artifact). The presence of the marker zip is enough to confirm a
+  // previous successful extraction.
+  const destDirCached = `./${artifactName}`;
+  const cachedZip = join(destDirCached, `${artifactName}.zip`);
+  try {
+    await access(cachedZip, fsConstants.F_OK);
+    return destDirCached;
+  } catch {
+    // not cached — fall through to download
   }
 
   // GitHub redirects to a pre-signed S3 URL. Follow manually so the
@@ -918,6 +964,139 @@ async function collectE2ECounts() {
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// E2E per-spec wall-clock timings (top-level `e2e_test_times` namespace)
+// Consumed by .github/scripts/e2e-split-tags-shards.mjs (PR #28667) for
+// time-based bin-packing of the smoke-shard distribution.
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes XML entities that may appear in attribute values (`&amp;`, `&quot;`,
+ * `&#39;`, etc.). The merged junit.xml only escapes a handful of characters,
+ * so a tiny lookup table is sufficient.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function decodeXmlEntities(value) {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Extracts every `<testcase>` open tag from a JUnit XML string and returns
+ * its `classname` and `time` attributes.
+ *
+ * The merged `junit.xml` produced by `e2e-merge-detox-junit-reports.mjs`
+ * uses `classNameTemplate: '{filepath}'` (see `tests/jest.e2e.detox.config.js`),
+ * so `classname` holds the absolute path to the spec file. Self-closing
+ * tags (`<testcase ... />`) and tags wrapping `<failure>`/`<skipped>` are
+ * both supported because we only inspect the open-tag string.
+ *
+ * @param {string} rawXml
+ * @returns {Array<{ classname: string, time: number }>}
+ */
+export function parseTestcaseTimings(rawXml) {
+  const out = [];
+  const tagRe = /<testcase\b[^>]*>/g;
+  let m;
+  while ((m = tagRe.exec(rawXml)) !== null) {
+    const tag = m[0];
+    const classMatch = tag.match(/\bclassname="([^"]*)"/);
+    const timeMatch = tag.match(/\btime="([^"]*)"/);
+    if (!classMatch || !timeMatch) continue;
+    const classname = decodeXmlEntities(classMatch[1]);
+    const time = Number(timeMatch[1]);
+    if (!Number.isFinite(time)) continue;
+    out.push({ classname, time });
+  }
+  return out;
+}
+
+/**
+ * Maps a JUnit `classname` to the canonical repo-relative spec path used as
+ * the `e2e_test_times` key (e.g. `tests/smoke/.../foo.spec.ts`).
+ *
+ * `classname` may be absolute (`/var/folders/.../tests/smoke/foo.spec.ts`),
+ * already relative, or use OS-specific separators. Anything that does not
+ * resolve to a `tests/...spec.{ts,tsx,js,jsx}` path is rejected so that
+ * non-spec entries cannot pollute the output.
+ *
+ * @param {string} classname
+ * @returns {string|null}
+ */
+export function normalizeSpecPath(classname) {
+  if (!classname) return null;
+  const unified = classname.replace(/\\/g, '/');
+  const idx = unified.indexOf('tests/');
+  if (idx === -1) return null;
+  const rel = unified.slice(idx);
+  if (!/\.spec\.(ts|tsx|js|jsx)$/.test(rel)) return null;
+  return rel;
+}
+
+/**
+ * Folds the testcase timings parsed from one junit.xml into an accumulator
+ * shaped `{ <spec>: { android?: number, ios?: number } }`. Duplicate
+ * testcases for the same spec are summed; non-positive durations are
+ * ignored to avoid corrupting the consumer's median fallback.
+ *
+ * @param {string} rawXml
+ * @param {'android' | 'ios'} platform
+ * @param {Record<string, Record<string, number>>} acc
+ */
+export function aggregateTimingsFromJUnit(rawXml, platform, acc) {
+  for (const { classname, time } of parseTestcaseTimings(rawXml)) {
+    if (time <= 0) continue;
+    const spec = normalizeSpecPath(classname);
+    if (!spec) continue;
+    const entry = acc[spec] ?? (acc[spec] = {});
+    entry[platform] = (entry[platform] ?? 0) + time;
+  }
+}
+
+/**
+ * Builds the `e2e_test_times` map consumed by PR #28667's shard splitter.
+ *
+ * Only `main` channel artifacts are considered; flask runs the same spec
+ * files but on a separate matrix, so including them would collide on the
+ * spec-path key with potentially different durations.
+ *
+ * @returns {Promise<Record<string, { android?: number, ios?: number }>>}
+ */
+async function collectE2ETestTimes() {
+  const artifacts = await getArtifactList();
+  const e2eArtifacts = artifacts
+    .map((a) => ({ artifact: a, dims: getE2EArtifactDimensions(a.name) }))
+    .filter(({ dims }) => dims && dims.channel === 'main');
+
+  console.log(`[e2e_test_times] found ${e2eArtifacts.length} main-channel JUnit artifact(s)`);
+  if (e2eArtifacts.length === 0) return {};
+
+  const acc = {};
+  for (const { artifact, dims } of e2eArtifacts) {
+    const destDir = await downloadArtifact(artifact.name);
+    const junitXml = await readFile(join(destDir, 'junit.xml'), 'utf8');
+    aggregateTimingsFromJUnit(junitXml, dims.platform, acc);
+  }
+
+  // Round to 3 decimals to match the shape of tests/e2e-test-times.json.
+  for (const spec of Object.keys(acc)) {
+    for (const platform of Object.keys(acc[spec])) {
+      acc[spec][platform] = Math.round(acc[spec][platform] * 1000) / 1000;
+    }
+  }
+
+  const specCount = Object.keys(acc).length;
+  console.log(`[e2e_test_times] aggregated timings for ${specCount} spec file(s)`);
+  return acc;
+}
+
 /**
  * Counts executed performance scenarios by scanning *.spec.js files
  * under tests/performance/ and counting non-skipped test() calls.
@@ -1005,9 +1184,15 @@ async function main() {
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'component_view', collect: collectComponentViewTestCount },
     { namespace: 'e2e', collect: collectE2ECounts },
+    { namespace: 'e2e_test_times', collect: collectE2ETestTimes },
     { namespace: 'metametrics', collect: collectMetametricsQaStats },
     { namespace: 'performance', collect: collectPerformanceTestCounts },
-    { namespace: 'feature_flags', collect: collectFeatureFlagCoverage },
+    // The feature-flag collector shells out to ts-node and depends on a full
+    // workspace install. Skip it in local fixture mode so the smoke test
+    // stays self-contained.
+    ...(LOCAL_FIXTURES_DIR
+      ? []
+      : [{ namespace: 'feature_flags', collect: collectFeatureFlagCoverage }]),
   ];
 
   for (const { namespace, collect } of collectors) {
@@ -1026,7 +1211,14 @@ async function main() {
   console.log(`✅ QA stats written to ${outputPath}:`, stats);
 }
 
-main().catch((err) => {
-  console.error('\n❌ Unexpected error:', err);
-  process.exit(1);
-});
+// Only execute when run directly (e.g. `node collect-qa-stats.mjs`). When the
+// module is imported (unit tests), skip the side-effecting `main()` invocation.
+const isDirectInvocation =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isDirectInvocation) {
+  main().catch((err) => {
+    console.error('\n❌ Unexpected error:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Adds a new top-level `e2e_test_times` namespace to qa-stats.json, shaped `{ <spec>: { android, ios } }`, by aggregating per-testcase timings from the existing main-channel `test-e2e-*-junit-results` artifacts. Consumed by the time-based shard splitter in #28667.

Flask artifacts are excluded to avoid spec-path collisions; specs with non-positive durations are skipped to keep the consumer's median fallback intact.

Also makes downloadArtifact idempotent so collectors that request the same artifact don't re-download, and adds a hidden LOCAL_QA_STATS_FIXTURES_DIR override to allow running the script without GITHUB_TOKEN against on-disk artifact directories.

Made-with: Cursor

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI/QA metrics generation and adds new JUnit XML parsing used to influence E2E shard bin-packing; incorrect parsing or path normalization could skew timings and impact CI stability.
> 
> **Overview**
> Adds a new top-level `e2e_test_times` section to `qa-stats.json` by aggregating per-`<testcase>` `time` values from main-channel E2E `junit.xml` artifacts, keyed by normalized `tests/.../*.spec.*` paths and split by platform (`android`/`ios`).
> 
> Makes `downloadArtifact()` idempotent within a single run by reusing an already-downloaded/extracted artifact directory when its marker zip is present, reducing duplicate downloads when multiple collectors request the same artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793b12a05f5888e5665057be0a7489aacb8f6fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->