### PR TITLE
feat: tempo disable tx management for testnet moderato

### DIFF
--- a/app/util/tempo/tempo-tx-utils.test.ts
+++ b/app/util/tempo/tempo-tx-utils.test.ts
@@ -200,8 +200,8 @@ describe('tempo-tx-utils', () => {
     it('return true for Tempo Mainnet', () => {
       expect(isTempoChain('0x1079')).toBe(true);
     });
-    it('return true for Tempo Moderato Testnet', () => {
-      expect(isTempoChain('0xa5bf')).toBe(true);
+    it('return false for Tempo Moderato Testnet', () => {
+      expect(isTempoChain('0xa5bf')).toBe(false);
     });
     it('return false for Polygon Mainnet', () => {
       expect(isTempoChain('0x89')).toBe(false);
@@ -215,11 +215,8 @@ describe('tempo-tx-utils', () => {
         gasFeeToken: '0x20c0000000000000000000000000000000000000',
       });
     });
-    it('return params for Tempo Moderato Testnet', () => {
-      expect(getTempoExtraOptionsForChain('0xa5bf')).toEqual({
-        excludeNativeTokenForFee: true,
-        gasFeeToken: '0x20c0000000000000000000000000000000000000',
-      });
+    it('return an empty object for Tempo Moderato Testnet', () => {
+      expect(getTempoExtraOptionsForChain('0xa5bf')).toEqual({});
     });
     it('return an empty object for Polygon Mainnet', () => {
       expect(getTempoExtraOptionsForChain('0x89')).toEqual({});

--- a/app/util/tempo/tempo-tx-utils.ts
+++ b/app/util/tempo/tempo-tx-utils.ts
@@ -27,12 +27,6 @@ const TEMPO_CONFIG: TempoConfig = {
         symbol: 'pathUSD',
       },
     },
-    '0xa5bf': {
-      defaultFeeToken: {
-        address: '0x20c0000000000000000000000000000000000000',
-        symbol: 'pathUSD',
-      },
-    },
   },
 } as const;
 

--- a/app/util/transaction-controller/index.test.ts
+++ b/app/util/transaction-controller/index.test.ts
@@ -90,7 +90,7 @@ const TRANSACTION_OPTIONS_MOCK = {
   origin: 'origin',
 };
 
-const TEMPO_VALID_CHAIN_ID = '0xa5bf' as Hex;
+const TEMPO_VALID_CHAIN_ID = '0x1079' as Hex;
 const BATCHID_MOCK = '0xmockBatchId' as Hex;
 const FROM_FIELD_MOCK = '0x1';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sentinel is not enabled for Tempo Moderato Testnet on `prod`, making the 7702-leveraged flow fail on that testnet.
This PR disables Tempo tx transformation for Tempo Moderato Testnet, while preserving the asset-hiding logic.
Limitations will be the same as for Hardware Wallet: `pathUSD` will always show as fee token for all txs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: tempo disable tx management for testnet moderato

## **Related issues**

Fixes:

## **Manual testing steps**

1. Switch to Tempo Moderato Testnet.
2. Perform a "send" of any token.
3. Observe that tx with be announced as paid with `pathUSD` regardless of user holding.
4. The tx should go through as long as the user has `pathUSD` balance.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/2ae13ff8-bdb6-42ef-b906-203bd686671e" />

### **After**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f41c6f22-209c-42d6-ab75-0f22bd346179" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a config-level removal that stops treating `0xa5bf` as a Tempo-supported chain, mainly affecting transaction option injection and batch handling on that testnet.
> 
> **Overview**
> Disables Tempo transaction management for Tempo Moderato Testnet (`0xa5bf`) by removing its entry from the Tempo per-chain config, so `isTempoChain` returns false and `getTempoExtraOptionsForChain` no longer injects `gasFeeToken`/`excludeNativeTokenForFee` for that chain.
> 
> Updates unit tests to reflect the new behavior and switches the transaction-controller Tempo-chain test fixture to use Tempo Mainnet (`0x1079`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be47bffdebf7877b256f8ae8dcbe1dea9d3a7bb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->