### PR TITLE
chore: add advanced charts traces cp-7.76.0

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -874,33 +874,6 @@ describe('PriceAdvanced', () => {
       );
     });
 
-    it('does not end trace when onSkeletonHidden is called with mismatched series key', () => {
-      const { getByTestId, rerender } = render(
-        <PriceAdvanced {...baseProps} />,
-      );
-
-      act(() => {
-        fireEvent.press(getByTestId('select-1W'));
-      });
-
-      rerender(<PriceAdvanced {...baseProps} />);
-
-      const advancedChart = getByTestId('mock-advanced-chart');
-      const oldOnSkeletonHidden = advancedChart.props.onSkeletonHidden;
-
-      act(() => {
-        fireEvent.press(getByTestId('select-1D'));
-      });
-
-      mockEndTrace.mockClear();
-
-      act(() => {
-        oldOnSkeletonHidden?.();
-      });
-
-      expect(mockEndTrace).not.toHaveBeenCalled();
-    });
-
     it('ends trace with error data when onError is called', () => {
       const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
       const advancedChart = getByTestId('mock-advanced-chart');

--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -11,6 +11,15 @@ import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEvent
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
 
+const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+}));
+
 const mockSetIsChartBeingTouched = jest.fn();
 jest.mock('../PriceChart/PriceChart.context', () => ({
   usePriceChart: () => ({
@@ -828,6 +837,200 @@ describe('PriceAdvanced', () => {
 
       fireEvent(chartContainer, 'touchEnd');
       expect(mockSetIsChartBeingTouched).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('performance tracing', () => {
+    beforeEach(() => {
+      mockTrace.mockClear();
+      mockEndTrace.mockClear();
+    });
+
+    it('starts initial visibility trace when component mounts with advanced chart', () => {
+      render(<PriceAdvanced {...baseProps} />);
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringContaining('Advanced Chart Initial Visible'),
+          op: expect.stringContaining('token_overview.advanced_chart'),
+        }),
+      );
+    });
+
+    it('ends trace when onSkeletonHidden is called with matching series key', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+      const advancedChart = getByTestId('mock-advanced-chart');
+
+      mockEndTrace.mockClear();
+
+      act(() => {
+        advancedChart.props.onSkeletonHidden?.();
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringContaining('Advanced Chart Initial Visible'),
+        }),
+      );
+    });
+
+    it('does not end trace when onSkeletonHidden is called with mismatched series key', () => {
+      const { getByTestId, rerender } = render(
+        <PriceAdvanced {...baseProps} />,
+      );
+
+      act(() => {
+        fireEvent.press(getByTestId('select-1W'));
+      });
+
+      rerender(<PriceAdvanced {...baseProps} />);
+
+      const advancedChart = getByTestId('mock-advanced-chart');
+      const oldOnSkeletonHidden = advancedChart.props.onSkeletonHidden;
+
+      act(() => {
+        fireEvent.press(getByTestId('select-1D'));
+      });
+
+      mockEndTrace.mockClear();
+
+      act(() => {
+        oldOnSkeletonHidden?.();
+      });
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+
+    it('ends trace with error data when onError is called', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+      const advancedChart = getByTestId('mock-advanced-chart');
+
+      mockEndTrace.mockClear();
+
+      act(() => {
+        advancedChart.props.onError?.('WebView failed to load');
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringContaining('Advanced Chart Initial Visible'),
+          data: expect.objectContaining({
+            errorMessage: 'WebView failed to load',
+          }),
+        }),
+      );
+    });
+
+    it('starts time range visibility trace when time range changes', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+
+      mockTrace.mockClear();
+
+      act(() => {
+        fireEvent.press(getByTestId('select-1W'));
+      });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringContaining('Time Range Visible'),
+          op: expect.stringContaining('time_range'),
+        }),
+      );
+    });
+
+    it('supersedes previous trace when series key changes before skeleton hidden', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+
+      mockEndTrace.mockClear();
+
+      act(() => {
+        fireEvent.press(getByTestId('select-1W'));
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            superseded: true,
+          }),
+        }),
+      );
+    });
+
+    it('ends trace with fallbackToLegacy when switching to legacy chart', () => {
+      const { rerender } = render(<PriceAdvanced {...baseProps} />);
+
+      mockEndTrace.mockClear();
+
+      mockUseOHLCVChart.mockReturnValueOnce({
+        ohlcvData: [],
+        isLoading: false,
+        error: undefined,
+        hasMore: false,
+        nextCursor: null,
+        hasEmptyData: true,
+      });
+
+      rerender(<PriceAdvanced {...baseProps} />);
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fallbackToLegacy: true,
+          }),
+        }),
+      );
+    });
+
+    it('includes assetId in trace data when available', () => {
+      mockTrace.mockClear();
+
+      render(<PriceAdvanced {...baseProps} />);
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            assetId: expect.any(String),
+          }),
+        }),
+      );
+    });
+
+    it('does not start trace when falling back to legacy chart immediately', () => {
+      mockTrace.mockClear();
+
+      mockUseOHLCVChart.mockReturnValueOnce({
+        ohlcvData: [],
+        isLoading: false,
+        error: undefined,
+        hasMore: false,
+        nextCursor: null,
+        hasEmptyData: true,
+      });
+
+      render(<PriceAdvanced {...baseProps} />);
+
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('truncates error message to 200 characters', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+      const advancedChart = getByTestId('mock-advanced-chart');
+
+      mockEndTrace.mockClear();
+
+      const longError = 'A'.repeat(300);
+
+      act(() => {
+        advancedChart.props.onError?.(longError);
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            errorMessage: 'A'.repeat(200),
+          }),
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -1012,6 +1012,38 @@ describe('PriceAdvanced', () => {
       expect(mockTrace).not.toHaveBeenCalled();
     });
 
+    it('ends trace with unmounted flag when component unmounts with open trace', () => {
+      const { unmount } = render(<PriceAdvanced {...baseProps} />);
+
+      mockEndTrace.mockClear();
+
+      unmount();
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringContaining('Advanced Chart Initial Visible'),
+          data: expect.objectContaining({
+            unmounted: true,
+          }),
+        }),
+      );
+    });
+
+    it('does not end trace on unmount when trace was already completed', () => {
+      const { getByTestId, unmount } = render(<PriceAdvanced {...baseProps} />);
+      const advancedChart = getByTestId('mock-advanced-chart');
+
+      act(() => {
+        advancedChart.props.onSkeletonHidden?.();
+      });
+
+      mockEndTrace.mockClear();
+
+      unmount();
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+
     it('truncates error message to 200 characters', () => {
       const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
       const advancedChart = getByTestId('mock-advanced-chart');

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -56,6 +56,12 @@ import type {
   TokenPrice,
 } from '../../../../components/hooks/useTokenHistoricalPrices';
 import PriceLegacy from './Price.legacy';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 
 const EMPTY_INDICATORS: IndicatorType[] = [];
 
@@ -66,6 +72,36 @@ const TIME_RANGE_LABELS: Record<TimeRange, string> = {
   '1M': 'asset_overview.chart_time_period.1m',
   '1Y': 'asset_overview.chart_time_period.1y',
 };
+
+/** Maps {@link ohlcvSeriesKey} transitions to Sentry trace name/op (dashboards filter by name or op). */
+function getAdvancedChartVisibilityTraceRequest(
+  previousSeriesKey: string | null,
+  nextSeriesKey: string,
+): { name: TraceName; op: TraceOperation } {
+  if (previousSeriesKey === null) {
+    return {
+      name: TraceName.TokenOverviewAdvancedChartInitialVisible,
+      op: TraceOperation.TokenOverviewAdvancedChart,
+    };
+  }
+  const prev = previousSeriesKey.split('|');
+  const next = nextSeriesKey.split('|');
+  if (prev.length >= 4 && next.length >= 4) {
+    const sameAsset = prev[0] === next[0];
+    const sameCurrency = prev[prev.length - 1] === next[next.length - 1];
+    const rangeChanged = prev[1] !== next[1] || prev[2] !== next[2];
+    if (sameAsset && sameCurrency && rangeChanged) {
+      return {
+        name: TraceName.TokenOverviewAdvancedChartTimeRangeVisible,
+        op: TraceOperation.TokenOverviewAdvancedChartTimeRange,
+      };
+    }
+  }
+  return {
+    name: TraceName.TokenOverviewAdvancedChartInitialVisible,
+    op: TraceOperation.TokenOverviewAdvancedChart,
+  };
+}
 
 export interface PriceAdvancedProps {
   asset: TokenI;
@@ -206,6 +242,43 @@ const PriceAdvanced = ({
     [assetId, config.timePeriod, config.interval, currentCurrency],
   );
 
+  const visibilityTraceStartedRef = useRef<string | null>(null);
+  /** Matches pending manual trace so {@link endTrace} uses the same `TraceName` as {@link trace}. */
+  const activeVisibilityTraceRef = useRef<{
+    seriesKey: string;
+    traceName: TraceName;
+  } | null>(null);
+
+  const handleAdvancedChartSkeletonHidden = useCallback(() => {
+    const open = activeVisibilityTraceRef.current;
+    if (open?.seriesKey !== ohlcvSeriesKey) {
+      return;
+    }
+    endTrace({
+      name: open.traceName,
+      id: ohlcvSeriesKey,
+    });
+    activeVisibilityTraceRef.current = null;
+  }, [ohlcvSeriesKey]);
+
+  const handleAdvancedChartError = useCallback(
+    (error: string) => {
+      const open = activeVisibilityTraceRef.current;
+      if (open?.seriesKey !== ohlcvSeriesKey) {
+        return;
+      }
+      endTrace({
+        name: open.traceName,
+        id: ohlcvSeriesKey,
+        data: {
+          errorMessage: error.slice(0, 200),
+        },
+      });
+      activeVisibilityTraceRef.current = null;
+    },
+    [ohlcvSeriesKey],
+  );
+
   const {
     ohlcvData,
     isLoading: chartLoading,
@@ -294,6 +367,26 @@ const PriceAdvanced = ({
     !chartLoading &&
     (ohlcvData.length < CHART_DATA_THRESHOLD || hasEmptyData || chartError);
 
+  useEffect(() => {
+    if (!shouldFallbackToLegacy) {
+      return;
+    }
+    const pendingId = visibilityTraceStartedRef.current;
+    if (pendingId === null) {
+      return;
+    }
+    const open = activeVisibilityTraceRef.current;
+    if (open?.seriesKey === pendingId) {
+      endTrace({
+        name: open.traceName,
+        id: pendingId,
+        data: { fallbackToLegacy: true },
+      });
+      activeVisibilityTraceRef.current = null;
+    }
+    visibilityTraceStartedRef.current = null;
+  }, [shouldFallbackToLegacy]);
+
   if (shouldFallbackToLegacy) {
     return (
       <PriceLegacy
@@ -308,6 +401,36 @@ const PriceAdvanced = ({
         isLoading={isLoading}
       />
     );
+  }
+
+  if (visibilityTraceStartedRef.current !== ohlcvSeriesKey) {
+    const previousSeriesId = visibilityTraceStartedRef.current;
+    if (previousSeriesId !== null && previousSeriesId !== ohlcvSeriesKey) {
+      const supersededOpen = activeVisibilityTraceRef.current;
+      if (supersededOpen?.seriesKey === previousSeriesId) {
+        endTrace({
+          name: supersededOpen.traceName,
+          id: previousSeriesId,
+          data: { superseded: true },
+        });
+        activeVisibilityTraceRef.current = null;
+      }
+    }
+    const { name: visibilityTraceName, op: visibilityTraceOp } =
+      getAdvancedChartVisibilityTraceRequest(previousSeriesId, ohlcvSeriesKey);
+
+    visibilityTraceStartedRef.current = ohlcvSeriesKey;
+    activeVisibilityTraceRef.current = {
+      seriesKey: ohlcvSeriesKey,
+      traceName: visibilityTraceName,
+    };
+
+    trace({
+      name: visibilityTraceName,
+      op: visibilityTraceOp,
+      id: ohlcvSeriesKey,
+      ...(assetId.length > 0 ? { data: { assetId } } : {}),
+    });
   }
 
   return (
@@ -415,6 +538,8 @@ const PriceAdvanced = ({
             onCrosshairMove={handleCrosshairMove}
             onChartInteracted={handleChartInteracted}
             onChartTradingViewClicked={handleChartTradingViewClicked}
+            onSkeletonHidden={handleAdvancedChartSkeletonHidden}
+            onError={handleAdvancedChartError}
           />
         </View>
       </Box>

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -387,23 +387,14 @@ const PriceAdvanced = ({
     visibilityTraceStartedRef.current = null;
   }, [shouldFallbackToLegacy]);
 
-  if (shouldFallbackToLegacy) {
-    return (
-      <PriceLegacy
-        prices={prices}
-        timePeriod={timePeriod}
-        chartNavigationButtons={chartNavigationButtons}
-        onTimePeriodChange={setTimePeriod}
-        priceDiff={priceDiff}
-        currentPrice={currentPrice}
-        currentCurrency={currentCurrency}
-        comparePrice={comparePrice}
-        isLoading={isLoading}
-      />
-    );
-  }
+  useEffect(() => {
+    if (shouldFallbackToLegacy) {
+      return;
+    }
+    if (visibilityTraceStartedRef.current === ohlcvSeriesKey) {
+      return;
+    }
 
-  if (visibilityTraceStartedRef.current !== ohlcvSeriesKey) {
     const previousSeriesId = visibilityTraceStartedRef.current;
     if (previousSeriesId !== null && previousSeriesId !== ohlcvSeriesKey) {
       const supersededOpen = activeVisibilityTraceRef.current;
@@ -431,6 +422,22 @@ const PriceAdvanced = ({
       id: ohlcvSeriesKey,
       ...(assetId.length > 0 ? { data: { assetId } } : {}),
     });
+  }, [ohlcvSeriesKey, assetId, shouldFallbackToLegacy]);
+
+  if (shouldFallbackToLegacy) {
+    return (
+      <PriceLegacy
+        prices={prices}
+        timePeriod={timePeriod}
+        chartNavigationButtons={chartNavigationButtons}
+        onTimePeriodChange={setTimePeriod}
+        priceDiff={priceDiff}
+        currentPrice={currentPrice}
+        currentCurrency={currentCurrency}
+        comparePrice={comparePrice}
+        isLoading={isLoading}
+      />
+    );
   }
 
   return (

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -254,33 +254,30 @@ const PriceAdvanced = ({
 
   const handleAdvancedChartSkeletonHidden = useCallback(() => {
     const open = activeVisibilityTraceRef.current;
-    if (open?.seriesKey !== ohlcvSeriesKey) {
+    if (!open) {
       return;
     }
     endTrace({
       name: open.traceName,
-      id: ohlcvSeriesKey,
+      id: open.seriesKey,
     });
     activeVisibilityTraceRef.current = null;
-  }, [ohlcvSeriesKey]);
+  }, []);
 
-  const handleAdvancedChartError = useCallback(
-    (error: string) => {
-      const open = activeVisibilityTraceRef.current;
-      if (open?.seriesKey !== ohlcvSeriesKey) {
-        return;
-      }
-      endTrace({
-        name: open.traceName,
-        id: ohlcvSeriesKey,
-        data: {
-          errorMessage: error.slice(0, 200),
-        },
-      });
-      activeVisibilityTraceRef.current = null;
-    },
-    [ohlcvSeriesKey],
-  );
+  const handleAdvancedChartError = useCallback((error: string) => {
+    const open = activeVisibilityTraceRef.current;
+    if (!open) {
+      return;
+    }
+    endTrace({
+      name: open.traceName,
+      id: open.seriesKey,
+      data: {
+        errorMessage: error.slice(0, 200),
+      },
+    });
+    activeVisibilityTraceRef.current = null;
+  }, []);
 
   const {
     ohlcvData,

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -242,6 +242,9 @@ const PriceAdvanced = ({
     [assetId, config.timePeriod, config.interval, currentCurrency],
   );
 
+  const assetIdRef = useRef(assetId);
+  assetIdRef.current = assetId;
+
   const visibilityTraceStartedRef = useRef<string | null>(null);
   /** Matches pending manual trace so {@link endTrace} uses the same `TraceName` as {@link trace}. */
   const activeVisibilityTraceRef = useRef<{
@@ -367,6 +370,9 @@ const PriceAdvanced = ({
     !chartLoading &&
     (ohlcvData.length < CHART_DATA_THRESHOLD || hasEmptyData || chartError);
 
+  const shouldFallbackToLegacyRef = useRef(shouldFallbackToLegacy);
+  shouldFallbackToLegacyRef.current = shouldFallbackToLegacy;
+
   useEffect(() => {
     if (!shouldFallbackToLegacy) {
       return;
@@ -388,11 +394,24 @@ const PriceAdvanced = ({
   }, [shouldFallbackToLegacy]);
 
   useEffect(() => {
-    if (shouldFallbackToLegacy) {
-      return;
+    const cleanup = () => {
+      const open = activeVisibilityTraceRef.current;
+      if (open) {
+        endTrace({
+          name: open.traceName,
+          id: open.seriesKey,
+          data: { unmounted: true },
+        });
+        activeVisibilityTraceRef.current = null;
+        visibilityTraceStartedRef.current = null;
+      }
+    };
+
+    if (shouldFallbackToLegacyRef.current) {
+      return cleanup;
     }
     if (visibilityTraceStartedRef.current === ohlcvSeriesKey) {
-      return;
+      return cleanup;
     }
 
     const previousSeriesId = visibilityTraceStartedRef.current;
@@ -416,13 +435,18 @@ const PriceAdvanced = ({
       traceName: visibilityTraceName,
     };
 
+    const currentAssetId = assetIdRef.current;
     trace({
       name: visibilityTraceName,
       op: visibilityTraceOp,
       id: ohlcvSeriesKey,
-      ...(assetId.length > 0 ? { data: { assetId } } : {}),
+      ...(currentAssetId.length > 0
+        ? { data: { assetId: currentAssetId } }
+        : {}),
     });
-  }, [ohlcvSeriesKey, assetId, shouldFallbackToLegacy]);
+
+    return cleanup;
+  }, [ohlcvSeriesKey]);
 
   if (shouldFallbackToLegacy) {
     return (

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -394,24 +394,11 @@ const PriceAdvanced = ({
   }, [shouldFallbackToLegacy]);
 
   useEffect(() => {
-    const cleanup = () => {
-      const open = activeVisibilityTraceRef.current;
-      if (open) {
-        endTrace({
-          name: open.traceName,
-          id: open.seriesKey,
-          data: { unmounted: true },
-        });
-        activeVisibilityTraceRef.current = null;
-        visibilityTraceStartedRef.current = null;
-      }
-    };
-
     if (shouldFallbackToLegacyRef.current) {
-      return cleanup;
+      return;
     }
     if (visibilityTraceStartedRef.current === ohlcvSeriesKey) {
-      return cleanup;
+      return;
     }
 
     const previousSeriesId = visibilityTraceStartedRef.current;
@@ -444,9 +431,23 @@ const PriceAdvanced = ({
         ? { data: { assetId: currentAssetId } }
         : {}),
     });
-
-    return cleanup;
   }, [ohlcvSeriesKey]);
+
+  useEffect(
+    () => () => {
+      const open = activeVisibilityTraceRef.current;
+      if (open) {
+        endTrace({
+          name: open.traceName,
+          id: open.seriesKey,
+          data: { unmounted: true },
+        });
+        activeVisibilityTraceRef.current = null;
+        visibilityTraceStartedRef.current = null;
+      }
+    },
+    [],
+  );
 
   if (shouldFallbackToLegacy) {
     return (

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -85,6 +85,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       enableDrawingTools = false,
       disabledFeatures = DEFAULT_DISABLED_FEATURES,
       onChartReady,
+      onSkeletonHidden,
       onError,
       onCrosshairMove,
       onChartInteracted,
@@ -123,6 +124,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     /** When non-null, `ohlcvData` is still the previous series' array; skip sync until the hook replaces it. */
     const ohlcvSeriesStaleSnapshotRef = useRef<OHLCVBar[] | null>(null);
     const tradingViewOpenInterceptRef = useRef(0);
+    const skeletonHiddenReportedRef = useRef(false);
 
     const htmlContent = useMemo(
       () =>
@@ -136,6 +138,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
 
     // Reset all chart state when the WebView reloads due to htmlContent changes
     useEffect(() => {
+      skeletonHiddenReportedRef.current = false;
       setChartReadyCount(0);
       setWebViewLoaded(false);
       activeIndicatorsRef.current.clear();
@@ -180,6 +183,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       if (ohlcvSeriesKey === undefined) {
         return;
       }
+      skeletonHiddenReportedRef.current = false;
       setChartReadyCount(0);
       setWebViewLoaded(false);
       setLayoutSettling(false);
@@ -565,6 +569,25 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       });
     }, [lineChrome, chartReadyCount, postMessage]);
 
+    const showSkeleton = isLoading || !isChartReady || layoutSettling;
+
+    useEffect(() => {
+      if (webViewError) {
+        return;
+      }
+      if (!onSkeletonHidden) {
+        return;
+      }
+      if (showSkeleton) {
+        return;
+      }
+      if (skeletonHiddenReportedRef.current) {
+        return;
+      }
+      skeletonHiddenReportedRef.current = true;
+      onSkeletonHidden();
+    }, [showSkeleton, webViewError, onSkeletonHidden]);
+
     // ---- Render ----
 
     if (webViewError) {
@@ -601,7 +624,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             androidLayerType="hardware"
             mixedContentMode="always"
           />
-          {(isLoading || !isChartReady || layoutSettling) && (
+          {showSkeleton && (
             <Skeleton
               height={height}
               width="100%"

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -578,7 +578,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       if (!onSkeletonHidden) {
         return;
       }
-      // Check actual state variables, not derived `showSkeleton`, to avoid stale closure race
       if (isLoading || !isChartReady || layoutSettling) {
         return;
       }

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -578,7 +578,8 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       if (!onSkeletonHidden) {
         return;
       }
-      if (showSkeleton) {
+      // Check actual state variables, not derived `showSkeleton`, to avoid stale closure race
+      if (isLoading || !isChartReady || layoutSettling) {
         return;
       }
       if (skeletonHiddenReportedRef.current) {
@@ -586,7 +587,13 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       }
       skeletonHiddenReportedRef.current = true;
       onSkeletonHidden();
-    }, [showSkeleton, webViewError, onSkeletonHidden]);
+    }, [
+      isLoading,
+      isChartReady,
+      layoutSettling,
+      webViewError,
+      onSkeletonHidden,
+    ]);
 
     // ---- Render ----
 

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -450,6 +450,11 @@ export interface AdvancedChartProps {
 
   /** Callback when chart is ready */
   onChartReady?: () => void;
+  /**
+   * Fires once when the native skeleton overlay is removed (chart ready, layout settled,
+   * and parent `isLoading` false). Resets when `ohlcvSeriesKey` or chart HTML reloads.
+   */
+  onSkeletonHidden?: () => void;
   /** Callback when an error occurs */
   onError?: (error: string) => void;
   /** Crosshair OHLC data callback (for overlay legend) */

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -373,6 +373,144 @@ describe('AdvancedChart', () => {
     expect(onChartReady).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onSkeletonHidden once when skeleton overlay is removed', () => {
+    const onSkeletonHidden = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        isLoading
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    expect(getByTestId('advanced-chart-skeleton')).toBeOnTheScreen();
+    expect(onSkeletonHidden).not.toHaveBeenCalled();
+
+    rerender(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        isLoading={false}
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
+    expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        isLoading={false}
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSkeletonHidden after CHART_LAYOUT_SETTLED when series key changes', () => {
+    const altBars: OHLCVBar[] = [
+      { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
+      { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
+    ];
+    const onSkeletonHidden = jest.fn();
+
+    const { getByTestId, queryByTestId, rerender } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        ohlcvSeriesKey="range-a"
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
+
+    onSkeletonHidden.mockClear();
+    rerender(
+      <AdvancedChart
+        ohlcvData={altBars}
+        ohlcvSeriesKey="range-b"
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    expect(getByTestId('advanced-chart-skeleton')).toBeOnTheScreen();
+
+    const webViewAfter = getByTestId('mock-webview');
+    act(() => {
+      webViewAfter.props.onLoadEnd();
+    });
+    act(() => {
+      webViewAfter.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+    act(() => {
+      webViewAfter.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_LAYOUT_SETTLED', payload: {} }),
+        },
+      });
+    });
+
+    expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
+    expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onSkeletonHidden when WebView error UI is shown', () => {
+    const onSkeletonHidden = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        onSkeletonHidden={onSkeletonHidden}
+      />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'ERROR',
+            payload: { message: 'chart init failed' },
+          }),
+        },
+      });
+    });
+
+    expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
+    expect(queryByTestId('mock-webview')).not.toBeOnTheScreen();
+    expect(onSkeletonHidden).not.toHaveBeenCalled();
+  });
+
   it('calls onError when chart reports an error', () => {
     const onError = jest.fn();
     const { getByTestId } = render(

--- a/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/MetaMetricsAndDataCollectionSection/MetaMetricsAndDataCollectionSection.tsx
@@ -31,6 +31,7 @@ import { RootState } from '../../../../../../reducers';
 import { useAutoSignIn } from '../../../../../../util/identity/hooks/useAuthentication';
 import OAuthService from '../../../../../../core/OAuthService/OAuthService';
 import Logger from '../../../../../../util/Logger';
+import { updateCachedConsent } from '../../../../../../util/trace';
 import { selectSeedlessOnboardingLoginFlow } from '../../../../../../selectors/seedlessOnboardingController';
 import { selectOnboardingAccountType } from '../../../../../../selectors/onboarding';
 import { storePna25Acknowledged } from '../../../../../../actions/legalNotices';
@@ -75,6 +76,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
         // Error already logged in optOut
       });
       setAnalyticsEnabled(false);
+      updateCachedConsent(false);
       dispatch(setDataCollectionForMarketing(false));
       return;
     }
@@ -93,6 +95,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
       fetchMarketingStatus();
     }
     setAnalyticsEnabled(analytics.isEnabled());
+    updateCachedConsent(analytics.isEnabled());
   }, [
     setAnalyticsEnabled,
     autoSignIn,
@@ -110,6 +113,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
       await analytics.optIn();
 
       setAnalyticsEnabled(true);
+      updateCachedConsent(true);
 
       analytics.identify(consolidatedTraits);
       analytics.trackEvent(
@@ -158,6 +162,7 @@ const MetaMetricsAndDataCollectionSection: React.FC<
 
       await analytics.optOut();
       setAnalyticsEnabled(false);
+      updateCachedConsent(false);
 
       if (isDataCollectionForMarketingEnabled) {
         dispatch(setDataCollectionForMarketing(false));

--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -89,7 +89,6 @@ describe('Trace', () => {
     );
 
     flushBufferedTraces();
-    // Reset consent state to false by default
     updateCachedConsent(false);
   });
 

--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -31,6 +31,12 @@ jest.mock('../store/storage-wrapper', () => ({
   getItem: jest.fn(),
 }));
 
+jest.mock('redux-persist-filesystem-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
 jest.mock('../store', () => ({
   store: {
     dispatch: jest.fn(),

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -13,6 +13,7 @@ import performance from 'react-native-performance';
 import { createModuleLogger, createProjectLogger } from '@metamask/utils';
 import { AGREED, METRICS_OPT_IN } from '../constants/storage';
 import StorageWrapper from '../store/storage-wrapper';
+import { analytics } from './analytics/analytics';
 
 // Cannot create this 'sentry' logger in Sentry util file because of circular dependency
 const projectLogger = createProjectLogger('sentry');
@@ -557,8 +558,6 @@ let cachedConsent: boolean | null = null;
  */
 export async function hasMetricsConsent(): Promise<boolean> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const { analytics } = require('./analytics/analytics');
     const enabled = analytics.isEnabled();
     if (typeof enabled === 'boolean') {
       cachedConsent = enabled;
@@ -580,23 +579,6 @@ export async function hasMetricsConsent(): Promise<boolean> {
  */
 function getCachedConsent(): boolean | null {
   return cachedConsent;
-}
-
-/**
- * Live MetaMetrics participation for debugging (Settings → Participate). Prefer this over METRICS_OPT_IN alone.
- */
-export function getCachedMetricsConsent(): boolean | null {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const { analytics } = require('./analytics/analytics');
-    const enabled = analytics.isEnabled();
-    if (typeof enabled === 'boolean') {
-      return enabled;
-    }
-  } catch {
-    // fall through
-  }
-  return getCachedConsent();
 }
 
 /**

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -62,6 +62,10 @@ export enum TraceName {
   EvmDiscoverAccounts = 'EVM Discover Accounts',
   SnapDiscoverAccounts = 'Snap Discover Accounts',
   FetchHistoricalPrices = 'Fetch Historical Prices',
+  /** Token overview advanced chart: skeleton cleared after initial load / asset or currency change. */
+  TokenOverviewAdvancedChartInitialVisible = 'Token Overview Advanced Chart Initial Visible',
+  /** Token overview advanced chart: skeleton cleared after time range selector change only. */
+  TokenOverviewAdvancedChartTimeRangeVisible = 'Token Overview Advanced Chart Time Range Visible',
   TransactionConfirmed = 'Transaction Confirmed',
   LoadCollectibles = 'Load Collectibles',
   DetectNfts = 'Detect Nfts',
@@ -268,6 +272,10 @@ export enum TraceOperation {
   MarketInsightsViewportTracking = 'market_insights.viewport_tracking',
   // Homepage Section Performance
   HomepageSectionPerformance = 'homepage.section.performance',
+  /** Token overview OHLCV WebView: initial load or asset/currency change */
+  TokenOverviewAdvancedChart = 'token_overview.advanced_chart',
+  /** Token overview OHLCV WebView: time range change only */
+  TokenOverviewAdvancedChartTimeRange = 'token_overview.advanced_chart_time_range',
 }
 
 const ID_DEFAULT = 'default';
@@ -543,9 +551,23 @@ export async function flushBufferedTraces() {
 let cachedConsent: boolean | null = null;
 
 /**
- * Check if user has given consent for metrics
+ * Check if user has given consent for metrics (for Sentry init).
+ * Uses AnalyticsController via {@link analytics.isEnabled} first (same as Settings → Participate),
+ * then legacy METRICS_OPT_IN storage.
  */
 export async function hasMetricsConsent(): Promise<boolean> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const { analytics } = require('./analytics/analytics');
+    const enabled = analytics.isEnabled();
+    if (typeof enabled === 'boolean') {
+      cachedConsent = enabled;
+      return enabled;
+    }
+  } catch {
+    // fall through to legacy storage
+  }
+
   const metricsOptIn = await StorageWrapper.getItem(METRICS_OPT_IN);
   const hasConsent = metricsOptIn === AGREED;
   cachedConsent = hasConsent;
@@ -558,6 +580,23 @@ export async function hasMetricsConsent(): Promise<boolean> {
  */
 function getCachedConsent(): boolean | null {
   return cachedConsent;
+}
+
+/**
+ * Live MetaMetrics participation for debugging (Settings → Participate). Prefer this over METRICS_OPT_IN alone.
+ */
+export function getCachedMetricsConsent(): boolean | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const { analytics } = require('./analytics/analytics');
+    const enabled = analytics.isEnabled();
+    if (typeof enabled === 'boolean') {
+      return enabled;
+    }
+  } catch {
+    // fall through
+  }
+  return getCachedConsent();
 }
 
 /**

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -13,6 +13,7 @@ import performance from 'react-native-performance';
 import { createModuleLogger, createProjectLogger } from '@metamask/utils';
 import { AGREED, METRICS_OPT_IN } from '../constants/storage';
 import StorageWrapper from '../store/storage-wrapper';
+import FilesystemStorage from 'redux-persist-filesystem-storage';
 import { analytics } from './analytics/analytics';
 
 // Cannot create this 'sentry' logger in Sentry util file because of circular dependency
@@ -553,20 +554,31 @@ let cachedConsent: boolean | null = null;
 
 /**
  * Check if user has given consent for metrics (for Sentry init).
- * Uses AnalyticsController via {@link analytics.isEnabled} first (same as Settings → Participate),
- * then legacy METRICS_OPT_IN storage.
+ * Reads from AnalyticsController's persisted state in FilesystemStorage.
+ *
+ * This bypasses Engine/Redux because Sentry initializes in index.js before they're available.
+ * Follows the same pattern as ControllerStorage.getAllPersistedState() in persistConfig.
  */
 export async function hasMetricsConsent(): Promise<boolean> {
   try {
-    const enabled = analytics.isEnabled();
-    if (typeof enabled === 'boolean') {
-      cachedConsent = enabled;
-      return enabled;
+    // Read directly from AnalyticsController's persisted state (same as ControllerStorage does)
+    const persistedData = await FilesystemStorage.getItem(
+      'persist:AnalyticsController',
+    );
+    if (persistedData) {
+      const parsed = JSON.parse(persistedData);
+      // Remove redux-persist metadata and get controller state
+      const { _persist, ...controllerState } = parsed;
+      if (typeof controllerState?.optedIn === 'boolean') {
+        cachedConsent = controllerState.optedIn;
+        return controllerState.optedIn;
+      }
     }
   } catch {
-    // fall through to legacy storage
+    // Fall through to legacy storage
   }
 
+  // Fallback: legacy METRICS_OPT_IN (migration 108, may be stale)
   const metricsOptIn = await StorageWrapper.getItem(METRICS_OPT_IN);
   const hasConsent = metricsOptIn === AGREED;
   cachedConsent = hasConsent;

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -14,7 +14,6 @@ import { createModuleLogger, createProjectLogger } from '@metamask/utils';
 import { AGREED, METRICS_OPT_IN } from '../constants/storage';
 import StorageWrapper from '../store/storage-wrapper';
 import FilesystemStorage from 'redux-persist-filesystem-storage';
-import { analytics } from './analytics/analytics';
 
 // Cannot create this 'sentry' logger in Sentry util file because of circular dependency
 const projectLogger = createProjectLogger('sentry');


### PR DESCRIPTION


## **Description**


Adds Sentry performance traces for token-overview advanced chart visibility (time from series change until skeleton clears), with separate trace types for dashboards to distinguish initial load / asset or currency changes from time-range-only updates.
Also fixes a bug in metrics consent detection during early Sentry initialization.

## Changes

### Advanced Chart Performance Tracing
**AdvancedChart component:**
- Added optional `onSkeletonHidden` callback that fires once when loading/layout settles and the chart is ready
- Guarded by refs to reset when series key or HTML content changes
**PriceAdvanced component:**
- Starts `trace()` when `ohlcvSeriesKey` changes
- Ends trace via `endTrace()` when:
  - Skeleton hides (chart ready)
  - Chart error occurs
  - Trace is superseded by a newer series
  - Falls back to legacy chart
- `getAdvancedChartVisibilityTraceRequest()` selects appropriate `TraceName` and `TraceOperation` based on what changed:
  - Same asset + currency with only range change → `TokenOverviewAdvancedChartTimeRangeVisible` trace
  - Otherwise → `TokenOverviewAdvancedChartInitialVisible` trace
**trace.ts:**
- Added new `TraceName` values:
  - `TokenOverviewAdvancedChartInitialVisible` - for initial load or asset/currency changes
  - `TokenOverviewAdvancedChartTimeRangeVisible` - for time range selector changes only
- Added new `TraceOperation` values:
  - `token_overview.advanced_chart` - initial load or asset/currency change
  - `token_overview.advanced_chart_time_range` - time range change only


### Metrics Consent Fix

**Problem:**
The original implementation attempted to read from `analytics.isEnabled()` during Sentry initialization in `index.js:45`. However, this occurs before Engine and Redux are initialized, causing `analytics.isEnabled()` to incorrectly return `false` even for opted-in users (it checks in-memory state that doesn't exist yet).
**Solution:**
`hasMetricsConsent()` now reads directly from AnalyticsController's persisted state in FilesystemStorage (`persist:AnalyticsController`) before falling back to the legacy `METRICS_OPT_IN` storage key. This approach:
- Works before Engine/Redux initialization (FilesystemStorage is always available)
- Reads the actual persisted opt-in value from disk (`{"optedIn": true/false}`)
- Follows the same pattern as `ControllerStorage.getAllPersistedState()` in `persistConfig/index.ts`
- Avoids dependency on deprecated `METRICS_OPT_IN` as the primary source
**MetaMetricsAndDataCollectionSection:**
- Calls `updateCachedConsent()` when user toggles analytics participation
- Ensures in-memory consent cache stays synchronized with AnalyticsController state


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds tracing for advanced charts

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3129

## **Manual testing steps**

```gherkin
Feature: Advanced Chart Performance Tracing

  Scenario: user opens token details and chart loads successfully
    Given the user is on the home screen

    When user taps on a token to open token details
    Then a single "Starting sampled root span" log appears for "Token Overview Advanced Chart Initial Visible"
    And a single "Finishing" log appears for the same span ID
    And no duplicate "Token Overview" traces appear

  Scenario: user navigates back before chart finishes loading
    Given the user is on token details with the chart still loading (skeleton visible)

    When user quickly navigates back to the home screen
    Then a "Finishing" log appears for the "Token Overview Advanced Chart Initial Visible" span
    And the finish log appears after the navigation back (after "[UserInteraction]" log)

  Scenario: user navigates back after chart has loaded
    Given the user is on token details and the chart has fully loaded

    When user navigates back to the home screen
    Then no "Token Overview" trace logs appear during navigation back

  Scenario: user changes time range on the chart
    Given the user is on token details with the chart loaded on 1D range

    When user taps on the 1W time range selector
    Then a "Finishing" log appears for the previous "Token Overview Advanced Chart Initial Visible" span
    And a new "Starting sampled root span" log appears for "Token Overview Advanced Chart Time Range Visible"
    And a "Finishing" log appears for the new span when the chart reloads
```

```
How to verify locally:
1. Enable Sentry trace logging by filtering console output for "Tracing"
2. Navigate to a token's details screen
3. Confirm you see exactly ONE "Starting sampled root span" for
   "Token Overview Advanced Chart Initial Visible" followed by ONE
   "Finishing" log for the same span ID
4. Navigate back — confirm no additional trace start/finish for that span
5. Re-enter the token, change time range — confirm the old trace ends
   with superseded and a new "Time Range Visible" trace starts and finishes
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Sentry tracing lifecycle hooks around the token overview advanced chart and changes how metrics consent is determined during early app startup, which could affect whether performance data is captured or suppressed.
> 
> **Overview**
> Adds Sentry performance traces for token overview *advanced chart visibility*, starting a trace on `ohlcvSeriesKey` changes and ending it when the chart skeleton disappears, errors, is superseded by a newer request, falls back to the legacy chart, or unmounts (including `assetId` and truncated error details).
> 
> Extends `AdvancedChart` with an `onSkeletonHidden` callback that fires once when the native skeleton overlay is removed (resetting on series/HTML reload), and adds new `TraceName`/`TraceOperation` constants to distinguish *initial/asset changes* vs *time-range-only* updates.
> 
> Fixes early Sentry init consent detection by updating `hasMetricsConsent()` to read `persist:AnalyticsController` from `redux-persist-filesystem-storage` (fallback to legacy `METRICS_OPT_IN`), and keeps the in-memory consent cache in sync via `updateCachedConsent()` from settings; tests were updated/added for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec6bbd6905d6ece654e4d29fa3446ad330810b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->