### PR TITLE
feat(money): show Convert to mUSD footer when stablecoins are eligible (MUSD-722 slice 1/4)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -254,17 +254,25 @@ describe('MoneyHomeView', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ACTIVITY);
   });
 
-  it.each([
-    ['action row Add', MoneyActionButtonRowTestIds.ADD_BUTTON],
-    ['footer Add money', MoneyFooterTestIds.ADD_MONEY_BUTTON],
-  ])('opens the Add money sheet from the %s button', (_label, testId) => {
+  it('opens the Add money sheet when the action row Add button is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
-    fireEvent.press(getByTestId(testId));
+    fireEvent.press(getByTestId(MoneyActionButtonRowTestIds.ADD_BUTTON));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
     });
+  });
+
+  it('renders the Convert to mUSD footer when stablecoins are eligible', () => {
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <MoneyHomeView />,
+    );
+
+    expect(
+      getByTestId(MoneyFooterTestIds.CONVERT_TO_MUSD_BUTTON),
+    ).toBeOnTheScreen();
+    expect(queryByTestId(MoneyFooterTestIds.ADD_MONEY_BUTTON)).toBeNull();
   });
 
   describe('milestone state (1-9 transactions)', () => {

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -61,6 +61,7 @@ const MoneyHomeView = () => {
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
 
   const isCardholder = useSelector(selectIsCardholder);
+  const hasEligibleStablecoins = conversionTokens.length > 0;
 
   const homeState = getMoneyHomeState(allTransactions.length);
   const isMilestone = homeState === 'milestone' || homeState === 'filled';
@@ -78,6 +79,8 @@ const MoneyHomeView = () => {
       screen: Routes.MONEY.MODALS.ADD_MONEY_SHEET,
     });
   }, [navigation]);
+  // TODO(MUSD-722): route to the Single Convert screen when it ships.
+  const handleConvertPress = displayUnderConstructionAlert;
   const handleTransferPress = displayUnderConstructionAlert;
   const handleCardPress = displayUnderConstructionAlert;
   const handleApyInfoPress = displayUnderConstructionAlert;
@@ -233,7 +236,11 @@ const MoneyHomeView = () => {
           />
         )}
       </ScrollView>
-      <MoneyFooter onAddMoneyPress={handleAddPress} />
+      <MoneyFooter
+        variant={hasEligibleStablecoins ? 'convert-musd' : 'add-money'}
+        onAddMoneyPress={handleAddPress}
+        onConvertPress={handleConvertPress}
+      />
     </Box>
   );
 };

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.test.tsx
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.test.tsx
@@ -35,4 +35,27 @@ describe('MoneyFooter', () => {
       fireEvent.press(getByTestId(MoneyFooterTestIds.ADD_MONEY_BUTTON));
     }).not.toThrow();
   });
+
+  describe('convert-musd variant', () => {
+    it('renders the Convert to mUSD button instead of Add money', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MoneyFooter variant="convert-musd" />,
+      );
+
+      expect(
+        getByTestId(MoneyFooterTestIds.CONVERT_TO_MUSD_BUTTON),
+      ).toBeOnTheScreen();
+      expect(queryByTestId(MoneyFooterTestIds.ADD_MONEY_BUTTON)).toBeNull();
+    });
+
+    it('calls onConvertPress when Convert to mUSD is pressed', () => {
+      const mockConvert = jest.fn();
+      const { getByTestId } = render(
+        <MoneyFooter variant="convert-musd" onConvertPress={mockConvert} />,
+      );
+
+      fireEvent.press(getByTestId(MoneyFooterTestIds.CONVERT_TO_MUSD_BUTTON));
+      expect(mockConvert).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.testIds.ts
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.testIds.ts
@@ -1,4 +1,5 @@
 export const MoneyFooterTestIds = {
   CONTAINER: 'money-footer-container',
   ADD_MONEY_BUTTON: 'money-footer-add-money-button',
+  CONVERT_TO_MUSD_BUTTON: 'money-footer-convert-to-musd-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyFooter/MoneyFooter.tsx
+++ b/app/components/UI/Money/components/MoneyFooter/MoneyFooter.tsx
@@ -10,12 +10,18 @@ import { strings } from '../../../../../../locales/i18n';
 import { MoneyFooterTestIds } from './MoneyFooter.testIds';
 import createStyles from './MoneyFooter.styles';
 
+export type MoneyFooterVariant = 'add-money' | 'convert-musd';
+
 interface MoneyFooterProps {
+  variant?: MoneyFooterVariant;
   onAddMoneyPress?: () => void;
+  onConvertPress?: () => void;
 }
 
 const MoneyFooter = ({
+  variant = 'add-money',
   onAddMoneyPress = () => undefined,
+  onConvertPress = () => undefined,
 }: MoneyFooterProps) => {
   const { bottom } = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(bottom), [bottom]);
@@ -26,15 +32,27 @@ const MoneyFooter = ({
       style={styles.container}
       testID={MoneyFooterTestIds.CONTAINER}
     >
-      <Button
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Lg}
-        isFullWidth
-        onPress={onAddMoneyPress}
-        testID={MoneyFooterTestIds.ADD_MONEY_BUTTON}
-      >
-        {strings('money.footer.add_money')}
-      </Button>
+      {variant === 'convert-musd' ? (
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={onConvertPress}
+          testID={MoneyFooterTestIds.CONVERT_TO_MUSD_BUTTON}
+        >
+          {strings('money.footer.convert_to_musd')}
+        </Button>
+      ) : (
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={onAddMoneyPress}
+          testID={MoneyFooterTestIds.ADD_MONEY_BUTTON}
+        >
+          {strings('money.footer.add_money')}
+        </Button>
+      )}
     </Box>
   );
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6577,7 +6577,8 @@
       "learn_more": "Learn more"
     },
     "footer": {
-      "add_money": "Add money"
+      "add_money": "Add money",
+      "convert_to_musd": "Convert to mUSD"
     },
     "add_money_sheet": {
       "title": "Add money",


### PR DESCRIPTION
## **Description**

First slice of MUSD-722 (Money Hub stablecoin-holder Convert flow): the Money Hub footer now flips from the single **Add money** primary button to a single **Convert to mUSD** primary button whenever the user holds eligible convert-source stablecoins (USDC, USDT, DAI). This matches the Figma frame for State 1 of MUSD-722.

The press handler is intentionally a placeholder (under-construction alert). The Single Convert screen that the button should open ships in a follow-up PR.

This slice:
- Adds a `convert-musd` variant to `MoneyFooter`.
- Wires `MoneyHomeView` to choose the variant from `useMusdConversionTokens().tokens.length > 0`.
- Adds the new i18n key `money.footer.convert_to_musd`.

The remaining MUSD-722 slices (Single Convert screen, Max Convert sheet, Convert info tooltip) will be opened as separate PRs to stay within the ~500–1000 LOC ceiling.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: [MUSD-722](https://consensyssoftware.atlassian.net/browse/MUSD-722) (slice 1/4)

## **Manual testing steps**

```gherkin
Feature: Money Hub footer for stablecoin holders

  Scenario: User holds eligible stablecoins
    Given I am on the Money Hub
    And my wallet holds at least one of USDC, USDT, or DAI above the min balance threshold
    Then the footer renders a single primary "Convert to mUSD" button
    And the "Add money" button is not rendered

  Scenario: User holds no eligible stablecoins
    Given I am on the Money Hub
    And my wallet holds none of USDC, USDT, or DAI
    Then the footer renders the existing "Add money" button
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-722]: https://consensyssoftware.atlassian.net/browse/MUSD-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ