### PR TITLE
feat(confirmations): support Predict pUSD token

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
@@ -8,7 +8,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { strings } from '../../../../../../../locales/i18n';
 import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl';
 import { useNetworkName } from '../../../hooks/useNetworkName';
-import { POLYGON_USDCE } from '../../../constants/predict';
+import { POLYGON_PUSD } from '../../../constants/predict';
 import { selectBridgeHistoryForAccount } from '../../../../../../selectors/bridgeStatusController';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
@@ -118,7 +118,7 @@ describe('ReceiveSummaryLine', () => {
     expect(
       getByText(
         strings('transaction_details.summary_title.bridge_receive', {
-          targetSymbol: POLYGON_USDCE.symbol,
+          targetSymbol: POLYGON_PUSD.symbol,
           targetChain: 'Arbitrum',
         }),
       ),

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -8,7 +8,7 @@ import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
-import { POLYGON_USDCE } from '../../../constants/predict';
+import { POLYGON_PUSD } from '../../../constants/predict';
 import { TransactionSummaryLine } from './transaction-summary-line';
 
 const HYPERLIQUID_EXPLORER_URL = 'https://app.hyperliquid.xyz/explorer/tx';
@@ -39,7 +39,7 @@ export function ReceiveSummaryLine({
     targetNetworkName = 'Hyperliquid';
     receiveChainId = CHAIN_IDS.ARBITRUM;
   } else if (isPredictDeposit) {
-    targetSymbol = POLYGON_USDCE.symbol;
+    targetSymbol = POLYGON_PUSD.symbol;
   }
 
   const title =

--- a/app/components/Views/confirmations/components/info/predict-deposit-info/predict-deposit-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-deposit-info/predict-deposit-info.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useNavbar from '../../../hooks/ui/useNavbar';
 import { CustomAmountInfo } from '../custom-amount-info';
 import { strings } from '../../../../../../../locales/i18n';
-import { POLYGON_USDCE, PREDICT_CURRENCY } from '../../../constants/predict';
+import { POLYGON_PUSD, PREDICT_CURRENCY } from '../../../constants/predict';
 import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 
@@ -11,10 +11,10 @@ export function PredictDepositInfo() {
 
   useAddToken({
     chainId: CHAIN_IDS.POLYGON,
-    decimals: POLYGON_USDCE.decimals,
-    name: POLYGON_USDCE.name,
-    symbol: POLYGON_USDCE.symbol,
-    tokenAddress: POLYGON_USDCE.address,
+    decimals: POLYGON_PUSD.decimals,
+    name: POLYGON_PUSD.name,
+    symbol: POLYGON_PUSD.symbol,
+    tokenAddress: POLYGON_PUSD.address,
   });
 
   return <CustomAmountInfo currency={PREDICT_CURRENCY} />;

--- a/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.tsx
@@ -3,7 +3,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import useNavbar from '../../../hooks/ui/useNavbar';
 import { CustomAmountInfo } from '../custom-amount-info';
 import { PredictWithdrawBalance } from '../../predict-confirmations/predict-withdraw-balance/predict-withdraw-balance';
-import { POLYGON_USDCE, PREDICT_CURRENCY } from '../../../constants/predict';
+import { POLYGON_PUSD, PREDICT_CURRENCY } from '../../../constants/predict';
 import { useAddToken } from '../../../hooks/tokens/useAddToken';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
@@ -15,10 +15,10 @@ export function PredictWithdrawInfo() {
 
   useAddToken({
     chainId: CHAIN_IDS.POLYGON,
-    decimals: POLYGON_USDCE.decimals,
-    name: POLYGON_USDCE.name,
-    symbol: POLYGON_USDCE.symbol,
-    tokenAddress: POLYGON_USDCE.address,
+    decimals: POLYGON_PUSD.decimals,
+    name: POLYGON_PUSD.name,
+    symbol: POLYGON_PUSD.symbol,
+    tokenAddress: POLYGON_PUSD.address,
   });
 
   return (

--- a/app/components/Views/confirmations/constants/predict.ts
+++ b/app/components/Views/confirmations/constants/predict.ts
@@ -9,3 +9,10 @@ export const POLYGON_USDCE = {
   name: 'USD Coin (PoS)',
   symbol: 'USDC.e',
 };
+
+export const POLYGON_PUSD = {
+  address: '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB' as Hex,
+  decimals: 6,
+  name: 'Polymarket USD',
+  symbol: 'pUSD',
+};

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
@@ -11,6 +11,7 @@ const CHAIN_ID_1_MOCK = '0x123';
 const CHAIN_ID_2_MOCK = '0x456';
 const ADDRESS_1_MOCK = '0x789';
 const ADDRESS_2_MOCK = '0xabc';
+const POLYGON_PUSD_ADDRESS_MOCK = '0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb';
 const PRICE_1_MOCK = 2;
 const PRICE_2_MOCK = 3;
 const TICKER_1_MOCK = 'USD';
@@ -111,6 +112,20 @@ describe('useTokenFiatRates', () => {
         {
           address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
           chainId: CHAIN_IDS.ARBITRUM,
+          currency: 'usd',
+        },
+      ],
+    });
+
+    expect(result).toEqual([1]);
+  });
+
+  it('returns fixed exchange rate for Polygon pUSD when currency is USD', () => {
+    const result = runHook({
+      requests: [
+        {
+          address: POLYGON_PUSD_ADDRESS_MOCK,
+          chainId: CHAIN_IDS.POLYGON,
           currency: 'usd',
         },
       ],

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -28,6 +28,7 @@ const STABLECOINS: Record<Hex, Hex[]> = {
   ],
   [CHAIN_IDS.POLYGON]: [
     '0x2791bca1f2de4661ed88a30c99a7a9449aa84174', // USDC.e
+    '0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb', // pUSD
   ],
 };
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6897,7 +6897,7 @@
         "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
-        "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predictions. Swap providers may charge a fee, but MetaMask won't."
+        "transaction_fee": "We'll swap your tokens for pUSD on Polygon, the network used by Predictions. Swap providers may charge a fee, but MetaMask won't."
       },
       "perps_withdraw": {
         "transaction_fee": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD."


### PR DESCRIPTION
## **Description**

This PR updates Predict confirmation UI to use Polymarket USD (pUSD) metadata instead of legacy Polygon USDC.e metadata.

It includes:
- A new `POLYGON_PUSD` confirmation token constant while keeping `POLYGON_USDCE` for existing callers.
- Predict deposit/withdraw confirmation token metadata updates.
- Predict receive-summary copy/token symbol updates.
- pUSD as a Polygon stablecoin in confirmation fiat-rate fallback logic.
- English confirmation copy updated from USDC.e to pUSD.

Stack note: this is the confirmations-only PR in a two-PR split. The Predict core migration PR is stacked on top of this branch.

## **Changelog**

CHANGELOG entry: Updated Predict confirmations to display pUSD as the Predict token.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Predict pUSD confirmations

  Scenario: user reviews a Predict deposit confirmation
    Given the user starts a Predict deposit
    When the confirmation screen is displayed
    Then the Predict token metadata and fee copy refer to pUSD on Polygon

  Scenario: user reviews a Predict withdraw confirmation
    Given the user starts a Predict withdraw
    When the confirmation screen is displayed
    Then the Predict token metadata refers to pUSD on Polygon
```

## **Screenshots/Recordings**

### **Before**

N/A — code-only split PR; no screenshots captured.

### **After**

N/A — code-only split PR; no screenshots captured.

## **Testing**

- `yarn lint:tsc`
- `yarn jest app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx app/components/Views/confirmations/components/info/predict-withdraw-info/predict-withdraw-info.test.tsx --runInBand --forceExit`

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Predict confirmation token metadata, UI copy, and stablecoin fiat-rate fallback logic; incorrect token address/symbol here could cause misleading confirmation details or 1:1 USD pricing assumptions.
> 
> **Overview**
> Predict deposit/withdraw confirmations now use Polygon `pUSD` token metadata (new `POLYGON_PUSD` constant) instead of `USDC.e`, including the receive summary title for `predictDeposit` activity.
> 
> Confirmation fiat-rate fallback logic treats Polygon `pUSD` as a USD-pegged stablecoin (returns `1` when currency is USD), with tests updated/added accordingly, and English tooltip copy updated from *USDC.e* to *pUSD*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa301450ff691733f8f68a02ecfb881eeb6a43d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->