### PR TITLE
feat(social-leaderboard): top-rank decorations, skeleton alignment, chain icon overlay

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -12,6 +12,7 @@ const mockTraders = [
   {
     id: 'trader-1',
     rank: 1,
+    overallRank: 1,
     username: 'alice',
     percentageChange: 96.2,
     pnlValue: 963000,
@@ -134,7 +135,7 @@ describe('TopTradersSection', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.SOCIAL_LEADERBOARD.PROFILE,
-      { traderId: 'trader-1', traderName: 'alice' },
+      { traderId: 'trader-1', traderName: 'alice', rank: 1 },
     );
   });
 

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -1,3 +1,7 @@
+import { Box } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import React, {
   forwardRef,
   useCallback,
@@ -6,24 +10,20 @@ import React, {
 } from 'react';
 import { View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { useNavigation } from '@react-navigation/native';
-import type { StackNavigationProp } from '@react-navigation/stack';
-import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
-import { Box } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
-import { SectionRefreshHandle } from '../../types';
-import { selectSocialLeaderboardEnabled } from '../../../../../selectors/featureFlagController/socialLeaderboard';
 import { strings } from '../../../../../../locales/i18n';
+import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import Routes from '../../../../../constants/navigation/Routes';
+import type { RootStackParamList } from '../../../../../core/NavigationService/types';
+import { selectSocialLeaderboardEnabled } from '../../../../../selectors/featureFlagController/socialLeaderboard';
+import ViewMoreCard from '../../components/ViewMoreCard';
 import useHomeViewedEvent, {
   HomeSectionNames,
 } from '../../hooks/useHomeViewedEvent';
+import { useSectionPerformance } from '../../hooks/useSectionPerformance';
+import { SectionRefreshHandle } from '../../types';
 import { TopTraderCard, TopTraderCardSkeleton } from './components';
 import { useTopTraders } from './hooks';
-import { useSectionPerformance } from '../../hooks/useSectionPerformance';
-import ViewMoreCard from '../../components/ViewMoreCard';
 
 const HOME_TRADER_LIMIT = 3;
 const SKELETON_KEYS = Array.from(
@@ -89,10 +89,11 @@ const TopTradersSection = forwardRef<
   }, [navigation]);
 
   const handleTraderPress = useCallback(
-    (traderId: string, traderName: string) => {
+    (traderId: string, traderName: string, rank: number) => {
       navigation.navigate(Routes.SOCIAL_LEADERBOARD.PROFILE, {
         traderId,
         traderName,
+        rank,
       });
     },
     [navigation],

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -115,6 +115,29 @@ describe('TopTraderCard', () => {
     );
   });
 
+  it('forwards trader.overallRank (not the filtered rank) to onTraderPress so the profile podium gates on true top-3 traders', () => {
+    const filteredTrader: TopTrader = {
+      ...baseTrader,
+      rank: 1,
+      overallRank: 50,
+    };
+    renderWithProvider(
+      <TopTraderCard
+        trader={filteredTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+
+    expect(mockOnTraderPress).toHaveBeenCalledWith(
+      'trader-1',
+      'sniperliquid',
+      50,
+    );
+  });
+
   it('does not call onTraderPress when the prop is not provided', () => {
     renderWithProvider(
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -7,6 +7,7 @@ import type { TopTrader } from '../types';
 const baseTrader: TopTrader = {
   id: 'trader-1',
   rank: 1,
+  overallRank: 1,
   username: 'sniperliquid',
   avatarUri: 'https://example.com/avatar.png',
   percentageChange: 43,
@@ -96,7 +97,7 @@ describe('TopTraderCard', () => {
     expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
   });
 
-  it('calls onTraderPress with trader.id and username when card content is tapped', () => {
+  it('calls onTraderPress with trader id, username, and rank when card content is tapped', () => {
     renderWithProvider(
       <TopTraderCard
         trader={baseTrader}
@@ -107,7 +108,11 @@ describe('TopTraderCard', () => {
 
     fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
 
-    expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'sniperliquid');
+    expect(mockOnTraderPress).toHaveBeenCalledWith(
+      'trader-1',
+      'sniperliquid',
+      1,
+    );
   });
 
   it('does not call onTraderPress when the prop is not provided', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -21,7 +21,7 @@ import { formatPnl } from '../utils/formatPnl';
 export interface TopTraderCardProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
-  onTraderPress?: (traderId: string, traderName: string) => void;
+  onTraderPress?: (traderId: string, traderName: string, rank: number) => void;
   testID?: string;
 }
 
@@ -57,7 +57,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         activeOpacity={onTraderPress ? 0.7 : 1}
         onPress={
           onTraderPress
-            ? () => onTraderPress(trader.id, trader.username)
+            ? () => onTraderPress(trader.id, trader.username, trader.rank)
             : undefined
         }
         disabled={!onTraderPress}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -21,7 +21,17 @@ import { formatPnl } from '../utils/formatPnl';
 export interface TopTraderCardProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
-  onTraderPress?: (traderId: string, traderName: string, rank: number) => void;
+  /**
+   * Invoked when the card is tapped. The third argument is the trader's
+   * **overall** (unfiltered) rank — used downstream to gate the profile's
+   * podium decoration on true top-3 traders, never the filtered display
+   * rank.
+   */
+  onTraderPress?: (
+    traderId: string,
+    traderName: string,
+    overallRank: number,
+  ) => void;
   testID?: string;
 }
 
@@ -57,7 +67,8 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         activeOpacity={onTraderPress ? 0.7 : 1}
         onPress={
           onTraderPress
-            ? () => onTraderPress(trader.id, trader.username, trader.rank)
+            ? () =>
+                onTraderPress(trader.id, trader.username, trader.overallRank)
             : undefined
         }
         disabled={!onTraderPress}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -1,14 +1,15 @@
+import { fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { screen, fireEvent } from '@testing-library/react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
-import TraderRow from './TraderRow';
 import type { TopTrader } from '../types';
+import TraderRow from './TraderRow';
 
 const baseTrader: TopTrader = {
   id: 'trader-1',
   rank: 1,
+  overallRank: 1,
   username: 'sniperliquid',
   avatarUri: 'https://example.com/avatar.png',
   percentageChange: 43,
@@ -29,7 +30,7 @@ describe('TraderRow', () => {
     renderWithProvider(
       <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
-    expect(screen.getByText('1.')).toBeOnTheScreen();
+    expect(screen.getByText('1')).toBeOnTheScreen();
     expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
     expect(screen.getByText('+43.0%')).toBeOnTheScreen();
     expect(screen.getByText('+$963K')).toBeOnTheScreen();
@@ -82,7 +83,11 @@ describe('TraderRow', () => {
       />,
     );
     fireEvent.press(screen.getByText('sniperliquid'));
-    expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'sniperliquid');
+    expect(mockOnTraderPress).toHaveBeenCalledWith(
+      'trader-1',
+      'sniperliquid',
+      1,
+    );
   });
 
   it('does not fire onTraderPress when the prop is undefined', () => {
@@ -137,6 +142,13 @@ describe('TraderRow', () => {
       return flat?.minWidth;
     };
 
+    const resolveAlignSelf = (node: ReactTestInstance): string | undefined => {
+      const flat = StyleSheet.flatten(node.props.style) as
+        | { alignSelf?: string }
+        | undefined;
+      return flat?.alignSelf;
+    };
+
     it('renders the stats line with numberOfLines=1 so it does not wrap when the button grows', () => {
       const trader: TopTrader = {
         ...baseTrader,
@@ -172,7 +184,11 @@ describe('TraderRow', () => {
     });
 
     it('renders the rank on a single line so the trailing dot does not wrap for double-digit ranks', () => {
-      const doubleDigitTrader: TopTrader = { ...baseTrader, rank: 20 };
+      const doubleDigitTrader: TopTrader = {
+        ...baseTrader,
+        rank: 20,
+        overallRank: 20,
+      };
       renderWithProvider(
         <TraderRow
           trader={doubleDigitTrader}
@@ -180,9 +196,23 @@ describe('TraderRow', () => {
         />,
       );
 
-      const rankText = screen.getByText('20.');
+      const rankText = screen.getByText('20');
 
       expect(rankText.props.numberOfLines).toBe(1);
+    });
+
+    it('vertically centers the Follow button so it sits in the middle of the row (overrides ButtonBase self-start default)', () => {
+      renderWithProvider(
+        <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+      );
+
+      const followLabel = screen.getByText('Follow');
+      const buttonWithAlignSelf = findAncestor(
+        followLabel,
+        (node) => resolveAlignSelf(node) === 'center',
+      );
+
+      expect(buttonWithAlignSelf).not.toBeNull();
     });
 
     it('keeps the same minimum width when toggling between Follow and Following', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -90,6 +90,29 @@ describe('TraderRow', () => {
     );
   });
 
+  it('forwards trader.overallRank (not the filtered rank) to onTraderPress so the profile podium gates on true top-3 traders', () => {
+    const filteredTrader: TopTrader = {
+      ...baseTrader,
+      rank: 1,
+      overallRank: 50,
+    };
+    renderWithProvider(
+      <TraderRow
+        trader={filteredTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('sniperliquid'));
+
+    expect(mockOnTraderPress).toHaveBeenCalledWith(
+      'trader-1',
+      'sniperliquid',
+      50,
+    );
+  });
+
   it('does not fire onTraderPress when the prop is undefined', () => {
     renderWithProvider(
       <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -29,7 +29,17 @@ export const TRADER_ROW_HEIGHT = 64;
 export interface TraderRowProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
-  onTraderPress?: (traderId: string, traderName: string, rank: number) => void;
+  /**
+   * Invoked when the row is tapped. The third argument is the trader's
+   * **overall** (unfiltered) rank — used downstream to gate the profile's
+   * podium decoration on true top-3 traders, never the filtered display
+   * rank.
+   */
+  onTraderPress?: (
+    traderId: string,
+    traderName: string,
+    overallRank: number,
+  ) => void;
   testID?: string;
 }
 
@@ -66,7 +76,8 @@ const TraderRow: React.FC<TraderRowProps> = ({
         activeOpacity={onTraderPress ? 0.7 : 1}
         onPress={
           onTraderPress
-            ? () => onTraderPress(trader.id, trader.username, trader.rank)
+            ? () =>
+                onTraderPress(trader.id, trader.username, trader.overallRank)
             : undefined
         }
         style={tw.style('flex-1 min-w-0 mr-3')}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -19,13 +19,17 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 import { formatPnl } from '../utils/formatPnl';
+import { TopRankAvatar, TopRankIndicator } from '../topRank';
 
 const AVATAR_SIZE = 40;
+// Fixed row height so the skeleton placeholder can match it exactly without
+// drifting due to font-scale or button-size differences.
+export const TRADER_ROW_HEIGHT = 64;
 
 export interface TraderRowProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
-  onTraderPress?: (traderId: string, traderName: string) => void;
+  onTraderPress?: (traderId: string, traderName: string, rank: number) => void;
   testID?: string;
 }
 
@@ -54,14 +58,15 @@ const TraderRow: React.FC<TraderRowProps> = ({
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
-      twClassName="px-4 py-3"
+      twClassName="px-4"
+      style={{ height: TRADER_ROW_HEIGHT }}
       testID={testID ?? `trader-row-${trader.id}`}
     >
       <TouchableOpacity
         activeOpacity={onTraderPress ? 0.7 : 1}
         onPress={
           onTraderPress
-            ? () => onTraderPress(trader.id, trader.username)
+            ? () => onTraderPress(trader.id, trader.username, trader.rank)
             : undefined
         }
         style={tw.style('flex-1 min-w-0 mr-3')}
@@ -72,30 +77,27 @@ const TraderRow: React.FC<TraderRowProps> = ({
           alignItems={BoxAlignItems.Center}
           gap={3}
         >
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-            numberOfLines={1}
-            twClassName="w-8 text-right"
-          >
-            {`${trader.rank}.`}
-          </Text>
+          <TopRankIndicator
+            rank={trader.rank}
+            podiumRank={trader.overallRank}
+          />
 
-          {trader.avatarUri ? (
-            <Image
-              source={{ uri: trader.avatarUri }}
-              style={tw.style(
-                `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-              )}
-              resizeMode="cover"
-            />
-          ) : (
-            <AvatarBase
-              size={AvatarBaseSize.Lg}
-              fallbackText={trader.username.charAt(0).toUpperCase()}
-            />
-          )}
+          <TopRankAvatar rank={trader.overallRank}>
+            {trader.avatarUri ? (
+              <Image
+                source={{ uri: trader.avatarUri }}
+                style={tw.style(
+                  `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
+                )}
+                resizeMode="cover"
+              />
+            ) : (
+              <AvatarBase
+                size={AvatarBaseSize.Lg}
+                fallbackText={trader.username.charAt(0).toUpperCase()}
+              />
+            )}
+          </TopRankAvatar>
 
           <Box twClassName="flex-1 min-w-0">
             <Text
@@ -155,7 +157,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
         }
         size={ButtonSize.Md}
         onPress={() => onFollowPress(trader.id)}
-        twClassName="min-w-[96px]"
+        twClassName="min-w-[96px] self-center"
       >
         {trader.isFollowing
           ? strings('social_leaderboard.following')

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -28,11 +28,11 @@ const TraderRowSkeleton: React.FC = () => {
       >
         <View style={tw.style('flex-row items-center')}>
           {/* Rank placeholder — outer cell mirrors the rendered rank's
-              `w-6 text-right` (24px container, content right-aligned) so the
+              `w-8 text-right` (32px container, content right-aligned) so the
               bar's visible right edge lines up with where the loaded digit
               sits. The inner bar's width (`w-4`) approximates a 1–2 digit
               rank glyph. */}
-          <View style={tw.style('w-6 mr-3 items-end')}>
+          <View style={tw.style('w-8 mr-3 items-end')}>
             <View style={tw.style('w-4 h-5 rounded')} />
           </View>
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -3,38 +3,53 @@ import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../../util/theme';
+import { TRADER_ROW_HEIGHT } from './TraderRow';
 
 /**
  * TraderRowSkeleton — loading placeholder that mirrors the TraderRow layout.
  *
  * Uses react-native-skeleton-placeholder to animate shimmer effect
  * over rank, avatar, username/stats text, and action button shapes.
+ *
+ * Outer wrapper height is locked to `TRADER_ROW_HEIGHT` so the skeleton
+ * occupies the exact same vertical space as a rendered <TraderRow />.
  */
 const TraderRowSkeleton: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
 
   return (
-    <View style={tw.style('px-4 py-3')}>
+    <View
+      style={[tw.style('px-4 justify-center'), { height: TRADER_ROW_HEIGHT }]}
+    >
       <SkeletonPlaceholder
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
         <View style={tw.style('flex-row items-center')}>
-          {/* Rank placeholder */}
-          <View style={tw.style('w-8 h-4 rounded mr-3')} />
+          {/* Rank placeholder — outer cell mirrors the rendered rank's
+              `w-6 text-right` (24px container, content right-aligned) so the
+              bar's visible right edge lines up with where the loaded digit
+              sits. The inner bar's width (`w-4`) approximates a 1–2 digit
+              rank glyph. */}
+          <View style={tw.style('w-6 mr-3 items-end')}>
+            <View style={tw.style('w-4 h-5 rounded')} />
+          </View>
 
           {/* Avatar placeholder */}
           <View style={tw.style('w-10 h-10 rounded-full mr-3')} />
 
-          {/* Text info placeholder */}
-          <View style={tw.style('flex-1 gap-1.5')}>
-            <View style={tw.style('w-24 h-4 rounded')} />
-            <View style={tw.style('w-40 h-3 rounded')} />
+          {/* Text info placeholder — total height matches the avatar (40px)
+              so the two bars line up with the actual BodyMd + BodySm text rows
+              (~20px + ~16px) and don't appear vertically centered with gaps. */}
+          <View style={tw.style('flex-1 gap-1')}>
+            <View style={tw.style('w-24 h-5 rounded')} />
+            <View style={tw.style('w-40 h-4 rounded')} />
           </View>
 
-          {/* Button placeholder */}
-          <View style={tw.style('w-20 h-8 rounded-xl ml-3')} />
+          {/* Button placeholder — `min-w-[96px]` matches the rendered Follow
+              button so the right edge of the row aligns between states. */}
+          <View style={tw.style('w-24 h-8 rounded-xl ml-3')} />
         </View>
       </SkeletonPlaceholder>
     </View>

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -111,6 +111,7 @@ describe('useTopTraders', () => {
       expect(result.current.traders[0]).toEqual({
         id: first.profileId,
         rank: first.rank,
+        overallRank: first.rank,
         username: first.name,
         avatarUri: first.imageUrl,
         percentageChange: first.roiPercent30d * 100,

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -48,6 +48,7 @@ export const useTopTraders = (
     return data.traders.map((entry) => ({
       id: entry.profileId,
       rank: entry.rank,
+      overallRank: entry.rank,
       username: entry.name,
       avatarUri: entry.imageUrl ?? undefined,
       percentageChange: (entry.roiPercent30d ?? 0) * 100,

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/CrownEmoji.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/CrownEmoji.tsx
@@ -9,8 +9,8 @@ interface CrownEmojiProps {
 }
 
 /**
- * Floating emoji anchored above the top-right corner of the avatar (rank
- * 1 = 👑, rank 2 = 🥈, rank 3 = 🥉).
+ * Floating medal emoji anchored above the top-right corner of the avatar
+ * (rank 1 = 🥇, rank 2 = 🥈, rank 3 = 🥉).
  *
  * Slight rotation makes the emoji look like it is sitting on the avatar's
  * shoulder rather than perfectly aligned, which reads better at this size.

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/CrownEmoji.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/CrownEmoji.tsx
@@ -1,0 +1,39 @@
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React from 'react';
+import { Text, View } from 'react-native';
+import { isTopRank, PODIUM_EMOJI } from './topRank.colors';
+
+interface CrownEmojiProps {
+  rank: number;
+  children: React.ReactNode;
+}
+
+/**
+ * Floating emoji anchored above the top-right corner of the avatar (rank
+ * 1 = 👑, rank 2 = 🥈, rank 3 = 🥉).
+ *
+ * Slight rotation makes the emoji look like it is sitting on the avatar's
+ * shoulder rather than perfectly aligned, which reads better at this size.
+ */
+const CrownEmoji: React.FC<CrownEmojiProps> = ({ rank, children }) => {
+  const tw = useTailwind();
+
+  if (!isTopRank(rank)) {
+    return <>{children}</>;
+  }
+
+  const emoji = PODIUM_EMOJI[rank as 1 | 2 | 3];
+
+  return (
+    <View style={tw.style('relative')} testID={`top-rank-crown-${rank}`}>
+      {children}
+      <View
+        style={tw.style('absolute -top-[14px] -right-[12px] rotate-[15deg]')}
+      >
+        <Text style={tw.style('text-[28px] leading-[32px]')}>{emoji}</Text>
+      </View>
+    </View>
+  );
+};
+
+export default CrownEmoji;

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/GradientRing.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/GradientRing.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import { getMedalColors } from './topRank.colors';
+
+interface GradientRingProps {
+  rank: number;
+  children: React.ReactNode;
+}
+
+const RING_WIDTH = 4;
+const AVATAR_SIZE = 40;
+const OUTER_SIZE = AVATAR_SIZE + RING_WIDTH * 2;
+const INSET = -RING_WIDTH;
+const OUTER_RADIUS = OUTER_SIZE / 2;
+
+// Narrow diagonal sheen band rendered on top of the base gradient. The
+// transparent → bright-white → transparent ramp simulates a polished-metal
+// specular highlight; running it perpendicular to the base gradient maximises
+// the cross-pattern that reads as "shiny chrome".
+const SHEEN_COLORS = [
+  'rgba(255, 255, 255, 0)',
+  'rgba(255, 255, 255, 0.65)',
+  'rgba(255, 255, 255, 0)',
+] as const;
+const SHEEN_LOCATIONS = [0.38, 0.5, 0.62] as const;
+
+/**
+ * Chrome-like multi-stop gradient ring with a perpendicular specular sheen
+ * overlay for a polished-metal look around an avatar.
+ *
+ * The wrapper keeps the avatar's exact 40x40 footprint so the row's flex
+ * layout is identical to a non-podium row (no horizontal shift). The
+ * gradient (and its sheen overlay) bleeds 4px outside the footprint on every
+ * side, with the avatar (an opaque round image) sitting on top to mask the
+ * center, leaving only the visible ring.
+ */
+const GradientRing: React.FC<GradientRingProps> = ({ rank, children }) => {
+  const colors = getMedalColors(rank);
+
+  if (!colors) {
+    return <>{children}</>;
+  }
+
+  const ringStyle = {
+    position: 'absolute' as const,
+    top: INSET,
+    left: INSET,
+    right: INSET,
+    bottom: INSET,
+    borderRadius: OUTER_RADIUS,
+  };
+
+  return (
+    <View
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+      testID={`top-rank-gradient-ring-${rank}`}
+    >
+      <LinearGradient
+        colors={[...colors.gradient]}
+        locations={[...colors.gradientLocations]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={ringStyle}
+      />
+      <LinearGradient
+        colors={[...SHEEN_COLORS]}
+        locations={[...SHEEN_LOCATIONS]}
+        // Perpendicular to the base gradient so the sheen crosses the ring
+        // and reads as a moving specular highlight.
+        start={{ x: 1, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={ringStyle}
+        pointerEvents="none"
+      />
+      {children}
+    </View>
+  );
+};
+
+export default GradientRing;

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react-native';
 import React from 'react';
 import { Text, View } from 'react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
@@ -16,21 +17,23 @@ describe('TopRankAvatar', () => {
   it.each([1, 2, 3])(
     'wraps the avatar with a gradient ring and floating crown for rank %s',
     (rank) => {
-      const { getByTestId } = renderWithRank(rank);
+      renderWithRank(rank);
 
-      expect(getByTestId(`top-rank-gradient-ring-${rank}`)).toBeTruthy();
-      expect(getByTestId(`top-rank-crown-${rank}`)).toBeTruthy();
-      expect(getByTestId('avatar-child')).toBeTruthy();
+      expect(
+        screen.getByTestId(`top-rank-gradient-ring-${rank}`),
+      ).toBeOnTheScreen();
+      expect(screen.getByTestId(`top-rank-crown-${rank}`)).toBeOnTheScreen();
+      expect(screen.getByTestId('avatar-child')).toBeOnTheScreen();
     },
   );
 
   it.each([0, 4, 5, 19, 100])(
     'passes children through unchanged for non-podium rank %s',
     (rank) => {
-      const { getByTestId, queryByTestId } = renderWithRank(rank);
+      renderWithRank(rank);
 
-      expect(getByTestId('avatar-child')).toBeTruthy();
-      expect(queryByTestId(/top-rank-/)).toBeNull();
+      expect(screen.getByTestId('avatar-child')).toBeOnTheScreen();
+      expect(screen.queryByTestId(/top-rank-/)).not.toBeOnTheScreen();
     },
   );
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import TopRankAvatar from './TopRankAvatar';
+
+const renderWithRank = (rank: number) =>
+  renderWithProvider(
+    <TopRankAvatar rank={rank}>
+      <View testID="avatar-child">
+        <Text>A</Text>
+      </View>
+    </TopRankAvatar>,
+  );
+
+describe('TopRankAvatar', () => {
+  it.each([1, 2, 3])(
+    'wraps the avatar with a gradient ring and floating crown for rank %s',
+    (rank) => {
+      const { getByTestId } = renderWithRank(rank);
+
+      expect(getByTestId(`top-rank-gradient-ring-${rank}`)).toBeTruthy();
+      expect(getByTestId(`top-rank-crown-${rank}`)).toBeTruthy();
+      expect(getByTestId('avatar-child')).toBeTruthy();
+    },
+  );
+
+  it.each([0, 4, 5, 19, 100])(
+    'passes children through unchanged for non-podium rank %s',
+    (rank) => {
+      const { getByTestId, queryByTestId } = renderWithRank(rank);
+
+      expect(getByTestId('avatar-child')).toBeTruthy();
+      expect(queryByTestId(/top-rank-/)).toBeNull();
+    },
+  );
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import GradientRing from './GradientRing';
+import CrownEmoji from './CrownEmoji';
+import { isTopRank } from './topRank.colors';
+
+interface TopRankAvatarProps {
+  /**
+   * Rank used to decide whether to decorate the avatar. Pass the trader's
+   * overall (unfiltered) rank so the gold/silver/bronze treatment only fires
+   * for true top-3 traders.
+   */
+  rank: number;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps an avatar with the top-rank decoration for podium ranks (1–3): a
+ * chrome gradient ring around the avatar plus a floating crown / medal emoji
+ * above its top-right corner.
+ *
+ * For ranks > 3, `children` is rendered unchanged.
+ */
+const TopRankAvatar: React.FC<TopRankAvatarProps> = ({ rank, children }) => {
+  if (!isTopRank(rank)) {
+    return <>{children}</>;
+  }
+
+  return (
+    <CrownEmoji rank={rank}>
+      <GradientRing rank={rank}>{children}</GradientRing>
+    </CrownEmoji>
+  );
+};
+
+export default TopRankAvatar;

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankIndicator.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankIndicator.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import TopRankIndicator from './TopRankIndicator';
+
+describe('TopRankIndicator', () => {
+  it.each([1, 2, 3])(
+    'colors the rank digit with the medal color for podium rank %s',
+    (rank) => {
+      renderWithProvider(<TopRankIndicator rank={rank} />);
+
+      expect(
+        screen.getByTestId(`top-rank-medal-color-${rank}`),
+      ).toBeOnTheScreen();
+      expect(screen.getByText(String(rank))).toBeOnTheScreen();
+    },
+  );
+
+  it.each([0, 4, 19, 100])(
+    'renders the plain rank digit for non-podium rank %s',
+    (rank) => {
+      renderWithProvider(<TopRankIndicator rank={rank} />);
+
+      expect(screen.queryByTestId(/top-rank-medal-color-/)).toBeNull();
+      expect(screen.getByText(String(rank))).toBeOnTheScreen();
+    },
+  );
+
+  describe('podiumRank gating', () => {
+    it('does not apply the podium color when the overall rank is outside the top 3 even if the displayed rank is 1', () => {
+      renderWithProvider(<TopRankIndicator rank={1} podiumRank={19} />);
+
+      expect(screen.queryByTestId('top-rank-medal-color-1')).toBeNull();
+      expect(screen.queryByTestId('top-rank-medal-color-19')).toBeNull();
+      expect(screen.getByText('1')).toBeOnTheScreen();
+    });
+
+    it('applies the podium color when the overall rank is in the top 3 even if the displayed rank is larger', () => {
+      renderWithProvider(<TopRankIndicator rank={5} podiumRank={2} />);
+
+      expect(screen.getByTestId('top-rank-medal-color-2')).toBeOnTheScreen();
+      expect(screen.getByText('5')).toBeOnTheScreen();
+    });
+  });
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankIndicator.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankIndicator.tsx
@@ -1,0 +1,67 @@
+import {
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React from 'react';
+import {
+  getMedalColors,
+  getPodiumRankIndicatorStyle,
+  isTopRank,
+} from './topRank.colors';
+
+interface TopRankIndicatorProps {
+  /** The rank digit to display in the cell (e.g. position within a filter). */
+  rank: number;
+  /**
+   * Optional gating rank used to decide whether podium styling applies.
+   * Defaults to `rank`. Pass the trader's overall (unfiltered) rank when the
+   * displayed rank is a filtered position so the gold/silver/bronze treatment
+   * only fires for true top-3 traders.
+   */
+  podiumRank?: number;
+}
+
+/**
+ * Renders the rank cell for a `TraderRow`. For podium ranks (1–3), the digit
+ * is rendered bold and tinted with the matching medal color so it visually
+ * echoes the avatar's gradient ring. For other ranks it renders as the
+ * secondary (muted) body text so podium ranks read as the focal ranks.
+ */
+const TopRankIndicator: React.FC<TopRankIndicatorProps> = ({
+  rank,
+  podiumRank = rank,
+}) => {
+  if (isTopRank(podiumRank)) {
+    const colors = getMedalColors(podiumRank);
+    return (
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Bold}
+        numberOfLines={1}
+        twClassName="w-8 text-right"
+        style={
+          colors ? getPodiumRankIndicatorStyle(colors.rankDigit) : undefined
+        }
+        testID={`top-rank-medal-color-${podiumRank}`}
+      >
+        {rank}
+      </Text>
+    );
+  }
+
+  return (
+    <Text
+      variant={TextVariant.BodyMd}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.TextAlternative}
+      numberOfLines={1}
+      twClassName="w-8 text-right"
+    >
+      {rank}
+    </Text>
+  );
+};
+
+export default TopRankIndicator;

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/index.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/index.ts
@@ -1,0 +1,2 @@
+export { default as TopRankAvatar } from './TopRankAvatar';
+export { default as TopRankIndicator } from './TopRankIndicator';

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex */
+import { getMedalColors, isTopRank, PODIUM_EMOJI } from './topRank.colors';
+
+describe('isTopRank', () => {
+  it.each([1, 2, 3])('returns true for podium rank %s', (rank) => {
+    expect(isTopRank(rank)).toBe(true);
+  });
+
+  it.each([0, 4, 5, 100, -1])('returns false for rank %s', (rank) => {
+    expect(isTopRank(rank)).toBe(false);
+  });
+});
+
+describe('getMedalColors', () => {
+  it('returns the gold palette for rank 1', () => {
+    const colors = getMedalColors(1);
+
+    expect(colors).not.toBeNull();
+    expect(colors?.rankDigit).toBe('#FFEE58');
+    expect(colors?.gradient.length).toBeGreaterThanOrEqual(3);
+    expect(colors?.gradientLocations.length).toBe(colors?.gradient.length);
+  });
+
+  it('returns the silver palette for rank 2', () => {
+    expect(getMedalColors(2)?.rankDigit).toBe('#ECEFF1');
+  });
+
+  it('returns the bronze palette for rank 3', () => {
+    expect(getMedalColors(3)?.rankDigit).toBe('#FFAB40');
+  });
+
+  it.each([0, 4, 5, 100, -1])('returns null for rank %s', (rank) => {
+    expect(getMedalColors(rank)).toBeNull();
+  });
+});
+
+describe('PODIUM_EMOJI', () => {
+  it('uses a crown for rank 1 and medal emojis for ranks 2 and 3', () => {
+    expect(PODIUM_EMOJI[1]).toBe('👑');
+    expect(PODIUM_EMOJI[2]).toBe('🥈');
+    expect(PODIUM_EMOJI[3]).toBe('🥉');
+  });
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.test.ts
@@ -35,8 +35,8 @@ describe('getMedalColors', () => {
 });
 
 describe('PODIUM_EMOJI', () => {
-  it('uses a crown for rank 1 and medal emojis for ranks 2 and 3', () => {
-    expect(PODIUM_EMOJI[1]).toBe('👑');
+  it('uses gold/silver/bronze medal emojis for ranks 1, 2 and 3', () => {
+    expect(PODIUM_EMOJI[1]).toBe('🥇');
     expect(PODIUM_EMOJI[2]).toBe('🥈');
     expect(PODIUM_EMOJI[3]).toBe('🥉');
   });

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.ts
@@ -93,11 +93,12 @@ export const getMedalColors = (rank: number): MedalColors | null => {
 };
 
 /**
- * Emoji that floats above each podium avatar. Rank 1 gets a crown to give the
- * top spot a more distinctive treatment than a plain gold medal.
+ * Medal emoji that floats above each podium avatar. The same glyph family
+ * (gold / silver / bronze medal) is used for all three ranks so they share
+ * a consistent visual footprint.
  */
 export const PODIUM_EMOJI: Readonly<Record<1 | 2 | 3, string>> = {
-  1: '👑',
+  1: '🥇',
   2: '🥈',
   3: '🥉',
 };

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/topRank.colors.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex -- Decorative podium medal chrome; no DS tokens for multi-stop metallic gradients. */
+/**
+ * Metallic palette for the top-rank decorations.
+ *
+ * Each medal exposes a bright `rankDigit` color for legible rank numerals on
+ * dark backgrounds and a multi-stop chrome gradient used by the avatar ring.
+ */
+
+export interface MedalColors {
+  /**
+   * High-luminance tint for the rank numeral on dark backgrounds. Kept separate
+   * from the chrome `gradient` palette so the digit stays as legible and vivid
+   * as default body text (ranks 4+), which muted metallics alone do not achieve.
+   */
+  rankDigit: string;
+  /**
+   * Multi-stop chrome gradient (dark rim → bright peak → mid → deep → bright
+   * peak → mid → dark rim). The alternating peaks fake the polished-metal
+   * look of a real coin/medal rim. Must contain at least 3 stops.
+   */
+  gradient: readonly string[];
+  /**
+   * Stop positions (0–1) for `gradient`. Length must equal `gradient.length`.
+   */
+  gradientLocations: readonly number[];
+}
+
+// Stop positions shared by all chrome palettes. Two narrow bright peaks at
+// ~15% and ~65% create the alternating highlight/shadow bands that give the
+// ring its specular "shiny" appearance.
+const CHROME_LOCATIONS: readonly number[] = [0, 0.15, 0.3, 0.5, 0.65, 0.85, 1];
+
+const GOLD: MedalColors = {
+  rankDigit: '#FFEE58',
+  gradient: [
+    '#5C4400',
+    '#FFF8DC',
+    '#FFC400',
+    '#8B6508',
+    '#FFE066',
+    '#D4AF37',
+    '#3D2C00',
+  ],
+  gradientLocations: CHROME_LOCATIONS,
+};
+
+const SILVER: MedalColors = {
+  rankDigit: '#ECEFF1',
+  gradient: [
+    '#2A2A2A',
+    '#FFFFFF',
+    '#D8D8D8',
+    '#5A5A5A',
+    '#F0F0F0',
+    '#A0A0A0',
+    '#1F1F1F',
+  ],
+  gradientLocations: CHROME_LOCATIONS,
+};
+
+const BRONZE: MedalColors = {
+  rankDigit: '#FFAB40',
+  gradient: [
+    '#3D2410',
+    '#FFD7A8',
+    '#CD7F32',
+    '#5C3712',
+    '#F4A460',
+    '#A0612A',
+    '#2D1A08',
+  ],
+  gradientLocations: CHROME_LOCATIONS,
+};
+
+/** Whether `rank` is a podium position (1, 2 or 3). */
+export const isTopRank = (rank: number): boolean => rank >= 1 && rank <= 3;
+
+/**
+ * Returns the metallic color set for a given rank, or `null` if the rank is
+ * not a podium position (rank > 3).
+ */
+export const getMedalColors = (rank: number): MedalColors | null => {
+  switch (rank) {
+    case 1:
+      return GOLD;
+    case 2:
+      return SILVER;
+    case 3:
+      return BRONZE;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Emoji that floats above each podium avatar. Rank 1 gets a crown to give the
+ * top spot a more distinctive treatment than a plain gold medal.
+ */
+export const PODIUM_EMOJI: Readonly<Record<1 | 2 | 3, string>> = {
+  1: '👑',
+  2: '🥈',
+  3: '🥉',
+};
+
+/**
+ * Subtle shadow under podium rank numerals for contrast on varied backgrounds.
+ */
+export const PODIUM_RANK_TEXT_SHADOW_COLOR = 'rgba(0, 0, 0, 0.35)';
+
+/** Style fragment shared by all podium rank digits (shadow only; color from medal). */
+const PODIUM_RANK_TEXT_SHADOW_STYLE = {
+  textShadowColor: PODIUM_RANK_TEXT_SHADOW_COLOR,
+  textShadowOffset: { width: 0, height: 1 },
+  textShadowRadius: 2,
+} as const;
+
+/**
+ * Combined podium rank numeral style for a medal `rankDigit` color.
+ */
+export const getPodiumRankIndicatorStyle = (rankDigit: string) => ({
+  color: rankDigit,
+  ...PODIUM_RANK_TEXT_SHADOW_STYLE,
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/types.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/types.ts
@@ -6,8 +6,18 @@
 export interface TopTrader {
   /** Clicker profile ID. */
   id: string;
-  /** Rank position in the leaderboard (1-based). */
+  /**
+   * Displayed rank position (1-based). When the leaderboard is filtered by
+   * chain this is recomputed against the filtered slice — e.g. the #1 row in
+   * the Solana filter has `rank === 1` even if it sits much lower overall.
+   */
   rank: number;
+  /**
+   * Overall rank across all chains (1-based). Preserved through chain
+   * filtering so podium decorations (gold/silver/bronze treatments) only
+   * apply to true top-3 traders rather than the top of an arbitrary filter.
+   */
+  overallRank: number;
   /** Display username or truncated address. */
   username: string;
   /** Profile avatar URL. */

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -238,6 +238,30 @@ describe('TopTradersView', () => {
     expect(screen.queryByText('3')).not.toBeOnTheScreen();
   });
 
+  it('preserves the upstream overallRank when navigating to a profile (does not re-derive it from the displayed rank)', () => {
+    mockUseTopTradersHook.mockReturnValueOnce({
+      ...defaultUseTopTradersResult,
+      traders: [
+        {
+          ...fixtureTraders[0],
+          rank: 1,
+          overallRank: 50,
+        },
+      ],
+    });
+    renderWithProvider(<TopTradersView />);
+
+    fireEvent.press(screen.getByText('sniperliquid.hl'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'TraderProfileView',
+      expect.objectContaining({
+        traderId: 'trader-1',
+        rank: 50,
+      }),
+    );
+  });
+
   it('renders skeletons during initial load', () => {
     mockUseTopTradersHook.mockReturnValueOnce({
       ...defaultUseTopTradersResult,

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -1,11 +1,11 @@
+import { act, fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
-import { act, screen, fireEvent } from '@testing-library/react-native';
+import Logger from '../../../../util/Logger';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
-import TopTradersView from './TopTradersView';
-import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 import type { UseTopTradersResult } from '../../Homepage/Sections/TopTraders/hooks/useTopTraders';
 import type { TopTrader } from '../../Homepage/Sections/TopTraders/types';
-import Logger from '../../../../util/Logger';
+import TopTradersView from './TopTradersView';
+import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
@@ -235,7 +235,7 @@ describe('TopTradersView', () => {
       screen.getByTestId(TopTradersViewSelectorsIDs.CHAIN_FILTER_SOLANA),
     );
     expect(screen.getByText('1')).toBeOnTheScreen();
-    expect(screen.queryByText('3.')).not.toBeOnTheScreen();
+    expect(screen.queryByText('3')).not.toBeOnTheScreen();
   });
 
   it('renders skeletons during initial load', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -28,6 +28,7 @@ const fixtureTraders: TopTrader[] = [
   {
     id: 'trader-1',
     rank: 1,
+    overallRank: 1,
     username: 'sniperliquid.hl',
     avatarUri: 'https://example.com/avatar1.png',
     percentageChange: 43,
@@ -38,6 +39,7 @@ const fixtureTraders: TopTrader[] = [
   {
     id: 'trader-2',
     rank: 2,
+    overallRank: 2,
     username: 'nervousdegen',
     avatarUri: 'https://example.com/avatar2.png',
     percentageChange: 359,
@@ -48,6 +50,7 @@ const fixtureTraders: TopTrader[] = [
   {
     id: 'trader-3',
     rank: 3,
+    overallRank: 3,
     username: 'baznocap',
     avatarUri: 'https://example.com/avatar3.png',
     percentageChange: 617,
@@ -128,7 +131,7 @@ describe('TopTradersView', () => {
 
   it('renders the rank for the top trader', () => {
     renderWithProvider(<TopTradersView />);
-    expect(screen.getByText('1.')).toBeOnTheScreen();
+    expect(screen.getByText('1')).toBeOnTheScreen();
   });
 
   it('renders the ROI for the first trader', () => {
@@ -231,7 +234,7 @@ describe('TopTradersView', () => {
     fireEvent.press(
       screen.getByTestId(TopTradersViewSelectorsIDs.CHAIN_FILTER_SOLANA),
     );
-    expect(screen.getByText('1.')).toBeOnTheScreen();
+    expect(screen.getByText('1')).toBeOnTheScreen();
     expect(screen.queryByText('3.')).not.toBeOnTheScreen();
   });
 

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -162,7 +162,7 @@ const TopTradersView = () => {
     // so podium decorations only apply to true top-3 traders.
     return filtered
       .slice(0, 50)
-      .map((t, i) => ({ ...t, rank: i + 1, overallRank: t.rank }));
+      .map((t, i) => ({ ...t, rank: i + 1, overallRank: t.overallRank }));
   }, [traders, selectedChain]);
 
   const handleBack = useCallback(() => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -5,7 +5,6 @@ import {
   BoxJustifyContent,
   ButtonIcon,
   ButtonIconSize,
-  FontWeight,
   IconName,
   Text,
   TextColor,

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -1,51 +1,48 @@
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
   Pressable,
   RefreshControl,
+  Text as RNText,
   ScrollView,
   StyleSheet,
-  Text as RNText,
+  useWindowDimensions,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import {
-  Box,
-  Text,
-  TextVariant,
-  ButtonIcon,
-  ButtonIconSize,
-  IconName,
-  BoxFlexDirection,
-  BoxAlignItems,
-  BoxJustifyContent,
-  TextColor,
-} from '@metamask/design-system-react-native';
-import { fontStyles } from '../../../../styles/common';
-import { useTheme } from '../../../../util/theme';
-import Logger from '../../../../util/Logger';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
-import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
-import {
-  TraderRow,
-  TraderRowSkeleton,
-} from '../../Homepage/Sections/TopTraders/components';
-import { useTopTraders } from '../../Homepage/Sections/TopTraders/hooks';
 import Routes from '../../../../constants/navigation/Routes';
-import { selectSocialLeaderboardEnabled } from '../../../../selectors/featureFlagController/socialLeaderboard';
 import {
   BASE_DISPLAY_NAME,
   MAINNET_DISPLAY_NAME,
   SOLANA_DISPLAY_NAME,
 } from '../../../../core/Engine/constants';
-
-const SKELETON_COUNT = 5;
-const SKELETON_KEYS = Array.from(
-  { length: SKELETON_COUNT },
-  (_, i) => `top-trader-skeleton-${i}`,
-);
+import { selectSocialLeaderboardEnabled } from '../../../../selectors/featureFlagController/socialLeaderboard';
+import { fontStyles } from '../../../../styles/common';
+import Logger from '../../../../util/Logger';
+import { useTheme } from '../../../../util/theme';
+import {
+  TraderRow,
+  TraderRowSkeleton,
+} from '../../Homepage/Sections/TopTraders/components';
+import { TRADER_ROW_HEIGHT } from '../../Homepage/Sections/TopTraders/components/TraderRow';
+import { useTopTraders } from '../../Homepage/Sections/TopTraders/hooks';
+import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 
 type ChainFilter = 'all' | 'base' | 'solana' | 'ethereum';
 
@@ -60,6 +57,10 @@ const getChainFilters = (): { key: ChainFilter; label: string }[] => [
 ];
 
 const styles = StyleSheet.create({
+  filterScrollView: {
+    flexGrow: 0,
+    flexShrink: 0,
+  },
   filterRow: {
     paddingHorizontal: 16,
     paddingTop: 12,
@@ -126,10 +127,18 @@ const TopTradersView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
   const { colors } = useTheme();
+  const { height: windowHeight } = useWindowDimensions();
   const isEnabled = useSelector(selectSocialLeaderboardEnabled);
 
   const [selectedChain, setSelectedChain] = useState<ChainFilter>('all');
   const [refreshing, setRefreshing] = useState(false);
+
+  // Render enough skeleton rows to cover the visible list area. Add a couple of
+  // extras so users can see the shimmer continue past the fold while scrolling.
+  const skeletonKeys = useMemo(() => {
+    const count = Math.ceil(windowHeight / TRADER_ROW_HEIGHT) + 2;
+    return Array.from({ length: count }, (_, i) => `top-trader-skeleton-${i}`);
+  }, [windowHeight]);
 
   const { traders, isLoading, refresh, toggleFollow } = useTopTraders({
     limit: 250,
@@ -148,7 +157,12 @@ const TopTradersView = () => {
         ? traders
         : traders.filter((t) => (t.pnlPerChain[selectedChain] ?? 0) !== 0);
 
-    return filtered.slice(0, 50).map((t, i) => ({ ...t, rank: i + 1 }));
+    // Re-number the displayed rank to reflect the trader's position within the
+    // filtered slice, but keep `overallRank` pointing at the unfiltered rank
+    // so podium decorations only apply to true top-3 traders.
+    return filtered
+      .slice(0, 50)
+      .map((t, i) => ({ ...t, rank: i + 1, overallRank: t.rank }));
   }, [traders, selectedChain]);
 
   const handleBack = useCallback(() => {
@@ -174,10 +188,11 @@ const TopTradersView = () => {
   }, [refresh]);
 
   const handleTraderPress = useCallback(
-    (traderId: string, traderName: string) => {
+    (traderId: string, traderName: string, rank: number) => {
       navigation.navigate(Routes.SOCIAL_LEADERBOARD.PROFILE, {
         traderId,
         traderName,
+        rank,
       });
     },
     [navigation],
@@ -217,6 +232,10 @@ const TopTradersView = () => {
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
+        // `flexGrow: 0` + `flexShrink: 0` pin the ScrollView's height to
+        // its content so neither the FlatList nor the loading ScrollView
+        // below can stretch or compress it.
+        style={styles.filterScrollView}
         contentContainerStyle={styles.filterRow}
       >
         {getChainFilters().map(({ key, label }) => (
@@ -232,6 +251,9 @@ const TopTradersView = () => {
 
       {isLoading ? (
         <ScrollView
+          // `flex-1` matches FlatList's default behavior so the list area sits
+          // directly under the filters and skeletons render top-aligned.
+          style={tw.style('flex-1')}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tw.style('pb-6')}
           refreshControl={
@@ -243,7 +265,7 @@ const TopTradersView = () => {
             />
           }
         >
-          {SKELETON_KEYS.map((key) => (
+          {skeletonKeys.map((key) => (
             <TraderRowSkeleton key={key} />
           ))}
         </ScrollView>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
@@ -30,9 +30,7 @@ const QuickBuyHeader: React.FC<QuickBuyHeaderProps> = ({
     gap={4}
     twClassName="h-20 px-4"
   >
-    <Box twClassName="w-12 h-12 rounded-xl overflow-hidden">
-      <PositionTokenAvatar position={position} />
-    </Box>
+    <PositionTokenAvatar position={position} showChainBadge />
     <Box twClassName="flex-1">
       <Text
         variant={TextVariant.HeadingSm}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTokenInfoRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTokenInfoRow.tsx
@@ -42,7 +42,7 @@ const TraderTokenInfoRow: React.FC<TraderTokenInfoRowProps> = ({
       twClassName="flex-1 min-w-0 mr-3"
     >
       {position ? (
-        <PositionTokenAvatar position={position} />
+        <PositionTokenAvatar position={position} showChainBadge />
       ) : (
         <AvatarToken name={symbol} size={AvatarTokenSize.Lg} />
       )}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -87,7 +87,7 @@ const TraderProfileView = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const route = useRoute<RouteProp<RootStackParamList, 'TraderProfileView'>>();
   const tw = useTailwind();
-  const { traderId, traderName } = route.params;
+  const { traderId, traderName, rank } = route.params;
 
   const {
     profile,
@@ -206,6 +206,7 @@ const TraderProfileView = () => {
                 profile={profile.profile}
                 followerCount={profile.followerCount}
                 twitterHandle={profile.socialHandles?.twitter}
+                rank={rank}
               />
             )}
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -19,6 +19,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import type { TraderProfile } from '@metamask/social-controllers';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
+import { TopRankAvatar } from '../../../Homepage/Sections/TopTraders/topRank';
 
 const AVATAR_SIZE = 40;
 
@@ -26,12 +27,18 @@ export interface ProfileHeaderProps {
   profile: TraderProfile;
   followerCount: number;
   twitterHandle?: string | null;
+  /**
+   * Optional leaderboard rank used to render the top-rank decoration
+   * (gradient ring + crown emoji) around the avatar for ranks 1-3.
+   */
+  rank?: number;
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   profile,
   followerCount,
   twitterHandle,
+  rank,
 }) => {
   const tw = useTailwind();
 
@@ -49,20 +56,22 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
       gap={4}
       testID={TraderProfileViewSelectorsIDs.HEADER}
     >
-      {profile.imageUrl ? (
-        <Image
-          source={{ uri: profile.imageUrl }}
-          style={tw.style(
-            `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-          )}
-          resizeMode="cover"
-        />
-      ) : (
-        <AvatarBase
-          size={AvatarBaseSize.Lg}
-          fallbackText={profile.name.charAt(0).toUpperCase()}
-        />
-      )}
+      <TopRankAvatar rank={rank ?? 0}>
+        {profile.imageUrl ? (
+          <Image
+            source={{ uri: profile.imageUrl }}
+            style={tw.style(
+              `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
+            )}
+            resizeMode="cover"
+          />
+        ) : (
+          <AvatarBase
+            size={AvatarBaseSize.Lg}
+            fallbackText={profile.name.charAt(0).toUpperCase()}
+          />
+        )}
+      </TopRankAvatar>
 
       <Box twClassName="flex-1 min-w-0">
         <Box

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -557,7 +557,7 @@ export interface RootStackParamList extends ParamListBase {
 
   // Social Leaderboard routes
   TopTradersView: undefined;
-  TraderProfileView: { traderId: string; traderName: string };
+  TraderProfileView: { traderId: string; traderName: string; rank?: number };
   TraderPositionView: {
     traderId: string;
     tokenSymbol: string;


### PR DESCRIPTION
## **Description**

### Remove the dot next to the rank in trader rows
Also switch the non-podium numbers (4,5,6,..) to muted color.
<img width="418" height="380" alt="image" src="https://github.com/user-attachments/assets/520fedd8-014e-431a-a5f1-69e1bbe843a2" />

### Podium decorations in Leaderboard
Add decorations on the 1, 2, 3 ranks (gold/silver/bronze gradient ring on the avatar, floating crown/medal emoji, and tinted rank digit). Decorations are gated on the trader's **overall** rank (not the displayed/filtered rank), so a trader who is only top-3 within a chain filter does not get podium styling.
<img width="414" height="863" alt="image" src="https://github.com/user-attachments/assets/f3f07b39-6f2b-4512-9af2-3a05db51de78" />
<img width="438" height="887" alt="image" src="https://github.com/user-attachments/assets/54eef59d-d809-4522-9eb2-870ca5d68e0c" />

### Podium decorations in Profile
Decoration shows on the trader's profile too (profile header avatar and rank chip).
<img width="437" height="886" alt="image" src="https://github.com/user-attachments/assets/04dbe623-0595-4b55-8632-bbbdf17b8867" />

### Leaderboard Skeleton alignment
Improve leaderboard skeleton to perfectly align with the loaded content (avatar size, rank column width, name/PnL columns, row spacing).
<img width="1191" height="887" alt="image" src="https://github.com/user-attachments/assets/082cb070-779c-4b25-87f9-408b24213904" />

### Chain icon on token icon
Overlay chain icon on the token avatar in the position page and the quick buy bottom sheet.
<img width="438" height="887" alt="image" src="https://github.com/user-attachments/assets/d0a6a658-acf6-4ecf-b821-2a7943360a4d" />

## **Changelog**

CHANGELOG entry: Polished the social leaderboard with podium decorations on the top 3 traders, a tighter loading skeleton, and a chain icon overlay on token avatars in the trader position and quick buy views.

## **Related issues**

Refs: internal follow-trading polish

## **Manual testing steps**

```gherkin
Feature: Social leaderboard polish

  Scenario: top traders carousel highlights the podium
    Given the user opens the wallet homepage
    When the Top Traders section finishes loading
    Then ranks 1, 2 and 3 show a gold/silver/bronze gradient ring around the avatar with a crown/medal emoji and a tinted rank digit
    And ranks 4+ show no decoration
    And there is no dot separator next to the rank

  Scenario: leaderboard view keeps decorations on overall top-3 only
    Given the user opens the full Top Traders view
    When the user filters by a single chain
    Then a trader who is only top-3 within that filter does not get podium decoration
    And a trader whose overall rank is 1, 2 or 3 keeps the podium decoration

  Scenario: trader profile inherits podium decoration
    Given a trader with overall rank 1 is open in the profile view
    Then the profile header shows the gold gradient ring and crown

  Scenario: skeleton matches the loaded layout
    Given the user opens the leaderboard with a slow network
    When the skeleton is shown
    Then each skeleton row aligns 1:1 with the loaded trader row (avatar size, columns, spacing) with no shift on load

  Scenario: chain icon overlays the token in trader position and quick buy
    Given the user opens a trader position on a non-default chain
    Then the token avatar in the position header shows a chain badge in the bottom-right
    When the user opens the quick buy bottom sheet
    Then the same chain badge is shown on the token avatar in the quick buy header
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: updates leaderboard/profile navigation params to include optional `rank` and threads a new `overallRank` field through trader models, which could break routing or UI gating if miswired. Mostly UI/layout changes (decorations, skeleton sizing) with limited data-handling impact.
> 
> **Overview**
> Adds *podium (top-3) visual treatments* across the social leaderboard: new `topRank` components render a medal-tinted rank digit plus an avatar gradient ring and floating medal emoji, and `TraderRow`/profile header now use these decorations.
> 
> Introduces `overallRank` on `TopTrader` and updates `useTopTraders`, homepage cards/rows, and `TopTradersView` chain filtering to **re-rank display positions while preserving overall rank**; navigation to `TraderProfileView` now passes `rank` (overall) and the route type is updated accordingly.
> 
> Polishes loading and layout: locks trader row height via `TRADER_ROW_HEIGHT`, aligns `TraderRowSkeleton` to the real row, dynamically sizes skeleton count to window height, removes the trailing dot from rank display, and vertically centers the Follow button.
> 
> Enables chain badge overlays on token avatars by passing `showChainBadge` to `PositionTokenAvatar` in the quick-buy header and trader position info row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b061bc97f3a07efa5989704612f9b7754a3472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->