### PR TITLE
fix: fixed lending empty state rendering for unsupported asset like Linea DAI cp-7.75.0

### DIFF
--- a/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
@@ -63,6 +63,7 @@ export interface EarnLendingBalanceProps {
 }
 
 const { selectEarnTokenPair, selectEarnOutputToken } = earnSelectors;
+
 const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
   const { shouldShowAssetOverviewCta } = useMusdCtaVisibility();
   const dispatch = useDispatch();
@@ -219,7 +220,9 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
     }
 
     const shouldRenderLendingEmptyStateCta =
-      !isAssetReceiptToken && !userHasLendingPositions;
+      !isAssetReceiptToken &&
+      !userHasLendingPositions &&
+      earnToken?.experience.type === EARN_EXPERIENCES.STABLECOIN_LENDING;
 
     if (shouldRenderLendingEmptyStateCta) {
       return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Fixes a bug where the stablecoin lending empty state CTA was rendered for assets that weren't supported **but** were supported for the mUSD conversion feature.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed bug where the stablecoin lending empty state CTA was rendered for assets that weren't supported **but** were supported for the mUSD conversion feature.

## **Related issues**

Fixes: 
- Github issue: https://github.com/MetaMask/metamask-mobile/issues/29504
- Jira ticket: [MUSD-725: Stablecoin lending empty state CTA rendered for unsupported tokens (DAI Linea)](https://consensyssoftware.atlassian.net/browse/MUSD-725)

## **Manual testing steps**

```gherkin
Feature: Stablecoin Lending Empty State CTA rendering behaviour

  Scenario: user does not see the stablecoin lending empty state CTA rendered
    Given user has Linea DAI balance > $0.01

    When user navigates to Linea DAI asset details screen
    And user dismisses the mUSD conversion CTA banner
    Then user does not see the stablecoin lending empty state CTA
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/3f3d9d15-6ae0-47d9-a86c-2e72ed5d80a3

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-logic change that only tightens CTA rendering conditions; low chance of side effects beyond Earn CTA visibility.
> 
> **Overview**
> Fixes an Earn asset-details UI bug where the stablecoin lending *empty state* CTA could appear for unsupported assets.
> 
> `EarnLendingBalance` now renders `EarnEmptyStateCta` only when the token is part of the `STABLECOIN_LENDING` experience (in addition to the existing checks for not being a receipt token and having no lending positions), while still prioritizing the mUSD conversion CTA when applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701ba3106975be40022b48761f7cf8746e3e4ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->