### PR TITLE
chore: Bump `snaps-controllers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "@metamask/signature-controller": "^39.2.0",
     "@metamask/slip44": "^4.2.0",
     "@metamask/smart-transactions-controller": "^24.0.0",
-    "@metamask/snaps-controllers": "^20.0.1",
+    "@metamask/snaps-controllers": "^20.0.3",
     "@metamask/snaps-execution-environments": "^11.0.2",
     "@metamask/snaps-rpc-methods": "^15.1.1",
     "@metamask/snaps-sdk": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9970,9 +9970,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^20.0.1":
-  version: 20.0.1
-  resolution: "@metamask/snaps-controllers@npm:20.0.1"
+"@metamask/snaps-controllers@npm:^20.0.3":
+  version: 20.0.3
+  resolution: "@metamask/snaps-controllers@npm:20.0.3"
   dependencies:
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/base-controller": "npm:^9.0.1"
@@ -10005,11 +10005,11 @@ __metadata:
     semver: "npm:^7.5.4"
     tar-stream: "npm:^3.1.7"
   peerDependencies:
-    "@metamask/snaps-execution-environments": ^11.0.2
+    "@metamask/snaps-execution-environments": ^11.1.0
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 10/ccacdffa8b630a777f7e95ad2a795a95663b0ae4da1fe78c35fa4b1e3590318687e5edb3cd769661e74fc03ee2e59bcd62098657e9b00163b216eb8424b8a135
+  checksum: 10/83aa7cfa4f42ba8bf28120f56582beea907d532d621ff7e93ae0e0fa890c87ad45f8d08c2749ae821001492376e3b8f1cccb2f9b2c927fb2b3b51cd42ae82b7a
   languageName: node
   linkType: hard
 
@@ -35729,7 +35729,7 @@ __metadata:
     "@metamask/signature-controller": "npm:^39.2.0"
     "@metamask/slip44": "npm:^4.2.0"
     "@metamask/smart-transactions-controller": "npm:^24.0.0"
-    "@metamask/snaps-controllers": "npm:^20.0.1"
+    "@metamask/snaps-controllers": "npm:^20.0.3"
     "@metamask/snaps-execution-environments": "npm:^11.0.2"
     "@metamask/snaps-rpc-methods": "npm:^15.1.1"
     "@metamask/snaps-sdk": "npm:^11.1.0"


### PR DESCRIPTION
## **Description**

Bump `snaps-controllers` in preparation for breaking changes to the `accounts-controller`. There should be no functional difference in behaviour.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-988

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; behavior should remain unchanged but could surface regressions if the updated snaps controller package has subtle internal changes.
> 
> **Overview**
> Updates the `@metamask/snaps-controllers` dependency from `^20.0.1` to `^20.0.3`.
> 
> Refreshes `yarn.lock` to pin `snaps-controllers@20.0.3` (including updated lockfile metadata like peer dependency range for `@metamask/snaps-execution-environments`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4408d56e3c97ff8b14f3254cea9a1adc04494701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->