### PR TITLE
chore: Revert "fix: Zip iOS .app bundles for runway bucket"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,19 +419,13 @@ jobs:
         run: node scripts/rename-artifacts.js ${{ matrix.platform }}
 
       # Upload build artifacts (only if build succeeded)
-      # ios_simulator_path is set by scripts/rename-artifacts.js (staged under ios-simulator-upload/
-      # in CI so upload-artifact uploads a .zip file, not a .app directory).
       - name: Upload iOS simulator app
-        if: success() && matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
+        if: matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ios-app-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_simulator_path }}
           if-no-files-found: error
-
-      - name: Remove iOS simulator staging directory
-        if: success() && matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
-        run: rm -rf ios-simulator-upload
 
       - name: Upload iOS IPA
         if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')

--- a/scripts/rename-artifacts.js
+++ b/scripts/rename-artifacts.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execSync } = require('child_process');
 
 const platform = process.argv[2];
 
@@ -72,11 +72,9 @@ if (!buildType || !environment) {
  */
 function findFiles(dir, pattern) {
   try {
-    const output = execFileSync(
-      'find',
-      [dir, '-name', pattern, '-type', 'f'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
-    ).trim();
+    const output = execSync(`find "${dir}" -name "${pattern}" -type f 2>/dev/null || true`, {
+      encoding: 'utf8',
+    }).trim();
     return output ? output.split('\n') : [];
   } catch {
     return [];
@@ -88,11 +86,9 @@ function findFiles(dir, pattern) {
  */
 function findDirs(dir, pattern) {
   try {
-    const output = execFileSync(
-      'find',
-      [dir, '-name', pattern, '-type', 'd'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
-    ).trim();
+    const output = execSync(`find "${dir}" -name "${pattern}" -type d 2>/dev/null || true`, {
+      encoding: 'utf8',
+    }).trim();
     return output ? output.split('\n') : [];
   } catch {
     return [];
@@ -219,26 +215,9 @@ function setGithubOutput(key, value) {
 }
 
 /**
- * Path relative to GITHUB_WORKSPACE (or cwd) for upload-artifact.
- * upload-artifact treats `.app` bundles as directories; staging the outer zip
- * under ios-simulator-upload/ and emitting this path ensures the artifact is a file.
- */
-function toRepoRelative(absFilePath) {
-  const root = process.env.GITHUB_WORKSPACE || process.cwd();
-  const resolved = path.resolve(absFilePath);
-  const rel = path.relative(root, resolved);
-  if (rel.startsWith('..')) {
-    return resolved;
-  }
-  return rel;
-}
-
-/**
  * Rename iOS artifacts
  *
- * Simulator-only: ios_simulator_path — inner zip is ditto of .app; outer zip is
- * ditto of that inner zip (double-zip). Under CI, the outer zip is copied to
- * ios-simulator-upload/ for upload-artifact.
+ * Simulator-only: ios_simulator_path (zipped .app).
  * Device-only: ios_ipa_path, ios_archive_path, ios_sourcemap_path.
  * Dual (IS_SIM_BUILD + IS_DEVICE_BUILD, e.g. main-dev): all of the above.
  */
@@ -281,36 +260,15 @@ function renameIos() {
     const oldApp = path.join(simProductsDir, `${appName}.app`);
     if (fs.existsSync(oldApp)) {
       const newApp = path.join(simProductsDir, `${newSimBaseName}.app`);
-      execFileSync('cp', ['-r', oldApp, newApp], { stdio: 'inherit' });
+      execSync(`cp -r "${oldApp}" "${newApp}"`);
       console.log(`✅ Renamed simulator .app: ${newApp}`);
 
       const zipPath = path.join(simProductsDir, `${newSimBaseName}.zip`);
-      execFileSync(
-        'ditto',
-        ['-c', '-k', '--sequesterRsrc', '--keepParent', newApp, zipPath],
-        { stdio: 'inherit' },
+      execSync(
+        `ditto -c -k --sequesterRsrc --keepParent "${newApp}" "${zipPath}"`,
       );
       console.log(`✅ Zipped: ${zipPath}`);
-
-      const doubleZipPath = path.join(simProductsDir, `${newSimBaseName}.app.zip`);
-      execFileSync(
-        'ditto',
-        ['-c', '-k', '--sequesterRsrc', zipPath, doubleZipPath],
-        { stdio: 'inherit' },
-      );
-      console.log(`✅ Double-zipped (outer contains inner .zip): ${doubleZipPath}`);
-
-      let simulatorUploadPath = doubleZipPath;
-      if (process.env.GITHUB_OUTPUT) {
-        const stagingDir = path.join(__dirname, '../ios-simulator-upload');
-        fs.rmSync(stagingDir, { recursive: true, force: true });
-        fs.mkdirSync(stagingDir, { recursive: true });
-        const stagedZip = path.join(stagingDir, path.basename(doubleZipPath));
-        fs.copyFileSync(doubleZipPath, stagedZip);
-        simulatorUploadPath = stagedZip;
-        console.log(`✅ Staged simulator double-zip for CI upload: ${stagedZip}`);
-      }
-      setGithubOutput('ios_simulator_path', toRepoRelative(simulatorUploadPath));
+      setGithubOutput('ios_simulator_path', zipPath);
     } else {
       console.log(`⚠️  Simulator .app not found: ${oldApp}`);
     }
@@ -338,10 +296,8 @@ function renameIos() {
         __dirname,
         `../ios/build/${newDeviceBaseName}.xcarchive.zip`,
       );
-      execFileSync(
-        'ditto',
-        ['-c', '-k', '--sequesterRsrc', '--keepParent', oldArchive, archiveZip],
-        { stdio: 'inherit' },
+      execSync(
+        `ditto -c -k --sequesterRsrc --keepParent "${oldArchive}" "${archiveZip}"`,
       );
       console.log(`✅ Zipped archive: ${archiveZip}`);
       setGithubOutput('ios_archive_path', archiveZip);


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#29377

Shouldn't need double zip anymore since Runway should support .app bundles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI artifact packaging and paths for iOS simulator outputs, which could break downstream consumers or uploads if the expected zip naming/location differs.
> 
> **Overview**
> Reverts the iOS simulator artifact workaround that **double-zipped and staged** `.app` bundles before upload, returning to a single `.zip` produced directly from the simulator `.app` and emitting that path via `ios_simulator_path`.
> 
> The build workflow is simplified by removing simulator upload staging/cleanup logic and loosening the upload step condition (dropping the redundant `success()` guard). The artifact renaming script also switches from `execFileSync` to `execSync` for `find`/`cp`/`ditto` invocations and removes repo-relative path conversion for simulator uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 255c3e064ff19608b7483d30adf215fb10316346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->