### PR TITLE
fix: show collection name in nft details

### DIFF
--- a/app/components/Views/NftDetails/NftDetails.test.ts
+++ b/app/components/Views/NftDetails/NftDetails.test.ts
@@ -205,6 +205,7 @@ describe('NftDetails', () => {
     );
 
     expect(getByText(TEST_COLLECTIBLE.name)).toBeOnTheScreen();
+    expect(getByText(TEST_COLLECTIBLE.collection.name)).toBeOnTheScreen();
   });
 
   it('tracks NFT Details Opened event with mobile-nft-list source', () => {

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -529,6 +529,12 @@ const NftDetails = () => {
           ) : null}
 
           <NftDetailsInformationRow
+            title={strings('collectible.collection')}
+            value={collectible.collection?.name}
+            titleStyle={styles.informationRowTitleStyle}
+            valueStyle={styles.informationRowValueStyle}
+          />
+          <NftDetailsInformationRow
             title={strings('nft_details.unique_token_holders')}
             value={collectible.collection?.ownerCount}
             titleStyle={styles.informationRowTitleStyle}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Adds the missing collection name field to the NFT details screen. The data already existed on `collectible.collection.name`, but the screen did not render it.

## **Changelog**

CHANGELOG entry: fix: NFT details did not show the collection name

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/29362 https://consensyssoftware.atlassian.net/browse/ASSETS-3125

## **Manual testing steps**

```gherkin
Feature: NFT details collection metadata

  Scenario: User views an NFT details page
    Given the user has imported NFTs from a collection
    When user opens the details screen for one NFT
    Then the screen displays the collection name in the Collection section
```

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="318" height="102" alt="Screenshot 2026-05-07 at 10 49 53" src="https://github.com/user-attachments/assets/6e3bd63d-e2db-46ab-990f-2e6d9f5193b7" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2131bb9a-ffff-464e-9da8-8a287e0d8b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2131bb9a-ffff-464e-9da8-8a287e0d8b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

