### PR TITLE
refactor: dedupe swaps quote data validation calls

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -272,6 +272,16 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
     .mockImplementation(() => mockUseBridgeQuoteData),
 }));
 
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
+  const { useBridgeQuoteData } = jest.requireMock(
+    '../../hooks/useBridgeQuoteData',
+  );
+  return {
+    BridgeQuoteDataProvider: ({ children }: { children: unknown }) => children,
+    useBridgeQuoteDataContext: jest.fn(() => useBridgeQuoteData()),
+  };
+});
+
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   isHardwareAccount: jest.fn(),

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.test.tsx
@@ -37,6 +37,15 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
     .mockImplementation(() => mockUseBridgeQuoteData),
 }));
 
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
+  const { useBridgeQuoteData } = jest.requireMock(
+    '../../hooks/useBridgeQuoteData',
+  );
+  return {
+    useBridgeQuoteDataContext: jest.fn(() => useBridgeQuoteData()),
+  };
+});
+
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   isHardwareAccount: jest.fn(),

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
@@ -11,7 +11,7 @@ import {
   selectIsSolanaSourced,
 } from '../../../../../core/redux/slices/bridge';
 import { strings } from '../../../../../../locales/i18n';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import BannerAlert from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert';
 import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
@@ -55,9 +55,7 @@ export const BridgeViewFooter = ({
   const isSolanaSourced = useSelector(selectIsSolanaSourced);
 
   const { activeQuote, isLoading, blockaidError, needsNewQuote } =
-    useBridgeQuoteData({
-      latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
-    });
+    useBridgeQuoteDataContext();
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -64,7 +64,10 @@ import Routes from '../../../../../constants/navigation/Routes';
 import QuoteDetailsCard from '../../components/QuoteDetailsCard';
 import QuoteDetailsCardSkeleton from '../../components/QuoteDetailsCard/QuoteDetailsCardSkeleton';
 import { useBridgeQuoteRequest } from '../../hooks/useBridgeQuoteRequest';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import {
+  BridgeQuoteDataProvider,
+  useBridgeQuoteDataContext,
+} from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { createStyles } from './BridgeView.styles';
 import { useInitialSourceToken } from '../../hooks/useInitialSourceToken';
 import { useInitialDestToken } from '../../hooks/useInitialDestToken';
@@ -112,7 +115,11 @@ import { hasMissingPriceData } from '../../utils/hasMissingPriceData';
 
 const SCROLL_NEAR_BOTTOM_PX = 160;
 
-const BridgeView = () => {
+interface BridgeViewContentProps {
+  latestSourceBalance: ReturnType<typeof useLatestBalance>;
+}
+
+const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   const [isNearBottom, setIsNearBottom] = useState(false);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
 
@@ -233,13 +240,6 @@ const BridgeView = () => {
 
   const hasDestinationPicker = isEvmNonEvmBridge || isNonEvmNonEvmBridge;
 
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-  });
-
   const updateQuoteParams = useBridgeQuoteRequest({
     latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
   });
@@ -253,9 +253,7 @@ const BridgeView = () => {
     quoteFetchError,
     shouldShowPriceImpactWarning,
     needsNewQuote,
-  } = useBridgeQuoteData({
-    latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
-  });
+  } = useBridgeQuoteDataContext();
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
@@ -632,6 +630,24 @@ const BridgeView = () => {
         </SwapsKeypad>
       </Box>
     </ScreenView>
+  );
+};
+
+const BridgeView = () => {
+  const sourceToken = useSelector(selectSourceToken);
+  const latestSourceBalance = useLatestBalance({
+    address: sourceToken?.address,
+    decimals: sourceToken?.decimals,
+    chainId: sourceToken?.chainId,
+    balance: sourceToken?.balance,
+  });
+
+  return (
+    <BridgeQuoteDataProvider
+      latestSourceAtomicBalance={latestSourceBalance?.atomicBalance}
+    >
+      <BridgeViewContent latestSourceBalance={latestSourceBalance} />
+    </BridgeQuoteDataProvider>
   );
 };
 

--- a/app/components/UI/Bridge/components/MissingPriceModal/MissingPriceModal.test.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/MissingPriceModal.test.tsx
@@ -5,11 +5,13 @@ import { MissingPriceModal } from './index';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
+import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
 import { useSelector } from 'react-redux';
 import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
 import { strings } from '../../../../../../locales/i18n';
 import { Hex } from '@metamask/utils';
+import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactModule = jest.requireActual('react');
@@ -56,6 +58,10 @@ jest.mock('../../hooks/useBridgeConfirm', () => ({
   useBridgeConfirm: jest.fn(),
 }));
 
+jest.mock('../../hooks/useBridgeQuoteData', () => ({
+  useBridgeQuoteData: jest.fn(),
+}));
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
@@ -72,6 +78,9 @@ const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
 >;
 const mockUseBridgeConfirm = useBridgeConfirm as jest.MockedFunction<
   typeof useBridgeConfirm
+>;
+const mockUseBridgeQuoteData = useBridgeQuoteData as jest.MockedFunction<
+  typeof useBridgeQuoteData
 >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
@@ -98,6 +107,9 @@ describe('MissingPriceModal', () => {
       location: MetaMetricsSwapsEventSource.MainView,
     });
     mockUseLatestBalance.mockReturnValue(undefined);
+    mockUseBridgeQuoteData.mockReturnValue({
+      activeQuote: mockQuoteWithMetadata,
+    } as ReturnType<typeof useBridgeQuoteData>);
     mockUseBridgeConfirm.mockReturnValue(mockConfirmBridge);
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectSourceToken) {

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -7,6 +7,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useBridgeConfirm } from '../../hooks/useBridgeConfirm';
+import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
 import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
 import {
   BottomSheet,
@@ -42,9 +43,12 @@ export const MissingPriceModal = () => {
     decimals: sourceToken?.decimals,
     chainId: sourceToken?.chainId,
   });
+  const { activeQuote } = useBridgeQuoteData({
+    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
+  });
 
   const confirmBridge = useBridgeConfirm({
-    latestSourceBalance: tokenBalance,
+    activeQuote,
     location,
   });
 

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -32,12 +32,13 @@ export const PriceImpactModal = () => {
     chainId: token?.chainId,
   });
 
+  const { formattedQuoteData, activeQuote } = useBridgeQuoteData({
+    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
+  });
   const confirmBridge = useBridgeConfirm({
-    latestSourceBalance: tokenBalance,
+    activeQuote,
     location,
   });
-
-  const { formattedQuoteData, activeQuote } = useBridgeQuoteData();
   const priceImpactViewData = usePriceImpactViewData(
     activeQuote?.quote.priceData?.priceImpact,
   );

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -83,6 +83,15 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
   })),
 }));
 
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
+  const { useBridgeQuoteData } = jest.requireMock(
+    '../../hooks/useBridgeQuoteData',
+  );
+  return {
+    useBridgeQuoteDataContext: jest.fn(() => useBridgeQuoteData()),
+  };
+});
+
 // Mock useRewards hook
 jest.mock('../../hooks/useRewards', () => ({
   useRewards: jest.fn().mockImplementation(() => ({

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -20,7 +20,7 @@ import {
   IconColor,
 } from '@metamask/design-system-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useSelector } from 'react-redux';
 import {
   selectSourceAmount,
@@ -77,7 +77,7 @@ const QuoteDetailsCard: React.FC<QuoteDetailsCardProps> = ({
     formattedQuoteData,
     activeQuote,
     isLoading: isQuoteLoading,
-  } = useBridgeQuoteData();
+  } = useBridgeQuoteDataContext();
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -139,6 +139,15 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
     .mockImplementation(() => mockUseBridgeQuoteData),
 }));
 
+jest.mock('../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => {
+  const { useBridgeQuoteData } = jest.requireMock(
+    '../../hooks/useBridgeQuoteData',
+  );
+  return {
+    useBridgeQuoteDataContext: jest.fn(() => useBridgeQuoteData()),
+  };
+});
+
 // Mock useIsInsufficientBalance
 jest.mock('../../hooks/useInsufficientBalance', () => ({
   __esModule: true,

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -19,7 +19,7 @@ import { isNegativeSecurityType } from '../../utils/tokenSecurityUtils';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
 import { useHasSufficientGas } from '../../hooks/useHasSufficientGas';
-import { useBridgeQuoteData } from '../../hooks/useBridgeQuoteData';
+import { useBridgeQuoteDataContext } from '../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
 import { useBridgeQuoteRequest } from '../../hooks/useBridgeQuoteRequest';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
@@ -55,11 +55,6 @@ export const SwapsConfirmButton = ({
   transactionActiveAbTests,
 }: Props) => {
   const navigation = useNavigation();
-  const handleConfirm = useBridgeConfirm({
-    latestSourceBalance,
-    location,
-    transactionActiveAbTests,
-  });
 
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const destToken = useSelector(selectDestToken);
@@ -90,8 +85,12 @@ export const SwapsConfirmButton = ({
     quoteFetchError,
     isNoQuotesAvailable,
     isActiveQuoteForCurrentTokenPair,
-  } = useBridgeQuoteData({
-    latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
+  } = useBridgeQuoteDataContext();
+
+  const handleConfirm = useBridgeConfirm({
+    activeQuote,
+    location,
+    transactionActiveAbTests,
   });
 
   const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });

--- a/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
+++ b/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
@@ -108,16 +108,18 @@ export const TokenWarningModal = () => {
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
-  const { activeQuote } = useBridgeQuoteData();
 
   const tokenBalance = useLatestBalance({
     address: sourceToken?.address,
     decimals: sourceToken?.decimals,
     chainId: sourceToken?.chainId,
   });
+  const { activeQuote } = useBridgeQuoteData({
+    latestSourceAtomicBalance: tokenBalance?.atomicBalance,
+  });
 
   const confirmBridge = useBridgeConfirm({
-    latestSourceBalance: tokenBalance,
+    activeQuote,
     location,
   });
 

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
@@ -1,22 +1,21 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useBridgeQuoteData } from '../useBridgeQuoteData';
+import type { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { useNavigation } from '@react-navigation/native';
 import { setIsSubmittingTx } from '../../../../../core/redux/slices/bridge';
 import Routes from '../../../../../constants/navigation/Routes';
 import useSubmitBridgeTx from '../../../../../util/bridge/hooks/useSubmitBridgeTx';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
-import { useLatestBalance } from '../useLatestBalance';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
 interface Params {
+  activeQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] | null;
   location: MetaMetricsSwapsEventSource;
-  latestSourceBalance: ReturnType<typeof useLatestBalance>;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
 }
 
 export const useBridgeConfirm = ({
-  latestSourceBalance,
+  activeQuote,
   location,
   transactionActiveAbTests,
 }: Params) => {
@@ -24,9 +23,6 @@ export const useBridgeConfirm = ({
   const navigation = useNavigation();
   const { submitBridgeTx } = useSubmitBridgeTx();
   const walletAddress = useSelector(selectSourceWalletAddress);
-  const { activeQuote } = useBridgeQuoteData({
-    latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
-  });
 
   const handleConfirm = async () => {
     try {

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
@@ -1,24 +1,16 @@
 import { act, waitFor } from '@testing-library/react-native';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useBridgeConfirm } from './index';
-import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { mockUseBridgeQuoteData } from '../../_mocks_/useBridgeQuoteData.mock';
 import Routes from '../../../../../constants/navigation/Routes';
-import { BigNumber } from 'ethers';
 
 const WALLET_ADDRESS = '0x1234567890123456789012345678901234567890';
 
-const mockLatestSourceBalance = {
-  displayBalance: '2.0',
-  atomicBalance: BigNumber.from('2000000000000000000'),
-};
-
 const defaultParams = {
+  activeQuote: mockQuoteWithMetadata,
   location: MetaMetricsSwapsEventSource.MainView,
-  latestSourceBalance: mockLatestSourceBalance,
 };
 
 // Navigation
@@ -26,11 +18,6 @@ const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({ navigate: mockNavigate }),
-}));
-
-// useBridgeQuoteData
-jest.mock('../useBridgeQuoteData', () => ({
-  useBridgeQuoteData: jest.fn(),
 }));
 
 // selectSourceWalletAddress
@@ -79,10 +66,6 @@ function renderHook(
 describe('useBridgeConfirm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(useBridgeQuoteData).mockReturnValue({
-      ...mockUseBridgeQuoteData,
-      activeQuote: mockQuoteWithMetadata,
-    } as ReturnType<typeof useBridgeQuoteData>);
     jest.mocked(selectSourceWalletAddress).mockReturnValue(WALLET_ADDRESS);
     mockSubmitBridgeTx.mockResolvedValue({ success: true });
   });
@@ -148,38 +131,11 @@ describe('useBridgeConfirm', () => {
         ).toBe(false);
       });
     });
-
-    it('passes latestSourceAtomicBalance to useBridgeQuoteData', () => {
-      renderHook();
-
-      expect(jest.mocked(useBridgeQuoteData)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          latestSourceAtomicBalance: mockLatestSourceBalance.atomicBalance,
-        }),
-      );
-    });
-
-    it('passes undefined atomicBalance when latestSourceBalance is undefined', () => {
-      renderHook({ ...defaultParams, latestSourceBalance: undefined });
-
-      expect(jest.mocked(useBridgeQuoteData)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          latestSourceAtomicBalance: undefined,
-        }),
-      );
-    });
   });
 
   describe('when activeQuote is null', () => {
-    beforeEach(() => {
-      jest.mocked(useBridgeQuoteData).mockReturnValue({
-        ...mockUseBridgeQuoteData,
-        activeQuote: null,
-      } as ReturnType<typeof useBridgeQuoteData>);
-    });
-
     it('does not call submitBridgeTx', async () => {
-      const { result } = renderHook();
+      const { result } = renderHook({ ...defaultParams, activeQuote: null });
 
       await act(async () => {
         await result.current();
@@ -189,7 +145,7 @@ describe('useBridgeConfirm', () => {
     });
 
     it('still navigates to TRANSACTIONS_VIEW', async () => {
-      const { result } = renderHook();
+      const { result } = renderHook({ ...defaultParams, activeQuote: null });
 
       await act(async () => {
         await result.current();

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react-native';
+import { BigNumber } from 'ethers';
+import { SolScope } from '@metamask/keyring-api';
+import {
+  selectBridgeQuotes,
+  selectBridgeFeatureFlags,
+} from '@metamask/bridge-controller';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import {
+  BridgeQuoteDataProvider,
+  useBridgeQuoteDataContext,
+} from './BridgeQuoteDataContext';
+import { createBridgeTestState } from '../../testUtils';
+import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
+import {
+  getQuoteRefreshRate,
+  isQuoteExpired,
+  shouldRefreshQuote,
+} from '../../utils/quoteUtils';
+
+jest.mock('../../utils/quoteUtils', () => ({
+  isQuoteExpired: jest.fn(),
+  getQuoteRefreshRate: jest.fn(),
+  shouldRefreshQuote: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../../core/redux/slices/bridge/utils/hasMinimumRequiredVersion',
+  () => ({
+    hasMinimumRequiredVersion: jest.fn(() => true),
+  }),
+);
+
+jest.mock('@metamask/bridge-controller', () => {
+  const actual = jest.requireActual('@metamask/bridge-controller');
+  return {
+    ...actual,
+    selectBridgeQuotes: jest.fn(),
+    selectBridgeFeatureFlags: jest.fn().mockImplementation(() => ({
+      minimumVersion: '7.58.0',
+      priceImpactThreshold: {
+        gasless: 0.4,
+        normal: 0.19,
+        warning: 0.05,
+        error: 0.25,
+      },
+    })),
+  };
+});
+
+const mockValidateBridgeTx = jest.fn();
+jest.mock('../../../../../util/bridge/hooks/useValidateBridgeTx', () => ({
+  __esModule: true,
+  default: () => ({
+    validateBridgeTx: mockValidateBridgeTx,
+  }),
+}));
+
+const mockUseIsInsufficientBalance = jest.fn();
+jest.mock('../useInsufficientBalance', () => ({
+  __esModule: true,
+  default: (params: unknown) => mockUseIsInsufficientBalance(params),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    NetworkController: {
+      findNetworkClientIdByChainId: jest.fn(() => 'mainnet'),
+      getNetworkClientById: jest.fn(() => ({
+        configuration: {
+          chainId: '0x1',
+        },
+      })),
+    },
+  },
+}));
+
+jest.mock('../../../../../util/notifications/methods/common', () => ({
+  getProviderByChainId: jest.fn(() => ({
+    getBalance: jest.fn().mockResolvedValue('1000000000000000000'),
+  })),
+}));
+
+function Consumer() {
+  useBridgeQuoteDataContext();
+  return null;
+}
+
+describe('BridgeQuoteDataContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isQuoteExpired as jest.Mock).mockReturnValue(false);
+    (getQuoteRefreshRate as jest.Mock).mockReturnValue(5000);
+    (shouldRefreshQuote as jest.Mock).mockReturnValue(false);
+    mockUseIsInsufficientBalance.mockReturnValue(false);
+    mockValidateBridgeTx.mockResolvedValue({ status: 'SUCCESS' });
+    (selectBridgeQuotes as unknown as jest.Mock).mockImplementation(() => ({
+      recommendedQuote: mockQuoteWithMetadata,
+      sortedQuotes: [mockQuoteWithMetadata],
+    }));
+    (selectBridgeFeatureFlags as unknown as jest.Mock).mockImplementation(
+      () => ({
+        minimumVersion: '7.58.0',
+        priceImpactThreshold: {
+          gasless: 0.4,
+          normal: 0.19,
+          warning: 0.05,
+          error: 0.25,
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shares one bridge quote data instance across multiple consumers', async () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides: {
+        sourceAmount: '0.5',
+        sourceToken: {
+          symbol: 'SOL',
+          chainId: SolScope.Mainnet,
+          address:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:11111111111111111111111111111111',
+          decimals: 9,
+        },
+        destToken: {
+          symbol: 'USDC',
+          chainId: SolScope.Mainnet,
+          address:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          decimals: 6,
+        },
+      },
+    });
+
+    renderWithProvider(
+      <BridgeQuoteDataProvider
+        latestSourceAtomicBalance={BigNumber.from('1000000000')}
+      >
+        <Consumer />
+        <Consumer />
+        <Consumer />
+        <Consumer />
+        <Consumer />
+      </BridgeQuoteDataProvider>,
+      { state: testState },
+    );
+
+    await waitFor(() => {
+      expect(mockValidateBridgeTx).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('throws when used outside BridgeQuoteDataProvider', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() => {
+      renderWithProvider(<Consumer />);
+    }).toThrow(
+      'useBridgeQuoteDataContext must be used within BridgeQuoteDataProvider',
+    );
+  });
+});

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext } from 'react';
+import { BigNumber as EthersBigNumber } from 'ethers';
+import { useBridgeQuoteData } from './index';
+
+type BridgeQuoteDataContextValue = ReturnType<typeof useBridgeQuoteData>;
+
+const BridgeQuoteDataContext =
+  createContext<BridgeQuoteDataContextValue | null>(null);
+
+interface BridgeQuoteDataProviderProps {
+  children: React.ReactNode;
+  latestSourceAtomicBalance?: EthersBigNumber;
+}
+
+export function BridgeQuoteDataProvider({
+  children,
+  latestSourceAtomicBalance,
+}: BridgeQuoteDataProviderProps) {
+  const value = useBridgeQuoteData({
+    latestSourceAtomicBalance,
+  });
+
+  return (
+    <BridgeQuoteDataContext.Provider value={value}>
+      {children}
+    </BridgeQuoteDataContext.Provider>
+  );
+}
+
+export function useBridgeQuoteDataContext(): BridgeQuoteDataContextValue {
+  const context = useContext(BridgeQuoteDataContext);
+
+  if (!context) {
+    throw new Error(
+      'useBridgeQuoteDataContext must be used within BridgeQuoteDataProvider',
+    );
+  }
+
+  return context;
+}

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -61,6 +61,10 @@ export const useBridgeQuoteData = ({
   const [blockaidError, setBlockaidError] = useState<string | null>(null);
   // Ref to track the current validation ID to prevent race conditions
   const currentValidationIdRef = useRef<number>(0);
+  const lastValidatedQuoteRef = useRef<{
+    requestId: string;
+    validateBridgeTx: typeof validateBridgeTx;
+  } | null>(null);
 
   const {
     quoteFetchError,
@@ -279,49 +283,65 @@ export const useBridgeQuoteData = ({
   );
 
   const validateQuote = useCallback(async () => {
+    if (!activeQuote || (!isSolanaSwap && !isSolanaToNonSolana)) {
+      lastValidatedQuoteRef.current = null;
+      setBlockaidError(null);
+      return;
+    }
+
+    const activeQuoteRequestId = activeQuote.quote.requestId;
+    const hasValidatedCurrentQuote =
+      lastValidatedQuoteRef.current?.requestId === activeQuoteRequestId &&
+      lastValidatedQuoteRef.current?.validateBridgeTx === validateBridgeTx;
+
+    if (hasValidatedCurrentQuote) {
+      return;
+    }
+
+    lastValidatedQuoteRef.current = {
+      requestId: activeQuoteRequestId,
+      validateBridgeTx,
+    };
+
     // Increment validation ID for this request
     const validationId = ++currentValidationIdRef.current;
     // Cancel any ongoing request
     abortController.current?.abort();
     abortController.current = new AbortController();
 
-    if (activeQuote && (isSolanaSwap || isSolanaToNonSolana)) {
-      try {
-        const validationResult = await validateBridgeTx({
-          quoteResponse: activeQuote,
-          signal: abortController.current?.signal,
-        });
+    try {
+      const validationResult = await validateBridgeTx({
+        quoteResponse: activeQuote,
+        signal: abortController.current?.signal,
+      });
 
-        // Check if this is still the current validation after async operation
-        if (validationId !== currentValidationIdRef.current) {
-          // This validation is outdated, ignore the result
-          return;
-        }
+      // Check if this is still the current validation after async operation
+      if (validationId !== currentValidationIdRef.current) {
+        // This validation is outdated, ignore the result
+        return;
+      }
 
-        if (validationResult.status === 'ERROR') {
-          const isValidationError = !!validationResult.result.validation.reason;
-          const { error_details } = validationResult;
-          const fallbackErrorMessage = isValidationError
-            ? validationResult.result.validation.reason
-            : validationResult.error;
-          const error = error_details?.message
-            ? `The ${error_details.message}.`
-            : fallbackErrorMessage;
-          setBlockaidError(error);
-        } else {
-          setBlockaidError(null);
-        }
-      } catch (error) {
-        // Check if this is still the current validation after async operation
-        if (validationId !== currentValidationIdRef.current) {
-          // This validation is outdated, ignore the result
-          return;
-        }
-
-        console.error('Swaps Quote Data Validation error:', error);
+      if (validationResult.status === 'ERROR') {
+        const isValidationError = !!validationResult.result.validation.reason;
+        const { error_details } = validationResult;
+        const fallbackErrorMessage = isValidationError
+          ? validationResult.result.validation.reason
+          : validationResult.error;
+        const error = error_details?.message
+          ? `The ${error_details.message}.`
+          : fallbackErrorMessage;
+        setBlockaidError(error);
+      } else {
         setBlockaidError(null);
       }
-    } else {
+    } catch (error) {
+      // Check if this is still the current validation after async operation
+      if (validationId !== currentValidationIdRef.current) {
+        // This validation is outdated, ignore the result
+        return;
+      }
+
+      console.error('Swaps Quote Data Validation error:', error);
       setBlockaidError(null);
     }
   }, [activeQuote, isSolanaSwap, isSolanaToNonSolana, validateBridgeTx]);

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -342,6 +342,12 @@ export const useBridgeQuoteData = ({
       }
 
       console.error('Swaps Quote Data Validation error:', error);
+      if (
+        lastValidatedQuoteRef.current?.requestId === activeQuoteRequestId &&
+        lastValidatedQuoteRef.current?.validateBridgeTx === validateBridgeTx
+      ) {
+        lastValidatedQuoteRef.current = null;
+      }
       setBlockaidError(null);
     }
   }, [activeQuote, isSolanaSwap, isSolanaToNonSolana, validateBridgeTx]);
@@ -356,7 +362,7 @@ export const useBridgeQuoteData = ({
     }
   }, [manuallySelectedQuote, dispatch]);
 
-  return {
+  const returnValue = {
     bestQuote,
     quoteFetchError,
     activeQuote,
@@ -374,4 +380,6 @@ export const useBridgeQuoteData = ({
     isActiveQuoteForCurrentTokenPair:
       isQuoteSourceTokenMatch && isQuoteDestTokenMatch,
   };
+
+  return returnValue;
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -16,10 +16,11 @@ import {
 import AppConstants from '../../../../../core/AppConstants';
 import { useBridgeQuoteData } from '.';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { waitFor } from '@testing-library/react-native';
+import { act, waitFor } from '@testing-library/react-native';
 import { BigNumber } from 'ethers';
 import { SolScope } from '@metamask/keyring-api';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
 
 jest.mock('../../utils/quoteUtils', () => ({
   isQuoteExpired: jest.fn(),
@@ -1021,6 +1022,82 @@ describe('useBridgeQuoteData', () => {
     await waitFor(() => {
       expect(result.current.blockaidError).toBe(null);
     });
+  });
+
+  it('retries validation for the same requestId after validation throws', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(jest.fn());
+    const requestId = 'same-request-id';
+    const firstMockQuote = {
+      ...mockQuoteWithMetadata,
+      quote: {
+        ...mockQuoteWithMetadata.quote,
+        requestId,
+      },
+    };
+    const secondMockQuote = {
+      ...mockQuoteWithMetadata,
+      quote: {
+        ...mockQuoteWithMetadata.quote,
+        requestId,
+      },
+    };
+    let recommendedQuote = firstMockQuote;
+
+    (selectBridgeQuotes as unknown as jest.Mock).mockImplementation(() => ({
+      recommendedQuote,
+      alternativeQuotes: [],
+    }));
+
+    mockValidateBridgeTx
+      .mockRejectedValueOnce(new Error('Network timeout'))
+      .mockResolvedValueOnce({ status: 'SUCCESS' });
+
+    const bridgeReducerOverrides = {
+      sourceToken: {
+        symbol: 'SOL',
+        chainId: SolScope.Mainnet,
+        address: '11111111111111111111111111111112',
+        decimals: 9,
+      },
+      destToken: {
+        symbol: 'USDC',
+        chainId: SolScope.Mainnet,
+        address:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        decimals: 6,
+      },
+    };
+
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides,
+    });
+
+    const { store } = renderHookWithProvider(() => useBridgeQuoteData(), {
+      state: testState,
+    });
+
+    await waitFor(() => {
+      expect(mockValidateBridgeTx).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Swaps Quote Data Validation error:',
+        expect.any(Error),
+      );
+    });
+
+    recommendedQuote = secondMockQuote;
+    act(() => {
+      store.dispatch(setSourceAmount('2'));
+    });
+
+    await waitFor(() => {
+      expect(mockValidateBridgeTx).toHaveBeenCalledTimes(2);
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 
   // Test validQuotes filtering

--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -243,16 +243,26 @@ export const useLatestBalance = (token: {
     return { displayBalance, atomicBalance };
   }, [token.balance, token.decimals]);
 
-  if (!token.address || !token.decimals) {
-    return undefined;
-  }
+  const latestBalance = useMemo(() => {
+    if (!token.address || !token.decimals) {
+      return undefined;
+    }
 
-  // If the token identity has changed, return cached balance of new token
-  // so we have time to fetch the new balance.
-  if (tokenIdentityChanged) {
-    return cachedBalance;
-  }
+    // If the token identity has changed, return cached balance of new token
+    // so we have time to fetch the new balance.
+    if (tokenIdentityChanged) {
+      return cachedBalance;
+    }
 
-  // Return balance if it exists, otherwise return cached balance of new token
-  return balance ?? cachedBalance;
+    // Return balance if it exists, otherwise return cached balance of new token
+    return balance ?? cachedBalance;
+  }, [
+    balance,
+    cachedBalance,
+    token.address,
+    token.decimals,
+    tokenIdentityChanged,
+  ]);
+
+  return latestBalance;
 };

--- a/app/util/bridge/hooks/useValidateBridgeTx.ts
+++ b/app/util/bridge/hooks/useValidateBridgeTx.ts
@@ -4,45 +4,49 @@ import { SolMethod } from '@metamask/keyring-api';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { base58 } from 'ethers/lib/utils';
 import AppConstants from '../../../core/AppConstants';
+import { useCallback } from 'react';
 
 export default function useValidateBridgeTx() {
   const selectedAccount = useSelector(selectSelectedInternalAccount);
 
-  const validateBridgeTx = async ({
-    quoteResponse,
-    signal,
-  }: {
-    quoteResponse: QuoteResponse & QuoteMetadata;
-    signal?: AbortSignal;
-  }) => {
-    const response = await fetch(
-      `${AppConstants.SECURITY_ALERTS_API.URL}/solana/message/scan`,
-      {
-        signal,
-        headers: {
-          'Content-Type': 'application/json',
-          accept: 'application/json',
-        },
-        method: 'POST',
-        body: JSON.stringify({
-          method: SolMethod.SignAndSendTransaction,
-          encoding: 'base64',
-          account_address: selectedAccount?.address
-            ? Buffer.from(base58.decode(selectedAccount.address)).toString(
-                'base64',
-              )
-            : undefined,
-          chain: 'mainnet',
-          transactions: [quoteResponse.trade],
-          options: ['simulation', 'validation'],
-          metadata: {
-            url: null,
+  const validateBridgeTx = useCallback(
+    async ({
+      quoteResponse,
+      signal,
+    }: {
+      quoteResponse: QuoteResponse & QuoteMetadata;
+      signal?: AbortSignal;
+    }) => {
+      const response = await fetch(
+        `${AppConstants.SECURITY_ALERTS_API.URL}/solana/message/scan`,
+        {
+          signal,
+          headers: {
+            'Content-Type': 'application/json',
+            accept: 'application/json',
           },
-        }),
-      },
-    );
-    return response.json();
-  };
+          method: 'POST',
+          body: JSON.stringify({
+            method: SolMethod.SignAndSendTransaction,
+            encoding: 'base64',
+            account_address: selectedAccount?.address
+              ? Buffer.from(base58.decode(selectedAccount.address)).toString(
+                  'base64',
+                )
+              : undefined,
+            chain: 'mainnet',
+            transactions: [quoteResponse.trade],
+            options: ['simulation', 'validation'],
+            metadata: {
+              url: null,
+            },
+          }),
+        },
+      );
+      return response.json();
+    },
+    [selectedAccount?.address],
+  );
 
   return { validateBridgeTx };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR reduces duplicate Bridge quote data work in the main Bridge/Unified Swaps screen. Previously, multiple components in the `BridgeView` subtree called `useBridgeQuoteData` independently, which could trigger repeated Blockaid validation for the same active quote.

The main `BridgeView` subtree now shares a single quote-data result through `BridgeQuoteDataProvider`. `useBridgeConfirm` accepts the caller's `activeQuote`, modal route roots keep their local quote data, and validation is guarded by quote `requestId` plus validation callback identity so the same quote/account context is not validated repeatedly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

No issue: maintenance-only Bridge performance/refactor to reduce duplicate quote validation calls.

## **Manual testing steps**

```gherkin
Feature: Bridge quote validation deduplication

  Scenario: main Bridge screen validates one active Solana quote once
    Given the app is unlocked with an account that can quote a Solana swap or bridge
    And the user is on the Bridge/Unified Swaps screen
    And network inspection or temporary local logging is available for Blockaid validation requests

    When the user selects a Solana source token and enters a swappable amount
    And the quote details, footer, and confirm button are visible for the same active quote
    Then the app should not send repeated Blockaid validation requests for the same quote requestId
    And the confirm flow should still navigate through token warning, missing price, or price impact modals when applicable
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/49e2389b-1150-439e-8b53-9e436f980113



### **After**

https://github.com/user-attachments/assets/873e1df4-592f-4c0d-bf68-6df23491d259


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Bridge/Swaps quoting and confirmation flow by centralizing `useBridgeQuoteData` and changing `useBridgeConfirm` to consume a passed-in `activeQuote`, which could affect when quotes/validations run and what gets submitted. Risk is mitigated by added unit tests around context usage and validation retry behavior.
> 
> **Overview**
> Reduces duplicate quote-data work in the main `BridgeView` subtree by introducing `BridgeQuoteDataProvider`/`useBridgeQuoteDataContext` and switching key consumers (footer, quote details, confirm button) to read a single shared `useBridgeQuoteData` result.
> 
> Updates quote validation to **skip repeated Blockaid validations** for the same quote by caching the last validated `requestId` + `validateBridgeTx` function identity, while still retrying after a thrown validation error.
> 
> Refactors `useBridgeConfirm` to no longer fetch quote data internally; callers now pass `activeQuote` (modals fetch their own quote as needed). Includes test updates/new tests to reflect the context provider and new confirm/validation wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda75d820816303f463f451d4d3fe688e566eadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->