### PR TITLE
fix(android): use committed dev keystore for local prodDebug builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -302,6 +302,19 @@ android {
     buildTypes {
         debug {
             manifestPlaceholders.isDebug = true
+            // AGP installs a built-in default debug signingConfig on this buildType
+            // (pointing at ~/.android/debug.keystore on the developer's machine), and
+            // during variant merging the buildType's signingConfig wins over the
+            // productFlavor's. For local dev builds (METAMASK_ENVIRONMENT=dev) this
+            // silently overrides the prod/flask `*Dev` signingConfigs declared on the
+            // productFlavors below, so APKs ship with each developer's personal keystore
+            // instead of the committed `android/app/debug.keystore` whose SHA-1 is
+            // registered in GCP for Google Sign-In. Pin the committed keystore here for
+            // dev-env builds; non-dev envs retain AGP's auto-default (Bitrise CI builds
+            // Release, so its signing path is unaffected).
+            if (System.getenv("METAMASK_ENVIRONMENT") == "dev") {
+                signingConfig signingConfigs.mainDev
+            }
         }
         release {
             manifestPlaceholders.isDebug = false


### PR DESCRIPTION
## **Description**

**TLDR:** Running `yarn start:android` on the Android emulator: social login (Google Sign-In) does not work, because the resulting APK is signed with the developer's personal `~/.android/debug.keystore` instead of the committed `android/app/debug.keystore` (added in [#15637](https://github.com/MetaMask/metamask-mobile/pull/15637)). After this PR, dev builds use the committed keystore and Google Sign-In works on the emulator.

### Background

The committed `android/app/debug.keystore` was added so all developers' local builds would share a SHA-1 registered in GCP for the Android Google Sign-In OAuth client. The wiring only took effect on Bitrise CI (which builds Release) — locally, `*Debug` variants kept getting signed with each developer's personal keystore, so Credential Manager rejected the id-token request (`Auth.Api … cgfd: UnsupportedApiOperation` in logcat).

### Root cause + fix

AGP installs a default debug `signingConfig` on the `debug` buildType (→ `~/.android/debug.keystore`), and during variant merging it wins over the productFlavor's `mainDev` / `flaskDev`. Pin `signingConfigs.mainDev` on the `debug` buildType when `METAMASK_ENVIRONMENT=dev` (same keystore file as `flaskDev`, so both flavors are covered). Non-dev envs and Release variants are untouched, so Bitrise CI is unaffected.

Note: `android/app/build.gradle` has no explicit owner in CODEOWNERS — flagging mobile-platform for awareness.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Originating intent: [#15637](https://github.com/MetaMask/metamask-mobile/pull/15637).

Fixes:

## **Manual testing steps**

```gherkin
Feature: Google Sign-In works on the Android emulator for dev builds

  Scenario: Fresh sign-in via Onboarding
    Given a booted Android emulator
      And METAMASK_ENVIRONMENT=dev and METAMASK_BUILD_TYPE=main

    When the developer runs `adb uninstall io.metamask` then `yarn start:android`
      And taps "I have an existing wallet" → "Continue with Google" and picks an account
    Then logcat shows `GoogleAcm: Google ID Token Credential ID: <email>` and `Social Login Completed`
     And there is no `Auth.Api … cgfd: UnsupportedApiOperation` after a real account tap
```

## **Screenshots/Recordings**

### **Before**

N/A — build-config change.

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-configuration change scoped to local `debug` builds when `METAMASK_ENVIRONMENT=dev`, but it could affect developer build/signing expectations if the env var is set incorrectly.
> 
> **Overview**
> Ensures local Android *dev-environment* `debug` variants are signed with the committed `android/app/debug.keystore` instead of each developer’s default `~/.android/debug.keystore`.
> 
> This conditionally pins the `debug` buildType signing config to `signingConfigs.mainDev` when `METAMASK_ENVIRONMENT=dev`, preventing flavor-level `*Dev` signing configs from being overridden during variant merge and unblocking Google Sign-In for local emulator builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c7c49422b254976a238f9e411d1b55b12f2cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->