### PR TITLE
fix: Polish Money activity filters for consistency

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -17,6 +17,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import I18n, { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
@@ -95,7 +96,8 @@ const MoneyActivityView = () => {
   const renderSectionHeader = ({ section }: { section: DateSection }) => (
     <Box twClassName="px-4 pt-2 pb-1 bg-default">
       <Text
-        variant={TextVariant.BodySm}
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
         color={TextColor.TextAlternative}
         testID={MoneyActivityViewTestIds.DATE_HEADER}
       >
@@ -139,7 +141,7 @@ const MoneyActivityView = () => {
         />
       </Box>
 
-      <Box paddingHorizontal={4} paddingTop={4} paddingBottom={6}>
+      <Box paddingHorizontal={4} paddingTop={2} paddingBottom={4}>
         <Text
           variant={TextVariant.HeadingLg}
           testID={MoneyActivityViewTestIds.TITLE}
@@ -150,7 +152,7 @@ const MoneyActivityView = () => {
 
       <Box
         flexDirection={BoxFlexDirection.Row}
-        gap={4}
+        gap={2}
         paddingHorizontal={4}
         paddingBottom={3}
       >
@@ -161,7 +163,7 @@ const MoneyActivityView = () => {
               : ButtonVariant.Secondary
           }
           size={ButtonSize.Md}
-          twClassName="min-w-0 shrink"
+          twClassName="min-w-0 shrink px-3"
           onPress={() => setFilter(MoneyActivityFilter.All)}
           testID={MoneyActivityViewTestIds.FILTER_ALL}
         >
@@ -174,7 +176,7 @@ const MoneyActivityView = () => {
               : ButtonVariant.Secondary
           }
           size={ButtonSize.Md}
-          twClassName="min-w-0 shrink"
+          twClassName="min-w-0 shrink px-3"
           onPress={() => setFilter(MoneyActivityFilter.Deposits)}
           testID={MoneyActivityViewTestIds.FILTER_DEPOSITS}
         >
@@ -187,7 +189,7 @@ const MoneyActivityView = () => {
               : ButtonVariant.Secondary
           }
           size={ButtonSize.Md}
-          twClassName="min-w-0 shrink"
+          twClassName="min-w-0 shrink px-3"
           onPress={() => setFilter(MoneyActivityFilter.Transfers)}
           testID={MoneyActivityViewTestIds.FILTER_TRANSFERS}
         >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR refines the spacing for headers and filters for consistency. It's part of a larger initiative to refine our design patterns, improving UI polish. [See this page](https://www.figma.com/design/aRyo0N82L0IoNlMVIKvSpc/Mobile-Papercuts?node-id=1204-1329) for more context.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: adjust spacing for money activity filers

## **Related issues**

Related PRs:
https://github.com/MetaMask/metamask-mobile/pull/29391
https://github.com/MetaMask/metamask-mobile/pull/29400
https://github.com/MetaMask/metamask-mobile/pull/29462

## **Manual testing steps**

```gherkin
Feature: Polish Money activity screen layout (filters, title, and date headers)

  Scenario: user opens Money Activity and sees the updated layout while filters still work
    Given the user has navigated to the Money Activity screen with transactions visible

    When the user looks at the "Activity" title, the All / Deposits / Transfers chips, and the date group headers, then taps Deposits, Transfers, and All in turn
    Then the title and filter row use the tighter spacing and chip padding from the design update, date headers use body-md-medium, and the list updates correctly for each filter without errors
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="317" height="694" alt="Screenshot 2026-04-29 at 10 54 42 AM" src="https://github.com/user-attachments/assets/8dbbc90d-ad97-4670-bff1-f47afb9c94dc" />


### **After**

<img width="320" height="696" alt="Screenshot 2026-04-29 at 10 54 57 AM" src="https://github.com/user-attachments/assets/830f0102-dbc5-43c9-975b-4ff63dcef721" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit aa7ceef888e3df42bdbdeec968a0525c0a7f6f7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->