### PR TITLE
chore: enable swaps asset picker security tags

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
@@ -1,1 +1,0 @@
-export const SHOW_TOKEN_WARNINGS = true;

--- a/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.config.ts
@@ -1,1 +1,1 @@
-export const SHOW_TOKEN_WARNINGS = false;
+export const SHOW_TOKEN_WARNINGS = true;

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -12,8 +12,6 @@ import {
   TOKEN_RATE_UNDEFINED,
 } from '../../Tokens/constants';
 
-jest.mock('./TokenSelectorItem.config', () => ({ SHOW_TOKEN_WARNINGS: true }));
-
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => []),
 }));

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -61,7 +61,6 @@ import {
   IconName,
   IconSize,
 } from '@metamask/design-system-react-native';
-import { SHOW_TOKEN_WARNINGS } from './TokenSelectorItem.config';
 import { getBridgeTokenSecurityConfig } from '../utils/tokenSecurityUtils';
 
 const createStyles = ({
@@ -321,9 +320,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
     ? ACCOUNT_TYPE_LABELS[token.accountType]
     : undefined;
 
-  const securityTag = SHOW_TOKEN_WARNINGS
-    ? getSecurityTag(token.securityData?.type)
-    : null;
+  const securityTag = getSecurityTag(token.securityData?.type);
 
   return (
     <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes the `SHOW_TOKEN_WARNINGS` kill-switch in `app/components/UI/Bridge/components/TokenSelectorItem.config.ts` entirely, enabling the **Suspicious** / **Malicious** security pills next to token symbols in the Swaps/Bridge asset picker.

The underlying feature (rendering, tag config, i18n, tests) was shipped in #29070 (SWAPS-4372) but kept dark behind this constant. We've decided to roll it out unconditionally, so the flag and its config file are no longer needed.

**What changed:**

- Deleted `app/components/UI/Bridge/components/TokenSelectorItem.config.ts`
- Removed the `SHOW_TOKEN_WARNINGS` import and ternary in `TokenSelectorItem.tsx` — `getSecurityTag(token.securityData?.type)` is now always called
- Removed the now-redundant `jest.mock('./TokenSelectorItem.config', ...)` from `TokenSelectorItem.test.tsx`

The existing 41 `TokenSelectorItem` tests continue to pass without the mock; they were already exercising the "flag on" code path.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Enabled Suspicious and Malicious security badges on tokens in the Swaps/Bridge asset picker

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4372
Refs: https://github.com/MetaMask/metamask-mobile/pull/29070

## **Manual testing steps**

```gherkin
Feature: Token security badges in the Swaps/Bridge asset picker

  Scenario: user sees a Suspicious badge on a Warning/Spam token
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Warning" or "Spam" display an orange "Suspicious" pill with a triangle icon next to the token symbol

  Scenario: user sees a Malicious badge on a Malicious token
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Malicious" display a red "Malicious" pill with a danger icon next to the token symbol

  Scenario: user sees no security badge on safe tokens
    Given the user has opened the Swaps or Bridge flow
    When user taps to open the source or destination token picker
    Then tokens with securityData.type of "Info", "Benign", or "Verified" display no security pill
    And the existing verified checkmark still appears for tokens with isVerified=true
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — pills hidden behind the kill-switch. See [#29070](https://github.com/MetaMask/metamask-mobile/pull/29070) for the visual before/after of the underlying feature.

### **After**

N/A — same rendering as the recordings in [#29070](https://github.com/MetaMask/metamask-mobile/pull/29070), now reachable in production builds.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.