### PR TITLE
fix(predict): normalize live game score ordering

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
@@ -33,6 +33,7 @@ import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
 import { isDrawCapableLeague } from '../../constants/sports';
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
+import { parseScore } from '../../utils/gameParser';
 import FeaturedCarouselCardFooter from './FeaturedCarouselCardFooter';
 import FeaturedCarouselPayoutRow from './FeaturedCarouselPayoutRow';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
@@ -68,12 +69,9 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
   const showDraw = isDrawCapableLeague(game.league);
 
   const liveData = useMemo(() => {
-    const parseScore = (raw: string | null | undefined) => {
-      if (!raw) return null;
-      const [away, home] = raw.split('-').map(Number);
-      return !isNaN(away) && !isNaN(home) ? { away, home } : null;
-    };
-    const liveScore = gameUpdate?.score ? parseScore(gameUpdate.score) : null;
+    const liveScore = gameUpdate?.score
+      ? parseScore(gameUpdate.score, game.league)
+      : null;
     return {
       homeScore: liveScore?.home ?? game.score?.home ?? 0,
       awayScore: liveScore?.away ?? game.score?.away ?? 0,

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
@@ -458,6 +458,33 @@ describe('PredictSportScoreboard', () => {
       expect(queryByText('7')).toBeNull();
     });
 
+    it('normalizes home-first live scores when determining the winner', () => {
+      const game = createGame({
+        league: 'ucl',
+        status: 'ended',
+        period: 'FT',
+        score: { away: 0, home: 0, raw: '0-0' },
+      });
+      mockUseLiveGameUpdates.mockReturnValue(
+        createLiveUpdate({
+          gameUpdate: {
+            gameId: 'game-123',
+            score: '2-1',
+            elapsed: '90:00',
+            period: 'FT',
+            status: 'ended' as PredictGameStatus,
+          },
+        }),
+      );
+
+      const { getByTestId, queryByTestId } = render(
+        <PredictSportScoreboard game={game} testID="scoreboard" />,
+      );
+
+      expect(getByTestId('scoreboard-home-winner')).toBeOnTheScreen();
+      expect(queryByTestId('scoreboard-away-winner')).toBeNull();
+    });
+
     it('uses live status when available', () => {
       const game = createGame({ status: 'scheduled' });
       mockUseLiveGameUpdates.mockReturnValue(

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -16,31 +16,13 @@ import PredictSportWinner from '../PredictSportWinner/PredictSportWinner';
 import { PredictMarketGame } from '../../types';
 import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
 import { isDrawCapableLeague } from '../../constants/sports';
+import { parseScore } from '../../utils/gameParser';
 import { PREDICT_SPORT_SCOREBOARD_TEST_IDS } from './PredictSportScoreboard.testIds';
 
 export interface PredictSportScoreboardProps {
   game: PredictMarketGame;
   testID?: string;
 }
-
-/**
- * Parses score string "away-home" (e.g., "21-14") into { away, home } numbers.
- */
-const parseScoreString = (
-  scoreString: string | null | undefined,
-): { away: number; home: number } | null => {
-  if (!scoreString) return null;
-
-  const parts = scoreString.split('-');
-  if (parts.length !== 2) return null;
-
-  const away = parseInt(parts[0], 10);
-  const home = parseInt(parts[1], 10);
-
-  if (isNaN(away) || isNaN(home)) return null;
-
-  return { away, home };
-};
 
 /**
  * Formats startTime to { date: "Sat, Jan 17", time: "2:30 PM" }.
@@ -92,7 +74,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
 
   const mergedData = useMemo(() => {
     const liveScore = gameUpdate?.score
-      ? parseScoreString(gameUpdate.score)
+      ? parseScore(gameUpdate.score, game.league)
       : null;
 
     return {

--- a/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.test.ts
@@ -213,6 +213,32 @@ describe('GameCache', () => {
       expect(result.game?.turn).toBe('DEN');
     });
 
+    it('normalizes cached scores for home-first leagues', () => {
+      const cache = GameCache.getInstance();
+      const update = createMockGameUpdate({
+        gameId: 'game-123',
+        score: '2-1',
+        status: 'ended',
+        period: 'FT',
+      });
+      const market = createMockMarketWithGame();
+
+      if (!market.game) {
+        throw new Error('Expected market.game to exist');
+      }
+
+      cache.updateGame('game-123', update);
+      const result = cache.overlayOnMarket({
+        ...market,
+        game: {
+          ...market.game,
+          league: 'ucl',
+        },
+      });
+
+      expect(result.game?.score).toEqual({ away: 1, home: 2, raw: '2-1' });
+    });
+
     it('preserves non-overlaid game properties', () => {
       const cache = GameCache.getInstance();
       const update = createMockGameUpdate({ gameId: 'game-123' });

--- a/app/components/UI/Predict/providers/polymarket/GameCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/GameCache.ts
@@ -66,7 +66,7 @@ export class GameCache {
       ...market,
       game: {
         ...market.game,
-        score: parseScore(cachedUpdate.score),
+        score: parseScore(cachedUpdate.score, market.game.league),
         elapsed: cachedUpdate.elapsed || null,
         period: cachedUpdate.period || null,
         status: cachedUpdate.status,

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -196,11 +196,11 @@ export type PredictSportTeam = {
   alias?: string; // Team alias (e.g., "Seahawks")
 };
 
-// Parsed score data
+// Parsed score data normalized into away/home values
 export type PredictGameScore = {
   away: number;
   home: number;
-  raw: string; // Original "away-home" format (e.g., "21-14")
+  raw: string; // Original provider format (e.g., "21-14")
 };
 
 export type PredictGamePeriod =
@@ -231,7 +231,7 @@ export type PredictMarketGame = {
   league: PredictSportsLeague;
   elapsed: string | null; // Game clock, null if not available
   period: PredictGamePeriod | null; // Current period, null if not available
-  score: PredictGameScore | null; // Parsed score with away/home values, null if not available
+  score: PredictGameScore | null; // Parsed score normalized to away/home values, null if not available
   homeTeam: PredictSportTeam;
   awayTeam: PredictSportTeam;
   turn?: string; // Team abbreviation with possession

--- a/app/components/UI/Predict/utils/gameParser.test.ts
+++ b/app/components/UI/Predict/utils/gameParser.test.ts
@@ -369,6 +369,57 @@ describe('gameParser', () => {
       });
     });
 
+    it('normalizes score order for home-first leagues', () => {
+      const homeTeam: PredictSportTeam = {
+        id: 'team-home',
+        name: 'Real Madrid',
+        logo: 'https://example.com/rma.png',
+        abbreviation: 'RMA',
+        color: TEST_HEX_COLORS.WHITE_FULL,
+        alias: 'Madrid',
+      };
+
+      const awayTeam: PredictSportTeam = {
+        id: 'team-away',
+        name: 'Barcelona',
+        logo: 'https://example.com/bar.png',
+        abbreviation: 'BAR',
+        color: TEST_HEX_COLORS.PURE_BLACK,
+        alias: 'Barça',
+      };
+
+      const homeFirstTeamLookup = (
+        league: PredictSportsLeague,
+        abbr: string,
+      ): PredictSportTeam | undefined => {
+        if (league !== 'ucl') return undefined;
+        const teams: Record<string, PredictSportTeam> = {
+          rma: homeTeam,
+          bar: awayTeam,
+        };
+        return teams[abbr.toLowerCase()];
+      };
+
+      const event = createMockEvent({
+        gameId: 'game-456',
+        slug: 'ucl-rma-bar-2025-01-12',
+        title: 'Real Madrid vs Barcelona',
+        tags: [
+          { id: '1', label: 'UCL', slug: 'ucl' },
+          { id: '2', label: 'Games', slug: 'games' },
+        ],
+        score: '2-1',
+        period: 'FT',
+        ended: true,
+      });
+
+      const result = buildGameData(event, 'ucl', homeFirstTeamLookup);
+
+      expect(result?.score).toEqual({ away: 1, home: 2, raw: '2-1' });
+      expect(result?.homeTeam).toEqual(homeTeam);
+      expect(result?.awayTeam).toEqual(awayTeam);
+    });
+
     it('returns null when gameId is missing', () => {
       const event = createMockEvent({ gameId: undefined });
 
@@ -455,6 +506,12 @@ describe('gameParser', () => {
       const result = parseScore('14-7');
 
       expect(result).toEqual({ away: 14, home: 7, raw: '14-7' });
+    });
+
+    it('normalizes home-first league scores into away and home values', () => {
+      const result = parseScore('2-1', 'ucl');
+
+      expect(result).toEqual({ away: 1, home: 2, raw: '2-1' });
     });
 
     it('returns null for undefined score', () => {

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -10,11 +10,11 @@ import {
   PolymarketApiTeam,
 } from '../providers/polymarket/types';
 
-type SlugTeamOrder = 'away-home' | 'home-away';
+type LeagueTeamOrder = 'away-home' | 'home-away';
 
 interface LeagueSlugConfig {
   pattern: RegExp;
-  teamOrder: SlugTeamOrder;
+  teamOrder: LeagueTeamOrder;
   tagSlug?: string; // if different than league slug
 }
 
@@ -263,7 +263,7 @@ export function parseGameSlugTeams(
   if (!match) {
     return null;
   }
-  const isHomeFirst = config.teamOrder === 'home-away';
+  const isHomeFirst = getLeagueTeamOrder(league) === 'home-away';
   return {
     awayAbbreviation: isHomeFirst ? match[2] : match[1],
     homeAbbreviation: isHomeFirst ? match[1] : match[2],
@@ -334,7 +334,18 @@ export function mapApiTeamToPredictTeam(
   };
 }
 
-export function parseScore(scoreString?: string): PredictGameScore | null {
+function getLeagueTeamOrder(league?: PredictSportsLeague): LeagueTeamOrder {
+  if (!league) {
+    return 'away-home';
+  }
+
+  return LEAGUE_SLUG_CONFIGS[league].teamOrder;
+}
+
+export function parseScore(
+  scoreString?: string,
+  league?: PredictSportsLeague,
+): PredictGameScore | null {
   if (!scoreString || scoreString === '0-0') {
     return null;
   }
@@ -344,14 +355,20 @@ export function parseScore(scoreString?: string): PredictGameScore | null {
     return null;
   }
 
-  const away = parseInt(parts[0], 10);
-  const home = parseInt(parts[1], 10);
+  const firstScore = parseInt(parts[0].trim(), 10);
+  const secondScore = parseInt(parts[1].trim(), 10);
 
-  if (isNaN(away) || isNaN(home)) {
+  if (isNaN(firstScore) || isNaN(secondScore)) {
     return null;
   }
 
-  return { away, home, raw: scoreString };
+  const isHomeFirst = getLeagueTeamOrder(league) === 'home-away';
+
+  return {
+    away: isHomeFirst ? secondScore : firstScore,
+    home: isHomeFirst ? firstScore : secondScore,
+    raw: scoreString,
+  };
 }
 
 export function buildGameData(
@@ -384,7 +401,7 @@ export function buildGameData(
     league,
     elapsed: event.elapsed || null,
     period: event.period || null,
-    score: parseScore(event.score),
+    score: parseScore(event.score, league),
     homeTeam,
     awayTeam,
   };


### PR DESCRIPTION
## **Description**

This PR fixes a Predict sports scoring bug where live WebSocket score updates were always treated as `away-home`.

Some leagues send scores in `home-away` order instead (for example, soccer/UCL). This change normalizes score parsing by league so live updates, cached game data, and rendered scoreboards all map scores to the correct home and away teams.

It also adds regression coverage for both away-first and home-first leagues.

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing live Predict sports scores to appear in reverse order for some leagues.

## **Related issues**

Fixes: [PRED-849](https://consensyssoftware.atlassian.net/browse/PRED-849)

## **Manual testing steps**

```gherkin
Feature: Predict live sports score ordering

  Scenario: NFL live score continues to render correctly
    Given a Predict market for an NFL game with a live websocket score update
    When the game card or game details scoreboard renders the live score
    Then the away team score is shown with the away team
    And the home team score is shown with the home team

  Scenario: Home-first league live score renders correctly
    Given a Predict market for a home-first league such as UCL
    And the websocket sends a score update in "home-away" order
    When the game card or game details scoreboard renders the live score
    Then the home team score is shown with the home team
    And the away team score is shown with the away team
    And the correct winner indicator is displayed at full time
```

## **Screenshots/Recordings**

### **Before**

<img width="400" alt="Simulator Screenshot - mm-blue - 2026-04-28 at 14 41 54" src="https://github.com/user-attachments/assets/c2af5d5a-9437-4af4-a1e4-4a2ba39d0db5" />


### **After**

<img width="400" alt="Simulator Screenshot - mm-red - 2026-04-28 at 14 41 55" src="https://github.com/user-attachments/assets/d2ed552c-60fb-4955-b989-9842399e862c" />


Will be added after PR creation.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-849]: https://consensyssoftware.atlassian.net/browse/PRED-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ