### PR TITLE
fix(bridge): hide sponsored label on cross-chain bridge with insufficient balance

### DIFF
--- a/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.test.ts
@@ -2,6 +2,10 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useShouldRenderGasSponsoredBanner } from './index';
 import { useIsNetworkGasSponsored } from '../useIsNetworkGasSponsored';
 import { useSelector } from 'react-redux';
+import {
+  selectSourceToken,
+  selectDestToken,
+} from '../../../../../core/redux/slices/bridge';
 
 jest.mock('../useIsNetworkGasSponsored');
 jest.mock('react-redux', () => ({
@@ -14,10 +18,38 @@ const mockUseIsNetworkGasSponsored =
   >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
+const SOURCE_CHAIN_ID = '0x1';
+const SAME_CHAIN_DEST_CHAIN_ID = '0x1';
+const DIFFERENT_DEST_CHAIN_ID = '0x89';
+
+const buildToken = (chainId: string | undefined) =>
+  chainId
+    ? {
+        address: '0x0000000000000000000000000000000000000000',
+        symbol: 'TKN',
+        decimals: 18,
+        chainId,
+      }
+    : null;
+
+const mockTokens = ({
+  sourceChainId,
+  destChainId,
+}: {
+  sourceChainId?: string;
+  destChainId?: string;
+}) => {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectSourceToken) return buildToken(sourceChainId);
+    if (selector === selectDestToken) return buildToken(destChainId);
+    return null;
+  });
+};
+
 describe('useShouldRenderGasSponsoredBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(null);
+    mockTokens({});
     mockUseIsNetworkGasSponsored.mockReturnValue(false);
   });
 
@@ -72,8 +104,12 @@ describe('useShouldRenderGasSponsoredBanner', () => {
   });
 
   describe('returns true when insufficient balance and network is sponsored', () => {
-    it('returns true when user has insufficient balance and network is sponsored', () => {
+    it('returns true when user has insufficient balance and network is sponsored on a same-chain swap', () => {
       // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
       // Act
@@ -86,6 +122,26 @@ describe('useShouldRenderGasSponsoredBanner', () => {
 
       // Assert
       expect(result.current).toBe(true);
+    });
+
+    it('returns false on a cross-chain bridge with insufficient balance even on a sponsored source network', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: DIFFERENT_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(true);
+
+      // Act
+      const { result } = renderHook(() =>
+        useShouldRenderGasSponsoredBanner({
+          quoteGasSponsored: false,
+          hasInsufficientBalance: true,
+        }),
+      );
+
+      // Assert
+      expect(result.current).toBe(false);
     });
   });
 
@@ -108,6 +164,10 @@ describe('useShouldRenderGasSponsoredBanner', () => {
 
     it('returns false when insufficient balance but network is not sponsored', () => {
       // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
       // Act
@@ -124,6 +184,10 @@ describe('useShouldRenderGasSponsoredBanner', () => {
 
     it('returns false when sufficient balance but network is sponsored', () => {
       // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
       // Act
@@ -156,9 +220,15 @@ describe('useShouldRenderGasSponsoredBanner', () => {
   });
 
   describe('truth table for all conditions', () => {
-    it('quoteGasSponsored=true, hasInsufficientBalance=true, isNetworkGasSponsored=true → returns true', () => {
+    it('quoteGasSponsored=true, hasInsufficientBalance=true, isNetworkGasSponsored=true, isSameChain=true → returns true', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: true,
@@ -166,12 +236,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
 
-    it('quoteGasSponsored=true, hasInsufficientBalance=true, isNetworkGasSponsored=false → returns true', () => {
+    it('quoteGasSponsored=true, hasInsufficientBalance=true, isNetworkGasSponsored=false, isSameChain=true → returns true', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: true,
@@ -179,12 +256,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
 
-    it('quoteGasSponsored=true, hasInsufficientBalance=false, isNetworkGasSponsored=true → returns true', () => {
+    it('quoteGasSponsored=true, hasInsufficientBalance=false, isNetworkGasSponsored=true, isSameChain=true → returns true', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: true,
@@ -192,12 +276,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
 
-    it('quoteGasSponsored=true, hasInsufficientBalance=false, isNetworkGasSponsored=false → returns true', () => {
+    it('quoteGasSponsored=true, hasInsufficientBalance=false, isNetworkGasSponsored=false, isSameChain=true → returns true', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: true,
@@ -205,12 +296,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
 
-    it('quoteGasSponsored=false, hasInsufficientBalance=true, isNetworkGasSponsored=true → returns true', () => {
+    it('quoteGasSponsored=false, hasInsufficientBalance=true, isNetworkGasSponsored=true, isSameChain=true → returns true', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: false,
@@ -218,12 +316,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
 
-    it('quoteGasSponsored=false, hasInsufficientBalance=true, isNetworkGasSponsored=false → returns false', () => {
-      mockUseIsNetworkGasSponsored.mockReturnValue(false);
+    it('quoteGasSponsored=false, hasInsufficientBalance=true, isNetworkGasSponsored=true, isSameChain=false → returns false', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: DIFFERENT_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: false,
@@ -231,25 +336,39 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(false);
     });
 
-    it('quoteGasSponsored=false, hasInsufficientBalance=false, isNetworkGasSponsored=true → returns false', () => {
-      mockUseIsNetworkGasSponsored.mockReturnValue(true);
+    it('quoteGasSponsored=false, hasInsufficientBalance=true, isNetworkGasSponsored=false, isSameChain=true → returns false', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: false,
-          hasInsufficientBalance: false,
+          hasInsufficientBalance: true,
         }),
       );
 
+      // Assert
       expect(result.current).toBe(false);
     });
 
-    it('quoteGasSponsored=false, hasInsufficientBalance=false, isNetworkGasSponsored=false → returns false', () => {
-      mockUseIsNetworkGasSponsored.mockReturnValue(false);
+    it('quoteGasSponsored=false, hasInsufficientBalance=false, isNetworkGasSponsored=true, isSameChain=true → returns false', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: false,
@@ -257,14 +376,37 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
+      expect(result.current).toBe(false);
+    });
+
+    it('quoteGasSponsored=false, hasInsufficientBalance=false, isNetworkGasSponsored=false, isSameChain=true → returns false', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(false);
+
+      // Act
+      const { result } = renderHook(() =>
+        useShouldRenderGasSponsoredBanner({
+          quoteGasSponsored: false,
+          hasInsufficientBalance: false,
+        }),
+      );
+
+      // Assert
       expect(result.current).toBe(false);
     });
   });
 
   describe('edge cases', () => {
     it('handles undefined quoteGasSponsored as false', () => {
+      // Arrange
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: undefined,
@@ -272,12 +414,19 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(false);
     });
 
-    it('returns true when quoteGasSponsored is undefined but insufficient balance with network sponsored', () => {
+    it('returns true when quoteGasSponsored is undefined but insufficient balance with same-chain sponsored network', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
+      // Act
       const { result } = renderHook(() =>
         useShouldRenderGasSponsoredBanner({
           quoteGasSponsored: undefined,
@@ -285,6 +434,7 @@ describe('useShouldRenderGasSponsoredBanner', () => {
         }),
       );
 
+      // Assert
       expect(result.current).toBe(true);
     });
   });
@@ -292,14 +442,10 @@ describe('useShouldRenderGasSponsoredBanner', () => {
   describe('selector integration', () => {
     it('calls useIsNetworkGasSponsored with sourceToken chainId', () => {
       // Arrange
-      const sourceToken = {
-        address: '0x0000000000000000000000000000000000000000',
-        symbol: 'ETH',
-        decimals: 18,
-        chainId: '0x1',
-      };
-
-      mockUseSelector.mockReturnValue(sourceToken);
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
       // Act
@@ -311,12 +457,14 @@ describe('useShouldRenderGasSponsoredBanner', () => {
       );
 
       // Assert
-      expect(mockUseIsNetworkGasSponsored).toHaveBeenCalledWith('0x1');
+      expect(mockUseIsNetworkGasSponsored).toHaveBeenCalledWith(
+        SOURCE_CHAIN_ID,
+      );
     });
 
     it('calls useIsNetworkGasSponsored with undefined when sourceToken is null', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(null);
+      mockTokens({});
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
       // Act
@@ -349,8 +497,12 @@ describe('useShouldRenderGasSponsoredBanner', () => {
       expect(result.current).toBe(true);
     });
 
-    it('shows banner when user has insufficient balance on sponsored network', () => {
+    it('shows banner when user has insufficient balance on a same-chain sponsored swap', () => {
       // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(true);
 
       // Act
@@ -363,6 +515,26 @@ describe('useShouldRenderGasSponsoredBanner', () => {
 
       // Assert
       expect(result.current).toBe(true);
+    });
+
+    it('does not show banner on a cross-chain bridge with insufficient balance, even on a sponsored source network', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: DIFFERENT_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(true);
+
+      // Act
+      const { result } = renderHook(() =>
+        useShouldRenderGasSponsoredBanner({
+          quoteGasSponsored: false,
+          hasInsufficientBalance: true,
+        }),
+      );
+
+      // Assert
+      expect(result.current).toBe(false);
     });
 
     it('does not show banner for regular quote with sufficient balance', () => {
@@ -383,6 +555,10 @@ describe('useShouldRenderGasSponsoredBanner', () => {
 
     it('does not show banner when insufficient balance on non-sponsored network', () => {
       // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
       mockUseIsNetworkGasSponsored.mockReturnValue(false);
 
       // Act

--- a/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.ts
@@ -1,6 +1,9 @@
 import { useIsNetworkGasSponsored } from '../useIsNetworkGasSponsored';
 import { useSelector } from 'react-redux';
-import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
+import {
+  selectSourceToken,
+  selectDestToken,
+} from '../../../../../core/redux/slices/bridge';
 
 interface Props {
   quoteGasSponsored?: boolean;
@@ -12,10 +15,20 @@ export const useShouldRenderGasSponsoredBanner = ({
   hasInsufficientBalance,
 }: Props) => {
   const sourceToken = useSelector(selectSourceToken);
+  const destToken = useSelector(selectDestToken);
   const isNetworkGasSponsored = useIsNetworkGasSponsored(sourceToken?.chainId);
 
+  // Sponsorship only applies to same-chain (swap) flows; cross-chain bridges
+  // are never sponsored even on networks listed as sponsored.
+  const isSameChain = Boolean(
+    sourceToken?.chainId &&
+      destToken?.chainId &&
+      sourceToken.chainId === destToken.chainId,
+  );
+
   const shouldShowGasSponsored =
-    quoteGasSponsored || (hasInsufficientBalance && isNetworkGasSponsored);
+    quoteGasSponsored ||
+    (hasInsufficientBalance && isNetworkGasSponsored && isSameChain);
 
   return shouldShowGasSponsored;
 };


### PR DESCRIPTION
## **Description**
This pull request enhances the logic and test coverage for the `useShouldRenderGasSponsoredBanner` hook, ensuring that gas sponsorship banners are only shown for same-chain (swap) flows and never for cross-chain bridges, even if the source network is sponsored. The changes include updates to both the implementation and the associated tests, adding clear handling for same-chain vs. cross-chain scenarios.

Key changes:

**Feature Logic Update:**

* Updated `useShouldRenderGasSponsoredBanner` to check if the source and destination tokens are on the same chain (`isSameChain`), restricting gas sponsorship to same-chain swaps only. Cross-chain bridges will not show the sponsored banner, regardless of sponsorship status.

**Selector and Hook Integration:**

* Added usage of `selectDestToken` alongside `selectSourceToken` to access both source and destination token information, enabling the new same-chain check.

**Test Enhancements:**

* Refactored tests to use a new `mockTokens` helper, allowing simulation of various same-chain and cross-chain scenarios by mocking source and destination chain IDs.
* Expanded and clarified test cases to explicitly cover both same-chain and cross-chain logic, including updates to the truth table and additional edge cases.
* Improved test descriptions and assertions to make the intent and coverage of each scenario clearer, and ensured that the correct chain IDs are passed to mocked hooks.

These changes make the sponsorship logic more robust and the tests more comprehensive and maintainable.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: hide sponsored label on cross-chain bridge with insufficient balance

## **Related issues**

Fixes: Sponsored label is shown on bridge trx when amount above the max owned is entered

## **Manual testing steps**

```gherkin

1. Start the bridge scenario
2. Try to bridge Sei/Mon to any other network
3. Enter Sei/Mon amount above the max owned
4. Notice there is no more "Paid by Metamask" info in the network fee field

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" height="550" alt="BEFORE" src="https://github.com/user-attachments/assets/2b62266d-5abc-42ce-ae93-d5652d3423c6" />


### **After**

<img width="300" height="550" alt="AFTER" src="https://github.com/user-attachments/assets/83a22197-a2e6-471a-9c50-a35951c53f3e" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-logic change that only tightens the conditions for showing the gas sponsorship banner; main risk is unintentionally hiding the banner if token chain IDs are missing or mis-selected.
> 
> **Overview**
> Updates `useShouldRenderGasSponsoredBanner` to only show the gas sponsorship banner when the flow is **same-chain** (source and destination token `chainId` match), preventing the banner from appearing on cross-chain bridges even if the source network is sponsored.
> 
> Expands/refactors tests to mock both source/destination tokens via `selectSourceToken`/`selectDestToken`, and adds explicit coverage for same-chain vs cross-chain scenarios (including an updated truth table and realistic cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420feddfc6f4d0d3e1001b2c15fab50e16bbb6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->