### PR TITLE
fix(card): require Linea funding before Cashback redemption

### DIFF
--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -443,6 +443,41 @@ describe('Cashback Component', () => {
 
       expect(mockWithdraw).not.toHaveBeenCalled();
     });
+
+    it('shows the generic loading error instead of missing-funding warning when card home data failed to load', () => {
+      mockHookReturn.cashbackWallet = {
+        id: 'w1',
+        balance: '10.00',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.estimation = {
+        wei: '100000',
+        eth: '0.0001',
+        price: '0.50',
+      };
+
+      render({
+        cardHomeData: null,
+        cardHomeDataStatus: 'error',
+      });
+
+      expect(
+        screen.queryByTestId(CashbackSelectors.FUNDING_WARNING),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByText('Failed to load cashback. Please try again.'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(CashbackSelectors.DETAILS_CARD),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(screen.getByTestId(CashbackSelectors.WITHDRAW_BUTTON));
+
+      expect(mockWithdraw).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('withdraw action', () => {

--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -3,6 +3,7 @@ const mockShowToast = jest.fn();
 const mockCloseToast = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
+const mockNavigate = jest.fn();
 
 const mockEventBuilder = {
   addProperties: jest.fn().mockReturnThis(),
@@ -43,6 +44,7 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       goBack: mockGoBack,
+      navigate: mockNavigate,
     }),
   };
 });
@@ -71,6 +73,11 @@ jest.mock('../../../../../../locales/i18n', () => ({
         'Withdrawal failed. Please try again.',
       'card.cashback_screen.loading_error':
         'Failed to load cashback. Please try again.',
+      'card.cashback_screen.funding_required.title': 'Set up Linea funding',
+      'card.cashback_screen.funding_required.description':
+        'You need at least one approved funding source on Linea before redeeming cashback.',
+      'card.cashback_screen.funding_required.confirm_button_label':
+        'Set up funding',
     };
     return translations[key] ?? key;
   },
@@ -116,6 +123,8 @@ import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { ToastContext } from '../../../../../component-library/components/Toast';
 import Cashback from './Cashback';
 import { CashbackSelectors } from './Cashback.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import { FundingAssetStatus } from '../../../../../core/Engine/controllers/card-controller/provider-types';
 
 const mockToastRef = {
   current: {
@@ -124,13 +133,37 @@ const mockToastRef = {
   },
 };
 
+const mockLineaUsdcFundingAsset = {
+  symbol: 'USDC',
+  name: 'USD Coin',
+  address: '0xusdc000000000000000000000000000000000001',
+  walletAddress: '0xwallet000000000000000000000000000000000002',
+  decimals: 6,
+  chainId: 'eip155:59144',
+  spendableBalance: '10',
+  spendingCap: '100',
+  priority: 1,
+  status: FundingAssetStatus.Active,
+};
+
+const mockCardHomeData = {
+  primaryFundingAsset: mockLineaUsdcFundingAsset,
+  fundingAssets: [mockLineaUsdcFundingAsset],
+  availableFundingAssets: [mockLineaUsdcFundingAsset],
+  card: null,
+  account: null,
+  alerts: [],
+  actions: [],
+  delegationSettings: null,
+};
+
 const CashbackWithToast = () => (
   <ToastContext.Provider value={{ toastRef: mockToastRef }}>
     <Cashback />
   </ToastContext.Provider>
 );
 
-function render() {
+function render(cardControllerOverrides = {}) {
   return renderScreen(
     CashbackWithToast,
     {
@@ -142,6 +175,16 @@ function render() {
           backgroundState: {
             PreferencesController: {
               isIpfsGatewayEnabled: true,
+            },
+            CardController: {
+              selectedCountry: null,
+              activeProviderId: 'baanx',
+              isAuthenticated: true,
+              cardholderAccounts: [],
+              providerData: {},
+              cardHomeData: mockCardHomeData,
+              cardHomeDataStatus: 'success',
+              ...cardControllerOverrides,
             },
           },
         },
@@ -333,6 +376,72 @@ describe('Cashback Component', () => {
       render();
 
       expect(screen.getByText('Withdrawal unavailable')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Linea funding requirement', () => {
+    it('shows a warning when the user has no approved Linea funding', () => {
+      render({
+        cardHomeData: {
+          ...mockCardHomeData,
+          fundingAssets: [],
+        },
+      });
+
+      expect(
+        screen.getByTestId(CashbackSelectors.FUNDING_WARNING),
+      ).toBeOnTheScreen();
+      expect(screen.getByText('Set up Linea funding')).toBeOnTheScreen();
+      expect(
+        screen.getByText(
+          'You need at least one approved funding source on Linea before redeeming cashback.',
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('navigates to Spending Limit with USDC on Linea pre-selected', () => {
+      render({
+        cardHomeData: {
+          ...mockCardHomeData,
+          fundingAssets: [],
+        },
+      });
+
+      fireEvent.press(screen.getByText('Set up funding'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SPENDING_LIMIT, {
+        flow: 'enable',
+        selectedToken: expect.objectContaining({
+          symbol: 'USDC',
+          caipChainId: 'eip155:59144',
+        }),
+      });
+    });
+
+    it('blocks withdrawal when approved Linea funding is missing', () => {
+      mockHookReturn.cashbackWallet = {
+        id: 'w1',
+        balance: '10.00',
+        currency: 'musd',
+        isWithdrawable: true,
+        type: 'reward',
+      };
+      mockHookReturn.estimation = {
+        wei: '100000',
+        eth: '0.0001',
+        price: '0.50',
+      };
+
+      render({
+        cardHomeData: {
+          ...mockCardHomeData,
+          fundingAssets: [],
+        },
+      });
+
+      fireEvent.press(screen.getByTestId(CashbackSelectors.WITHDRAW_BUTTON));
+
+      expect(mockWithdraw).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Card/Views/Cashback/Cashback.testIds.ts
+++ b/app/components/UI/Card/Views/Cashback/Cashback.testIds.ts
@@ -2,6 +2,7 @@ export const CashbackSelectors = {
   CONTAINER: 'cashback-container',
   BALANCE_TITLE: 'cashback-balance-title',
   DETAILS_CARD: 'cashback-details-card',
+  FUNDING_WARNING: 'cashback-funding-warning',
   NETWORK_FEE_ROW: 'cashback-network-fee-row',
   EXPECTED_TO_RECEIVE_ROW: 'cashback-expected-to-receive-row',
   WITHDRAW_BUTTON: 'cashback-withdraw-button',

--- a/app/components/UI/Card/Views/Cashback/Cashback.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.tsx
@@ -90,8 +90,13 @@ const Cashback: React.FC = () => {
   const hasInsufficientBalance = balanceNum <= 0 || balanceNum <= feeNum;
   const isFundingStatusLoading =
     cardHomeDataStatus === 'idle' || cardHomeDataStatus === 'loading';
+  const hasFundingStatusError = cardHomeDataStatus === 'error';
+  const isFundingStatusLoaded = cardHomeDataStatus === 'success';
   const requiresLineaFunding =
-    !isFundingStatusLoading && !hasApprovedLineaFunding;
+    isFundingStatusLoaded && !hasApprovedLineaFunding;
+  const isFundingStatusUnavailable =
+    isFundingStatusLoading || hasFundingStatusError;
+  const showLoadingError = !!error || hasFundingStatusError;
 
   useEffect(() => {
     if (cashbackWallet) {
@@ -156,7 +161,7 @@ const Cashback: React.FC = () => {
   );
 
   const handleWithdraw = useCallback(() => {
-    if (requiresLineaFunding) return;
+    if (requiresLineaFunding || isFundingStatusUnavailable) return;
 
     trackEvent(
       createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
@@ -167,7 +172,14 @@ const Cashback: React.FC = () => {
         .build(),
     );
     withdraw(balance);
-  }, [balance, withdraw, trackEvent, createEventBuilder, requiresLineaFunding]);
+  }, [
+    balance,
+    withdraw,
+    trackEvent,
+    createEventBuilder,
+    requiresLineaFunding,
+    isFundingStatusUnavailable,
+  ]);
 
   const handleNavigateToSpendingLimit = useCallback(() => {
     navigation.navigate(Routes.CARD.SPENDING_LIMIT, {
@@ -179,11 +191,21 @@ const Cashback: React.FC = () => {
   const isProcessing = isWithdrawing || monitoringStatus === 'monitoring';
 
   const buttonLabel = useMemo(() => {
-    if (!isWithdrawable || hasInsufficientBalance) {
+    if (
+      !isWithdrawable ||
+      hasInsufficientBalance ||
+      requiresLineaFunding ||
+      isFundingStatusUnavailable
+    ) {
       return strings('card.cashback_screen.withdraw_unavailable');
     }
     return strings('card.cashback_screen.withdraw');
-  }, [isWithdrawable, hasInsufficientBalance]);
+  }, [
+    isWithdrawable,
+    hasInsufficientBalance,
+    requiresLineaFunding,
+    isFundingStatusUnavailable,
+  ]);
 
   const isButtonDisabled =
     isLoading ||
@@ -191,7 +213,7 @@ const Cashback: React.FC = () => {
     isProcessing ||
     isEstimating ||
     hasInsufficientBalance ||
-    isFundingStatusLoading ||
+    isFundingStatusUnavailable ||
     requiresLineaFunding;
 
   return (
@@ -227,7 +249,7 @@ const Cashback: React.FC = () => {
           </Text>
         </Box>
 
-        {error ? (
+        {showLoadingError ? (
           <Box twClassName="rounded-xl bg-background-muted p-4 items-center">
             <Text
               variant={TextVariant.BodyMd}

--- a/app/components/UI/Card/Views/Cashback/Cashback.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.tsx
@@ -25,6 +25,15 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardActions } from '../../util/metrics';
 import { CashbackSelectors } from './Cashback.testIds';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import {
+  selectCardHasApprovedLineaFunding,
+  selectCardHomeDataStatus,
+  selectCardLineaUsdcToken,
+} from '../../../../../selectors/cardController';
+import CardMessageBox from '../../components/CardMessageBox/CardMessageBox';
+import { CardMessageBoxType } from '../../types';
+import Routes from '../../../../../constants/navigation/Routes';
 
 const CURRENCY_DISPLAY_MAP: Record<string, string> = {
   musd: 'mUSD',
@@ -44,11 +53,16 @@ const formatAmount = (value: string | number): string => {
 };
 
 const Cashback: React.FC = () => {
-  const { goBack } = useNavigation();
+  const navigation = useNavigation();
   const tw = useTailwind();
   const theme = useTheme();
   const { toastRef } = useContext(ToastContext);
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const hasApprovedLineaFunding = useSelector(
+    selectCardHasApprovedLineaFunding,
+  );
+  const lineaUsdcToken = useSelector(selectCardLineaUsdcToken);
+  const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
 
   const {
     cashbackWallet,
@@ -74,6 +88,10 @@ const Cashback: React.FC = () => {
   const feeNum = parseFloat(feeRaw);
   const expectedToReceiveNum = Math.max(0, balanceNum - feeNum);
   const hasInsufficientBalance = balanceNum <= 0 || balanceNum <= feeNum;
+  const isFundingStatusLoading =
+    cardHomeDataStatus === 'idle' || cardHomeDataStatus === 'loading';
+  const requiresLineaFunding =
+    !isFundingStatusLoading && !hasApprovedLineaFunding;
 
   useEffect(() => {
     if (cashbackWallet) {
@@ -94,9 +112,9 @@ const Cashback: React.FC = () => {
         iconColor: theme.colors.success.default,
         hasNoTimeout: false,
       });
-      goBack();
+      navigation.goBack();
     }
-  }, [monitoringStatus, toastRef, theme, goBack]);
+  }, [monitoringStatus, toastRef, theme, navigation]);
 
   useEffect(() => {
     if (monitoringStatus === 'failed' || monitoringError) {
@@ -138,6 +156,8 @@ const Cashback: React.FC = () => {
   );
 
   const handleWithdraw = useCallback(() => {
+    if (requiresLineaFunding) return;
+
     trackEvent(
       createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
         .addProperties({
@@ -147,7 +167,14 @@ const Cashback: React.FC = () => {
         .build(),
     );
     withdraw(balance);
-  }, [balance, withdraw, trackEvent, createEventBuilder]);
+  }, [balance, withdraw, trackEvent, createEventBuilder, requiresLineaFunding]);
+
+  const handleNavigateToSpendingLimit = useCallback(() => {
+    navigation.navigate(Routes.CARD.SPENDING_LIMIT, {
+      flow: 'enable',
+      ...(lineaUsdcToken ? { selectedToken: lineaUsdcToken } : {}),
+    });
+  }, [navigation, lineaUsdcToken]);
 
   const isProcessing = isWithdrawing || monitoringStatus === 'monitoring';
 
@@ -163,7 +190,9 @@ const Cashback: React.FC = () => {
     !isWithdrawable ||
     isProcessing ||
     isEstimating ||
-    hasInsufficientBalance;
+    hasInsufficientBalance ||
+    isFundingStatusLoading ||
+    requiresLineaFunding;
 
   return (
     <SafeAreaView
@@ -172,6 +201,15 @@ const Cashback: React.FC = () => {
       testID={CashbackSelectors.CONTAINER}
     >
       <Box twClassName="flex-1 px-4">
+        {requiresLineaFunding ? (
+          <Box twClassName="pt-4" testID={CashbackSelectors.FUNDING_WARNING}>
+            <CardMessageBox
+              messageType={CardMessageBoxType.CashbackFundingRequired}
+              onConfirm={handleNavigateToSpendingLimit}
+            />
+          </Box>
+        ) : null}
+
         <Box twClassName="py-4" testID={CashbackSelectors.BALANCE_TITLE}>
           {isLoading ? (
             <Skeleton height={32} width={160} style={tw.style('rounded-lg')} />

--- a/app/components/UI/Card/components/CardMessageBox/CardMessageBox.test.tsx
+++ b/app/components/UI/Card/components/CardMessageBox/CardMessageBox.test.tsx
@@ -24,6 +24,11 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.card_spending_limit.dismiss': 'Dismiss',
       'card.card_authentication.auth_prompt_info':
         'Log in to your card account to access this feature.',
+      'card.cashback_screen.funding_required.title': 'Set up Linea funding',
+      'card.cashback_screen.funding_required.description':
+        'You need at least one approved funding source on Linea before redeeming cashback.',
+      'card.cashback_screen.funding_required.confirm_button_label':
+        'Set up funding',
     };
     return mockStrings[key] || key;
   }),
@@ -186,6 +191,35 @@ describe('CardMessageBox', () => {
     });
   });
 
+  describe('CashbackFundingRequired warning', () => {
+    it('renders title and description', () => {
+      const { getByText } = renderWithProvider(() => (
+        <CardMessageBox
+          messageType={CardMessageBoxType.CashbackFundingRequired}
+        />
+      ));
+
+      expect(getByText('Set up Linea funding')).toBeOnTheScreen();
+      expect(
+        getByText(
+          'You need at least one approved funding source on Linea before redeeming cashback.',
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('calls onConfirm when the funding setup button is pressed', () => {
+      const { getByText } = renderWithProvider(() => (
+        <CardMessageBox
+          messageType={CardMessageBoxType.CashbackFundingRequired}
+          onConfirm={mockOnConfirm}
+        />
+      ));
+
+      fireEvent.press(getByText('Set up funding'));
+      expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('common behaviors', () => {
     it('renders dismiss button when onDismiss is provided', () => {
       const { getByTestId } = renderWithProvider(() => (
@@ -238,6 +272,7 @@ describe('CardMessageBox', () => {
         CardMessageBoxType.KYCPending,
         CardMessageBoxType.CardProvisioning,
         CardMessageBoxType.AuthPrompt,
+        CardMessageBoxType.CashbackFundingRequired,
       ];
 
       allMessageTypes.forEach((messageType) => {

--- a/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
+++ b/app/components/UI/Card/components/CardMessageBox/CardMessageBox.tsx
@@ -63,6 +63,16 @@ const CardMessageBox = ({
         variant: CardMessageBoxVariant.Info,
         title: strings('card.card_authentication.auth_prompt_info'),
       },
+      [CardMessageBoxType.CashbackFundingRequired]: {
+        variant: CardMessageBoxVariant.Warning,
+        title: strings('card.cashback_screen.funding_required.title'),
+        description: strings(
+          'card.cashback_screen.funding_required.description',
+        ),
+        confirmButtonLabel: strings(
+          'card.cashback_screen.funding_required.confirm_button_label',
+        ),
+      },
     }),
     [],
   );

--- a/app/components/UI/Card/types.ts
+++ b/app/components/UI/Card/types.ts
@@ -38,6 +38,7 @@ export enum CardMessageBoxType {
   KYCPending = 'kyc_pending',
   CardProvisioning = 'card_provisioning',
   AuthPrompt = 'auth_prompt',
+  CashbackFundingRequired = 'cashback_funding_required',
 }
 
 export type CardUserPhase =

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -13,6 +13,8 @@ import {
   selectCardAvailableTokens,
   selectCardFundingTokens,
   selectCardDelegationSettings,
+  selectCardHasApprovedLineaFunding,
+  selectCardLineaUsdcToken,
 } from './cardController';
 import type { CardControllerState } from '../core/Engine/controllers/card-controller/types';
 import {
@@ -444,5 +446,93 @@ describe('selectCardDelegationSettings', () => {
     expect(selectCardDelegationSettings(state)).toStrictEqual(
       mockCardHomeData.delegationSettings,
     );
+  });
+});
+
+describe('selectCardHasApprovedLineaFunding', () => {
+  it('returns false when cardHomeData is null', () => {
+    const state = createMockRootState({ cardHomeData: null });
+    expect(selectCardHasApprovedLineaFunding(state)).toBe(false);
+  });
+
+  it('returns true when a Linea funding asset is approved', () => {
+    const state = createMockRootState({
+      cardHomeData:
+        mockCardHomeData as unknown as CardControllerState['cardHomeData'],
+    });
+
+    expect(selectCardHasApprovedLineaFunding(state)).toBe(true);
+  });
+
+  it('returns false when Linea funding assets are inactive', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        fundingAssets: [
+          {
+            ...mockPrimaryAsset,
+            status: FundingAssetStatus.Inactive,
+          },
+        ],
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+
+    expect(selectCardHasApprovedLineaFunding(state)).toBe(false);
+  });
+
+  it('returns false when approved funding assets are not on Linea', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        fundingAssets: [
+          {
+            ...mockPrimaryAsset,
+            chainId: 'eip155:8453',
+            status: FundingAssetStatus.Active,
+          },
+        ],
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+
+    expect(selectCardHasApprovedLineaFunding(state)).toBe(false);
+  });
+});
+
+describe('selectCardLineaUsdcToken', () => {
+  it('returns null when cardHomeData is null', () => {
+    const state = createMockRootState({ cardHomeData: null });
+    expect(selectCardLineaUsdcToken(state)).toBeNull();
+  });
+
+  it('returns the USDC token on Linea from available funding assets', () => {
+    const state = createMockRootState({
+      cardHomeData:
+        mockCardHomeData as unknown as CardControllerState['cardHomeData'],
+    });
+
+    expect(selectCardLineaUsdcToken(state)).toEqual(
+      expect.objectContaining({
+        symbol: 'USDC',
+        caipChainId: 'eip155:59144',
+        fundingStatus: FundingStatus.Limited,
+      }),
+    );
+  });
+
+  it('returns null when USDC is not available on Linea', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        availableFundingAssets: [
+          {
+            ...mockPrimaryAsset,
+            symbol: 'USDC',
+            chainId: 'eip155:8453',
+          },
+        ],
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+
+    expect(selectCardLineaUsdcToken(state)).toBeNull();
   });
 });

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -6,7 +6,10 @@ import {
   type CardControllerState,
   type CardHomeDataStatus,
 } from '../core/Engine/controllers/card-controller/types';
-import type { CardHomeData } from '../core/Engine/controllers/card-controller/provider-types';
+import {
+  FundingAssetStatus,
+  type CardHomeData,
+} from '../core/Engine/controllers/card-controller/provider-types';
 import type {
   CardLocation,
   CardFundingToken,
@@ -15,6 +18,9 @@ import type {
 import { toCardFundingToken } from '../components/UI/Card/util/toCardTokenAllowance';
 import { selectSelectedInternalAccountByScope } from './multichainAccounts/accounts';
 import { isEthAccount } from '../core/Multichain/utils';
+
+const LINEA_MAINNET_CAIP_CHAIN_ID = 'eip155:59144';
+const CASHBACK_FUNDING_SYMBOL = 'USDC';
 
 const selectCardControllerState = (state: RootState) =>
   state.engine?.backgroundState?.CardController;
@@ -114,4 +120,28 @@ export const selectCardFundingTokens = createSelector(
 export const selectCardDelegationSettings = createSelector(
   selectCardHomeData,
   (data): DelegationSettingsResponse | null => data?.delegationSettings ?? null,
+);
+
+export const selectCardHasApprovedLineaFunding = createSelector(
+  selectCardHomeData,
+  (data): boolean =>
+    (data?.fundingAssets ?? []).some(
+      (asset) =>
+        asset.chainId === LINEA_MAINNET_CAIP_CHAIN_ID &&
+        asset.status !== FundingAssetStatus.Inactive,
+    ),
+);
+
+export const selectCardLineaUsdcToken = createSelector(
+  selectCardHomeData,
+  (data): CardFundingToken | null => {
+    const asset =
+      (data?.availableFundingAssets ?? []).find(
+        (fundingAsset) =>
+          fundingAsset.chainId === LINEA_MAINNET_CAIP_CHAIN_ID &&
+          fundingAsset.symbol?.toUpperCase() === CASHBACK_FUNDING_SYMBOL,
+      ) ?? null;
+
+    return asset ? toCardFundingToken(asset) : null;
+  },
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7927,7 +7927,12 @@
       "withdrawal_success": "Withdrawal completed successfully",
       "withdrawal_failed": "Withdrawal failed. Please try again.",
       "no_cashback": "No cashback available",
-      "loading_error": "Failed to load cashback. Please try again."
+      "loading_error": "Failed to load cashback. Please try again.",
+      "funding_required": {
+        "title": "Set up Linea funding",
+        "description": "You need at least one approved funding source on Linea before redeeming cashback.",
+        "confirm_button_label": "Set up funding"
+      }
     },
     "change_asset": {
       "title": "Change token and network",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Cashback redemptions are sent to the first wallet the user delegated on Linea. Users without an approved Linea funding source should not be able to start redemption until they set up funding.

This change adds selector-driven Linea funding eligibility for Card cashback, shows a reusable warning banner when no approved Linea funding exists, disables the Cashback withdraw action in that state, and routes the warning CTA to the Spending Limit screen with USDC on Linea preselected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed cashback redemption to require an approved Linea funding source.

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Cashback redemption Linea funding requirement

  Scenario: User without approved Linea funding opens Cashback
    Given I am logged in to MetaMask Card
    And my card home data has no active or limited funding asset on Linea
    When I open the Cashback screen
    Then I see a warning that Linea funding is required
    And the cashback withdrawal button is disabled
    When I tap "Set up funding"
    Then the Spending Limit screen opens
    And USDC on Linea is preselected

  Scenario: User with approved Linea funding opens Cashback
    Given I am logged in to MetaMask Card
    And my card home data has at least one active or limited funding asset on Linea
    When I open the Cashback screen
    Then I do not see the Linea funding warning
    And I can continue with cashback redemption when the wallet is withdrawable
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - not captured locally. Previous behavior allowed the Cashback screen to proceed without an approved Linea funding source.

### **After**

https://github.com/user-attachments/assets/7fbbe8ec-45ab-472e-b604-45ac55d327ee

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cashback redemption eligibility and navigation flows; incorrect selector logic or card home status handling could inadvertently block withdrawals or misroute users.
> 
> **Overview**
> Cashback withdrawals are now gated on Card home funding state: if Card home data is loaded and the user has **no approved Linea funding**, the Cashback screen shows a warning `CardMessageBox`, disables the withdraw CTA, and prevents `withdraw()` from firing.
> 
> Adds selectors to detect approved Linea funding and to derive a preselected USDC-on-Linea token, then wires the warning CTA to navigate to `Routes.CARD.SPENDING_LIMIT` with that token when available. Also broadens the Cashback error state to show the generic loading error when Card home data fails.
> 
> Includes new i18n strings, a new `CardMessageBoxType.CashbackFundingRequired`, a new `CashbackSelectors.FUNDING_WARNING` test id, and expanded unit tests for the new gating + navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b75f8192a1d976a0cb6654fc97cb6d7be98c535c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->