### PR TITLE
fix(rewards): cap displayed qualified days at max to prevent 12/10 display

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -156,7 +156,7 @@ const OndoCampaignStatsView: React.FC = () => {
       : formatTierDisplayName(leaderboardPosition.projectedTier);
 
   const daysHeldValue = leaderboardPosition
-    ? `${leaderboardPosition.qualifiedDays}/${ONDO_GM_REQUIRED_QUALIFIED_DAYS}`
+    ? `${Math.min(leaderboardPosition.qualifiedDays, ONDO_GM_REQUIRED_QUALIFIED_DAYS)}/${ONDO_GM_REQUIRED_QUALIFIED_DAYS}`
     : '-';
 
   const tierMinDeposit = useMemo(


### PR DESCRIPTION
## Summary
- `qualifiedDays` from the API can exceed the campaign max of 10, causing the "Days held" stat to display as e.g. `12/10`
- Wraps the numerator with `Math.min(qualifiedDays, ONDO_GM_REQUIRED_QUALIFIED_DAYS)` so it caps at 10

## **Changelog**

CHANGELOG entry: null
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects display formatting for the Ondo campaign stats view; no backend logic or data mutations are modified.
> 
> **Overview**
> Prevents the Ondo campaign "Days held" stat from displaying values above the campaign maximum (e.g., `12/10`) by capping the displayed `qualifiedDays` numerator with `Math.min(..., ONDO_GM_REQUIRED_QUALIFIED_DAYS)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecccc96241d54f55ec1003fc1d33bd37ef184987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->