### PR TITLE
fix: polish top trader cards, skeleton alignment, and navigation

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -23,9 +23,13 @@ import useHomeViewedEvent, {
 import { useSectionPerformance } from '../../hooks/useSectionPerformance';
 import { SectionRefreshHandle } from '../../types';
 import { TopTraderCard, TopTraderCardSkeleton } from './components';
+import {
+  TOP_TRADER_CARD_HEIGHT,
+  TOP_TRADER_CARD_WIDTH,
+} from './components/TopTraderCard';
 import { useTopTraders } from './hooks';
 
-const HOME_TRADER_LIMIT = 3;
+const HOME_TRADER_LIMIT = 10;
 const SKELETON_KEYS = Array.from(
   { length: HOME_TRADER_LIMIT },
   (_, i) => `home-trader-skeleton-${i}`,
@@ -40,7 +44,7 @@ interface TopTradersSectionProps {
  * TopTradersSection -- Social leaderboard entry point on the homepage.
  *
  * Renders a section header plus a horizontally scrollable row of the
- * top 3 trader cards. Tapping the header chevron navigates to the
+ * top 10 trader cards. Tapping the header chevron navigates to the
  * full TopTradersView.
  */
 const TopTradersSection = forwardRef<
@@ -131,7 +135,7 @@ const TopTradersSection = forwardRef<
           {!isLoading && traders.length > 0 && (
             <ViewMoreCard
               onPress={handleViewAll}
-              twClassName="w-[200px] h-[180px]"
+              twClassName={`w-[${TOP_TRADER_CARD_WIDTH}px] h-[${TOP_TRADER_CARD_HEIGHT}px]`}
               testID="top-traders-view-more-card"
             />
           )}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -24,13 +24,20 @@ describe('TopTraderCard', () => {
     jest.clearAllMocks();
   });
 
-  it('renders username, ROI, and PnL', () => {
+  it('renders username and 30D PnL', () => {
     renderWithProvider(
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
     expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
-    expect(screen.getByText('+43.0%')).toBeOnTheScreen();
     expect(screen.getByText('+$963K')).toBeOnTheScreen();
+    expect(screen.getByText(/30D/)).toBeOnTheScreen();
+  });
+
+  it('does not display ROI percentage on the card', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+    expect(screen.queryByText('+43.0%')).not.toBeOnTheScreen();
   });
 
   it('renders with default testID when none is provided', () => {
@@ -163,7 +170,7 @@ describe('TopTraderCard', () => {
     expect(mockOnTraderPress).not.toHaveBeenCalled();
   });
 
-  it('displays negative ROI and PnL values with correct sign', () => {
+  it('displays negative PnL values with correct sign', () => {
     const negativeTrader: TopTrader = {
       ...baseTrader,
       percentageChange: -15.3,
@@ -175,7 +182,6 @@ describe('TopTraderCard', () => {
         onFollowPress={mockOnFollowPress}
       />,
     );
-    expect(screen.getByText('-15.3%')).toBeOnTheScreen();
     expect(screen.getByText('-$500')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
-import { Image, TouchableOpacity } from 'react-native';
 import {
-  Box,
-  Text,
-  TextVariant,
-  FontWeight,
-  TextColor,
-  BoxAlignItems,
   AvatarBase,
   AvatarBaseSize,
+  Box,
+  BoxAlignItems,
   Button,
-  ButtonVariant,
   ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React from 'react';
+import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 import { formatPnl } from '../utils/formatPnl';
@@ -35,20 +35,9 @@ export interface TopTraderCardProps {
   testID?: string;
 }
 
+// Fixed dimensions for every tile in the homepage Top Traders carousel
 const AVATAR_SIZE = 60;
-/**
- * Fixed dimensions for every tile in the homepage Top Traders carousel
- * (`TopTraderCard`, `TopTraderCardSkeleton`, `ViewMoreCard`). The carousel
- * deliberately does NOT grow with content — long usernames ellipsize via
- * `numberOfLines={1}` so all tiles stay visually identical regardless of
- * trader name length.
- */
 export const TOP_TRADER_CARD_WIDTH = 200;
-// Per Figma (node 1797:15424): 16 (top padding) + 60 (avatar) + 4 (gap) +
-// 48 (HeadingSm 24 line-height + 2 inner gap + BodySm 22 line-height) + 4
-// (gap) + 40 (ButtonSize.Md) + 16 (bottom padding) = 188. Setting it to
-// any larger value leaks visible empty space below the button because
-// children stack from the top of the column.
 export const TOP_TRADER_CARD_HEIGHT = 188;
 
 /**

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -35,13 +35,27 @@ export interface TopTraderCardProps {
   testID?: string;
 }
 
-const AVATAR_SIZE = 40;
+const AVATAR_SIZE = 60;
+/**
+ * Fixed dimensions for every tile in the homepage Top Traders carousel
+ * (`TopTraderCard`, `TopTraderCardSkeleton`, `ViewMoreCard`). The carousel
+ * deliberately does NOT grow with content — long usernames ellipsize via
+ * `numberOfLines={1}` so all tiles stay visually identical regardless of
+ * trader name length.
+ */
+export const TOP_TRADER_CARD_WIDTH = 200;
+// Per Figma (node 1797:15424): 16 (top padding) + 60 (avatar) + 4 (gap) +
+// 48 (HeadingSm 24 line-height + 2 inner gap + BodySm 22 line-height) + 4
+// (gap) + 40 (ButtonSize.Md) + 16 (bottom padding) = 188. Setting it to
+// any larger value leaks visible empty space below the button because
+// children stack from the top of the column.
+export const TOP_TRADER_CARD_HEIGHT = 188;
 
 /**
  * TopTraderCard -- compact card for the homepage horizontal scroll.
  *
- * Displays a trader's avatar, username, performance stats (ROI + PnL),
- * and a Follow/Following toggle.
+ * Displays a trader's avatar (top-left), username, 30D PnL stats, and a
+ * Follow/Following toggle pinned to the bottom.
  */
 const TopTraderCard: React.FC<TopTraderCardProps> = ({
   trader,
@@ -51,18 +65,14 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
 }) => {
   const tw = useTailwind();
 
-  const roiSign = trader.percentageChange >= 0 ? '+' : '';
-  const roiText = `${roiSign}${trader.percentageChange.toFixed(1)}%`;
   const pnlText = formatPnl(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
-  const isRoiPositive = trader.percentageChange >= 0;
 
   return (
     <Box
-      twClassName="w-[200px] rounded-2xl bg-muted p-4 overflow-hidden"
+      twClassName={`w-[${TOP_TRADER_CARD_WIDTH}px] h-[${TOP_TRADER_CARD_HEIGHT}px] rounded-2xl bg-muted p-4 overflow-hidden gap-1`}
       testID={testID ?? `top-trader-card-${trader.id}`}
     >
-      {/* Top content: avatar + name + stats */}
       <TouchableOpacity
         activeOpacity={onTraderPress ? 0.7 : 1}
         onPress={
@@ -74,8 +84,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         disabled={!onTraderPress}
         testID={`top-trader-card-pressable-${trader.id}`}
       >
-        <Box alignItems={BoxAlignItems.Center} twClassName="flex-1 gap-2 mb-3">
-          {/* Avatar */}
+        <Box alignItems={BoxAlignItems.Center} twClassName="gap-1">
           {trader.avatarUri ? (
             <Image
               source={{ uri: trader.avatarUri }}
@@ -87,60 +96,50 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
             />
           ) : (
             <AvatarBase
-              size={AvatarBaseSize.Lg}
+              size={AvatarBaseSize.Xl}
               fallbackText={trader.username.charAt(0).toUpperCase()}
+              twClassName={`w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px]`}
             />
           )}
 
-          {/* Username */}
-          <Text
-            variant={TextVariant.HeadingSm}
-            fontWeight={FontWeight.Bold}
-            color={TextColor.TextDefault}
-            numberOfLines={1}
-          >
-            {trader.username}
-          </Text>
-
-          {/* Stats: +96.2% · +$963K 30D */}
-          <Text variant={TextVariant.BodyXs} fontWeight={FontWeight.Medium}>
+          <Box twClassName="w-full gap-0.5">
             <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              twClassName={
-                isRoiPositive ? 'text-success-default' : 'text-error-default'
-              }
-            >
-              {roiText}
-            </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Bold}
               color={TextColor.TextDefault}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              twClassName="text-center"
             >
-              {' \u00B7 '}
+              {trader.username}
             </Text>
+
             <Text
-              variant={TextVariant.BodyXs}
+              variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
-              twClassName={
-                isPnlPositive ? 'text-success-default' : 'text-error-default'
-              }
+              twClassName="text-center"
             >
-              {pnlText}
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                twClassName={
+                  isPnlPositive ? 'text-success-default' : 'text-error-default'
+                }
+              >
+                {pnlText}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextAlternative}
+              >
+                {' 30D'}
+              </Text>
             </Text>
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-            >
-              {' 30D'}
-            </Text>
-          </Text>
+          </Box>
         </Box>
       </TouchableOpacity>
 
-      {/* Follow / Following button pinned to bottom */}
       <Button
         variant={
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCardSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCardSkeleton.tsx
@@ -1,27 +1,42 @@
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../../util/theme';
+import { TOP_TRADER_CARD_HEIGHT, TOP_TRADER_CARD_WIDTH } from './TopTraderCard';
 
 /**
  * TopTraderCardSkeleton -- loading placeholder that mirrors the TopTraderCard layout.
+ *
+ * Wrapper dimensions are locked to the same fixed footprint as `TopTraderCard`
+ * so loading and loaded states never shift the carousel layout.
  */
 const TopTraderCardSkeleton: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
 
   return (
-    <View style={tw.style('w-[200px] rounded-2xl bg-muted p-4')}>
+    <View
+      style={tw.style(
+        `w-[${TOP_TRADER_CARD_WIDTH}px] h-[${TOP_TRADER_CARD_HEIGHT}px] rounded-2xl bg-muted p-4`,
+      )}
+    >
       <SkeletonPlaceholder
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
-        <View style={tw.style('items-start gap-2')}>
-          <View style={tw.style('w-10 h-10 rounded-full')} />
-          <View style={tw.style('w-24 h-5 rounded self-center')} />
-          <View style={tw.style('w-36 h-3 rounded self-center')} />
-          <View style={tw.style('w-full h-8 rounded-xl')} />
+        {/* Mirrors the loaded TopTraderCard's structure AND its exact
+            vertical metrics so every shimmer shape lands on the same pixel
+            as its loaded counterpart */}
+        <View style={tw.style('gap-1')}>
+          <View style={tw.style('items-center gap-1')}>
+            <View style={tw.style('w-[60px] h-[60px] rounded-full')} />
+            <View style={tw.style('items-center gap-0.5')}>
+              <View style={tw.style('w-24 h-6 rounded')} />
+              <View style={tw.style('w-32 h-[22px] rounded')} />
+            </View>
+          </View>
+          <View style={tw.style('h-10 rounded-xl')} />
         </View>
       </SkeletonPlaceholder>
     </View>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCardSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCardSkeleton.tsx
@@ -25,9 +25,6 @@ const TopTraderCardSkeleton: React.FC = () => {
         backgroundColor={colors.background.section}
         highlightColor={colors.background.subsection}
       >
-        {/* Mirrors the loaded TopTraderCard's structure AND its exact
-            vertical metrics so every shimmer shape lands on the same pixel
-            as its loaded counterpart */}
         <View style={tw.style('gap-1')}>
           <View style={tw.style('items-center gap-1')}>
             <View style={tw.style('w-[60px] h-[60px] rounded-full')} />

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -14,8 +14,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { TopRankAvatar, TopRankIndicator } from '../topRank';
@@ -58,11 +57,6 @@ const TraderRow: React.FC<TraderRowProps> = ({
   const pnlText = formatPnl(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
   const isRoiPositive = trader.percentageChange >= 0;
-
-  const handleFollowPress = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Light);
-    onFollowPress(trader.id);
-  }, [onFollowPress, trader.id]);
 
   return (
     <Box
@@ -168,7 +162,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
         size={ButtonSize.Md}
-        onPress={handleFollowPress}
+        onPress={() => onFollowPress(trader.id)}
         twClassName="min-w-[96px] self-center"
       >
         {trader.isFollowing

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -1,26 +1,26 @@
-import React, { useCallback } from 'react';
-import { Image, TouchableOpacity } from 'react-native';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
-  Box,
-  Text,
-  TextVariant,
-  FontWeight,
-  TextColor,
-  BoxFlexDirection,
-  BoxAlignItems,
-  BoxJustifyContent,
   AvatarBase,
   AvatarBaseSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
   Button,
-  ButtonVariant,
   ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import React, { useCallback } from 'react';
+import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
+import { TopRankAvatar, TopRankIndicator } from '../topRank';
 import type { TopTrader } from '../types';
 import { formatPnl } from '../utils/formatPnl';
-import { TopRankAvatar, TopRankIndicator } from '../topRank';
 
 const AVATAR_SIZE = 40;
 // Fixed row height so the skeleton placeholder can match it exactly without
@@ -30,15 +30,10 @@ export const TRADER_ROW_HEIGHT = 64;
 export interface TraderRowProps {
   trader: TopTrader;
   onFollowPress: (traderId: string) => void;
-  /**
-   * Invoked when the row is tapped. The third argument is the trader's
-   * **overall** (unfiltered) rank — used downstream to gate the profile's
-   * podium decoration on true top-3 traders, never the filtered display
-   * rank.
-   */
   onTraderPress?: (
     traderId: string,
     traderName: string,
+    /* Used downstream for podium decoration */
     overallRank: number,
   ) => void;
   testID?: string;

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Image, TouchableOpacity } from 'react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -62,6 +63,11 @@ const TraderRow: React.FC<TraderRowProps> = ({
   const pnlText = formatPnl(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
   const isRoiPositive = trader.percentageChange >= 0;
+
+  const handleFollowPress = useCallback(() => {
+    impactAsync(ImpactFeedbackStyle.Light);
+    onFollowPress(trader.id);
+  }, [onFollowPress, trader.id]);
 
   return (
     <Box
@@ -167,7 +173,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
         size={ButtonSize.Md}
-        onPress={() => onFollowPress(trader.id)}
+        onPress={handleFollowPress}
         twClassName="min-w-[96px] self-center"
       >
         {trader.isFollowing

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -195,11 +195,11 @@ describe('TraderPositionView', () => {
     expect(screen.getByText('No trades for this interval')).toBeOnTheScreen();
   });
 
-  it('calls goBack when the close button is pressed', () => {
+  it('calls goBack when the back button is pressed', () => {
     renderWithProvider(<TraderPositionView />, { state: mockState });
 
     fireEvent.press(
-      screen.getByTestId(TraderPositionViewSelectorsIDs.CLOSE_BUTTON),
+      screen.getByTestId(TraderPositionViewSelectorsIDs.BACK_BUTTON),
     );
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
@@ -1,6 +1,6 @@
 export const TraderPositionViewSelectorsIDs = {
   CONTAINER: 'trader-position-view-container',
-  CLOSE_BUTTON: 'trader-position-view-close-button',
+  BACK_BUTTON: 'trader-position-view-back-button',
   BUY_BUTTON: 'trader-position-view-buy-button',
   SKELETON: 'trader-position-skeleton',
   FALLBACK: 'trader-position-fallback',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -78,7 +78,7 @@ const TraderPositionView = () => {
     timePeriods,
   } = positionData;
 
-  const handleClose = useCallback(() => {
+  const handleBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
@@ -108,8 +108,8 @@ const TraderPositionView = () => {
     >
       <TraderPositionHeader
         traderName={traderName}
-        onClose={handleClose}
-        closeButtonTestID={TraderPositionViewSelectorsIDs.CLOSE_BUTTON}
+        onBack={handleBack}
+        backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
       />
 
       {isInitialLoading ? (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
@@ -15,14 +15,14 @@ import {
 
 export interface TraderPositionHeaderProps {
   traderName: string;
-  onClose: () => void;
-  closeButtonTestID: string;
+  onBack: () => void;
+  backButtonTestID: string;
 }
 
 const TraderPositionHeader: React.FC<TraderPositionHeaderProps> = ({
   traderName,
-  onClose,
-  closeButtonTestID,
+  onBack,
+  backButtonTestID,
 }) => (
   <Box
     flexDirection={BoxFlexDirection.Row}
@@ -30,7 +30,14 @@ const TraderPositionHeader: React.FC<TraderPositionHeaderProps> = ({
     justifyContent={BoxJustifyContent.Between}
     twClassName="px-2 py-2"
   >
-    <Box twClassName="w-10" />
+    <Box twClassName="w-10">
+      <ButtonIcon
+        iconName={IconName.ArrowLeft}
+        size={ButtonIconSize.Md}
+        onPress={onBack}
+        testID={backButtonTestID}
+      />
+    </Box>
     <Text
       variant={TextVariant.HeadingSm}
       fontWeight={FontWeight.Bold}
@@ -39,14 +46,7 @@ const TraderPositionHeader: React.FC<TraderPositionHeaderProps> = ({
     >
       {traderName}
     </Text>
-    <Box twClassName="w-10 items-end">
-      <ButtonIcon
-        iconName={IconName.Close}
-        size={ButtonIconSize.Md}
-        onPress={onClose}
-        testID={closeButtonTestID}
-      />
-    </Box>
+    <Box twClassName="w-10" />
   </Box>
 );
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -10,7 +10,6 @@ import {
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -119,11 +118,6 @@ const TraderProfileView = () => {
   const handleBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
-
-  const handleFollowPress = useCallback(() => {
-    impactAsync(ImpactFeedbackStyle.Light);
-    toggleFollow();
-  }, [toggleFollow]);
 
   const handleNotificationPress = useCallback(() => {
     // Don't open any sheet while preferences are still loading — the enabled
@@ -235,7 +229,7 @@ const TraderProfileView = () => {
                         : ButtonVariant.Primary
                     }
                     isFullWidth
-                    onPress={handleFollowPress}
+                    onPress={toggleFollow}
                     testID={TraderProfileViewSelectorsIDs.FOLLOW_BUTTON}
                   >
                     {isFollowing

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -10,6 +10,7 @@ import {
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -118,6 +119,11 @@ const TraderProfileView = () => {
   const handleBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
+
+  const handleFollowPress = useCallback(() => {
+    impactAsync(ImpactFeedbackStyle.Light);
+    toggleFollow();
+  }, [toggleFollow]);
 
   const handleNotificationPress = useCallback(() => {
     // Don't open any sheet while preferences are still loading — the enabled
@@ -229,7 +235,7 @@ const TraderProfileView = () => {
                         : ButtonVariant.Primary
                     }
                     isFullWidth
-                    onPress={toggleFollow}
+                    onPress={handleFollowPress}
                     testID={TraderProfileViewSelectorsIDs.FOLLOW_BUTTON}
                   >
                     {isFollowing

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useSelector } from 'react-redux';
 import Engine from '../../core/Engine';
 import Logger from '../../util/Logger';
@@ -120,6 +121,42 @@ describe('useFollowToggle', () => {
         expect.any(Error),
         'useFollowToggle: toggleFollow failed',
       );
+    });
+
+    it('fires light haptic feedback on every toggle press', async () => {
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('still fires haptic feedback when a toggle is debounced as in-flight', async () => {
+      let resolveCall: (value: unknown) => void = () => undefined;
+      (Engine.controllerMessenger.call as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCall = resolve;
+          }),
+      );
+
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        result.current.toggleFollow();
+      });
+      await act(async () => {
+        result.current.toggleFollow();
+      });
+
+      expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
+      expect(impactAsync).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        resolveCall({ followed: [], unfollowed: [] });
+      });
     });
 
     it('ignores concurrent toggle calls while one is in flight', async () => {

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -1,3 +1,4 @@
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../core/Engine';
@@ -36,6 +37,13 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
 
   const toggleFollow = useCallback(
     async (addressOrId: string): Promise<void> => {
+      // Fire haptic on every user-initiated toggle so feedback is consistent
+      // across all Follow entry points (homepage carousel, leaderboard rows,
+      // trader profile). Placed before the inflight guard so a quick repeat
+      // tap still produces a tactile response even when the API call is
+      // debounced.
+      impactAsync(ImpactFeedbackStyle.Light);
+
       if (inflightIdsRef.current.has(addressOrId)) {
         return;
       }


### PR DESCRIPTION
## **Description**

- **TopTraderCard**: bumped avatar to 60px and locked the card to `200x188` (per [Figma](https://www.figma.com/design/HzPB0InxHBY5hPkOukPCqv/Social?node-id=1485-37072&t=2uvptc7KPIwV5tsC-0)). Removed the ROI percentage line, ellipsize long usernames, and center-align text — every tile in the carousel now has identical, constrained dimensions regardless of trader name length.
<img width="409" height="242" alt="image" src="https://github.com/user-attachments/assets/58c57f6a-494c-43df-9afe-781c9ec3ab09" />

- **TopTraderCardSkeleton**: now mirrors the loaded card's flex structure and exact text line-heights (`HeadingSm` 24px, `BodySm` 22px, button 40px). Total content sums to exactly 188px so each shimmer shape lands on the same pixel as its loaded counterpart — the button shimmer no longer floats above its final position.
<img width="487" height="236" alt="image" src="https://github.com/user-attachments/assets/d004610a-ff10-4d52-a110-deaeaf421ddd" />
 
- **TopTradersSection**: raised the homepage carousel limit from 3 to 10 trader cards.
- **TraderRow / TraderProfileView**: added a single light haptic on Follow / Following toggle, consistent across all entry points.
- **TraderPositionView**: replaced the close (X) button with a back arrow (and renamed the related test ID and props from `close` → `back`) so the navigation gesture matches the rest of the stack.
<img width="294" height="601" alt="image" src="https://github.com/user-attachments/assets/69f9ff22-1319-4118-9c98-4420605fd271" />


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:



## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow/unfollow interaction behavior (adds haptics even when requests are debounced) and changes a navigation control/test IDs; issues would primarily be UX regressions rather than data/security problems.
> 
> **Overview**
> Polishes the homepage *Top Traders* carousel by increasing the displayed trader limit from 3 to 10 and locking card/skeleton/ViewMore tile sizing via shared `TOP_TRADER_CARD_WIDTH/HEIGHT` constants.
> 
> Updates `TopTraderCard` layout to match design (larger avatar, ellipsized/centered username) and removes ROI from the card UI; tests are adjusted to assert the new 30D PnL-only display.
> 
> Replaces `TraderPositionView` header’s close (X) action with a back arrow, renaming related props and selector IDs (`CLOSE_BUTTON` → `BACK_BUTTON`) and updating tests accordingly.
> 
> Adds light haptic feedback to `useFollowToggleMany.toggleFollow` on every tap (including when a toggle is ignored due to an in-flight request), with new unit tests covering the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f480896476d68fbd4b0b2516095e1ba921594e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->