### PR TITLE
ci: skip E2E for locale translation changes

### DIFF
--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -24,6 +24,10 @@ low_level_test_files: &low_level_test_files
   - '**/*.stories.*'
   - '**/*.snap'
 
+# LOCALE TRANSLATION FILES
+locale_translation_files: &locale_translation_files
+  - 'locales/languages/**/*.json'
+
 # CONFIG FILES
 config_files: &config_files
   - '.eslint*'
@@ -47,6 +51,7 @@ e2e_ignorable:
   - *documentation_files
   - *asset_files
   - *low_level_test_files
+  - *locale_translation_files
   - *config_files
   - *ci_files
 
@@ -74,6 +79,7 @@ android_or_ignorable:
   - *documentation_files
   - *asset_files
   - *low_level_test_files
+  - *locale_translation_files
   - *config_files
   - *ci_files
 
@@ -82,6 +88,7 @@ ios_or_ignorable:
   - *documentation_files
   - *asset_files
   - *low_level_test_files
+  - *locale_translation_files
   - *config_files
   - *ci_files
 


### PR DESCRIPTION
## **Description**

This PR updates the post-#29305 CI requirement filters so locale translation JSON changes are treated as E2E-ignorable.

Locale-only PRs under `locales/languages/**/*.json` should now skip Smart E2E selection plus Android/iOS E2E builds and smoke tests. The change also adds the same locale rule to the Android/iOS platform-or-ignorable filters, so mixed platform + locale changes keep platform-specific E2E behavior instead of expanding to both platforms.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MCWP-440

## **Manual testing steps**

```gherkin
Feature: CI requirements for locale translation changes

  Scenario: locale translation PR skips E2E
    Given a pull request changes only files under locales/languages/**/*.json
    When the ci workflow runs get-requirements
    Then Smart E2E selection is skipped
    And Android E2E build and smoke test jobs are skipped
    And iOS E2E build and smoke test jobs are skipped
    And pr-not-ready-for-e2e does not block merge for the ignorable-only change
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
