### PR TITLE
fix: add timeouts and cleanup to ledger adapter

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -586,6 +586,27 @@ describe('HardwareWalletProvider', () => {
           ConnectionStatus.Disconnected,
         );
       });
+
+      it('disconnects the active adapter so Ledger BLE is released after signing', async () => {
+        const { result } = renderWithActions();
+
+        await waitFor(() => {
+          expect(mockCreateAdapter).toHaveBeenCalledWith(
+            HardwareWalletType.Ledger,
+            expect.any(Object),
+          );
+        });
+
+        await act(async () => {
+          result.current.actions.showAwaitingConfirmation('transaction');
+        });
+
+        await act(async () => {
+          result.current.actions.hideAwaitingConfirmation();
+        });
+
+        expect(mockAdapterInstance.disconnect).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -849,11 +870,66 @@ describe('HardwareWalletProvider', () => {
         internalCancel();
       });
 
-      // Adapter should disconnect
-      expect(mockAdapterInstance.disconnect).toHaveBeenCalled();
+      // Adapter should disconnect once via hideAwaitingConfirmation
+      expect(mockAdapterInstance.disconnect).toHaveBeenCalledTimes(1);
       // Rejection callback should fire
       expect(onReject).toHaveBeenCalled();
       // State should return to disconnected
+      expect(result.current.state.connectionState.status).toBe(
+        ConnectionStatus.Disconnected,
+      );
+    });
+
+    it('still hides confirmation and disconnects when rejection callback throws', async () => {
+      mockUseSelector.mockReturnValue({ address: '0x1234' });
+      mockGetHardwareWalletType.mockReturnValue(HardwareWalletType.Ledger);
+
+      const onReject = jest.fn(() => {
+        throw new Error('reject failed');
+      });
+      let thrownError: unknown;
+
+      const useTestActions = () => {
+        const hw = useHardwareWallet();
+        return {
+          actions: hw,
+          state: { connectionState: hw.connectionState },
+        };
+      };
+
+      const { result } = renderHook(() => useTestActions(), {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <HardwareWalletProvider>{children}</HardwareWalletProvider>
+        ),
+      });
+
+      await waitFor(() => {
+        expect(mockCreateAdapter).toHaveBeenCalledWith(
+          HardwareWalletType.Ledger,
+          expect.any(Object),
+        );
+      });
+
+      await act(async () => {
+        result.current.actions.showAwaitingConfirmation(
+          'transaction',
+          onReject,
+        );
+      });
+
+      const internalCancel =
+        capturedBottomSheetProps.onAwaitingConfirmationCancel as () => void;
+
+      await act(async () => {
+        try {
+          internalCancel();
+        } catch (error) {
+          thrownError = error;
+        }
+      });
+
+      expect(thrownError).toEqual(new Error('reject failed'));
+      expect(mockAdapterInstance.disconnect).toHaveBeenCalledTimes(1);
       expect(result.current.state.connectionState.status).toBe(
         ConnectionStatus.Disconnected,
       );

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -158,8 +158,11 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   const hideAwaitingConfirmation = useCallback(() => {
     DevLogger.log('[HardwareWallet] hideAwaitingConfirmation');
     awaitingConfirmationRejectRef.current = null;
+    // Ledger BLE transports are cached by device id inside the transport
+    // package, so release the transport once signing is no longer awaiting.
+    refs.adapterRef.current?.disconnect().catch(() => undefined);
     updateConnectionState({ status: ConnectionStatus.Disconnected });
-  }, [updateConnectionState]);
+  }, [refs, updateConnectionState]);
 
   const handleCloseFlow = useCallback(() => {
     awaitingConfirmationRejectRef.current = null;
@@ -187,15 +190,16 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   }, [handleCloseFlow, retryEnsureDeviceReady]);
   const handleAwaitingConfirmationCancel = useCallback(() => {
     DevLogger.log('[HardwareWallet] handleAwaitingConfirmationCancel');
-    // eslint-disable-next-line no-empty-function
-    refs.adapterRef.current?.disconnect().catch(() => {});
     const onReject = awaitingConfirmationRejectRef.current;
     awaitingConfirmationRejectRef.current = null;
     operationTypeRef.current = null;
     setAnalyticsFlow(HardwareWalletAnalyticsFlow.Connection);
-    onReject?.();
-    hideAwaitingConfirmation();
-  }, [hideAwaitingConfirmation, refs.adapterRef]);
+    try {
+      onReject?.();
+    } finally {
+      hideAwaitingConfirmation();
+    }
+  }, [hideAwaitingConfirmation]);
 
   const setPendingOperationAddress = useCallback(
     (address: string | null) => {

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.test.ts
@@ -521,6 +521,29 @@ describe('LedgerBluetoothAdapter', () => {
       );
     });
 
+    it('closes transport when opening Ethereum app times out', async () => {
+      jest.useFakeTimers();
+      jest.mocked(connectLedgerHardware).mockResolvedValue('BOLOS');
+      const { openEthereumAppOnLedger } = jest.requireMock(
+        '../../Ledger/Ledger',
+      ) as { openEthereumAppOnLedger: jest.Mock };
+      openEthereumAppOnLedger.mockImplementationOnce(
+        // eslint-disable-next-line no-empty-function
+        () => new Promise(() => {}),
+      );
+
+      const resultPromise = adapter.ensureDeviceReady('device-123');
+      await jest.advanceTimersByTimeAsync(11000);
+
+      await expect(resultPromise).resolves.toBe(false);
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
+      expect(adapter.isConnected()).toBe(false);
+
+      jest.useRealTimers();
+    });
+
     it('returns false when wrong app open and closeRunningAppOnLedger rejects', async () => {
       jest.mocked(connectLedgerHardware).mockResolvedValue('Bitcoin');
       const { closeRunningAppOnLedger } = jest.requireMock(
@@ -531,6 +554,29 @@ describe('LedgerBluetoothAdapter', () => {
       const result = await adapter.ensureDeviceReady('device-123');
 
       expect(result).toBe(false);
+    });
+
+    it('closes transport when closing the current app times out', async () => {
+      jest.useFakeTimers();
+      jest.mocked(connectLedgerHardware).mockResolvedValue('Bitcoin');
+      const { closeRunningAppOnLedger } = jest.requireMock(
+        '../../Ledger/Ledger',
+      ) as { closeRunningAppOnLedger: jest.Mock };
+      closeRunningAppOnLedger.mockImplementationOnce(
+        // eslint-disable-next-line no-empty-function
+        () => new Promise(() => {}),
+      );
+
+      const resultPromise = adapter.ensureDeviceReady('device-123');
+      await jest.advanceTimersByTimeAsync(11000);
+
+      await expect(resultPromise).resolves.toBe(false);
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
+      expect(adapter.isConnected()).toBe(false);
+
+      jest.useRealTimers();
     });
 
     it('emits DeviceLocked and throws when connectLedgerHardware throws device locked', async () => {
@@ -614,6 +660,30 @@ describe('LedgerBluetoothAdapter', () => {
         name: 'LedgerTimeoutError',
         message: 'Device unresponsive',
       });
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
+      expect(adapter.isConnected()).toBe(false);
+
+      jest.useRealTimers();
+    });
+
+    it('closes transport when device verification times out', async () => {
+      jest.useFakeTimers();
+      jest.mocked(connectLedgerHardware).mockResolvedValue('Ethereum');
+      mockGetAddress.mockImplementation(
+        // eslint-disable-next-line no-empty-function
+        () => new Promise(() => {}),
+      );
+
+      const resultPromise = adapter.ensureDeviceReady('device-123');
+      await jest.advanceTimersByTimeAsync(11000);
+
+      await expect(resultPromise).resolves.toBe(false);
+      expect(mockedTransportBLE.disconnectDevice).toHaveBeenCalledWith(
+        'device-123',
+      );
+      expect(adapter.isConnected()).toBe(false);
 
       jest.useRealTimers();
     });

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -412,10 +412,19 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
 
     try {
       DevLogger.log('[LedgerBluetoothAdapter] Checking app...');
+      const abortController = new AbortController();
       const currentAppName = await this.#withTimeout(
-        connectLedgerHardware(this.#transport, deviceId),
+        connectLedgerHardware(
+          this.#transport,
+          deviceId,
+          abortController.signal,
+        ),
         LEDGER_OPERATION_TIMEOUT_MS,
         'Device unresponsive',
+        () => {
+          abortController.abort();
+          return this.#closeTransport();
+        },
       );
       DevLogger.log('[LedgerBluetoothAdapter] Got app name:', currentAppName);
 
@@ -460,6 +469,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         eth.getAddress("44'/60'/0'/0/0", false),
         LEDGER_OPERATION_TIMEOUT_MS,
         'Device unresponsive during verification',
+        () => this.#closeTransport(),
       );
       DevLogger.log('[LedgerBluetoothAdapter] Device verified unlocked!');
 
@@ -509,7 +519,12 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         DevLogger.log(
           '[LedgerBluetoothAdapter] Requesting Ethereum app to open...',
         );
-        await openEthereumAppOnLedger();
+        await this.#withTimeout(
+          openEthereumAppOnLedger(),
+          LEDGER_OPERATION_TIMEOUT_MS,
+          'Device unresponsive while opening Ethereum app',
+          () => this.#closeTransport(),
+        );
         DevLogger.log('[LedgerBluetoothAdapter] Open app command sent');
       } catch (openError) {
         DevLogger.log(
@@ -520,7 +535,12 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     } else {
       try {
         DevLogger.log('[LedgerBluetoothAdapter] Closing wrong app:', appName);
-        await closeRunningAppOnLedger();
+        await this.#withTimeout(
+          closeRunningAppOnLedger(),
+          LEDGER_OPERATION_TIMEOUT_MS,
+          'Device unresponsive while closing current app',
+          () => this.#closeTransport(),
+        );
         DevLogger.log('[LedgerBluetoothAdapter] Close app command sent');
       } catch (closeError) {
         DevLogger.log(
@@ -713,18 +733,28 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
     promise: Promise<T>,
     timeoutMs: number,
     errorMessage: string,
+    onTimeout?: () => void | Promise<void>,
   ): Promise<T> {
     const timeoutError = new Error(errorMessage);
     timeoutError.name = 'LedgerTimeoutError';
 
     let timeoutId: ReturnType<typeof setTimeout>;
+    let timedOut = false;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => reject(timeoutError), timeoutMs);
+      timeoutId = setTimeout(() => {
+        timedOut = true;
+        reject(timeoutError);
+      }, timeoutMs);
     });
 
-    return Promise.race([promise, timeoutPromise]).finally(() =>
-      clearTimeout(timeoutId),
-    );
+    return Promise.race([promise, timeoutPromise]).finally(() => {
+      clearTimeout(timeoutId);
+      if (!timedOut || !onTimeout) {
+        return;
+      }
+
+      Promise.resolve(onTimeout()).catch(() => undefined);
+    });
   }
 
   /**

--- a/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
+++ b/app/core/HardwareWallet/adapters/LedgerBluetoothAdapter.ts
@@ -753,7 +753,7 @@ export class LedgerBluetoothAdapter implements HardwareWalletAdapter {
         return;
       }
 
-      Promise.resolve(onTimeout()).catch(() => undefined);
+      return Promise.resolve(onTimeout()).catch(() => undefined);
     });
   }
 

--- a/app/core/HardwareWallet/errors/mappings.test.ts
+++ b/app/core/HardwareWallet/errors/mappings.test.ts
@@ -440,6 +440,12 @@ describe('ERROR_NAME_MAPPINGS', () => {
     );
   });
 
+  it('maps LedgerOperationAbortedError to DeviceUnresponsive', () => {
+    expect(ERROR_NAME_MAPPINGS.LedgerOperationAbortedError).toBe(
+      ErrorCode.DeviceUnresponsive,
+    );
+  });
+
   it('maps TransportOpenUserCancelled to UserCancelled', () => {
     expect(ERROR_NAME_MAPPINGS.TransportOpenUserCancelled).toBe(
       ErrorCode.UserCancelled,

--- a/app/core/HardwareWallet/errors/mappings.ts
+++ b/app/core/HardwareWallet/errors/mappings.ts
@@ -250,6 +250,7 @@ export const ERROR_NAME_MAPPINGS: Record<string, ErrorCode> = {
   TransportError: ErrorCode.BluetoothConnectionFailed,
   LockedDeviceError: ErrorCode.AuthenticationDeviceLocked,
   LedgerTimeoutError: ErrorCode.DeviceUnresponsive,
+  LedgerOperationAbortedError: ErrorCode.DeviceUnresponsive,
   TransportOpenUserCancelled: ErrorCode.UserCancelled,
   BluetoothRequired: ErrorCode.BluetoothDisabled,
   PairingFailed: ErrorCode.BluetoothConnectionFailed,

--- a/app/core/HardwareWallet/helpers.test.ts
+++ b/app/core/HardwareWallet/helpers.test.ts
@@ -4,7 +4,11 @@ import {
   getConnectionTipsForWalletType,
   getDeviceIdForAddress,
 } from './helpers';
-import { HardwareWalletType } from '@metamask/hw-wallet-sdk';
+import {
+  ErrorCode,
+  HardwareWalletError,
+  HardwareWalletType,
+} from '@metamask/hw-wallet-sdk';
 
 jest.mock('../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -161,6 +165,30 @@ describe('HardwareWallet helpers', () => {
         'ledger-device-id',
       );
       expect(mockGetDeviceId).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects with a HardwareWalletError when Ledger device id lookup times out', async () => {
+      jest.useFakeTimers();
+      mockIsHardwareAccount.mockReset();
+      mockIsHardwareAccount
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      mockGetDeviceId.mockReturnValueOnce(
+        // eslint-disable-next-line no-empty-function
+        new Promise(() => {}),
+      );
+
+      const resultPromise = getDeviceIdForAddress(testAddress).catch(
+        (error) => error,
+      );
+      await jest.advanceTimersByTimeAsync(6000);
+      const error = await resultPromise;
+
+      expect(error).toEqual(expect.any(HardwareWalletError));
+      expect(error).toMatchObject({
+        code: ErrorCode.DeviceUnresponsive,
+      });
+      jest.useRealTimers();
     });
 
     it('returns undefined for QR accounts', async () => {

--- a/app/core/HardwareWallet/helpers.ts
+++ b/app/core/HardwareWallet/helpers.ts
@@ -1,8 +1,48 @@
 import { isHardwareAccount } from '../../util/address';
 import ExtendedKeyringTypes from '../../constants/keyringTypes';
-import { HardwareWalletType } from '@metamask/hw-wallet-sdk';
+import {
+  Category,
+  ErrorCode,
+  HardwareWalletError,
+  HardwareWalletType,
+  Severity,
+} from '@metamask/hw-wallet-sdk';
 import { strings } from '../../../locales/i18n';
 import { getDeviceId } from '../Ledger/Ledger';
+
+const LEDGER_DEVICE_ID_LOOKUP_TIMEOUT_MS = 5000;
+
+const createLedgerDeviceIdLookupTimeoutError = () =>
+  new HardwareWalletError('Ledger device id lookup timed out', {
+    code: ErrorCode.DeviceUnresponsive,
+    severity: Severity.Warning,
+    category: Category.Connection,
+    userMessage: strings('hardware_wallet.errors.connection_timeout'),
+    metadata: {
+      walletType: HardwareWalletType.Ledger,
+      errorName: 'LedgerDeviceIdLookupTimeoutError',
+    },
+  });
+
+const withLedgerDeviceIdLookupTimeout = async <Result>(
+  promise: Promise<Result>,
+): Promise<Result> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(createLedgerDeviceIdLookupTimeoutError()),
+      LEDGER_DEVICE_ID_LOOKUP_TIMEOUT_MS,
+    );
+  });
+
+  return await Promise.race([promise, timeoutPromise]).finally(() => {
+    // This only releases the caller. If another keyring operation already holds
+    // the mutex, it still releases when that underlying operation settles.
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
+};
 
 /**
  * Helper to get wallet type display name
@@ -51,7 +91,7 @@ export async function getDeviceIdForAddress(
 
   switch (walletType) {
     case HardwareWalletType.Ledger:
-      return await getDeviceId();
+      return await withLedgerDeviceIdLookupTimeout(getDeviceId());
     default:
       return undefined;
   }

--- a/app/core/Ledger/Ledger.test.ts
+++ b/app/core/Ledger/Ledger.test.ts
@@ -176,6 +176,57 @@ describe('Ledger core', () => {
       expect(ledgerKeyring.setHdPath).toHaveBeenCalled();
       expect(ledgerKeyring.setDeviceId).toHaveBeenCalled();
     });
+
+    it('releases the keyring lock before requesting app metadata from the device', async () => {
+      const events: string[] = [];
+      ledgerKeyring.bridge.getAppNameAndVersion.mockImplementationOnce(
+        async () => {
+          events.push('getAppNameAndVersion');
+          return { appName: 'Ethereum' };
+        },
+      );
+      MockEngine.context.KeyringController.withKeyring.mockImplementationOnce(
+        async (_selector, operation) => {
+          const result = await operation({
+            // @ts-expect-error The Ledger keyring is not compatible with our keyring type yet
+            keyring: ledgerKeyring,
+            metadata: { id: '1234', name: 'Ledger Hardware' },
+          });
+          events.push('withKeyring settled');
+          return result;
+        },
+      );
+
+      await expect(connectLedgerHardware(mockTransport, 'bar')).resolves.toBe(
+        'Ethereum',
+      );
+
+      expect(ledgerKeyring.bridge.updateTransportMethod).toHaveBeenCalled();
+      expect(ledgerKeyring.bridge.getAppNameAndVersion).toHaveBeenCalled();
+      expect(events).toEqual(['withKeyring settled', 'getAppNameAndVersion']);
+    });
+
+    it('skips app metadata request when aborted before the BLE exchange starts', async () => {
+      const abortController = new AbortController();
+      ledgerKeyring.bridge.updateTransportMethod.mockImplementationOnce(
+        async () => {
+          abortController.abort();
+        },
+      );
+
+      const resultPromise = connectLedgerHardware(
+        mockTransport,
+        'bar',
+        abortController.signal,
+      );
+      const error = await resultPromise.catch((caughtError) => caughtError);
+
+      expect(error).toMatchObject({
+        name: 'LedgerOperationAbortedError',
+      });
+
+      expect(ledgerKeyring.bridge.getAppNameAndVersion).not.toHaveBeenCalled();
+    });
   });
 
   describe('openEthereumAppOnLedger', () => {
@@ -183,12 +234,56 @@ describe('Ledger core', () => {
       await openEthereumAppOnLedger();
       expect(ledgerKeyring.bridge.openEthApp).toHaveBeenCalled();
     });
+
+    it('releases the keyring lock before opening the Ethereum app on the device', async () => {
+      const events: string[] = [];
+      ledgerKeyring.bridge.openEthApp.mockImplementationOnce(async () => {
+        events.push('openEthApp');
+      });
+      MockEngine.context.KeyringController.withKeyring.mockImplementationOnce(
+        async (_selector, operation) => {
+          const result = await operation({
+            // @ts-expect-error The Ledger keyring is not compatible with our keyring type yet
+            keyring: ledgerKeyring,
+            metadata: { id: '1234', name: 'Ledger Hardware' },
+          });
+          events.push('withKeyring settled');
+          return result;
+        },
+      );
+
+      await openEthereumAppOnLedger();
+
+      expect(events).toEqual(['withKeyring settled', 'openEthApp']);
+    });
   });
 
   describe('closeRunningAppOnLedger', () => {
     it('calls keyring.quitApp', async () => {
       await closeRunningAppOnLedger();
       expect(ledgerKeyring.bridge.closeApps).toHaveBeenCalled();
+    });
+
+    it('releases the keyring lock before closing the current app on the device', async () => {
+      const events: string[] = [];
+      ledgerKeyring.bridge.closeApps.mockImplementationOnce(async () => {
+        events.push('closeApps');
+      });
+      MockEngine.context.KeyringController.withKeyring.mockImplementationOnce(
+        async (_selector, operation) => {
+          const result = await operation({
+            // @ts-expect-error The Ledger keyring is not compatible with our keyring type yet
+            keyring: ledgerKeyring,
+            metadata: { id: '1234', name: 'Ledger Hardware' },
+          });
+          events.push('withKeyring settled');
+          return result;
+        },
+      );
+
+      await closeRunningAppOnLedger();
+
+      expect(events).toEqual(['withKeyring settled', 'closeApps']);
     });
   });
 

--- a/app/core/Ledger/Ledger.ts
+++ b/app/core/Ledger/Ledger.ts
@@ -20,6 +20,16 @@ import { keyringTypeToName } from '@metamask/accounts-controller';
 import { removeAccountsFromPermissions } from '../Permissions';
 import { isEthAppNotOpenError } from './ledgerErrors';
 
+const throwIfLedgerOperationAborted = (abortSignal?: AbortSignal) => {
+  if (!abortSignal?.aborted) {
+    return;
+  }
+
+  const error = new Error('Ledger operation aborted');
+  error.name = 'LedgerOperationAbortedError';
+  throw error;
+};
+
 /**
  * Perform an operation with the Ledger keyring.
  *
@@ -58,16 +68,23 @@ export const withLedgerKeyring = async <CallbackResult = void>(
 export const connectLedgerHardware = async (
   transport: BleTransport,
   deviceId: string,
+  abortSignal?: AbortSignal,
 ): Promise<string> => {
-  const appAndVersion = await withLedgerKeyring(async ({ keyring }) => {
+  throwIfLedgerOperationAborted(abortSignal);
+
+  const bridge = await withLedgerKeyring(async ({ keyring }) => {
     keyring.setHdPath(LEDGER_LIVE_PATH);
     keyring.setDeviceId(deviceId);
 
-    const bridge = keyring.bridge as LedgerMobileBridge;
-    await bridge.updateTransportMethod(transport);
-    return await bridge.getAppNameAndVersion();
+    const ledgerBridge = keyring.bridge as LedgerMobileBridge;
+    await ledgerBridge.updateTransportMethod(transport);
+    return ledgerBridge;
   });
 
+  // Keep the BLE exchange outside the KeyringController mutex. Hardware-wallet
+  // flows are serialized at the adapter/provider layer.
+  throwIfLedgerOperationAborted(abortSignal);
+  const appAndVersion = await bridge.getAppNameAndVersion();
   return appAndVersion.appName;
 };
 
@@ -75,20 +92,20 @@ export const connectLedgerHardware = async (
  * Automatically opens the Ethereum app on the Ledger device.
  */
 export const openEthereumAppOnLedger = async (): Promise<void> => {
-  await withLedgerKeyring(async ({ keyring }) => {
-    const bridge = keyring.bridge as LedgerMobileBridge;
-    await bridge.openEthApp();
-  });
+  const bridge = await withLedgerKeyring(
+    async ({ keyring }) => keyring.bridge as LedgerMobileBridge,
+  );
+  await bridge.openEthApp();
 };
 
 /**
  * Automatically closes the current app on the Ledger device.
  */
 export const closeRunningAppOnLedger = async (): Promise<void> => {
-  await withLedgerKeyring(async ({ keyring }) => {
-    const bridge = keyring.bridge as LedgerMobileBridge;
-    await bridge.closeApps();
-  });
+  const bridge = await withLedgerKeyring(
+    async ({ keyring }) => keyring.bridge as LedgerMobileBridge,
+  );
+  await bridge.closeApps();
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR attempts to fix the scenario where the device id could protentially lead to a stale bt connection. It also separates mutexes that can be slower to respond. 

The fix addresses three separate surfaces. First, `connectLedgerHardware` (and the related `openEthereumAppOnLedger` / `closeRunningAppOnLedger` helpers) now release the keyring mutex *before* issuing the BLE exchange that talks to the device — the mutex is only needed to configure the keyring, not to hold it while waiting for a slow hardware response. An `AbortSignal` is threaded through `connectLedgerHardware` so callers (the adapter) can cancel the operation before the expensive BLE round-trip starts. Second, `LedgerBluetoothAdapter.#withTimeout` now accepts an `onTimeout` callback that closes the BLE transport when any timed-out step (`ensureDeviceReady`, `openEthereumAppOnLedger`, `closeRunningAppOnLedger`, or address verification) exceeds the 10 s limit. Third, `HardwareWalletProvider.hideAwaitingConfirmation` calls `adapter.disconnect()` so the BLE transport is released once signing completes, and `getDeviceIdForAddress` wraps the Ledger device-id lookup in a 5 s timeout with a proper `HardwareWalletError`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Ledger BLE transport that prevented reconnecting to a Ledger device after a timeout or completed signing flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1738?atlOrigin=eyJpIjoiZjVlYWI4YjRkOWNjNGRiZDliNGYzM2E3NGVkNTRjODciLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: Ledger BLE transport cleanup
  Scenario: Ledger reconnects after a signing flow completes
    Given a Ledger device is paired via Bluetooth
    And the user has completed a transaction signing flow
    When the "Awaiting confirmation" sheet is dismissed
    Then the BLE transport should be disconnected
    And the user should be able to start a new signing flow without restarting the app
  Scenario: Ledger reconnects after a connection timeout
    Given a Ledger device is paired but unresponsive
    When a hardware-wallet operation times out after 10 seconds
    Then the BLE transport should be closed
    And a DeviceUnresponsive error should be surfaced to the user
    And the user should be able to retry the connection
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch Ledger BLE transport lifecycle and keyring/adapter control flow; mistakes could cause stuck connections or incorrect error handling during signing and device readiness checks.
> 
> **Overview**
> Improves Ledger BLE reliability by **actively releasing transports** after signing and on various timeout paths, reducing stale BLE sessions that block reconnect.
> 
> `LedgerBluetoothAdapter` now aborts/cleans up long-running operations: `#withTimeout` supports an `onTimeout` hook that closes the transport, and `ensureDeviceReady` applies this to app checks, app switching (open/close), and address verification.
> 
> `connectLedgerHardware` is refactored to **avoid holding the KeyringController mutex during BLE exchanges**, adds optional abort support (surfaced as `LedgerOperationAbortedError`), and error mappings/tests are updated accordingly. `getDeviceIdForAddress` adds a 5s timeout that rejects with a `HardwareWalletError` (`DeviceUnresponsive`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3439dbb2f3af293ce8c592972311f59876aa8300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->