### PR TITLE
test: enables back GEOLOCATION when BROWSERSTACK_LOCAL is not set

### DIFF
--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Compute BrowserStack Local Identifier
         id: bs-local-id
+        if: inputs.build_type == 'mm-connect'
         run: |
           # Strip any character that is not alphanumeric or a hyphen (covers spaces, /, \, @, etc.)
           BUILD_TYPE_SAFE=$(printf '%s' "${{ inputs.build_type }}" | tr -c 'a-zA-Z0-9-' '_')
@@ -141,6 +142,7 @@ jobs:
           echo "value=${{ github.run_id }}-${BUILD_TYPE_SAFE}-${DEVICE_SAFE}" >> "$GITHUB_OUTPUT"
 
       - name: Setup BrowserStack Local
+        if: inputs.build_type == 'mm-connect'
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
           local-testing: start
@@ -150,10 +152,11 @@ jobs:
           local-args: '--force-local --verbose'
 
       - name: Wait for BrowserStack Local
+        if: inputs.build_type == 'mm-connect'
         run: |
           echo "Waiting for BrowserStack Local to be ready..."
-          # mm-connect needs the tunnel ready so the device can reach bs-local.com:8090; allow extra time
-          sleep ${{ inputs.build_type == 'mm-connect' && 15 || 10 }}
+          # mm-connect needs the tunnel ready so the device can reach bs-local.com:8090
+          sleep 15
           echo "BrowserStack Local should be ready now"
 
       - name: Set Test Environment
@@ -226,8 +229,8 @@ jobs:
 
       - name: Run Tests
         env:
-          BROWSERSTACK_LOCAL: 'true'
-          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ steps.bs-local-id.outputs.value }}
+          BROWSERSTACK_LOCAL: ${{ inputs.build_type == 'mm-connect' && 'true' || 'false' }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ inputs.build_type == 'mm-connect' && steps.bs-local-id.outputs.value || '' }}
           BROWSERSTACK_BUILD_NAME: ${{ inputs.browserstack_build_name }}
         working-directory: '.'
         run: |

--- a/docs/readme/e2e-testing.md
+++ b/docs/readme/e2e-testing.md
@@ -557,8 +557,15 @@ You can get your BrowserStack username and access key from the Access key dropdo
 ```bash
 export BROWSERSTACK_USERNAME='your_username'
 export BROWSERSTACK_ACCESS_KEY='your_access_key'
+```
+
+For **MM Connect** performance tests on BrowserStack, you also need the **BrowserStack Local tunnel** running so the cloud device can reach the local Browser Playground dapp. Start the [BrowserStack Local](https://www.browserstack.com/docs/local-testing/binary-params) binary, then set:
+
+```bash
 export BROWSERSTACK_LOCAL='true'
 ```
+
+Do **not** set `BROWSERSTACK_LOCAL=true` unless the tunnel is running. Other BrowserStack performance suites (for example onboarding) run **without** local testing unless you intentionally enable it.
 
 Update the config file with the appropriate BrowserStack app URL. You’ll need a BrowserStack URL first. To get it:
 

--- a/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
+++ b/tests/framework/services/providers/browserstack/BrowserStackConfigBuilder.ts
@@ -95,7 +95,9 @@ export class BrowserStackConfigBuilder {
           appProfiling: true,
           selfHeal: device.selfHeal ?? true,
           networkProfile: '4g-lte-advanced-good',
-          // geoLocation: process.env.BROWSERSTACK_GEO_LOCATION || 'ES',
+          ...(process.env.BROWSERSTACK_LOCAL?.toLowerCase() !== 'true'
+            ? { geoLocation: process.env.BROWSERSTACK_GEO_LOCATION || 'ES' }
+            : {}),
           enableCameraImageInjection: device.enableCameraImageInjection,
           ...(process.env.BROWSERSTACK_LOCAL_IDENTIFIER
             ? { localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER }

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -141,11 +141,13 @@ yarn run-playwright:ios-onboarding-bs      # Run onboarding tests on BrowserStac
 
 # MM Connect (Multichain API + local Browser Playground dapp)
 yarn run-playwright:mm-connect-android-local    # Local Android emulator (dapp on 10.0.2.2:8090)
-yarn run-playwright:mm-connect-android-bs      # BrowserStack Android (no tunnel; use remote dapp if any)
-yarn run-playwright:mm-connect-android-bs-local # BrowserStack Android + Local tunnel (see below)
+yarn run-playwright:mm-connect-android-bs       # BrowserStack Android (same Playwright project as below)
+yarn run-playwright:mm-connect-android-bs-local # BrowserStack Android (alias; tunnel still required — see below)
 ```
 
 #### MM Connect on BrowserStack (local dapp)
+
+**BrowserStack Local (tunnel) must be enabled** when you run mm-connect tests against BrowserStack: the suite serves the Browser Playground from your machine on port **8090**, and only the tunnel lets cloud devices reach it via `bs-local.com`. Start the tunnel **before** the test and set `BROWSERSTACK_LOCAL=true` (see step 2 below). Performance CI starts the tunnel and sets these variables **only for the mm-connect build type**; other performance jobs do not use the tunnel.
 
 The `connection-multichain` test starts a **local dapp server** (Browser Playground) on port **8090**. To run it on BrowserStack, the cloud device must reach that server via **BrowserStack Local** (tunnel).
 
@@ -178,7 +180,7 @@ The `connection-multichain` test starts a **local dapp server** (Browser Playgro
 - **One tunnel per account:** don't run multiple Local binaries for the same account unless you use different `localIdentifier` values and pass them in capabilities.
 - **Tunnel timeouts** (`TIMEOUT_CONNECTING` to port 45691 in the Local terminal): the cloud device cannot reach your Local binary. Allow incoming connections for ports **45690** and **45691** in your firewall, or try a different network (e.g. avoid strict NAT). See [BrowserStack Local troubleshooting](https://www.browserstack.com/docs/app-automate/appium/troubleshooting/local-issues) for more.
 
-**CI:** BrowserStack Local is enabled for all performance build types (not only mm-connect); the tunnel is started and `local: true` plus `localIdentifier` are sent in capabilities so every run can use the tunnel (e.g. for future test dapps). The workflow starts the tunnel with `--force-local --verbose` only (no `--include-hosts`). Using `--include-hosts localhost 127.0.0.1` can prevent requests to `bs-local.com:8090` from being forwarded to the runner's localhost; the device then cannot load the dapp. The workflow waits 15s for mm-connect (10s for other build types) after starting the tunnel before running tests.
+**CI:** For **mm-connect** runs only, the workflow starts BrowserStack Local (`--force-local --verbose`, no `--include-hosts`), sets `BROWSERSTACK_LOCAL=true` and `BROWSERSTACK_LOCAL_IDENTIFIER`, and waits **15s** after the tunnel is up before running tests. Other performance build types (for example onboarding) **do not** start the tunnel or enable local capabilities. Using `--include-hosts localhost 127.0.0.1` can prevent requests to `bs-local.com:8090` from reaching the runner; the device then cannot load the dapp.
 
 ### Using CLI Directly
 

--- a/tests/performance/mm-connect/README.md
+++ b/tests/performance/mm-connect/README.md
@@ -324,5 +324,9 @@ The other three spec files (`connection-evm`, `connection-multichain`,
 Playground dApp in Chrome. These tests do not require a separate APK — the dApp
 server is started automatically in `test.beforeAll`.
 
+On **BrowserStack**, the tunnel (**BrowserStack Local**) must be running and
+`BROWSERSTACK_LOCAL=true` must be set so devices can reach that server (see the
+parent README). CI enables the tunnel **only** for mm-connect performance jobs.
+
 See the [parent README](../README.md) for details on BrowserStack Local setup
 and other run configurations.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
We've recently enabled the Browserstack tunnel on all appium runs but this is incompatible with setting the GEOLOCATION so prediction tests may fail if the device that spins up in a location where prediction is not enabled.
Browserstack local is now only enabled on non mm-connect tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1753

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BrowserStack capability generation and the performance GitHub Action workflow, which could affect stability of BrowserStack performance runs (especially `mm-connect`) if tunnel/env gating is incorrect.
> 
> **Overview**
> **BrowserStack Local is now gated to `mm-connect` only** in the reusable performance workflow: Local identifier computation, tunnel startup, and the 15s readiness wait run only for `inputs.build_type == 'mm-connect'`, and the test step sets `BROWSERSTACK_LOCAL`/`BROWSERSTACK_LOCAL_IDENTIFIER` conditionally.
> 
> **BrowserStack capabilities restore geolocation when not using Local** by adding `geoLocation` only when `BROWSERSTACK_LOCAL` is not `true` (to avoid the Local+geolocation incompatibility).
> 
> Docs were updated to clarify that `mm-connect` BrowserStack runs require the Local tunnel and that other performance suites should not set `BROWSERSTACK_LOCAL`; the performance README also clarifies/aliases the `mm-connect` BrowserStack scripts accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ddcfec76cbeb0975d7f2c6fba24d3340a29d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->