### PR TITLE
fix: Polish Top Traders filter patterns for consistency

### DIFF
--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -22,8 +22,8 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
   TextColor,
-  FontWeight,
 } from '@metamask/design-system-react-native';
+import { fontStyles } from '../../../../styles/common';
 import { useTheme } from '../../../../util/theme';
 import Logger from '../../../../util/Logger';
 import { strings } from '../../../../../locales/i18n';
@@ -70,19 +70,16 @@ const styles = StyleSheet.create({
   },
   pill: {
     borderRadius: 12,
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
     paddingVertical: 8,
-    marginRight: 16,
+    marginRight: 8,
     alignItems: 'center',
     justifyContent: 'center',
-    minHeight: 38,
-  },
-  pillBorder: {
-    borderWidth: 1,
+    minHeight: 40,
   },
   pillText: {
-    fontSize: 14,
-    fontWeight: FontWeight.Medium,
+    ...fontStyles.medium,
+    fontSize: 16,
   },
 });
 
@@ -110,7 +107,7 @@ const ChainPill: React.FC<ChainPillProps> = ({
         styles.pill,
         isSelected
           ? { backgroundColor: colors.icon.default }
-          : [styles.pillBorder, { borderColor: colors.border.muted }],
+          : { backgroundColor: colors.background.muted },
       ]}
     >
       <RNText
@@ -211,12 +208,8 @@ const TopTradersView = () => {
         />
       </Box>
 
-      <Box twClassName="px-4 pt-2 pb-3 mb-2">
-        <Text
-          variant={TextVariant.HeadingLg}
-          color={TextColor.TextDefault}
-          fontWeight={FontWeight.Medium}
-        >
+      <Box twClassName="px-4 pt-2 pb-3">
+        <Text variant={TextVariant.HeadingLg} color={TextColor.TextDefault}>
           {strings('social_leaderboard.top_traders_view.title')}
         </Text>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR refines the filter patterns for consistency across features. It's part of an initiative to standardize our design patterns across features for filters. See [this page](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1204-1329) for more context.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related PRs:

https://github.com/MetaMask/metamask-mobile/pull/29396
https://github.com/MetaMask/metamask-mobile/pull/29391

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="310" height="620" alt="Screenshot 2026-04-28 at 7 59 30 PM" src="https://github.com/user-attachments/assets/8b9c8555-a11a-49e8-82ec-029d5110fc92" />


### **After**

<img width="1269" height="712" alt="Screenshot 2026-04-28 at 1 45 07 PM" src="https://github.com/user-attachments/assets/4e8c9cd3-d057-4dcf-8fd1-417758fa6837" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to UI styling (spacing, typography, and colors) in `TopTradersView` with no logic or data-flow modifications.
> 
> **Overview**
> Updates `TopTradersView` chain filter pills for consistent styling: adjusts pill padding/margins/height, switches the unselected state from an outlined border to a muted background fill, and updates pill text to use `fontStyles.medium` with a larger font size.
> 
> Also removes explicit `FontWeight` usage on the screen title and tweaks surrounding spacing to match the refreshed layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5288e067d084f4c39fbbae0558279d5720b3b77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->