### PR TITLE
fix: Withdrawal broken for Hyperliquid Unified Account Mode users

### DIFF
--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -390,6 +390,15 @@ const PerpsWithdrawView: React.FC = () => {
               alignItems={BoxAlignItems.Center}
               marginBottom={2}
             >
+              <Text
+                variant={TextVariant.DisplayMD}
+                style={tw.style(
+                  'text-[54px] leading-[70px] font-medium mb-2 text-default',
+                  withdrawAmount === '0' && 'text-alternative',
+                )}
+              >
+                {formatDisplayAmount}
+              </Text>
               <Animated.View
                 testID="cursor"
                 style={[

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -374,16 +374,16 @@ const PerpsWithdrawView: React.FC = () => {
     <SafeAreaView style={tw.style('flex-1 bg-default')}>
       <Box twClassName="flex-1 bg-default">
         {/* Header */}
-        {/* <HeaderCompactStandard
+        <HeaderCompactStandard
           title={strings('perps.withdrawal.title')}
           onBack={handleBack}
           backButtonProps={{
             testID: PerpsWithdrawViewSelectorsIDs.BACK_BUTTON,
           }}
-        /> */}
+        />
 
         {/* Amount Display */}
-        {/* <Pressable onPress={handleAmountPress}>
+        <Pressable onPress={handleAmountPress}>
           <Box alignItems={BoxAlignItems.Center} twClassName="py-12 px-4">
             <Box
               flexDirection={BoxFlexDirection.Row}
@@ -410,7 +410,7 @@ const PerpsWithdrawView: React.FC = () => {
               })}
             </Text>
           </Box>
-        </Pressable> */}
+        </Pressable>
 
         {/* Receive Section */}
         <Box
@@ -424,9 +424,9 @@ const PerpsWithdrawView: React.FC = () => {
             alignItems={BoxAlignItems.Center}
             twClassName="gap-2"
           >
-            {/* <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
               {strings('perps.withdrawal.receive')}
-            </Text> */}
+            </Text>
             <Pressable
               onPress={() =>
                 handleTooltipPress('receive' as PerpsTooltipContentKey)

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -374,31 +374,22 @@ const PerpsWithdrawView: React.FC = () => {
     <SafeAreaView style={tw.style('flex-1 bg-default')}>
       <Box twClassName="flex-1 bg-default">
         {/* Header */}
-        <HeaderCompactStandard
+        {/* <HeaderCompactStandard
           title={strings('perps.withdrawal.title')}
           onBack={handleBack}
           backButtonProps={{
             testID: PerpsWithdrawViewSelectorsIDs.BACK_BUTTON,
           }}
-        />
+        /> */}
 
         {/* Amount Display */}
-        <Pressable onPress={handleAmountPress}>
+        {/* <Pressable onPress={handleAmountPress}>
           <Box alignItems={BoxAlignItems.Center} twClassName="py-12 px-4">
             <Box
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
               marginBottom={2}
             >
-              <Text
-                variant={TextVariant.DisplayMD}
-                style={tw.style(
-                  'text-[54px] leading-[70px] font-medium mb-2 text-default',
-                  withdrawAmount === '0' && 'text-alternative',
-                )}
-              >
-                {formatDisplayAmount}
-              </Text>
               <Animated.View
                 testID="cursor"
                 style={[
@@ -419,7 +410,7 @@ const PerpsWithdrawView: React.FC = () => {
               })}
             </Text>
           </Box>
-        </Pressable>
+        </Pressable> */}
 
         {/* Receive Section */}
         <Box
@@ -433,9 +424,9 @@ const PerpsWithdrawView: React.FC = () => {
             alignItems={BoxAlignItems.Center}
             twClassName="gap-2"
           >
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            {/* <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
               {strings('perps.withdrawal.receive')}
-            </Text>
+            </Text> */}
             <Pressable
               onPress={() =>
                 handleTooltipPress('receive' as PerpsTooltipContentKey)

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -19,14 +19,6 @@ export function PerpsWithdrawBalance() {
   const { styles } = useStyles(styleSheet, {});
   const { account } = usePerpsLiveAccount();
 
-  // formatPerpsBalance truncates (ROUND_DOWN) to 2 decimals so the displayed
-  // balance matches the Max button value and never overstates what the user
-  // can actually withdraw.
-  // const balanceFormatted = useMemo(
-  //   () => formatPerpsBalance(account?.availableBalance),
-  //   [account?.availableBalance],
-  // );
-
   const availableBalance = useMemo(() => {
     const balance =
       account?.availableToTradeBalance ?? account?.availableBalance;
@@ -39,7 +31,7 @@ export function PerpsWithdrawBalance() {
       <Text
         variant={TextVariant.BodyMDMedium}
         color={TextColor.Alternative}
-      >{`${strings('confirm.available_balance')}${availableBalance}`}</Text>
+      >{`${strings('confirm.available_balance')}${formatPerpsBalance(availableBalance)}`}</Text>
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import Text, {
   TextColor,
@@ -8,23 +8,15 @@ import { useStyles } from '../../../../../../component-library/hooks';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems } from '../../../../../UI/Box/box.types';
 import { usePerpsLiveAccount } from '../../../../../UI/Perps/hooks/stream/usePerpsLiveAccount';
-import {
-  formatPerpsBalance,
-  parseCurrencyString,
-  truncateToTwoDecimals,
-} from '../../../../../UI/Perps/utils/formatUtils';
+import { formatPerpsBalance } from '../../../../../UI/Perps/utils/formatUtils';
 import styleSheet from './perps-withdraw-balance.styles';
 
 export function PerpsWithdrawBalance() {
   const { styles } = useStyles(styleSheet, {});
   const { account } = usePerpsLiveAccount();
 
-  const availableBalance = useMemo(() => {
-    const balance =
-      account?.availableToTradeBalance ?? account?.availableBalance;
-    if (!balance) return 0;
-    return truncateToTwoDecimals(parseCurrencyString(balance));
-  }, [account?.availableBalance, account?.availableToTradeBalance]);
+  const availableBalance =
+    account?.availableToTradeBalance ?? account?.availableBalance;
 
   return (
     <Box alignItems={AlignItems.center} style={styles.container}>

--- a/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/app/components/Views/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -8,7 +8,11 @@ import { useStyles } from '../../../../../../component-library/hooks';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems } from '../../../../../UI/Box/box.types';
 import { usePerpsLiveAccount } from '../../../../../UI/Perps/hooks/stream/usePerpsLiveAccount';
-import { formatPerpsBalance } from '../../../../../UI/Perps/utils/formatUtils';
+import {
+  formatPerpsBalance,
+  parseCurrencyString,
+  truncateToTwoDecimals,
+} from '../../../../../UI/Perps/utils/formatUtils';
 import styleSheet from './perps-withdraw-balance.styles';
 
 export function PerpsWithdrawBalance() {
@@ -18,17 +22,24 @@ export function PerpsWithdrawBalance() {
   // formatPerpsBalance truncates (ROUND_DOWN) to 2 decimals so the displayed
   // balance matches the Max button value and never overstates what the user
   // can actually withdraw.
-  const balanceFormatted = useMemo(
-    () => formatPerpsBalance(account?.availableBalance),
-    [account?.availableBalance],
-  );
+  // const balanceFormatted = useMemo(
+  //   () => formatPerpsBalance(account?.availableBalance),
+  //   [account?.availableBalance],
+  // );
+
+  const availableBalance = useMemo(() => {
+    const balance =
+      account?.availableToTradeBalance ?? account?.availableBalance;
+    if (!balance) return 0;
+    return truncateToTwoDecimals(parseCurrencyString(balance));
+  }, [account?.availableBalance, account?.availableToTradeBalance]);
 
   return (
     <Box alignItems={AlignItems.center} style={styles.container}>
       <Text
         variant={TextVariant.BodyMDMedium}
         color={TextColor.Alternative}
-      >{`${strings('confirm.available_balance')}${balanceFormatted}`}</Text>
+      >{`${strings('confirm.available_balance')}${availableBalance}`}</Text>
     </Box>
   );
 }

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
@@ -30,8 +30,16 @@ export function useInsufficientPerpsBalanceAlert({
   const quotes = useTransactionPayQuotes();
   const hasQuotes = Boolean(quotes?.length);
 
+  // For Unified Account Mode users, `availableBalance` mirrors HL's
+  // `clearinghouseState.withdrawable` which is $0 (collateral lives in spot).
+  // `availableToTradeBalance` is the unified-aware value computed by
+  // `addSpotBalanceToAccountState` and matches what `withdraw3` actually draws
+  // from. Fall back to `availableBalance` for legacy / Standard-mode accounts
+  // where the unified field is undefined.
   const availableBalance = useSelector(
     (state: RootState) =>
+      state.engine.backgroundState.PerpsController?.accountState
+        ?.availableToTradeBalance ??
       state.engine.backgroundState.PerpsController?.accountState
         ?.availableBalance,
   );

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -230,7 +230,13 @@ function useTokenBalance(tokenUsdRate: number) {
 
   if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
     const perpsState = Engine.context.PerpsController?.state;
-    const availableBalance = perpsState?.accountState?.availableBalance;
+    // Prefer `availableToTradeBalance` so Unified Account / Portfolio Margin
+    // users see the correct balance behind the percentage buttons. Falls back
+    // to `availableBalance` for Standard-mode accounts where the unified
+    // field isn't populated.
+    const availableBalance =
+      perpsState?.accountState?.availableToTradeBalance ??
+      perpsState?.accountState?.availableBalance;
     return availableBalance ? parseFloat(availableBalance) : 0;
   }
 

--- a/app/controllers/perps/providers/HyperLiquidProvider.test.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.test.ts
@@ -431,6 +431,8 @@ describe('HyperLiquidProvider', () => {
       getCachedOrders: jest.fn().mockReturnValue([]),
       // Atomic getter - returns null when cache not initialized (prevents race condition)
       getOrdersCacheIfInitialized: jest.fn().mockReturnValue(null),
+      // Abstraction-mode cache invalidation (unified account migration)
+      invalidateUserAbstractionCache: jest.fn(),
     } as Partial<HyperLiquidSubscriptionService> as jest.Mocked<HyperLiquidSubscriptionService>;
 
     // Mock constructors
@@ -8865,6 +8867,93 @@ describe('HyperLiquidProvider', () => {
         attempted: true,
         enabled: true,
       });
+    });
+
+    // ─────────────────────────────────────────────────
+    // invalidateUserAbstractionCache is called on every success path
+    // ─────────────────────────────────────────────────
+
+    it('calls invalidateUserAbstractionCache when account is already unifiedAccount', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          userAbstraction: jest.fn().mockResolvedValue('unifiedAccount'),
+        }),
+      );
+
+      await provider.getMarketDataWithPrices();
+
+      expect(
+        mockSubscriptionService.invalidateUserAbstractionCache,
+      ).toHaveBeenCalledWith(USER_ADDRESS);
+    });
+
+    it('calls invalidateUserAbstractionCache when account is already portfolioMargin', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          userAbstraction: jest.fn().mockResolvedValue('portfolioMargin'),
+        }),
+      );
+
+      await provider.getMarketDataWithPrices();
+
+      expect(
+        mockSubscriptionService.invalidateUserAbstractionCache,
+      ).toHaveBeenCalledWith(USER_ADDRESS);
+    });
+
+    it('calls invalidateUserAbstractionCache after migrating from default → unifiedAccount', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          userAbstraction: jest.fn().mockResolvedValue('default'),
+        }),
+      );
+      mockClientService.getExchangeClient = jest
+        .fn()
+        .mockReturnValue(createMockExchangeClient());
+
+      await provider.getMarketDataWithPrices();
+
+      expect(
+        mockSubscriptionService.invalidateUserAbstractionCache,
+      ).toHaveBeenCalledWith(USER_ADDRESS);
+    });
+
+    it('calls invalidateUserAbstractionCache after migrating from dexAbstraction → unifiedAccount', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          userAbstraction: jest.fn().mockResolvedValue('dexAbstraction'),
+        }),
+      );
+      mockClientService.getExchangeClient = jest
+        .fn()
+        .mockReturnValue(createMockExchangeClient());
+
+      await provider.getMarketDataWithPrices();
+
+      expect(
+        mockSubscriptionService.invalidateUserAbstractionCache,
+      ).toHaveBeenCalledWith(USER_ADDRESS);
+    });
+
+    it('does NOT call invalidateUserAbstractionCache when migration fails', async () => {
+      const mockExchangeClient = createMockExchangeClient();
+      mockExchangeClient.agentSetAbstraction = jest
+        .fn()
+        .mockRejectedValue(new Error('network error'));
+      mockClientService.getInfoClient = jest.fn().mockReturnValue(
+        createMockInfoClient({
+          userAbstraction: jest.fn().mockResolvedValue('default'),
+        }),
+      );
+      mockClientService.getExchangeClient = jest
+        .fn()
+        .mockReturnValue(mockExchangeClient);
+
+      await provider.getMarketDataWithPrices();
+
+      expect(
+        mockSubscriptionService.invalidateUserAbstractionCache,
+      ).not.toHaveBeenCalled();
     });
 
     // ─────────────────────────────────────────────────

--- a/app/controllers/perps/providers/HyperLiquidProvider.ts
+++ b/app/controllers/perps/providers/HyperLiquidProvider.ts
@@ -672,6 +672,9 @@ export class HyperLiquidProvider implements PerpsProvider {
           attempted: true,
           enabled: true,
         });
+        // Evict any stale pre-migration abstraction mode the subscription service
+        // may have cached so the next aggregation uses the correct fold behaviour.
+        this.#subscriptionService.invalidateUserAbstractionCache(userAddress);
         completeInFlight();
         return;
       }
@@ -732,6 +735,10 @@ export class HyperLiquidProvider implements PerpsProvider {
         attempted: true,
         enabled: true,
       });
+      // Evict the pre-migration abstraction mode from the subscription service
+      // so it immediately re-aggregates with fold=true and surfaces the correct
+      // unified balance rather than waiting for the next #refreshSpotState.
+      this.#subscriptionService.invalidateUserAbstractionCache(userAddress);
       completeInFlight();
     } catch (error) {
       // If keyring is locked, don't cache so it retries when unlocked

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3838,36 +3838,37 @@ describe('HyperLiquidSubscriptionService', () => {
     });
 
     it('triggers a re-aggregation and notifies account subscribers when dex cache is populated', async () => {
+      // Prime the abstraction cache with 'default' (fold=false) BEFORE the
+      // initial subscribe so the cached aggregated state does NOT include
+      // folded spot. After invalidation the cache becomes empty, which
+      // defaults to fold=true (null → fold), causing spot to fold in.
+      // That state change flips the account hash and triggers a callback —
+      // which is what we want to assert.
+      mockClientService.getInfoClient = jest.fn(() => ({
+        spotClearinghouseState: mockSpotClearinghouseState,
+        userAbstraction: jest.fn().mockResolvedValue('default'),
+      })) as never;
+
       const accountCallback = jest.fn();
       const unsubscribe = service.subscribeToAccount({
         callback: accountCallback,
       });
       await jest.runAllTimersAsync();
 
-      // Clear call history so we can count fresh notifications.
+      // Sanity: initial subscribe primed the dex cache and notified once.
+      expect(accountCallback).toHaveBeenCalled();
       accountCallback.mockClear();
 
-      // Override userAbstraction to return 'default' so the cache holds a
-      // pre-migration value, then invalidate — the re-aggregation should
-      // fire the callback since the hash will change (fold toggled).
-      mockClientService.getInfoClient = jest.fn(() => ({
-        spotClearinghouseState: mockSpotClearinghouseState,
-        userAbstraction: jest.fn().mockResolvedValue('default'),
-      })) as never;
-
-      // Force a spot refresh with the stale 'default' mode so the cache
-      // is in a pre-migration state (foldIntoCollateral=false while spot>0).
-      // We do this by triggering a second subscribeToAccount which calls
-      // #ensureSpotState again (cache miss for new address pattern would work
-      // but we can verify via the notification path instead).
+      // Invalidate — should re-aggregate (#dexAccountCache.size > 0) and
+      // notify subscribers because the fold behavior flipped.
       service.invalidateUserAbstractionCache('0x123');
-
       await jest.runAllTimersAsync();
 
-      // After invalidation the dex cache is populated, so #aggregateAndNotify
-      // is called, which may or may not produce a new callback depending on
-      // whether the hash changed. The important thing is no error is thrown.
-      expect(accountCallback).toBeDefined();
+      expect(accountCallback).toHaveBeenCalled();
+      const lastCall = accountCallback.mock.calls.at(-1)?.[0];
+      // After fold flips to true, availableToTradeBalance should reflect
+      // the perps withdrawable plus folded spot USDC.
+      expect(lastCall?.availableToTradeBalance).toBeDefined();
 
       unsubscribe();
     });

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.test.ts
@@ -3800,6 +3800,79 @@ describe('HyperLiquidSubscriptionService', () => {
     });
   });
 
+  describe('invalidateUserAbstractionCache', () => {
+    it('evicts the cached abstraction mode for the given address', async () => {
+      // Prime the cache via #refreshSpotState (called inside subscribeToAccount)
+      const unsubscribe = service.subscribeToAccount({ callback: jest.fn() });
+      await jest.runAllTimersAsync();
+
+      // The mock resolves userAbstraction as 'unifiedAccount' — confirm fold
+      // is active by checking that the cached account includes a non-zero
+      // availableToTradeBalance (spot was folded in).
+      const callbackAfterSubscribe = jest.fn();
+      service.subscribeToAccount({ callback: callbackAfterSubscribe });
+      await jest.runAllTimersAsync();
+      const before = callbackAfterSubscribe.mock.calls.at(-1)?.[0];
+      expect(before?.availableToTradeBalance).not.toBeUndefined();
+
+      // Invalidate — should not throw, even for an address with no cached entry.
+      expect(() =>
+        service.invalidateUserAbstractionCache('0x123'),
+      ).not.toThrow();
+
+      unsubscribe();
+    });
+
+    it('is case-insensitive (checksummed address matches cached lowercase key)', async () => {
+      const unsubscribe = service.subscribeToAccount({ callback: jest.fn() });
+      await jest.runAllTimersAsync();
+
+      // Should not throw regardless of casing
+      expect(() =>
+        service.invalidateUserAbstractionCache(
+          '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        ),
+      ).not.toThrow();
+
+      unsubscribe();
+    });
+
+    it('triggers a re-aggregation and notifies account subscribers when dex cache is populated', async () => {
+      const accountCallback = jest.fn();
+      const unsubscribe = service.subscribeToAccount({
+        callback: accountCallback,
+      });
+      await jest.runAllTimersAsync();
+
+      // Clear call history so we can count fresh notifications.
+      accountCallback.mockClear();
+
+      // Override userAbstraction to return 'default' so the cache holds a
+      // pre-migration value, then invalidate — the re-aggregation should
+      // fire the callback since the hash will change (fold toggled).
+      mockClientService.getInfoClient = jest.fn(() => ({
+        spotClearinghouseState: mockSpotClearinghouseState,
+        userAbstraction: jest.fn().mockResolvedValue('default'),
+      })) as never;
+
+      // Force a spot refresh with the stale 'default' mode so the cache
+      // is in a pre-migration state (foldIntoCollateral=false while spot>0).
+      // We do this by triggering a second subscribeToAccount which calls
+      // #ensureSpotState again (cache miss for new address pattern would work
+      // but we can verify via the notification path instead).
+      service.invalidateUserAbstractionCache('0x123');
+
+      await jest.runAllTimersAsync();
+
+      // After invalidation the dex cache is populated, so #aggregateAndNotify
+      // is called, which may or may not produce a new callback depending on
+      // whether the hash changed. The important thing is no error is thrown.
+      expect(accountCallback).toBeDefined();
+
+      unsubscribe();
+    });
+  });
+
   describe('spot-adjusted account balance parity', () => {
     it('includes spot balance exactly once in streamed totalBalance across multiple DEXs', async () => {
       jest.mocked(adaptAccountStateFromSDK).mockImplementation(() => ({

--- a/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/controllers/perps/services/HyperLiquidSubscriptionService.ts
@@ -1051,6 +1051,24 @@ export class HyperLiquidSubscriptionService {
     };
   }
 
+  /**
+   * Evict a user's cached abstraction mode so the next aggregation uses the
+   * fail-open default (Unified). Call this immediately after a successful
+   * Unified Account migration so the subscription service doesn't keep serving
+   * the pre-migration mode until the next #refreshSpotState completes.
+   *
+   * If the DEX account cache is already populated the corrected balance is
+   * pushed to subscribers immediately.
+   *
+   * @param userAddress - The EVM address whose cached mode should be evicted.
+   */
+  public invalidateUserAbstractionCache(userAddress: string): void {
+    this.#abstractionModeByUser.delete(userAddress.toLowerCase());
+    if (this.#dexAccountCache.size > 0) {
+      this.#aggregateAndNotifySubscribers();
+    }
+  }
+
   async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
     const userAddress =
       await this.#walletService.getUserAddressWithDefault(accountId);

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -304,6 +304,57 @@ describe('spot balance helpers', () => {
     expect(result.availableToTradeBalance).toBe('7');
   });
 
+  it('folds spot USDC into availableToTradeBalance when withdrawable=0 but freeSpot>0 (stale-cache fail-open guard)', () => {
+    // Simulates a Unified-mode user whose abstraction-mode cache was stale
+    // (foldIntoCollateral=false) but perps withdrawable is 0 because HL
+    // holds all collateral in spot for Unified accounts.
+    const accountState: AccountState = {
+      availableBalance: '0',
+      totalBalance: '0',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(
+      accountState,
+      {
+        balances: [{ coin: 'USDC', total: '2500', hold: '0' }],
+      } as never,
+      { foldIntoCollateral: false },
+    );
+
+    // The fail-open guard detects available=0 + freeSpot>0 and forces folding,
+    // matching withdraw3's actual behaviour on Unified accounts.
+    expect(result.availableToTradeBalance).toBe('2500');
+    expect(result.totalBalance).toBe('2500');
+  });
+
+  it('does NOT apply fail-open guard when Standard mode has both perps and spot balances', () => {
+    // Standard mode: user has perps collateral AND separate spot holdings.
+    // foldIntoCollateral=false, but currentAvailable > 0 so the guard
+    // must NOT trigger — spot stays separate for Standard users.
+    const accountState: AccountState = {
+      availableBalance: '7',
+      totalBalance: '10',
+      marginUsed: '0',
+      unrealizedPnl: '0',
+      returnOnEquity: '0',
+    };
+
+    const result = addSpotBalanceToAccountState(
+      accountState,
+      {
+        balances: [{ coin: 'USDC', total: '25', hold: '0' }],
+      } as never,
+      { foldIntoCollateral: false },
+    );
+
+    // Guard skipped because currentAvailable (7) > 0 → spot kept separate.
+    expect(result.availableToTradeBalance).toBe('7');
+    expect(result.totalBalance).toBe('35');
+  });
+
   it('returns the original account state when spot balance is zero', () => {
     const accountState: AccountState = {
       availableBalance: '1',

--- a/app/controllers/perps/utils/accountUtils.test.ts
+++ b/app/controllers/perps/utils/accountUtils.test.ts
@@ -304,10 +304,11 @@ describe('spot balance helpers', () => {
     expect(result.availableToTradeBalance).toBe('7');
   });
 
-  it('folds spot USDC into availableToTradeBalance when withdrawable=0 but freeSpot>0 (stale-cache fail-open guard)', () => {
-    // Simulates a Unified-mode user whose abstraction-mode cache was stale
-    // (foldIntoCollateral=false) but perps withdrawable is 0 because HL
-    // holds all collateral in spot for Unified accounts.
+  it('keeps spot USDC separate from availableToTradeBalance even when withdrawable=0 in Standard mode', () => {
+    // Standard / DEX-abstraction users with $0 perps withdrawable but free
+    // spot USDC must NOT see spot fold into availableToTradeBalance —
+    // withdraw3 only draws from the perps ledger in those modes. Folding
+    // would surface a withdrawable amount the API can't actually fulfill.
     const accountState: AccountState = {
       availableBalance: '0',
       totalBalance: '0',
@@ -324,16 +325,11 @@ describe('spot balance helpers', () => {
       { foldIntoCollateral: false },
     );
 
-    // The fail-open guard detects available=0 + freeSpot>0 and forces folding,
-    // matching withdraw3's actual behaviour on Unified accounts.
-    expect(result.availableToTradeBalance).toBe('2500');
+    expect(result.availableToTradeBalance).toBe('0');
     expect(result.totalBalance).toBe('2500');
   });
 
-  it('does NOT apply fail-open guard when Standard mode has both perps and spot balances', () => {
-    // Standard mode: user has perps collateral AND separate spot holdings.
-    // foldIntoCollateral=false, but currentAvailable > 0 so the guard
-    // must NOT trigger — spot stays separate for Standard users.
+  it('keeps spot separate when Standard mode has both perps and spot balances', () => {
     const accountState: AccountState = {
       availableBalance: '7',
       totalBalance: '10',
@@ -350,7 +346,6 @@ describe('spot balance helpers', () => {
       { foldIntoCollateral: false },
     );
 
-    // Guard skipped because currentAvailable (7) > 0 → spot kept separate.
     expect(result.availableToTradeBalance).toBe('7');
     expect(result.totalBalance).toBe('35');
   });

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -195,23 +195,14 @@ export function addSpotBalanceToAccountState(
     };
   }
 
-  // Fail-open guard: a user with withdrawable=0 but free spot USDC is, by
-  // HL's own contract, in unifiedAccount / portfolioMargin (Standard mode
-  // keeps perps and spot independent, so Standard users always have a
-  // non-zero perps withdrawable when they have collateral). Folding is the
-  // only way to surface a non-zero balance, and withdraw3 will draw from
-  // the unified ledger directly, so this matches the API's actual behaviour.
-  // This catches the race where the abstraction-mode cache is stale
-  // (e.g. subscriptionService fetched it before migration completed).
-  const stuckOnPerpsOnly =
-    !foldIntoCollateral &&
-    Number.isFinite(currentAvailable) &&
-    currentAvailable === 0 &&
-    freeSpot > 0;
-  const effectiveFold = foldIntoCollateral || stuckOnPerpsOnly;
-
+  // Folding is gated strictly on the resolved abstraction mode. Standard /
+  // DEX-abstraction users keep perps and spot independent, so spot must NOT
+  // surface as a perps-withdrawable balance for them — withdraw3 only draws
+  // from the perps ledger in those modes. Unified / portfolio-margin users
+  // get the fold; if the mode hasn't been resolved yet, the caller defaults
+  // foldIntoCollateral=true.
   let availableToTrade = accountState.availableBalance;
-  if (effectiveFold) {
+  if (foldIntoCollateral) {
     availableToTrade = Number.isFinite(currentAvailable)
       ? (currentAvailable + freeSpot).toString()
       : freeSpot.toString();

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -160,33 +160,6 @@ export function addSpotBalanceToAccountState(
   }
 
   if (spotBalance === 0) {
-    // For unified / portfolio-margin accounts the USDC may be represented as
-    // perps equity rather than an explicit spot balance (e.g. a user who
-    // migrated from Standard mode — HL keeps the collateral inside the perps
-    // ledger and doesn't surface it via spotClearinghouseState until the next
-    // settlement cycle). In this case withdraw3 draws from the unified balance
-    // directly, so compute a conservative available amount from
-    //   accountValue − initialMarginUsed
-    // rather than returning $0. Standard-mode users are unaffected because
-    // foldIntoCollateral is false for them and their withdrawable is already > 0.
-    if (
-      foldIntoCollateral &&
-      Number.isFinite(currentAvailable) &&
-      currentAvailable === 0 &&
-      currentTotal > 0
-    ) {
-      const marginUsed = parseFloat(accountState.marginUsed);
-      const freeEquity = Number.isFinite(marginUsed)
-        ? Math.max(0, currentTotal - marginUsed)
-        : currentTotal;
-      if (freeEquity > 0) {
-        return {
-          ...accountState,
-          availableToTradeBalance: freeEquity.toString(),
-        };
-      }
-    }
-
     return {
       ...accountState,
       availableToTradeBalance: Number.isFinite(currentAvailable)

--- a/app/controllers/perps/utils/accountUtils.ts
+++ b/app/controllers/perps/utils/accountUtils.ts
@@ -160,6 +160,33 @@ export function addSpotBalanceToAccountState(
   }
 
   if (spotBalance === 0) {
+    // For unified / portfolio-margin accounts the USDC may be represented as
+    // perps equity rather than an explicit spot balance (e.g. a user who
+    // migrated from Standard mode — HL keeps the collateral inside the perps
+    // ledger and doesn't surface it via spotClearinghouseState until the next
+    // settlement cycle). In this case withdraw3 draws from the unified balance
+    // directly, so compute a conservative available amount from
+    //   accountValue − initialMarginUsed
+    // rather than returning $0. Standard-mode users are unaffected because
+    // foldIntoCollateral is false for them and their withdrawable is already > 0.
+    if (
+      foldIntoCollateral &&
+      Number.isFinite(currentAvailable) &&
+      currentAvailable === 0 &&
+      currentTotal > 0
+    ) {
+      const marginUsed = parseFloat(accountState.marginUsed);
+      const freeEquity = Number.isFinite(marginUsed)
+        ? Math.max(0, currentTotal - marginUsed)
+        : currentTotal;
+      if (freeEquity > 0) {
+        return {
+          ...accountState,
+          availableToTradeBalance: freeEquity.toString(),
+        };
+      }
+    }
+
     return {
       ...accountState,
       availableToTradeBalance: Number.isFinite(currentAvailable)
@@ -168,8 +195,23 @@ export function addSpotBalanceToAccountState(
     };
   }
 
+  // Fail-open guard: a user with withdrawable=0 but free spot USDC is, by
+  // HL's own contract, in unifiedAccount / portfolioMargin (Standard mode
+  // keeps perps and spot independent, so Standard users always have a
+  // non-zero perps withdrawable when they have collateral). Folding is the
+  // only way to surface a non-zero balance, and withdraw3 will draw from
+  // the unified ledger directly, so this matches the API's actual behaviour.
+  // This catches the race where the abstraction-mode cache is stale
+  // (e.g. subscriptionService fetched it before migration completed).
+  const stuckOnPerpsOnly =
+    !foldIntoCollateral &&
+    Number.isFinite(currentAvailable) &&
+    currentAvailable === 0 &&
+    freeSpot > 0;
+  const effectiveFold = foldIntoCollateral || stuckOnPerpsOnly;
+
   let availableToTrade = accountState.availableBalance;
-  if (foldIntoCollateral) {
+  if (effectiveFold) {
     availableToTrade = Number.isFinite(currentAvailable)
       ? (currentAvailable + freeSpot).toString()
       : freeSpot.toString();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Users who had enabled Unified Account Mode in Hyperliquid were seeing $0 available balance in the withdrawal flow, with the withdraw button disabled due to "Insufficient funds." This made it impossible to withdraw.

The root cause: in Unified Account Mode, USDC collateral lives in the spot clearinghouse rather than the perps clearinghouse. Our existing balance fields only read the perps-side withdrawable (which is $0 in unified mode), leaving the real balance invisible.

This PR fixes it across the full withdrawal stack:

Balance aggregation (accountUtils.ts) — folds free spot USDC into availableToTradeBalance when unified mode is active. Adds a fallback for accounts where USDC is held as perps equity rather than explicit spot (common after migrating from Standard mode).
Cache correctness (HyperLiquidSubscriptionService) — adds invalidateUserAbstractionCache so stale pre-migration mode data can't block the fold from applying.
Migration wiring (HyperLiquidProvider) — calls the invalidation after both the "already unified" and "just migrated" success paths, ensuring the WebSocket re-aggregates immediately.
Confirmation flow (useInsufficientPerpsBalanceAlert, useTransactionCustomAmount) — alert and percentage-button calculations now use availableToTradeBalance ?? availableBalance instead of reading only the perps-side balance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix withdrawable balance for unified account

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/25567eb9-1c97-4e08-8f3f-0e2b0f574405

<img width="287" height="534" alt="Screenshot 2026-04-29 at 5 47 54 PM" src="https://github.com/user-attachments/assets/1991f514-d14e-415d-9451-049fd6547a2c" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps withdrawal balance computation/validation and subscription cache behavior; a mistake could incorrectly block withdrawals or overstate withdrawable funds, but the change is localized and covered by new tests.
> 
> **Overview**
> Fixes HyperLiquid perps withdrawal UX for Unified Account/Portfolio Margin users by consistently using `availableToTradeBalance ?? availableBalance` for the displayed withdrawable balance, insufficient-funds blocking alert, and percentage-based amount calculations.
> 
> Adds `HyperLiquidSubscriptionService.invalidateUserAbstractionCache()` and wires `HyperLiquidProvider` to call it on successful “already enabled” and “migrated to unified” paths so the streamed account aggregation immediately re-computes with the correct fold behavior instead of serving stale pre-migration balances.
> 
> Tightens spot-folding semantics in `addSpotBalanceToAccountState` so folding into `availableToTradeBalance` is strictly gated by abstraction mode (preventing Standard/DEX-abstraction users from seeing spot USDC as perps-withdrawable), with expanded unit tests covering cache invalidation and standard-mode balance separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e356163c096bdd236095ca8d69717a5843b06c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->