### PR TITLE
fix(ramp): keep stable action text node in build quote

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -1739,9 +1739,12 @@ describe('BuildQuote', () => {
         // selectedToken. tokenStateIsSettled is false during this render.
         mockUseParams.mockReturnValue({ assetId: 'eip155:1/slip44:999' });
 
-        const { queryByText, getByTestId } = renderWithProvider(<BuildQuote />, {
-          state: initialRootState,
-        });
+        const { queryByText, getByTestId } = renderWithProvider(
+          <BuildQuote />,
+          {
+            state: initialRootState,
+          },
+        );
 
         expect(queryByText('Powered by MoonPay')).not.toBeOnTheScreen();
         expect(

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.test.tsx
@@ -4,6 +4,7 @@ import BuildQuote, {
   createBuildQuoteNavDetails,
   isBailedOrderStatus,
 } from './BuildQuote';
+import { BUILD_QUOTE_TEST_IDS } from './BuildQuote.testIds';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import initialRootState from '../../../../../util/test/initial-root-state';
 import { BuildQuoteSelectors } from '../../Aggregator/Views/BuildQuote/BuildQuote.testIds';
@@ -1738,11 +1739,14 @@ describe('BuildQuote', () => {
         // selectedToken. tokenStateIsSettled is false during this render.
         mockUseParams.mockReturnValue({ assetId: 'eip155:1/slip44:999' });
 
-        const { queryByText } = renderWithProvider(<BuildQuote />, {
+        const { queryByText, getByTestId } = renderWithProvider(<BuildQuote />, {
           state: initialRootState,
         });
 
         expect(queryByText('Powered by MoonPay')).not.toBeOnTheScreen();
+        expect(
+          getByTestId(BUILD_QUOTE_TEST_IDS.ACTION_MESSAGE_PLACEHOLDER),
+        ).toBeOnTheScreen();
       });
 
       it('shows Continue button as loading while nav params have not caught up to controller-selected token', () => {

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.testIds.ts
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.testIds.ts
@@ -1,4 +1,5 @@
 export const BUILD_QUOTE_TEST_IDS = {
   BACK_BUTTON: 'build-quote-back-button',
   SETTINGS_BUTTON: 'build-quote-settings-button',
+  ACTION_MESSAGE_PLACEHOLDER: 'build-quote-action-message-placeholder',
 } as const;

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -718,7 +718,13 @@ function BuildQuote() {
         </Text>
       );
     }
-    return null;
+    return (
+      <Text
+        testID={BUILD_QUOTE_TEST_IDS.ACTION_MESSAGE_PLACEHOLDER}
+        variant={TextVariant.BodySm}
+        style={styles.poweredByText}
+      />
+    );
   })();
 
   return (

--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -723,7 +723,9 @@ function BuildQuote() {
         testID={BUILD_QUOTE_TEST_IDS.ACTION_MESSAGE_PLACEHOLDER}
         variant={TextVariant.BodySm}
         style={styles.poweredByText}
-      />
+      >
+        {''}
+      </Text>
     );
   })();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This fixes a Build Quote UI stability issue from TRAM-3519 by always rendering a stable action-message text node in the footer area.

Previously, when neither an inline error nor `Powered by <Provider>` was present, the message slot returned `null`. Later renders could append a new node when one of those messages appeared, causing visual shift in the action section.

This PR:
- renders an empty placeholder `Text` node in that fallback case (instead of `null`), preserving layout structure
- adds a dedicated testID for the placeholder node
- updates BuildQuote tests to assert the placeholder exists in the sync-gap scenario where `Powered by` is intentionally suppressed

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-3519

## **Manual testing steps**

```gherkin
Feature: Stable action message layout in Build Quote

  Scenario: Footer message slot remains stable when provider text is absent
    Given the user is on the Buy > Build Quote screen
    And the selected token is temporarily out of sync with nav params so "Powered by <Provider>" is not rendered
    And there is no inline provider/error message
    When the action section is rendered
    Then an empty placeholder text node is present in the action message slot
    And the Continue button position remains stable without message-slot insertion shift
```

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/cbd7d132-68f3-4d82-bbf3-36d6f5329c9c



### **After**


https://github.com/user-attachments/assets/9c12efdc-c4c5-4faf-8a6e-ab980f208ee0



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a9b275-9946-40d6-8ee0-8da97f7d1b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a9b275-9946-40d6-8ee0-8da97f7d1b2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

