### PR TITLE
fix: remove large push notification icon from Braze configuration

### DIFF
--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -22,5 +22,4 @@
 
   <!-- Push notification icons -->
   <drawable name="com_braze_push_small_notification_icon">@mipmap/ic_notification_small</drawable>
-  <drawable name="com_braze_push_large_notification_icon">@mipmap/ic_notification</drawable>
 </resources>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The `com_braze_push_large_notification_icon` resource in braze.xml was configured to use @mipmap/ic_notification (the MetaMask fox) as the default large icon for every Braze push notification. When no per-campaign icon is set in the Braze dashboard, Android uses both the small icon (circle, left) and the large icon (rounded square, right) simultaneously, causing the fox logo to appear twice. Removing the resource default eliminates the duplication for campaigns that don't explicitly specify a large icon, while preserving the ability for individual campaigns to override it from the Braze dashboard.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

APK available [here](https://github.com/MetaMask/metamask-mobile/actions/runs/25115160889)

To test:
1. Send a notification from Braze without any image => it should only see the left image
2. Send a notification from Braze with an image => it should still work, and show the fox logo on the left, and your image on the right

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1440" height="1294" alt="Screenshot_20260429_151009_One UI Home" src="https://github.com/user-attachments/assets/65f3dac5-2c60-404d-b31b-b8b7caaba1bc" />

### **After**

<!-- [screenshots/recordings] -->
<img width="992" height="257" alt="Screenshot_20260429-172206" src="https://github.com/user-attachments/assets/66d83877-3d84-498d-b00c-8afdc7b1512a" />
<img width="916" height="257" alt="Screenshot_20260429-172105" src="https://github.com/user-attachments/assets/147e2720-1d24-4df1-bf6b-4d5dedfeac2c" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects how Braze selects the *large* push notification icon on Android.
> 
> **Overview**
> Removes the `com_braze_push_large_notification_icon` resource override from `android/app/src/main/res/values/braze.xml`, leaving only the small notification icon configured for Braze push notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93690c46dfa10ea060820b3ed23f23956477c6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->