### PR TITLE
fix: Android warm-start deeplinks dropping UTM attribution [GE-49 GE-198]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,6 @@ app/core/Engine/index.ts                                    @MetaMask/mobile-pla
 app/core/Engine/README.md                                   @MetaMask/mobile-platform
 app/core/Engine/types.ts                                    @MetaMask/mobile-platform
 app/core/Engine/controllers/remote-feature-flag-controller/ @MetaMask/mobile-platform
-app/core/DeeplinkManager                                    @MetaMask/mobile-platform
 scripts/build.sh                                            @MetaMask/mobile-platform
 fingerprint.config.js                                       @MetaMask/mobile-platform
 builds.yml                                                  @MetaMask/mobile-platform
@@ -137,6 +136,7 @@ app/components/Views/Settings/NotificationsSettings @MetaMask/notifications
 **/Notification/** @MetaMask/notifications
 **/notifications/** @MetaMask/notifications
 **/notification/** @MetaMask/notifications
+app/core/DeeplinkManager @MetaMask/notifications
 
 # LavaMoat Team
 ses.cjs                              @MetaMask/supply-chain

--- a/app/core/DeeplinkManager/DeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.test.ts
@@ -1,9 +1,11 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { waitFor } from '@testing-library/react-native';
+import { Linking, Platform } from 'react-native';
 import FCMService from '../../util/notifications/services/FCMService';
 import NavigationService from '../NavigationService';
 import SharedDeeplinkManager, {
   DeeplinkManager,
+  isAndroidBranchStubUrl,
   rewriteBranchUri,
 } from './DeeplinkManager';
 import type { BranchParams } from './types/deepLinkAnalytics.types';
@@ -557,5 +559,169 @@ describe('DeeplinkManager.start Branch deeplink handling', () => {
     expect(handleDeeplink).toHaveBeenCalledWith({
       uri: 'https://link.metamask.io/swap/token',
     });
+  });
+
+  it('does not re-dispatch the deeplink when the subscription fires for a non-Branch click without uri', async () => {
+    // Simulates a `metamask://` URL warm start on Android: Linking has already
+    // delivered the URL, then branch.subscribe fires for the same intent with
+    // no uri and clicked=false (Branch stores it under +non_branch_link).
+    // We must not call handleDeeplink again from the subscribe path.
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
+      '+clicked_branch_link': false,
+      '+non_branch_link': 'metamask://buy',
+    });
+    DeeplinkManager.start();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Reset any handleDeeplink calls coming from the cold-start
+    // getBranchDeeplink() workaround (line ~252 in DeeplinkManager.ts).
+    (handleDeeplink as jest.Mock).mockClear();
+
+    const callback = (branch.subscribe as jest.Mock).mock.calls[0][0];
+    callback({
+      uri: undefined,
+      params: { '+clicked_branch_link': false },
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDeeplink).not.toHaveBeenCalled();
+  });
+
+  it('does not re-dispatch the deeplink when the subscription fires with empty params (no uri, no click flag)', async () => {
+    // Defensive: subscribe sometimes fires with a bare `{}` (e.g. when Branch
+    // resolves an intent with no relevant data). Treat it as already-handled.
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({
+      '+non_branch_link': 'metamask://buy',
+    });
+    DeeplinkManager.start();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    (handleDeeplink as jest.Mock).mockClear();
+
+    const callback = (branch.subscribe as jest.Mock).mock.calls[0][0];
+    callback({});
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDeeplink).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAndroidBranchStubUrl', () => {
+  const originalOS = Platform.OS;
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  it('returns true on Android for a metamask:// URL with _branch_referrer and no UTMs', () => {
+    Platform.OS = 'android';
+    const url =
+      'metamask://trending?_branch_referrer=H4sIAA&link_click_id=1515351622014093579';
+    expect(isAndroidBranchStubUrl(url)).toBe(true);
+  });
+
+  it('returns false on Android when the URL has no _branch_referrer', () => {
+    Platform.OS = 'android';
+    const url = 'https://link.metamask.io/swap?amount=100';
+    expect(isAndroidBranchStubUrl(url)).toBe(false);
+  });
+
+  it('returns false on iOS even when the URL matches the stub shape', () => {
+    Platform.OS = 'ios';
+    const url =
+      'metamask://trending?_branch_referrer=H4sIAA&link_click_id=1515351622014093579';
+    expect(isAndroidBranchStubUrl(url)).toBe(false);
+  });
+});
+
+describe('DeeplinkManager.start Android Branch stub deferral', () => {
+  const originalOS = Platform.OS;
+  let linkingListener: ((event: { url: string }) => void) | undefined;
+  let addEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    Platform.OS = 'android';
+    linkingListener = undefined;
+    addEventListenerSpy = jest
+      .spyOn(Linking, 'addEventListener')
+      .mockImplementation(((event: string, listener: unknown) => {
+        if (event === 'url') {
+          linkingListener = listener as (event: { url: string }) => void;
+        }
+        return { remove: jest.fn() };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any);
+    // Quiet other start() side effects.
+    (branch.getLatestReferringParams as jest.Mock).mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    addEventListenerSpy.mockRestore();
+    Platform.OS = originalOS;
+  });
+
+  const stubUrl =
+    'metamask://trending?_branch_referrer=H4sIAA&link_click_id=1515351622014093579';
+
+  it('does not call handleDeeplink immediately for an Android Branch stub URL', () => {
+    DeeplinkManager.start();
+    expect(linkingListener).toBeDefined();
+
+    linkingListener?.({ url: stubUrl });
+
+    expect(handleDeeplink).not.toHaveBeenCalledWith({ uri: stubUrl });
+  });
+
+  it('cancels the deferred stub when branch.subscribe resolves the deeplink', async () => {
+    DeeplinkManager.start();
+    const branchCallback = (branch.subscribe as jest.Mock).mock.calls[0][0];
+
+    linkingListener?.({ url: stubUrl });
+
+    branchCallback({
+      uri: 'https://link.metamask.io/trending?utm_source=twitter&utm_medium=social',
+      params: { '+clicked_branch_link': true },
+    });
+    await Promise.resolve();
+
+    // Branch path delivers the resolved URL.
+    expect(handleDeeplink).toHaveBeenCalledWith({
+      uri: 'https://link.metamask.io/trending?utm_source=twitter&utm_medium=social',
+    });
+
+    // Advance past the fallback timeout — the stub must NOT fire.
+    jest.advanceTimersByTime(5000);
+    expect(handleDeeplink).not.toHaveBeenCalledWith({ uri: stubUrl });
+  });
+
+  it('falls back to the stub URL if branch.subscribe never fires within the timeout', () => {
+    DeeplinkManager.start();
+
+    linkingListener?.({ url: stubUrl });
+    expect(handleDeeplink).not.toHaveBeenCalledWith({ uri: stubUrl });
+
+    jest.advanceTimersByTime(3000);
+
+    expect(handleDeeplink).toHaveBeenCalledWith({ uri: stubUrl });
+  });
+
+  it('processes a non-stub URL on Android immediately', () => {
+    DeeplinkManager.start();
+    const resolvedUrl = 'https://link.metamask.io/trending?utm_source=twitter';
+
+    linkingListener?.({ url: resolvedUrl });
+
+    expect(handleDeeplink).toHaveBeenCalledWith({ uri: resolvedUrl });
+  });
+
+  it('processes the stub URL immediately on iOS (no deferral)', () => {
+    Platform.OS = 'ios';
+    DeeplinkManager.start();
+
+    linkingListener?.({ url: stubUrl });
+
+    expect(handleDeeplink).toHaveBeenCalledWith({ uri: stubUrl });
   });
 });

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -2,7 +2,7 @@
 
 import parseDeeplink from './utils/parseDeeplink';
 import branch from 'react-native-branch';
-import { Linking } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import Logger from '../../util/Logger';
 import { handleDeeplink } from './handlers/legacy/handleDeeplink';
 import FCMService from '../../util/notifications/services/FCMService';
@@ -12,6 +12,39 @@ import {
   getBrazeInitialDeeplink,
   subscribeToBrazePushDeeplinks,
 } from '../Braze/BrazeDeeplinks';
+
+/**
+ * Time to wait for `branch.subscribe` to fire with the resolved Branch
+ * params after Android delivered a Branch stub URL via Linking.
+ * If Branch hasn't fired by then we fall back to the stub so that the
+ * deeplink is never lost — at the cost of attribution for that click.
+ */
+const ANDROID_BRANCH_STUB_FALLBACK_MS = 3000;
+
+/**
+ * Detects the Branch stub URL Android delivers to Linking.addEventListener
+ * (and Linking.getInitialURL) when the user clicks a Branch deeplink while
+ * the app is already open.
+ *
+ * The stub looks like `metamask://<path>?_branch_referrer=<encrypted>&link_click_id=<id>`.
+ *
+ * The `_branch_referrer` query parameter is an opaque token; the actual
+ * UTM parameters are only available later, when the Branch RN SDK fires
+ * `branch.subscribe` with the decoded params (~500 ms later in measurement).
+ *
+ * Processing the stub URL would:
+ * 1. Fire `DEEP_LINK_USED` analytics with no UTM data (attribution lost).
+ * 2. Cause the deeplink handler to run twice (stub then resolved URL).
+ *
+ * We therefore defer the stub URL on Android and let `branch.subscribe`
+ * deliver the resolved URL with UTMs intact. iOS Universal Links already
+ * deliver the resolved URL inline, so this only applies to Android.
+ *
+ * @internal exported for tests
+ */
+export function isAndroidBranchStubUrl(url: string): boolean {
+  return Platform.OS === 'android' && url.includes('_branch_referrer=');
+}
 
 /**
  * When Branch resolves a short link (e.g. metamask-alternate.app.link/1WkF6GmE40b),
@@ -89,6 +122,21 @@ export class DeeplinkManager {
   static start() {
     DeeplinkManager.getInstance();
 
+    // [Android warm start] State for deferring Branch stub URLs until
+    // `branch.subscribe` resolves with the decoded UTM params. See
+    // `isAndroidBranchStubUrl` for context.
+    let pendingAndroidBranchStub: {
+      url: string;
+      timer: ReturnType<typeof setTimeout>;
+    } | null = null;
+
+    const clearAndroidBranchStub = () => {
+      if (pendingAndroidBranchStub) {
+        clearTimeout(pendingAndroidBranchStub.timer);
+        pendingAndroidBranchStub = null;
+      }
+    };
+
     const getBranchDeeplink = async (uri?: string) => {
       if (uri) {
         handleDeeplink({ uri });
@@ -161,6 +209,18 @@ export class DeeplinkManager {
 
     Linking.addEventListener('url', (params) => {
       const { url } = params;
+      if (isAndroidBranchStubUrl(url)) {
+        // Defer the stub: branch.subscribe will fire shortly with the resolved URL (and UTMs) and trigger handleDeeplink itself.
+        clearAndroidBranchStub();
+        const timer = setTimeout(() => {
+          // Safety net: process the stub anyway so the deeplink isn't lost if Branch never resolves (network failure, SDK error, ...).
+          pendingAndroidBranchStub = null;
+          handleDeeplink({ uri: url });
+        }, ANDROID_BRANCH_STUB_FALLBACK_MS);
+        pendingAndroidBranchStub = { url, timer };
+        return;
+      }
+
       handleDeeplink({ uri: url });
     });
 
@@ -175,6 +235,19 @@ export class DeeplinkManager {
         const branchError = new Error(error);
         Logger.error(branchError, 'Error subscribing to branch.');
       }
+      // Branch resolved — cancel any deferred Android stub fallback so we don't double-process the deeplink.
+      clearAndroidBranchStub();
+
+      // Branch.subscribe fires for every onNewIntent on Android, including
+      // intents that carry a non-Branch URI (e.g. `metamask://buy`). For those
+      // we have no uri and `+clicked_branch_link` is false; the URI has
+      // already been delivered to handleDeeplink via Linking.addEventListener
+      // (warm start) or Linking.getInitialURL (cold start). Falling through
+      // to getBranchDeeplink would re-fetch the same URI from
+      // `+non_branch_link` and dispatch it a second time.
+      const isBranchClick = opts.params?.['+clicked_branch_link'] === true;
+      if (!opts.uri && !isBranchClick) return;
+
       const rewritten = rewriteBranchUri(
         opts.uri,
         opts.params as Record<string, unknown> | undefined,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
On Android, when a Branch deeplink is clicked while the app is already open, the Branch SDK delivers two events in sequence:

1. Linking.addEventListener fires immediately with an opaque stub URL (metamask://<path>?_branch_referrer=<token>) -> no UTMs present.
2. branch.subscribe fires ~500 ms later with the resolved URL and decoded UTM params.
Previously, the app processed the stub URL on arrival (step 1), firing the DEEP_LINK_USED analytics event with empty UTMs before Branch had resolved the attribution. branch.subscribe then triggered a second processing pass, causing the deeplink handler to run twice.

Changes:
- DeeplinkManager.ts: When Linking.addEventListener receives an Android Branch stub URL (detected by the presence of _branch_referrer=), processing is deferred and branch.subscribe is allowed to deliver the resolved URL with UTMs. A 3-second fallback timer ensures the deeplink is never silently lost if Branch fails to resolve (network error, SDK failure). Once branch.subscribe fires, the pending stub is cancelled.
  Additionally, branch.subscribe now skips the getBranchDeeplink() fallback for non-Branch clicks (+clicked_branch_link=false, no uri). On Android this callback fires for every onNewIntent — including plain metamask:// scheme links — causing those deeplinks to be processed twice (once via Linking, once via branch.subscribe re-fetching the same URL from +non_branch_link).
- DeeplinkManager.test.ts: Unit tests covering both fixes — stub deferral, stub cancellation, 3-second fallback, iOS unaffected, non-Branch skip.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-49
Fixes: https://consensyssoftware.atlassian.net/browse/GE-198

## **Manual testing steps**

**Manual testing steps**

All tests on Android (warm start is the primary fix; include cold start to cover the full scope).

**Branch deeplink with UTMs — warm start (primary fix)**
1. Open the app, navigate to any screen, background it.
2. Click a Branch deeplink with UTM params (e.g. `https://metamask.app.link/buy?utm_source=twitter`).
3. Verify in logcat "DeepLinkAnalytics: Tracked" event:
   - `DEEP_LINK_USED` fires once
   - `utm_source` is populated

**Branch deeplink with UTMs — cold start**
1. Force-kill the app.
2. Click the same Branch deeplink.
3. Same assertions as above.

**Plain `metamask://` deeplink — warm start (double-dispatch fix)**
1. Background the app.
2. Open `https://link.metamask.io/buy?assetId=solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501`.
3. Verify you land on the buy page for SOL, not the asset selector like on previous versions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android warm-start deeplink dispatch timing and adds a timeout-based fallback, which could affect deeplink handling order and introduce edge-case double/late dispatch if incorrect. Covered by new unit tests, but impacts a core entry path for navigation/analytics.
> 
> **Overview**
> Fixes Android *warm-start* Branch deeplink handling by **deferring processing of Branch “stub” `metamask://...?_branch_referrer=...` URLs** until `branch.subscribe` provides the resolved URL with UTM params, with a **3s fallback timer** to avoid losing the deeplink if Branch never resolves.
> 
> Prevents **duplicate deeplink dispatch** by cancelling any pending stub fallback when Branch resolves, and by skipping the `getBranchDeeplink()` fallback path when `branch.subscribe` fires for non-Branch intents (no `uri` and not a Branch click). Adds targeted unit tests for stub detection/deferral, fallback, and non-Branch no-op behavior, and updates `CODEOWNERS` to route `app/core/DeeplinkManager` to `@MetaMask/notifications`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adff9464a6eccf6c13e9fd3d8a31dc4401e1f79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->