### PR TITLE
test(e2e): mock signature-insights to remove from allowlist (MMQA-1779)

### DIFF
--- a/tests/api-mocking/mock-e2e-allowlist.ts
+++ b/tests/api-mocking/mock-e2e-allowlist.ts
@@ -23,13 +23,10 @@ export const ALLOWLISTED_HOSTS = [
 export const ALLOWLISTED_URLS = [
   // Temporarily allow existing live requests during migration
   'https://api.avax.network/ext/bc/C/rpc',
-  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x539',
   'https://mainnet.era.zksync.io/',
   'https://rpc.atlantischain.network/',
   'https://nft.api.cx.metamask.io/collections?chainId=0x539&contract=0xb2552e4f4bc23e1572041677234d192774558bf0',
   'https://metamask.github.io/test-dapp/metamask-fox.svg',
   'https://nft.api.cx.metamask.io/collections?contract=0xb66a603f4cfe17e3d27b87a8bfcad319856518b8&chainId=1',
   'https://nft.api.cx.metamask.io/users/0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3/tokens?chainIds=1&limit=50&includeTopBid=true&continuation=',
-  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x1',
-  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0xaa36a7',
 ];

--- a/tests/api-mocking/mock-responses/defaults/index.ts
+++ b/tests/api-mocking/mock-responses/defaults/index.ts
@@ -32,6 +32,7 @@ import { TX_SENTINEL_NETWORKS_MAP } from '../tx-sentinel-networks-map.ts';
 import { DIGEST_API_MOCKS } from './digest-api.ts';
 import { MONEY_ACCOUNT_MOCKS } from './money-account.ts';
 import { STATIC_ASSETS_MOCKS } from './static-assets.ts';
+import { SIGNATURE_INSIGHTS_MOCKS } from './signature-insights.ts';
 
 // Get auth mocks
 const authMocks = getAuthMocks();
@@ -153,6 +154,7 @@ export const DEFAULT_MOCKS = {
     ...(METAMETRICS_API_MOCKS.POST || []),
     ...(DEFAULT_RPC_ENDPOINT_MOCKS.POST || []),
     ...(INFURA_MOCKS.POST || []),
+    ...(SIGNATURE_INSIGHTS_MOCKS.POST || []),
     {
       urlEndpoint: 'https://api.mixpanel.com/track',
       responseCode: 200,

--- a/tests/api-mocking/mock-responses/defaults/signature-insights.ts
+++ b/tests/api-mocking/mock-responses/defaults/signature-insights.ts
@@ -1,0 +1,18 @@
+import { MockEventsObject } from '../../../framework';
+
+export const SIGNATURE_INSIGHTS_MOCKS: MockEventsObject = {
+  POST: [
+    {
+      urlEndpoint:
+        /^https:\/\/signature-insights\.api\.cx\.metamask\.io\/v1\/signature\?chainId=0x[0-9a-fA-F]+$/,
+      responseCode: 200,
+      response: {
+        stateChanges: null,
+        error: {
+          message: 'Unsupported signature.',
+          type: 'UNSUPPORTED_SIGNATURE',
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## **Description**

Tier 3 of MMQA-1364 (allowlist reduction), scoped to the `signature-insights` endpoint only. NFT API entries (`/users/.../tokens`, `/collections`, `/explore/sites`, prod/dev/uat hosts) are deferred to follow-up tickets in the same tier.

| Matcher | Method | Response |
| --- | --- | --- |
| `^https://signature-insights\.api\.cx\.metamask\.io/v1/signature\?chainId=0x[0-9a-fA-F]+$` | POST | `{ stateChanges: null, error: { message: 'Unsupported signature.', type: 'UNSUPPORTED_SIGNATURE' } }` |

**Why this response shape.** The SDK's own `decodeSignature` (`@metamask/signature-controller/utils/decoding-api`) returns this exact shape (`type: 'UNSUPPORTED_SIGNATURE'`) when the signature method is anything other than `SignTypedDataV3`/`V4`. The wallet's `TypedSignV3V4Simulation` (`app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/simulation.tsx:18-22`) checks `decodingData?.error` and falls through to either the permit fallback or the "simulation unavailable" placeholder in `DecodedSimulation`. Returning the same shape keeps the wallet on a known-graceful code path with no errors logged.

**Why regex, not exact URLs.** Same rationale as Tier 2: covers any future chainId without re-introducing live requests when a new chain is added to default fixtures. Sanity-checked against the 3 chainIds in the previous allowlist (`0x1`, `0x539`, `0xaa36a7`), plus mixed-case hex, plus rejection cases (non-hex, extra query params, different host).

**Spec audit.** Grepped E2E specs that exercise SignTypedDataV3/V4:
- `tests/smoke/confirmations/signatures/signatures-typed.spec.ts` — V3/V4 cases on `chainId=0x539`. Will trigger the mock. Assertions are on row components (`AccountNetwork`, `Message`, `OriginInfo`); no asserts on decoded simulation content. Safe.
- `tests/smoke/confirmations/signatures/alert-system.spec.ts` — V1 only on Sepolia (`0xaa36a7`). V1 doesn't call the API per SDK code. Unrelated.
- Snap and api-spec tests — peripheral, no decoded-content asserts.

No spec asserts on `decodingData.stateChanges` rendering, so the default mock is safe across the codebase.

### Files changed
- `tests/api-mocking/mock-responses/defaults/signature-insights.ts` — new
- `tests/api-mocking/mock-responses/defaults/index.ts` — import + spread into `DEFAULT_MOCKS.POST`
- `tests/api-mocking/mock-e2e-allowlist.ts` — removed 3 entries

### Out of scope
- NFT API entries (`/users/tokens`, `/collections`, `/explore/sites`, prod/dev/uat hosts) — deferred to separate Tier 3 tickets

## **Changelog**

CHANGELOG entry: null

## **Related issues**

[MMQA-1779](https://consensyssoftware.atlassian.net/browse/MMQA-1779) — parent epic [MMQA-1364](https://consensyssoftware.atlassian.net/browse/MMQA-1364)

## **Manual testing steps**

```gherkin
Feature: signature-insights default mock for E2E tests

  Scenario: SignTypedDataV4 confirmation does not hit live signature-insights
    Given the E2E mock server is running with default mocks loaded
    And a dapp is connected on any EVM chain
    When the user triggers an eth_signTypedData_v4 request
    Then mockttp returns the UNSUPPORTED_SIGNATURE error shape
    And the wallet renders the "simulation unavailable" placeholder
    And validateLiveRequests() does not record a live request to signature-insights
```

## **Screenshots/Recordings**

### **Before**

Every `eth_signTypedData_v3` / `_v4` exercised by smoke specs fired a live POST to `signature-insights.api.cx.metamask.io`. The 3 chainId-specific allowlist entries silenced `validateLiveRequests()`, but the call still reached the live decoding API and whatever it returned was rendered as decoded state changes in the wallet UI.

### **After**

mockttp intercepts the POST and returns the SDK's own `UNSUPPORTED_SIGNATURE` error shape. The wallet's `TypedSignV3V4Simulation` checks `decodingData?.error` and falls through to the `confirm.simulation.unavailable` placeholder in `DecodedSimulation` — the same path the wallet takes when the API errors live. Spec assertions on row components (origin, message, account/network) continue to pass. `validateLiveRequests()` records zero leaks for `signature-insights`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1779]: https://consensyssoftware.atlassian.net/browse/MMQA-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that replace live `signature-insights` requests with a deterministic mock and tighten the E2E allowlist.
> 
> **Overview**
> E2E tests no longer rely on live calls to `signature-insights.api.cx.metamask.io`: the PR removes the chainId-specific allowlisted URLs and adds a default POST mock that matches any hex `chainId` and returns an `UNSUPPORTED_SIGNATURE` error shape.
> 
> The new `SIGNATURE_INSIGHTS_MOCKS` is wired into `DEFAULT_MOCKS.POST`, reducing network leakage during signature-related smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8335a5e39df77420fc14130fdde60c4a4a0f1009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->