### PR TITLE
chore: ramps-controller preview b9e7d98a6 (core#8574)

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.0.2",
-    "@metamask/ramps-controller": "^13.2.0",
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@13.2.0-preview-b9e7d98a6",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/react-native-acm": "1.2.0",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9649,6 +9649,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@13.2.0-preview-b9e7d98a6":
+  version: 13.2.0-preview-b9e7d98a6
+  resolution: "@metamask-previews/ramps-controller@npm:13.2.0-preview-b9e7d98a6"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/messenger": "npm:^1.1.1"
+  checksum: 10/4c8c8767b94b914815d7982b207149662c7e1a6e456004a30172e66ec0c3c9bfa4b2e3ed8acf4bf95d7d38af61fca8841dc785c4a32656fda550422819408cf5
+  languageName: node
+  linkType: hard
+
 "@metamask/ramps-controller@npm:^13.2.0":
   version: 13.2.0
   resolution: "@metamask/ramps-controller@npm:13.2.0"
@@ -35711,7 +35722,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^13.2.0"
+    "@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@13.2.0-preview-b9e7d98a6"
     "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/react-native-acm": "npm:1.2.0"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## Summary

Draft PR to validate **MetaMask/core** [\#8574](https://github.com/MetaMask/core/pull/8574) on mobile.

- Bumps `@metamask/ramps-controller` to install [`@metamask-previews/ramps-controller@13.2.0-preview-b9e7d98a6`](https://www.npmjs.com/package/@metamask-previews/ramps-controller/v/13.2.0-preview-b9e7d98a6) via Yarn `npm:` alias so existing `@metamask/ramps-controller` imports are unchanged.

## Verification

- [ ] `yarn install` (lockfile updated)
- [ ] Smoke ramps / on-ramp flows in dev build as needed

**Do not merge** until the core PR ships a stable release and mobile moves back to `@metamask/ramps-controller@^x`.

Made with [Cursor](https://cursor.com)