### PR TITLE
fix: incident 1588

### DIFF
--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -8,10 +8,16 @@
       - MM_BRAZE_SDK_ENDPOINT
   -->
 
-  <!-- Automatic FCM token registration — Braze will obtain and register a push token when permissions are granted -->
-  <bool translatable="false" name="com_braze_firebase_cloud_messaging_registration_enabled">true</bool>
-  <!-- Resolved at build time from google-services.json via the com.google.gms.google-services plugin -->
-  <string translatable="false" name="com_braze_firebase_cloud_messaging_sender_id">@string/gcm_defaultSenderId</string>
+  <!--
+    Manual FCM token registration. We let @react-native-firebase own the FCM
+    token lifecycle (single source of truth for the in-house notification
+    service NaaP) and forward each token to Braze via Braze.registerPushToken
+    in app/util/notifications/services/FCMService.ts. Setting this to `true`
+    makes Braze register its own token in parallel, which on Android
+    invalidates the RN-Firebase token and surfaces as MismatchSenderId /
+    NotRegistered failures from FCM when NaaP tries to deliver a push.
+  -->
+  <bool translatable="false" name="com_braze_firebase_cloud_messaging_registration_enabled">false</bool>
 
   <!-- Forward non-Braze push notifications to the existing RN Firebase service -->
   <bool name="com_braze_fallback_firebase_cloud_messaging_service_enabled">true</bool>

--- a/app/util/notifications/services/FCMService.test.ts
+++ b/app/util/notifications/services/FCMService.test.ts
@@ -1,6 +1,7 @@
 import messaging, {
   type FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
+import Braze from '@braze/react-native-sdk';
 // eslint-disable-next-line import-x/no-namespace
 import { processNotification } from '@metamask/notification-services-controller/notification-services';
 import { createMockNotificationEthSent } from '@metamask/notification-services-controller/notification-services/mocks';
@@ -22,6 +23,7 @@ jest.mock('@react-native-firebase/messaging', () => {
   const onMessage = jest.fn();
   const getInitialNotification = jest.fn();
   const onNotificationOpenedApp = jest.fn();
+  const onTokenRefresh = jest.fn();
 
   // Messaging() function mock
   const mockMessaging = jest.fn(() => ({
@@ -34,6 +36,7 @@ jest.mock('@react-native-firebase/messaging', () => {
     onMessage,
     getInitialNotification,
     onNotificationOpenedApp,
+    onTokenRefresh,
   }));
 
   // Retain the messaging properties
@@ -45,6 +48,15 @@ jest.mock('@react-native-firebase/messaging', () => {
     default: mockMessaging,
   };
 });
+
+// Braze SDK mock — overrides the global testSetup mock so we can assert
+// against `registerPushToken` calls per test.
+jest.mock('@braze/react-native-sdk', () => ({
+  __esModule: true,
+  default: {
+    registerPushToken: jest.fn(),
+  },
+}));
 
 // Notification Services Mock
 jest.mock('@metamask/notification-services-controller/notification-services');
@@ -68,6 +80,11 @@ const arrangeFirebaseMocks = () => {
   const mockOnNotificationOpenedApp = jest.mocked(
     messaging().onNotificationOpenedApp,
   );
+  // Return a real unsubscribe handle so FCMService's `#hasRegisteredTokenRefresh`
+  // guard treats the listener as registered (matches the real API contract).
+  const mockOnTokenRefresh = jest
+    .mocked(messaging().onTokenRefresh)
+    .mockReturnValue(jest.fn());
 
   return {
     mockHasPermission,
@@ -77,6 +94,7 @@ const arrangeFirebaseMocks = () => {
     mockOnMessage,
     mockGetInitialNotification,
     mockOnNotificationOpenedApp,
+    mockOnTokenRefresh,
   };
 };
 
@@ -91,8 +109,15 @@ const arrangeNativeModuleMocks = () => {
 };
 
 describe('FCMService - createRegToken()', () => {
+  const originalOS = Platform.OS;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    FCMService.clearRegistration();
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
   });
 
   it('creates registration token', async () => {
@@ -126,6 +151,72 @@ describe('FCMService - createRegToken()', () => {
     const result = await FCMService.createRegToken();
     expect(result).toBe(null);
     expect(firebaseMocks.mockGetToken).toHaveBeenCalled();
+  });
+
+  describe('Braze push token sync', () => {
+    const mockBrazeRegisterPushToken = jest.mocked(Braze.registerPushToken);
+
+    it('forwards the FCM token to Braze on Android', async () => {
+      Platform.OS = 'android';
+      arrangeFirebaseMocks();
+
+      await FCMService.createRegToken();
+
+      expect(mockBrazeRegisterPushToken).toHaveBeenCalledWith('MOCK_FCM_TOKEN');
+    });
+
+    it('does not forward the token to Braze on iOS (APNs is registered natively)', async () => {
+      Platform.OS = 'ios';
+      arrangeFirebaseMocks();
+
+      await FCMService.createRegToken();
+
+      expect(mockBrazeRegisterPushToken).not.toHaveBeenCalled();
+    });
+
+    it('subscribes to FCM token refreshes once and forwards refreshed tokens to Braze on Android', async () => {
+      Platform.OS = 'android';
+      const firebaseMocks = arrangeFirebaseMocks();
+
+      await FCMService.createRegToken();
+      await FCMService.createRegToken();
+
+      expect(firebaseMocks.mockOnTokenRefresh).toHaveBeenCalledTimes(1);
+
+      // Forward a rotated token through the captured listener.
+      const refreshListener =
+        firebaseMocks.mockOnTokenRefresh.mock.calls[0][0];
+      refreshListener('ROTATED_FCM_TOKEN');
+
+      expect(mockBrazeRegisterPushToken).toHaveBeenCalledWith(
+        'ROTATED_FCM_TOKEN',
+      );
+    });
+
+    it('does not subscribe to token refreshes when push permissions are denied', async () => {
+      Platform.OS = 'android';
+      const firebaseMocks = arrangeFirebaseMocks();
+      firebaseMocks.mockHasPermission.mockResolvedValue(
+        messaging.AuthorizationStatus.DENIED,
+      );
+
+      await FCMService.createRegToken();
+
+      expect(firebaseMocks.mockOnTokenRefresh).not.toHaveBeenCalled();
+      expect(mockBrazeRegisterPushToken).not.toHaveBeenCalled();
+    });
+
+    it('does not crash if Braze.registerPushToken throws', async () => {
+      Platform.OS = 'android';
+      arrangeFirebaseMocks();
+      mockBrazeRegisterPushToken.mockImplementationOnce(() => {
+        throw new Error('TEST ERROR');
+      });
+
+      const result = await FCMService.createRegToken();
+
+      expect(result).toBe('MOCK_FCM_TOKEN');
+    });
   });
 });
 

--- a/app/util/notifications/services/FCMService.ts
+++ b/app/util/notifications/services/FCMService.ts
@@ -8,6 +8,7 @@ import {
 import messaging, {
   type FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
+import Braze from '@braze/react-native-sdk';
 import { NativeModules, Platform } from 'react-native';
 import Logger from '../../../util/Logger';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -127,6 +128,30 @@ async function registerForRemoteMessages() {
 }
 
 /**
+ * Forward an FCM token to Braze on Android.
+ *
+ * The native `braze.xml` has `com_braze_firebase_cloud_messaging_registration_enabled`
+ * disabled, so Braze does not register its own FCM token. We let
+ * `@react-native-firebase/messaging` own the token and replay it to Braze
+ * here. Without this, Braze pushes are not delivered on Android.
+ *
+ * iOS is a no-op: APNs tokens are registered natively in `AppDelegate` via
+ * `Braze.notifications.register(deviceToken:)`, and the FCM token returned
+ * here is not what Braze expects on iOS.
+ */
+function syncBrazePushToken(token: string | null | undefined) {
+  if (!token || Platform.OS !== 'android') {
+    return;
+  }
+  try {
+    Braze.registerPushToken(token);
+  } catch (error) {
+    // Silently fail — Braze pushes will simply not arrive until the next
+    // successful sync; this must never break the in-house token flow.
+  }
+}
+
+/**
  * Processes and handles a remote firebase message.
  * Currently firebase messages only support wallet notifications (from our notification services).
  * @param payload - Firebase Remote Message Payload.
@@ -180,9 +205,34 @@ class FCMService {
     try {
       await registerForRemoteMessages();
       const fcmToken = await messaging().getToken();
+      syncBrazePushToken(fcmToken);
+      this.#registerTokenRefreshOnce();
       return fcmToken;
     } catch {
       return null;
+    }
+  };
+
+  /**
+   * Tracks the active `messaging().onTokenRefresh` subscription so we
+   * register it at most once for the lifetime of the app.
+   */
+  #hasRegisteredTokenRefresh: UnsubscribeFunc | null = null;
+
+  /**
+   * Subscribe to FCM token rotations and forward each new token to Braze.
+   * Idempotent: subsequent calls are no-ops.
+   */
+  #registerTokenRefreshOnce = () => {
+    if (this.#hasRegisteredTokenRefresh) {
+      return;
+    }
+    try {
+      this.#hasRegisteredTokenRefresh = messaging().onTokenRefresh((token) => {
+        syncBrazePushToken(token);
+      });
+    } catch {
+      // Do nothing - silently fail
     }
   };
 
@@ -260,6 +310,8 @@ class FCMService {
   clearRegistration = () => {
     this.#hasRegisteredForeground?.();
     this.#hasRegisteredForeground = null;
+    this.#hasRegisteredTokenRefresh?.();
+    this.#hasRegisteredTokenRefresh = null;
   };
 
   onClickPushNotificationWhenAppClosed = async () => {

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -579,6 +579,7 @@ jest.mock('@braze/react-native-sdk', () => ({
     addListener: jest.fn(() => ({ remove: jest.fn() })),
     Events: { PUSH_NOTIFICATION_EVENT: 'push_notification_event' },
     getInitialPushPayload: jest.fn(),
+    registerPushToken: jest.fn(),
   },
 }));
 

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -622,5 +622,6 @@ jest.mock('@braze/react-native-sdk', () => ({
     addListener: jest.fn(() => ({
       remove: jest.fn(),
     })),
+    registerPushToken: jest.fn(),
   },
 }));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android push-token registration flow by disabling Braze auto-registration and forwarding/refreshing FCM tokens to Braze in JS; mistakes could break Braze or in-house push delivery on Android. iOS behavior is intentionally unchanged but still touches shared token code paths and test mocks.
> 
> **Overview**
> **Fixes Android Braze push delivery by switching to manual FCM token syncing.** Braze’s automatic FCM registration is disabled in `braze.xml`, and `FCMService.createRegToken()` now forwards the RN-Firebase token to `Braze.registerPushToken` (Android-only) and subscribes once to `messaging().onTokenRefresh` to keep Braze updated.
> 
> Adds defensive error handling around Braze token forwarding, ensures listener cleanup in `clearRegistration()`, and expands unit tests/mocks to cover Android vs iOS behavior, token refresh idempotency, permission-denied cases, and Braze failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4034360431a5fb42614826840a1e48c23bac6c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->