### PR TITLE
fix: Zip iOS .app bundles for runway bucket

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,13 +462,19 @@ jobs:
         run: node scripts/rename-artifacts.js ${{ matrix.platform }}
 
       # Upload build artifacts (only if build succeeded)
+      # ios_simulator_path is set by scripts/rename-artifacts.js (staged under ios-simulator-upload/
+      # in CI so upload-artifact uploads a .zip file, not a .app directory).
       - name: Upload iOS simulator app
-        if: matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
+        if: success() && matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ios-app-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_simulator_path }}
           if-no-files-found: error
+
+      - name: Remove iOS simulator staging directory
+        if: success() && matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
+        run: rm -rf ios-simulator-upload
 
       - name: Upload iOS IPA
         if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -215,9 +215,25 @@ function setGithubOutput(key, value) {
 }
 
 /**
+ * Path relative to GITHUB_WORKSPACE (or cwd) for upload-artifact.
+ * upload-artifact treats `.app` bundles as directories; staging the ditto zip
+ * under ios-simulator-upload/ and emitting this path ensures the artifact is a file.
+ */
+function toRepoRelative(absFilePath) {
+  const root = process.env.GITHUB_WORKSPACE || process.cwd();
+  const resolved = path.resolve(absFilePath);
+  const rel = path.relative(root, resolved);
+  if (rel.startsWith('..')) {
+    return resolved;
+  }
+  return rel;
+}
+
+/**
  * Rename iOS artifacts
  *
- * Simulator-only: ios_simulator_path (zipped .app).
+ * Simulator-only: ios_simulator_path (zipped .app; under CI, copied to
+ * ios-simulator-upload/ so upload-artifact uploads a .zip file, not a .app directory).
  * Device-only: ios_ipa_path, ios_archive_path, ios_sourcemap_path.
  * Dual (IS_SIM_BUILD + IS_DEVICE_BUILD, e.g. main-dev): all of the above.
  */
@@ -268,7 +284,18 @@ function renameIos() {
         `ditto -c -k --sequesterRsrc --keepParent "${newApp}" "${zipPath}"`,
       );
       console.log(`✅ Zipped: ${zipPath}`);
-      setGithubOutput('ios_simulator_path', zipPath);
+
+      let simulatorUploadPath = zipPath;
+      if (process.env.GITHUB_OUTPUT) {
+        const stagingDir = path.join(__dirname, '../ios-simulator-upload');
+        fs.rmSync(stagingDir, { recursive: true, force: true });
+        fs.mkdirSync(stagingDir, { recursive: true });
+        const stagedZip = path.join(stagingDir, path.basename(zipPath));
+        fs.copyFileSync(zipPath, stagedZip);
+        simulatorUploadPath = stagedZip;
+        console.log(`✅ Staged simulator zip for CI upload: ${stagedZip}`);
+      }
+      setGithubOutput('ios_simulator_path', toRepoRelative(simulatorUploadPath));
     } else {
       console.log(`⚠️  Simulator .app not found: ${oldApp}`);
     }

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -286,7 +286,7 @@ function renameIos() {
       );
       console.log(`✅ Zipped: ${zipPath}`);
 
-      const doubleZipPath = path.join(simProductsDir, `${newSimBaseName}.double.zip`);
+      const doubleZipPath = path.join(simProductsDir, `${newSimBaseName}.app.zip`);
       execSync(
         `ditto -c -k --sequesterRsrc "${zipPath}" "${doubleZipPath}"`,
       );

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -216,7 +216,7 @@ function setGithubOutput(key, value) {
 
 /**
  * Path relative to GITHUB_WORKSPACE (or cwd) for upload-artifact.
- * upload-artifact treats `.app` bundles as directories; staging the ditto zip
+ * upload-artifact treats `.app` bundles as directories; staging the outer zip
  * under ios-simulator-upload/ and emitting this path ensures the artifact is a file.
  */
 function toRepoRelative(absFilePath) {
@@ -232,8 +232,9 @@ function toRepoRelative(absFilePath) {
 /**
  * Rename iOS artifacts
  *
- * Simulator-only: ios_simulator_path (zipped .app; under CI, copied to
- * ios-simulator-upload/ so upload-artifact uploads a .zip file, not a .app directory).
+ * Simulator-only: ios_simulator_path — inner zip is ditto of .app; outer zip is
+ * ditto of that inner zip (double-zip). Under CI, the outer zip is copied to
+ * ios-simulator-upload/ for upload-artifact.
  * Device-only: ios_ipa_path, ios_archive_path, ios_sourcemap_path.
  * Dual (IS_SIM_BUILD + IS_DEVICE_BUILD, e.g. main-dev): all of the above.
  */
@@ -285,15 +286,21 @@ function renameIos() {
       );
       console.log(`✅ Zipped: ${zipPath}`);
 
-      let simulatorUploadPath = zipPath;
+      const doubleZipPath = path.join(simProductsDir, `${newSimBaseName}.double.zip`);
+      execSync(
+        `ditto -c -k --sequesterRsrc "${zipPath}" "${doubleZipPath}"`,
+      );
+      console.log(`✅ Double-zipped (outer contains inner .zip): ${doubleZipPath}`);
+
+      let simulatorUploadPath = doubleZipPath;
       if (process.env.GITHUB_OUTPUT) {
         const stagingDir = path.join(__dirname, '../ios-simulator-upload');
         fs.rmSync(stagingDir, { recursive: true, force: true });
         fs.mkdirSync(stagingDir, { recursive: true });
-        const stagedZip = path.join(stagingDir, path.basename(zipPath));
-        fs.copyFileSync(zipPath, stagedZip);
+        const stagedZip = path.join(stagingDir, path.basename(doubleZipPath));
+        fs.copyFileSync(doubleZipPath, stagedZip);
         simulatorUploadPath = stagedZip;
-        console.log(`✅ Staged simulator zip for CI upload: ${stagedZip}`);
+        console.log(`✅ Staged simulator double-zip for CI upload: ${stagedZip}`);
       }
       setGithubOutput('ios_simulator_path', toRepoRelative(simulatorUploadPath));
     } else {

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 const platform = process.argv[2];
 
@@ -72,9 +72,11 @@ if (!buildType || !environment) {
  */
 function findFiles(dir, pattern) {
   try {
-    const output = execSync(`find "${dir}" -name "${pattern}" -type f 2>/dev/null || true`, {
-      encoding: 'utf8',
-    }).trim();
+    const output = execFileSync(
+      'find',
+      [dir, '-name', pattern, '-type', 'f'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
     return output ? output.split('\n') : [];
   } catch {
     return [];
@@ -86,9 +88,11 @@ function findFiles(dir, pattern) {
  */
 function findDirs(dir, pattern) {
   try {
-    const output = execSync(`find "${dir}" -name "${pattern}" -type d 2>/dev/null || true`, {
-      encoding: 'utf8',
-    }).trim();
+    const output = execFileSync(
+      'find',
+      [dir, '-name', pattern, '-type', 'd'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
     return output ? output.split('\n') : [];
   } catch {
     return [];
@@ -277,18 +281,22 @@ function renameIos() {
     const oldApp = path.join(simProductsDir, `${appName}.app`);
     if (fs.existsSync(oldApp)) {
       const newApp = path.join(simProductsDir, `${newSimBaseName}.app`);
-      execSync(`cp -r "${oldApp}" "${newApp}"`);
+      execFileSync('cp', ['-r', oldApp, newApp], { stdio: 'inherit' });
       console.log(`✅ Renamed simulator .app: ${newApp}`);
 
       const zipPath = path.join(simProductsDir, `${newSimBaseName}.zip`);
-      execSync(
-        `ditto -c -k --sequesterRsrc --keepParent "${newApp}" "${zipPath}"`,
+      execFileSync(
+        'ditto',
+        ['-c', '-k', '--sequesterRsrc', '--keepParent', newApp, zipPath],
+        { stdio: 'inherit' },
       );
       console.log(`✅ Zipped: ${zipPath}`);
 
       const doubleZipPath = path.join(simProductsDir, `${newSimBaseName}.app.zip`);
-      execSync(
-        `ditto -c -k --sequesterRsrc "${zipPath}" "${doubleZipPath}"`,
+      execFileSync(
+        'ditto',
+        ['-c', '-k', '--sequesterRsrc', zipPath, doubleZipPath],
+        { stdio: 'inherit' },
       );
       console.log(`✅ Double-zipped (outer contains inner .zip): ${doubleZipPath}`);
 
@@ -330,8 +338,10 @@ function renameIos() {
         __dirname,
         `../ios/build/${newDeviceBaseName}.xcarchive.zip`,
       );
-      execSync(
-        `ditto -c -k --sequesterRsrc --keepParent "${oldArchive}" "${archiveZip}"`,
+      execFileSync(
+        'ditto',
+        ['-c', '-k', '--sequesterRsrc', '--keepParent', oldArchive, archiveZip],
+        { stdio: 'inherit' },
       );
       console.log(`✅ Zipped archive: ${archiveZip}`);
       setGithubOutput('ios_archive_path', archiveZip);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In the past, we've experienced issues where Runway buckets would not pick up .app bundles. Our fix at the time was to zip the bundle since Runway recognizes zipped files. This change applies the zipped solution to Expo Dev Builds for iOS simulator builds.

Expo Dev Build - https://github.com/MetaMask/metamask-mobile/actions/runs/25011093158

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:  https://consensyssoftware.atlassian.net/browse/MCWP-559

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="300" height="53" alt="image" src="https://github.com/user-attachments/assets/39f2fa71-9fde-4f42-9f17-09d052a518cb" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI artifact packaging and upload paths for iOS simulator builds, which could break build outputs or downstream consumers if the new double-zip/staging behavior is misaligned.
> 
> **Overview**
> iOS simulator build artifacts are now **packaged as a double-zipped file** and, in CI, **staged under `ios-simulator-upload/`** so `actions/upload-artifact` uploads a single `.zip` file instead of treating the `.app` bundle as a directory.
> 
> The artifact renaming script switches from shell-string `execSync` calls to `execFileSync` for `find`, `cp`, and `ditto`, and emits repo-relative paths for GitHub Actions outputs. The build workflow also tightens the upload condition to `success()` and cleans up the simulator staging directory after upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666b47b7d86935aa0d9882b4979d21b07cfbab8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->