### PR TITLE
chore(predict): track success and error for pwat

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -7990,6 +7990,191 @@ describe('PredictController', () => {
       );
     });
 
+    it('stores paymentTokenAddress in activeBuyOrders when transitioning to DEPOSITING', async () => {
+      await withController(
+        async ({ controller }) => {
+          controller.setSelectedPaymentToken({
+            address: '0xpaymenttoken',
+            chainId: '0x89',
+            symbol: 'USDC',
+          });
+
+          setActiveOrderForTest(controller, {
+            state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+          });
+
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await controller.placeOrder({
+            analyticsProperties: { marketId: 'market-1' },
+            preview,
+            transactionId: 'tx-deposit-1',
+          });
+
+          expect(
+            controller.state.activeBuyOrders[MOCK_ADDRESS]?.paymentTokenAddress,
+          ).toBe('0xpaymenttoken');
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest
+              .fn()
+              .mockReturnValue(REMOTE_FEATURE_FLAG_STATE_WITH_PAY_ANY_TOKEN),
+          },
+        },
+      );
+    });
+
+    it('includes paymentTokenAddress in SUCCEEDED event for pay-with-any-token orders', async () => {
+      const mockResult = {
+        success: true as const,
+        response: {
+          id: 'order-123',
+          spentAmount: '100',
+          receivedAmount: '200',
+        },
+      };
+      await withController(
+        async ({ controller }) => {
+          controller.setSelectedPaymentToken({
+            address: '0xtoken',
+            chainId: '0x89',
+            symbol: 'MATIC',
+          });
+
+          setActiveOrderForTest(controller, {
+            state: ActiveOrderState.PREVIEW,
+          });
+          mockPolymarketProvider.placeOrder.mockResolvedValue(mockResult);
+
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await controller.placeOrder({
+            analyticsProperties: { marketId: 'market-1' },
+            preview,
+          });
+
+          const calls = (analytics.trackEvent as jest.Mock).mock.calls;
+          const succeededCall = calls.find(
+            (call: unknown[]) =>
+              (call[0] as { properties: { status: string } }).properties
+                .status === 'succeeded',
+          );
+
+          expect(succeededCall).toBeDefined();
+          expect(
+            (succeededCall[0] as { properties: Record<string, unknown> })
+              .properties,
+          ).toMatchObject({
+            predict_token_address: '0xtoken',
+          });
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest
+              .fn()
+              .mockReturnValue(REMOTE_FEATURE_FLAG_STATE_WITH_PAY_ANY_TOKEN),
+          },
+        },
+      );
+    });
+
+    it('includes paymentTokenAddress in FAILED event for pay-with-any-token orders', async () => {
+      mockPolymarketProvider.placeOrder.mockRejectedValue(
+        new Error('Order failed'),
+      );
+      await withController(
+        async ({ controller }) => {
+          controller.setSelectedPaymentToken({
+            address: '0xtoken',
+            chainId: '0x89',
+            symbol: 'MATIC',
+          });
+
+          setActiveOrderForTest(controller, {
+            state: ActiveOrderState.PREVIEW,
+          });
+
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await expect(
+            controller.placeOrder({
+              analyticsProperties: { marketId: 'market-1' },
+              preview,
+            }),
+          ).rejects.toThrow('Order failed');
+
+          const calls = (analytics.trackEvent as jest.Mock).mock.calls;
+          const failedCall = calls.find(
+            (call: unknown[]) =>
+              (call[0] as { properties: { status: string } }).properties
+                .status === 'failed',
+          );
+
+          expect(failedCall).toBeDefined();
+          expect(
+            (failedCall[0] as { properties: Record<string, unknown> })
+              .properties,
+          ).toMatchObject({
+            predict_token_address: '0xtoken',
+          });
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest
+              .fn()
+              .mockReturnValue(REMOTE_FEATURE_FLAG_STATE_WITH_PAY_ANY_TOKEN),
+          },
+        },
+      );
+    });
+
+    it('does not include paymentTokenAddress in SUCCEEDED event for balance flow', async () => {
+      const mockResult = {
+        success: true as const,
+        response: {
+          id: 'order-123',
+          spentAmount: '100',
+          receivedAmount: '200',
+        },
+      };
+      await withController(
+        async ({ controller }) => {
+          setActiveOrderForTest(controller, {
+            state: ActiveOrderState.PREVIEW,
+          });
+          mockPolymarketProvider.placeOrder.mockResolvedValue(mockResult);
+
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await controller.placeOrder({
+            analyticsProperties: { marketId: 'market-1' },
+            preview,
+          });
+
+          const calls = (analytics.trackEvent as jest.Mock).mock.calls;
+          const succeededCall = calls.find(
+            (call: unknown[]) =>
+              (call[0] as { properties: { status: string } }).properties
+                .status === 'succeeded',
+          );
+
+          expect(succeededCall).toBeDefined();
+          expect(
+            (succeededCall[0] as { properties: Record<string, unknown> })
+              .properties,
+          ).not.toHaveProperty('predict_token_address');
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest
+              .fn()
+              .mockReturnValue(REMOTE_FEATURE_FLAG_STATE_WITH_PAY_ANY_TOKEN),
+          },
+        },
+      );
+    });
+
     it('does not publish order depositing event when flag is disabled', async () => {
       const mockResult = {
         success: true as const,
@@ -9094,6 +9279,66 @@ describe('PredictController', () => {
         expect(handler).toHaveBeenCalledWith(
           expect.objectContaining({ type: 'order', status: 'failed' }),
         );
+      });
+    });
+
+    it('fires FAILED analytics event with paymentTokenAddress when depositAndOrder fails', () => {
+      withController(({ controller, messenger }) => {
+        setActiveOrderForTest(controller, {
+          state: ActiveOrderState.DEPOSITING,
+          transactionId: 'tx-1',
+          paymentTokenAddress: '0xpaytoken',
+        });
+
+        (
+          controller as unknown as {
+            pendingOrderPreviews: {
+              [transactionId: string]: {
+                preview: OrderPreview;
+                signerAddress: string;
+                analyticsProperties?: { marketId?: string };
+              };
+            };
+          }
+        ).pendingOrderPreviews['tx-1'] = {
+          preview: createMockOrderPreview({ side: Side.BUY }),
+          signerAddress: accountAddress,
+          analyticsProperties: { marketId: 'market-1' },
+        };
+
+        jest
+          .spyOn(controller, 'initPayWithAnyToken')
+          .mockResolvedValue(undefined as never);
+
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictDeposit,
+          status: TransactionStatus.failed,
+        });
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta: {
+            ...transactionMeta,
+            type: TransactionType.predictDepositAndOrder,
+            nestedTransactions: [
+              { type: TransactionType.predictDepositAndOrder },
+            ],
+            error: { message: 'Deposit reverted' },
+          },
+        } as { transactionMeta: TransactionMeta });
+
+        const calls = (analytics.trackEvent as jest.Mock).mock.calls;
+        const failedCall = calls.find(
+          (call: unknown[]) =>
+            (call[0] as { properties: { status: string } }).properties
+              .status === 'failed',
+        );
+
+        expect(failedCall).toBeDefined();
+        expect(
+          (failedCall[0] as { properties: Record<string, unknown> }).properties,
+        ).toMatchObject({
+          predict_token_address: '0xpaytoken',
+        });
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -143,6 +143,7 @@ export type PredictControllerState = {
       transactionId?: string;
       state: ActiveOrderState;
       error?: string;
+      paymentTokenAddress?: string;
     };
   };
 
@@ -1021,6 +1022,8 @@ export class PredictController extends BaseController<
             ActiveOrderState.DEPOSITING;
           state.activeBuyOrders[activeOrderAddress].transactionId =
             transactionId;
+          state.activeBuyOrders[activeOrderAddress].paymentTokenAddress =
+            state.selectedPaymentToken?.address;
         }
       });
 
@@ -1066,9 +1069,17 @@ export class PredictController extends BaseController<
         if (state.activeBuyOrders[activeOrderAddress]) {
           state.activeBuyOrders[activeOrderAddress].state =
             ActiveOrderState.PLACING_ORDER;
+          state.activeBuyOrders[activeOrderAddress].paymentTokenAddress =
+            state.activeBuyOrders[activeOrderAddress].paymentTokenAddress ??
+            state.selectedPaymentToken?.address;
         }
       });
     }
+
+    const paymentTokenAddress = isBuyWithAnyToken
+      ? (this.state.activeBuyOrders[activeOrderAddress]?.paymentTokenAddress ??
+        this.state.selectedPaymentToken?.address)
+      : undefined;
 
     const startTime = performance.now();
     const { analyticsProperties, preview } = params;
@@ -1113,6 +1124,7 @@ export class PredictController extends BaseController<
         analyticsProperties,
         sharePrice,
         orderType: preview.orderType,
+        paymentTokenAddress,
       });
 
       // Invalidate query cache (to avoid nonce issues)
@@ -1192,6 +1204,7 @@ export class PredictController extends BaseController<
         completionDuration,
         sharePrice: realSharePrice,
         orderType: preview.orderType,
+        paymentTokenAddress,
       });
 
       traceData = { success: true, side: preview.side };
@@ -1212,6 +1225,7 @@ export class PredictController extends BaseController<
         completionDuration,
         failureReason: errorMessage,
         orderType: preview.orderType,
+        paymentTokenAddress,
       });
 
       // Update error state for Sentry integration
@@ -2144,6 +2158,17 @@ export class PredictController extends BaseController<
         : null;
       const marketId = pendingOrder?.analyticsProperties?.marketId;
       const outcomeTokenId = pendingOrder?.preview?.outcomeTokenId;
+
+      // Track deposit failure analytics with payment token
+      this.trackPredictOrderEvent({
+        status: PredictTradeStatus.FAILED,
+        analyticsProperties: pendingOrder?.analyticsProperties,
+        failureReason:
+          transactionMeta.error?.message ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED,
+        paymentTokenAddress:
+          this.state.activeBuyOrders[address]?.paymentTokenAddress,
+        orderType: pendingOrder?.preview?.orderType,
+      });
 
       const isBackgroundOrder =
         transactionId !== undefined &&


### PR DESCRIPTION
# **Description**

Currently `paymentTokenAddress` is only sent on the initial SUBMITTED analytics event when a pay-with-any-token order enters the DEPOSITING state. The second SUBMITTED (actual order placement), SUCCEEDED, and FAILED events do not include it, and deposit failures fire no analytics event at all.

This PR:
- Persists `paymentTokenAddress` on `activeBuyOrders[address]` when the order begins (DEPOSITING and PLACING_ORDER transitions) so the value survives `selectedPaymentToken` being cleared on error paths.
- Passes `paymentTokenAddress` to all three `trackPredictOrderEvent` calls in `placeOrder()` — SUBMITTED, SUCCEEDED, and FAILED.
- Fires a new FAILED analytics event in `handleTransactionSideEffects` when a `depositAndOrder` transaction fails, including `paymentTokenAddress` from the stored active order.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: paymentTokenAddress tracked on order success and failure

  Scenario: user places a pay-with-any-token order that succeeds
    Given user is on the Predict buy screen with an external payment token selected
    When user places a buy order and the order succeeds
    Then the SUCCEEDED analytics event includes predict_token_address matching the selected token

  Scenario: user places a pay-with-any-token order that fails
    Given user is on the Predict buy screen with an external payment token selected
    When user places a buy order and the order fails
    Then the FAILED analytics event includes predict_token_address matching the selected token

  Scenario: deposit-and-order transaction fails before order placement
    Given user initiated a deposit-and-order flow with an external payment token
    When the deposit transaction fails on-chain
    Then a FAILED analytics event fires with predict_token_address from the stored active order

  Scenario: user places a direct balance order
    Given user is on the Predict buy screen with Predict balance selected (no external token)
    When user places a buy order
    Then the SUBMITTED, SUCCEEDED, and FAILED analytics events do not include predict_token_address
```

## **Screenshots/Recordings**

N/A — analytics-only change with no UI impact.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Predict order/deposit flow by persisting `paymentTokenAddress` on `activeBuyOrders` and emitting additional FAILED analytics on `depositAndOrder` failures; risk is mainly around order-state transitions and potential null/incorrect token attribution, not funds movement.
> 
> **Overview**
> Ensures pay-with-any-token (PWAT) orders consistently attribute analytics to the chosen payment token by persisting `paymentTokenAddress` on `activeBuyOrders` during the `DEPOSITING`/`PLACING_ORDER` transitions and reusing it even if `selectedPaymentToken` is later cleared.
> 
> Updates `placeOrder()` to pass `paymentTokenAddress` into the SUBMITTED/SUCCEEDED/FAILED `trackPredictOrderEvent` calls for PWAT buys, and adds a new FAILED analytics event when a `depositAndOrder` transaction fails (sourced from the stored active order). Tests were expanded to cover these new analytics/state behaviors and to ensure the balance flow does not emit `predict_token_address`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fc91b68c9e3470ca70acef3bb2a32edcd59bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->