### PR TITLE
ci: fix scheduled e2e runs

### DIFF
--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -11,7 +11,7 @@ flowchart TD
     GR -->|PR label: pr-not-ready-for-e2e| L2[No E2E]
     L2 -->|ignorable-only changes| NoBlock[No merge block]
     L2 -->|non-ignorable changes| Skip2[Merge blocked]
-    GR -->|PR ignorable-only changes| Ignorable[No E2E - merge not blocked]
+    GR -->|PR ignorable-only changes| Ignorable[No E2E]
     GR -->|PR has Android-only changes| Android[Android Build + Tests needed]
     GR -->|PR has iOS-only changes| iOS[iOS Build + Test needed]
     GR -->|PR other files changed| Both[Both Build + Tests needed]

--- a/.github/scripts/e2e-report-fixture-validation.mjs
+++ b/.github/scripts/e2e-report-fixture-validation.mjs
@@ -39,9 +39,6 @@ function buildComment(results) {
   }
 
   if (!results) {
-    if (VALIDATION_RESULT === 'success') {
-      return `✅ ${COMMENT_MARKER} — Passed**\n[View details](${RUN_URL})`;
-    }
     return null;
   }
 
@@ -66,11 +63,7 @@ function buildComment(results) {
     ].join('\n');
   }
 
-  if (valueMismatches > 0) {
-    return `✅ ${COMMENT_MARKER} — Schema is up to date**\n${valueMismatches} value mismatches detected (expected — fixture represents an existing user).\n[View details](${RUN_URL})`;
-  }
-
-  return `✅ ${COMMENT_MARKER} — No differences found**\nFixture is up to date. [View details](${RUN_URL})`;
+  return null;
 }
 
 function emitAnnotation(results) {
@@ -148,11 +141,16 @@ async function main() {
 
   // Post PR comment if this is a PR
   if (PR_NUMBER) {
+    // Always clean up any prior fixture-validation comments so passing runs
+    // remove stale "structural changes" comments from previous failures.
+    await deletePreviousComments();
+
     const comment = buildComment(results);
     if (comment) {
-      await deletePreviousComments();
       await postComment(comment);
       console.log(`Posted fixture validation comment on PR #${PR_NUMBER}`);
+    } else {
+      console.log(`No actionable fixture validation findings for PR #${PR_NUMBER} — skipping comment.`);
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,7 +748,7 @@ jobs:
   ios-tests-ready:
     name: 'iOS Tests Ready'
     runs-on: ubuntu-latest
-    if: ${{ needs.build-ios-apps.result == 'success' }}
+    if: ${{ !cancelled() && needs.build-ios-apps.result == 'success' }}
     needs: [build-ios-apps]
     steps:
       - name: iOS build complete

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -125,7 +125,7 @@ jobs:
           SHOULD_SKIP_E2E: ${{ steps.skip-e2e-tag.outputs.SKIP == 'true' || steps.check-labels.outputs.SKIP_E2E == 'true' }}
           LABEL_BLOCKS_MERGE: ${{ steps.check-labels.outputs.LABEL_BLOCKS_MERGE }}
           ALL_CHANGES_COUNT: ${{ steps.filter.outputs.all_changes_count }}
-          ALL_CHANGES_FILES: ${{ steps.filter.outputs.all_changes_files }}
+          ALL_CHANGES_FILES: ${{ github.event_name == 'pull_request' && steps.filter.outputs.all_changes_files || '' }}
           IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_ignorable_count }}
           E2E_WORKFLOWS_COUNT: ${{ steps.filter.outputs.e2e_relevant_workflows_count }}
           ANDROID_COUNT: ${{ steps.filter.outputs.android_count }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fix two CI E2E bugs:

iOS smoke tests not running on push-to-main — ios-tests-ready was missing !cancelled() in its if:, causing GitHub's implicit success() wrap to skip it when smart-e2e-selection was skipped (push events). Added !cancelled() && to match the Android gate pattern.

Scheduled runs crashing with "Argument list too long" — ALL_CHANGES_FILES was always injected as an env var, but on schedule/push events dorny/paths-filter emits the full repo file list (no diff baseline), overflowing ARG_MAX. The variable is only consumed on PR events, so it's now conditionally empty otherwise.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions conditions and env wiring for E2E selection, which can inadvertently skip or over-trigger CI runs if misconfigured, but the changes are small and localized to CI logic.
> 
> **Overview**
> Fixes a couple of CI edge cases that were preventing E2E coverage from running reliably on non-PR events.
> 
> In `ci.yml`, updates the `ios-tests-ready` gate to include `!cancelled()` so iOS smoke tests still run on `push`/`schedule` flows where upstream jobs may be skipped/cancelled implicitly. In `get-requirements.yml`, stops exporting `ALL_CHANGES_FILES` on non-PR events to avoid scheduled/push runs injecting a full-repo file list and hitting “argument list too long”.
> 
> Also adjusts fixture-validation reporting to **only** comment on actionable findings (failure without results or structural changes), while always deleting prior fixture-validation comments so passing runs clear stale warnings; and updates the E2E decision-tree doc to match the current “ignorable-only” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed246634b9a56151905e9f93ea4ac1f386d12ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->