### PR TITLE
chore: Follow-trading-quick-buy-style-fixes

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -172,6 +172,7 @@ const TraderPositionView = () => {
           <QuickBuyBottomSheet
             isVisible={isQuickBuyVisible}
             position={resolvedPosition ?? null}
+            marketCap={marketCap}
             onClose={handleQuickBuyClose}
           />
         </>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.test.tsx
@@ -64,11 +64,19 @@ jest.mock('./QuickBuyHeader', () => {
   const { Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ position }: { position: Position }) =>
+    default: ({
+      position,
+      marketCap,
+    }: {
+      position: Position;
+      marketCap?: number;
+    }) =>
       ReactMock.createElement(
         Text,
         { testID: 'mock-header' },
-        position.tokenSymbol,
+        marketCap != null
+          ? `${position.tokenSymbol}:${marketCap}`
+          : position.tokenSymbol,
       ),
   };
 });
@@ -254,6 +262,19 @@ describe('QuickBuyBottomSheet', () => {
 
       expect(screen.getByTestId('mock-header')).toBeOnTheScreen();
       expect(screen.getByText('PEPE')).toBeOnTheScreen();
+    });
+
+    it('forwards the marketCap prop to the header', () => {
+      renderWithProvider(
+        <QuickBuyBottomSheet
+          isVisible
+          position={createPosition({ tokenSymbol: 'PEPE' })}
+          marketCap={2_300_000}
+          onClose={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('PEPE:2300000')).toBeOnTheScreen();
     });
 
     it('renders the skeleton body before deferred content becomes ready', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
@@ -12,7 +12,11 @@ import type { Position } from '@metamask/social-controllers';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 // `react-native-gesture-handler` ScrollView is required for scrolling on
 // Android inside a gesture-handler-managed BottomSheet.
-import { ScrollView } from 'react-native-gesture-handler';
+import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
+import Animated, {
+  type AnimatedRef,
+  useAnimatedRef,
+} from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
@@ -37,13 +41,22 @@ interface InnerProps {
   onClose: () => void;
 }
 
+// `Animated.createAnimatedComponent` lets us attach `useAnimatedRef` to the
+// gesture-handler ScrollView so worklets running on the UI thread can drive
+// `scrollTo` in lockstep with the Reanimated height animations.
+const AnimatedScrollView = Animated.createAnimatedComponent(
+  GestureHandlerScrollView,
+);
+
+export type QuickBuyScrollAnimatedRef = AnimatedRef<GestureHandlerScrollView>;
+
 interface ContentProps extends InnerProps {
   /**
-   * Invoked by the footer whenever the Pay-with picker or Total breakdown
-   * expands, so the ScrollView can scroll to the bottom and keep the Buy
-   * button visible.
+   * Animated ref to the parent ScrollView. The footer's `useAnimatedReaction`
+   * uses this to call Reanimated's `scrollTo` synchronously while the picker
+   * or Total breakdown grows, so the Buy button stays pinned at the bottom.
    */
-  onContentExpand: () => void;
+  scrollAnimatedRef: QuickBuyScrollAnimatedRef;
 }
 
 /**
@@ -54,7 +67,7 @@ interface ContentProps extends InnerProps {
 const QuickBuyBottomSheetContent: React.FC<ContentProps> = ({
   position,
   onClose,
-  onContentExpand,
+  scrollAnimatedRef,
 }) => {
   const { colors } = useTheme();
   const {
@@ -143,7 +156,7 @@ const QuickBuyBottomSheetContent: React.FC<ContentProps> = ({
             getButtonLabel={getButtonLabel}
             onPresetPress={handlePresetPress}
             onConfirm={handleConfirm}
-            onContentExpand={onContentExpand}
+            scrollAnimatedRef={scrollAnimatedRef}
             colors={colors}
           />
         </>
@@ -157,11 +170,6 @@ const QuickBuyBottomSheetContent: React.FC<ContentProps> = ({
  * so the animation runs on an idle JS thread. The heavy content tree is
  * mounted after the sheet reports its open animation has finished.
  */
-// Total expansion time = height animation duration + a small buffer so we
-// catch the final `onContentSizeChange` after the animation settles. Must
-// stay slightly above the matching value in QuickBuyFooter.
-const FOLLOW_BOTTOM_DURATION_MS = 280;
-
 const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
   position,
   marketCap,
@@ -169,15 +177,7 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
 }) => {
   const tw = useTailwind();
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const scrollViewRef = useRef<ScrollView>(null);
-  // While `true`, every content-size change while the height animation is
-  // running snaps the scroll offset to the new bottom. This makes the content
-  // visually grow upward, leaving the Buy button pinned at the bottom of the
-  // sheet during the transition.
-  const isFollowingBottomRef = useRef(false);
-  const followBottomTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const scrollAnimatedRef = useAnimatedRef<GestureHandlerScrollView>();
   const [isContentReady, setIsContentReady] = useState(false);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
 
@@ -187,33 +187,8 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
     });
   }, []);
 
-  useEffect(
-    () => () => {
-      if (followBottomTimeoutRef.current) {
-        clearTimeout(followBottomTimeoutRef.current);
-      }
-    },
-    [],
-  );
-
   const handleClose = useCallback(() => {
     bottomSheetRef.current?.onCloseBottomSheet();
-  }, []);
-
-  const handleContentExpand = useCallback(() => {
-    isFollowingBottomRef.current = true;
-    if (followBottomTimeoutRef.current) {
-      clearTimeout(followBottomTimeoutRef.current);
-    }
-    followBottomTimeoutRef.current = setTimeout(() => {
-      isFollowingBottomRef.current = false;
-      followBottomTimeoutRef.current = null;
-    }, FOLLOW_BOTTOM_DURATION_MS);
-  }, []);
-
-  const handleContentSizeChange = useCallback(() => {
-    if (!isFollowingBottomRef.current) return;
-    scrollViewRef.current?.scrollToEnd({ animated: false });
   }, []);
 
   return (
@@ -234,24 +209,29 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
        * `flexShrink: 1` lets this ScrollView size to its content normally,
        * but compress within the cap so its inner content scrolls instead of
        * overflowing the sheet.
+       *
+       * The footer drives `scrollTo` on this animated ref synchronously with
+       * its height animations (UI thread), so the content visually grows
+       * upward and the Buy button stays pinned during the transition without
+       * the JS-thread lag a `scrollToEnd` from `onContentSizeChange` would
+       * incur.
        */}
-      <ScrollView
-        ref={scrollViewRef}
+      <AnimatedScrollView
+        ref={scrollAnimatedRef}
         style={tw.style('shrink')}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        onContentSizeChange={handleContentSizeChange}
       >
         {isContentReady ? (
           <QuickBuyBottomSheetContent
             position={position}
             onClose={onClose}
-            onContentExpand={handleContentExpand}
+            scrollAnimatedRef={scrollAnimatedRef}
           />
         ) : (
           <QuickBuyBottomSheetSkeleton />
         )}
-      </ScrollView>
+      </AnimatedScrollView>
     </BottomSheet>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
@@ -7,8 +7,12 @@ import {
   TextVariant,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Position } from '@metamask/social-controllers';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+// `react-native-gesture-handler` ScrollView is required for scrolling on
+// Android inside a gesture-handler-managed BottomSheet.
+import { ScrollView } from 'react-native-gesture-handler';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
@@ -33,14 +37,24 @@ interface InnerProps {
   onClose: () => void;
 }
 
+interface ContentProps extends InnerProps {
+  /**
+   * Invoked by the footer whenever the Pay-with picker or Total breakdown
+   * expands, so the ScrollView can scroll to the bottom and keep the Buy
+   * button visible.
+   */
+  onContentExpand: () => void;
+}
+
 /**
  * Heavy subtree — deferred until after the open animation so its hook
  * tree (bridge quotes, balances, rewards, metadata) does not starve the
  * JS thread while the sheet is animating in.
  */
-const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
+const QuickBuyBottomSheetContent: React.FC<ContentProps> = ({
   position,
   onClose,
+  onContentExpand,
 }) => {
   const { colors } = useTheme();
   const {
@@ -129,6 +143,7 @@ const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
             getButtonLabel={getButtonLabel}
             onPresetPress={handlePresetPress}
             onConfirm={handleConfirm}
+            onContentExpand={onContentExpand}
             colors={colors}
           />
         </>
@@ -142,12 +157,27 @@ const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
  * so the animation runs on an idle JS thread. The heavy content tree is
  * mounted after the sheet reports its open animation has finished.
  */
+// Total expansion time = height animation duration + a small buffer so we
+// catch the final `onContentSizeChange` after the animation settles. Must
+// stay slightly above the matching value in QuickBuyFooter.
+const FOLLOW_BOTTOM_DURATION_MS = 280;
+
 const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
   position,
   marketCap,
   onClose,
 }) => {
+  const tw = useTailwind();
   const bottomSheetRef = useRef<BottomSheetRef>(null);
+  const scrollViewRef = useRef<ScrollView>(null);
+  // While `true`, every content-size change while the height animation is
+  // running snaps the scroll offset to the new bottom. This makes the content
+  // visually grow upward, leaving the Buy button pinned at the bottom of the
+  // sheet during the transition.
+  const isFollowingBottomRef = useRef(false);
+  const followBottomTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const [isContentReady, setIsContentReady] = useState(false);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
 
@@ -157,8 +187,33 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
     });
   }, []);
 
+  useEffect(
+    () => () => {
+      if (followBottomTimeoutRef.current) {
+        clearTimeout(followBottomTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
   const handleClose = useCallback(() => {
     bottomSheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleContentExpand = useCallback(() => {
+    isFollowingBottomRef.current = true;
+    if (followBottomTimeoutRef.current) {
+      clearTimeout(followBottomTimeoutRef.current);
+    }
+    followBottomTimeoutRef.current = setTimeout(() => {
+      isFollowingBottomRef.current = false;
+      followBottomTimeoutRef.current = null;
+    }, FOLLOW_BOTTOM_DURATION_MS);
+  }, []);
+
+  const handleContentSizeChange = useCallback(() => {
+    if (!isFollowingBottomRef.current) return;
+    scrollViewRef.current?.scrollToEnd({ animated: false });
   }, []);
 
   return (
@@ -172,11 +227,31 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
         marketCap={marketCap}
         onClose={handleClose}
       />
-      {isContentReady && true ? (
-        <QuickBuyBottomSheetContent position={position} onClose={onClose} />
-      ) : (
-        <QuickBuyBottomSheetSkeleton />
-      )}
+      {/*
+       * The BottomSheet caps its dialog at `safe-area height`; without a
+       * scroller, content beyond that cap is clipped (e.g. when both the
+       * source-token picker and the Total fee breakdown are expanded).
+       * `flexShrink: 1` lets this ScrollView size to its content normally,
+       * but compress within the cap so its inner content scrolls instead of
+       * overflowing the sheet.
+       */}
+      <ScrollView
+        ref={scrollViewRef}
+        style={tw.style('shrink')}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        onContentSizeChange={handleContentSizeChange}
+      >
+        {isContentReady ? (
+          <QuickBuyBottomSheetContent
+            position={position}
+            onClose={onClose}
+            onContentExpand={handleContentExpand}
+          />
+        ) : (
+          <QuickBuyBottomSheetSkeleton />
+        )}
+      </ScrollView>
     </BottomSheet>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
@@ -23,11 +23,13 @@ import QuickBuyBottomSheetSkeleton from './QuickBuyBottomSheetSkeleton';
 export interface QuickBuyBottomSheetProps {
   isVisible: boolean;
   position: Position | null;
+  marketCap?: number;
   onClose: () => void;
 }
 
 interface InnerProps {
   position: Position;
+  marketCap?: number;
   onClose: () => void;
 }
 
@@ -142,6 +144,7 @@ const QuickBuyBottomSheetContent: React.FC<InnerProps> = ({
  */
 const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
   position,
+  marketCap,
   onClose,
 }) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
@@ -164,7 +167,11 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
       isInteractable={!isSubmittingTx}
       onClose={onClose}
     >
-      <QuickBuyHeader position={position} onClose={handleClose} />
+      <QuickBuyHeader
+        position={position}
+        marketCap={marketCap}
+        onClose={handleClose}
+      />
       {isContentReady ? (
         <QuickBuyBottomSheetContent position={position} onClose={onClose} />
       ) : (
@@ -182,10 +189,17 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
 const QuickBuyBottomSheet: React.FC<QuickBuyBottomSheetProps> = ({
   isVisible,
   position,
+  marketCap,
   onClose,
 }) => {
   if (!isVisible || !position) return null;
-  return <QuickBuyBottomSheetInner position={position} onClose={onClose} />;
+  return (
+    <QuickBuyBottomSheetInner
+      position={position}
+      marketCap={marketCap}
+      onClose={onClose}
+    />
+  );
 };
 
 export default QuickBuyBottomSheet;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheet.tsx
@@ -1,24 +1,24 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import {
-  Box,
   BottomSheet,
-  Text,
-  TextVariant,
-  TextColor,
+  Box,
   BoxAlignItems,
+  Text,
+  TextColor,
+  TextVariant,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import type { Position } from '@metamask/social-controllers';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
-import { useTheme } from '../../../../../../util/theme';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
-import { useQuickBuyBottomSheet } from './useQuickBuyBottomSheet';
-import QuickBuyHeader from './QuickBuyHeader';
+import { useTheme } from '../../../../../../util/theme';
 import QuickBuyAmountInput from './QuickBuyAmountInput';
 import QuickBuyBanners from './QuickBuyBanners';
-import QuickBuyFooter from './QuickBuyFooter';
 import QuickBuyBottomSheetSkeleton from './QuickBuyBottomSheetSkeleton';
+import QuickBuyFooter from './QuickBuyFooter';
+import QuickBuyHeader from './QuickBuyHeader';
+import { useQuickBuyBottomSheet } from './useQuickBuyBottomSheet';
 
 export interface QuickBuyBottomSheetProps {
   isVisible: boolean;
@@ -172,7 +172,7 @@ const QuickBuyBottomSheetInner: React.FC<InnerProps> = ({
         marketCap={marketCap}
         onClose={handleClose}
       />
-      {isContentReady ? (
+      {isContentReady && true ? (
         <QuickBuyBottomSheetContent position={position} onClose={onClose} />
       ) : (
         <QuickBuyBottomSheetSkeleton />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheetSkeleton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyBottomSheetSkeleton.tsx
@@ -109,12 +109,14 @@ const QuickBuyBottomSheetSkeleton: React.FC = () => {
 
       <Box twClassName="px-4 pb-6" gap={6}>
         <Box gap={4}>
-          <QuickBuySkeletonRow
-            label={strings('social_leaderboard.quick_buy.pay_with')}
-            valueWidth={92}
-            showTokenBadge
-            showTrailingIcon
-          />
+          <Box twClassName="rounded-xl bg-muted px-4 py-3">
+            <QuickBuySkeletonRow
+              label={strings('social_leaderboard.quick_buy.pay_with')}
+              valueWidth={92}
+              showTokenBadge
+              showTrailingIcon
+            />
+          </Box>
 
           <QuickBuySkeletonRow
             label={strings('social_leaderboard.quick_buy.total')}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
@@ -20,6 +20,9 @@ import {
   BoxJustifyContent,
   AvatarToken,
   AvatarTokenSize,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  BadgeNetwork,
   Icon as IconDS,
   IconSize as IconSizeDS,
 } from '@metamask/design-system-react-native';
@@ -31,15 +34,12 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../../component-library/components/Badges/BadgeWrapper';
-import BadgeNetwork from '../../../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
 import { getNetworkImageSource } from '../../../../../../util/networks';
 import type { Hex } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import type { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
 import SourceTokenPicker from './SourceTokenPicker';
+import { getBridgeTokenImageSource } from './getBridgeTokenImageSource';
 import { strings } from '../../../../../../../locales/i18n';
 
 const USD_PRESETS = ['1', '20', '50', '100'];
@@ -203,14 +203,15 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
                   gap={2}
                 >
                   <BadgeWrapper
-                    badgePosition={BadgePosition.BottomRight}
-                    badgeElement={
+                    position={BadgeWrapperPosition.BottomRight}
+                    badge={
                       sourceChainId ? (
                         <BadgeNetwork
                           name={sourceToken?.symbol ?? ''}
-                          imageSource={getNetworkImageSource({
+                          src={getNetworkImageSource({
                             chainId: sourceChainId,
                           })}
+                          twClassName="scale-75"
                         />
                       ) : null
                     }
@@ -218,8 +219,8 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
                     <AvatarToken
                       name={sourceToken?.symbol ?? ''}
                       src={
-                        sourceToken?.image
-                          ? { uri: sourceToken.image }
+                        sourceToken
+                          ? getBridgeTokenImageSource(sourceToken)
                           : undefined
                       }
                       size={AvatarTokenSize.Xs}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
@@ -2,10 +2,13 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { type LayoutChangeEvent, TouchableOpacity, View } from 'react-native';
 import Animated, {
   Easing,
+  scrollTo,
+  useAnimatedReaction,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import type { QuickBuyScrollAnimatedRef } from './QuickBuyBottomSheet';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -72,11 +75,12 @@ interface QuickBuyFooterProps {
   onPresetPress: (preset: string) => void;
   onConfirm: () => Promise<void>;
   /**
-   * Called whenever the Pay-with picker or Total breakdown transitions to
-   * expanded, so the parent ScrollView can scroll to the bottom and keep the
-   * Buy button visible.
+   * Animated ref to the parent ScrollView. Used by `useAnimatedReaction` to
+   * drive `scrollTo` on the UI thread in lockstep with the picker/total
+   * height animations, so the Buy button stays pinned at the bottom of the
+   * sheet while content grows above it.
    */
-  onContentExpand?: () => void;
+  scrollAnimatedRef?: QuickBuyScrollAnimatedRef;
   colors: { icon: { alternative: string } };
 }
 
@@ -102,7 +106,7 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
   getButtonLabel,
   onPresetPress,
   onConfirm,
-  onContentExpand,
+  scrollAnimatedRef,
   colors,
 }) => {
   const tw = useTailwind();
@@ -188,24 +192,26 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
     );
   }, [isTotalExpanded, totalBreakdownHeight]);
 
-  // Notify the parent ScrollView that an expandable section is opening, so it
-  // can pin its scroll offset to the bottom for the duration of the height
-  // animation. Each section has its own effect so that toggling one doesn't
-  // re-arm following caused by the other.
-  // We fire immediately (no delay): the parent scrolls to the new bottom on
-  // every `onContentSizeChange` while following, so the content grows upward
-  // and the Buy button stays in place during the transition.
-  useEffect(() => {
-    if (isSourcePickerOpen) {
-      onContentExpand?.();
-    }
-  }, [isSourcePickerOpen, onContentExpand]);
-
-  useEffect(() => {
-    if (isTotalExpanded) {
-      onContentExpand?.();
-    }
-  }, [isTotalExpanded, onContentExpand]);
+  // Drive the parent ScrollView's offset on the UI thread, in lockstep with
+  // the picker/total height animations. Calling `scrollTo` from inside a
+  // worklet that depends on the height shared values means the scroll snaps
+  // to the new bottom on the same frame the content grows — eliminating the
+  // 1-frame snap that a JS-thread `onContentSizeChange` → `scrollToEnd` round
+  // trip produces. The large `y` value is clamped natively to the current
+  // max content offset, so we always land exactly at the bottom.
+  useAnimatedReaction(
+    () => pickerHeight.value + totalBreakdownHeight.value,
+    (sum, prev) => {
+      // Only follow when content is growing (or on the first run, e.g. when
+      // the breakdown starts open). Shrinking is handled implicitly: native
+      // ScrollViews clamp the offset to the new max, keeping us at the
+      // bottom without an explicit scroll command.
+      if (prev !== null && sum <= prev) return;
+      if (!scrollAnimatedRef) return;
+      scrollTo(scrollAnimatedRef, 0, Number.MAX_SAFE_INTEGER, false);
+    },
+    [scrollAnimatedRef],
+  );
 
   const handleSourcePickerToggle = useCallback(() => {
     setIsSourcePickerOpen((prev) => !prev);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
@@ -71,6 +71,12 @@ interface QuickBuyFooterProps {
   getButtonLabel: () => string;
   onPresetPress: (preset: string) => void;
   onConfirm: () => Promise<void>;
+  /**
+   * Called whenever the Pay-with picker or Total breakdown transitions to
+   * expanded, so the parent ScrollView can scroll to the bottom and keep the
+   * Buy button visible.
+   */
+  onContentExpand?: () => void;
   colors: { icon: { alternative: string } };
 }
 
@@ -96,6 +102,7 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
   getButtonLabel,
   onPresetPress,
   onConfirm,
+  onContentExpand,
   colors,
 }) => {
   const tw = useTailwind();
@@ -136,6 +143,69 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
       },
     );
   }, [isSourcePickerOpen, pickerHeight]);
+
+  // Animate the Total fee-breakdown the same way. `isTotalExpanded` can start
+  // `true` (when price impact is unsafe) so we use an `initialized` ref to
+  // commit the first measurement without an animation; subsequent toggles run
+  // through `withTiming` so the parent BottomSheet grows smoothly.
+  const totalBreakdownHeight = useSharedValue(0);
+  const measuredTotalBreakdownHeight = useRef(0);
+  const totalBreakdownInitialized = useRef(false);
+
+  const animatedTotalBreakdownStyle = useAnimatedStyle(() => ({
+    height: totalBreakdownHeight.value,
+  }));
+
+  const handleTotalBreakdownLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { height } = event.nativeEvent.layout;
+      if (height <= 0 || height === measuredTotalBreakdownHeight.current)
+        return;
+      measuredTotalBreakdownHeight.current = height;
+      if (!totalBreakdownInitialized.current) {
+        totalBreakdownInitialized.current = true;
+        totalBreakdownHeight.value = isTotalExpanded ? height : 0;
+        return;
+      }
+      if (isTotalExpanded) {
+        totalBreakdownHeight.value = withTiming(height, {
+          duration: PAY_WITH_ANIMATION_DURATION_MS,
+          easing: PAY_WITH_ANIMATION_EASING,
+        });
+      }
+    },
+    [isTotalExpanded, totalBreakdownHeight],
+  );
+
+  useEffect(() => {
+    if (!totalBreakdownInitialized.current) return;
+    totalBreakdownHeight.value = withTiming(
+      isTotalExpanded ? measuredTotalBreakdownHeight.current : 0,
+      {
+        duration: PAY_WITH_ANIMATION_DURATION_MS,
+        easing: PAY_WITH_ANIMATION_EASING,
+      },
+    );
+  }, [isTotalExpanded, totalBreakdownHeight]);
+
+  // Notify the parent ScrollView that an expandable section is opening, so it
+  // can pin its scroll offset to the bottom for the duration of the height
+  // animation. Each section has its own effect so that toggling one doesn't
+  // re-arm following caused by the other.
+  // We fire immediately (no delay): the parent scrolls to the new bottom on
+  // every `onContentSizeChange` while following, so the content grows upward
+  // and the Buy button stays in place during the transition.
+  useEffect(() => {
+    if (isSourcePickerOpen) {
+      onContentExpand?.();
+    }
+  }, [isSourcePickerOpen, onContentExpand]);
+
+  useEffect(() => {
+    if (isTotalExpanded) {
+      onContentExpand?.();
+    }
+  }, [isTotalExpanded, onContentExpand]);
 
   const handleSourcePickerToggle = useCallback(() => {
     setIsSourcePickerOpen((prev) => !prev);
@@ -269,145 +339,156 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
           </Box>
 
           {/* Total row (tap to expand fee breakdown) */}
-          <TouchableOpacity
-            onPress={() => setIsTotalExpanded((prev) => !prev)}
-            testID="quick-buy-total-row"
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Between}
+          <Box>
+            <TouchableOpacity
+              onPress={() => setIsTotalExpanded((prev) => !prev)}
+              testID="quick-buy-total-row"
             >
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
-                gap={2}
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.quick_buy.total')}
-                </Text>
-                <Icon
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={colors.icon.alternative}
-                />
-              </Box>
-              {isTotalLoading ? (
-                <Skeleton
-                  width={56}
-                  height={20}
-                  style={tw.style('rounded-md')}
-                  testID="skeleton-view"
-                />
-              ) : (
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                >
-                  {totalAmountUsd}
-                </Text>
-              )}
-            </Box>
-          </TouchableOpacity>
-
-          {/* Expanded fee breakdown (subsection of Total) */}
-          {isTotalExpanded && (
-            <Box twClassName="pl-4" gap={3}>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
                 justifyContent={BoxJustifyContent.Between}
               >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.quick_buy.network_fee')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                >
-                  {formattedNetworkFee}
-                </Text>
-              </Box>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Between}
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.quick_buy.slippage')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                >
-                  {formattedSlippage}
-                </Text>
-              </Box>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Between}
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.quick_buy.minimum_received')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                >
-                  {formattedMinimumReceived}
-                </Text>
-              </Box>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Between}
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('social_leaderboard.quick_buy.price_impact')}
-                </Text>
                 <Box
                   flexDirection={BoxFlexDirection.Row}
                   alignItems={BoxAlignItems.Center}
-                  gap={1}
-                  testID="quick-buy-price-impact"
+                  gap={2}
                 >
-                  {priceImpactViewData.icon && (
-                    <IconDS
-                      name={priceImpactViewData.icon.name}
-                      size={IconSizeDS.Sm}
-                      color={priceImpactViewData.icon.color}
-                    />
-                  )}
                   <Text
                     variant={TextVariant.BodyMd}
-                    color={
-                      priceImpactViewData.icon
-                        ? priceImpactViewData.textColor
-                        : TextColor.TextDefault
-                    }
+                    color={TextColor.TextAlternative}
                   >
-                    {formattedPriceImpact}
+                    {strings('social_leaderboard.quick_buy.total')}
                   </Text>
+                  <Icon
+                    name={
+                      isTotalExpanded ? IconName.ArrowUp : IconName.ArrowDown
+                    }
+                    size={IconSize.Sm}
+                    color={colors.icon.alternative}
+                  />
                 </Box>
+                {isTotalLoading ? (
+                  <Skeleton
+                    width={56}
+                    height={20}
+                    style={tw.style('rounded-md')}
+                    testID="skeleton-view"
+                  />
+                ) : (
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
+                    {totalAmountUsd}
+                  </Text>
+                )}
               </Box>
-            </Box>
-          )}
+            </TouchableOpacity>
+
+            {/* Expanded fee breakdown (subsection of Total) */}
+            <Animated.View
+              style={[tw.style('overflow-hidden'), animatedTotalBreakdownStyle]}
+            >
+              <View
+                onLayout={handleTotalBreakdownLayout}
+                style={tw.style('absolute inset-x-0 top-0 pt-4 pl-4')}
+              >
+                <Box gap={3}>
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    justifyContent={BoxJustifyContent.Between}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('social_leaderboard.quick_buy.network_fee')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextDefault}
+                    >
+                      {formattedNetworkFee}
+                    </Text>
+                  </Box>
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    justifyContent={BoxJustifyContent.Between}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('social_leaderboard.quick_buy.slippage')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextDefault}
+                    >
+                      {formattedSlippage}
+                    </Text>
+                  </Box>
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    justifyContent={BoxJustifyContent.Between}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('social_leaderboard.quick_buy.minimum_received')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextDefault}
+                    >
+                      {formattedMinimumReceived}
+                    </Text>
+                  </Box>
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    justifyContent={BoxJustifyContent.Between}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('social_leaderboard.quick_buy.price_impact')}
+                    </Text>
+                    <Box
+                      flexDirection={BoxFlexDirection.Row}
+                      alignItems={BoxAlignItems.Center}
+                      gap={1}
+                      testID="quick-buy-price-impact"
+                    >
+                      {priceImpactViewData.icon && (
+                        <IconDS
+                          name={priceImpactViewData.icon.name}
+                          size={IconSizeDS.Sm}
+                          color={priceImpactViewData.icon.color}
+                        />
+                      )}
+                      <Text
+                        variant={TextVariant.BodyMd}
+                        color={
+                          priceImpactViewData.icon
+                            ? priceImpactViewData.textColor
+                            : TextColor.TextDefault
+                        }
+                      >
+                        {formattedPriceImpact}
+                      </Text>
+                    </Box>
+                  </Box>
+                </Box>
+              </View>
+            </Animated.View>
+          </Box>
         </Box>
 
         {/* Buy button */}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyFooter.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
-import { TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { type LayoutChangeEvent, TouchableOpacity, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 import {
   Box,
   Text,
@@ -18,6 +23,7 @@ import {
   Icon as IconDS,
   IconSize as IconSizeDS,
 } from '@metamask/design-system-react-native';
+import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 import QuickBuyConfirmButton, {
   type ConfirmButtonState,
 } from './QuickBuyConfirmButton';
@@ -37,6 +43,9 @@ import SourceTokenPicker from './SourceTokenPicker';
 import { strings } from '../../../../../../../locales/i18n';
 
 const USD_PRESETS = ['1', '20', '50', '100'];
+
+const PAY_WITH_ANIMATION_DURATION_MS = 220;
+const PAY_WITH_ANIMATION_EASING = Easing.out(Easing.cubic);
 
 interface QuickBuyFooterProps {
   usdAmount: string;
@@ -92,6 +101,54 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
   const tw = useTailwind();
   const isPriceImpactSafe = !priceImpactViewData.icon;
   const [isTotalExpanded, setIsTotalExpanded] = useState(!isPriceImpactSafe);
+
+  // Animate the source picker's real `height` so React Native's layout system
+  // re-measures the parent BottomSheet on each frame; this lets the whole sheet
+  // grow/shrink smoothly instead of jumping.
+  const pickerHeight = useSharedValue(0);
+  const measuredPickerHeight = useRef(0);
+
+  const animatedPickerStyle = useAnimatedStyle(() => ({
+    height: pickerHeight.value,
+  }));
+
+  const handlePickerLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { height } = event.nativeEvent.layout;
+      if (height <= 0 || height === measuredPickerHeight.current) return;
+      measuredPickerHeight.current = height;
+      if (isSourcePickerOpen) {
+        pickerHeight.value = withTiming(height, {
+          duration: PAY_WITH_ANIMATION_DURATION_MS,
+          easing: PAY_WITH_ANIMATION_EASING,
+        });
+      }
+    },
+    [isSourcePickerOpen, pickerHeight],
+  );
+
+  useEffect(() => {
+    pickerHeight.value = withTiming(
+      isSourcePickerOpen ? measuredPickerHeight.current : 0,
+      {
+        duration: PAY_WITH_ANIMATION_DURATION_MS,
+        easing: PAY_WITH_ANIMATION_EASING,
+      },
+    );
+  }, [isSourcePickerOpen, pickerHeight]);
+
+  const handleSourcePickerToggle = useCallback(() => {
+    setIsSourcePickerOpen((prev) => !prev);
+  }, [setIsSourcePickerOpen]);
+
+  const handleSourceTokenSelect = useCallback(
+    (token: BridgeToken) => {
+      setSelectedSourceToken(token);
+      setIsSourcePickerOpen(false);
+    },
+    [setSelectedSourceToken, setIsSourcePickerOpen],
+  );
+
   return (
     <Box twClassName="w-full">
       {/* Preset pills */}
@@ -120,87 +177,95 @@ const QuickBuyFooter: React.FC<QuickBuyFooterProps> = ({
       {/* Footer details */}
       <Box twClassName="px-4 pb-6" gap={6}>
         <Box gap={4}>
-          {/* Pay with row */}
-          <TouchableOpacity
-            onPress={() => setIsSourcePickerOpen((prev) => !prev)}
-            disabled={sourceTokenOptions.length === 0}
-            testID="quick-buy-pay-with-row"
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Between}
+          {/* Pay with card (tap to expand source picker inline) */}
+          <Box twClassName="rounded-xl bg-muted overflow-hidden">
+            <TouchableOpacity
+              onPress={handleSourcePickerToggle}
+              disabled={sourceTokenOptions.length === 0}
+              activeOpacity={0.7}
+              testID="quick-buy-pay-with-row"
             >
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {strings('social_leaderboard.quick_buy.pay_with')}
-              </Text>
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
-                gap={2}
+                justifyContent={BoxJustifyContent.Between}
+                twClassName="px-4 py-3"
               >
-                <BadgeWrapper
-                  badgePosition={BadgePosition.BottomRight}
-                  badgeElement={
-                    sourceChainId ? (
-                      <BadgeNetwork
-                        name={sourceToken?.symbol ?? ''}
-                        imageSource={getNetworkImageSource({
-                          chainId: sourceChainId,
-                        })}
-                      />
-                    ) : null
-                  }
-                >
-                  <AvatarToken
-                    name={sourceToken?.symbol ?? ''}
-                    src={
-                      sourceToken?.image
-                        ? { uri: sourceToken.image }
-                        : undefined
-                    }
-                    size={AvatarTokenSize.Xs}
-                  />
-                </BadgeWrapper>
                 <Text
                   variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
+                  color={TextColor.TextAlternative}
                 >
-                  {sourceToken?.symbol ?? ''}
+                  {strings('social_leaderboard.quick_buy.pay_with')}
                 </Text>
-                {sourceBalanceFiat && (
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={2}
+                >
+                  <BadgeWrapper
+                    badgePosition={BadgePosition.BottomRight}
+                    badgeElement={
+                      sourceChainId ? (
+                        <BadgeNetwork
+                          name={sourceToken?.symbol ?? ''}
+                          imageSource={getNetworkImageSource({
+                            chainId: sourceChainId,
+                          })}
+                        />
+                      ) : null
+                    }
+                  >
+                    <AvatarToken
+                      name={sourceToken?.symbol ?? ''}
+                      src={
+                        sourceToken?.image
+                          ? { uri: sourceToken.image }
+                          : undefined
+                      }
+                      size={AvatarTokenSize.Xs}
+                    />
+                  </BadgeWrapper>
                   <Text
                     variant={TextVariant.BodyMd}
-                    color={TextColor.TextAlternative}
+                    color={TextColor.TextDefault}
                   >
-                    {`(${sourceBalanceFiat})`}
+                    {sourceToken?.symbol ?? ''}
                   </Text>
-                )}
-                <Icon
-                  name={
-                    isSourcePickerOpen ? IconName.ArrowUp : IconName.ArrowDown
-                  }
-                  size={IconSize.Sm}
-                  color={colors.icon.alternative}
-                />
+                  {sourceBalanceFiat && (
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {`(${sourceBalanceFiat})`}
+                    </Text>
+                  )}
+                  <Icon
+                    name={
+                      isSourcePickerOpen ? IconName.ArrowUp : IconName.ArrowDown
+                    }
+                    size={IconSize.Sm}
+                    color={colors.icon.alternative}
+                  />
+                </Box>
               </Box>
-            </Box>
-          </TouchableOpacity>
+            </TouchableOpacity>
 
-          {/* Inline source token dropdown */}
-          {isSourcePickerOpen && (
-            <SourceTokenPicker
-              options={sourceTokenOptions}
-              selectedToken={selectedSourceToken}
-              onSelect={(token) => {
-                setSelectedSourceToken(token);
-                setIsSourcePickerOpen(false);
-              }}
-            />
-          )}
+            <Animated.View
+              pointerEvents={isSourcePickerOpen ? 'auto' : 'none'}
+              style={[tw.style('overflow-hidden'), animatedPickerStyle]}
+            >
+              <View
+                onLayout={handlePickerLayout}
+                style={tw.style('absolute inset-x-0 top-0')}
+              >
+                <SourceTokenPicker
+                  options={sourceTokenOptions}
+                  selectedToken={selectedSourceToken}
+                  onSelect={handleSourceTokenSelect}
+                />
+              </View>
+            </Animated.View>
+          </Box>
 
           {/* Total row (tap to expand fee breakdown) */}
           <TouchableOpacity

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import type { Position } from '@metamask/social-controllers';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import QuickBuyHeader from './QuickBuyHeader';
+
+jest.mock('../../../components/PositionTokenAvatar', () => {
+  const ReactMock = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ position }: { position: Position }) =>
+      ReactMock.createElement(
+        Text,
+        { testID: 'mock-position-token-avatar' },
+        position.tokenSymbol,
+      ),
+  };
+});
+
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: Record<string, string>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+}));
+
+const createPosition = (overrides: Partial<Position> = {}): Position =>
+  ({
+    chain: 'base',
+    tokenAddress: '0x1234567890123456789012345678901234567890',
+    tokenSymbol: 'PEPE',
+    tokenName: 'Pepe',
+    positionAmount: 1000,
+    boughtUsd: 500,
+    soldUsd: 0,
+    realizedPnl: 0,
+    costBasis: 500,
+    trades: [],
+    lastTradeAt: 0,
+    currentValueUSD: 900,
+    pnlValueUsd: 400,
+    pnlPercent: 80,
+    ...overrides,
+  }) as Position;
+
+describe('QuickBuyHeader', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the title with the token symbol', () => {
+    renderWithProvider(
+      <QuickBuyHeader
+        position={createPosition({ tokenSymbol: 'PEPE' })}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('social_leaderboard.quick_buy.title:{"symbol":"PEPE"}'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the position token avatar', () => {
+    renderWithProvider(
+      <QuickBuyHeader
+        position={createPosition({ tokenSymbol: 'PEPE' })}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('mock-position-token-avatar')).toBeOnTheScreen();
+  });
+
+  describe('market cap subtitle', () => {
+    it('renders only the label when marketCap is undefined', () => {
+      renderWithProvider(
+        <QuickBuyHeader position={createPosition()} onClose={jest.fn()} />,
+      );
+
+      expect(
+        screen.getByText('social_leaderboard.quick_buy.market_cap_label'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders the formatted market cap with the label when provided in millions', () => {
+      renderWithProvider(
+        <QuickBuyHeader
+          position={createPosition()}
+          marketCap={2_300_000}
+          onClose={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByText('$2.3M social_leaderboard.quick_buy.market_cap_label'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders the formatted market cap with the label when provided in thousands', () => {
+      renderWithProvider(
+        <QuickBuyHeader
+          position={createPosition()}
+          marketCap={25_000}
+          onClose={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByText('$25K social_leaderboard.quick_buy.market_cap_label'),
+      ).toBeOnTheScreen();
+    });
+
+    it('treats a zero marketCap as a present value and prefixes "$0"', () => {
+      renderWithProvider(
+        <QuickBuyHeader
+          position={createPosition()}
+          marketCap={0}
+          onClose={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByText('$0 social_leaderboard.quick_buy.market_cap_label'),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('close button', () => {
+    it('calls onClose when the close button is pressed', () => {
+      const onClose = jest.fn();
+      renderWithProvider(
+        <QuickBuyHeader position={createPosition()} onClose={onClose} />,
+      );
+
+      fireEvent.press(screen.getByTestId('quick-buy-close-button'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
@@ -13,15 +13,18 @@ import {
 } from '@metamask/design-system-react-native';
 import type { Position } from '@metamask/social-controllers';
 import { strings } from '../../../../../../../locales/i18n';
+import { formatCompactUsd } from '../../../../../UI/Rewards/utils/formatUtils';
 import PositionTokenAvatar from '../../../components/PositionTokenAvatar';
 
 interface QuickBuyHeaderProps {
   position: Position;
+  marketCap?: number;
   onClose: () => void;
 }
 
 const QuickBuyHeader: React.FC<QuickBuyHeaderProps> = ({
   position,
+  marketCap,
   onClose,
 }) => (
   <Box
@@ -48,7 +51,9 @@ const QuickBuyHeader: React.FC<QuickBuyHeaderProps> = ({
         fontWeight={FontWeight.Medium}
         color={TextColor.TextAlternative}
       >
-        {strings('social_leaderboard.quick_buy.market_cap_label')}
+        {marketCap != null
+          ? `${formatCompactUsd(marketCap)} ${strings('social_leaderboard.quick_buy.market_cap_label')}`
+          : strings('social_leaderboard.quick_buy.market_cap_label')}
       </Text>
     </Box>
     <ButtonIcon

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/QuickBuyHeader.tsx
@@ -30,7 +30,9 @@ const QuickBuyHeader: React.FC<QuickBuyHeaderProps> = ({
     gap={4}
     twClassName="h-20 px-4"
   >
-    <PositionTokenAvatar position={position} showChainBadge />
+    <Box twClassName="pb-1">
+      <PositionTokenAvatar position={position} showChainBadge />
+    </Box>
     <Box twClassName="flex-1">
       <Text
         variant={TextVariant.HeadingSm}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/SourceTokenPicker.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/SourceTokenPicker.tsx
@@ -1,29 +1,29 @@
-import React, { useCallback } from 'react';
-import { TouchableOpacity } from 'react-native';
 import {
-  Box,
-  Text,
-  TextVariant,
-  TextColor,
-  FontWeight,
-  BoxFlexDirection,
-  BoxAlignItems,
-  BoxJustifyContent,
   AvatarToken,
   AvatarTokenSize,
+  BadgeNetwork,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
+import React, { useCallback } from 'react';
+import { TouchableOpacity } from 'react-native';
 import Icon, {
-  IconSize,
   IconName,
+  IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../../component-library/components/Badges/BadgeWrapper';
-import BadgeNetwork from '../../../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
 import { getNetworkImageSource } from '../../../../../../util/networks';
-import type { BridgeToken } from '../../../../../UI/Bridge/types';
-import { getTokenKey } from './sourceTokenCandidates';
 import { useTheme } from '../../../../../../util/theme';
+import type { BridgeToken } from '../../../../../UI/Bridge/types';
+import { getBridgeTokenImageSource } from './getBridgeTokenImageSource';
+import { getTokenKey } from './sourceTokenCandidates';
 
 interface SourceTokenPickerProps {
   options: BridgeToken[];
@@ -78,23 +78,26 @@ const SourceTokenPicker: React.FC<SourceTokenPickerProps> = ({
                 alignItems={BoxAlignItems.Center}
                 gap={3}
               >
-                <BadgeWrapper
-                  badgePosition={BadgePosition.BottomRight}
-                  badgeElement={
-                    <BadgeNetwork
+                <Box twClassName="pb-0.5">
+                  <BadgeWrapper
+                    position={BadgeWrapperPosition.BottomRight}
+                    badge={
+                      <BadgeNetwork
+                        name={item.symbol}
+                        src={getNetworkImageSource({
+                          chainId: item.chainId,
+                        })}
+                        twClassName="scale-75"
+                      />
+                    }
+                  >
+                    <AvatarToken
                       name={item.symbol}
-                      imageSource={getNetworkImageSource({
-                        chainId: item.chainId,
-                      })}
+                      src={getBridgeTokenImageSource(item)}
+                      size={AvatarTokenSize.Sm}
                     />
-                  }
-                >
-                  <AvatarToken
-                    name={item.symbol}
-                    src={item.image ? { uri: item.image } : undefined}
-                    size={AvatarTokenSize.Sm}
-                  />
-                </BadgeWrapper>
+                  </BadgeWrapper>
+                </Box>
                 <Box>
                   <Text
                     variant={TextVariant.BodyMd}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/getBridgeTokenImageSource.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/getBridgeTokenImageSource.ts
@@ -1,0 +1,23 @@
+import type { ImageURISource } from 'react-native';
+import { getAssetImageUrl } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import type { BridgeToken } from '../../../../../UI/Bridge/types';
+
+/**
+ * Resolves the best available image source for a `BridgeToken` candidate.
+ *
+ * Order of preference:
+ * 1. The token's own `image` URL (set for stablecoins and most ERC-20s).
+ * 2. The MetaMask static token-icon CDN URL derived from the token address +
+ * chain (covers native tokens — ETH, BNB, POL, etc. — whose `image` field
+ * from `getNativeSourceToken` is often empty).
+ * 3. `undefined`, in which case `AvatarToken` renders the symbol monogram.
+ */
+export const getBridgeTokenImageSource = (
+  token: BridgeToken,
+): ImageURISource | undefined => {
+  if (token.image) {
+    return { uri: token.image };
+  }
+  const fallback = getAssetImageUrl(token.address, token.chainId);
+  return fallback ? { uri: fallback } : undefined;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This update enhances the QuickBuyBottomSheet component by implementing an animated ScrollView that synchronizes scrolling with content expansion. The QuickBuyFooter now utilizes an animated reference to control scrolling, ensuring the Buy button remains visible during transitions. This change improves the overall user experience by providing smoother interactions and maintaining accessibility of key actions during content changes.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
