### PR TITLE
feat(money): show mUSD bonus as Tag pill on wallet-home Money row

### DIFF
--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -11,6 +11,8 @@ import type { Hex } from '@metamask/utils';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
   Text,
   TextVariant,
   TextColor,
@@ -55,6 +57,8 @@ import {
   ToastContext,
   ToastVariants,
 } from '../../../../../component-library/components/Toast';
+import TagColored from '../../../../../component-library/components-temp/TagColored';
+import { TagColor } from '../../../../../component-library/components-temp/TagColored/TagColored.types';
 import { useCashNavigation } from './useCashNavigation';
 
 interface CashGetMusdEmptyStateProps {
@@ -305,22 +309,22 @@ const CashGetMusdEmptyState = ({
             >
               {MUSD_TOKEN.name}
             </Text>
-            <Box twClassName="flex-row gap-1">
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              twClassName="gap-2"
+            >
               <Text
                 variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
               >
-                {musdPriceFormatted} {'\u2022'}
+                {musdPriceFormatted}
               </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.SuccessDefault}
-              >
+              <TagColored color={TagColor.Success}>
                 {strings('earn.percentage_bonus', {
                   percentage: MUSD_CONVERSION_APY,
                 })}
-              </Text>
+              </TagColored>
             </Box>
           </Box>
         </Pressable>

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.test.tsx
@@ -83,14 +83,14 @@ describe('MusdAggregatedRow', () => {
     expect(screen.getByText(/1,800\.5\s*mUSD/)).toBeOnTheScreen();
   });
 
-  it('shows green "3% bonus" when no claimable reward', () => {
+  it('shows "3% bonus" tag when no claimable reward', () => {
     renderWithProvider(<MusdAggregatedRow />);
 
     expect(screen.queryByText('Claim 3% bonus')).toBeNull();
     expect(screen.getByText('3% bonus')).toBeOnTheScreen();
   });
 
-  it('shows blue "Claim 3% bonus" when claimable reward exists', () => {
+  it('shows "Claim 3% bonus" link when claimable reward exists', () => {
     mockUseMerklBonusClaim.mockReturnValue({
       claimableReward: '0.02',
       hasPendingClaim: false,

--- a/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/MusdAggregatedRow.tsx
@@ -37,6 +37,8 @@ import { MUSD_EVENTS_CONSTANTS } from '../../../../UI/Earn/constants/events';
 import { LINEA_MUSD_ASSET_FOR_MERKL } from './CashGetMusdEmptyState.constants';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import TagColored from '../../../../../component-library/components-temp/TagColored';
+import { TagColor } from '../../../../../component-library/components-temp/TagColored/TagColored.types';
 
 const MusdAggregatedRow = () => {
   const tw = useTailwind();
@@ -127,29 +129,24 @@ const MusdAggregatedRow = () => {
             </SensitiveText>
             {isClaiming ? (
               <Spinner color={IconColor.PrimaryDefault} />
-            ) : (
-              <TouchableOpacity
-                disabled={!hasClaimableBonus}
-                onPress={handleClaimBonus}
-              >
+            ) : hasClaimableBonus ? (
+              <TouchableOpacity onPress={handleClaimBonus}>
                 <Text
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
-                  color={
-                    hasClaimableBonus
-                      ? TextColor.PrimaryDefault
-                      : TextColor.SuccessDefault
-                  }
+                  color={TextColor.PrimaryDefault}
                 >
-                  {hasClaimableBonus
-                    ? strings('earn.musd_conversion.claim_percentage_bonus', {
-                        percentage: MUSD_CONVERSION_APY,
-                      })
-                    : strings('earn.musd_conversion.percentage_bonus', {
-                        percentage: MUSD_CONVERSION_APY,
-                      })}
+                  {strings('earn.musd_conversion.claim_percentage_bonus', {
+                    percentage: MUSD_CONVERSION_APY,
+                  })}
                 </Text>
               </TouchableOpacity>
+            ) : (
+              <TagColored color={TagColor.Success}>
+                {strings('earn.percentage_bonus', {
+                  percentage: MUSD_CONVERSION_APY,
+                })}
+              </TagColored>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## **Description**

Replaces the inline green-text **3% bonus** affordance on the wallet-home Money section row with a `TagColored` pill, aligning the row with the Figma state matrix for the mUSD/bonus combinations:

- **MUSD-717** — user holds mUSD and has already claimed: row shows `MetaMask USD` / token amount + fiat value + `3% bonus` tag (no inline claim link).
- **MUSD-718** — user holds zero mUSD and has a claimable bonus: row shows the `$1.00` peg price + `3% bonus` tag + **Get mUSD** button, with a full-width **Claim $X.XX bonus** button beneath. (Layout already in place; tag-pill swap completes it.)
- **MUSD-719** — user holds zero mUSD and has already claimed: row shows the `$1.00` peg price + `3% bonus` tag + **Get mUSD** button, no claim button.

Behaviour, navigation, analytics, and feature flags are unchanged. The bullet separator between `$1.00` and the bonus on the empty-state row is removed to match the design.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MUSD-717](https://consensyssoftware.atlassian.net/browse/MUSD-717), [MUSD-718](https://consensyssoftware.atlassian.net/browse/MUSD-718), [MUSD-719](https://consensyssoftware.atlassian.net/browse/MUSD-719)

## **Manual testing steps**

```gherkin
Feature: mUSD wallet-home Money row variants

  Scenario: User holds mUSD and has already claimed the bonus
    Given I am on the wallet home with a non-zero mUSD balance
    And I have no claimable Merkl bonus
    Then the Money section shows MetaMask USD with my token amount and fiat value
    And the bottom-right of the row shows a "3% bonus" green Tag pill (no inline link)

  Scenario: User holds zero mUSD and has a claimable bonus
    Given I am on the wallet home with a zero mUSD balance
    And I have a claimable Merkl bonus
    Then the Money section row shows "$1.00" followed by a "3% bonus" Tag pill (no bullet)
    And the row has a "Get mUSD" button on the right
    And below the row a full-width "Claim $X.XX bonus" button is present

  Scenario: User holds zero mUSD and has already claimed
    Given I am on the wallet home with a zero mUSD balance
    And I have no claimable Merkl bonus
    Then the Money section row shows "$1.00" followed by a "3% bonus" Tag pill
    And the row has a "Get mUSD" button on the right
    And no claim button is rendered below the row
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-717]: https://consensyssoftware.atlassian.net/browse/MUSD-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ