### PR TITLE
fix(perps): limit price percentage buttons now compound on current price

### DIFF
--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
@@ -515,6 +515,37 @@ describe('PerpsLimitPriceBottomSheet', () => {
     });
   });
 
+  describe('Compound percentage regression (TAT-3097)', () => {
+    it('uses limitPrice as base (not currentPrice) when limitPrice is already set', () => {
+      // Regression: old code always used currentPrice, so repeated presses had no effect
+      // because the calculated value never changed.
+      const { BigNumber: MockBigNumber } = jest.requireMock('bignumber.js');
+
+      render(
+        <PerpsLimitPriceBottomSheet
+          {...defaultProps}
+          direction="long"
+          limitPrice="3100"
+          currentPrice={3000}
+        />,
+      );
+
+      // Clear constructor calls that may have occurred during rendering
+      MockBigNumber.mockClear();
+
+      fireEvent.press(screen.getByText('-1%'));
+
+      // BigNumber must be called with the limitPrice (3100), not currentPrice (3000).
+      // The mock's toString() returns its constructor argument, so this assertion
+      // would fail on the pre-fix code that always passed currentPrice.
+      const constructorArgs = MockBigNumber.mock.calls.map(
+        ([arg]: [number]) => arg,
+      );
+      expect(constructorArgs).toContain(3100);
+      expect(constructorArgs).not.toContain(3000);
+    });
+  });
+
   describe('Preset decimal precision (TAT-2399)', () => {
     const xrpProps = {
       ...defaultProps,

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -284,7 +284,8 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
   }, [limitPrice, currentPrice, direction, isClosingPosition]);
 
   /**
-   * Calculate limit price based on percentage from current market price
+   * Calculate limit price based on percentage from the current limit price (or
+   * market price when no limit price is set yet).
    * @param percentage - Percentage to add/subtract from current price
    * @returns Calculated price as string (e.g., "45123.50")
    *
@@ -293,8 +294,10 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
    */
   const calculatePriceForPercentage = useCallback(
     (percentage: number) => {
-      // Use the current market price (not limit price) for percentage calculations
-      const basePrice = currentPrice;
+      const parsedLimitPrice = limitPrice
+        ? parseFloat(limitPrice.replace(/[$,]/g, ''))
+        : 0;
+      const basePrice = parsedLimitPrice > 0 ? parsedLimitPrice : currentPrice;
 
       if (!basePrice || basePrice === 0) {
         return '';
@@ -304,11 +307,9 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
       const calculatedPrice = BigNumber(basePrice)
         .multipliedBy(multiplier)
         .toString();
-      // Return the raw numeric value as a string (without formatting)
-      // The display will format it when needed
       return calculatedPrice;
     },
-    [currentPrice],
+    [currentPrice, limitPrice],
   );
 
   const footerButtonProps = [


### PR DESCRIPTION
## **Description**

Pressing `-1%` or `-2%` in the "Set limit price" modal only changed the displayed price on the first press. Subsequent presses had no effect.

Root cause: `calculatePriceForPercentage` always used the live market price as the base. Every press returned the same calculated value, so React skipped the state update entirely.

Fix: use the currently displayed `limitPrice` as the base for each calculation, falling back to market price only when the field is empty. Each press now compounds correctly ($78,181 → $77,399 → $76,625 → …).

Regression introduced in #24069 (TAT-2114).

## **Changelog**

CHANGELOG entry: Fixed a bug where the -1%/-2% limit price preset buttons only applied on the first press.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3097

## **Manual testing steps**

\`\`\`gherkin
Feature: Limit price percentage presets

  Scenario: User presses -1% multiple times
    Given user is on the order form with direction set to Long
    When user taps "Limit" order type and opens the limit price modal
    And user taps the "-1%" button once
    Then limit price decreases by 1% from market price
    When user taps the "-1%" button again
    Then limit price decreases by another 1% from the previous value
    When user taps the "-1%" button a third time
    Then limit price decreases by another 1% again (compounds correctly)
\`\`\`

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e3a9de99-a0ba-4f65-a0fb-f163021acef4


### **After**

[<!-- [screenshots/recordings] -->
](https://github.com/user-attachments/assets/4fb3e130-b802-477c-af0d-5e664dc93556)
## **Pre-merge author checklist**




- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI price calculation logic with added test coverage; minimal risk beyond preset price behavior.
> 
> **Overview**
> Fixes the limit-price percentage preset calculation in `PerpsLimitPriceBottomSheet` so `%` buttons compound off the *currently entered* `limitPrice` (sanitized/parsed), falling back to `currentPrice` only when no limit is set.
> 
> Adds a regression test (TAT-3097) asserting the percentage calculation uses `limitPrice` as the BigNumber base when it’s already populated, preventing the “only first press works” bug from returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699decd520b4a60f5159202e0c42895e05efd2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

