### PR TITLE
feat(money): no-stablecoin Money Hub layout (MUSD-720/721/723/724)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -101,6 +101,38 @@ jest.mock('../../components/YourBonusCard', () => ({
   default: () => null,
 }));
 
+const mockUseMusdBalance = jest.fn(() => ({
+  hasMusdBalanceOnAnyChain: false,
+  hasMusdBalanceOnChain: () => false,
+  tokenBalanceByChain: {},
+  fiatBalanceByChain: {},
+  fiatBalanceFormattedByChain: {},
+  tokenBalanceAggregated: '0',
+  fiatBalanceAggregated: undefined,
+  fiatBalanceAggregatedFormatted: '$0.00',
+}));
+jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
+  useMusdBalance: () => mockUseMusdBalance(),
+}));
+
+const mockUseMerklBonusClaim = jest.fn(() => ({
+  claimableReward: null,
+  hasPendingClaim: false,
+  isClaiming: false,
+  claimRewards: jest.fn(),
+  lifetimeBonusClaimed: null,
+}));
+jest.mock(
+  '../../../Earn/components/MerklRewards/hooks/useMerklBonusClaim',
+  () => ({
+    useMerklBonusClaim: () => mockUseMerklBonusClaim(),
+  }),
+);
+
+jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: () => ({ goToBuy: jest.fn() }),
+}));
+
 jest.mock('../../components/MoneyActivityItem/MoneyActivityItem', () => {
   const { View, Text } = jest.requireActual('react-native');
   return {
@@ -112,6 +144,13 @@ jest.mock('../../components/MoneyActivityItem/MoneyActivityItem', () => {
     ),
   };
 });
+jest.mock(
+  '../../components/MoneyConvertStablecoins/MoneyConvertStablecoins',
+  () => ({
+    __esModule: true,
+    default: () => null,
+  }),
+);
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 jest.mock('@react-native-masked-view/masked-view', () => 'MaskedView');
 jest.mock('../../../../UI/AssetOverview/Balance/Balance', () => ({
@@ -486,6 +525,49 @@ describe('MoneyHomeView', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
         screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
+      });
+    });
+  });
+
+  describe('no-eligible-stablecoins state', () => {
+    let originalTokens: typeof mockConversionTokens;
+
+    beforeEach(() => {
+      originalTokens = mockConversionTokens.slice();
+      mockConversionTokens.length = 0;
+    });
+
+    afterEach(() => {
+      mockConversionTokens.length = 0;
+      mockConversionTokens.push(...originalTokens);
+    });
+
+    it('renders the Your balance section instead of the milestone summary', () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <MoneyHomeView />,
+      );
+
+      expect(getByTestId('money-balance-list-container')).toBeOnTheScreen();
+      expect(queryByTestId('money-balance-summary-container')).toBeNull();
+    });
+
+    it('renders the Swap/Buy footer instead of the Add money button', () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <MoneyHomeView />,
+      );
+
+      expect(getByTestId('money-footer-swap-button')).toBeOnTheScreen();
+      expect(getByTestId('money-footer-buy-button')).toBeOnTheScreen();
+      expect(queryByTestId('money-footer-add-money-button')).toBeNull();
+    });
+
+    it('navigates to the Bridge view when Swap is pressed', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      fireEvent.press(getByTestId('money-footer-swap-button'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.ROOT, {
+        screen: Routes.BRIDGE.BRIDGE_VIEW,
       });
     });
   });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import BigNumber from 'bignumber.js';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { ScrollView, Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +8,7 @@ import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import MoneyHeader from '../../components/MoneyHeader';
+import MoneyBalanceList from '../../components/MoneyBalanceList';
 import MoneyBalanceSummary from '../../components/MoneyBalanceSummary';
 import MoneyActionButtonRow from '../../components/MoneyActionButtonRow';
 import MoneyEarnings from '../../components/MoneyEarnings';
@@ -15,12 +17,17 @@ import MoneyMusdTokenRow from '../../components/MoneyMusdTokenRow';
 import MoneyOnboardingCard from '../../components/MoneyOnboardingCard';
 import MoneyCondensedInfoCards from '../../components/MoneyCondensedInfoCards';
 import MoneyHowItWorks from '../../components/MoneyHowItWorks';
+import MoneyConvertStablecoins from '../../components/MoneyConvertStablecoins/MoneyConvertStablecoins';
 import MoneyPotentialEarnings from '../../components/MoneyPotentialEarnings';
 import { hasConvertibleTokensWithBalance } from '../../components/MoneyPotentialEarnings/MoneyPotentialEarnings';
 import MoneyMetaMaskCard from '../../components/MoneyMetaMaskCard';
 import MoneyWhatYouGet from '../../components/MoneyWhatYouGet';
 import MoneyActivityList from '../../components/MoneyActivityList';
 import MoneyFooter from '../../components/MoneyFooter';
+import { useMerklBonusClaim } from '../../../Earn/components/MerklRewards/hooks/useMerklBonusClaim';
+import { MUSD_EVENTS_CONSTANTS } from '../../../Earn/constants/events';
+import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MoneyHomeViewTestIds } from './MoneyHomeView.testIds';
 import styleSheet from './MoneyHomeView.styles';
@@ -28,7 +35,10 @@ import { useMusdConversionTokens } from '../../../Earn/hooks/useMusdConversionTo
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import { showMoneyActivityUnderConstructionAlert } from '../../constants/showMoneyActivityUnderConstructionAlert';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
-import { MUSD_MAINNET_ASSET_FOR_DETAILS } from '../../../../Views/Homepage/Sections/Cash/CashGetMusdEmptyState.constants';
+import {
+  LINEA_MUSD_ASSET_FOR_MERKL,
+  MUSD_MAINNET_ASSET_FOR_DETAILS,
+} from '../../../../Views/Homepage/Sections/Cash/CashGetMusdEmptyState.constants';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import AppConstants from '../../../../../core/AppConstants';
 import NavigationService from '../../../../../core/NavigationService';
@@ -62,6 +72,17 @@ const MoneyHomeView = () => {
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
 
   const isCardholder = useSelector(selectIsCardholder);
+  const { hasMusdBalanceOnAnyChain } = useMusdBalance();
+  const { lifetimeBonusClaimed } = useMerklBonusClaim(
+    LINEA_MUSD_ASSET_FOR_MERKL,
+    MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.MONEY_HUB,
+  );
+  const { goToBuy } = useRampNavigation();
+
+  const hasEligibleStablecoins = conversionTokens.length > 0;
+  const hasLifetimeBonus =
+    !!lifetimeBonusClaimed && new BigNumber(lifetimeBonusClaimed).gt(0);
+  const isReturningUser = hasMusdBalanceOnAnyChain || hasLifetimeBonus;
 
   const homeState = getMoneyHomeState(allTransactions.length);
   const isMilestone = homeState === 'milestone' || homeState === 'filled';
@@ -79,6 +100,14 @@ const MoneyHomeView = () => {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
     });
   }, [navigation]);
+  const handleSwapPress = useCallback(() => {
+    navigation.navigate(Routes.BRIDGE.ROOT, {
+      screen: Routes.BRIDGE.BRIDGE_VIEW,
+    });
+  }, [navigation]);
+  const handleBuyPress = useCallback(() => {
+    goToBuy();
+  }, [goToBuy]);
   const handleTransferPress = displayUnderConstructionAlert;
   const handleCardPress = displayUnderConstructionAlert;
   const handleApyInfoPress = displayUnderConstructionAlert;
@@ -135,6 +164,47 @@ const MoneyHomeView = () => {
   // TODO: Remove before launch
   // Useful for testing how zero and non-zero APYs are handled quickly.
   const DEV_APY = __DEV__ ? 4 : vaultApyQuery.data?.apy;
+
+  if (!hasEligibleStablecoins) {
+    return (
+      <Box
+        style={[styles.safeArea, { paddingTop: insets.top }]}
+        twClassName="flex-1 bg-default"
+        testID={MoneyHomeViewTestIds.CONTAINER}
+      >
+        <MoneyHeader
+          onBackPress={handleBackPress}
+          onMenuPress={handleMenuPress}
+        />
+        <ScrollView
+          testID={MoneyHomeViewTestIds.SCROLL_VIEW}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <MoneyBalanceList isReturningUser={isReturningUser} />
+          <Divider />
+          <YourBonusCard />
+          <MoneyConvertStablecoins
+            tokens={[]}
+            onMaxPress={() => undefined}
+            onEditPress={() => undefined}
+            onLearnMorePress={handleLearnMorePress}
+          />
+          <Divider />
+          <MoneyHowItWorks
+            apy={DEV_APY}
+            onHeaderPress={handleHowItWorksHeaderPress}
+            isLoading={vaultApyQuery.isLoading}
+          />
+        </ScrollView>
+        <MoneyFooter
+          variant="swap-buy"
+          onSwapPress={handleSwapPress}
+          onBuyPress={handleBuyPress}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import MoneyBalanceList from './MoneyBalanceList';
+import { MoneyBalanceListTestIds } from './MoneyBalanceList.testIds';
+
+const mockUseMusdBalance = jest.fn();
+
+jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
+  useMusdBalance: () => mockUseMusdBalance(),
+}));
+
+jest.mock(
+  '../../../../../component-library/components/Badges/BadgeWrapper',
+  () => ({
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => children,
+    BadgePosition: { BottomRight: 'BottomRight' },
+  }),
+);
+
+jest.mock('../../../../../component-library/components/Badges/Badge', () => ({
+  __esModule: true,
+  default: () => null,
+  BadgeVariant: { Network: 'Network' },
+}));
+
+jest.mock('../../../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: () => 1,
+}));
+
+const ZERO_BALANCE_HOOK = {
+  hasMusdBalanceOnAnyChain: false,
+  hasMusdBalanceOnChain: () => false,
+  tokenBalanceByChain: {},
+  fiatBalanceByChain: {},
+  fiatBalanceFormattedByChain: {},
+  tokenBalanceAggregated: '0',
+  fiatBalanceAggregated: undefined,
+  fiatBalanceAggregatedFormatted: '$0.00',
+};
+
+describe('MoneyBalanceList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseMusdBalance.mockReturnValue(ZERO_BALANCE_HOOK);
+  });
+
+  it('renders the Your balance title', () => {
+    const { getByTestId } = render(<MoneyBalanceList />);
+    expect(getByTestId(MoneyBalanceListTestIds.TITLE)).toBeOnTheScreen();
+  });
+
+  it('renders a single zero-balance row for first-time users', () => {
+    const { getAllByTestId } = render(<MoneyBalanceList />);
+    expect(getAllByTestId(MoneyBalanceListTestIds.ROW)).toHaveLength(1);
+  });
+
+  it('renders one zero-balance row per supported chain for returning users', () => {
+    const { getAllByTestId } = render(<MoneyBalanceList isReturningUser />);
+    expect(getAllByTestId(MoneyBalanceListTestIds.ROW)).toHaveLength(2);
+  });
+
+  it('renders one row per chain that has a positive mUSD balance', () => {
+    mockUseMusdBalance.mockReturnValue({
+      ...ZERO_BALANCE_HOOK,
+      hasMusdBalanceOnAnyChain: true,
+      hasMusdBalanceOnChain: (chainId: string) => chainId === '0x1',
+      tokenBalanceByChain: { '0x1': '1280.34' },
+      fiatBalanceFormattedByChain: { '0x1': '$1,280.34' },
+    });
+
+    const { getAllByTestId, getByText } = render(<MoneyBalanceList />);
+    expect(getAllByTestId(MoneyBalanceListTestIds.ROW)).toHaveLength(1);
+    expect(getByText('$1,280.34')).toBeOnTheScreen();
+    expect(getByText(/1,280\.34\s*mUSD/)).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.testIds.ts
@@ -1,0 +1,7 @@
+export const MoneyBalanceListTestIds = {
+  CONTAINER: 'money-balance-list-container',
+  TITLE: 'money-balance-list-title',
+  ROW: 'money-balance-list-row',
+  ROW_FIAT: 'money-balance-list-row-fiat',
+  ROW_TOKEN: 'money-balance-list-row-token',
+} as const;

--- a/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceList/MoneyBalanceList.tsx
@@ -1,0 +1,195 @@
+import React, { useMemo } from 'react';
+import { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import I18n, { strings } from '../../../../../../locales/i18n';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import { NetworkBadgeSource } from '../../../AssetOverview/Balance/Balance';
+import { MUSD_TOKEN } from '../../../Earn/constants/musd';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
+import { getIntlNumberFormatter } from '../../../../../util/intl';
+import type { ImageOrSvgSrc } from '@metamask/design-system-react-native/dist/components/temp-components/ImageOrSvg/ImageOrSvg.types.d.cts';
+import { MoneyBalanceListTestIds } from './MoneyBalanceList.testIds';
+
+const SUPPORTED_MUSD_CHAIN_IDS: readonly Hex[] = [
+  CHAIN_IDS.MAINNET,
+  CHAIN_IDS.LINEA_MAINNET,
+] as const;
+
+interface MoneyBalanceListProps {
+  /**
+   * When true, renders one zero-balance row per supported chain even if the
+   * user holds no mUSD on any chain. When false, falls back to a single
+   * zero-balance row without a network badge.
+   */
+  isReturningUser?: boolean;
+}
+
+const formatTokenAmount = (tokenBalance: string | undefined): string => {
+  const value = Number(tokenBalance ?? 0);
+  return `${getIntlNumberFormatter(I18n.locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value)} ${MUSD_TOKEN.symbol}`;
+};
+
+const formatZeroFiat = (): string =>
+  getIntlNumberFormatter(I18n.locale, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(0);
+
+interface MoneyBalanceRowProps {
+  chainId?: Hex;
+  fiatFormatted: string;
+  tokenFormatted: string;
+}
+
+const MoneyBalanceRow = ({
+  chainId,
+  fiatFormatted,
+  tokenFormatted,
+}: MoneyBalanceRowProps) => {
+  const networkBadgeSource = useMemo(
+    () => (chainId ? NetworkBadgeSource(chainId) : null),
+    [chainId],
+  );
+
+  const avatar = (
+    <AvatarToken
+      name={MUSD_TOKEN.symbol}
+      src={MUSD_TOKEN.imageSource as ImageOrSvgSrc}
+      size={AvatarTokenSize.Md}
+    />
+  );
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="px-4 py-3 gap-4"
+      testID={MoneyBalanceListTestIds.ROW}
+    >
+      {networkBadgeSource ? (
+        <BadgeWrapper
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            <Badge
+              variant={BadgeVariant.Network}
+              imageSource={networkBadgeSource}
+            />
+          }
+        >
+          {avatar}
+        </BadgeWrapper>
+      ) : (
+        avatar
+      )}
+      <Box twClassName="flex-1">
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {MUSD_TOKEN.name}
+        </Text>
+      </Box>
+      <Box alignItems={BoxAlignItems.End}>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          testID={MoneyBalanceListTestIds.ROW_FIAT}
+        >
+          {fiatFormatted}
+        </Text>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          testID={MoneyBalanceListTestIds.ROW_TOKEN}
+        >
+          {tokenFormatted}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+const MoneyBalanceList = ({
+  isReturningUser = false,
+}: MoneyBalanceListProps) => {
+  const {
+    hasMusdBalanceOnAnyChain,
+    hasMusdBalanceOnChain,
+    tokenBalanceByChain,
+    fiatBalanceFormattedByChain,
+  } = useMusdBalance();
+
+  const rows: { chainId?: Hex; fiat: string; token: string }[] = useMemo(() => {
+    if (hasMusdBalanceOnAnyChain) {
+      return SUPPORTED_MUSD_CHAIN_IDS.filter((chainId) =>
+        hasMusdBalanceOnChain(chainId),
+      ).map((chainId) => ({
+        chainId,
+        fiat: fiatBalanceFormattedByChain[chainId] ?? formatZeroFiat(),
+        token: formatTokenAmount(tokenBalanceByChain[chainId]),
+      }));
+    }
+    if (isReturningUser) {
+      return SUPPORTED_MUSD_CHAIN_IDS.map((chainId) => ({
+        chainId,
+        fiat: formatZeroFiat(),
+        token: formatTokenAmount('0'),
+      }));
+    }
+    return [{ fiat: formatZeroFiat(), token: formatTokenAmount('0') }];
+  }, [
+    hasMusdBalanceOnAnyChain,
+    hasMusdBalanceOnChain,
+    tokenBalanceByChain,
+    fiatBalanceFormattedByChain,
+    isReturningUser,
+  ]);
+
+  return (
+    <Box testID={MoneyBalanceListTestIds.CONTAINER}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
+        alignItems={BoxAlignItems.Center}
+        twClassName="px-4 pb-2"
+      >
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          testID={MoneyBalanceListTestIds.TITLE}
+        >
+          {strings('money.balance_list.title')}
+        </Text>
+      </Box>
+      {rows.map((row, index) => (
+        <MoneyBalanceRow
+          key={row.chainId ?? `zero-${index}`}
+          chainId={row.chainId}
+          fiatFormatted={row.fiat}
+          tokenFormatted={row.token}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default MoneyBalanceList;

--- a/app/components/UI/Money/components/MoneyBalanceList/index.ts
+++ b/app/components/UI/Money/components/MoneyBalanceList/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MoneyBalanceList';
+export { MoneyBalanceListTestIds } from './MoneyBalanceList.testIds';

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.test.tsx
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.test.tsx
@@ -35,4 +35,36 @@ describe('MoneyFooter', () => {
       fireEvent.press(getByTestId(MoneyFooterTestIds.ADD_MONEY_BUTTON));
     }).not.toThrow();
   });
+
+  describe('swap-buy variant', () => {
+    it('renders Swap and Buy buttons instead of Add money', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MoneyFooter variant="swap-buy" />,
+      );
+
+      expect(getByTestId(MoneyFooterTestIds.SWAP_BUTTON)).toBeOnTheScreen();
+      expect(getByTestId(MoneyFooterTestIds.BUY_BUTTON)).toBeOnTheScreen();
+      expect(queryByTestId(MoneyFooterTestIds.ADD_MONEY_BUTTON)).toBeNull();
+    });
+
+    it('calls onSwapPress when Swap button is pressed', () => {
+      const mockSwap = jest.fn();
+      const { getByTestId } = render(
+        <MoneyFooter variant="swap-buy" onSwapPress={mockSwap} />,
+      );
+
+      fireEvent.press(getByTestId(MoneyFooterTestIds.SWAP_BUTTON));
+      expect(mockSwap).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onBuyPress when Buy button is pressed', () => {
+      const mockBuy = jest.fn();
+      const { getByTestId } = render(
+        <MoneyFooter variant="swap-buy" onBuyPress={mockBuy} />,
+      );
+
+      fireEvent.press(getByTestId(MoneyFooterTestIds.BUY_BUTTON));
+      expect(mockBuy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.testIds.ts
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.testIds.ts
@@ -1,4 +1,6 @@
 export const MoneyFooterTestIds = {
   CONTAINER: 'money-footer-container',
   ADD_MONEY_BUTTON: 'money-footer-add-money-button',
+  SWAP_BUTTON: 'money-footer-swap-button',
+  BUY_BUTTON: 'money-footer-buy-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.tsx
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Box,
+  BoxFlexDirection,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -10,12 +11,20 @@ import { strings } from '../../../../../../locales/i18n';
 import { MoneyFooterTestIds } from './MoneyFooter.testIds';
 import createStyles from './MoneyFooter.styles';
 
+export type MoneyFooterVariant = 'add-money' | 'swap-buy';
+
 interface MoneyFooterProps {
+  variant?: MoneyFooterVariant;
   onAddMoneyPress?: () => void;
+  onSwapPress?: () => void;
+  onBuyPress?: () => void;
 }
 
 const MoneyFooter = ({
+  variant = 'add-money',
   onAddMoneyPress = () => undefined,
+  onSwapPress = () => undefined,
+  onBuyPress = () => undefined,
 }: MoneyFooterProps) => {
   const { bottom } = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(bottom), [bottom]);
@@ -26,15 +35,42 @@ const MoneyFooter = ({
       style={styles.container}
       testID={MoneyFooterTestIds.CONTAINER}
     >
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Lg}
-        isFullWidth
-        onPress={onAddMoneyPress}
-        testID={MoneyFooterTestIds.ADD_MONEY_BUTTON}
-      >
-        {strings('money.footer.add_money')}
-      </Button>
+      {variant === 'swap-buy' ? (
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
+          <Box twClassName="flex-1">
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={onSwapPress}
+              testID={MoneyFooterTestIds.SWAP_BUTTON}
+            >
+              {strings('money.footer.swap')}
+            </Button>
+          </Box>
+          <Box twClassName="flex-1">
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={onBuyPress}
+              testID={MoneyFooterTestIds.BUY_BUTTON}
+            >
+              {strings('money.footer.buy')}
+            </Button>
+          </Box>
+        </Box>
+      ) : (
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={onAddMoneyPress}
+          testID={MoneyFooterTestIds.ADD_MONEY_BUTTON}
+        >
+          {strings('money.footer.add_money')}
+        </Button>
+      )}
     </Box>
   );
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6543,7 +6543,12 @@
       "learn_more": "Learn more"
     },
     "footer": {
-      "add_money": "Add money"
+      "add_money": "Add money",
+      "swap": "Swap",
+      "buy": "Buy"
+    },
+    "balance_list": {
+      "title": "Your balance"
     },
     "add_money_sheet": {
       "title": "Add money",


### PR DESCRIPTION
## **Description**

Adds a simplified Money Hub layout for users who hold no eligible convert-source stablecoins (USDC, USDT, DAI). Instead of the milestone-based layout (balance summary, action pills, onboarding, earnings, activity, MetaMask Card upsell, etc.), the Hub renders:

- `MoneyHeader`
- `MoneyBalanceList` *(new)* — `Your balance` section with per-network mUSD rows; collapses to a single zero-balance row for first-time users
- `YourBonusCard` (returns null when neither claimable nor lifetime bonus exists)
- `MoneyConvertStablecoins` empty/informational variant (cluster image + title + body + 4 attribute tags, no per-token rows — already supported by the component)
- `MoneyHowItWorks`
- `MoneyFooter` with a new **`swap-buy`** variant that renders **Swap | Buy** instead of the single Add money button

The first-time vs returning user split (MUSD-721) is derived from `lifetimeBonusClaimed > 0 || hasMusdBalanceOnAnyChain`.

This is **stacked on top of `kureev/MUSD-716`** so the new layout can lean on `YourBonusCard` introduced in that PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MUSD-720](https://consensyssoftware.atlassian.net/browse/MUSD-720), [MUSD-721](https://consensyssoftware.atlassian.net/browse/MUSD-721), [MUSD-723](https://consensyssoftware.atlassian.net/browse/MUSD-723), [MUSD-724](https://consensyssoftware.atlassian.net/browse/MUSD-724)

## **Manual testing steps**

```gherkin
Feature: Money Hub layout for no-stablecoin states

  Scenario: User holds mUSD plus an unclaimed bonus but no stablecoins (MUSD-720)
    Given I am on the Money Hub
    And I hold mUSD on at least one supported chain
    And I have a claimable Merkl bonus
    And I hold no USDC/USDT/DAI
    Then the Your balance section renders one row per chain that holds mUSD
    And the Your bonus card is visible with the Claim button
    And the Convert to mUSD section shows the stablecoin cluster image and 4 feature tags
    And the footer shows Swap and Buy buttons

  Scenario: First-time user with empty wallet (MUSD-721 first-time, MUSD-724)
    Given I am on the Money Hub
    And I have no mUSD on any chain
    And lifetimeBonusClaimed is zero or null
    And I hold no USDC/USDT/DAI
    Then the Your balance section renders a single $0.00 row (no network badge)
    And the Your bonus card is hidden
    And the Convert to mUSD section shows the empty/informational variant
    And the footer shows Swap and Buy buttons

  Scenario: Returning user with zero mUSD and prior bonus claims (MUSD-721 returning)
    Given I am on the Money Hub
    And I have no mUSD on any chain right now
    And lifetimeBonusClaimed is greater than zero
    And I hold no USDC/USDT/DAI
    Then the Your balance section renders one $0.00 row per supported chain (with badges)
    And the Your bonus card shows lifetime claimed amount

  Scenario: User holds other tokens but no stablecoins (MUSD-723)
    Given I am on the Money Hub
    And I hold ETH (or any non-stablecoin)
    And I hold no USDC/USDT/DAI
    Then the same simplified layout is rendered
    And the footer Swap button opens the Bridge view
    And the footer Buy button opens the Ramp Buy flow
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-720]: https://consensyssoftware.atlassian.net/browse/MUSD-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ