### PR TITLE
test: mock accounts v4 transactions endpoint

### DIFF
--- a/tests/api-mocking/MockServerE2E.ts
+++ b/tests/api-mocking/MockServerE2E.ts
@@ -14,6 +14,7 @@ import {
   findMatchingPostEvent,
   processPostRequestBody,
   setupAccountsV2SupportedNetworksMock,
+  setupAccountsV4TransactionsMock,
 } from './helpers/mockHelpers.ts';
 import { getLocalHost } from '../framework/fixtures/FixtureUtils.ts';
 import PortManager, { ResourceType } from '../framework/PortManager.ts';
@@ -298,6 +299,7 @@ export default class MockServerE2E implements Resource {
     }
 
     await setupAccountsV2SupportedNetworksMock(this._server);
+    await setupAccountsV4TransactionsMock(this._server);
 
     await this._server
       .forAnyRequest()

--- a/tests/api-mocking/helpers/mockHelpers.ts
+++ b/tests/api-mocking/helpers/mockHelpers.ts
@@ -463,6 +463,24 @@ export async function setupAccountsV2SupportedNetworksMock(
   });
 }
 
+/**
+ * Registers a default empty history response for Accounts API v4 transactions.
+ */
+export async function setupAccountsV4TransactionsMock(server: Mockttp) {
+  await setupMockRequest(server, {
+    requestMethod: 'GET',
+    url: /^https:\/\/accounts\.api\.cx\.metamask\.io\/v4\/multiaccount\/transactions(\?.*)?$/,
+    response: {
+      data: [],
+      pageInfo: {
+        count: 0,
+        hasNextPage: false,
+      },
+    },
+    responseCode: 200,
+  });
+}
+
 export interface SeenProxiedRequest {
   method: string;
   proxiedUrl: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Registers a mock empty Accounts API v4 transactions response for testing. 

Part of breaking down the Activity transactions PR into smaller chunks.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #29536

## **Manual testing steps**

N/A - test infrastructure mock-only change.

## **Screenshots/Recordings**

N/A - no user-facing UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A - mock-only change.
- [x] I've tested with a power user scenario
  - N/A - mock-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A - mock-only change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f352c865-12ef-417e-b135-ece1f40ce868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f352c865-12ef-417e-b135-ece1f40ce868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

