### PR TITLE
fix: Refactor Predictions search for consistency

### DIFF
--- a/app/components/UI/Predict/Predict.testIds.ts
+++ b/app/components/UI/Predict/Predict.testIds.ts
@@ -49,7 +49,6 @@ export const getPredictMarketListSelector = {
 export const PredictFeedSelectorsIDs = {
   TABS: 'predict-feed-tabs',
   PAGER: 'predict-feed-pager',
-  SEARCH_ICON: 'search-icon',
 } as const;
 
 export const getPredictFeedSelector = {

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -323,30 +323,32 @@ describe('PredictFeed', () => {
     });
 
     it('hides search overlay on initial render', () => {
-      const { queryByTestId } = render(<PredictFeed />);
+      const { queryByPlaceholderText } = render(<PredictFeed />);
 
-      expect(queryByTestId(PredictFeedSelectorsIDs.SEARCH_ICON)).toBeNull();
+      expect(queryByPlaceholderText('Search prediction markets')).toBeNull();
     });
   });
 
   describe('search functionality', () => {
     it('opens search overlay when search button pressed', () => {
-      const { getByTestId } = render(<PredictFeed />);
+      const { getByTestId, getByPlaceholderText } = render(<PredictFeed />);
 
       fireEvent.press(getByTestId(PredictSearchSelectorsIDs.SEARCH_BUTTON));
 
       expect(
-        getByTestId(PredictFeedSelectorsIDs.SEARCH_ICON),
+        getByPlaceholderText('Search prediction markets'),
       ).toBeOnTheScreen();
     });
 
     it('closes search overlay when cancel button pressed', () => {
-      const { getByTestId, getByText, queryByTestId } = render(<PredictFeed />);
+      const { getByTestId, getByText, queryByPlaceholderText } = render(
+        <PredictFeed />,
+      );
 
       fireEvent.press(getByTestId(PredictSearchSelectorsIDs.SEARCH_BUTTON));
       fireEvent.press(getByText('Cancel'));
 
-      expect(queryByTestId(PredictFeedSelectorsIDs.SEARCH_ICON)).toBeNull();
+      expect(queryByPlaceholderText('Search prediction markets')).toBeNull();
     });
   });
 
@@ -957,10 +959,10 @@ describe('PredictFeed', () => {
           },
         });
 
-        const { getByTestId } = render(<PredictFeed />);
+        const { getByPlaceholderText } = render(<PredictFeed />);
 
         expect(
-          getByTestId(PredictFeedSelectorsIDs.SEARCH_ICON),
+          getByPlaceholderText('Search prediction markets'),
         ).toBeOnTheScreen();
       },
     );
@@ -990,14 +992,15 @@ describe('PredictFeed', () => {
         },
       });
 
-      const { getByText, getByTestId, queryByTestId } = render(<PredictFeed />);
+      const { getByText, queryByPlaceholderText, getByPlaceholderText } =
+        render(<PredictFeed />);
 
       expect(
-        getByTestId(PredictFeedSelectorsIDs.SEARCH_ICON),
+        getByPlaceholderText('Search prediction markets'),
       ).toBeOnTheScreen();
 
       fireEvent.press(getByText('Cancel'));
-      expect(queryByTestId(PredictFeedSelectorsIDs.SEARCH_ICON)).toBeNull();
+      expect(queryByPlaceholderText('Search prediction markets')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -8,9 +8,7 @@ import React, {
 import { useSelector } from 'react-redux';
 import {
   View,
-  Pressable,
   RefreshControl,
-  TextInput,
   Platform,
   LayoutChangeEvent,
 } from 'react-native';
@@ -22,8 +20,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  BoxAlignItems,
-  BoxFlexDirection,
   Icon,
   IconColor,
   IconName,
@@ -89,6 +85,9 @@ import {
   TabsBar,
 } from '../../../../../component-library/components-temp/Tabs';
 import HeaderCompactStandard from '../../../../../component-library/components-temp/HeaderCompactStandard';
+import HeaderSearch, {
+  HeaderSearchVariant,
+} from '../../../../../component-library/components-temp/HeaderSearch';
 
 type PredictFlashListRef = FlashListRef<PredictMarketType>;
 type PredictFlashListProps = FlashListProps<PredictMarketType> & {
@@ -545,54 +544,31 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
         backgroundColor: colors.background.default,
       })}
     >
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        twClassName="w-full py-2 px-4 gap-3"
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="flex-1 bg-muted rounded-lg px-3 py-2"
-        >
-          <Icon
-            testID={PredictFeedSelectorsIDs.SEARCH_ICON}
-            name={IconName.Search}
-            size={IconSize.Sm}
-            color={IconColor.IconMuted}
-            style={tw.style('mr-2')}
-          />
-          <TextInput
-            placeholder={strings('predict.search_placeholder')}
-            placeholderTextColor={colors.text.muted}
-            value={searchQuery}
-            onChangeText={onSearchChange}
-            style={tw.style('flex-1 text-base text-default')}
-            autoFocus
-          />
-          {searchQuery.length > 0 && (
-            <Pressable
-              testID={PredictSearchSelectorsIDs.CLEAR_BUTTON}
-              onPress={() => onSearchChange('')}
-            >
-              <Icon
-                name={IconName.CircleX}
-                size={IconSize.Md}
-                color={IconColor.IconMuted}
-              />
-            </Pressable>
-          )}
-        </Box>
-        <Pressable onPress={onClose}>
-          <Text variant={TextVariant.BodyMd} style={tw.style('font-medium')}>
-            {strings('predict.search_cancel')}
-          </Text>
-        </Pressable>
+      <Box twClassName="w-full py-2">
+        <HeaderSearch
+          variant={HeaderSearchVariant.Inline}
+          onPressCancelButton={onClose}
+          cancelButtonProps={{
+            // ButtonBase applies self-start when not full width, which top-aligns the
+            // Cancel control vs. the centered TextFieldSearch row.
+            style: { alignSelf: 'center' },
+          }}
+          textFieldSearchProps={{
+            value: searchQuery,
+            onChangeText: onSearchChange,
+            onPressClearButton: () => onSearchChange(''),
+            placeholder: strings('predict.search_placeholder'),
+            autoFocus: true,
+            clearButtonProps: {
+              testID: PredictSearchSelectorsIDs.CLEAR_BUTTON,
+            },
+          }}
+        />
       </Box>
 
       <Box twClassName="flex-1">
         {isSearchLoading ? (
-          <Box twClassName="px-4 pt-4">
+          <Box twClassName="px-4">
             <PredictMarketSkeleton
               testID={getPredictFeedSelector.searchSkeleton(1)}
             />
@@ -619,7 +595,7 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
             data={marketData}
             renderItem={renderItem}
             keyExtractor={keyExtractor}
-            contentContainerStyle={tw.style('px-4 pt-4 pb-4')}
+            contentContainerStyle={tw.style('px-4 pb-4')}
             showsVerticalScrollIndicator={false}
           />
         )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR polishes the search pattern to use design system components. It improves overall cohesion of the product. For more design context, [see this page](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1204-1329).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict markets feed — search overlay (HeaderSearch)

  Scenario: user opens Predict search, queries markets, clears text, and dismisses search
    Given I am logged into MetaMask Mobile on the Predict feed with the main header and market list visible

    When user opens the Predict search experience, types a query that returns or loads matching markets, uses clear when text is present, and taps cancel to leave search

    Then the search UI uses the shared inline header search pattern (field, clear when applicable, cancel aligned with the field), results or loading state show with updated list top spacing, and cancel returns me to the normal Predict feed without the overlay
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="343" height="715" alt="Screenshot 2026-04-28 at 7 42 52 PM" src="https://github.com/user-attachments/assets/2b56fecf-b9dc-40ee-9fc7-9cd3243dc6d8" />


### **After**

<img width="642" height="706" alt="Screenshot 2026-04-28 at 4 46 34 PM" src="https://github.com/user-attachments/assets/04095b41-750d-4160-ab8d-88ac47a49087" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor: swaps the Predict feed search overlay UI to a design-system component and updates selectors/tests accordingly, with minimal logic changes.
> 
> **Overview**
> Refactors the Predict feed search overlay to use the design-system `HeaderSearch` (inline variant) instead of a custom `TextInput`/`Pressable` header, including wiring the cancel and clear actions through the new component.
> 
> Removes the `PredictFeedSelectorsIDs.SEARCH_ICON` test id and updates `PredictFeed` tests to assert search visibility via the search field placeholder text; also makes small layout tweaks to search results/skeleton padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5a54cec2f9938fc163bb289b761ec63f2e96a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->