### PR TITLE
fix(card): preserve Card Home data during refresh

### DIFF
--- a/app/components/UI/Card/hooks/useCardHomeData.test.ts
+++ b/app/components/UI/Card/hooks/useCardHomeData.test.ts
@@ -149,6 +149,12 @@ describe('useCardHomeData', () => {
       expect(result.current.isLoading).toBe(true);
     });
 
+    it("is false when status is 'loading' with cached data", () => {
+      setupSelectors({ primaryFundingAsset: null }, 'loading');
+      const { result } = renderHook(() => useCardHomeData());
+      expect(result.current.isLoading).toBe(false);
+    });
+
     it("is false when status is 'success'", () => {
       setupSelectors({ primaryFundingAsset: null }, 'success');
       const { result } = renderHook(() => useCardHomeData());
@@ -169,6 +175,12 @@ describe('useCardHomeData', () => {
       expect(result.current.isError).toBe(true);
     });
 
+    it("is false when status is 'error' with cached data", () => {
+      setupSelectors({ primaryFundingAsset: null }, 'error');
+      const { result } = renderHook(() => useCardHomeData());
+      expect(result.current.isError).toBe(false);
+    });
+
     it("is false when status is 'success'", () => {
       setupSelectors({ primaryFundingAsset: null }, 'success');
       const { result } = renderHook(() => useCardHomeData());
@@ -179,6 +191,20 @@ describe('useCardHomeData', () => {
       setupSelectors(null, 'idle');
       const { result } = renderHook(() => useCardHomeData());
       expect(result.current.isError).toBe(false);
+    });
+  });
+
+  describe('isRefreshing', () => {
+    it("is true when status is 'loading' with cached data", () => {
+      setupSelectors({ primaryFundingAsset: null }, 'loading');
+      const { result } = renderHook(() => useCardHomeData());
+      expect(result.current.isRefreshing).toBe(true);
+    });
+
+    it("is false when status is 'loading' without cached data", () => {
+      setupSelectors(null, 'loading');
+      const { result } = renderHook(() => useCardHomeData());
+      expect(result.current.isRefreshing).toBe(false);
     });
   });
 

--- a/app/components/UI/Card/hooks/useCardHomeData.ts
+++ b/app/components/UI/Card/hooks/useCardHomeData.ts
@@ -98,10 +98,13 @@ export const useCardHomeData = () => {
     [fundingTokensRaw, balanceMap],
   );
 
+  const hasData = data !== null;
+
   return {
     data,
-    isLoading: status === 'loading' || status === 'idle',
-    isError: status === 'error',
+    isLoading: !hasData && (status === 'loading' || status === 'idle'),
+    isRefreshing: hasData && status === 'loading',
+    isError: !hasData && status === 'error',
     refetch,
     primaryToken,
     availableTokens,

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -1,5 +1,14 @@
 import axios, { isAxiosError } from 'axios';
 import { BaanxService } from '../services/BaanxService';
+import { CardStatus, CardType } from '../../../../../components/UI/Card/types';
+import {
+  CardAccountStatus,
+  CardAction,
+  CardDetails,
+  CardFundingAsset,
+  FundingAssetStatus,
+} from '../provider-types';
+import { BaanxProvider } from './BaanxProvider';
 
 jest.mock('axios');
 jest.mock('../../../../../util/Logger');
@@ -259,6 +268,66 @@ describe('BaanxService', () => {
           headers: expect.objectContaining({ 'x-us-env': 'true' }),
         }),
       );
+    });
+  });
+});
+
+describe('BaanxProvider', () => {
+  describe('buildActions', () => {
+    const provider = new BaanxProvider({ service: {} as BaanxService });
+    const buildActions = (
+      asset: CardFundingAsset | null,
+      card: CardDetails | null,
+      account: CardAccountStatus | null,
+    ) =>
+      (
+        provider as unknown as {
+          buildActions: (
+            asset: CardFundingAsset | null,
+            card: CardDetails | null,
+            account: CardAccountStatus | null,
+          ) => CardAction[];
+        }
+      ).buildActions(asset, card, account);
+
+    const asset: CardFundingAsset = {
+      symbol: 'USDC',
+      name: 'USD Coin',
+      address: '0xusdc',
+      walletAddress: '0xwallet',
+      decimals: 6,
+      chainId: 'eip155:59144',
+      spendableBalance: '100',
+      spendingCap: '100',
+      priority: 1,
+      status: FundingAssetStatus.Active,
+    };
+
+    const account: CardAccountStatus = {
+      verificationStatus: 'VERIFIED',
+      provisioningEligible: true,
+      holderName: 'Test User',
+      shippingAddress: null,
+    };
+
+    const card: CardDetails = {
+      id: 'card-1',
+      status: CardStatus.ACTIVE,
+      type: CardType.VIRTUAL,
+      lastFour: '1234',
+      isFreezable: true,
+    };
+
+    it('keeps add funds available when the card is frozen', () => {
+      expect(
+        buildActions(asset, { ...card, status: CardStatus.FROZEN }, account),
+      ).toStrictEqual([{ type: 'add_funds', enabled: true }]);
+    });
+
+    it('does not show add funds when the card is blocked', () => {
+      expect(
+        buildActions(asset, { ...card, status: CardStatus.BLOCKED }, account),
+      ).toStrictEqual([]);
     });
   });
 });

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -1502,7 +1502,7 @@ export class BaanxProvider implements ICardProvider {
       return [{ type: 'enable_card' }];
     }
 
-    if (card.status === CardStatus.ACTIVE && asset) {
+    if (card.status !== CardStatus.BLOCKED && asset) {
       return [{ type: 'add_funds', enabled: true }];
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a Card Home refresh state issue where cached card data could briefly be replaced by skeleton loading UI during a background refresh. The Card Home hook now distinguishes initial loading from refresh loading, so skeletons only render when there is no cached data available.

It also keeps the Add funds action available for frozen cards. Frozen cards should still allow funding actions; only blocked cards suppress the Add funds action.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Card Home flickering during refresh and kept Add funds available for frozen cards

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card Home refresh state

  Scenario: Card Home refreshes with cached data
    Given a user has Card Home data loaded
    When Card Home starts a background refresh
    Then the existing card data remains visible
    And skeleton loading UI is not shown over the cached data

  Scenario: User freezes a card
    Given a user has an active card with a funding asset
    When the user freezes the card
    Then the card shows the frozen state
    And the Add funds button remains visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect UI state rendering during fetches and the availability of the `add_funds` action, which could alter user-visible behavior if edge cases around cached data or card statuses are missed.
> 
> **Overview**
> Card Home data loading flags are adjusted so cached `selectCardHomeData` is preserved during background fetches: `isLoading`/`isError` now only apply when *no cached data* exists, and a new `isRefreshing` flag signals `status === 'loading'` with cached data.
> 
> Baanx card actions logic is loosened so `add_funds` remains available for any non-`BLOCKED` card status (including `FROZEN`), with new unit tests covering both the refreshed hook state and the frozen/blocked action behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b23146789a6a04943b93ed49d855090464e269a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->