### PR TITLE
test: Fix SmokeTrade E2E tests

### DIFF
--- a/tests/helpers/swap/swap-mocks.ts
+++ b/tests/helpers/swap/swap-mocks.ts
@@ -6,6 +6,7 @@ import {
   setupMockRequest,
   setupSSEMockRequest,
 } from '../../api-mocking/helpers/mockHelpers';
+import { getDecodedProxiedURL } from '../../smoke/notifications/utils/helpers';
 import {
   GET_QUOTE_ETH_USDC_RESPONSE,
   GET_QUOTE_ETH_USDC_RESPONSE_CUSTOM_SLIPPAGE,
@@ -29,6 +30,9 @@ const USDT_MAINNET = '0xdac17f958d2ee523a2206206994597c13d831ec7';
 const WETH_MAINNET = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const GOOGLON_MAINNET = '0xba47214edd2bb43099611b208f75e4b42fdcfedc';
 const MUSD_MAINNET = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/** SocialService leaderboard response shape (empty list is valid for E2E). */
+const SOCIAL_LEADERBOARD_EMPTY_RESPONSE = { traders: [] };
 
 /**
  * Mock spot prices so balance display (balance * price) does not show NaN.
@@ -77,10 +81,64 @@ export async function setupSpotPricesMock(mockServer: Mockttp): Promise<void> {
   });
 }
 
+/**
+ * Social leaderboard + compliance batch — used by swap `testSpecificMock` and
+ * bridge/trending specs that do not use swap-mocks’ full mock bundle.
+ */
+export async function setupSwapSocialAndComplianceMocks(
+  mockServer: Mockttp,
+): Promise<void> {
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: /social\.api\.cx\.metamask\.io\/api\/v1\/leaderboard/,
+      response: SOCIAL_LEADERBOARD_EMPTY_RESPONSE,
+      responseCode: 200,
+    },
+    1001,
+  );
+
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      try {
+        const decodedUrl = getDecodedProxiedURL(request.url);
+        return /compliance\.(dev-api|api|uat-api)\.cx\.metamask\.io\/v1\/wallet\/batch/.test(
+          decodedUrl,
+        );
+      } catch {
+        return false;
+      }
+    })
+    .asPriority(1001)
+    .thenCallback(async (request) => {
+      let addresses: string[] = [];
+      try {
+        const text = await request.body.getText();
+        if (text) {
+          const parsed = JSON.parse(text) as unknown;
+          if (Array.isArray(parsed)) {
+            addresses = parsed.filter(
+              (a): a is string => typeof a === 'string',
+            );
+          }
+        }
+      } catch {
+        /* ignore malformed body */
+      }
+      return {
+        statusCode: 200,
+        json: addresses.map((address) => ({ address, blocked: false })),
+      };
+    });
+}
+
 export const testSpecificMock: TestSpecificMock = async (
   mockServer: Mockttp,
 ) => {
   await setupSpotPricesMock(mockServer);
+  await setupSwapSocialAndComplianceMocks(mockServer);
 
   // Catch-all for getQuoteStream with no slippage param (initial render before
   // useInitialSlippage fires). Registered first so specific mocks below at

--- a/tests/helpers/swap/swap-mocks.ts
+++ b/tests/helpers/swap/swap-mocks.ts
@@ -206,7 +206,10 @@ export const testSpecificMock: TestSpecificMock = async (
 
   await interceptProxyUrl(
     mockServer,
-    (url) => url.includes('getQuote') && url.includes('insufficientBal=false'),
+    (url) =>
+      url.includes('getQuote') &&
+      !url.includes('getQuoteStream') &&
+      url.includes('insufficientBal=false'),
     (url) => url.replace('insufficientBal=false', 'insufficientBal=true'),
   );
 };

--- a/tests/helpers/swap/swap-unified-ui.ts
+++ b/tests/helpers/swap/swap-unified-ui.ts
@@ -33,13 +33,11 @@ export async function submitSwapUnifiedUI(
   await QuoteView.tapDestinationToken();
   await QuoteView.tapToken(chainId, destTokenSymbol);
 
-  const networkFeeLabelWaitStarted = Date.now();
+  const getQuoteStarted = Date.now();
   await Assertions.expectElementToBeVisible(QuoteView.networkFeeLabel, {
     timeout: 60000,
   });
-  logger.debug(
-    `✅✅✅✅ network fee label visible after ${Date.now() - networkFeeLabelWaitStarted}ms`,
-  );
+  logger.debug(`⏳ Quote visible after ${Date.now() - getQuoteStarted}ms`);
 
   // Dismiss the keypad so quote details (slippage, confirm) are not obscured
   await QuoteView.dismissKeypad();
@@ -53,13 +51,7 @@ export async function submitSwapUnifiedUI(
     await QuoteView.verifySlippageDisplayed(DEFAULT_SLIPPAGE_VALUE);
   }
 
-  const confirmSwapWaitStarted = Date.now();
-  await Assertions.expectElementToBeVisible(QuoteView.confirmSwap, {
-    timeout: 30000,
-  });
-  logger.debug(
-    `✅✅✅✅ confirm swap visible after ${Date.now() - confirmSwapWaitStarted}ms`,
-  );
+  await Assertions.expectElementToBeVisible(QuoteView.confirmSwap);
 
   await QuoteView.tapConfirmSwap();
 }

--- a/tests/helpers/swap/swap-unified-ui.ts
+++ b/tests/helpers/swap/swap-unified-ui.ts
@@ -46,7 +46,9 @@ export async function submitSwapUnifiedUI(
     await QuoteView.verifySlippageDisplayed(DEFAULT_SLIPPAGE_VALUE);
   }
 
-  await Assertions.expectElementToBeVisible(QuoteView.confirmSwap);
+  await Assertions.expectElementToBeVisible(QuoteView.confirmSwap, {
+    timeout: 30000,
+  });
 
   await QuoteView.tapConfirmSwap();
 }

--- a/tests/helpers/swap/swap-unified-ui.ts
+++ b/tests/helpers/swap/swap-unified-ui.ts
@@ -1,8 +1,11 @@
 import QuoteView from '../../page-objects/swaps/QuoteView';
 import SlippageModal from '../../page-objects/swaps/SlippageModal';
 import { Assertions } from '../../framework';
+import { createLogger } from '../../framework/logger';
 import ActivitiesView from '../../page-objects/Transactions/ActivitiesView';
 import { ActivitiesViewSelectorsText } from '../../../app/components/Views/ActivityView/ActivitiesView.testIds';
+
+const logger = createLogger({ name: 'SwapUnifiedUI' });
 
 interface SwapOptions {
   /** Custom slippage percentage (e.g., "2.5" for 2.5%) */
@@ -30,9 +33,13 @@ export async function submitSwapUnifiedUI(
   await QuoteView.tapDestinationToken();
   await QuoteView.tapToken(chainId, destTokenSymbol);
 
+  const networkFeeLabelWaitStarted = Date.now();
   await Assertions.expectElementToBeVisible(QuoteView.networkFeeLabel, {
     timeout: 60000,
   });
+  logger.debug(
+    `✅✅✅✅ network fee label visible after ${Date.now() - networkFeeLabelWaitStarted}ms`,
+  );
 
   // Dismiss the keypad so quote details (slippage, confirm) are not obscured
   await QuoteView.dismissKeypad();
@@ -46,9 +53,13 @@ export async function submitSwapUnifiedUI(
     await QuoteView.verifySlippageDisplayed(DEFAULT_SLIPPAGE_VALUE);
   }
 
+  const confirmSwapWaitStarted = Date.now();
   await Assertions.expectElementToBeVisible(QuoteView.confirmSwap, {
     timeout: 30000,
   });
+  logger.debug(
+    `✅✅✅✅ confirm swap visible after ${Date.now() - confirmSwapWaitStarted}ms`,
+  );
 
   await QuoteView.tapConfirmSwap();
 }

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -62,9 +62,9 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 10000));
+          // eslint-disable-next-line no-restricted-syntax
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_FULL,
@@ -125,9 +125,9 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 10000));
+          // eslint-disable-next-line no-restricted-syntax
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_BASE,
@@ -183,9 +183,9 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 10000));
+          // eslint-disable-next-line no-restricted-syntax
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
             url: invalidDeeplink,

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -11,6 +11,7 @@ import Assertions from '../../framework/Assertions';
 import { asDetoxElement } from '../../framework';
 import QuoteView from '../../page-objects/swaps/QuoteView';
 import { testSpecificMock } from '../../helpers/swap/swap-mocks';
+import TestHelpers from '../../helpers';
 import WalletView from '../../page-objects/wallet/WalletView';
 
 // Deep link URLs for testing unified swap/bridge experience
@@ -63,8 +64,7 @@ describe(
           await loginToApp();
           await device.sendToHome();
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          // eslint-disable-next-line no-restricted-syntax
-          await new Promise((r) => setTimeout(r, 1000));
+          if (device.getPlatform() === 'ios') await TestHelpers.delay(1000);
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_FULL,
@@ -126,8 +126,7 @@ describe(
           await loginToApp();
           await device.sendToHome();
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          // eslint-disable-next-line no-restricted-syntax
-          await new Promise((r) => setTimeout(r, 1000));
+          if (device.getPlatform() === 'ios') await TestHelpers.delay(1000);
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_BASE,
@@ -184,8 +183,7 @@ describe(
           await loginToApp();
           await device.sendToHome();
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          // eslint-disable-next-line no-restricted-syntax
-          await new Promise((r) => setTimeout(r, 1000));
+          if (device.getPlatform() === 'ios') await TestHelpers.delay(1000);
           await device.launchApp({
             newInstance: false,
             url: invalidDeeplink,

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -64,7 +64,7 @@ describe(
           await device.sendToHome();
           // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 1000));
+          await new Promise((r) => setTimeout(r, 10000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_FULL,
@@ -127,7 +127,7 @@ describe(
           await device.sendToHome();
           // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 1000));
+          await new Promise((r) => setTimeout(r, 10000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_BASE,
@@ -185,7 +185,7 @@ describe(
           await device.sendToHome();
           // eslint-disable-next-line no-restricted-syntax
           // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 1000));
+          await new Promise((r) => setTimeout(r, 10000));
           await device.launchApp({
             newInstance: false,
             url: invalidDeeplink,

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -126,7 +126,8 @@ describe(
           await loginToApp();
           await device.sendToHome();
           // eslint-disable-next-line no-restricted-syntax
-          // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).          await new Promise((r) => setTimeout(r, 1000));
+          // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_BASE,

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -62,7 +62,10 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
+          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
+            newInstance: false,
             url: SWAP_DEEPLINK_FULL,
           });
 
@@ -121,7 +124,10 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
+          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
+            newInstance: false,
             url: SWAP_DEEPLINK_BASE,
           });
 
@@ -175,7 +181,10 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
+          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
+            newInstance: false,
             url: invalidDeeplink,
           });
 

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -62,7 +62,8 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          // eslint-disable-next-line no-restricted-syntax
+          // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
           await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
@@ -124,8 +125,8 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
-          await new Promise((r) => setTimeout(r, 1000));
+          // eslint-disable-next-line no-restricted-syntax
+          // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).          await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,
             url: SWAP_DEEPLINK_BASE,
@@ -181,7 +182,8 @@ describe(
         async () => {
           await loginToApp();
           await device.sendToHome();
-          // Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
+          // eslint-disable-next-line no-restricted-syntax
+          // intentional: Detox iOS 16+ sendToHome briefly opens Settings; wait before launchApp({ url }).
           await new Promise((r) => setTimeout(r, 1000));
           await device.launchApp({
             newInstance: false,

--- a/tests/smoke/swap/swap-trending-tokens.spec.ts
+++ b/tests/smoke/swap/swap-trending-tokens.spec.ts
@@ -11,6 +11,7 @@ import TokenOverview from '../../page-objects/wallet/TokenOverview';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment';
 import { testSpecificMock } from '../../helpers/swap/bridge-mocks';
+import { setupSwapSocialAndComplianceMocks } from '../../helpers/swap/swap-mocks';
 import { GET_QUOTE_ETH_USDC_RESPONSE } from '../../helpers/swap/constants';
 import { getDecodedProxiedURL } from '../notifications/utils/helpers';
 import { SmokeSwap } from '../../tags';
@@ -62,8 +63,6 @@ const TRENDING_ALL_NETWORKS_RESPONSE = [
 
 const TRENDING_BASE_ONLY_RESPONSE = [TRENDING_ALL_NETWORKS_RESPONSE[1]];
 
-const SOCIAL_LEADERBOARD_EMPTY_RESPONSE = { traders: [] };
-
 const setupSwapsTrendingTokensMock = async (mockServer: Mockttp) => {
   const { response } = createRemoteFeatureFlagsMock({
     swapsTrendingTokens: true,
@@ -80,48 +79,7 @@ const setupSwapsTrendingTokensMock = async (mockServer: Mockttp) => {
     1001,
   );
 
-  await setupMockRequest(
-    mockServer,
-    {
-      requestMethod: 'GET',
-      url: /social\.api\.cx\.metamask\.io\/api\/v1\/leaderboard/,
-      response: SOCIAL_LEADERBOARD_EMPTY_RESPONSE,
-      responseCode: 200,
-    },
-    1001,
-  );
-
-  await mockServer
-    .forPost('/proxy')
-    .matching((request) => {
-      try {
-        const decodedUrl = getDecodedProxiedURL(request.url);
-        return /compliance\.(dev-api|api|uat-api)\.cx\.metamask\.io\/v1\/wallet\/batch/.test(
-          decodedUrl,
-        );
-      } catch {
-        return false;
-      }
-    })
-    .asPriority(1001)
-    .thenCallback(async (request) => {
-      let addresses: string[] = [];
-      try {
-        const text = await request.body.getText();
-        if (text) {
-          const parsed = JSON.parse(text) as unknown;
-          if (Array.isArray(parsed)) {
-            addresses = parsed.filter(
-              (a): a is string => typeof a === 'string',
-            );
-          }
-        }
-      } catch {
-        /* ignore malformed body */
-      }
-      const json = addresses.map((address) => ({ address, blocked: false }));
-      return { statusCode: 200, json };
-    });
+  await setupSwapSocialAndComplianceMocks(mockServer);
 };
 
 const setupTrendingTokensMock = async (mockServer: Mockttp) => {

--- a/tests/smoke/swap/swap-trending-tokens.spec.ts
+++ b/tests/smoke/swap/swap-trending-tokens.spec.ts
@@ -62,6 +62,8 @@ const TRENDING_ALL_NETWORKS_RESPONSE = [
 
 const TRENDING_BASE_ONLY_RESPONSE = [TRENDING_ALL_NETWORKS_RESPONSE[1]];
 
+const SOCIAL_LEADERBOARD_EMPTY_RESPONSE = { traders: [] };
+
 const setupSwapsTrendingTokensMock = async (mockServer: Mockttp) => {
   const { response } = createRemoteFeatureFlagsMock({
     swapsTrendingTokens: true,
@@ -77,6 +79,49 @@ const setupSwapsTrendingTokensMock = async (mockServer: Mockttp) => {
     },
     1001,
   );
+
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: /social\.api\.cx\.metamask\.io\/api\/v1\/leaderboard/,
+      response: SOCIAL_LEADERBOARD_EMPTY_RESPONSE,
+      responseCode: 200,
+    },
+    1001,
+  );
+
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      try {
+        const decodedUrl = getDecodedProxiedURL(request.url);
+        return /compliance\.(dev-api|api|uat-api)\.cx\.metamask\.io\/v1\/wallet\/batch/.test(
+          decodedUrl,
+        );
+      } catch {
+        return false;
+      }
+    })
+    .asPriority(1001)
+    .thenCallback(async (request) => {
+      let addresses: string[] = [];
+      try {
+        const text = await request.body.getText();
+        if (text) {
+          const parsed = JSON.parse(text) as unknown;
+          if (Array.isArray(parsed)) {
+            addresses = parsed.filter(
+              (a): a is string => typeof a === 'string',
+            );
+          }
+        }
+      } catch {
+        /* ignore malformed body */
+      }
+      const json = addresses.map((address) => ({ address, blocked: false }));
+      return { statusCode: 200, json };
+    });
 };
 
 const setupTrendingTokensMock = async (mockServer: Mockttp) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR should fix the following SmokeTrade tests:

[SmokeTrade: Swap from Actions swaps ETH->USDC with custom slippage and USDC->ETH](https://github.com/MetaMask/metamask-mobile/blob/main/tests/smoke/swap/swap-action-smoke.spec.ts) (failed 1 time, 0 retries) - [last log](https://github.com/MetaMask/metamask-mobile/actions/runs/25038568774/job/73337207314)

[SmokeTrade: Swap Deep Link Tests - Unified Bridge Experience navigate to bridge view with full parameters (USDC to USDT)](https://github.com/MetaMask/metamask-mobile/blob/main/tests/smoke/swap/swap-deeplink-smoke.spec.ts) (failed 1 time, 0 retries) - [last log](https://github.com/MetaMask/metamask-mobile/actions/runs/25126033339/job/73641257634)

[SmokeTrade: Gasless Swap - completes a gasless 7702 ETH to MUSD swap (native source)](https://github.com/MetaMask/metamask-mobile/blob/main/tests/smoke/swap/gasless-swap.spec.ts) (failed 1 time, 0 retries) - [last log](https://github.com/MetaMask/metamask-mobile/actions/runs/25119563042/job/73618309111)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust Detox app launching behavior and add additional HTTP mocks; low risk to production code, with minor risk of masking real integration issues if mock matching is too broad.
> 
> **Overview**
> Stabilizes swap deeplink smoke tests on iOS by adding a short post-`sendToHome()` delay and launching deeplinks with `newInstance: false` to ensure URLs are delivered to the existing app instance.
> 
> Expands swap E2E mocking by introducing reusable `setupSwapSocialAndComplianceMocks()` to stub the Social leaderboard and compliance batch endpoints, wiring it into swap and trending-token smoke setups. Also tightens the swap proxy URL interception so the `insufficientBal` rewrite only targets JSON `getQuote` requests (not `getQuoteStream`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbfe2c5137f11d4968fe4e7a5088ccc3e55de20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->