### PR TITLE
feat(social-ai): add haptic feedback to follow & top traders surfaces

### DIFF
--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { mockTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
@@ -57,6 +59,15 @@ jest.mock('../../../../selectors/currencyRateController', () => ({
   selectCurrentCurrency: jest.fn(),
 }));
 
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Shared mock primitives
 // ---------------------------------------------------------------------------
@@ -71,6 +82,7 @@ const mockUseNotificationPreferences =
 const mockSelectCurrentCurrency = selectCurrentCurrency as jest.MockedFunction<
   typeof selectCurrentCurrency
 >;
+const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
 
 const makeTrader = (
   id: string,
@@ -516,6 +528,202 @@ describe('NotificationPreferencesView', () => {
       );
 
       expect(setEnabled).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('haptic feedback', () => {
+    const originalPlatform = Platform.OS;
+
+    afterEach(() => {
+      Platform.OS = originalPlatform;
+    });
+
+    it('fires a medium impact when toggling the master switch on iOS', () => {
+      Platform.OS = 'ios';
+      renderScreen();
+
+      fireEvent(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.GLOBAL_TOGGLE,
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('fires a medium impact when toggling the master switch on Android', () => {
+      Platform.OS = 'android';
+      renderScreen();
+
+      fireEvent(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.GLOBAL_TOGGLE,
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('fires a light impact when toggling a per-trader switch on Android', () => {
+      Platform.OS = 'android';
+      renderScreen();
+
+      fireEvent(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.TRADER_TOGGLE('trader-1'),
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('does not fire a haptic when toggling a per-trader switch on iOS', () => {
+      Platform.OS = 'ios';
+      renderScreen();
+
+      fireEvent(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.TRADER_TOGGLE('trader-1'),
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('fires a light impact when changing the threshold to a new value', () => {
+      Platform.OS = 'ios';
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.THRESHOLD_OPTION(100),
+        ),
+      );
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('does not fire a haptic when re-tapping the already-selected threshold', () => {
+      const setTxAmountLimit = jest.fn().mockResolvedValue(undefined);
+      mockUseNotificationPreferences.mockReturnValue(
+        makeUseNotificationPreferencesResult({
+          preferences: makePreferences({ txAmountLimit: 500 }),
+          setTxAmountLimit,
+        }),
+      );
+
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.THRESHOLD_OPTION(500),
+        ),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(setTxAmountLimit).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when pressing the back button', () => {
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(NotificationPreferencesViewSelectorsIDs.BACK_BUTTON),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when pressing a trader row to navigate to the profile', () => {
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.TRADER_PRESS('trader-1'),
+        ),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when toggling a per-trader switch while the master toggle is off', () => {
+      const toggleTraderNotification = jest.fn().mockResolvedValue(undefined);
+      mockUseNotificationPreferences.mockReturnValue(
+        makeUseNotificationPreferencesResult({
+          preferences: makePreferences({ enabled: false }),
+          toggleTraderNotification,
+        }),
+      );
+
+      renderScreen();
+
+      fireEvent(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.TRADER_TOGGLE('trader-1'),
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(toggleTraderNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when tapping a threshold while the master toggle is off', () => {
+      const setTxAmountLimit = jest.fn().mockResolvedValue(undefined);
+      mockUseNotificationPreferences.mockReturnValue(
+        makeUseNotificationPreferencesResult({
+          preferences: makePreferences({ enabled: false }),
+          setTxAmountLimit,
+        }),
+      );
+
+      renderScreen();
+
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationPreferencesViewSelectorsIDs.THRESHOLD_OPTION(100),
+        ),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(setTxAmountLimit).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when the master toggle handler is invoked while preferences are loading', () => {
+      const setEnabled = jest.fn().mockResolvedValue(undefined);
+      mockUseNotificationPreferences.mockReturnValue(
+        makeUseNotificationPreferencesResult({
+          isLoading: true,
+          preferences: makePreferences({ enabled: true }),
+          setEnabled,
+        }),
+      );
+
+      renderScreen();
+
+      // The Switch is hidden behind a skeleton during loading, so this is a
+      // belt-and-suspenders defense: if the handler ever gets invoked from
+      // a stale render or accessibility path, the haptic must stay silent.
+      expect(
+        screen.queryByTestId(
+          NotificationPreferencesViewSelectorsIDs.GLOBAL_TOGGLE,
+        ),
+      ).toBeNull();
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+      expect(setEnabled).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferencesView/NotificationPreferencesView.tsx
@@ -10,6 +10,7 @@ import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -29,6 +30,7 @@ import { useTheme } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
+import { fireSwitchHaptic } from '../../../../util/haptics';
 import { NotificationPreferencesViewSelectorsIDs } from './NotificationPreferencesView.testIds';
 import {
   useNotificationPreferences,
@@ -194,6 +196,54 @@ const NotificationPreferencesView = () => {
   // the preferences GET is in flight.
   const globalOff = isLoadingPreferences || !preferences.enabled;
 
+  // Master switch is the gating control for the whole feature, so it should
+  // feel weightier than the native iOS UISwitch tick — `override: true`
+  // ensures the Medium impact also fires on iOS. Skipped while preferences
+  // are still loading even though the switch is hidden behind the skeleton,
+  // to keep the haptic and the persisted call symmetric.
+  const handleSetEnabled = useCallback(
+    (value: boolean) => {
+      if (isLoadingPreferences) {
+        return Promise.resolve();
+      }
+      fireSwitchHaptic(ImpactFeedbackStyle.Medium, { override: true });
+      return setEnabled(value);
+    },
+    [isLoadingPreferences, setEnabled],
+  );
+
+  // Per-trader switch is a subordinate toggle; rely on iOS UISwitch's native
+  // tick on iOS, fire a Light impact only on Android where there is none.
+  // The Switch is also rendered with `disabled={globalOff}`, but we guard
+  // here too so the haptic never leaks through if the callback fires while
+  // the row is disabled (mid-interaction state flips, a11y taps, etc.).
+  const handleToggleTrader = useCallback(
+    (traderId: string) => {
+      if (globalOff) {
+        return Promise.resolve();
+      }
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+      return toggleTraderNotification(traderId);
+    },
+    [globalOff, toggleTraderNotification],
+  );
+
+  // Threshold rows are TouchableOpacity (no native iOS haptic), so fire on
+  // both platforms — but only when the value actually changes, to avoid a
+  // phantom buzz when the user re-taps the already-selected option. Also
+  // guarded against firing while the section is disabled by the master
+  // toggle, even though the row's TouchableOpacity is itself `disabled`.
+  const handleSetTxAmountLimit = useCallback(
+    (value: TxAmountThreshold) => {
+      if (globalOff || value === preferences.txAmountLimit) {
+        return Promise.resolve();
+      }
+      impactAsync(ImpactFeedbackStyle.Light);
+      return setTxAmountLimit(value);
+    },
+    [globalOff, preferences.txAmountLimit, setTxAmountLimit],
+  );
+
   const showFollowedError =
     Boolean(followedError) && followedTraders.length === 0;
   const showFollowedLoading =
@@ -252,7 +302,7 @@ const NotificationPreferencesView = () => {
               </Text>
               <Switch
                 value={preferences.enabled}
-                onValueChange={setEnabled}
+                onValueChange={handleSetEnabled}
                 trackColor={{
                   true: colors.primary.default,
                   false: colors.border.muted,
@@ -267,7 +317,7 @@ const NotificationPreferencesView = () => {
 
             <ThresholdRadioList
               selected={(preferences.txAmountLimit ?? 500) as TxAmountThreshold}
-              onChange={setTxAmountLimit}
+              onChange={handleSetTxAmountLimit}
               isDisabled={globalOff}
               currency={currentCurrency}
               labelText={strings(
@@ -346,7 +396,7 @@ const NotificationPreferencesView = () => {
               avatarUri={trader.avatarUri}
               isEnabled={isTraderNotificationEnabled(trader.id)}
               isDisabled={globalOff}
-              onToggle={toggleTraderNotification}
+              onToggle={handleToggleTrader}
               onPress={handleTraderPress}
             />
           ))

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import TraderPositionView from './TraderPositionView';
 import { TraderPositionViewSelectorsIDs } from './TraderPositionView.testIds';
@@ -80,6 +81,17 @@ jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),
   handleFetch: jest.fn().mockResolvedValue({}),
 }));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+}));
+
+const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
 
 // New hooks added for deep-link self-sufficiency. Existing tests pass `position`
 // via route params, so these are effectively no-ops in the existing flow.
@@ -294,6 +306,33 @@ describe('TraderPositionView', () => {
     expect(
       screen.getByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
     ).toBeOnTheScreen();
+  });
+
+  it('fires a medium impact haptic when the buy button is pressed', () => {
+    renderWithProvider(<TraderPositionView />, { state: mockState });
+
+    fireEvent.press(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
+    );
+
+    expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+    expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+  });
+
+  it('does not fire a haptic when the buy button is pressed without a resolved position', () => {
+    mockRouteParams.position = undefined;
+    (mockRouteParams as { positionId?: string }).positionId = 'unresolved-id';
+
+    renderWithProvider(<TraderPositionView />, { state: mockState });
+
+    const buyButton = screen.queryByTestId(
+      TraderPositionViewSelectorsIDs.BUY_BUTTON,
+    );
+    if (buyButton) {
+      fireEvent.press(buyButton);
+    }
+
+    expect(mockImpactAsync).not.toHaveBeenCalled();
   });
 
   it('builds the token image URL when the position chain is supported', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -9,6 +9,7 @@ import {
 import type { RootStackParamList } from '../../../../core/NavigationService/types';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Button,
@@ -83,9 +84,15 @@ const TraderPositionView = () => {
   }, [navigation]);
 
   const handleBuyPress = useCallback(() => {
-    if (resolvedPosition) {
-      setIsQuickBuyVisible(true);
+    if (!resolvedPosition) {
+      return;
     }
+    // Primary CTA opening the buy flow — Medium impact mirrors the weight
+    // used for other elevated commit-style actions (Save, master toggle).
+    // The terminal Success/Error notification haptic is fired later in
+    // useQuickBuyBottomSheet once the transaction resolves.
+    impactAsync(ImpactFeedbackStyle.Medium);
+    setIsQuickBuyVisible(true);
   }, [resolvedPosition]);
 
   const handleQuickBuyClose = useCallback(() => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useEffect } from 'react';
+import { Platform } from 'react-native';
 import { screen, fireEvent, act } from '@testing-library/react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TraderNotificationsBottomSheet, {
   type TraderNotificationsBottomSheetRef,
@@ -20,6 +22,17 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({ navigate: mockNavigate }),
   };
 });
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+}));
+
+const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
 
 jest.mock(
   '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet',
@@ -376,6 +389,143 @@ describe('TraderNotificationsBottomSheet', () => {
 
       expect(mockOnDismiss).toHaveBeenCalledTimes(1);
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('haptic feedback', () => {
+    const originalPlatform = Platform.OS;
+
+    afterEach(() => {
+      Platform.OS = originalPlatform;
+    });
+
+    it('fires a medium impact when pressing save', () => {
+      Platform.OS = 'ios';
+      renderWithProvider(
+        <OpenedSheet
+          traderId="trader-1"
+          isTraderNotificationEnabled={() => true}
+        />,
+      );
+
+      fireEvent(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
+        'valueChange',
+        false,
+      );
+      mockImpactAsync.mockClear();
+
+      act(() => {
+        fireEvent.press(
+          screen.getByTestId(
+            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
+          ),
+        );
+      });
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('fires a medium impact when pressing save even if the value did not change', () => {
+      Platform.OS = 'ios';
+      renderWithProvider(
+        <OpenedSheet
+          traderId="trader-1"
+          isTraderNotificationEnabled={() => true}
+        />,
+      );
+
+      act(() => {
+        fireEvent.press(
+          screen.getByTestId(
+            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
+          ),
+        );
+      });
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+      expect(mockToggleTraderNotification).not.toHaveBeenCalled();
+    });
+
+    it('fires a light impact when toggling the local switch on Android', () => {
+      Platform.OS = 'android';
+      renderWithProvider(
+        <OpenedSheet
+          traderId="trader-1"
+          isTraderNotificationEnabled={() => true}
+        />,
+      );
+
+      fireEvent(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('does not fire a haptic when toggling the local switch on iOS', () => {
+      Platform.OS = 'ios';
+      renderWithProvider(
+        <OpenedSheet
+          traderId="trader-1"
+          isTraderNotificationEnabled={() => true}
+        />,
+      );
+
+      fireEvent(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when toggling the local switch while the global toggle is off', () => {
+      Platform.OS = 'android';
+      renderWithProvider(
+        <OpenedSheet
+          traderId="trader-1"
+          preferences={makePreferences({ enabled: false })}
+        />,
+      );
+
+      fireEvent(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
+        'valueChange',
+        false,
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when pressing the close button', () => {
+      renderWithProvider(<OpenedSheet />);
+
+      fireEvent.press(
+        screen.getByTestId(
+          TraderNotificationsBottomSheetSelectorsIDs.CLOSE_BUTTON,
+        ),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a haptic when pressing the manage traders row', () => {
+      renderWithProvider(<OpenedSheet />);
+
+      fireEvent.press(
+        screen.getByTestId(
+          TraderNotificationsBottomSheetSelectorsIDs.MANAGE_TRADERS_ROW,
+        ),
+      );
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import {
   Box,
   Text,
@@ -22,6 +23,7 @@ import HeaderCompactStandard from '../../../../../../component-library/component
 import { ButtonVariants } from '../../../../../../component-library/components/Buttons/Button/Button.types';
 import { strings } from '../../../../../../../locales/i18n';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { fireSwitchHaptic } from '../../../../../../util/haptics';
 import type { SocialAIPreference } from '../../../NotificationPreferencesView/hooks';
 import AllowPushNotificationsRow from '../../../NotificationPreferencesView/components/AllowPushNotificationsRow';
 import { TraderNotificationsBottomSheetSelectorsIDs } from './TraderNotificationsBottomSheet.testIds';
@@ -84,7 +86,10 @@ const TraderNotificationsBottomSheet = forwardRef<
 
     // Only persist when the user explicitly confirms with Save.
     // If the local draft differs from the remote value, issue one toggle call.
+    // Save is a deliberate primary-action commit, so always fire the haptic
+    // — including when the value didn't change — to acknowledge the press.
     const handleSave = useCallback(() => {
+      impactAsync(ImpactFeedbackStyle.Medium);
       if (localEnabled !== isTraderNotificationEnabled(traderId)) {
         toggleTraderNotification(traderId);
       }
@@ -133,9 +138,13 @@ const TraderNotificationsBottomSheet = forwardRef<
           )}
           value={localEnabled}
           onValueChange={(next: boolean) => {
-            if (!globalOff) {
-              setLocalEnabled(next);
+            if (globalOff) {
+              return;
             }
+            // Subordinate switch: rely on iOS UISwitch's native tick on iOS,
+            // fire a Light impact only on Android where there is none.
+            fireSwitchHaptic(ImpactFeedbackStyle.Light);
+            setLocalEnabled(next);
           }}
           disabled={globalOff}
           toggleTestID={TraderNotificationsBottomSheetSelectorsIDs.TOGGLE}

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -123,7 +123,19 @@ describe('useFollowToggle', () => {
       );
     });
 
-    it('fires light haptic feedback on every toggle press', async () => {
+    it('fires a medium haptic when following a new trader', async () => {
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(impactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('fires a light haptic when unfollowing a currently followed trader', async () => {
+      mockUseSelector.mockReturnValue(['trader-1']);
+
       const { result } = renderHook(() => useFollowToggle('trader-1'));
 
       await act(async () => {
@@ -153,6 +165,11 @@ describe('useFollowToggle', () => {
 
       expect(Engine.controllerMessenger.call).toHaveBeenCalledTimes(1);
       expect(impactAsync).toHaveBeenCalledTimes(2);
+      expect(impactAsync).toHaveBeenNthCalledWith(
+        1,
+        ImpactFeedbackStyle.Medium,
+      );
+      expect(impactAsync).toHaveBeenNthCalledWith(2, ImpactFeedbackStyle.Light);
 
       await act(async () => {
         resolveCall({ followed: [], unfollowed: [] });

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -37,22 +37,24 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
 
   const toggleFollow = useCallback(
     async (addressOrId: string): Promise<void> => {
-      // Fire haptic on every user-initiated toggle so feedback is consistent
-      // across all Follow entry points (homepage carousel, leaderboard rows,
-      // trader profile). Placed before the inflight guard so a quick repeat
+      const currentlyFollowing =
+        optimisticFollowState[addressOrId] ??
+        followingProfileIds.includes(addressOrId);
+      const nextValue = !currentlyFollowing;
+
+      // Directional haptic: a weightier "Medium" thump rewards the
+      // constructive Follow action, while Unfollow stays on a neutral
+      // "Light" tick. Fired before the inflight guard so a quick repeat
       // tap still produces a tactile response even when the API call is
       // debounced.
-      impactAsync(ImpactFeedbackStyle.Light);
+      impactAsync(
+        nextValue ? ImpactFeedbackStyle.Medium : ImpactFeedbackStyle.Light,
+      );
 
       if (inflightIdsRef.current.has(addressOrId)) {
         return;
       }
       inflightIdsRef.current.add(addressOrId);
-
-      const currentlyFollowing =
-        optimisticFollowState[addressOrId] ??
-        followingProfileIds.includes(addressOrId);
-      const nextValue = !currentlyFollowing;
 
       setOptimisticFollowState((prev) => ({
         ...prev,

--- a/app/util/haptics/index.ts
+++ b/app/util/haptics/index.ts
@@ -1,0 +1,1 @@
+export { fireSwitchHaptic } from './switchHaptic';

--- a/app/util/haptics/switchHaptic.test.ts
+++ b/app/util/haptics/switchHaptic.test.ts
@@ -1,0 +1,77 @@
+import { Platform } from 'react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+import { fireSwitchHaptic } from './switchHaptic';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+}));
+
+const mockImpactAsync = impactAsync as jest.MockedFunction<typeof impactAsync>;
+
+describe('fireSwitchHaptic', () => {
+  const originalPlatform = Platform.OS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  describe('on Android', () => {
+    beforeEach(() => {
+      Platform.OS = 'android';
+    });
+
+    it('fires impactAsync with the provided style', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Light);
+    });
+
+    it('passes Medium style through unchanged', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Medium);
+
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('fires impactAsync regardless of the override flag', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Medium, { override: true });
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+  });
+
+  describe('on iOS', () => {
+    beforeEach(() => {
+      Platform.OS = 'ios';
+    });
+
+    it('skips impactAsync by default to avoid layering with the native UISwitch tick', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it('fires impactAsync when override is explicitly enabled', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Medium, { override: true });
+
+      expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+      expect(mockImpactAsync).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    });
+
+    it('skips impactAsync when override is explicitly disabled', () => {
+      fireSwitchHaptic(ImpactFeedbackStyle.Light, { override: false });
+
+      expect(mockImpactAsync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/util/haptics/switchHaptic.ts
+++ b/app/util/haptics/switchHaptic.ts
@@ -1,0 +1,30 @@
+import { Platform } from 'react-native';
+import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
+
+/**
+ * Fire a haptic for a `<Switch>` toggle, respecting iOS UISwitch's built-in
+ * native tick.
+ *
+ * iOS UISwitch already emits a subtle native haptic on every toggle, so by
+ * default this util only fires `impactAsync` on Android — layering our own
+ * impact on top of the native iOS tick can read as a doubled feel,
+ * especially at the `Light` strength. Pass `override: true` for elevated
+ * controls (e.g. a master switch that should outrank subordinate toggles)
+ * that are intentionally weightier than the native tick on both platforms.
+ *
+ * Use plain `impactAsync` directly for non-Switch surfaces (buttons,
+ * `TouchableOpacity` rows, sliders) — those have no native iOS haptic
+ * to coexist with.
+ *
+ * @param style - The `ImpactFeedbackStyle` to play (e.g. `Light`, `Medium`).
+ * @param options.override - When `true`, also fire on iOS. Defaults to `false`.
+ */
+export const fireSwitchHaptic = (
+  style: ImpactFeedbackStyle,
+  options: { override?: boolean } = {},
+): void => {
+  if (Platform.OS === 'ios' && !options.override) {
+    return;
+  }
+  impactAsync(style);
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds tactile feedback to the Top Traders / Follow surfaces so user actions feel responsive and the relative weight of each control is communicated through touch, not just visuals.

**Why** — the feature has a few haptics, leaving primary CTAs (Buy, Save, master notification toggle) feeling indistinct from low-stakes settings tweaks. Follow / Unfollow also fired the same haptic in both directions, missing an opportunity to reward the constructive action.

**What changed** — three tiers of haptic feedback, applied consistently across the feature:

- **Elevated commit-style controls** → `impactAsync(Medium)` on both platforms:
  - Buy button on `TraderPositionView` (opens the QuickBuy flow)
  - Save button on `TraderNotificationsBottomSheet`
  - Master "Allow push notifications" Switch on `NotificationPreferencesView` (gates the entire feature)
  - Follow direction in `useFollowToggle` (Unfollow stays Light)
- **Subordinate switches** → `fireSwitchHaptic(Light)` (Android-only by default to avoid layering with iOS UISwitch's native tick):
  - Per-trader toggle on `NotificationPreferencesView`
  - Local "Allow push notifications" toggle on `TraderNotificationsBottomSheet`
- **Discrete settings taps** → `impactAsync(Light)` on both platforms (TouchableOpacity has no native iOS haptic):
  - Threshold radio rows ($10 / $100 / $500 / $1,000) — silent on no-op re-tap
- **Navigation surfaces** → no haptic (back, X close, drill-in to profile, "Manage traders you follow" row)

A new shared util `app/util/haptics/switchHaptic.ts` encodes the iOS UISwitch native-tick policy in one place, with an `override: true` escape hatch for elevated switches that should outrank the native feel.

All haptic call sites are gated against firing when their control is disabled (master toggle off, preferences loading, position not yet resolved, no-op re-tap on the selected threshold). The defensive in-handler guards complement (rather than replace) the native `disabled` prop on the underlying Switch / TouchableOpacity.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added haptic feedback across Top Traders surfaces (Follow, Buy, notification preferences, per-trader notifications) so primary actions feel weightier than subordinate settings.

## **Related issues**

Fixes:

No issue: UX polish driven by feature owners after the initial Top Traders ship.

## **Manual testing steps**

```gherkin
Feature: Haptic feedback on Top Traders surfaces

  Scenario: User follows then unfollows a trader
    Given user is on a trader profile (e.g. via Top Traders leaderboard)
    When user taps the "Follow" button
    Then the device emits a Medium impact haptic
    When user taps the now-active "Unfollow" button
    Then the device emits a Light impact haptic

  Scenario: User opens the Buy flow
    Given user is on TraderPositionView with a resolved position
    When user taps the full-width "Buy" button
    Then the device emits a Medium impact haptic
    And the QuickBuy bottom sheet opens

  Scenario: User toggles the master notifications switch
    Given user is on the Top Traders notification preferences screen
    When user toggles "Allow push notifications" on or off
    Then the device emits a Medium impact haptic on both iOS and Android

  Scenario: User toggles a per-trader notification switch
    Given user is on the Top Traders notification preferences screen
    And the master toggle is on
    When user toggles a per-trader switch on Android
    Then the device emits a Light impact haptic
    When user toggles a per-trader switch on iOS
    Then only the native iOS UISwitch tick is felt (no extra haptic)

  Scenario: User changes the trade-size threshold
    Given user is on the Top Traders notification preferences screen
    And the master toggle is on
    When user taps a different threshold amount
    Then the device emits a Light impact haptic on both platforms
    When user re-taps the already-selected threshold
    Then no haptic is emitted

  Scenario: Subordinate controls stay silent when disabled
    Given user is on the Top Traders notification preferences screen
    And the master toggle is off
    When user attempts to toggle a per-trader switch or change the threshold
    Then no haptic is emitted

  Scenario: User saves the per-trader notifications bottom sheet
    Given user is on a trader profile and opens the per-trader notifications sheet
    When user taps "Save"
    Then the device emits a Medium impact haptic
    And the sheet closes
    And the haptic fires even when the toggle value did not change

  Scenario: Navigation actions remain silent
    Given user is on TraderPositionView, the notification preferences screen, or the per-trader notifications sheet
    When user taps the back arrow, the X close button, a trader row, or the "Manage traders you follow" row
    Then no haptic is emitted
```

Real device required — haptics are no-ops in iOS Simulator and most Android emulators.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — visual UI is unchanged; the change is tactile-only.

### **After**

N/A — visual UI is unchanged; the change is tactile-only.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 27f3f8df9a735d49d7276c4244d3e6cbc272e07f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->