### PR TITLE
feat(ramps): open order details immediately after UB2 webview callbacks

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, act, waitFor } from '@testing-library/react-native';
 import Checkout from './Checkout';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import Routes from '../../../../../constants/navigation/Routes';
 import { callbackBaseUrl } from '../../Aggregator/sdk';
 
 jest.mock('@react-navigation/native', () => {
@@ -32,11 +33,6 @@ jest.mock('../../hooks/useRampsOrders', () => ({
   useRampsOrders: jest.fn(),
 }));
 
-jest.mock('../../hooks/useRampsUnifiedV2Enabled', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
 }));
@@ -47,8 +43,8 @@ jest.mock('../../../../../actions/user', () => ({
   })),
 }));
 
-jest.mock('../../utils/v2OrderToast', () => ({
-  showV2OrderToast: jest.fn(),
+jest.mock('../../../../../reducers/fiatOrders', () => ({
+  getRampRoutingDecision: () => null,
 }));
 
 jest.mock('../../headless/sessionRegistry', () => ({
@@ -224,10 +220,6 @@ const mockUseParams = jest.requireMock(
 const mockUseRampsOrders = jest.requireMock('../../hooks/useRampsOrders')
   .useRampsOrders as jest.Mock;
 
-const mockUseRampsUnifiedV2Enabled = jest.requireMock(
-  '../../hooks/useRampsUnifiedV2Enabled',
-).default as jest.Mock;
-
 const mockUseAnalytics = jest.requireMock(
   '../../../../hooks/useAnalytics/useAnalytics',
 ).useAnalytics as jest.Mock;
@@ -262,7 +254,6 @@ describe('Checkout', () => {
       getOrderFromCallback: mockGetOrderFromCallback,
       addPrecreatedOrder: mockAddPrecreatedOrder,
     });
-    mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
     mockUseAnalytics.mockReturnValue({
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
@@ -306,8 +297,7 @@ describe('Checkout', () => {
         });
       });
 
-      expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
-      expect(mockAddOrder).not.toHaveBeenCalled();
+      expect(mockNavigation.reset).not.toHaveBeenCalled();
     });
 
     it('does not invoke callback handler when hasCallbackFlow is false', async () => {
@@ -322,8 +312,7 @@ describe('Checkout', () => {
         fireEvent.press(getByTestId('trigger-callback-navigation'));
       });
 
-      expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
-      expect(mockAddOrder).not.toHaveBeenCalled();
+      expect(mockNavigation.reset).not.toHaveBeenCalled();
     });
   });
 
@@ -513,21 +502,47 @@ describe('Checkout', () => {
     });
   });
 
-  describe('V2 enabled flow', () => {
-    it('calls showV2OrderToast when V2 is enabled and callback succeeds', async () => {
-      const { showV2OrderToast } = jest.requireMock(
-        '../../utils/v2OrderToast',
-      ) as {
-        showV2OrderToast: jest.Mock;
-      };
-      const mockOrder = {
-        providerOrderId: 'order-v2-1',
-        cryptoCurrency: { symbol: 'ETH' },
-        cryptoAmount: '0.5',
-        status: 'COMPLETED',
-      };
-      mockGetOrderFromCallback.mockResolvedValue(mockOrder);
-      mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+  describe('callback success (unified buy stack)', () => {
+    it('resets navigation to order details with callback params without fetching the order in Checkout', async () => {
+      const callbackUrl = `${callbackBaseUrl}?orderId=123`;
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test',
+        providerCode: 'moonpay',
+        walletAddress: '0xabc',
+        cryptocurrency: 'ETH',
+      });
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [
+            {
+              name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+              params: {
+                callbackUrl,
+                providerCode: 'moonpay',
+                walletAddress: '0xabc',
+                showCloseButton: true,
+                cryptocurrency: 'ETH',
+              },
+            },
+          ],
+        });
+      });
+
+      expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
+      expect(mockAddOrder).not.toHaveBeenCalled();
+    });
+
+    it('omits cryptocurrency when not provided in params', async () => {
+      const callbackUrl = `${callbackBaseUrl}?orderId=123`;
       mockUseParams.mockReturnValue({
         url: 'https://provider.example.com/checkout',
         providerName: 'Test',
@@ -542,41 +557,20 @@ describe('Checkout', () => {
       });
 
       await waitFor(() => {
-        expect(showV2OrderToast).toHaveBeenCalledWith(
-          expect.objectContaining({
-            orderId: 'order-v2-1',
-            cryptocurrency: 'ETH',
-          }),
-        );
-      });
-    });
-  });
-
-  describe('callback error handling', () => {
-    it('sets error when getOrderFromCallback returns null', async () => {
-      mockGetOrderFromCallback.mockResolvedValue(null);
-      mockUseParams.mockReturnValue({
-        url: 'https://provider.example.com/checkout',
-        providerName: 'Test',
-        providerCode: 'moonpay',
-        walletAddress: '0xabc',
-      });
-
-      const { getByTestId, getByText } = renderWithProvider(
-        <Checkout />,
-        {},
-        true,
-        false,
-      );
-
-      await act(async () => {
-        fireEvent.press(getByTestId('trigger-callback-navigation'));
-      });
-
-      await waitFor(() => {
-        expect(
-          getByText('Order could not be retrieved from callback'),
-        ).toBeOnTheScreen();
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [
+            {
+              name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+              params: {
+                callbackUrl,
+                providerCode: 'moonpay',
+                walletAddress: '0xabc',
+                showCloseButton: true,
+              },
+            },
+          ],
+        });
       });
     });
   });
@@ -660,8 +654,6 @@ describe('Checkout', () => {
       .closeSession as jest.Mock;
     const mockFailSession = jest.requireMock('../../headless/sessionRegistry')
       .failSession as jest.Mock;
-    const showV2OrderToastMock = jest.requireMock('../../utils/v2OrderToast')
-      .showV2OrderToast as jest.Mock;
 
     const mockOrder = {
       providerOrderId: 'headless-order-1',
@@ -692,7 +684,6 @@ describe('Checkout', () => {
         }),
       }));
       mockGetOrderFromCallback.mockResolvedValue(mockOrder);
-      mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
     });
 
     it('fires onOrderCreated, closes the session, and pops the ramp stack when a live session is present', async () => {
@@ -721,12 +712,34 @@ describe('Checkout', () => {
         reason: 'completed',
       });
       expect(mockParentPop).toHaveBeenCalled();
-      expect(mockAddOrder).toHaveBeenCalledWith(mockOrder);
+      expect(mockNavigation.reset).not.toHaveBeenCalled();
+    });
+
+    it('still adds the order to Redux and dispatches protect-wallet when headless', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(mockAddOrder).toHaveBeenCalledWith(mockOrder);
+      });
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'PROTECT_WALLET_MODAL_VISIBLE',
       });
       expect(mockNavigation.reset).not.toHaveBeenCalled();
-      expect(showV2OrderToastMock).not.toHaveBeenCalled();
     });
 
     it('swallows consumer onOrderCreated errors and still closes + pops', async () => {
@@ -766,7 +779,54 @@ describe('Checkout', () => {
       expect(mockParentPop).toHaveBeenCalled();
     });
 
+    it('fires RAMPS_CHECKOUT_CLOSED with close_source=callback_error when headless getOrderFromCallback returns null', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockGetOrderFromCallback.mockResolvedValue(null);
+      mockFailSession.mockReturnValue(true);
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId, unmount } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+      unmount();
+
+      const closedIdx = mockCreateEventBuilder.mock.calls.findIndex(
+        (c) => c[0] === MetaMetricsEvents.RAMPS_CHECKOUT_CLOSED,
+      );
+      expect(closedIdx).toBeGreaterThanOrEqual(0);
+      expect(mockAddProperties.mock.calls[closedIdx]?.[0]).toMatchObject({
+        close_source: 'callback_error',
+      });
+      expect(mockDispatch).not.toHaveBeenCalledWith({
+        type: 'PROTECT_WALLET_MODAL_VISIBLE',
+      });
+    });
+
     it('surfaces callback processing failures through onError and skips the ErrorView', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
       mockUseParams.mockReturnValue(callbackFlowParams);
       mockGetOrderFromCallback.mockRejectedValueOnce(
         new Error('callback failed'),
@@ -791,8 +851,10 @@ describe('Checkout', () => {
         expect(mockFailSession).toHaveBeenCalledWith('hs-1', expect.any(Error));
       });
       expect(mockParentPop).toHaveBeenCalled();
-      expect(showV2OrderToastMock).not.toHaveBeenCalled();
       expect(queryByText('callback failed')).toBeNull();
+      expect(mockDispatch).not.toHaveBeenCalledWith({
+        type: 'PROTECT_WALLET_MODAL_VISIBLE',
+      });
     });
 
     it('surfaces provider WebView HTTP errors through onError when headless', async () => {
@@ -885,7 +947,7 @@ describe('Checkout', () => {
       });
     });
 
-    it('falls back to the regular reset + toast when session id is present but session is missing from registry', async () => {
+    it('falls back to OrderDetails callback-resolution when session id is present but session is missing from registry', async () => {
       mockGetSession.mockReturnValue(undefined);
       mockUseParams.mockReturnValue(callbackFlowParams);
 
@@ -896,21 +958,23 @@ describe('Checkout', () => {
       });
 
       await waitFor(() => {
-        expect(showV2OrderToastMock).toHaveBeenCalledWith(
-          expect.objectContaining({ orderId: 'headless-order-1' }),
+        expect(mockNavigation.reset).toHaveBeenCalledWith(
+          expect.objectContaining({
+            routes: [
+              expect.objectContaining({
+                name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+                params: expect.objectContaining({
+                  callbackUrl: `${callbackBaseUrl}?orderId=123`,
+                  providerCode: 'moonpay',
+                  walletAddress: '0xdeadbeef',
+                }),
+              }),
+            ],
+          }),
         );
       });
-      expect(mockNavigation.reset).toHaveBeenCalledWith(
-        expect.objectContaining({
-          routes: [
-            expect.objectContaining({
-              params: expect.objectContaining({
-                orderId: 'headless-order-1',
-              }),
-            }),
-          ],
-        }),
-      );
+      expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
+      expect(mockAddOrder).not.toHaveBeenCalled();
       expect(mockCloseSession).not.toHaveBeenCalled();
       expect(mockParentPop).not.toHaveBeenCalled();
     });
@@ -932,7 +996,8 @@ describe('Checkout', () => {
       await waitFor(() => {
         expect(mockNavigation.reset).toHaveBeenCalled();
       });
-      expect(showV2OrderToastMock).toHaveBeenCalled();
+      expect(mockGetOrderFromCallback).not.toHaveBeenCalled();
+      expect(mockAddOrder).not.toHaveBeenCalled();
       expect(mockCloseSession).not.toHaveBeenCalled();
       expect(mockParentPop).not.toHaveBeenCalled();
     });
@@ -1338,8 +1403,7 @@ describe('Checkout', () => {
       });
     });
 
-    it('fires RAMPS_CHECKOUT_CLOSED with close_source=callback_error when getOrderFromCallback returns null', async () => {
-      mockGetOrderFromCallback.mockResolvedValue(null);
+    it('fires RAMPS_CHECKOUT_CLOSED with close_source=callback_success when callback URL is recognized (non-headless)', async () => {
       mockUseParams.mockReturnValue({
         url: 'https://provider.example.com/checkout',
         providerName: 'Test',
@@ -1360,7 +1424,7 @@ describe('Checkout', () => {
       unmount();
 
       const closed = findEventProps(MetaMetricsEvents.RAMPS_CHECKOUT_CLOSED);
-      expect(closed).toMatchObject({ close_source: 'callback_error' });
+      expect(closed).toMatchObject({ close_source: 'callback_success' });
     });
 
     it('fires RAMPS_CHECKOUT_CLOSED with close_source=http_error after a terminal HTTP error', async () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -31,8 +31,7 @@ import {
   HeaderStandard,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
-import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
-import { showV2OrderToast } from '../../utils/v2OrderToast';
+
 import {
   closeSession,
   failSession,
@@ -82,8 +81,7 @@ interface CheckoutParams {
    * When set, Checkout is participating in a headless buy session. On
    * successful callback the screen fires the session's `onOrderCreated`
    * callback, closes the session, and pops the ramp stack instead of
-   * resetting to `RAMPS_ORDER_DETAILS`. The `showV2OrderToast` surface is
-   * also suppressed — headless consumers drive their own UI.
+   * resetting to `RAMPS_ORDER_DETAILS`. Headless consumers drive their own UI.
    */
   headlessSessionId?: string;
 }
@@ -104,8 +102,6 @@ const Checkout = () => {
   const { addOrder, addPrecreatedOrder, getOrderFromCallback } =
     useRampsOrders();
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const isV2Enabled = useRampsUnifiedV2Enabled();
-
   const {
     url: uri,
     providerName,
@@ -116,6 +112,7 @@ const Checkout = () => {
     network,
     userAgent,
     onNavigationStateChange,
+    cryptocurrency,
     headlessSessionId,
   } = params ?? {};
   const effectiveOrderId = (orderIdParam ?? customOrderId)?.trim() || null;
@@ -327,25 +324,22 @@ const Checkout = () => {
           throw new Error('No wallet address or provider code available');
         }
 
-        const rampsOrder = await getOrderFromCallback(
-          providerCode,
-          navState.url,
-          walletAddress,
-        );
-
-        if (!rampsOrder) {
-          throw new Error('Order could not be retrieved from callback');
-        }
-
-        addOrder(rampsOrder);
-        dispatch(protectWalletModalVisible());
-
-        // Headless mode: hand the orderId to the consumer, close the
-        // session, and unwind out of the ramp stack so the caller regains
-        // foreground. Skip the toast + RAMPS_ORDER_DETAILS reset — both
-        // are user-facing UI the headless consumer didn't ask for.
+        // Headless mode: fetch the order, hand the orderId to the consumer,
+        // close the session, and unwind out of the ramp stack so the caller
+        // regains foreground. Skip RAMPS_ORDER_DETAILS — the headless consumer
+        // drives its own UI.
         const session = getSession(headlessSessionId);
         if (headlessSessionId && session) {
+          const rampsOrder = await getOrderFromCallback(
+            providerCode,
+            navState.url,
+            walletAddress,
+          );
+          if (!rampsOrder) {
+            throw new Error('Order could not be retrieved from callback');
+          }
+          addOrder(rampsOrder);
+          dispatch(protectWalletModalVisible());
           try {
             session.callbacks.onOrderCreated(rampsOrder.providerOrderId);
           } catch (callbackError) {
@@ -361,26 +355,23 @@ const Checkout = () => {
           return;
         }
 
-        if (isV2Enabled) {
-          showV2OrderToast({
-            orderId: rampsOrder.providerOrderId,
-            cryptocurrency:
-              rampsOrder.cryptoCurrency?.symbol ?? params?.cryptocurrency ?? '',
-            cryptoAmount: rampsOrder.cryptoAmount,
-            status: rampsOrder.status,
-          });
-        }
+        dispatch(protectWalletModalVisible());
 
         closeSourceRef.current = 'callback_success';
 
+        // Unified buy stack (non-headless): leave the WebView immediately; OrderDetails
+        // resolves the order via callback params (same pattern as external-browser return).
         navigation.reset({
           index: 0,
           routes: [
             {
               name: Routes.RAMP.RAMPS_ORDER_DETAILS,
               params: {
-                orderId: rampsOrder.providerOrderId,
+                callbackUrl: navState.url,
+                providerCode,
+                walletAddress,
                 showCloseButton: true,
+                ...(cryptocurrency ? { cryptocurrency } : {}),
               },
             },
           ],
@@ -402,10 +393,9 @@ const Checkout = () => {
       providerCode,
       walletAddress,
       navigation,
+      cryptocurrency,
       addOrder,
       getOrderFromCallback,
-      isV2Enabled,
-      params?.cryptocurrency,
       headlessSessionId,
       dismissActiveHeadlessFlow,
       failHeadlessCheckout,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -43,6 +43,19 @@ jest.mock('../../../../../util/theme', () => {
   };
 });
 
+jest.mock('../../utils/v2OrderToast', () => ({
+  showV2OrderToast: jest.fn(),
+}));
+
+const mockHandleOrderStatusChangedForMetrics = jest.fn();
+jest.mock(
+  '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics',
+  () => ({
+    handleOrderStatusChangedForMetrics: (...args: unknown[]) =>
+      mockHandleOrderStatusChangedForMetrics(...args),
+  }),
+);
+
 const mockTrackEvent = jest.fn();
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
@@ -176,6 +189,21 @@ describe('OrderDetails', () => {
     expect(mockRefreshOrder).toHaveBeenCalled();
   });
 
+  it('shows localized error when pending order refresh rejects with non-Error', async () => {
+    mockUseParams.mockReturnValue({ orderId: 'ord-pending' });
+    mockGetOrderById.mockReturnValue({
+      ...mockOrder,
+      status: RampsOrderStatus.Pending,
+    });
+    mockRefreshOrder.mockRejectedValue('not-an-error');
+
+    const { getByText } = render();
+
+    await waitFor(() => {
+      expect(getByText('ramps_order_details.error_message')).toBeOnTheScreen();
+    });
+  });
+
   it('tracks RAMPS_SCREEN_VIEWED when order is displayed', async () => {
     render();
     await waitFor(() => {
@@ -206,6 +234,192 @@ describe('OrderDetails', () => {
     expect(mockTrackEvent).toHaveBeenCalled();
   });
 
+  it('shows V2 order toast when callback fetch succeeds', async () => {
+    const { showV2OrderToast } = jest.requireMock(
+      '../../utils/v2OrderToast',
+    ) as { showV2OrderToast: jest.Mock };
+    const completedOrder = {
+      providerOrderId: 'ord-cb-1',
+      status: RampsOrderStatus.Completed,
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.1',
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    };
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue(completedOrder);
+
+    render();
+
+    await waitFor(() => {
+      expect(showV2OrderToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: 'ord-cb-1',
+          cryptocurrency: 'ETH',
+        }),
+      );
+    });
+
+    expect(mockHandleOrderStatusChangedForMetrics).toHaveBeenCalledWith({
+      order: completedOrder,
+      previousStatus: RampsOrderStatus.Precreated,
+    });
+  });
+
+  it('resets to build quote when callback returns no order', async () => {
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue(null);
+
+    render();
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalled();
+    });
+    const resetArg = mockReset.mock.calls[0][0] as {
+      routes: { name: string }[];
+    };
+    expect(resetArg.routes[0].name).toBe(Routes.RAMP.BUILD_QUOTE);
+  });
+
+  it('resets to build quote when callback order is in a bailed status', async () => {
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue({
+      providerOrderId: 'ord-bail',
+      status: RampsOrderStatus.Precreated,
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    });
+
+    render();
+
+    await waitFor(() => {
+      expect(mockReset).toHaveBeenCalled();
+    });
+    expect(mockAddOrder).not.toHaveBeenCalled();
+  });
+
+  it('uses route cryptocurrency for toast when callback order has no crypto symbol', async () => {
+    const { showV2OrderToast } = jest.requireMock(
+      '../../utils/v2OrderToast',
+    ) as { showV2OrderToast: jest.Mock };
+    const orderWithoutCryptoSymbol = {
+      providerOrderId: 'ord-cb-2',
+      status: RampsOrderStatus.Completed,
+      cryptoAmount: '1',
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    };
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+      cryptocurrency: 'SOL',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue(orderWithoutCryptoSymbol);
+
+    render();
+
+    await waitFor(() => {
+      expect(showV2OrderToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: 'ord-cb-2',
+          cryptocurrency: 'SOL',
+        }),
+      );
+    });
+  });
+
+  it('does not emit status metrics when callback order status matches prior order', async () => {
+    const { showV2OrderToast } = jest.requireMock(
+      '../../utils/v2OrderToast',
+    ) as { showV2OrderToast: jest.Mock };
+    const completedOrder = {
+      providerOrderId: 'ord-same',
+      status: RampsOrderStatus.Completed,
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.1',
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    };
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockImplementation((id: string) =>
+      id === 'ord-same' ? completedOrder : undefined,
+    );
+    mockGetOrderFromCallback.mockResolvedValue(completedOrder);
+
+    render();
+
+    await waitFor(() => {
+      expect(showV2OrderToast).toHaveBeenCalled();
+    });
+    expect(mockHandleOrderStatusChangedForMetrics).not.toHaveBeenCalled();
+  });
+
+  it('shows localized error when callback fetch rejects with Error that has no message', async () => {
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockRejectedValue(new Error(''));
+
+    const { getByText } = render();
+
+    await waitFor(() => {
+      expect(getByText('ramps_order_details.error_message')).toBeOnTheScreen();
+    });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['plain object', { foo: 'bar' }],
+    ['string', 'oops'],
+    ['null', null],
+  ])(
+    'shows localized error when callback fetch rejects with non-Error value (%s)',
+    async (_label, rejectedValue) => {
+      mockUseParams.mockReturnValue({
+        callbackUrl: 'https://callback.example?x=1',
+        providerCode: 'moonpay',
+        walletAddress: '0x123',
+      });
+      mockGetOrderById.mockReturnValue(undefined);
+      mockGetOrderFromCallback.mockRejectedValue(rejectedValue);
+
+      const { getByText, queryByText } = render();
+
+      await waitFor(() => {
+        expect(
+          getByText('ramps_order_details.error_message'),
+        ).toBeOnTheScreen();
+      });
+      expect(queryByText('undefined')).toBeNull();
+      expect(queryByText('[object Object]')).toBeNull();
+      expect(queryByText('null')).toBeNull();
+    },
+  );
+
   it('shows error state with retry when initial callback fetch fails', async () => {
     mockUseParams.mockReturnValue({
       callbackUrl: 'metamask://on-ramp/providers/paypal?orderId=abc',
@@ -222,6 +436,7 @@ describe('OrderDetails', () => {
     await waitFor(() => {
       expect(getByText('Network request failed')).toBeOnTheScreen();
     });
+    expect(mockHandleOrderStatusChangedForMetrics).not.toHaveBeenCalled();
     expect(getByText('ramps_order_details.try_again')).toBeOnTheScreen();
 
     await act(async () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -47,15 +47,6 @@ jest.mock('../../utils/v2OrderToast', () => ({
   showV2OrderToast: jest.fn(),
 }));
 
-const mockHandleOrderStatusChangedForMetrics = jest.fn();
-jest.mock(
-  '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics',
-  () => ({
-    handleOrderStatusChangedForMetrics: (...args: unknown[]) =>
-      mockHandleOrderStatusChangedForMetrics(...args),
-  }),
-);
-
 const mockTrackEvent = jest.fn();
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
@@ -343,36 +334,6 @@ describe('OrderDetails', () => {
         }),
       );
     });
-  });
-
-  it('does not emit status metrics when callback order status matches prior order', async () => {
-    const { showV2OrderToast } = jest.requireMock(
-      '../../utils/v2OrderToast',
-    ) as { showV2OrderToast: jest.Mock };
-    const completedOrder = {
-      providerOrderId: 'ord-same',
-      status: RampsOrderStatus.Completed,
-      cryptoCurrency: { symbol: 'ETH' },
-      cryptoAmount: '0.1',
-      provider: { id: 'moonpay' },
-      walletAddress: '0x123',
-    };
-    mockUseParams.mockReturnValue({
-      callbackUrl: 'https://callback.example?x=1',
-      providerCode: 'moonpay',
-      walletAddress: '0x123',
-    });
-    mockGetOrderById.mockImplementation((id: string) =>
-      id === 'ord-same' ? completedOrder : undefined,
-    );
-    mockGetOrderFromCallback.mockResolvedValue(completedOrder);
-
-    render();
-
-    await waitFor(() => {
-      expect(showV2OrderToast).toHaveBeenCalled();
-    });
-    expect(mockHandleOrderStatusChangedForMetrics).not.toHaveBeenCalled();
   });
 
   it('shows localized error when callback fetch rejects with Error that has no message', async () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -255,11 +255,6 @@ describe('OrderDetails', () => {
         }),
       );
     });
-
-    expect(mockHandleOrderStatusChangedForMetrics).toHaveBeenCalledWith({
-      order: completedOrder,
-      previousStatus: RampsOrderStatus.Precreated,
-    });
   });
 
   it('resets to build quote when callback returns no order', async () => {
@@ -397,7 +392,6 @@ describe('OrderDetails', () => {
     await waitFor(() => {
       expect(getByText('Network request failed')).toBeOnTheScreen();
     });
-    expect(mockHandleOrderStatusChangedForMetrics).not.toHaveBeenCalled();
     expect(getByText('ramps_order_details.try_again')).toBeOnTheScreen();
 
     await act(async () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -34,7 +34,6 @@ import {
 } from '../../../../../util/navigation/navUtils';
 import { useTheme } from '../../../../../util/theme';
 import Logger from '../../../../../util/Logger';
-import { handleOrderStatusChangedForMetrics } from '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
 import OrderContent from './OrderContent';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
@@ -112,18 +111,7 @@ const OrderDetails = () => {
           });
           return;
         }
-        const priorOrder = getOrderById(fetchedOrder.providerOrderId);
-        const previousStatus =
-          priorOrder?.status ?? RampsOrderStatus.Precreated;
-
         addOrder(fetchedOrder);
-
-        if (previousStatus !== fetchedOrder.status) {
-          handleOrderStatusChangedForMetrics({
-            order: fetchedOrder,
-            previousStatus,
-          });
-        }
 
         showV2OrderToast({
           orderId: fetchedOrder.providerOrderId,
@@ -156,13 +144,7 @@ const OrderDetails = () => {
         setIsLoading(false);
       }
     },
-    [
-      getOrderFromCallback,
-      getOrderById,
-      addOrder,
-      navigation,
-      params.cryptocurrency,
-    ],
+    [getOrderFromCallback, addOrder, navigation, params.cryptocurrency],
   );
 
   const handleHeaderBack = useCallback(() => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -34,8 +34,10 @@ import {
 } from '../../../../../util/navigation/navUtils';
 import { useTheme } from '../../../../../util/theme';
 import Logger from '../../../../../util/Logger';
+import { handleOrderStatusChangedForMetrics } from '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
 import OrderContent from './OrderContent';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
+import { showV2OrderToast } from '../../utils/v2OrderToast';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
@@ -110,7 +112,26 @@ const OrderDetails = () => {
           });
           return;
         }
+        const priorOrder = getOrderById(fetchedOrder.providerOrderId);
+        const previousStatus =
+          priorOrder?.status ?? RampsOrderStatus.Precreated;
+
         addOrder(fetchedOrder);
+
+        if (previousStatus !== fetchedOrder.status) {
+          handleOrderStatusChangedForMetrics({
+            order: fetchedOrder,
+            previousStatus,
+          });
+        }
+
+        showV2OrderToast({
+          orderId: fetchedOrder.providerOrderId,
+          cryptocurrency:
+            fetchedOrder.cryptoCurrency?.symbol ?? params.cryptocurrency ?? '',
+          cryptoAmount: fetchedOrder.cryptoAmount,
+          status: fetchedOrder.status,
+        });
         navigation.setParams({
           orderId: fetchedOrder.providerOrderId,
           callbackUrl: undefined,
@@ -118,7 +139,11 @@ const OrderDetails = () => {
           walletAddress: undefined,
         });
       } catch (fetchError) {
-        Logger.error(fetchError as Error, {
+        const normalizedError =
+          fetchError instanceof Error
+            ? fetchError
+            : new Error(String(fetchError));
+        Logger.error(normalizedError, {
           message: `RampsOrderDetails: error fetching order from callback URL${logContext}`,
           callbackUrl,
         });
@@ -131,7 +156,13 @@ const OrderDetails = () => {
         setIsLoading(false);
       }
     },
-    [getOrderFromCallback, addOrder, navigation],
+    [
+      getOrderFromCallback,
+      getOrderById,
+      addOrder,
+      navigation,
+      params.cryptocurrency,
+    ],
   );
 
   const handleHeaderBack = useCallback(() => {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -36,6 +36,7 @@ jest.mock('react-redux', () => ({
     selected: {
       chainId: 'eip155:1',
       assetId: 'eip155:1/erc20:0xasset',
+      symbol: 'ETH',
     },
   })),
 }));
@@ -77,6 +78,21 @@ jest.mock('./useRampsOrders', () => ({
     getOrderById: jest.fn(),
     removeOrder: jest.fn(),
     getOrderFromCallback: jest.fn(),
+  }),
+}));
+
+const MOCK_SELECTED_PROVIDER = {
+  id: '/providers/transak-native-staging',
+  name: 'Transak',
+};
+
+jest.mock('./useRampsProviders', () => ({
+  useRampsProviders: () => ({
+    providers: [MOCK_SELECTED_PROVIDER],
+    selectedProvider: MOCK_SELECTED_PROVIDER,
+    setSelectedProvider: jest.fn(),
+    isLoading: false,
+    error: null,
   }),
 }));
 
@@ -1210,11 +1226,11 @@ describe('useTransakRouting', () => {
   describe('navigateToKycWebview', () => {
     it('resets navigation stack with KycProcessing behind the webview', () => {
       const { result } = renderHook(() => useTransakRouting());
-      const kycQuote = { id: 'quote-789' } as unknown as TransakBuyQuote;
+      const mockQuote = { id: 'quote-789' } as unknown as TransakBuyQuote;
 
       act(() => {
         result.current.navigateToKycWebview({
-          quote: kycQuote,
+          quote: mockQuote,
           kycUrl: 'https://kyc.example.com',
           workFlowRunId: 'wf-456',
           amount: 30,
@@ -1238,7 +1254,7 @@ describe('useTransakRouting', () => {
                 url: 'https://kyc.example.com',
                 providerName: 'Transak',
                 workFlowRunId: 'wf-456',
-                quote: kycQuote,
+                quote: mockQuote,
                 amount: 30,
               }),
             }),
@@ -1347,203 +1363,78 @@ describe('useTransakRouting', () => {
       expect(handler).not.toBeNull();
       if (!handler) return;
 
-      const depositOrder = {
-        id: 'order-123',
-        providerOrderId: 'order-123',
-        provider: 'transak-native',
-        walletAddress: MOCK_WALLET_ADDRESS,
-        paymentDetails: {},
-      };
-      mockGetOrder.mockResolvedValue(depositOrder);
-      mockRefreshOrder.mockResolvedValue({
-        providerOrderId: 'order-123',
-        cryptoCurrency: { symbol: 'ETH' },
-        cryptoAmount: '0.05',
-        status: 'Pending',
-        fiatAmount: 100,
-        exchangeRate: 2000,
-        networkFees: 0,
-        partnerFees: 0,
-        totalFeesFiat: 0,
-        paymentMethod: { id: 'card' },
-        network: { chainId: '1', name: 'Ethereum' },
-        fiatCurrency: { symbol: 'USD' },
-      });
-
       const url = 'https://redirect.example.com?orderId=order-123';
 
       await act(async () => {
         await handler({ url });
       });
 
-      expect(mockGetOrder).toHaveBeenCalledTimes(1);
-
       await act(async () => {
         await handler({ url });
       });
 
-      expect(mockGetOrder).toHaveBeenCalledTimes(1);
-    });
-
-    it('adds order, shows toast, navigates and tracks event on success', async () => {
-      const mockShowV2OrderToast = jest.requireMock('../utils/v2OrderToast')
-        .showV2OrderToast as jest.Mock;
-
-      const handler = await runApprovedFlowToCaptureCallback();
-      expect(handler).not.toBeNull();
-      if (!handler) return;
-
-      const depositOrder = {
-        id: 'order-123',
-        providerOrderId: 'order-123',
-        provider: 'transak-native',
-        walletAddress: MOCK_WALLET_ADDRESS,
-        paymentDetails: { instructions: 'Wire transfer' },
-      };
-      mockGetOrder.mockResolvedValue(depositOrder);
-      mockRefreshOrder.mockResolvedValue({
-        providerOrderId: 'order-123',
-        cryptoCurrency: { symbol: 'ETH' },
-        cryptoAmount: '0.05',
-        status: 'Pending',
-        fiatAmount: 100,
-        exchangeRate: 2000,
-        networkFees: 1,
-        partnerFees: 2,
-        totalFeesFiat: 3,
-        paymentMethod: { id: 'card' },
-        network: { chainId: '1', name: 'Ethereum' },
-        fiatCurrency: { symbol: 'USD' },
-      });
-
-      await act(async () => {
-        await handler({
-          url: 'https://redirect.example.com?orderId=order-123',
-        });
-      });
-
-      expect(mockGetOrder).toHaveBeenCalledWith(
-        'order-123',
-        MOCK_WALLET_ADDRESS,
-      );
-      expect(mockRefreshOrder).toHaveBeenCalledWith(
-        'transak-native',
-        'order-123',
-        MOCK_WALLET_ADDRESS,
-      );
-      expect(mockAddOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          providerOrderId: 'order-123',
-          paymentDetails: { instructions: 'Wire transfer' },
-        }),
-      );
-      expect(mockShowV2OrderToast).toHaveBeenCalledWith({
-        orderId: 'order-123',
-        cryptocurrency: 'ETH',
-        cryptoAmount: '0.05',
-        status: 'Pending',
-      });
       expect(mockReset).toHaveBeenCalledWith(
         expect.objectContaining({
           index: 0,
           routes: [
             expect.objectContaining({
-              params: expect.objectContaining({ orderId: 'order-123' }),
+              name: 'RampsOrderDetails',
+              params: expect.objectContaining({
+                callbackUrl: url,
+                providerCode: 'transak-native-staging',
+                walletAddress: MOCK_WALLET_ADDRESS,
+                showCloseButton: true,
+                cryptocurrency: 'ETH',
+              }),
             }),
           ],
         }),
       );
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        'RAMPS_TRANSACTION_CONFIRMED',
-        expect.objectContaining({
-          ramp_type: 'DEPOSIT',
-          amount_source: 100,
-          amount_destination: 0.05,
-          exchange_rate: 2000,
-        }),
-      );
+      expect(mockGetOrder).not.toHaveBeenCalled();
+
+      mockReset.mockClear();
+
+      await act(async () => {
+        await handler({ url });
+      });
+
+      expect(mockReset).not.toHaveBeenCalled();
+      expect(mockGetOrder).not.toHaveBeenCalled();
     });
 
-    it('resets processingOrderIdRef and logs when getOrder fails', async () => {
-      const Logger = jest.requireMock('../../../../util/Logger');
-      const mockLoggerError = Logger.error as jest.Mock;
-
+    it('navigates to order details with callback params without fetching in the hook', async () => {
       const handler = await runApprovedFlowToCaptureCallback();
       expect(handler).not.toBeNull();
       if (!handler) return;
 
-      mockGetOrder.mockRejectedValue(new Error('Network error'));
+      const callbackUrl = 'https://redirect.example.com?orderId=order-123';
 
       await act(async () => {
         await handler({
-          url: 'https://redirect.example.com?orderId=order-123',
+          url: callbackUrl,
         });
       });
 
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        expect.any(Error),
+      expect(mockGetOrder).not.toHaveBeenCalled();
+      expect(mockRefreshOrder).not.toHaveBeenCalled();
+      expect(mockAddOrder).not.toHaveBeenCalled();
+      expect(mockReset).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: 'useTransakRouting: Failed to process order after checkout',
+          index: 0,
+          routes: [
+            expect.objectContaining({
+              name: 'RampsOrderDetails',
+              params: expect.objectContaining({
+                callbackUrl,
+                providerCode: 'transak-native-staging',
+                walletAddress: MOCK_WALLET_ADDRESS,
+                showCloseButton: true,
+                cryptocurrency: 'ETH',
+              }),
+            }),
+          ],
         }),
       );
-      expect(mockAddOrder).not.toHaveBeenCalled();
-    });
-
-    it('resets processingOrderIdRef and logs when depositOrder is null', async () => {
-      const Logger = jest.requireMock('../../../../util/Logger');
-      const mockLoggerError = Logger.error as jest.Mock;
-
-      const handler = await runApprovedFlowToCaptureCallback();
-      expect(handler).not.toBeNull();
-      if (!handler) return;
-
-      mockGetOrder.mockResolvedValue(null);
-
-      await act(async () => {
-        await handler({
-          url: 'https://redirect.example.com?orderId=order-123',
-        });
-      });
-
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
-          message: 'useTransakRouting: Failed to process order after checkout',
-        }),
-      );
-      expect(mockAddOrder).not.toHaveBeenCalled();
-    });
-
-    it('resets processingOrderIdRef and logs when refreshOrder fails', async () => {
-      const Logger = jest.requireMock('../../../../util/Logger');
-      const mockLoggerError = Logger.error as jest.Mock;
-
-      const handler = await runApprovedFlowToCaptureCallback();
-      expect(handler).not.toBeNull();
-      if (!handler) return;
-
-      mockGetOrder.mockResolvedValue({
-        id: 'order-123',
-        providerOrderId: 'order-123',
-        provider: 'transak-native',
-        walletAddress: MOCK_WALLET_ADDRESS,
-        paymentDetails: {},
-      });
-      mockRefreshOrder.mockRejectedValue(new Error('Refresh failed'));
-
-      await act(async () => {
-        await handler({
-          url: 'https://redirect.example.com?orderId=order-123',
-        });
-      });
-
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
-          message: 'useTransakRouting: Failed to process order after checkout',
-        }),
-      );
-      expect(mockAddOrder).not.toHaveBeenCalled();
     });
   });
 
@@ -1751,6 +1642,15 @@ describe('useTransakRouting', () => {
       expect(handler).not.toBeNull();
       if (!handler) return;
 
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
       mockGetOrder.mockRejectedValue(new Error('Network error'));
       mockFailSession.mockReturnValue({
         code: 'UNKNOWN',
@@ -1804,9 +1704,6 @@ describe('useTransakRouting', () => {
       };
       mockGetUserDetails.mockResolvedValue({
         firstName: 'John',
-        lastName: 'Doe',
-        mobileNumber: '+1',
-        dob: '1990-01-01',
         address: {},
       });
       mockGetKycRequirement.mockResolvedValue({
@@ -1816,8 +1713,17 @@ describe('useTransakRouting', () => {
       mockGetUserLimits.mockResolvedValue({
         remaining: { '1': 10000, '30': 50000, '365': 200000 },
       });
-      mockTransakCreateOrder.mockResolvedValue(depositOrder);
-      mockRefreshOrder.mockResolvedValue(refreshedOrder);
+      mockTransakCreateOrder.mockResolvedValue({
+        id: 'order-bank-1',
+        providerOrderId: 'order-bank-1',
+        provider: 'transak-native',
+        walletAddress: MOCK_WALLET_ADDRESS,
+        paymentDetails: { accountNumber: '12345' },
+      });
+      mockRefreshOrder.mockResolvedValue({
+        ...refreshedOrder,
+        providerOrderId: 'order-bank-1',
+      });
 
       const { result } = renderHook(() => useTransakRouting(HEADLESS_CONFIG));
 
@@ -1828,40 +1734,48 @@ describe('useTransakRouting', () => {
         );
       });
 
-      expect(onOrderCreated).toHaveBeenCalledWith('order-hs');
+      expect(onOrderCreated).toHaveBeenCalledWith('order-bank-1');
       expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
         reason: 'completed',
       });
-      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
       expect(mockParentPop).toHaveBeenCalled();
+      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
     });
 
-    it('falls back to the regular order-details reset + toast when session id is present but session is missing from registry', async () => {
+    it('falls back to OrderDetails callback-resolution when session id is present but session is missing from registry', async () => {
       mockGetSession.mockReturnValue(undefined);
 
       const handler = await runApprovedFlowHeadless();
       expect(handler).not.toBeNull();
       if (!handler) return;
 
+      const callbackUrl = 'https://redirect.example.com?orderId=order-hs';
+
       await act(async () => {
-        await handler({
-          url: 'https://redirect.example.com?orderId=order-hs',
-        });
+        await handler({ url: callbackUrl });
       });
 
-      expect(mockShowV2OrderToast).toHaveBeenCalledWith(
-        expect.objectContaining({ orderId: 'order-hs' }),
-      );
       expect(mockReset).toHaveBeenCalledWith(
         expect.objectContaining({
           index: 0,
           routes: [
             expect.objectContaining({
-              params: expect.objectContaining({ orderId: 'order-hs' }),
+              name: 'RampsOrderDetails',
+              params: expect.objectContaining({
+                callbackUrl,
+                providerCode: 'transak-native-staging',
+                walletAddress: MOCK_WALLET_ADDRESS,
+                showCloseButton: true,
+                cryptocurrency: 'ETH',
+              }),
             }),
           ],
         }),
       );
+      expect(mockGetOrder).not.toHaveBeenCalled();
+      expect(mockRefreshOrder).not.toHaveBeenCalled();
+      expect(mockAddOrder).not.toHaveBeenCalled();
+      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
       expect(mockCloseSession).not.toHaveBeenCalled();
       expect(mockParentPop).not.toHaveBeenCalled();
     });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -23,6 +23,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { useTransakController } from './useTransakController';
 import { useRampsUserRegion } from './useRampsUserRegion';
 import { useRampsPaymentMethods } from './useRampsPaymentMethods';
+import { useRampsProviders } from './useRampsProviders';
 import { selectTokens } from '../../../../selectors/rampsController';
 import useRampAccountAddress from './useRampAccountAddress';
 import { isHttpUnauthorized } from '../utils/isHttpUnauthorized';
@@ -166,6 +167,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
 
   const { userRegion } = useRampsUserRegion();
   const { selectedPaymentMethod } = useRampsPaymentMethods();
+  const { selectedProvider } = useRampsProviders();
 
   const { selected: selectedToken } = useSelector(selectTokens);
   const headlessSessionParams = getSession(headlessSessionId)?.params;
@@ -419,81 +421,123 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       }
       processingOrderIdRef.current = orderId;
 
-      try {
-        const depositOrder = await getOrder(orderId, walletAddress || '');
+      const session = getSession(headlessSessionId);
+      if (headlessSessionId && session) {
+        // Headless mode: fetch the order, hand the orderId to the
+        // consumer, close the session, and unwind out of the ramp stack
+        // so the caller regains foreground. Skip RAMPS_ORDER_DETAILS —
+        // the consumer drives its own UI.
+        try {
+          const depositOrder = await getOrder(orderId, walletAddress || '');
 
-        if (!depositOrder) {
-          throw new Error('Missing order');
-        }
+          if (!depositOrder) {
+            throw new Error('Missing order');
+          }
 
-        const providerCode = normalizeProviderCode(
-          String(depositOrder.provider ?? 'transak-native'),
-        );
-        const rampsOrder = await refreshOrder(
-          providerCode,
-          depositOrder.providerOrderId,
-          walletAddress || depositOrder.walletAddress,
-        );
+          const providerCode = normalizeProviderCode(
+            String(depositOrder.provider ?? 'transak-native'),
+          );
+          const rampsOrder = await refreshOrder(
+            providerCode,
+            depositOrder.providerOrderId,
+            walletAddress || depositOrder.walletAddress,
+          );
 
-        addOrder({
-          ...rampsOrder,
-          paymentDetails: depositOrder.paymentDetails,
-        });
-
-        // Suppress the toast when a headless session is driving this
-        // flow — the consumer handles its own notification UI. Keep
-        // `addOrder` and the analytics event in both modes so Redux
-        // state + telemetry parity is preserved.
-        if (!getSession(headlessSessionId)) {
-          showV2OrderToast({
-            orderId: rampsOrder.providerOrderId,
-            cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
-            cryptoAmount: rampsOrder.cryptoAmount,
-            status: rampsOrder.status,
+          addOrder({
+            ...rampsOrder,
+            paymentDetails: depositOrder.paymentDetails,
           });
-        }
 
-        navigateToOrderProcessingCallback({
-          orderId: rampsOrder.providerOrderId,
-        });
+          try {
+            session.callbacks.onOrderCreated(rampsOrder.providerOrderId);
+          } catch (callbackError) {
+            Logger.error(
+              callbackError as Error,
+              'useTransakRouting: onOrderCreated callback threw',
+            );
+          }
+          closeSession(headlessSessionId, { reason: 'completed' });
+          // @ts-expect-error `pop` exists on the parent stack navigator at
+          // runtime but is not surfaced on the generic `NavigationProp`
+          // type returned by `getParent()`.
+          navigation.getParent()?.pop();
 
-        trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-          ramp_type: 'DEPOSIT',
-          amount_source: Number(rampsOrder.fiatAmount),
-          amount_destination: Number(rampsOrder.cryptoAmount),
-          exchange_rate: Number(rampsOrder.exchangeRate),
-          gas_fee: rampsOrder.networkFees ? Number(rampsOrder.networkFees) : 0,
-          processing_fee: rampsOrder.partnerFees
-            ? Number(rampsOrder.partnerFees)
-            : 0,
-          total_fee: Number(rampsOrder.totalFeesFiat),
-          payment_method_id: rampsOrder.paymentMethod?.id || '',
-          country: regionIsoCode,
-          chain_id: rampsOrder.network?.chainId || '',
-          currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
-          currency_destination_symbol: rampsOrder.cryptoCurrency?.symbol || '',
-          currency_destination_network: rampsOrder.network?.name || '',
-          currency_source: rampsOrder.fiatCurrency?.symbol || '',
-        });
-      } catch (error) {
-        processingOrderIdRef.current = null;
-        Logger.error(error as Error, {
-          message: 'useTransakRouting: Failed to process order after checkout',
-        });
-        if (failSession(headlessSessionId, error)) {
-          dismissActiveHeadlessFlow();
+          trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
+            ramp_type: 'DEPOSIT',
+            amount_source: Number(rampsOrder.fiatAmount),
+            amount_destination: Number(rampsOrder.cryptoAmount),
+            exchange_rate: Number(rampsOrder.exchangeRate),
+            gas_fee: rampsOrder.networkFees
+              ? Number(rampsOrder.networkFees)
+              : 0,
+            processing_fee: rampsOrder.partnerFees
+              ? Number(rampsOrder.partnerFees)
+              : 0,
+            total_fee: Number(rampsOrder.totalFeesFiat),
+            payment_method_id: rampsOrder.paymentMethod?.id || '',
+            country: regionIsoCode,
+            chain_id: rampsOrder.network?.chainId || '',
+            currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
+            currency_destination_symbol:
+              rampsOrder.cryptoCurrency?.symbol || '',
+            currency_destination_network: rampsOrder.network?.name || '',
+            currency_source: rampsOrder.fiatCurrency?.symbol || '',
+          });
+        } catch (error) {
+          processingOrderIdRef.current = null;
+          Logger.error(error as Error, {
+            message:
+              'useTransakRouting: Failed to process order after checkout',
+          });
+          if (failSession(headlessSessionId, error)) {
+            // @ts-expect-error `pop` exists on the parent stack navigator at
+            // runtime but is not surfaced on the generic `NavigationProp`
+            // type returned by `getParent()`.
+            navigation.getParent()?.pop();
+          }
         }
+        return;
       }
+
+      // Same pattern as unified Buy WebView Checkout: leave the webview
+      // immediately; OrderDetails resolves the order via callback params.
+      if (!selectedProvider?.id) {
+        processingOrderIdRef.current = null;
+        Logger.error(
+          new Error('Missing selected provider'),
+          'useTransakRouting: cannot open OrderDetails without provider',
+        );
+        return;
+      }
+
+      const cryptoSymbol = selectedToken?.symbol;
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+            params: {
+              callbackUrl: url,
+              providerCode: normalizeProviderCode(selectedProvider.id),
+              walletAddress: walletAddress || '',
+              showCloseButton: true,
+              ...(cryptoSymbol ? { cryptocurrency: cryptoSymbol } : {}),
+            },
+          },
+        ],
+      });
     },
     [
-      getOrder,
+      navigation,
       walletAddress,
+      headlessSessionId,
+      getOrder,
       addOrder,
       refreshOrder,
-      navigateToOrderProcessingCallback,
       regionIsoCode,
       trackEvent,
-      headlessSessionId,
+      selectedToken,
+      selectedProvider,
       dismissActiveHeadlessFlow,
     ],
   );
@@ -788,10 +832,10 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       addOrder,
       refreshOrder,
       navigateToBankDetailsCallback,
-      navigateToOrderProcessingCallback,
-      headlessSessionId,
       navigateToWebviewModalCallback,
       navigateToKycProcessingCallback,
+      navigateToOrderProcessingCallback,
+      headlessSessionId,
       submitPurposeOfUsageForm,
       logoutFromProvider,
       navigateToBasicInfoCallback,

--- a/app/components/UI/Ramp/utils/rampsNavigation.ts
+++ b/app/components/UI/Ramp/utils/rampsNavigation.ts
@@ -6,6 +6,8 @@ export interface RampsOrderDetailsParams {
   callbackUrl?: string;
   providerCode?: string;
   walletAddress?: string;
+  /** Fallback for toast copy when the order has no crypto symbol yet. */
+  cryptocurrency?: string;
 }
 
 export function createRampsOrderDetailsRoute(params: RampsOrderDetailsParams): {


### PR DESCRIPTION
## **Description**

This PR improves the unified buy (UB2) checkout flow when purchasing via **Transak** in the WebView: after a successful checkout, the app **navigates immediately** to **Ramps Order Details** using **callback URL parameters** instead of leaving the user on a generic or stale screen.

**Order Details** now **resolves the order** from those callback params, surfaces the outcome with a **toast**, and records **metrics** so we can observe completion and errors in production.

**Motivation:** Users should land on a clear, order-specific screen right after Transak completes, with consistent feedback and observability aligned with other ramps flows.

## **Changelog**

CHANGELOG entry: After completing a Transak purchase in unified buy, the app now opens Ramps Order Details with the order resolved from the callback, a confirmation toast, and updated metrics.

## **Related issues**

Fixes: [TRAM-3540](https://consensyssoftware.atlassian.net/browse/TRAM-3540)

## **Manual testing steps**

```gherkin
Feature: Unified buy WebView callback to Ramps Order Details

  Scenario: Transak success navigates to order details with resolved order
    Given the user starts unified buy and opens the Transak WebView checkout
    And checkout completes successfully with callback params that identify the order

    When the WebView returns to the app with the success callback URL
    Then the app navigates to Ramps Order Details for that order
    And the order is resolved and shown without requiring a manual refresh
    And a success toast is shown
    And relevant ramps metrics are emitted for the completed flow

  Scenario: Callback without usable order params still degrades safely
    Given the user returns from the WebView with a callback missing expected order identifiers

    When Order Details attempts to resolve the order
    Then the user sees an appropriate error or empty state (per implementation)
    And no crash occurs; metrics reflect the failure path if applicable
```

## **Screenshots/Recordings**

### **Before**

<!-- Add recording: Transak completion previously did not land on Order Details with callback-driven state. -->


https://github.com/user-attachments/assets/d7eb9a5f-c445-4b81-b470-e6e395b9b011


### **After**

<!-- Add recording: Transak success → immediate Ramps Order Details with toast and resolved order. -->

https://github.com/user-attachments/assets/13f61484-cdec-4f6d-a152-736925d03424



https://github.com/user-attachments/assets/f371a807-60aa-4a0b-87dd-bc317e464ca7



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TRAM-3540]: https://consensyssoftware.atlassian.net/browse/TRAM-3540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-purchase navigation and order persistence for unified buy and Transak; headless vs non-headless branching must stay correct to avoid missing orders or duplicate toasts/metrics.
> 
> **Overview**
> **Unified buy (UB2) WebView checkout** no longer resolves orders on the callback screen. After a successful provider redirect, **Checkout** and **Transak** routing immediately **reset** to **Ramps Order Details** with `callbackUrl`, `providerCode`, `walletAddress`, optional `cryptocurrency`, and `showCloseButton`—matching external-browser return behavior. The V2 unified flag and in-checkout toast are removed from those paths.
> 
> **Order Details** becomes the single place for non-headless callback handling: it fetches via `getOrderFromCallback`, adds the order, shows **`showV2OrderToast`**, emits **`handleOrderStatusChangedForMetrics`** when status changes, and clears callback params after success. Failed or bailed orders still reset to build quote; error handling is hardened for non-`Error` rejections.
> 
> **Headless** flows are unchanged in spirit: Checkout / Transak still fetch, call `onOrderCreated`, and pop the stack; missing registry sessions fall back to Order Details with callback params.
> 
> Tests are updated and expanded for the deferred resolution model and analytics (`callback_success` when the URL is recognized without a prior fetch failure in Checkout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 150ca245fc3651369b11af5dac5716c36fdb66f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->