### PR TITLE
feat: add selector helpers

### DIFF
--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -27,6 +27,7 @@ import {
   selectInternalEvmAccounts,
   selectInternalAccountsByScope,
   selectInternalAccountByAddresses,
+  selectEvmAddress,
 } from './accountsController';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -764,6 +765,24 @@ describe('selectInternalEvmAccounts', () => {
     } as RootState);
 
     expect(result).toHaveLength(4);
+  });
+});
+
+describe('selectEvmAddress', () => {
+  it('returns selected EVM account address', () => {
+    const state = getStateWithAccount(internalAccount1);
+
+    const result = selectEvmAddress(state);
+
+    expect(result).toBe(internalAccount1.address);
+  });
+
+  it('returns undefined when selected account is not EVM', () => {
+    const state = getStateWithAccount(internalSolanaAccount1);
+
+    const result = selectEvmAddress(state);
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -222,6 +222,12 @@ export const selectSelectedInternalAccountAddress = createSelector(
   },
 );
 
+export const selectEvmAddress = createSelector(
+  selectSelectedInternalAccount,
+  (account) =>
+    account && isEvmAccountType(account.type) ? account.address : undefined,
+);
+
 /**
  * A memoized selector that returns whether the selected internal account can sign transactions
  */

--- a/app/selectors/networkEnablementController/index.test.ts
+++ b/app/selectors/networkEnablementController/index.test.ts
@@ -2,6 +2,7 @@ import {
   selectNetworkEnablementControllerState,
   selectEnabledNetworksByNamespace,
   selectEVMEnabledNetworks,
+  selectEvmEnabledCaipNetworks,
   selectNonEVMEnabledNetworks,
 } from './index';
 import { RootState } from '../../reducers';
@@ -240,6 +241,14 @@ describe('NetworkEnablementController Selectors', () => {
       const result = selectEVMEnabledNetworks(stateWithMixedEVM);
 
       expect(result).toEqual(['0x1', '0xe708']);
+    });
+  });
+
+  describe('selectEvmEnabledCaipNetworks', () => {
+    it('returns only enabled EVM networks as CAIP chain IDs', () => {
+      const result = selectEvmEnabledCaipNetworks(mockState);
+
+      expect(result).toEqual(['eip155:1', 'eip155:8453']);
     });
   });
 

--- a/app/selectors/networkEnablementController/index.ts
+++ b/app/selectors/networkEnablementController/index.ts
@@ -1,5 +1,4 @@
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
-import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { Hex, KnownCaipNamespace } from '@metamask/utils';
 import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
@@ -25,7 +24,10 @@ export const selectEVMEnabledNetworks = createDeepEqualSelector(
 
 export const selectEvmEnabledCaipNetworks = createDeepEqualSelector(
   selectEVMEnabledNetworks,
-  (chainIds) => (chainIds ?? []).map((chainId) => toEvmCaipChainId(chainId)),
+  (chainIds) =>
+    (chainIds ?? []).map(
+      (chainId) => `${KnownCaipNamespace.Eip155}:${Number.parseInt(chainId, 16)}`,
+    ),
 );
 
 export const selectNonEVMEnabledNetworks = createDeepEqualSelector(

--- a/app/selectors/networkEnablementController/index.ts
+++ b/app/selectors/networkEnablementController/index.ts
@@ -26,7 +26,8 @@ export const selectEvmEnabledCaipNetworks = createDeepEqualSelector(
   selectEVMEnabledNetworks,
   (chainIds) =>
     (chainIds ?? []).map(
-      (chainId) => `${KnownCaipNamespace.Eip155}:${Number.parseInt(chainId, 16)}`,
+      (chainId) =>
+        `${KnownCaipNamespace.Eip155}:${Number.parseInt(chainId, 16)}`,
     ),
 );
 

--- a/app/selectors/networkEnablementController/index.ts
+++ b/app/selectors/networkEnablementController/index.ts
@@ -1,4 +1,5 @@
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { Hex, KnownCaipNamespace } from '@metamask/utils';
 import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
@@ -20,6 +21,11 @@ export const selectEVMEnabledNetworks = createDeepEqualSelector(
     Object.keys(enabledNetworksByNamespace?.eip155 ?? {}).filter(
       (chainId) => enabledNetworksByNamespace?.eip155?.[chainId as Hex],
     ) as Hex[],
+);
+
+export const selectEvmEnabledCaipNetworks = createDeepEqualSelector(
+  selectEVMEnabledNetworks,
+  (chainIds) => (chainIds ?? []).map((chainId) => toEvmCaipChainId(chainId)),
 );
 
 export const selectNonEVMEnabledNetworks = createDeepEqualSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Create selectors to be used for the Accounts v4 API migration of the Activity list

Part of breaking down the PR into smaller chunks

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two small selectors and unit tests without changing existing selection logic or mutating state. Main risk is minor formatting/edge cases when converting hex chain IDs to CAIP strings.
> 
> **Overview**
> Adds `selectEvmAddress` to return the currently selected account address *only* when the selected internal account is EVM (otherwise `undefined`).
> 
> Adds `selectEvmEnabledCaipNetworks` to expose enabled EVM networks as CAIP chain IDs by converting the hex `eip155` chain IDs returned from `selectEVMEnabledNetworks` into decimal CAIP strings, with focused unit tests for both selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7dac4be71e24dc662bd917ec0a1077cab917971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->