### PR TITLE
ci: Add new translation workflow for releases

### DIFF
--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   find-rc-branches:
     name: Find release candidate branches
-    if: ${{ github.ref_name != 'main' }}
+    if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         # If run on `main`, we download translations for all RCs
         # If run on a non-default branch, we just download translations for that individual branch
-        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || [github.ref_name] }}
+        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || fromJson(format('[{0}]', github.ref_name)) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -50,10 +50,8 @@ jobs:
         # If run on a non-default branch, we just download translations for that individual branch
         branch: >-
           ${{
-            (
-              github.ref_name == 'main' &&
-              fromJson(needs.find-rc-branches.outputs.branches)
-            ) ||
+            github.ref_name == 'main' &&
+            fromJson(needs.find-rc-branches.outputs.branches) ||
             fromJson(format('[{0}]', github.ref_name))
           }}
 

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -71,6 +71,8 @@ jobs:
           localization_branch_name: l10n_crowdin_translations_${{ matrix.branch }}
           pull_request_title: 'chore: New Crowdin Translations for ${{ matrix.branch }}'
           skip_ref_checkout: true
+          # This will be in dry-run mode until after we've tested this on `main`
+          dryrun_action: true
 
           github_user_name: metamaskbot
           github_user_email: metamaskbot@users.noreply.github.com

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -1,0 +1,80 @@
+name: Crowdin Download Approved RC Translations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  find-rc-branches:
+    name: Find release candidate branches
+    if: ${{ github.ref_name != 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      branches: ${{ steps.find-branches.outputs.branches }}
+    steps:
+      - name: Find release candidate branches
+        id: find-branches
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'stable',
+              state: 'open',
+            });
+
+            const releaseBranchRegex = /^release\/[0-9]+\.[0-9]+\.[0-9]+$/;
+
+            const branches = prs
+              .map((pr) => pr.head.ref)
+              .filter(releaseBranchRegex.test);
+
+            core.info(`Found release branches: ${branches.join(',')}`);
+            core.setOutput('branches', JSON.stringify(branches));
+
+
+  download-translations:
+    name: Download translations
+    # Use `!cancelled()` to ensure this runs even when `find-rc-branches` is skipped
+    if: ${{ !cancelled() }}
+    needs: [find-rc-branches]
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    strategy:
+      matrix:
+        # If run on `main`, we download translations for all RCs
+        # If run on a non-default branch, we just download translations for that individual branch
+        branch: ${{ github.ref == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || github.ref }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+          # Use PAT to ensure that the commit later can trigger status check workflows
+          token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+
+      - name: crowdin download approved translations
+        uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
+        with:
+          upload_sources: false
+          upload_translations: false # disabled to prevent translations overwriting Blends translations
+          download_translations: true # created separate action to pull down completed translations
+          export_only_approved: true
+
+          crowdin_branch_name: ${{ matrix.branch }}
+          localization_branch_name: l10n_crowdin_translations_${{ matrix.branch }}
+          pull_request_title: 'chore: New Crowdin Translations for ${{ matrix.branch }}'
+          skip_ref_checkout: true
+
+          github_user_name: metamaskbot
+          github_user_email: metamaskbot@users.noreply.github.com
+        env:
+          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          GITHUB_ACTOR: metamaskbot
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -48,7 +48,14 @@ jobs:
       matrix:
         # If run on `main`, we download translations for all RCs
         # If run on a non-default branch, we just download translations for that individual branch
-        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || fromJson(format('[{0}]', github.ref_name)) }}
+        branch: >-
+          ${{
+            (
+              github.ref_name == 'main' &&
+              fromJson(needs.find-rc-branches.outputs.branches)
+            ) ||
+            fromJson(format('[{0}]', github.ref_name))
+          }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         # If run on `main`, we download translations for all RCs
         # If run on a non-default branch, we just download translations for that individual branch
-        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || github.ref_name }}
+        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || [github.ref_name] }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -30,7 +30,7 @@ jobs:
 
             const branches = prs
               .map((pr) => pr.head.ref)
-              .filter(releaseBranchRegex.test);
+              .filter((branchName) => releaseBranchRegex.test(branchName));
 
             core.info(`Found release branches: ${branches.join(',')}`);
             core.setOutput('branches', JSON.stringify(branches));
@@ -48,7 +48,7 @@ jobs:
       matrix:
         # If run on `main`, we download translations for all RCs
         # If run on a non-default branch, we just download translations for that individual branch
-        branch: ${{ github.ref == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || github.ref }}
+        branch: ${{ github.ref_name == 'main' && fromJson(needs.find-rc-branches.outputs.branches) || github.ref_name }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -67,6 +67,7 @@ jobs:
           export_only_approved: true
 
           crowdin_branch_name: ${{ matrix.branch }}
+          pull_request_base_branch_name: ${{ matrix.branch }}
           localization_branch_name: l10n_crowdin_translations_${{ matrix.branch }}
           pull_request_title: 'chore: New Crowdin Translations for ${{ matrix.branch }}'
           skip_ref_checkout: true

--- a/.github/workflows/crowdin-rc-upload-sources.yml
+++ b/.github/workflows/crowdin-rc-upload-sources.yml
@@ -1,0 +1,32 @@
+name: Crowdin Upload RC Sources
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload-sources:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref:
+          # Use PAT to ensure that the commit later can trigger status check workflows
+          token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+
+      - name: crowdin upload sources
+        uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
+        with:
+          crowdin_branch_name: ${{ github.ref_name }}
+          upload_sources: true
+          upload_translations: false # disabled to prevent translations overwriting Blends translations
+          download_translations: false # created separate action to pull down completed translations
+          github_user_name: metamaskbot
+          github_user_email: metamaskbot@users.noreply.github.com
+        env:
+          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          GITHUB_ACTOR: metamaskbot
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-rc-upload-sources.yml
+++ b/.github/workflows/crowdin-rc-upload-sources.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
 

--- a/.github/workflows/crowdin-rc-upload-sources.yml
+++ b/.github/workflows/crowdin-rc-upload-sources.yml
@@ -22,6 +22,8 @@ jobs:
           upload_sources: true
           upload_translations: false # disabled to prevent translations overwriting Blends translations
           download_translations: false # created separate action to pull down completed translations
+          # This will be in dry-run mode until after we've tested this on `main`
+          dryrun_action: true
           github_user_name: metamaskbot
           github_user_email: metamaskbot@users.noreply.github.com
         env:


### PR DESCRIPTION
## **Description**

Two new CI workflows have been added for uploading localized messages from releaase branches, and downloading translations onto releaase branches.

Today we only use `main` as the source for localized messages, and all translations go through `main` first, then get cherry-picked onto the current RC. This process risks the translations getting out-of-sync with the sources on the current release (since they're derived from the localized message sources on `main`), which could cause severe localization errors. This process is also time-consuming for the delivery team.

These updated workflows bypass that problem completely. Translations will always be in-sync on release branches, and we will have no conflicts.

In the future this will run on a schedule, but it's just configured for manual workflow dispatch for now, so that we can test it further.

## **Changelog**

CHANGELOG entry: N/A

## **Related issues**

This is adapted from an older experiment: https://github.com/MetaMask/metamask-mobile/pull/8565

## **Manual testing steps**

This can't easily be tested (we'd have to setup a fork of the repo, and a new crowdin project, and new secrets, etc.). Instead it's configured to be run manually on targeted branches, so that we can test this after merge with minimal disruption.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new GitHub Actions that can create/commit translation PRs across release branches using a PAT, so misconfiguration could affect release branch contents and CI triggering (though currently `dryrun_action: true` limits impact).
> 
> **Overview**
> Adds two manually-triggered Crowdin GitHub Actions workflows for release candidates.
> 
> `crowdin-rc-upload-sources.yml` uploads localization source strings from the current branch to the matching Crowdin branch.
> 
> `crowdin-rc-download-translations.yml` downloads *approved* translations and opens per-branch localization PRs; when run on `main` it first discovers open `release/x.y.z` PR branches targeting `stable` and runs across them via a matrix, otherwise it runs only for the current branch. Both workflows use `METAMASKBOT_CROWDIN_TOKEN` and are currently configured in `dryrun_action` mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced310496a9778109824fd3815a866cf1aa31d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->