### PR TITLE
chore: refactor to use submittx

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
@@ -8,7 +8,8 @@ import { useQuickBuyQuotes } from './useQuickBuyQuotes';
 import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
 import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
 import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
-import useSubmitBridgeTx from '../../../../../../util/bridge/hooks/useSubmitBridgeTx';
+import { selectShouldUseSmartTransaction } from '../../../../../../selectors/smartTransactionsController';
+import Engine from '../../../../../../core/Engine';
 import {
   selectIsSubmittingTx,
   selectDestAddress,
@@ -73,9 +74,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../../../util/bridge/hooks/useSubmitBridgeTx', () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock('../../../../../../selectors/smartTransactionsController', () => ({
+  selectShouldUseSmartTransaction: jest.fn(),
 }));
 
 jest.mock('../../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
@@ -91,6 +91,7 @@ jest.mock('../../../../../../core/Engine', () => ({
   default: {
     context: {
       BridgeController: { resetState: jest.fn() },
+      BridgeStatusController: { submitTx: jest.fn() },
       NetworkController: {
         findNetworkClientIdByChainId: jest.fn(() => 'mainnet'),
       },
@@ -143,7 +144,6 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 }));
 
 const mockDispatch = jest.fn();
-const mockSubmitBridgeTx = jest.fn();
 
 const createPosition = (overrides: Partial<Position> = {}): Position =>
   ({
@@ -248,9 +248,12 @@ const setupDefaultMocks = () => {
 
   (useIsInsufficientBalance as jest.Mock).mockReturnValue(false);
   (useHasSufficientGas as jest.Mock).mockReturnValue(true);
-  (useSubmitBridgeTx as jest.Mock).mockReturnValue({
-    submitBridgeTx: mockSubmitBridgeTx,
-  });
+  (selectShouldUseSmartTransaction as unknown as jest.Mock).mockReturnValue(
+    false,
+  );
+  (
+    Engine.context.BridgeStatusController.submitTx as jest.Mock
+  ).mockResolvedValue(undefined);
 };
 
 describe('useQuickBuyBottomSheet', () => {
@@ -664,6 +667,67 @@ describe('useQuickBuyBottomSheet', () => {
       });
 
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleConfirm', () => {
+    it('submits via BridgeStatusController.submitTx with normalised approval and stxEnabled', async () => {
+      const activeQuote = {
+        ...createActiveQuote(),
+        approval: null,
+      } as unknown as ReturnType<typeof createActiveQuote>;
+
+      (useQuickBuyQuotes as jest.Mock).mockReturnValue({
+        activeQuote,
+        destTokenAmount: '1',
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+      });
+      (selectShouldUseSmartTransaction as unknown as jest.Mock).mockReturnValue(
+        true,
+      );
+
+      const onClose = jest.fn();
+      const { result } = renderHook(() =>
+        useQuickBuyBottomSheet(createPosition(), onClose),
+      );
+
+      await act(async () => {
+        await result.current.handleConfirm();
+      });
+
+      expect(
+        Engine.context.BridgeStatusController.submitTx,
+      ).toHaveBeenCalledWith(
+        '0xWALLET',
+        expect.objectContaining({ approval: undefined }),
+        true,
+      );
+    });
+
+    it('does not call submitTx when there is no active quote', async () => {
+      (useQuickBuyQuotes as jest.Mock).mockReturnValue({
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyBottomSheet(createPosition(), jest.fn()),
+      );
+
+      await act(async () => {
+        await result.current.handleConfirm();
+      });
+
+      expect(
+        Engine.context.BridgeStatusController.submitTx,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -39,7 +39,7 @@ import {
   parsePriceImpact,
   exceedsPriceImpactErrorThreshold,
 } from '../../../../../UI/Bridge/utils/getPriceImpactViewData';
-import useSubmitBridgeTx from '../../../../../../util/bridge/hooks/useSubmitBridgeTx';
+import { selectShouldUseSmartTransaction } from '../../../../../../selectors/smartTransactionsController';
 import { useRefreshSmartTransactionsLiveness } from '../../../../../hooks/useRefreshSmartTransactionsLiveness';
 import { useIsGasIncludedSTXSendBundleSupported } from '../../../../../UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
 import { useRecipientInitialization } from '../../../../../UI/Bridge/hooks/useRecipientInitialization';
@@ -299,7 +299,7 @@ export function useQuickBuyBottomSheet(
 
   const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
 
-  const { submitBridgeTx } = useSubmitBridgeTx();
+  const stxEnabled = useSelector(selectShouldUseSmartTransaction);
   const hasDestinationPicker = isEvmNonEvmBridge || isNonEvmNonEvmBridge;
   const isDestinationAddressMissing = hasDestinationPicker && !destAddress;
 
@@ -340,7 +340,11 @@ export function useQuickBuyBottomSheet(
 
     try {
       dispatch(setIsSubmittingTx(true));
-      await submitBridgeTx({ quoteResponse: activeQuote });
+      await Engine.context.BridgeStatusController.submitTx(
+        walletAddress,
+        { ...activeQuote, approval: activeQuote.approval ?? undefined },
+        stxEnabled,
+      );
       setTxPhase('success');
       notificationAsync(NotificationFeedbackType.Success);
       await new Promise((resolve) => setTimeout(resolve, 800));
@@ -352,14 +356,7 @@ export function useQuickBuyBottomSheet(
     } finally {
       dispatch(setIsSubmittingTx(false));
     }
-  }, [
-    activeQuote,
-    walletAddress,
-    submitBridgeTx,
-    dispatch,
-    onClose,
-    navigation,
-  ]);
+  }, [activeQuote, walletAddress, stxEnabled, dispatch, onClose, navigation]);
 
   const sourceBalanceFiat = useMemo(() => {
     if (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`QuickBuyBottomSheet` no longer goes through the `useSubmitBridgeTx` hook to dispatch a transaction — it calls `Engine.context.BridgeStatusController.submitTx` directly. The hook is the right entry point for the main Bridge view but carries Bridge-UI-specific ceremony (A/B-test attribution wrappers, intent-quote routing, optional analytics params) that doesn't apply to QuickBuy. Inlining the controller call makes the QuickBuy submit path lean and explicit.

## What changed

In `useQuickBuyBottomSheet.ts`:

```ts
// Before
const { submitBridgeTx } = useSubmitBridgeTx();
// ...
await submitBridgeTx({ quoteResponse: activeQuote });

// After
const stxEnabled = useSelector(selectShouldUseSmartTransaction);
// ...
await Engine.context.BridgeStatusController.submitTx(
  walletAddress,
  { ...activeQuote, approval: activeQuote.approval ?? undefined },
  stxEnabled,
);
```

## What was preserved

- **`walletAddress` null-guard.** `if (!activeQuote || !walletAddress) return` at the top of `handleConfirm` is unchanged.
- **`approval: ... ?? undefined` normalisation.** The bridge API can return a literal `null` for `approval`; `BridgeStatusController.submitTx` expects `undefined` for "no approval needed". The spread + coalesce keeps that mapping intact (it's the same normalisation `useSubmitBridgeTx` was doing internally).
- **`setIsSubmittingTx` lifecycle.** Already wrapped around the submit call in `handleConfirm`; behaviour is unchanged.
- **Success / error path.** Haptics, `setTxPhase('success')`, the 800ms confetti delay, `navigation.navigate(Routes.TRANSACTIONS_VIEW)`, and the error-haptic branch all stay as-is.

## What was intentionally dropped

| Behavior `useSubmitBridgeTx` provided | Why dropping is correct for QuickBuy |
|---|---|
| Numpad / token-selector / sticky-footer A/B-test attribution via `withPendingTransactionActiveAbTests` | Those A/B tests are scoped to Bridge UI surfaces QuickBuy never renders. Attributing them to a QuickBuy tx would be misleading analytics. |
| `selectAbTestContext` → `assetsASSETS2493AbtestTokenDetailsLayout` `abTests` map | Scoped to the Token Details layout test; not part of QuickBuy. |
| `submitIntent` branch when `quoteResponse.quote.intent` is set | QuickBuy quotes come from `BridgeController.fetchQuotes` for `featureId: 'quickBuy'`; they aren't intent quotes. If that ever changes the controller throws, which is a clearer failure than dispatching the wrong path. |
| `location` analytics arg (`MetaMetricsSwapsEventSource`) | Not currently set by QuickBuy; can be added later as a 5th positional arg if we want to attribute the entry point. |

`useSubmitBridgeTx` itself is unchanged — the main Bridge view still uses it.

## Files changed

| File | Change |
|---|---|
| `app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts` | Replaced `useSubmitBridgeTx` import/usage with `selectShouldUseSmartTransaction` + direct `Engine.context.BridgeStatusController.submitTx(walletAddress, quote, stxEnabled)` call |
| `app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts` | Replaced `useSubmitBridgeTx` mock with `selectShouldUseSmartTransaction` mock; added `BridgeStatusController.submitTx` to the Engine mock; added two `handleConfirm` tests asserting (a) `submitTx` is called with the correct 3-arg shape (wallet address, quote with normalised `approval`, `stxEnabled`) and (b) it's not called when there's no active quote |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the QuickBuy transaction submission path to call `BridgeStatusController.submitTx` directly and to conditionally enable Smart Transactions, which could affect how bridge swaps are sent and tracked.
> 
> **Overview**
> QuickBuy’s `handleConfirm` flow now bypasses `useSubmitBridgeTx` and submits directly via `Engine.context.BridgeStatusController.submitTx`, passing `stxEnabled` from `selectShouldUseSmartTransaction` and normalizing `approval` from `null` to `undefined`.
> 
> Tests were updated to mock the new selector/controller path and add coverage that `submitTx` is called with the expected arguments (and not called when there is no active quote).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c5f6341636f9cedc3fce6f10c492b88a0879a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->