### PR TITLE
test: skip changing the slippage in Swap smoke test due to bug

### DIFF
--- a/tests/helpers/analytics/expectations/swap-action.analytics.ts
+++ b/tests/helpers/analytics/expectations/swap-action.analytics.ts
@@ -102,7 +102,11 @@ const completedProperties: Record<
  *
  * Note: these expectations are run against events captured during the first swap only.
  * The `validate` callback handles the Input Changed events which require advanced checks
- * (count = 12, specific `input` values like chain_source, token_destination, slippage).
+ * (count = 11 without custom slippage; chain_source, token_destination).
+ *
+ * Slippage `INPUT_CHANGED` assertion is disabled: swap-action smoke no longer opens the
+ * slippage modal until https://github.com/MetaMask/metamask-mobile/issues/29615 is fixed,
+ * so that event is not emitted and the count is 11 instead of 12.
  */
 export const swapActionExpectations: AnalyticsExpectations = {
   eventNames: expectedEventNames,
@@ -126,7 +130,8 @@ export const swapActionExpectations: AnalyticsExpectations = {
   validate: async ({ events }) => {
     const inputChanged = filterEvents(events, INPUT_CHANGED);
 
-    await Assertions.checkIfArrayHasLength(inputChanged, 12);
+    // 11 while custom slippage is skipped (bug #29615); was 12 with slippage modal.
+    await Assertions.checkIfArrayHasLength(inputChanged, 11);
 
     for (const event of inputChanged) {
       await Assertions.checkIfValueIsDefined(event.properties.input);
@@ -145,10 +150,11 @@ export const swapActionExpectations: AnalyticsExpectations = {
         `Expected input=token_destination in Input Changed events. Found: ${inputs.join(', ')}`,
       );
     }
-    if (!inputs.includes('slippage')) {
-      throw new Error(
-        `Expected input=slippage in Input Changed events. Found: ${inputs.join(', ')}`,
-      );
-    }
+    // Re-enable when swap-action smoke sets custom slippage again (bug #29615).
+    // if (!inputs.includes('slippage')) {
+    //   throw new Error(
+    //     `Expected input=slippage in Input Changed events. Found: ${inputs.join(', ')}`,
+    //   );
+    // }
   },
 };

--- a/tests/smoke/swap/swap-action-smoke.spec.ts
+++ b/tests/smoke/swap/swap-action-smoke.spec.ts
@@ -59,7 +59,8 @@ describe(SmokeSwap('Swap from Actions'), (): void => {
 
         // Submit first swap: ETH->ERC20 (USDC) with custom slippage
         await submitSwapUnifiedUI('1', 'ETH', 'USDC', '0x1', {
-          slippage: '3.5',
+          // slippage: '3.5',
+          // comment out until bug #29615 is fixed
         });
         await checkSwapActivity('ETH', 'USDC');
 


### PR DESCRIPTION
<!--
This is a temporary patch until this bug is fixed ttps://github.com/MetaMask/metamask-mobile/issues/29615
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to smoke-test steps and analytics expectations, adjusting assertions to match a temporarily missing slippage event.
> 
> **Overview**
> Updates the swap action smoke test to **stop setting custom slippage** during the first ETH→USDC swap while bug `#29615` is unresolved.
> 
> Adjusts the associated analytics expectations by reducing `INPUT_CHANGED` event count from 12→11 and temporarily disabling the `slippage` input assertion, with comments indicating it should be re-enabled once the bug is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05981c9bf05a46255a68ff89fc7f007575183fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->