### PR TITLE
test: validate TRAM-3475 ramps-controller preview build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "metamask",
   "version": "7.76.0",
   "private": true,
+  "previewBuilds": {
+    "@metamask/ramps-controller": {
+      "type": "non-breaking",
+      "previewVersion": "13.2.0-preview-7cef09c77"
+    }
+  },
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",
     "anvil": "node_modules/.bin/anvil",
@@ -200,6 +206,7 @@
     "bn.js@npm:4.11.6": "4.12.3",
     "bn.js@npm:5.2.1": "5.2.3",
     "expo-web-browser@npm:~14.0.2": "patch:expo-web-browser@npm%3A14.0.2#~/.yarn/patches/expo-web-browser-npm-14.0.2-98d00ce880.patch",
+    "@metamask/messenger": "^1.2.0",
     "@metamask/messenger@^0.3.0": "^1.0.0",
     "@metamask/accounts-controller": "^37.2.0",
     "@metamask/profile-sync-controller": "^28.0.2",
@@ -286,7 +293,7 @@
     "@metamask/keyring-utils": "^3.2.0",
     "@metamask/logging-controller": "^8.0.0",
     "@metamask/message-signing-snap": "^1.1.2",
-    "@metamask/messenger": "^1.1.0",
+    "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9166,9 +9166,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0, @metamask/messenger@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@metamask/messenger@npm:1.1.1"
+"@metamask/messenger@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@metamask/messenger@npm:1.2.0"
   dependencies:
     "@metamask/utils": "npm:^11.9.0"
     yargs: "npm:^17.7.2"
@@ -9176,7 +9176,7 @@ __metadata:
     typescript: ">=5.0.0"
   bin:
     messenger-generate-action-types: ./dist/generate-action-types/cli.mjs
-  checksum: 10/a959af95e9e117aa0f7ad1c280f7817fef2c0b575c76837b1a6c884c9c9ef1dd0faeaef0c2c0c2035f68c7638d1f87cd172956ee962dec97d8ab6176fa6964e3
+  checksum: 10/6818e4609d6162a436cc07955905f9e57ff6dbef841e9066a5fb9cc0538e981526fbcb5eef1fa1968d79212d57ddda2fce4dda5f87eb64d8d98f7db1216a6a98
   languageName: node
   linkType: hard
 
@@ -9649,14 +9649,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^13.2.0":
-  version: 13.2.0
-  resolution: "@metamask/ramps-controller@npm:13.2.0"
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@13.2.0-preview-7cef09c77":
+  version: 13.2.0-preview-7cef09c77
+  resolution: "@metamask-previews/ramps-controller@npm:13.2.0-preview-7cef09c77"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/messenger": "npm:^1.1.1"
-  checksum: 10/17ce6e74c5a2894c7fbe3ee3a6c39cd820212de04a7dda86324293f9f09fdf03e9ccc11d9d29cd7131f01ec62073eb4cc8e7cb321de40c956bb52b1dce774f95
+    "@metamask/messenger": "npm:^1.2.0"
+  checksum: 10/fc22916bd9585e9cdc09560480018589490e1fba9c39e9f32fa2b9e9cb242445c1c75ed94f0cfdac86b6183dc9a7c276d208af339a3f37fb8c8c6a91124e0a19
   languageName: node
   linkType: hard
 
@@ -35686,7 +35686,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.2.0"
     "@metamask/logging-controller": "npm:^8.0.0"
     "@metamask/message-signing-snap": "npm:^1.1.2"
-    "@metamask/messenger": "npm:^1.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:3.1.1"
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"


### PR DESCRIPTION
## Summary
- consume the published `@metamask/ramps-controller` preview build from `MetaMask/core#8596`
- keep this isolated on top of the existing mobile companion branch so we can validate the packaged artifact without muddying the feature PR
- align `@metamask/messenger` onto `^1.2.0` via `dependencies` and `resolutions` so the preview package does not introduce a second nominally-incompatible `Messenger` type into the mobile tree

## Why
Amitab asked us to publish a preview of the core PR and validate it from mobile. When I first switched mobile to `@metamask-previews/ramps-controller@13.2.0-preview-7cef09c77`, `yarn lint:tsc` failed because mobile resolved two different `@metamask/messenger` versions (`1.1.1` and `1.2.0`). Since `Messenger` has a private field, TypeScript treats those versions as incompatible nominal types. This PR shows the minimal consumer-side alignment needed for the previewed ramps package to typecheck cleanly.

## Validation
- `yarn install`
- `yarn lint:tsc`
- `./node_modules/.bin/jest --runTestsByPath app/components/UI/Ramp/utils/parseUserFacingError.test.ts app/components/UI/Ramp/hooks/useRampsProviders.test.ts app/components/UI/Ramp/hooks/useRampsCountries.test.ts app/components/UI/Ramp/hooks/useRampsTokens.test.ts app/components/UI/Ramp/hooks/useRampsPaymentMethods.test.ts --runInBand`

## Notes
- This PR targets `saustrie-consensys/TRAM-3475-circuit-breaker-open-error` intentionally, so the diff stays focused on the preview-consumer changes only.
- Local `lint:tsc` also requires the repo's generated `app/util/termsOfUse/termsOfUseContent.ts` artifact to exist, which is already present in the main mobile worktree and is generated by `scripts/setup.mjs` in clean environments.