### PR TITLE
fix: Polish Transactions activity filters for consistency

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
@@ -309,9 +309,10 @@ function OrdersList() {
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={tw.style('flex-row gap-3')}
+            contentContainerStyle={tw.style('flex-row gap-2')}
           >
             <ButtonFilter
+              twClassName="min-w-0"
               onPress={() => setCurrentFilter('ALL')}
               isActive={currentFilter === 'ALL'}
               size={ButtonBaseSize.Md}
@@ -320,6 +321,7 @@ function OrdersList() {
               {strings('fiat_on_ramp_aggregator.All')}
             </ButtonFilter>
             <ButtonFilter
+              twClassName="min-w-0"
               onPress={() => setCurrentFilter('PURCHASE')}
               isActive={currentFilter === 'PURCHASE'}
               size={ButtonBaseSize.Md}
@@ -328,6 +330,7 @@ function OrdersList() {
               {strings('fiat_on_ramp_aggregator.Purchased')}
             </ButtonFilter>
             <ButtonFilter
+              twClassName="min-w-0"
               onPress={() => setCurrentFilter('SELL')}
               isActive={currentFilter === 'SELL'}
               size={ButtonBaseSize.Md}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR refines the spacing filters for consistency. It's part of a larger initiative to refine our design patterns, improving UI polish. [See this page](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1204-1329) for more context.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related PRs:
https://github.com/MetaMask/metamask-mobile/pull/29396
https://github.com/MetaMask/metamask-mobile/pull/29392
https://github.com/MetaMask/metamask-mobile/pull/29391

## **Manual testing steps**

```gherkin
Feature: Ramps Activity transfer filters — layout polish

  Scenario: user opens Activity and views Transfers filter chips
    Given the user is on the Activity screen
    And the Transfers tab is available and selected

    When the user looks at the All, Purchased, and Sold filter row
    Then each filter chip width follows its label and padding without a fixed wide minimum
    And spacing between the chips matches the updated tighter gap

  Scenario: user filters transfer orders by type
    Given the user is on Activity with the Transfers tab selected
    And the transfer list is showing (with or without orders)

    When the user taps Purchased, then Sold, then All
    Then the active filter updates for each tap
    And the list or empty state reflects the selected filter (purchases only, sells only, or all)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="317" height="674" alt="Screenshot 2026-04-29 at 10 32 21 AM" src="https://github.com/user-attachments/assets/a59c8d59-f330-4447-b593-50e6ab6a15c9" />


### **After**

<img width="1206" height="2622" alt="simulator_screenshot_D4438153-BF68-4904-949B-ABFA3FC2C84C" src="https://github.com/user-attachments/assets/1c504dfe-e755-41e8-a10e-d9ea13697bd9" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 523bad962e8262bd38fa12d6bca077a0536964bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->