### PR TITLE
test: improves performance on appium runs

### DIFF
--- a/tests/framework/DeviceInfoCache.ts
+++ b/tests/framework/DeviceInfoCache.ts
@@ -1,0 +1,80 @@
+/**
+ * Cached device information to avoid repeated HTTP calls to the Appium server.
+ *
+ * Used only on the Playwright + WebdriverIO/Appium path (`tests/framework/fixture`, gestures,
+ * utilities). Detox smoke/regression does not use this module — `PlatformDetector` reads from
+ * Detox `device` there, not from this cache.
+ *
+ * Populated once when the Playwright `driver` fixture creates the session.
+ */
+let cachedPlatform: 'android' | 'ios' = 'android';
+let cachedWindowSize: { width: number; height: number } = {
+  width: 0,
+  height: 0,
+};
+let isPopulated = false;
+
+const NOT_INITIALIZED_MESSAGE =
+  'Device info cache is not initialized. It must be populated via setDeviceInfo() after the driver session is created (Playwright fixture), or set explicitly in unit tests.';
+
+function assertPositiveWindowSize(windowSize: {
+  width: number;
+  height: number;
+}): void {
+  const { width, height } = windowSize;
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw new Error(
+      `Device info cache requires a positive window size; got width=${String(width)}, height=${String(height)}.`,
+    );
+  }
+}
+
+/**
+ * Initialize the device info cache from the driver session.
+ * Called once in the fixture at session creation.
+ */
+export function setDeviceInfo(
+  platform: 'android' | 'ios',
+  windowSize: { width: number; height: number },
+): void {
+  assertPositiveWindowSize(windowSize);
+  cachedPlatform = platform;
+  cachedWindowSize = windowSize;
+  isPopulated = true;
+}
+
+/**
+ * Restores the module cache to its initial state. Used by unit tests between cases.
+ */
+export function resetDeviceInfo(): void {
+  isPopulated = false;
+  cachedPlatform = 'android';
+  cachedWindowSize = { width: 0, height: 0 };
+}
+
+/**
+ * Get the cached platform.
+ * @throws If the cache was never populated (e.g. resetDeviceInfo() without setDeviceInfo()).
+ */
+export function getPlatform(): 'android' | 'ios' {
+  if (!isPopulated) {
+    throw new Error(NOT_INITIALIZED_MESSAGE);
+  }
+  return cachedPlatform;
+}
+
+/**
+ * Get the cached window size.
+ * @throws If the cache was never populated.
+ */
+export function getWindowSize(): { width: number; height: number } {
+  if (!isPopulated) {
+    throw new Error(NOT_INITIALIZED_MESSAGE);
+  }
+  return cachedWindowSize;
+}

--- a/tests/framework/EncapsulatedElement.test.ts
+++ b/tests/framework/EncapsulatedElement.test.ts
@@ -28,6 +28,7 @@ import {
   TestFramework,
 } from './index.ts';
 import type { PlaywrightElement } from './PlaywrightAdapter.ts';
+import { resetDeviceInfo, setDeviceInfo } from './DeviceInfoCache.ts';
 
 // Type augmentation for test globals
 declare const global: typeof globalThis & {
@@ -279,104 +280,92 @@ describe('EncapsulatedElement', () => {
   });
 
   describe('PlatformDetector', () => {
+    beforeEach(() => {
+      resetDeviceInfo();
+    });
+
     describe('getPlatform', () => {
-      it('returns platform from device.getPlatform() in Detox context', async () => {
+      it('returns platform from device.getPlatform() in Detox context', () => {
         FrameworkDetector.setFramework(TestFramework.DETOX);
         (global as Record<string, unknown>).device = {
           getPlatform: jest.fn().mockReturnValue('android'),
         };
 
-        const result = await PlatformDetector.getPlatform();
+        const result = PlatformDetector.getPlatform();
 
         expect(result).toBe('android');
       });
 
-      it('returns "android" when Appium capabilities platformName is "Android"', async () => {
+      it('returns "android" when Appium device info cache was set to android', () => {
         FrameworkDetector.setFramework(TestFramework.APPIUM);
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'Android' }),
-        };
+        setDeviceInfo('android', { width: 400, height: 800 });
 
-        const result = await PlatformDetector.getPlatform();
+        const result = PlatformDetector.getPlatform();
 
         expect(result).toBe('android');
       });
 
-      it('returns "ios" when Appium capabilities platformName is "iOS"', async () => {
+      it('returns "ios" when Appium device info cache was set to ios', () => {
         FrameworkDetector.setFramework(TestFramework.APPIUM);
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'iOS' }),
-        };
+        setDeviceInfo('ios', { width: 390, height: 844 });
 
-        const result = await PlatformDetector.getPlatform();
+        const result = PlatformDetector.getPlatform();
 
         expect(result).toBe('ios');
       });
 
-      it('returns "ios" when Appium capabilities platformName is undefined', async () => {
+      it('throws when Appium device info cache was reset and not repopulated', () => {
         FrameworkDetector.setFramework(TestFramework.APPIUM);
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({}),
-        };
 
-        const result = await PlatformDetector.getPlatform();
-
-        expect(result).toBe('ios');
-      });
-
-      it('throws error when unable to detect platform', async () => {
-        FrameworkDetector.setFramework(TestFramework.APPIUM);
-        // No driver defined
-
-        await expect(PlatformDetector.getPlatform()).rejects.toThrow(
-          'Unable to detect platform',
+        expect(() => PlatformDetector.getPlatform()).toThrow(
+          /Device info cache is not initialized/,
         );
       });
     });
 
     describe('isAndroid', () => {
-      it('returns true when platform is android', async () => {
+      it('returns true when platform is android', () => {
         FrameworkDetector.setFramework(TestFramework.DETOX);
         (global as Record<string, unknown>).device = {
           getPlatform: jest.fn().mockReturnValue('android'),
         };
 
-        const result = await PlatformDetector.isAndroid();
+        const result = PlatformDetector.isAndroid();
 
         expect(result).toBe(true);
       });
 
-      it('returns false when platform is ios', async () => {
+      it('returns false when platform is ios', () => {
         FrameworkDetector.setFramework(TestFramework.DETOX);
         (global as Record<string, unknown>).device = {
           getPlatform: jest.fn().mockReturnValue('ios'),
         };
 
-        const result = await PlatformDetector.isAndroid();
+        const result = PlatformDetector.isAndroid();
 
         expect(result).toBe(false);
       });
     });
 
     describe('isIOS', () => {
-      it('returns true when platform is ios', async () => {
+      it('returns true when platform is ios', () => {
         FrameworkDetector.setFramework(TestFramework.DETOX);
         (global as Record<string, unknown>).device = {
           getPlatform: jest.fn().mockReturnValue('ios'),
         };
 
-        const result = await PlatformDetector.isIOS();
+        const result = PlatformDetector.isIOS();
 
         expect(result).toBe(true);
       });
 
-      it('returns false when platform is android', async () => {
+      it('returns false when platform is android', () => {
         FrameworkDetector.setFramework(TestFramework.DETOX);
         (global as Record<string, unknown>).device = {
           getPlatform: jest.fn().mockReturnValue('android'),
         };
 
-        const result = await PlatformDetector.isIOS();
+        const result = PlatformDetector.isIOS();
 
         expect(result).toBe(false);
       });
@@ -426,6 +415,8 @@ describe('EncapsulatedElement', () => {
     describe('Appium context', () => {
       beforeEach(() => {
         FrameworkDetector.setFramework(TestFramework.APPIUM);
+        resetDeviceInfo();
+        setDeviceInfo('android', { width: 400, height: 800 });
       });
 
       it('returns Appium element when in Appium context with generic locator', async () => {
@@ -462,9 +453,6 @@ describe('EncapsulatedElement', () => {
       });
 
       it('uses platform-specific appium locator for android', async () => {
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'Android' }),
-        };
         const mockPlaywrightElement = createMockPlaywrightElement();
         const androidFn = jest.fn().mockResolvedValue(mockPlaywrightElement);
         const iosFn = jest.fn();
@@ -482,9 +470,7 @@ describe('EncapsulatedElement', () => {
       });
 
       it('uses platform-specific appium locator for ios', async () => {
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'iOS' }),
-        };
+        setDeviceInfo('ios', { width: 390, height: 844 });
         const mockPlaywrightElement = createMockPlaywrightElement();
         const androidFn = jest.fn();
         const iosFn = jest.fn().mockResolvedValue(mockPlaywrightElement);
@@ -502,9 +488,6 @@ describe('EncapsulatedElement', () => {
       });
 
       it('throws error when platform-specific locator is missing for android', async () => {
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'Android' }),
-        };
         const config: LocatorConfig = {
           appium: {
             ios: () => Promise.resolve(createMockPlaywrightElement()),
@@ -517,9 +500,7 @@ describe('EncapsulatedElement', () => {
       });
 
       it('throws error when platform-specific locator is missing for ios', async () => {
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'iOS' }),
-        };
+        setDeviceInfo('ios', { width: 390, height: 844 });
         const config: LocatorConfig = {
           appium: {
             android: () => Promise.resolve(createMockPlaywrightElement()),

--- a/tests/framework/EncapsulatedElement.ts
+++ b/tests/framework/EncapsulatedElement.ts
@@ -141,7 +141,7 @@ export class EncapsulatedElement {
     }
 
     // Otherwise, it's a platform-specific configuration
-    const platform = await PlatformDetector.getPlatform();
+    const platform = PlatformDetector.getPlatform();
     const platformLocator = config.appium[platform];
 
     if (!platformLocator) {

--- a/tests/framework/PageObjectMigrationTestUtils.ts
+++ b/tests/framework/PageObjectMigrationTestUtils.ts
@@ -2,6 +2,7 @@ import { FrameworkDetector, TestFramework } from './FrameworkDetector';
 import { EncapsulatedElement } from './EncapsulatedElement';
 import Matchers from './Matchers';
 import PlaywrightMatchers from './PlaywrightMatchers';
+import { resetDeviceInfo, setDeviceInfo } from './DeviceInfoCache.ts';
 
 function findPageObjectsWithEncapsulated(dir: string): string[] {
   const fs = jest.requireActual<typeof import('fs')>('fs');
@@ -121,14 +122,13 @@ function describeGetters(
         jest.clearAllMocks();
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.APPIUM);
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'iOS' }),
-        };
+        resetDeviceInfo();
+        setDeviceInfo('ios', { width: 390, height: 844 });
       });
 
       afterEach(() => {
         FrameworkDetector.reset();
-        delete (global as Record<string, unknown>).driver;
+        resetDeviceInfo();
       });
 
       for (const name of getterNames) {
@@ -150,14 +150,13 @@ function describeGetters(
         jest.clearAllMocks();
         FrameworkDetector.reset();
         FrameworkDetector.setFramework(TestFramework.APPIUM);
-        (global as Record<string, unknown>).driver = {
-          capabilities: Promise.resolve({ platformName: 'Android' }),
-        };
+        resetDeviceInfo();
+        setDeviceInfo('android', { width: 400, height: 800 });
       });
 
       afterEach(() => {
         FrameworkDetector.reset();
-        delete (global as Record<string, unknown>).driver;
+        resetDeviceInfo();
       });
 
       for (const name of getterNames) {

--- a/tests/framework/PlatformLocator.ts
+++ b/tests/framework/PlatformLocator.ts
@@ -1,39 +1,36 @@
 import { FrameworkDetector } from './FrameworkDetector.ts';
+import { getPlatform as getCachedPlatform } from './DeviceInfoCache.ts';
 
 /**
  * Platform detector for Appium/WebdriverIO and Detox context
+ * Uses cached device info to avoid repeated HTTP calls to the Appium server.
  */
 export class PlatformDetector {
   /**
-   * Get current platform (android/ios)
+   * Get current platform (android/ios).
+   * For Appium/WebdriverIO, reads from the cached device info populated once in the fixture.
+   * For Detox, reads from the Detox device object.
    */
-  static async getPlatform(): Promise<'android' | 'ios'> {
+  static getPlatform(): 'android' | 'ios' {
     if (FrameworkDetector.isDetox()) {
       return device.getPlatform() as 'android' | 'ios';
     }
 
-    // For Appium/WebdriverIO
-    if (typeof driver !== 'undefined') {
-      const capabilities = await driver.capabilities;
-      return capabilities.platformName?.toLowerCase() === 'android'
-        ? 'android'
-        : 'ios';
-    }
-
-    throw new Error('Unable to detect platform');
+    // For Appium/WebdriverIO, read from cache (no HTTP call)
+    return getCachedPlatform();
   }
 
   /**
    * Check if running on Android
    */
-  static async isAndroid(): Promise<boolean> {
-    return (await this.getPlatform()) === 'android';
+  static isAndroid(): boolean {
+    return PlatformDetector.getPlatform() === 'android';
   }
 
   /**
    * Check if running on iOS
    */
-  static async isIOS(): Promise<boolean> {
-    return (await this.getPlatform()) === 'ios';
+  static isIOS(): boolean {
+    return PlatformDetector.getPlatform() === 'ios';
   }
 }

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -1,3 +1,4 @@
+import { getWindowSize } from './DeviceInfoCache.ts';
 import { CurrentDeviceDetails } from './fixture';
 import { PlatformDetector } from './PlatformLocator';
 import { PlaywrightElement } from './PlaywrightAdapter';
@@ -252,7 +253,7 @@ export default class PlaywrightGestures {
 
     const location = await elem.unwrap().getLocation();
     const size = await elem.unwrap().getSize();
-    const windowSize = await drv.getWindowSize();
+    const windowSize = getWindowSize();
     const elementBottom = location.y + size.height;
     const safeBottom = windowSize.height * 0.85;
 
@@ -294,11 +295,14 @@ export default class PlaywrightGestures {
     let retries = maxRetries;
 
     if (
-      (await PlatformDetector.isAndroid()) &&
+      currentDeviceDetails.platform === 'android' &&
       currentDeviceDetails.packageName
     ) {
       bundleId = currentDeviceDetails.packageName;
-    } else if ((await PlatformDetector.isIOS()) && currentDeviceDetails.appId) {
+    } else if (
+      currentDeviceDetails.platform === 'ios' &&
+      currentDeviceDetails.appId
+    ) {
       bundleId = currentDeviceDetails.appId;
     } else {
       throw new Error('Package name or app id is not available');
@@ -376,7 +380,7 @@ export default class PlaywrightGestures {
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
 
-    if (await PlatformDetector.isAndroid()) {
+    if (PlatformDetector.isAndroid()) {
       await drv.hideKeyboard();
     } else {
       // iOS - try pressKey strategy first, fallback to tap outside

--- a/tests/framework/PlaywrightUtilities.ts
+++ b/tests/framework/PlaywrightUtilities.ts
@@ -1,5 +1,6 @@
 import test from '@playwright/test';
 import type { DeviceMatrix } from './types';
+import { getWindowSize } from './DeviceInfoCache.ts';
 import { PlaywrightElement } from './PlaywrightAdapter';
 import { CHROME_PACKAGE, DEFAULT_IMPLICIT_WAIT_MS } from './Constants';
 // eslint-disable-next-line import-x/no-nodejs-modules
@@ -143,7 +144,7 @@ class PlaywrightUtilities {
     width: number;
     height: number;
   }> {
-    const screenSize = await getDriver().getWindowSize();
+    const screenSize = getWindowSize();
     return { width: screenSize.width, height: screenSize.height };
   }
 

--- a/tests/framework/fixture/index.ts
+++ b/tests/framework/fixture/index.ts
@@ -22,6 +22,7 @@ import {
 import { getTeamInfoFromTags } from '../utils/teams';
 import { publishPerformanceScenarioToSentry } from '../../reporters/providers/sentry/PerformanceSentryPublisher';
 
+import { setDeviceInfo } from '../DeviceInfoCache.ts';
 // Extend globalThis to include driver property
 declare global {
   // eslint-disable-next-line no-var
@@ -166,6 +167,16 @@ export const test = base.extend<TestLevelFixtures>({
 
       // Make driver globally accessible for utilities
       globalThis.driver = driver;
+
+      // Populate device info cache once per session (avoid repeated Appium calls during tests).
+      const platformName = (await driver.capabilities)?.platformName;
+      const windowSize = await driver.getWindowSize();
+      setDeviceInfo(
+        (platformName?.toLowerCase() === 'android' ? 'android' : 'ios') as
+          | 'android'
+          | 'ios',
+        { width: windowSize.width, height: windowSize.height },
+      );
 
       // Add test metadata as annotations
       const deviceProviderName = project.use.device?.provider;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Playwright/Appium was hitting the server repeatedly for session-stable data—especially `getWindowSize()` in gesture helpers (e.g. scrollIntoViewFullyVisible), which could run on every scroll though geometry doesn’t change mid-session.

### Changes:
- Added `tests/framework/DeviceInfoCache.ts`: caches platform and window size after the WebdriverIO session exists.
- `tests/framework/fixture/index.ts`: after creating driver, reads capabilities and `getWindowSize()` once and calls setDeviceInfo().
- `PlatformDetector`: Appium path reads cached platform (sync); Detox still uses `device.getPlatform()` (no cache).
- `PlaywrightGestures` / `PlaywrightUtilities.getDeviceScreenSize()`: use `getWindowSize()` from cache instead of `driver.getWindowSize()` each time.
- terminateApp: uses currentDeviceDetails.platform for bundle id selection.
- Cache throws if never populated; `setDeviceInfo` validates positive dimensions; `resetDeviceInfo` is for unit tests only.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1735

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core test-framework plumbing (platform detection, element factory, and gesture helpers); incorrect cache initialization or stale values could cause widespread Appium test failures, though changes are test-only and session-scoped.
> 
> **Overview**
> Improves Playwright/WebdriverIO Appium test performance by introducing a session-scoped `DeviceInfoCache` for platform and window size, populated once when the driver fixture creates the session.
> 
> Updates `PlatformDetector`, `EncapsulatedElement`, and gesture/utility helpers to use the cached values (making platform detection synchronous and avoiding repeated `driver.getWindowSize()` calls), and adjusts Appium-related unit/migration tests to explicitly `setDeviceInfo`/`resetDeviceInfo` and assert the new “cache not initialized” error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1775505dd8a3c3f5d08a36a90d078df79f0cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->