### PR TITLE
feat: smart default source token selection (TSA-472)

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import type { Position } from '@metamask/social-controllers';
 import { useQuickBuyBottomSheet } from './useQuickBuyBottomSheet';
+import { selectDefaultSourceToken } from '../../../utils/tokenSelection';
 import { useQuickBuySetup } from './useQuickBuySetup';
 import { useSourceTokenOptions } from './useSourceTokenOptions';
 import { useQuickBuyQuotes } from './useQuickBuyQuotes';
@@ -639,7 +640,7 @@ describe('useQuickBuyBottomSheet', () => {
   });
 
   describe('source token auto-selection', () => {
-    it('auto-selects the first option when options load', () => {
+    it('auto-selects the first option when options load (legacy — native on dest chain matches priority 1)', () => {
       const firstToken = createSourceToken({ symbol: 'ETH' });
 
       (useSourceTokenOptions as jest.Mock).mockReturnValue({
@@ -651,7 +652,120 @@ describe('useQuickBuyBottomSheet', () => {
         useQuickBuyBottomSheet(createPosition(), jest.fn()),
       );
 
+      // createPosition uses chain 'base' → destChainId '0x1' in default mock,
+      // and ETH (zero address, chainId '0x1') is native on that chain → priority 1.
       expect(result.current.sourceToken?.symbol).toBe('ETH');
+    });
+  });
+
+  describe('selectDefaultSourceToken', () => {
+    const native = (chainId: string, fiat = 1000): BridgeToken =>
+      createSourceToken({
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: chainId as `0x${string}`,
+        symbol: 'ETH',
+        tokenFiatAmount: fiat,
+      });
+
+    const erc20 = (chainId: string, symbol: string, fiat = 1000): BridgeToken =>
+      createSourceToken({
+        address: `0xToken${symbol}`,
+        chainId: chainId as `0x${string}`,
+        symbol,
+        tokenFiatAmount: fiat,
+      });
+
+    it('returns undefined when options list is empty', () => {
+      expect(selectDefaultSourceToken([], '0x1')).toBeUndefined();
+    });
+
+    it('priority 1: selects native token on the destination chain', () => {
+      const ethOnBase = native('0x2105', 500);
+      const usdcOnBase = erc20('0x2105', 'USDC', 3000);
+      const ethOnMainnet = native('0x1', 2000);
+
+      // Sorted by highest fiat: USDC on Base, ETH mainnet, ETH on Base
+      const result = selectDefaultSourceToken(
+        [usdcOnBase, ethOnMainnet, ethOnBase],
+        '0x2105',
+      );
+
+      expect(result?.symbol).toBe('ETH');
+      expect(result?.chainId).toBe('0x2105');
+    });
+
+    it('priority 2: selects highest-balance token on the dest chain when no native exists there', () => {
+      const usdcOnBase = erc20('0x2105', 'USDC', 3000);
+      const usdtOnBase = erc20('0x2105', 'USDT', 1000);
+      const ethOnMainnet = native('0x1', 2000);
+
+      // Sorted by highest fiat: USDC on Base, ETH mainnet, USDT on Base
+      const result = selectDefaultSourceToken(
+        [usdcOnBase, ethOnMainnet, usdtOnBase],
+        '0x2105',
+      );
+
+      expect(result?.symbol).toBe('USDC');
+      expect(result?.chainId).toBe('0x2105');
+    });
+
+    it('priority 3: selects the native token with the highest balance when no tokens exist on the dest chain', () => {
+      const usdcOnMainnet = erc20('0x1', 'USDC', 5000);
+      const ethOnArbitrum = native('0xa4b1', 3000);
+      const ethOnMainnet = native('0x1', 2000);
+
+      // Sorted by highest fiat: USDC mainnet, ETH Arbitrum, ETH mainnet
+      const result = selectDefaultSourceToken(
+        [usdcOnMainnet, ethOnArbitrum, ethOnMainnet],
+        '0x2105', // Base — no tokens here
+      );
+
+      // ETH on Arbitrum (index 1) is the first native in the sorted list
+      expect(result?.symbol).toBe('ETH');
+      expect(result?.chainId).toBe('0xa4b1');
+    });
+
+    it('priority 3 fallback: returns first option when no native tokens exist on any chain', () => {
+      const usdcOnMainnet = erc20('0x1', 'USDC', 5000);
+      const usdtOnMainnet = erc20('0x1', 'USDT', 3000);
+
+      const result = selectDefaultSourceToken(
+        [usdcOnMainnet, usdtOnMainnet],
+        '0x2105', // Base — no tokens here
+      );
+
+      expect(result?.symbol).toBe('USDC');
+    });
+
+    it('selects native SOL as priority 3 when no EVM native is available', () => {
+      const solNative: BridgeToken = createSourceToken({
+        address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        symbol: 'SOL',
+        tokenFiatAmount: 2000,
+      });
+      const usdcOnMainnet = erc20('0x1', 'USDC', 5000);
+
+      const result = selectDefaultSourceToken(
+        [usdcOnMainnet, solNative],
+        '0x2105',
+      );
+
+      // SOL is native (slip44:501) and highest among natives
+      expect(result?.symbol).toBe('SOL');
+    });
+
+    it('works correctly when destChainId is undefined', () => {
+      const ethOnMainnet = native('0x1', 2000);
+      const usdcOnMainnet = erc20('0x1', 'USDC', 5000);
+
+      // Without destChainId, skip priorities 1 & 2 and go straight to priority 3
+      const result = selectDefaultSourceToken(
+        [usdcOnMainnet, ethOnMainnet],
+        undefined,
+      );
+
+      expect(result?.symbol).toBe('ETH');
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -6,6 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { Position } from '@metamask/social-controllers';
 import type { Hex } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
+import { selectDefaultSourceToken } from '../../../utils/tokenSelection';
 import { useQuickBuySetup } from './useQuickBuySetup';
 import { useSourceTokenOptions } from './useSourceTokenOptions';
 import { useQuickBuyQuotes } from './useQuickBuyQuotes';
@@ -150,12 +151,14 @@ export function useQuickBuyBottomSheet(
   >(undefined);
   const [isSourcePickerOpen, setIsSourcePickerOpen] = useState(false);
 
-  // Auto-select the first option (highest fiat balance) when options load
+  // Auto-select default source token using smart priority rules (see selectDefaultSourceToken)
   useEffect(() => {
     if (sourceTokenOptions.length > 0 && !selectedSourceToken) {
-      setSelectedSourceToken(sourceTokenOptions[0]);
+      setSelectedSourceToken(
+        selectDefaultSourceToken(sourceTokenOptions, destChainId),
+      );
     }
-  }, [sourceTokenOptions, selectedSourceToken]);
+  }, [sourceTokenOptions, selectedSourceToken, destChainId]);
 
   const sourceToken = selectedSourceToken;
   const sourceChainId = sourceToken?.chainId as Hex | undefined;

--- a/app/components/Views/SocialLeaderboard/utils/tokenSelection.ts
+++ b/app/components/Views/SocialLeaderboard/utils/tokenSelection.ts
@@ -1,0 +1,34 @@
+import type { CaipChainId, Hex } from '@metamask/utils';
+import type { BridgeToken } from '../../../UI/Bridge/types';
+
+const EVM_NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export const isNativeToken = (token: BridgeToken): boolean =>
+  token.address.toLowerCase() === EVM_NATIVE_ADDRESS ||
+  token.address.includes('slip44:501');
+
+/**
+ * Picks the best default "Pay with" token from the available options:
+ * 1. Native token on the destination chain (e.g. ETH on Base when buying on Base)
+ * 2. Any token on the destination chain with the highest balance
+ * 3. Native token on any other chain with the highest balance
+ * 4. Fallback: first option (highest overall fiat balance)
+ */
+export const selectDefaultSourceToken = (
+  options: BridgeToken[],
+  destChainId: Hex | CaipChainId | undefined,
+): BridgeToken | undefined => {
+  if (options.length === 0) return undefined;
+
+  if (destChainId) {
+    const nativeOnDest = options.find(
+      (t) => t.chainId === destChainId && isNativeToken(t),
+    );
+    if (nativeOnDest) return nativeOnDest;
+
+    const tokenOnDest = options.find((t) => t.chainId === destChainId);
+    if (tokenOnDest) return tokenOnDest;
+  }
+
+  return options.find(isNativeToken) ?? options[0];
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


### Smart default "Pay with" token selection for QuickBuy (TSA-472)

Updates the auto-selection logic for the "Pay with" token in the QuickBuy bottom sheet to minimise unnecessary cross-chain bridging.

New priority order:

- Native token on the destination chain (e.g. ETH on Base when buying a Base token) — avoids a bridge entirely
- Any token with balance on the destination chain, sorted by highest balance
- Native token on any other chain with the highest balance
- Fallback: token with the highest overall fiat balance

Previously the selection always picked the token with the highest fiat balance regardless of chain, which often triggered a cross-chain bridge even when the user held funds on the correct chain already.

### Changes:

`useQuickBuyBottomSheet.ts` — extracted `selectDefaultSourceToken` pure function implementing the priority logic; updated the auto-select `useEffect` to call it
`useQuickBuyBottomSheet.test.ts` — added unit tests covering all four priority levels including Solana native (SOL) detection

https://github.com/user-attachments/assets/48c1b5c5-ea78-4f16-8b47-b74cd1bcc2cd


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added quickbuy smart default

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c91523062ef90782b540c27b7fed55b693ed8479. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->