### PR TITLE
ci: fix `get-requirements.yml` checks for `pull_request` events

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 1
 
       - name: Fetch HEAD commit for message checks
-        if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
+        if: ${{ steps.skip-merge-queue.outputs.up-to-date != 'true' }}
         run: git fetch --depth=1 origin "${HEAD_COMMIT_HASH}"
 
       - name: Check skip E2E commit tag

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -55,7 +55,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          ref: ${{ env.HEAD_COMMIT_HASH }}
+
+      - name: Fetch HEAD commit for message checks
+        if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
+        run: git fetch --depth=1 origin "${HEAD_COMMIT_HASH}"
 
       - name: Check skip E2E commit tag
         id: skip-e2e-tag


### PR DESCRIPTION
## **Description**

When triggered by a `pull_request` event, the `get-requirements` workflow was checking out the wrong commit. It was using the tip of the `head` branch rather than `github.ref` (the tip of the pull request merge branch), which is what all of our other CI steps use.

As a consequence of this, files that are expected by `get-requirements` to exist may not exist (as we saw already with the `filter` step breaking on outdated PRs). But even more concerningly, the filter step will be using the _wrong diff_ to compute which checks are needed.

This has been fixed by removing the `ref` from the checkout step. The default ref (`github.ref`) is correct in this case. The filter step didn't need any adjustment either; `dorny/paths-filter` is already using the merge-base of the default branch (or PR base branch) and `github.ref` as the point of comparison by default.

## **Changelog**

CHANGELOG entry: N/A

## **Related issues**

This fixes a workflow bug introduced in https://github.com/MetaMask/metamask-mobile/pull/29305

This same bug was fixed in extension repository in this PR: https://github.com/MetaMask/metamask-extension/pull/39949/

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

Example failure: https://github.com/MetaMask/metamask-mobile/actions/runs/25134312565/job/73668793672?pr=29495

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating logic for which jobs run by altering what commit/ref is checked out and compared, so misconfiguration could incorrectly skip or run required checks. Scope is limited to a single GitHub Actions workflow.
> 
> **Overview**
> Fixes `get-requirements.yml` so `pull_request` runs operate on the default checked-out ref (the PR merge ref) instead of forcing `actions/checkout` to `HEAD_COMMIT_HASH`, ensuring file filtering and job requirement decisions are computed against the correct diff.
> 
> Adds an explicit `git fetch` of `HEAD_COMMIT_HASH` so the workflow can still inspect the latest head commit message (e.g., `[skip-e2e]`) without changing the working tree ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5de72bf89a3906634708935d7f88707868bc22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->