### PR TITLE
feat: Implement UI messengers

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -171,7 +171,7 @@ import BenefitFullView from '../../UI/Rewards/Views/BenefitFullView';
 import BenefitsFullView from '../../UI/Rewards/Views/BenefitsFullView';
 import { getDeFiProtocolPositionDetailsNavbarOptions } from '../../UI/Navbar';
 import MoneyTabPressTracker from '../../UI/Money/components/MoneyTabPressTracker';
-import { createRouteWithMessenger } from '../../../messengers/helpers/route-messenger-helpers';
+import { withMessenger } from '../../../messengers/helpers/route-messenger-helpers';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
@@ -434,8 +434,7 @@ const ExploreHome = () => {
 };
 
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-const SnapSettingsWithMessenger = createRouteWithMessenger({
-  Component: SnapSettings,
+const SnapSettingsWithMessenger = withMessenger(SnapSettings, {
   capabilities: SNAPS_SETTINGS_ROUTE_ALLOWED_CAPABILITIES,
 });
 

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -86,7 +86,10 @@ import SendTransaction from '../../UI/Ramp/Aggregator/Views/SendTransaction';
 import TabBar from '../../../component-library/components/Navigation/TabBar';
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
-import { SnapSettings } from '../../Views/Snaps/SnapSettings';
+import {
+  SnapSettings,
+  ALLOWED_CAPABILITIES as SNAPS_SETTINGS_ROUTE_ALLOWED_CAPABILITIES,
+} from '../../Views/Snaps/SnapSettings';
 import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
 ///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
@@ -168,6 +171,7 @@ import BenefitFullView from '../../UI/Rewards/Views/BenefitFullView';
 import BenefitsFullView from '../../UI/Rewards/Views/BenefitsFullView';
 import { getDeFiProtocolPositionDetailsNavbarOptions } from '../../UI/Navbar';
 import MoneyTabPressTracker from '../../UI/Money/components/MoneyTabPressTracker';
+import { createRouteWithMessenger } from '../../../messengers/helpers/route-messenger-helpers';
 
 const Stack = createStackNavigator();
 const NativeStack = createNativeStackNavigator();
@@ -430,6 +434,11 @@ const ExploreHome = () => {
 };
 
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+const SnapSettingsWithMessenger = createRouteWithMessenger({
+  Component: SnapSettings,
+  capabilities: SNAPS_SETTINGS_ROUTE_ALLOWED_CAPABILITIES,
+});
+
 const SnapsSettingsStack = () => {
   const { colors } = useTheme();
   return (
@@ -445,7 +454,7 @@ const SnapsSettingsStack = () => {
       />
       <NativeStack.Screen
         name={Routes.SNAPS.SNAP_SETTINGS}
-        component={SnapSettings}
+        component={SnapSettingsWithMessenger}
       />
     </NativeStack.Navigator>
   );

--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/lib/integration/react';
 import { store, persistor } from '../../../store';
@@ -24,6 +24,11 @@ import { ReducedMotionConfig, ReduceMotion } from 'react-native-reanimated';
 import { QueryClientProvider } from '@tanstack/react-query';
 import reactQueryService from '../../../core/ReactQueryService';
 import { HardwareWalletProvider } from '../../../core/HardwareWallet';
+import { UIMessengerProvider } from '../../../contexts/ui-messenger';
+import {
+  createUIMessenger,
+  UIMessenger,
+} from '../../../messengers/ui-messenger';
 
 /**
  * Top level of the component hierarchy
@@ -31,6 +36,14 @@ import { HardwareWalletProvider } from '../../../core/HardwareWallet';
  */
 const Root = ({ foxCode }: RootProps) => {
   const [isStoreLoading, setIsStoreLoading] = useState(true);
+
+  // We use a ref to make sure the UI messenger is only created once.
+  const uiMessengerRef = useRef<UIMessenger | null>(null);
+  if (!uiMessengerRef.current) {
+    uiMessengerRef.current = createUIMessenger();
+  }
+
+  const uiMessenger = uiMessengerRef.current;
 
   /**
    * Wait for store to be initialized in Detox tests
@@ -86,12 +99,14 @@ const Root = ({ foxCode }: RootProps) => {
                 <ThemeProvider>
                   <NavigationProvider>
                     <ControllersGate>
-                      <ToastContextWrapper>
-                        <HardwareWalletProvider>
-                          <ReducedMotionConfig mode={ReduceMotion.Never} />
-                          <App />
-                        </HardwareWalletProvider>
-                      </ToastContextWrapper>
+                      <UIMessengerProvider value={uiMessenger}>
+                        <ToastContextWrapper>
+                          <HardwareWalletProvider>
+                            <ReducedMotionConfig mode={ReduceMotion.Never} />
+                            <App />
+                          </HardwareWalletProvider>
+                        </ToastContextWrapper>
+                      </UIMessengerProvider>
                     </ControllersGate>
                   </NavigationProvider>
                 </ThemeProvider>

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -41,6 +41,8 @@ import { selectInternalAccounts } from '../../../../selectors/accountsController
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import Logger from '../../../../util/Logger';
 import { areAddressesEqual } from '../../../../util/address';
+import { RouteMessengerInstance } from './messenger';
+import { useMessenger } from '../../../../hooks/useMessenger';
 interface SnapSettingsProps {
   snap: Snap;
 }
@@ -52,6 +54,7 @@ const SnapSettings = () => {
   const { styles, theme } = useStyles(stylesheet, {});
   const { colors } = theme;
   const navigation = useNavigation();
+  const messenger = useMessenger<RouteMessengerInstance>();
 
   const { snap } = useParams<SnapSettingsProps>();
   const permissionsState = useSelector(selectPermissionControllerState);
@@ -104,8 +107,7 @@ const SnapSettings = () => {
   }, []);
 
   const removeSnap = useCallback(async () => {
-    const { SnapController } = Engine.context;
-    await SnapController.removeSnap(snap.id);
+    await messenger.call('SnapController:removeSnap', snap.id);
 
     if (isKeyringSnap && keyringAccounts.length > 0) {
       try {
@@ -120,7 +122,7 @@ const SnapSettings = () => {
       }
     }
     navigation.goBack();
-  }, [isKeyringSnap, keyringAccounts, navigation, snap.id]);
+  }, [isKeyringSnap, keyringAccounts, navigation, messenger, snap.id]);
 
   const handleRemoveSnap = useCallback(() => {
     if (isKeyringSnap && keyringAccounts.length > 0) {

--- a/app/components/Views/Snaps/SnapSettings/index.ts
+++ b/app/components/Views/Snaps/SnapSettings/index.ts
@@ -1,4 +1,5 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapSettings } from './SnapSettings';
+export { ALLOWED_CAPABILITIES } from './messenger';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/messenger.ts
+++ b/app/components/Views/Snaps/SnapSettings/messenger.ts
@@ -2,7 +2,11 @@ import { defineAllowedRouteCapabilities } from '../../../../messengers/helpers/r
 import type { RouteMessengerFromCapabilities } from '../../../../messengers/route-messenger';
 
 export const ALLOWED_CAPABILITIES = defineAllowedRouteCapabilities({
-  actions: ['SnapController:disconnectOrigin', 'SnapController:installSnaps'],
+  actions: [
+    'SnapController:disconnectOrigin',
+    'SnapController:installSnaps',
+    'SnapController:removeSnap',
+  ],
   events: [],
 });
 

--- a/app/components/Views/Snaps/SnapSettings/messenger.ts
+++ b/app/components/Views/Snaps/SnapSettings/messenger.ts
@@ -1,0 +1,11 @@
+import { defineAllowedRouteCapabilities } from '../../../../messengers/helpers/route-messenger-helpers';
+import type { RouteMessengerFromCapabilities } from '../../../../messengers/route-messenger';
+
+export const ALLOWED_CAPABILITIES = defineAllowedRouteCapabilities({
+  actions: ['SnapController:disconnectOrigin', 'SnapController:installSnaps'],
+  events: [],
+});
+
+export type RouteMessengerInstance = RouteMessengerFromCapabilities<
+  typeof ALLOWED_CAPABILITIES
+>;

--- a/app/components/Views/Snaps/SnapSettings/messenger.ts
+++ b/app/components/Views/Snaps/SnapSettings/messenger.ts
@@ -2,11 +2,7 @@ import { defineAllowedRouteCapabilities } from '../../../../messengers/helpers/r
 import type { RouteMessengerFromCapabilities } from '../../../../messengers/route-messenger';
 
 export const ALLOWED_CAPABILITIES = defineAllowedRouteCapabilities({
-  actions: [
-    'SnapController:disconnectOrigin',
-    'SnapController:installSnaps',
-    'SnapController:removeSnap',
-  ],
+  actions: ['SnapController:removeSnap'],
   events: [],
 });
 

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -30,6 +30,7 @@ import {
   KEYRING_SNAP_REMOVAL_WARNING_CONTINUE,
   KEYRING_SNAP_REMOVAL_WARNING_TEXT_INPUT,
 } from '../../KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.constants';
+import { createMockRouteMessenger } from '../../../../../util/test/mock-route-messenger';
 
 const MOCK_ACCOUNTS_CONTROLLER_STATE = createMockAccountsControllerState([
   MOCK_ADDRESS_1,
@@ -219,9 +220,6 @@ jest.mock('../../../../../core/Engine', () => {
     }),
     removeAccount: jest.fn(),
     context: {
-      SnapController: {
-        removeSnap: jest.fn(),
-      },
       KeyringController: {
         state: {
           keyrings: [
@@ -252,11 +250,16 @@ describe('SnapSettings with non keyring snap', () => {
   });
 
   it('renders correctly', () => {
+    const routeMessenger = createMockRouteMessenger({
+      'SnapController:removeSnap': jest.fn(),
+    });
+
     const { getAllByTestId, getByTestId } = renderWithProvider(
       <SnapSettings />,
       {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         state: initialState as any,
+        routeMessenger,
       },
     );
 
@@ -285,14 +288,22 @@ describe('SnapSettings with non keyring snap', () => {
   });
 
   it('remove snap and goes back when Remove button is pressed', async () => {
+    const routeMessenger = createMockRouteMessenger({
+      'SnapController:removeSnap': jest.fn(),
+    });
+
+    jest.spyOn(routeMessenger, 'call');
+
     const { getByTestId } = renderWithProvider(<SnapSettings />, {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       state: initialState as any,
+      routeMessenger,
     });
 
     const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
     fireEvent(removeButton, 'onPress');
-    expect(Engine.context.SnapController.removeSnap).toHaveBeenCalledWith(
+    expect(routeMessenger.call).toHaveBeenCalledWith(
+      'SnapController:removeSnap',
       'npm:@chainsafe/filsnap',
     );
     await waitFor(() => {
@@ -407,9 +418,14 @@ describe('SnapSettings with keyring snap', () => {
   };
 
   it('renders KeyringSnapRemovalWarning when removing a keyring snap', async () => {
+    const routeMessenger = createMockRouteMessenger({
+      'SnapController:removeSnap': jest.fn(),
+    });
+
     const { getByTestId } = renderWithProvider(<SnapSettings />, {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       state: initialStateWithKeyringSnap as any,
+      routeMessenger,
     });
 
     // Needed to allow for useEffect to run
@@ -423,10 +439,17 @@ describe('SnapSettings with keyring snap', () => {
     });
   });
 
-  it('calls Engine.context.SnapController and Engine.removeAccount when removing a keyring snap with accounts', async () => {
+  it('calls `SnapController:removeSnap` when removing a keyring snap with accounts', async () => {
+    const routeMessenger = createMockRouteMessenger({
+      'SnapController:removeSnap': jest.fn(),
+    });
+
+    jest.spyOn(routeMessenger, 'call');
+
     const { getByTestId } = renderWithProvider(<SnapSettings />, {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       state: initialStateWithKeyringSnap as any,
+      routeMessenger,
     });
 
     // Needed to allow for useEffect to run
@@ -456,7 +479,8 @@ describe('SnapSettings with keyring snap', () => {
 
     // Step 5: Verify that the removal functions are called
     await waitFor(() => {
-      expect(Engine.context.SnapController.removeSnap).toHaveBeenCalledWith(
+      expect(routeMessenger.call).toHaveBeenCalledWith(
+        'SnapController:removeSnap',
         mockKeyringSnapId,
       );
       expect(Engine.removeAccount).toHaveBeenCalledTimes(2);

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -278,9 +278,14 @@ describe('SnapSettings with non keyring snap', () => {
   });
 
   it('calls navigation.goBack when header back button is pressed', () => {
+    const routeMessenger = createMockRouteMessenger({
+      'SnapController:removeSnap': jest.fn(),
+    });
+
     const { getByTestId } = renderWithProvider(<SnapSettings />, {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       state: initialState as any,
+      routeMessenger,
     });
 
     fireEvent(getByTestId(SNAP_SETTINGS_BACK_BUTTON), 'onPress');

--- a/app/contexts/route-messenger.ts
+++ b/app/contexts/route-messenger.ts
@@ -1,5 +1,4 @@
-import { Component, createContext, ReactNode, useContext } from 'react';
-import PropTypes from 'prop-types';
+import { createContext, useContext } from 'react';
 
 import { RouteMessenger } from '../messengers/route-messenger';
 
@@ -26,38 +25,4 @@ export function useRouteMessenger(): RouteMessenger {
   }
 
   return messenger;
-}
-
-/**
- * Utility component which provides messengers to routes. Designed specifically
- * for legacy class components.
- *
- * @see {@link RouteWithMessenger}
- */
-export class LegacyRouteMessengerProvider extends Component<{
-  children?: ReactNode;
-}> {
-  static propTypes = {
-    children: PropTypes.node,
-  };
-
-  static defaultProps = {
-    children: undefined,
-  };
-
-  static contextType = RouteMessengerContext;
-
-  static childContextTypes = {
-    messenger: PropTypes.object,
-  };
-
-  getChildContext() {
-    return {
-      messenger: this.context,
-    };
-  }
-
-  render() {
-    return this.props.children;
-  }
 }

--- a/app/contexts/route-messenger.ts
+++ b/app/contexts/route-messenger.ts
@@ -1,0 +1,63 @@
+import { Component, createContext, ReactNode, useContext } from 'react';
+import PropTypes from 'prop-types';
+
+import { RouteMessenger } from '../messengers/route-messenger';
+
+/**
+ * Context that holds the messenger for the current route.
+ *
+ * @see {@link RouteWithMessenger}
+ */
+export const RouteMessengerContext = createContext<RouteMessenger | null>(null);
+
+/**
+ * Hook to access the messenger for the current route from context.
+ *
+ * @returns The route messenger in context.
+ * @throws If the route messenger has not been set.
+ */
+export function useRouteMessenger(): RouteMessenger {
+  const messenger = useContext(RouteMessengerContext);
+
+  if (!messenger) {
+    throw new Error(
+      'useRouteMessenger must be used within a route messenger context.',
+    );
+  }
+
+  return messenger;
+}
+
+/**
+ * Utility component which provides messengers to routes. Designed specifically
+ * for legacy class components.
+ *
+ * @see {@link RouteWithMessenger}
+ */
+export class LegacyRouteMessengerProvider extends Component<{
+  children?: ReactNode;
+}> {
+  static propTypes = {
+    children: PropTypes.node,
+  };
+
+  static defaultProps = {
+    children: undefined,
+  };
+
+  static contextType = RouteMessengerContext;
+
+  static childContextTypes = {
+    messenger: PropTypes.object,
+  };
+
+  getChildContext() {
+    return {
+      messenger: this.context,
+    };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/app/contexts/ui-messenger.tsx
+++ b/app/contexts/ui-messenger.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+import { UIMessenger } from '../messengers/ui-messenger';
+
+/**
+ * Context that holds the UI messenger.
+ */
+export const UIMessengerContext = createContext<UIMessenger | null>(null);
+
+/**
+ * Provides the UI messenger to child components via context.
+ *
+ * @param args - The arguments to this function.
+ * @param args.value - The UI messenger to load into context.
+ * @param args.children - The components to wrap.
+ */
+export const UIMessengerProvider = ({
+  value,
+  children,
+}: {
+  value: UIMessenger;
+  children: ReactNode;
+}) => (
+  <UIMessengerContext.Provider value={value}>
+    {children}
+  </UIMessengerContext.Provider>
+);
+
+/**
+ * Hook to access the UI messenger from context.
+ *
+ * Used to derive route-level messengers. Do not use this hook directly,
+ * only use it to define route-level messenger hooks.
+ *
+ * @returns The UI messenger in context.
+ * @throws If the UI messenger is not available (e.g., hook is used outside of
+ * the provider).
+ */
+export function useUIMessenger(): UIMessenger {
+  const messenger = useContext(UIMessengerContext);
+
+  if (!messenger) {
+    throw new Error(
+      'The `useUIMessenger` hook must be used within a `UIMessengerProvider`.',
+    );
+  }
+
+  return messenger;
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -517,7 +517,7 @@ type SnapsGlobalEvents =
   | PhishingControllerEvents;
 ///: END:ONLY_INCLUDE_IF
 
-type GlobalActions =
+export type GlobalActions =
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   | SamplePetnamesControllerActions
   ///: END:ONLY_INCLUDE_IF
@@ -607,7 +607,7 @@ type GlobalActions =
   | ChompApiServiceActions
   | MoneyAccountUpgradeControllerActions;
 
-type GlobalEvents =
+export type GlobalEvents =
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   | SamplePetnamesControllerEvents
   ///: END:ONLY_INCLUDE_IF

--- a/app/hooks/useMessenger.ts
+++ b/app/hooks/useMessenger.ts
@@ -1,0 +1,43 @@
+import { useRouteMessenger } from '../contexts/route-messenger';
+import type { RouteMessenger } from '../messengers/route-messenger';
+
+/**
+ * Use this hook to access the messenger that corresponds to the current route.
+ * You can then use the messenger to call actions and subscribe to events that
+ * the route has permission to access.
+ *
+ * Supply a {@link RouteMessenger} type as the type parameter to narrow the
+ * returned messenger to only the actions and events you need.
+ *
+ * @returns The route messenger cast to the requested messenger type.
+ * @example
+ * ```typescript
+ * type NetworkListMessenger = RouteMessenger<
+ *   'NetworkController:addNetwork',
+ *   never
+ * >;
+ *
+ * function NetworkList() {
+ *   const messenger = useMessenger<NetworkListMessenger>();
+ *
+ *   const onAddNetworkClick = async () => {
+ *     await messenger.call('NetworkController:addNetwork', ...);
+ *   }
+ *
+ *   return (
+ *     <Button onClick={onAddNetworkClick}>Add Sepolia</Button>
+ *   ):
+ * }
+ * ```
+ */
+export function useMessenger<
+  RouteMessengerInstance extends RouteMessenger,
+>(): RouteMessengerInstance {
+  const routeMessenger = useRouteMessenger();
+
+  // The context only tells us we have *some* kind of route messenger, but not
+  // what capabilities it has. We trust the caller's type parameter here — the
+  // route configuration is responsible for ensuring the messenger actually
+  // supports the requested actions/events.
+  return routeMessenger as unknown as RouteMessengerInstance;
+}

--- a/app/messengers/configs/helpers.ts
+++ b/app/messengers/configs/helpers.ts
@@ -1,0 +1,26 @@
+import type { ValidateElements } from '../helpers/route-messenger-helpers';
+import { GlobalActions, GlobalEvents } from '../../core/Engine';
+
+/**
+ * Helper function to define the excluded capabilities for a messenger. This is
+ * primarily a type-level helper to ensure that the excluded capabilities are
+ * valid and to get better type inference for the excluded capabilities.
+ *
+ * @param capabilities - The capabilities to exclude, which must be valid action
+ * and event types for the `RootMessenger`.
+ * @param capabilities.actions - The action types to exclude, which must be
+ * valid action types for the `RootMessenger`.
+ * @param capabilities.events - The event types to exclude, which must be valid
+ * event types for the `RootMessenger`.
+ * @returns The given capabilities, typed as the specific action and event types
+ * that were excluded.
+ */
+export function defineExcludedCapabilities<
+  const ActionTypes extends readonly string[],
+  const EventTypes extends readonly string[],
+>(capabilities: {
+  actions: ValidateElements<ActionTypes, GlobalActions['type']>;
+  events: ValidateElements<EventTypes, GlobalEvents['type']>;
+}): { actions: ActionTypes; events: EventTypes } {
+  return capabilities as { actions: ActionTypes; events: EventTypes };
+}

--- a/app/messengers/configs/index.ts
+++ b/app/messengers/configs/index.ts
@@ -1,0 +1,22 @@
+/* eslint-disable import-x/no-namespace */
+
+import * as keyringController from './keyring-controller';
+import { GlobalActions, GlobalEvents } from '../../core/Engine';
+
+interface MessengerExclusions {
+  // This is named like this since it's intended to be defined as a top-level
+  // property of a messenger configuration.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  EXCLUDED_CAPABILITIES: {
+    actions: readonly GlobalActions['type'][];
+    events: readonly GlobalEvents['type'][];
+  };
+}
+
+// If you need to exclude an action or event from being accessible in the UI,
+// add a file to this directory and then add the module to this list.
+// Note: A file does not need to exist for every controller or service, just
+// those that need to exclude certain actions and/or events.
+export const MESSENGERS_WITH_EXCLUSIONS = [
+  keyringController,
+] satisfies MessengerExclusions[];

--- a/app/messengers/configs/keyring-controller.ts
+++ b/app/messengers/configs/keyring-controller.ts
@@ -7,8 +7,11 @@ export const EXCLUDED_CAPABILITIES = defineExcludedCapabilities({
     'KeyringController:addNewKeyring',
     'KeyringController:getKeyringsByType',
     'KeyringController:getKeyringForAccount',
+    'KeyringController:withController',
     'KeyringController:withKeyring',
     'KeyringController:withKeyringUnsafe',
+    'KeyringController:withKeyringV2',
+    'KeyringController:withKeyringV2Unsafe',
   ],
   events: [],
 });

--- a/app/messengers/configs/keyring-controller.ts
+++ b/app/messengers/configs/keyring-controller.ts
@@ -1,0 +1,14 @@
+import { defineExcludedCapabilities } from './helpers';
+
+// By default, all actions and events are allowed. If there an action or event
+// you think should NOT be accessible from the UI, update this.
+export const EXCLUDED_CAPABILITIES = defineExcludedCapabilities({
+  actions: [
+    'KeyringController:addNewKeyring',
+    'KeyringController:getKeyringsByType',
+    'KeyringController:getKeyringForAccount',
+    'KeyringController:withKeyring',
+    'KeyringController:withKeyringUnsafe',
+  ],
+  events: [],
+});

--- a/app/messengers/helpers/route-messenger-helpers.test.tsx
+++ b/app/messengers/helpers/route-messenger-helpers.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { createRouteWithMessenger } from './route-messenger-helpers';
+
+describe('createRouteWithMessenger', () => {
+  const FooComponent = () => <div>Foo</div>;
+
+  it('returns a Route component with the expected shape', () => {
+    const Route = createRouteWithMessenger({
+      Component: FooComponent,
+      capabilities: {
+        actions: ['SnapController:installSnaps'],
+        events: ['SnapController:snapInstalled'],
+      },
+    });
+
+    expect(
+      <Route
+        route={{
+          key: 'test-route',
+          name: 'TestRoute',
+        }}
+        navigation={{
+          addListener: jest.fn(),
+          canGoBack: jest.fn(),
+          dispatch: jest.fn(),
+          isFocused: jest.fn(),
+          getId: jest.fn(),
+          getParent: jest.fn(),
+          getState: jest.fn(),
+          goBack: jest.fn(),
+          navigate: jest.fn(),
+          removeListener: jest.fn(),
+          reset: jest.fn(),
+          setOptions: jest.fn(),
+          setParams: jest.fn(),
+        }}
+      />,
+    ).toMatchInlineSnapshot(`
+      <RouteWithMessengerElement
+        navigation={
+          {
+            "addListener": [MockFunction],
+            "canGoBack": [MockFunction],
+            "dispatch": [MockFunction],
+            "getId": [MockFunction],
+            "getParent": [MockFunction],
+            "getState": [MockFunction],
+            "goBack": [MockFunction],
+            "isFocused": [MockFunction],
+            "navigate": [MockFunction],
+            "removeListener": [MockFunction],
+            "reset": [MockFunction],
+            "setOptions": [MockFunction],
+            "setParams": [MockFunction],
+          }
+        }
+        route={
+          {
+            "key": "test-route",
+            "name": "TestRoute",
+          }
+        }
+      />
+    `);
+  });
+});

--- a/app/messengers/helpers/route-messenger-helpers.test.tsx
+++ b/app/messengers/helpers/route-messenger-helpers.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { createRouteWithMessenger } from './route-messenger-helpers';
+import { withMessenger } from './route-messenger-helpers';
 
-describe('createRouteWithMessenger', () => {
+describe('withMessenger', () => {
   const FooComponent = () => <div>Foo</div>;
 
   it('returns a Route component with the expected shape', () => {
-    const Route = createRouteWithMessenger({
-      Component: FooComponent,
+    const Route = withMessenger(FooComponent, {
       capabilities: {
         actions: ['SnapController:installSnaps'],
         events: ['SnapController:snapInstalled'],

--- a/app/messengers/helpers/route-messenger-helpers.tsx
+++ b/app/messengers/helpers/route-messenger-helpers.tsx
@@ -1,9 +1,13 @@
 import React, { ComponentType, FunctionComponent } from 'react';
 import { UIMessengerActions, UIMessengerEvents } from '../ui-messenger';
 import { RouteWithMessenger } from '../route-with-messenger';
-import { NavigationProp } from '@react-navigation/native';
-import { EventMapBase, RouteProp, ParamListBase } from '@react-navigation/core';
-import type { NavigationState } from '@react-navigation/routers';
+import {
+  NavigationProp,
+  EventMapBase,
+  RouteProp,
+  ParamListBase,
+  NavigationState,
+} from '@react-navigation/native';
 
 /**
  * Validate that each element of a tuple is a member of the given union,

--- a/app/messengers/helpers/route-messenger-helpers.tsx
+++ b/app/messengers/helpers/route-messenger-helpers.tsx
@@ -47,24 +47,7 @@ export function defineAllowedRouteCapabilities<
   return capabilities as { actions: ActionTypes; events: EventTypes };
 }
 
-interface RouteWithMessengerProps<
-  ParamList extends ParamListBase,
-  RouteName extends keyof ParamList,
-  NavigatorID extends string | undefined = undefined,
-  State extends NavigationState = NavigationState<ParamList>,
-  ScreenOptions extends {} = {},
-  EventMap extends EventMapBase = {},
-> {
-  Component: ComponentType<
-    RouteProps<
-      ParamList,
-      RouteName,
-      NavigatorID,
-      State,
-      ScreenOptions,
-      EventMap
-    >
-  >;
+interface WithMessengerOptions {
   capabilities: {
     actions?: UIMessengerActions['type'][];
     events?: UIMessengerEvents['type'][];
@@ -94,31 +77,33 @@ interface RouteProps<
  * Create a route object with a {@link RouteWithMessenger} element that provides
  * a route messenger with the specified capabilities.
  *
+ * @param Component - The component to render for this route. This will be
+ * wrapped in a {@link RouteWithMessenger} component that provides the route
+ * messenger.
  * @param options - Options bag.
  * @param options.capabilities - Capabilities to delegate from the UI messenger
  * to the route messenger.
- * @param options.Component - The component to render for this route. This will
- * be wrapped in a {@link RouteWithMessenger} component that provides the route
- * messenger.
  */
-export function createRouteWithMessenger<
+export function withMessenger<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList,
   NavigatorID extends string | undefined = undefined,
   State extends NavigationState = NavigationState<ParamList>,
   ScreenOptions extends {} = {},
   EventMap extends EventMapBase = {},
->({
-  capabilities,
-  Component,
-}: RouteWithMessengerProps<
-  ParamList,
-  RouteName,
-  NavigatorID,
-  State,
-  ScreenOptions,
-  EventMap
->): FunctionComponent<
+>(
+  Component: ComponentType<
+    RouteProps<
+      ParamList,
+      RouteName,
+      NavigatorID,
+      State,
+      ScreenOptions,
+      EventMap
+    >
+  >,
+  { capabilities }: WithMessengerOptions,
+): FunctionComponent<
   RouteProps<ParamList, RouteName, NavigatorID, State, ScreenOptions, EventMap>
 > {
   return function RouteWithMessengerElement(

--- a/app/messengers/helpers/route-messenger-helpers.tsx
+++ b/app/messengers/helpers/route-messenger-helpers.tsx
@@ -1,0 +1,136 @@
+import React, { ComponentType, FunctionComponent } from 'react';
+import { UIMessengerActions, UIMessengerEvents } from '../ui-messenger';
+import { RouteWithMessenger } from '../route-with-messenger';
+import { NavigationProp } from '@react-navigation/native';
+import { EventMapBase, RouteProp, ParamListBase } from '@react-navigation/core';
+import type { NavigationState } from '@react-navigation/routers';
+
+/**
+ * Validate that each element of a tuple is a member of the given union,
+ * producing a type error for elements that aren't.
+ */
+export type ValidateElements<
+  Elements extends readonly string[],
+  AllowedElements extends string,
+> = {
+  [K in keyof Elements]: Elements[K] extends AllowedElements
+    ? Elements[K]
+    : AllowedElements;
+};
+
+/**
+ * Helper function to define the allowed capabilities for a route messenger.
+ * This is primarily a type-level helper to ensure that the allowed capabilities
+ * are valid UI messenger capabilities and to get better type inference for the
+ * allowed capabilities.
+ *
+ * @param capabilities - The capabilities to allow, which must be valid action
+ * and event types for the `UIMessenger`.
+ * @param capabilities.actions - The action types to allow, which must be
+ * valid action types for the `UIMessenger`.
+ * @param capabilities.events - The event types to allow, which must be valid
+ * event types for the `UIMessenger`.
+ * @returns The given capabilities, typed as the specific action and event types
+ * that were allowed.
+ */
+export function defineAllowedRouteCapabilities<
+  const ActionTypes extends string[],
+  const EventTypes extends string[],
+>(capabilities: {
+  actions: ValidateElements<ActionTypes, UIMessengerActions['type']>;
+  events: ValidateElements<EventTypes, UIMessengerEvents['type']>;
+}): { actions: ActionTypes; events: EventTypes } {
+  return capabilities as { actions: ActionTypes; events: EventTypes };
+}
+
+interface RouteWithMessengerProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList,
+  NavigatorID extends string | undefined = undefined,
+  State extends NavigationState = NavigationState<ParamList>,
+  ScreenOptions extends {} = {},
+  EventMap extends EventMapBase = {},
+> {
+  Component: ComponentType<
+    RouteProps<
+      ParamList,
+      RouteName,
+      NavigatorID,
+      State,
+      ScreenOptions,
+      EventMap
+    >
+  >;
+  capabilities: {
+    actions?: UIMessengerActions['type'][];
+    events?: UIMessengerEvents['type'][];
+  };
+}
+
+interface RouteProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList,
+  NavigatorID extends string | undefined = undefined,
+  State extends NavigationState = NavigationState<ParamList>,
+  ScreenOptions extends {} = {},
+  EventMap extends EventMapBase = {},
+> {
+  route: RouteProp<ParamList, RouteName>;
+  navigation: NavigationProp<
+    ParamList,
+    RouteName,
+    NavigatorID,
+    State,
+    ScreenOptions,
+    EventMap
+  >;
+}
+
+/**
+ * Create a route object with a {@link RouteWithMessenger} element that provides
+ * a route messenger with the specified capabilities.
+ *
+ * @param options - Options bag.
+ * @param options.capabilities - Capabilities to delegate from the UI messenger
+ * to the route messenger.
+ * @param options.Component - The component to render for this route. This will
+ * be wrapped in a {@link RouteWithMessenger} component that provides the route
+ * messenger.
+ */
+export function createRouteWithMessenger<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList,
+  NavigatorID extends string | undefined = undefined,
+  State extends NavigationState = NavigationState<ParamList>,
+  ScreenOptions extends {} = {},
+  EventMap extends EventMapBase = {},
+>({
+  capabilities,
+  Component,
+}: RouteWithMessengerProps<
+  ParamList,
+  RouteName,
+  NavigatorID,
+  State,
+  ScreenOptions,
+  EventMap
+>): FunctionComponent<
+  RouteProps<ParamList, RouteName, NavigatorID, State, ScreenOptions, EventMap>
+> {
+  return function RouteWithMessengerElement(
+    props: RouteProps<
+      ParamList,
+      RouteName,
+      NavigatorID,
+      State,
+      ScreenOptions,
+      EventMap
+    >,
+  ) {
+    return (
+      <RouteWithMessenger path={props.route.name} capabilities={capabilities}>
+        <Component {...props} />
+      </RouteWithMessenger>
+    );
+  };
+}

--- a/app/messengers/route-messenger.test.ts
+++ b/app/messengers/route-messenger.test.ts
@@ -4,7 +4,6 @@ import {
   createRouteMessenger,
   getRouteMessengerNamespace,
 } from './route-messenger';
-import { createMockUIMessenger } from '../util/test/mock-ui-messenger';
 
 describe('getRouteMessengerNamespace', () => {
   it.each([
@@ -20,7 +19,7 @@ describe('getRouteMessengerNamespace', () => {
 });
 
 describe('createRouteMessenger', () => {
-  it('creates a route messenger with the correct namespace and capabilities', () => {
+  it('creates a route messenger with the correct namespace', () => {
     const OriginalMessenger = messengerModule.Messenger;
     const MessengerSpy = jest
       .spyOn(messengerModule, 'Messenger')
@@ -29,39 +28,11 @@ describe('createRouteMessenger', () => {
           new OriginalMessenger(...args),
       );
 
-    const uiMessenger = createMockUIMessenger();
-    jest.spyOn(uiMessenger, 'delegate');
-
-    const routeMessenger = createRouteMessenger({
-      path: 'SomePath',
-      uiMessenger,
-      capabilities: {
-        actions: ['SnapController:installSnaps'],
-        events: ['SnapController:snapInstalled'],
-      },
-    });
-
-    expect(uiMessenger.delegate).toHaveBeenCalledWith({
-      messenger: routeMessenger,
-      actions: ['SnapController:installSnaps'],
-      events: ['SnapController:snapInstalled'],
-    });
+    createRouteMessenger({ path: 'SomePath' });
 
     expect(MessengerSpy).toHaveBeenCalledWith({
       namespace: 'SomePathRoute',
       captureException: expect.any(Function),
     });
-  });
-
-  it('throws an error if no actions or events are provided', () => {
-    const uiMessenger = createMockUIMessenger();
-
-    expect(() =>
-      createRouteMessenger({
-        path: 'Test',
-        uiMessenger,
-        capabilities: {},
-      }),
-    ).toThrow('There are no actions or events to delegate.');
   });
 });

--- a/app/messengers/route-messenger.test.ts
+++ b/app/messengers/route-messenger.test.ts
@@ -1,0 +1,69 @@
+// eslint-disable-next-line import-x/no-namespace
+import * as messengerModule from '@metamask/messenger';
+import {
+  createRouteMessenger,
+  getRouteMessengerNamespace,
+} from './route-messenger';
+import { createMockUIMessenger } from '../util/test/mock-ui-messenger';
+
+describe('getRouteMessengerNamespace', () => {
+  it.each([
+    ['SomePath', 'SomePathRoute'],
+    ['AnotherExampl', 'AnotherExampleRoute'],
+    ['/path/with/*', 'PathWithWildcardRoute'],
+    ['/path/with/:someParameter', 'PathWithSomeParameterRoute'],
+    ['/', 'Route'],
+  ])(
+    'derives the correct namespace from the path "%s"',
+    (path, expectedNamespace) => {
+      expect(getRouteMessengerNamespace(path)).toBe(expectedNamespace);
+    },
+  );
+});
+
+describe('createRouteMessenger', () => {
+  it('creates a route messenger with the correct namespace and capabilities', () => {
+    const OriginalMessenger = messengerModule.Messenger;
+    const MessengerSpy = jest
+      .spyOn(messengerModule, 'Messenger')
+      .mockImplementation(
+        (...args: ConstructorParameters<typeof messengerModule.Messenger>) =>
+          new OriginalMessenger(...args),
+      );
+
+    const uiMessenger = createMockUIMessenger();
+    jest.spyOn(uiMessenger, 'delegate');
+
+    const routeMessenger = createRouteMessenger({
+      path: '/some/path',
+      uiMessenger,
+      capabilities: {
+        actions: ['SnapController:installSnaps'],
+        events: ['SnapController:snapInstalled'],
+      },
+    });
+
+    expect(uiMessenger.delegate).toHaveBeenCalledWith({
+      messenger: routeMessenger,
+      actions: ['SnapController:installSnaps'],
+      events: ['SnapController:snapInstalled'],
+    });
+
+    expect(MessengerSpy).toHaveBeenCalledWith({
+      namespace: 'SomePathRoute',
+      captureException: expect.any(Function),
+    });
+  });
+
+  it('throws an error if no actions or events are provided', () => {
+    const uiMessenger = createMockUIMessenger();
+
+    expect(() =>
+      createRouteMessenger({
+        path: '/test',
+        uiMessenger,
+        capabilities: {},
+      }),
+    ).toThrow('There are no actions or events to delegate.');
+  });
+});

--- a/app/messengers/route-messenger.test.ts
+++ b/app/messengers/route-messenger.test.ts
@@ -33,7 +33,7 @@ describe('createRouteMessenger', () => {
     jest.spyOn(uiMessenger, 'delegate');
 
     const routeMessenger = createRouteMessenger({
-      path: 'SomePathRoute',
+      path: 'SomePath',
       uiMessenger,
       capabilities: {
         actions: ['SnapController:installSnaps'],

--- a/app/messengers/route-messenger.test.ts
+++ b/app/messengers/route-messenger.test.ts
@@ -9,10 +9,8 @@ import { createMockUIMessenger } from '../util/test/mock-ui-messenger';
 describe('getRouteMessengerNamespace', () => {
   it.each([
     ['SomePath', 'SomePathRoute'],
-    ['AnotherExampl', 'AnotherExampleRoute'],
-    ['/path/with/*', 'PathWithWildcardRoute'],
-    ['/path/with/:someParameter', 'PathWithSomeParameterRoute'],
-    ['/', 'Route'],
+    ['AnotherExample', 'AnotherExampleRoute'],
+    ['', 'Route'],
   ])(
     'derives the correct namespace from the path "%s"',
     (path, expectedNamespace) => {
@@ -35,7 +33,7 @@ describe('createRouteMessenger', () => {
     jest.spyOn(uiMessenger, 'delegate');
 
     const routeMessenger = createRouteMessenger({
-      path: '/some/path',
+      path: 'SomePathRoute',
       uiMessenger,
       capabilities: {
         actions: ['SnapController:installSnaps'],
@@ -60,7 +58,7 @@ describe('createRouteMessenger', () => {
 
     expect(() =>
       createRouteMessenger({
-        path: '/test',
+        path: 'Test',
         uiMessenger,
         capabilities: {},
       }),

--- a/app/messengers/route-messenger.ts
+++ b/app/messengers/route-messenger.ts
@@ -101,11 +101,17 @@ export function createRouteMessenger<
     throw new Error('There are no actions or events to delegate.');
   }
 
-  uiMessenger.delegate({
-    messenger: routeMessenger,
-    actions,
-    events,
-  });
+  uiMessenger
+    .delegate({
+      messenger: routeMessenger,
+      actions,
+      events,
+    })
+    .catch((error) => {
+      // Delegation should never fail, but if it does, we should at least
+      // capture the error so that it can be investigated and fixed.
+      captureException(error);
+    });
 
   return routeMessenger;
 }

--- a/app/messengers/route-messenger.ts
+++ b/app/messengers/route-messenger.ts
@@ -1,9 +1,5 @@
 import { Messenger } from '@metamask/messenger';
-import type {
-  UIMessenger,
-  UIMessengerActions,
-  UIMessengerEvents,
-} from './ui-messenger';
+import type { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
 import { captureException } from '@sentry/react-native';
 
 /**
@@ -57,61 +53,25 @@ export function getRouteMessengerNamespace(
 }
 
 /**
- * Derive a messenger for a route from the UI messenger.
+ * Create a messenger for a route.
  *
  * This is used when defining routes (that is, each route gets its own
- * messenger).
+ * messenger). Delegation of actions and events is handled separately by the
+ * caller (typically via `RouteWithMessenger`).
  *
  * @param args - Arguments for this function.
  * @param args.path - The path of the route. This is used for debugging purposes
  * and to ensure that the route messenger's namespace is unique across routes.
- * @param args.uiMessenger - The parent UI messenger.
- * @param args.capabilities - Capabilities to delegate from the UI messenger.
- * @param args.capabilities.actions - Action types to delegate from the UI
- * messenger.
- * @param args.capabilities.events - Event types to delegate from the UI
- * messenger.
- * @returns A messenger with access to the specified actions and events.
+ * @returns A messenger for the route.
  */
 export function createRouteMessenger<
   ActionTypes extends UIMessengerActions['type'],
   EventTypes extends UIMessengerEvents['type'],
->({
-  path,
-  uiMessenger,
-  capabilities: { actions = [], events = [] },
-}: {
-  path: string;
-  uiMessenger: UIMessenger;
-  capabilities: {
-    actions?: ActionTypes[];
-    events?: EventTypes[];
-  };
-}): RouteMessenger<ActionTypes, EventTypes> {
-  const routeMessenger = new Messenger<
-    `${string}Route`,
-    UIMessengerActions,
-    UIMessengerEvents
-  >({
-    namespace: getRouteMessengerNamespace(path),
-    captureException,
-  });
-
-  if (actions.length === 0 && events.length === 0) {
-    throw new Error('There are no actions or events to delegate.');
-  }
-
-  uiMessenger
-    .delegate({
-      messenger: routeMessenger,
-      actions,
-      events,
-    })
-    .catch((error) => {
-      // Delegation should never fail, but if it does, we should at least
-      // capture the error so that it can be investigated and fixed.
-      captureException(error);
-    });
-
-  return routeMessenger;
+>({ path }: { path: string }): RouteMessenger<ActionTypes, EventTypes> {
+  return new Messenger<`${string}Route`, UIMessengerActions, UIMessengerEvents>(
+    {
+      namespace: getRouteMessengerNamespace(path),
+      captureException,
+    },
+  );
 }

--- a/app/messengers/route-messenger.ts
+++ b/app/messengers/route-messenger.ts
@@ -1,0 +1,111 @@
+import { Messenger } from '@metamask/messenger';
+import type {
+  UIMessenger,
+  UIMessengerActions,
+  UIMessengerEvents,
+} from './ui-messenger';
+import { captureException } from '@sentry/react-native';
+
+/**
+ * Helper type to derive a route messenger type from a capabilities object.
+ */
+export type RouteMessengerFromCapabilities<
+  CapabilitiesType extends {
+    actions?: UIMessengerActions['type'][];
+    events?: UIMessengerEvents['type'][];
+  },
+> = RouteMessenger<
+  CapabilitiesType extends { actions: (infer ActionTypes)[] }
+    ? ActionTypes
+    : never,
+  CapabilitiesType extends { events: (infer EventTypes)[] } ? EventTypes : never
+>;
+
+/**
+ * A messenger that represents a route.
+ *
+ * This type is intentionally generic (a bit unusual for messenger "instance"
+ * types) because each route gets its own messenger (the "route messenger" isn't
+ * a singleton as is the case for controllers and services).
+ */
+export type RouteMessenger<
+  ActionTypes extends UIMessengerActions['type'] = UIMessengerActions['type'],
+  EventTypes extends UIMessengerEvents['type'] = UIMessengerEvents['type'],
+> = Messenger<
+  `${string}Route`,
+  Extract<UIMessengerActions, { type: ActionTypes }>,
+  Extract<UIMessengerEvents, { type: EventTypes }>
+>;
+
+/**
+ * Derive a route messenger namespace from a route path. Assumes the path is
+ * already formatted as PascalCase (e.g. 'SomePath' rather than '/some/path').
+ *
+ * @example
+ * ```typescript
+ * getRouteMessengerNamespace('SomePath'); // 'SomePathRoute'
+ * getRouteMessengerNamespace('AnotherExample'); // 'AnotherExampleRoute'
+ * getRouteMessengerNamespace(''); // 'Route'
+ * ```
+ * @param path - The route path to derive the namespace from.
+ * @returns A namespace string derived from the route path.
+ */
+export function getRouteMessengerNamespace(
+  path: string = '',
+): `${string}Route` {
+  return `${path}Route`;
+}
+
+/**
+ * Derive a messenger for a route from the UI messenger.
+ *
+ * This is used when defining routes (that is, each route gets its own
+ * messenger).
+ *
+ * @param args - Arguments for this function.
+ * @param args.path - The path of the route. This is used for debugging purposes
+ * and to ensure that the route messenger's namespace is unique across routes.
+ * @param args.uiMessenger - The parent UI messenger.
+ * @param args.capabilities - Capabilities to delegate from the UI messenger.
+ * @param args.capabilities.actions - Action types to delegate from the UI
+ * messenger.
+ * @param args.capabilities.events - Event types to delegate from the UI
+ * messenger.
+ * @returns A messenger with access to the specified actions and events.
+ */
+export function createRouteMessenger<
+  ActionTypes extends UIMessengerActions['type'],
+  EventTypes extends UIMessengerEvents['type'],
+>({
+  path,
+  uiMessenger,
+  capabilities: { actions = [], events = [] },
+}: {
+  path: string;
+  uiMessenger: UIMessenger;
+  capabilities: {
+    actions?: ActionTypes[];
+    events?: EventTypes[];
+  };
+}): RouteMessenger<ActionTypes, EventTypes> {
+  const routeMessenger = new Messenger<
+    `${string}Route`,
+    UIMessengerActions,
+    UIMessengerEvents
+  >({
+    namespace: getRouteMessengerNamespace(path),
+    captureException,
+  });
+
+  if (actions.length === 0 && events.length === 0) {
+    throw new Error('There are no actions or events to delegate.');
+  }
+
+  uiMessenger.delegate({
+    messenger: routeMessenger,
+    actions,
+    events,
+  });
+
+  return routeMessenger;
+}

--- a/app/messengers/route-with-messenger.test.tsx
+++ b/app/messengers/route-with-messenger.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+// eslint-disable-next-line import-x/no-namespace
+import * as routeMessengerModule from '../messengers/route-messenger';
+import { RouteWithMessenger } from './route-with-messenger';
+import renderWithProvider, {
+  renderScreen,
+} from '../util/test/renderWithProvider';
+import { View } from 'react-native';
+
+describe('RouteWithMessenger', () => {
+  it('renders children and provides a route messenger', () => {
+    const { getByTestId } = renderWithProvider(
+      <RouteWithMessenger
+        path="/test"
+        capabilities={{
+          actions: ['SnapController:installSnaps'],
+        }}
+      >
+        <View testID="child" />
+      </RouteWithMessenger>,
+    );
+
+    expect(getByTestId('child')).toBeOnTheScreen();
+  });
+
+  it('creates a route messenger with the correct path and capabilities', () => {
+    const createRouteMessengerSpy = jest.spyOn(
+      routeMessengerModule,
+      'createRouteMessenger',
+    );
+
+    const Component = () => (
+      <RouteWithMessenger
+        path="SomePath"
+        capabilities={{
+          actions: ['SnapController:installSnaps'],
+          events: ['SnapController:snapInstalled'],
+        }}
+      >
+        <div />
+      </RouteWithMessenger>
+    );
+
+    renderScreen(Component, {
+      name: 'SomePath',
+    });
+
+    expect(createRouteMessengerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'SomePath',
+        capabilities: {
+          actions: ['SnapController:installSnaps'],
+          events: ['SnapController:snapInstalled'],
+        },
+      }),
+    );
+  });
+});

--- a/app/messengers/route-with-messenger.test.tsx
+++ b/app/messengers/route-with-messenger.test.tsx
@@ -1,57 +1,93 @@
 import React from 'react';
+import { act } from '@testing-library/react-native';
+import { View } from 'react-native';
 // eslint-disable-next-line import-x/no-namespace
 import * as routeMessengerModule from '../messengers/route-messenger';
 import { RouteWithMessenger } from './route-with-messenger';
-import renderWithProvider, {
-  renderScreen,
-} from '../util/test/renderWithProvider';
-import { View } from 'react-native';
+import renderWithProvider from '../util/test/renderWithProvider';
+import { createMockUIMessenger } from '../util/test/mock-ui-messenger';
+import type { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
+
+const CAPABILITIES = {
+  actions: [
+    'SnapController:installSnaps' as unknown as UIMessengerActions['type'],
+  ],
+  events: [
+    'SnapController:snapInstalled' as unknown as UIMessengerEvents['type'],
+  ],
+};
 
 describe('RouteWithMessenger', () => {
-  it('renders children and provides a route messenger', () => {
-    const { getByTestId } = renderWithProvider(
-      <RouteWithMessenger
-        path="/test"
-        capabilities={{
-          actions: ['SnapController:installSnaps'],
-        }}
-      >
+  it('renders children once delegation is complete', async () => {
+    const uiMessenger = createMockUIMessenger();
+    jest.spyOn(uiMessenger, 'delegate').mockResolvedValue(undefined);
+
+    const { findByTestId } = renderWithProvider(
+      <RouteWithMessenger path="TestPath" capabilities={CAPABILITIES}>
         <View testID="child" />
       </RouteWithMessenger>,
+      { uiMessenger },
     );
 
-    expect(getByTestId('child')).toBeOnTheScreen();
+    expect(await findByTestId('child')).toBeOnTheScreen();
   });
 
-  it('creates a route messenger with the correct path and capabilities', () => {
+  it('delegates capabilities to the route messenger on mount', async () => {
+    const uiMessenger = createMockUIMessenger();
+    const delegateSpy = jest
+      .spyOn(uiMessenger, 'delegate')
+      .mockResolvedValue(undefined);
+
     const createRouteMessengerSpy = jest.spyOn(
       routeMessengerModule,
       'createRouteMessenger',
     );
 
-    const Component = () => (
-      <RouteWithMessenger
-        path="SomePath"
-        capabilities={{
-          actions: ['SnapController:installSnaps'],
-          events: ['SnapController:snapInstalled'],
-        }}
-      >
-        <div />
-      </RouteWithMessenger>
+    const { findByTestId } = renderWithProvider(
+      <RouteWithMessenger path="SomePath" capabilities={CAPABILITIES}>
+        <View testID="content" />
+      </RouteWithMessenger>,
+      { uiMessenger },
     );
 
-    renderScreen(Component, {
-      name: 'SomePath',
+    // Wait for delegation to complete.
+    await findByTestId('content');
+
+    expect(createRouteMessengerSpy).toHaveBeenCalledWith({ path: 'SomePath' });
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: CAPABILITIES.actions,
+        events: CAPABILITIES.events,
+      }),
+    );
+  });
+
+  it('revokes delegation when the component unmounts', async () => {
+    const uiMessenger = createMockUIMessenger();
+    jest.spyOn(uiMessenger, 'delegate').mockResolvedValue(undefined);
+
+    const revokeSpy = jest
+      .spyOn(uiMessenger, 'revoke')
+      .mockResolvedValue(undefined);
+
+    const { findByTestId, unmount } = renderWithProvider(
+      <RouteWithMessenger path="SomePath" capabilities={CAPABILITIES}>
+        <View testID="content" />
+      </RouteWithMessenger>,
+      { uiMessenger },
+    );
+
+    // Wait for delegation to complete before unmounting.
+    await findByTestId('content');
+
+    await act(async () => {
+      unmount();
     });
 
-    expect(createRouteMessengerSpy).toHaveBeenCalledWith(
+    expect(revokeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        path: 'SomePath',
-        capabilities: {
-          actions: ['SnapController:installSnaps'],
-          events: ['SnapController:snapInstalled'],
-        },
+        actions: CAPABILITIES.actions,
+        events: CAPABILITIES.events,
       }),
     );
   });

--- a/app/messengers/route-with-messenger.tsx
+++ b/app/messengers/route-with-messenger.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode, useRef } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
 import { RouteMessengerContext } from '../contexts/route-messenger';
 import { useUIMessenger } from '../contexts/ui-messenger';
 import { createRouteMessenger, type RouteMessenger } from './route-messenger';
+import { captureException } from '@sentry/react-native';
 
 /**
  * Utility component which creates a messenger representing a route and
@@ -43,6 +44,24 @@ export const RouteWithMessenger = ({
       capabilities,
     });
   }
+
+  useEffect(
+    () => () => {
+      if (routeMessengerRef.current) {
+        // Clean up the route messenger when the component unmounts.
+        uiMessenger
+          .revoke({
+            messenger: routeMessengerRef.current,
+            actions: capabilities.actions,
+            events: capabilities.events,
+          })
+          .catch((error) => {
+            captureException(error);
+          });
+      }
+    },
+    [uiMessenger, capabilities.actions, capabilities.events],
+  );
 
   const routeMessenger = routeMessengerRef.current;
 

--- a/app/messengers/route-with-messenger.tsx
+++ b/app/messengers/route-with-messenger.tsx
@@ -9,11 +9,16 @@ import { captureException } from '@sentry/react-native';
  * Utility component which creates a messenger representing a route and
  * provides it to children via context.
  *
+ * Do not use this component directly. Instead, use the `withMessenger` HOC to
+ * wrap route components, which will render this component internally.
+ *
  * @param props - Component props.
  * @param props.path - The path of the route. This is used for debugging
  * purposes and to ensure that the route messenger's namespace is unique across
  * routes.
  * @param props.capabilities - Capabilities to delegate to the route messenger.
+ * This must be a stable object (i.e. it should be memoized if defined inline)
+ * to avoid unnecessary re-delegation on every render.
  * @param props.capabilities.actions - Action types to delegate to the route
  * messenger.
  * @param props.capabilities.events - Event types to delegate to the route

--- a/app/messengers/route-with-messenger.tsx
+++ b/app/messengers/route-with-messenger.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
 import { RouteMessengerContext } from '../contexts/route-messenger';
 import { useUIMessenger } from '../contexts/ui-messenger';
@@ -34,36 +34,42 @@ export const RouteWithMessenger = ({
 }) => {
   const uiMessenger = useUIMessenger();
   const routeMessengerRef = useRef<RouteMessenger | null>(null);
+  const [isDelegated, setDelegated] = useState(false);
 
   // `useMemo` doesn't work here because `capabilities` is an object, so we use
   // a ref instead to ensure that we only create the route messenger once.
   if (!routeMessengerRef.current) {
-    routeMessengerRef.current = createRouteMessenger({
-      path,
-      uiMessenger,
-      capabilities,
-    });
+    routeMessengerRef.current = createRouteMessenger({ path });
   }
 
-  useEffect(
-    () => () => {
-      if (routeMessengerRef.current) {
-        // Clean up the route messenger when the component unmounts.
-        uiMessenger
-          .revoke({
-            messenger: routeMessengerRef.current,
-            actions: capabilities.actions,
-            events: capabilities.events,
-          })
-          .catch((error) => {
-            captureException(error);
-          });
-      }
-    },
-    [uiMessenger, capabilities.actions, capabilities.events],
-  );
+  useEffect(() => {
+    const messenger = routeMessengerRef.current;
+    if (!messenger) {
+      return;
+    }
+
+    const { actions, events } = capabilities;
+    uiMessenger
+      .delegate({ messenger, actions, events })
+      .then(() => setDelegated(true))
+      .catch(captureException);
+
+    return () => {
+      uiMessenger
+        .revoke({ messenger, actions, events })
+        .then(() => setDelegated(false))
+        .catch(captureException);
+    };
+  }, [uiMessenger, capabilities]);
 
   const routeMessenger = routeMessengerRef.current;
+
+  // Wait for delegation to complete before rendering children, to ensure that
+  // the route messenger has access to the delegated capabilities when children
+  // are rendered.
+  if (!isDelegated) {
+    return null;
+  }
 
   return (
     <RouteMessengerContext.Provider value={routeMessenger}>

--- a/app/messengers/route-with-messenger.tsx
+++ b/app/messengers/route-with-messenger.tsx
@@ -1,9 +1,6 @@
 import React, { ReactNode, useRef } from 'react';
 import { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
-import {
-  LegacyRouteMessengerProvider,
-  RouteMessengerContext,
-} from '../contexts/route-messenger';
+import { RouteMessengerContext } from '../contexts/route-messenger';
 import { useUIMessenger } from '../contexts/ui-messenger';
 import { createRouteMessenger, type RouteMessenger } from './route-messenger';
 
@@ -51,7 +48,7 @@ export const RouteWithMessenger = ({
 
   return (
     <RouteMessengerContext.Provider value={routeMessenger}>
-      <LegacyRouteMessengerProvider>{children}</LegacyRouteMessengerProvider>
+      {children}
     </RouteMessengerContext.Provider>
   );
 };

--- a/app/messengers/route-with-messenger.tsx
+++ b/app/messengers/route-with-messenger.tsx
@@ -1,0 +1,57 @@
+import React, { ReactNode, useRef } from 'react';
+import { UIMessengerActions, UIMessengerEvents } from './ui-messenger';
+import {
+  LegacyRouteMessengerProvider,
+  RouteMessengerContext,
+} from '../contexts/route-messenger';
+import { useUIMessenger } from '../contexts/ui-messenger';
+import { createRouteMessenger, type RouteMessenger } from './route-messenger';
+
+/**
+ * Utility component which creates a messenger representing a route and
+ * provides it to children via context.
+ *
+ * @param props - Component props.
+ * @param props.path - The path of the route. This is used for debugging
+ * purposes and to ensure that the route messenger's namespace is unique across
+ * routes.
+ * @param props.capabilities - Capabilities to delegate to the route messenger.
+ * @param props.capabilities.actions - Action types to delegate to the route
+ * messenger.
+ * @param props.capabilities.events - Event types to delegate to the route
+ * messenger.
+ * @param props.children - Child components.
+ */
+export const RouteWithMessenger = ({
+  path,
+  capabilities,
+  children,
+}: {
+  path: string;
+  capabilities: {
+    actions?: UIMessengerActions['type'][];
+    events?: UIMessengerEvents['type'][];
+  };
+  children: ReactNode;
+}) => {
+  const uiMessenger = useUIMessenger();
+  const routeMessengerRef = useRef<RouteMessenger | null>(null);
+
+  // `useMemo` doesn't work here because `capabilities` is an object, so we use
+  // a ref instead to ensure that we only create the route messenger once.
+  if (!routeMessengerRef.current) {
+    routeMessengerRef.current = createRouteMessenger({
+      path,
+      uiMessenger,
+      capabilities,
+    });
+  }
+
+  const routeMessenger = routeMessengerRef.current;
+
+  return (
+    <RouteMessengerContext.Provider value={routeMessenger}>
+      <LegacyRouteMessengerProvider>{children}</LegacyRouteMessengerProvider>
+    </RouteMessengerContext.Provider>
+  );
+};

--- a/app/messengers/ui-messenger.test.ts
+++ b/app/messengers/ui-messenger.test.ts
@@ -1,0 +1,298 @@
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  UIMessenger,
+  type UIMessengerActions,
+  type UIMessengerEvents,
+} from './ui-messenger';
+import Engine from '../core/Engine';
+
+jest.mock('../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+  },
+}));
+
+/**
+ * Create a delegatee messenger for testing. Uses MOCK_ANY_NAMESPACE to avoid
+ * namespace restrictions.
+ */
+function createDelegatee() {
+  return new Messenger<MockAnyNamespace, UIMessengerActions, UIMessengerEvents>(
+    { namespace: MOCK_ANY_NAMESPACE },
+  );
+}
+
+describe('UIMessenger', () => {
+  let uiMessenger: UIMessenger;
+  let mockCall: jest.Mock;
+  let mockSubscribe: jest.Mock;
+  let mockUnsubscribe: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uiMessenger = new UIMessenger();
+    mockCall = jest.mocked(Engine.controllerMessenger.call);
+    mockSubscribe = jest.mocked(Engine.controllerMessenger.subscribe);
+    mockUnsubscribe = jest.mocked(Engine.controllerMessenger.unsubscribe);
+  });
+
+  describe('delegate', () => {
+    describe('actions', () => {
+      it('registers a handler on the delegatee that routes to the background', async () => {
+        const delegatee = createDelegatee();
+        mockCall.mockReturnValue('result');
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        const result = await delegatee.call(
+          'SnapController:installSnaps',
+          'metamask',
+          {},
+        );
+
+        expect(mockCall).toHaveBeenCalledWith(
+          'SnapController:installSnaps',
+          'metamask',
+          {},
+        );
+        expect(result).toBe('result');
+      });
+
+      it('throws if an excluded action is called', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          // @ts-expect-error: Excluded action for testing purposes.
+          actions: ['KeyringController:addNewKeyring'],
+          messenger: delegatee,
+        });
+
+        // @ts-expect-error: Excluded action for testing purposes.
+        expect(() => delegatee.call('KeyringController:addNewKeyring')).toThrow(
+          `The action "KeyringController:addNewKeyring" has not been exposed to the UI.`,
+        );
+      });
+
+      it('throws if the same action is delegated to the same messenger twice', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).rejects.toThrow(
+          `The action "${'SnapController:installSnaps'}" has already been delegated to this messenger.`,
+        );
+      });
+
+      it('allows the same action to be delegated to different messengers', async () => {
+        const delegatee1 = createDelegatee();
+        const delegatee2 = createDelegatee();
+
+        await expect(
+          Promise.all([
+            uiMessenger.delegate({
+              actions: ['SnapController:installSnaps'],
+              messenger: delegatee1,
+            }),
+            uiMessenger.delegate({
+              actions: ['SnapController:installSnaps'],
+              messenger: delegatee2,
+            }),
+          ]),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('events', () => {
+      it('subscribes to the event via Engine.controllerMessenger', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        expect(mockSubscribe).toHaveBeenCalledWith(
+          'SnapController:snapInstalled',
+          expect.any(Function),
+        );
+      });
+
+      it('publishes background events to the delegatee', async () => {
+        const delegatee = createDelegatee();
+        const handler = jest.fn();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (delegatee as any).subscribe('SnapController:snapInstalled', handler);
+
+        let capturedCallback!: (...args: unknown[]) => void;
+        mockSubscribe.mockImplementation(
+          (_event: string, callback: unknown) => {
+            capturedCallback = callback as (...args: unknown[]) => void;
+          },
+        );
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        capturedCallback();
+
+        expect(handler).toHaveBeenCalled();
+      });
+
+      it('throws if the same event is delegated to the same messenger twice', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).rejects.toThrow(
+          `The event 'SnapController:snapInstalled' has already been delegated to this messenger`,
+        );
+      });
+
+      it('creates independent background subscriptions for different messengers', async () => {
+        const delegatee1 = createDelegatee();
+        const delegatee2 = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee1,
+        });
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee2,
+        });
+
+        expect(mockSubscribe).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('revoke', () => {
+    describe('actions', () => {
+      it('unregisters the action handler from the delegatee', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        expect(() =>
+          delegatee.call('SnapController:installSnaps', 'metamask', {}),
+        ).toThrow();
+      });
+
+      it('silently ignores actions that have not been delegated', async () => {
+        const delegatee = createDelegatee();
+
+        await expect(
+          uiMessenger.revoke({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+
+      it('allows re-delegation after revoking', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('events', () => {
+      it('calls Engine.controllerMessenger.unsubscribe for the event', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        expect(mockUnsubscribe).toHaveBeenCalledWith(
+          'SnapController:snapInstalled',
+          expect.any(Function),
+        );
+      });
+
+      it('allows re-delegation after revoking', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+
+      it('silently ignores events that have not been delegated', async () => {
+        const delegatee = createDelegatee();
+
+        await expect(
+          uiMessenger.revoke({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+});

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -1,0 +1,138 @@
+import {
+  Messenger,
+  ActionConstraint,
+  ExtractEventPayload,
+  ExtractActionResponse,
+  ExtractActionParameters,
+} from '@metamask/messenger';
+import type { Json } from '@metamask/utils';
+import { MESSENGERS_WITH_EXCLUSIONS } from './configs';
+import { captureException } from '@sentry/react-native';
+import Engine, { GlobalActions, GlobalEvents } from '../core/Engine';
+
+/**
+ * All actions we call through the UI messenger will go through the background
+ * connection and will therefore be asynchronous, even if they weren't
+ * originally. This type makes a function asynchronous.
+ */
+type MakeAsynchronous<InputFunction extends (...args: never[]) => unknown> =
+  InputFunction extends (...args: infer Args) => infer Return
+    ? (...args: Args) => Promise<Awaited<Return>>
+    : never;
+
+/**
+ * All actions we call through the UI messenger will go through the background
+ * connection and will therefore be asynchronous, even if they weren't
+ * originally. This type makes the given actions asynchronous.
+ */
+// Use a conditional type to ensure that TypeScript distributes a given union
+// and we get a union back (this is essentially a `map`)
+type MakeActionsAsynchronous<Action> = Action extends ActionConstraint
+  ? { type: Action['type']; handler: MakeAsynchronous<Action['handler']> }
+  : never;
+
+const EXCLUDED_ACTIONS = MESSENGERS_WITH_EXCLUSIONS.flatMap(
+  (config) => config.EXCLUDED_CAPABILITIES.actions,
+);
+
+type MessengerWithExclusions = (typeof MESSENGERS_WITH_EXCLUSIONS)[number];
+type ExcludedActionTypes =
+  MessengerWithExclusions['EXCLUDED_CAPABILITIES']['actions'][number];
+type ExcludedEventTypes =
+  MessengerWithExclusions['EXCLUDED_CAPABILITIES']['events'][number];
+
+/**
+ * Keeps only actions whose parameters and return value are JSON-serializable,
+ * since all actions go through the background connection.
+ */
+type WithJsonParams<Action extends ActionConstraint> =
+  Action extends ActionConstraint
+    ? Parameters<Action['handler']> extends Json[]
+      ? Action
+      : never
+    : never;
+
+/**
+ * Keeps only events whose payload is JSON-serializable, since all events come
+ * through the background connection.
+ */
+type WithJsonPayload<Event> = Event extends {
+  payload: infer P extends unknown[];
+}
+  ? P extends Json[]
+    ? Event
+    : never
+  : never;
+
+export type UIMessengerActions = MakeActionsAsynchronous<
+  WithJsonParams<Exclude<GlobalActions, { type: ExcludedActionTypes }>>
+>;
+
+export type UIMessengerEvents = WithJsonPayload<
+  Exclude<GlobalEvents, { type: ExcludedEventTypes }>
+>;
+
+const UI_MESSENGER_NAMESPACE = 'UI';
+
+export class UIMessenger extends Messenger<
+  typeof UI_MESSENGER_NAMESPACE,
+  UIMessengerActions,
+  UIMessengerEvents
+> {
+  constructor() {
+    super({ namespace: UI_MESSENGER_NAMESPACE, captureException });
+  }
+
+  // @ts-expect-error This `call` is purposely not the same `call` from
+  // `Messenger`.
+  async call<ActionType extends UIMessengerActions['type']>(
+    actionType: ActionType,
+    ...params: ExtractActionParameters<UIMessengerActions, ActionType>
+  ): Promise<Awaited<ExtractActionResponse<UIMessengerActions, ActionType>>> {
+    const excludedActions: string[] = EXCLUDED_ACTIONS;
+    const anyActionType: string = actionType;
+
+    if (!excludedActions.includes(anyActionType)) {
+      throw new Error(`Action '${actionType}' has not been exposed to the UI`);
+    }
+
+    // @ts-expect-error: Type of handler is not compatible.
+    return await Engine.controllerMessenger.call(actionType, ...params);
+  }
+
+  /**
+   * Subscribe to an event emitted by the background.
+   *
+   * Registers the given function as an event handler for the given event type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this
+   * event.
+   * @param handler - The event handler. The type of the parameters for this
+   * event handler must match the type of the payload for this event type.
+   * @returns A cleanup function that can be invoked to unsubscribe.
+   */
+  // @ts-expect-error: Intentionally different type than `messenger.subscribe`.
+  async subscribe<EventType extends UIMessengerEvents['type']>(
+    eventType: EventType,
+    handler: (
+      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
+    ) => void,
+  ): Promise<() => Promise<void>> {
+    // @ts-expect-error: Type of handler is not compatible.
+    Engine.controllerMessenger.subscribe(eventType, handler);
+
+    return async () => {
+      // @ts-expect-error: Type of handler is not compatible.
+      Engine.controllerMessenger.unsubscribe(eventType, handler);
+    };
+  }
+}
+
+/**
+ * Factory function to create a UI messenger instance.
+ *
+ * @returns A new instance of the UI messenger.
+ */
+export function createUIMessenger(): UIMessenger {
+  return new UIMessenger();
+}

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -104,7 +104,7 @@ export class UIMessenger extends Messenger<
       );
     }
 
-    return (...args: unknown[]) =>
+    return async (...args: unknown[]) =>
       // @ts-expect-error: `unknown[]` is not assignable to `args`, but the type
       // here is checked in `call`, so this is safe.
       Engine.controllerMessenger.call(actionType, ...args);

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -72,6 +72,13 @@ export type UIMessengerEvents = WithJsonPayload<
 
 const UI_MESSENGER_NAMESPACE = 'UI';
 
+// `UIMessenger` is a subclass of `Messenger` rather than a type alias because
+// it functions as a denylist rather than an allowlist.
+//
+// Although it is a "child" of the root messenger, it does not expect to be set
+// up using the conventional delegation pattern. Rather, it delegates all
+// actions and events to the root messenger by default, using an exclusion list
+// to guard action delegation in particular.
 export class UIMessenger extends Messenger<
   typeof UI_MESSENGER_NAMESPACE,
   UIMessengerActions,

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -2,8 +2,6 @@ import {
   Messenger,
   ActionConstraint,
   ExtractEventPayload,
-  ExtractActionResponse,
-  ExtractActionParameters,
 } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 import { MESSENGERS_WITH_EXCLUSIONS } from './configs';
@@ -11,9 +9,9 @@ import { captureException } from '@sentry/react-native';
 import Engine, { GlobalActions, GlobalEvents } from '../core/Engine';
 
 /**
- * All actions we call through the UI messenger will go through the background
- * connection and will therefore be asynchronous, even if they weren't
- * originally. This type makes a function asynchronous.
+ * All actions are made asynchronous to match the implementation of the
+ * extension, which routes all actions through the background connection. This
+ * type makes a function asynchronous.
  */
 type MakeAsynchronous<InputFunction extends (...args: never[]) => unknown> =
   InputFunction extends (...args: infer Args) => infer Return
@@ -21,9 +19,9 @@ type MakeAsynchronous<InputFunction extends (...args: never[]) => unknown> =
     : never;
 
 /**
- * All actions we call through the UI messenger will go through the background
- * connection and will therefore be asynchronous, even if they weren't
- * originally. This type makes the given actions asynchronous.
+ * All actions are made asynchronous to match the implementation of the
+ * extension, which routes all actions through the background connection. This
+ * type makes the given actions asynchronous.
  */
 // Use a conditional type to ensure that TypeScript distributes a given union
 // and we get a union back (this is essentially a `map`)
@@ -43,7 +41,7 @@ type ExcludedEventTypes =
 
 /**
  * Keeps only actions whose parameters and return value are JSON-serializable,
- * since all actions go through the background connection.
+ * to match the implementation of the extension.
  */
 type WithJsonParams<Action extends ActionConstraint> =
   Action extends ActionConstraint
@@ -53,8 +51,8 @@ type WithJsonParams<Action extends ActionConstraint> =
     : never;
 
 /**
- * Keeps only events whose payload is JSON-serializable, since all events come
- * through the background connection.
+ * Keeps only events whose payload is JSON-serializable, to match the
+ * implementation of the extension.
  */
 type WithJsonPayload<Event> = Event extends {
   payload: infer P extends unknown[];
@@ -87,8 +85,7 @@ export class UIMessenger extends Messenger<
    * Get the handler for a given action type.
    *
    * This is called when `call` is invoked on the messenger. We override it here
-   * to route all calls through the background connection, except for the
-   * excluded actions.
+   * to match the implementation of the extension.
    *
    * @param actionType - The action type. This is a unique identifier for this
    * action.
@@ -130,14 +127,33 @@ export class UIMessenger extends Messenger<
     handler: (
       ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
     ) => void,
-  ): Promise<() => Promise<void>> {
+  ): Promise<void> {
     // @ts-expect-error: Type of handler is not compatible.
     Engine.controllerMessenger.subscribe(eventType, handler);
+  }
 
-    return async () => {
-      // @ts-expect-error: Type of handler is not compatible.
-      Engine.controllerMessenger.unsubscribe(eventType, handler);
-    };
+  /**
+   * Unsubscribe from an event emitted by the background.
+   *
+   * Unregisters the given function as an event handler for the given event
+   * type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this
+   * event.
+   * @param handler - The event handler to remove. The type of the parameters
+   * for this event handler must match the type of the payload for this event
+   * type.
+   * @returns A promise that resolves when the unsubscription is complete.
+   */
+  // @ts-expect-error: Intentionally different type than `messenger.unsubscribe`.
+  async unsubscribe<EventType extends UIMessengerEvents['type']>(
+    eventType: EventType,
+    handler: (
+      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
+    ) => void,
+  ): Promise<void> {
+    // @ts-expect-error: Type of handler is not compatible.
+    Engine.controllerMessenger.unsubscribe(eventType, handler);
   }
 }
 

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -2,10 +2,15 @@ import {
   Messenger,
   ActionConstraint,
   ExtractEventPayload,
+  EventConstraint,
+  MessengerActions,
+  MessengerEvents,
+  ExtractActionParameters,
+  ExtractActionResponse,
+  ExtractEventHandler,
 } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 import { MESSENGERS_WITH_EXCLUSIONS } from './configs';
-import { captureException } from '@sentry/react-native';
 import Engine, { GlobalActions, GlobalEvents } from '../core/Engine';
 
 /**
@@ -70,97 +75,241 @@ export type UIMessengerEvents = WithJsonPayload<
   Exclude<GlobalEvents, { type: ExcludedEventTypes }>
 >;
 
-const UI_MESSENGER_NAMESPACE = 'UI';
+/**
+ * A messenger that actions and/or events can be delegated to.
+ *
+ * This is a minimal type interface to avoid complex incompatibilities resulting
+ * from generics over invariant types.
+ */
+type DelegatedMessenger = Pick<
+  // The type is broadened to all actions/events because some messenger methods
+  // are contravariant over this type (`registerDelegatedActionHandler` and
+  // `publishDelegated` for example). If this type is narrowed to just the
+  // delegated actions/events, the types for event payload and action parameters
+  // would not be wide enough.
+  Messenger<string, ActionConstraint, EventConstraint>,
+  | '_internalPublishDelegated'
+  | '_internalRegisterDelegatedActionHandler'
+  | '_internalUnregisterDelegatedActionHandler'
+  | 'captureException'
+>;
 
-// `UIMessenger` is a subclass of `Messenger` rather than a type alias because
-// it functions as a denylist rather than an allowlist.
-//
-// Although it is a "child" of the root messenger, it does not expect to be set
-// up using the conventional delegation pattern. Rather, it delegates all
-// actions and events to the root messenger by default, using an exclusion list
-// to guard action delegation in particular.
-export class UIMessenger extends Messenger<
-  typeof UI_MESSENGER_NAMESPACE,
-  UIMessengerActions,
-  UIMessengerEvents
-> {
-  constructor() {
-    super({ namespace: UI_MESSENGER_NAMESPACE, captureException });
-  }
+// We intentionally don't extend the base `Messenger` class here because the UI
+// messenger doesn't need to implement the full messenger API. It's only used as
+// a bridge between the root messenger and the route messengers, and it
+// delegates all of its actions and events to the root messenger by default, so
+// it doesn't need to implement the full API itself.
+export class UIMessenger {
+  /**
+   * The set of messengers we've delegated actions to, by action type.
+   */
+  readonly #actionDelegationTargets = new Map<
+    UIMessengerActions['type'],
+    Set<DelegatedMessenger>
+  >();
 
   /**
-   * Get the handler for a given action type.
-   *
-   * This is called when `call` is invoked on the messenger. We override it here
-   * to match the implementation of the extension.
-   *
-   * @param actionType - The action type. This is a unique identifier for this
-   * action.
-   * @returns The handler for this action type, or undefined if this action type
-   * is excluded or not found.
+   * The set of messengers we've delegated events to and their event handlers, by event type.
    */
-  protected override getAction(
-    actionType: UIMessengerActions['type'],
-  ): ActionConstraint['handler'] | undefined {
-    const excludedActions: string[] = EXCLUDED_ACTIONS;
-    const anyActionType: string = actionType;
+  readonly #subscriptionDelegationTargets = new Map<
+    UIMessengerEvents['type'],
+    Map<DelegatedMessenger, () => Promise<void>>
+  >();
 
-    if (excludedActions.includes(anyActionType)) {
-      throw new Error(
-        `The action "${actionType}" has not been exposed to the UI.`,
+  /**
+   * Delegate actions and events to a given messenger.
+   *
+   * Actions will be delegated by registering a handler on the delegatee
+   * messenger that submits a request to the background for the given action
+   * type and parameters. Events will be delegated by subscribing to the event
+   * on the root messenger and publishing it on the delegatee messenger when it
+   * occurs.
+   *
+   * @param options - The delegation options.
+   * @param options.actions - The action types to delegate.
+   * @param options.events - The event types to delegate.
+   * @param options.messenger - The messenger to delegate to.
+   * @throws If any action type has already been delegated to this messenger, or
+   * if any event type has already been delegated to this messenger.
+   */
+  async delegate<
+    Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      UIMessengerActions['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      UIMessengerEvents['type'])[],
+  >({
+    actions,
+    events,
+    messenger,
+  }: {
+    actions?: DelegatedActions;
+    events?: DelegatedEvents;
+    messenger: Delegatee;
+  }): Promise<void> {
+    for (const actionType of actions ?? []) {
+      const delegatedActionHandler = (
+        ...args: ExtractActionParameters<
+          MessengerActions<Delegatee> & UIMessengerActions,
+          typeof actionType
+        >
+      ): ExtractActionResponse<
+        MessengerActions<Delegatee> & UIMessengerActions,
+        typeof actionType
+      > => {
+        const excludedActions: string[] = EXCLUDED_ACTIONS;
+        if (excludedActions.includes(actionType)) {
+          throw new Error(
+            `The action "${actionType}" has not been exposed to the UI.`,
+          );
+        }
+
+        return Engine.controllerMessenger.call(
+          actionType,
+          ...args,
+        ) as ExtractActionResponse<
+          MessengerActions<Delegatee> & UIMessengerActions,
+          typeof actionType
+        >;
+      };
+
+      let delegationTargets = this.#actionDelegationTargets.get(actionType);
+      if (!delegationTargets) {
+        delegationTargets = new Set<DelegatedMessenger>();
+        this.#actionDelegationTargets.set(actionType, delegationTargets);
+      }
+
+      if (delegationTargets.has(messenger)) {
+        throw new Error(
+          `The action "${actionType}" has already been delegated to this messenger.`,
+        );
+      }
+
+      delegationTargets.add(messenger);
+
+      // Intentionally calling a "deprecated" method here, since this is the
+      // internal API for delegation.
+      messenger._internalRegisterDelegatedActionHandler(
+        actionType,
+        delegatedActionHandler,
       );
     }
 
-    return async (...args: unknown[]) =>
-      // @ts-expect-error: `unknown[]` is not assignable to `args`, but the type
-      // here is checked in `call`, so this is safe.
-      Engine.controllerMessenger.call(actionType, ...args);
+    const promises = (events ?? []).map(async (eventType) => {
+      const untypedSubscriber = (
+        ...payload: ExtractEventPayload<
+          MessengerEvents<Delegatee> & UIMessengerEvents,
+          typeof eventType
+        >
+      ): void => {
+        // Intentionally calling a "deprecated" method here, since this is the
+        // internal API for delegation.
+        messenger._internalPublishDelegated(eventType, ...payload);
+      };
+
+      // Cast to get more specific subscriber type for this specific event.
+      // The types get collapsed here to the type union of all delegated
+      // events, rather than the single subscriber type corresponding to this
+      // event.
+      const subscriber = untypedSubscriber as ExtractEventHandler<
+        MessengerEvents<Delegatee> & UIMessengerEvents,
+        typeof eventType
+      >;
+
+      let delegatedEventSubscriptions =
+        this.#subscriptionDelegationTargets.get(eventType);
+
+      if (!delegatedEventSubscriptions) {
+        delegatedEventSubscriptions = new Map();
+        this.#subscriptionDelegationTargets.set(
+          eventType,
+          delegatedEventSubscriptions,
+        );
+      }
+
+      if (delegatedEventSubscriptions.has(messenger)) {
+        throw new Error(
+          `The event '${eventType}' has already been delegated to this messenger`,
+        );
+      }
+
+      Engine.controllerMessenger.subscribe(eventType, subscriber);
+      const unsubscribe = async () =>
+        Engine.controllerMessenger.unsubscribe(eventType, subscriber);
+
+      delegatedEventSubscriptions.set(messenger, unsubscribe);
+    });
+
+    await Promise.all(promises);
   }
 
   /**
-   * Subscribe to an event emitted by the background.
+   * Revoke delegation of actions and events to a given messenger.
    *
-   * Registers the given function as an event handler for the given event type.
+   * This is essentially the inverse of `delegate`, and will remove the
+   * delegated action handlers and event subscriptions that were added in
+   * `delegate`.
    *
-   * @param eventType - The event type. This is a unique identifier for this
-   * event.
-   * @param handler - The event handler. The type of the parameters for this
-   * event handler must match the type of the payload for this event type.
-   * @returns A cleanup function that can be invoked to unsubscribe.
+   * @param options - The revocation options.
+   * @param options.actions - The action types to revoke delegation for.
+   * @param options.events - The event types to revoke delegation for.
+   * @param options.messenger - The messenger to revoke delegation from.
+   * @returns A promise that resolves when the revocation is complete.
    */
-  // @ts-expect-error: Intentionally different type than `messenger.subscribe`.
-  async subscribe<EventType extends UIMessengerEvents['type']>(
-    eventType: EventType,
-    handler: (
-      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
-    ) => void,
-  ): Promise<void> {
-    // @ts-expect-error: Type of handler is not compatible.
-    Engine.controllerMessenger.subscribe(eventType, handler);
-  }
+  async revoke<
+    Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      UIMessengerActions['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      UIMessengerEvents['type'])[],
+  >({
+    actions,
+    events,
+    messenger,
+  }: {
+    actions?: DelegatedActions;
+    events?: DelegatedEvents;
+    messenger: Delegatee;
+  }): Promise<void> {
+    for (const actionType of actions ?? []) {
+      const delegationTargets = this.#actionDelegationTargets.get(actionType);
+      if (!delegationTargets?.has(messenger)) {
+        // Nothing to revoke.
+        continue;
+      }
 
-  /**
-   * Unsubscribe from an event emitted by the background.
-   *
-   * Unregisters the given function as an event handler for the given event
-   * type.
-   *
-   * @param eventType - The event type. This is a unique identifier for this
-   * event.
-   * @param handler - The event handler to remove. The type of the parameters
-   * for this event handler must match the type of the payload for this event
-   * type.
-   * @returns A promise that resolves when the unsubscription is complete.
-   */
-  // @ts-expect-error: Intentionally different type than `messenger.unsubscribe`.
-  async unsubscribe<EventType extends UIMessengerEvents['type']>(
-    eventType: EventType,
-    handler: (
-      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
-    ) => void,
-  ): Promise<void> {
-    // @ts-expect-error: Type of handler is not compatible.
-    Engine.controllerMessenger.unsubscribe(eventType, handler);
+      // Intentionally calling a "deprecated" method here, since this is the
+      // internal API for delegation.
+      messenger._internalUnregisterDelegatedActionHandler(actionType);
+      delegationTargets.delete(messenger);
+
+      if (delegationTargets.size === 0) {
+        this.#actionDelegationTargets.delete(actionType);
+      }
+    }
+
+    for (const eventType of events ?? []) {
+      const delegationTargets =
+        this.#subscriptionDelegationTargets.get(eventType);
+
+      if (!delegationTargets) {
+        // Nothing to revoke.
+        continue;
+      }
+
+      const unsubscribe = delegationTargets.get(messenger);
+      if (!unsubscribe) {
+        // Nothing to revoke.
+        continue;
+      }
+
+      await unsubscribe();
+      delegationTargets.delete(messenger);
+
+      if (delegationTargets.size === 0) {
+        this.#subscriptionDelegationTargets.delete(eventType);
+      }
+    }
   }
 }
 

--- a/app/messengers/ui-messenger.ts
+++ b/app/messengers/ui-messenger.ts
@@ -83,21 +83,34 @@ export class UIMessenger extends Messenger<
     super({ namespace: UI_MESSENGER_NAMESPACE, captureException });
   }
 
-  // @ts-expect-error This `call` is purposely not the same `call` from
-  // `Messenger`.
-  async call<ActionType extends UIMessengerActions['type']>(
-    actionType: ActionType,
-    ...params: ExtractActionParameters<UIMessengerActions, ActionType>
-  ): Promise<Awaited<ExtractActionResponse<UIMessengerActions, ActionType>>> {
+  /**
+   * Get the handler for a given action type.
+   *
+   * This is called when `call` is invoked on the messenger. We override it here
+   * to route all calls through the background connection, except for the
+   * excluded actions.
+   *
+   * @param actionType - The action type. This is a unique identifier for this
+   * action.
+   * @returns The handler for this action type, or undefined if this action type
+   * is excluded or not found.
+   */
+  protected override getAction(
+    actionType: UIMessengerActions['type'],
+  ): ActionConstraint['handler'] | undefined {
     const excludedActions: string[] = EXCLUDED_ACTIONS;
     const anyActionType: string = actionType;
 
-    if (!excludedActions.includes(anyActionType)) {
-      throw new Error(`Action '${actionType}' has not been exposed to the UI`);
+    if (excludedActions.includes(anyActionType)) {
+      throw new Error(
+        `The action "${actionType}" has not been exposed to the UI.`,
+      );
     }
 
-    // @ts-expect-error: Type of handler is not compatible.
-    return await Engine.controllerMessenger.call(actionType, ...params);
+    return (...args: unknown[]) =>
+      // @ts-expect-error: `unknown[]` is not assignable to `args`, but the type
+      // here is checked in `call`, so this is safe.
+      Engine.controllerMessenger.call(actionType, ...args);
   }
 
   /**

--- a/app/util/test/mock-route-messenger.ts
+++ b/app/util/test/mock-route-messenger.ts
@@ -1,0 +1,50 @@
+import {
+  ActionHandler,
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  UIMessengerActions,
+  UIMessengerEvents,
+} from '../../messengers/ui-messenger';
+import { RouteMessenger } from '../../messengers/route-messenger';
+
+/**
+ * Create a route messenger for testing with the specified action handlers.
+ *
+ * This creates a real Messenger instance with a fake namespace and registers
+ * the provided action handlers on it.
+ *
+ * @param actionHandlers - A map of action type strings to handler functions.
+ * @returns A messenger with the specified action handlers registered.
+ * @example
+ * ```typescript
+ * const addNetwork = jest.fn().mockResolvedValue({ chainId: '0x1' });
+ * const messenger = createMockRouteMessenger({
+ *   'NetworkController:addNetwork': addNetwork,
+ * });
+ * ```
+ */
+export function createMockRouteMessenger<
+  Actions extends UIMessengerActions = never,
+>(actionHandlers?: {
+  [Action in Actions as Action['type']]: Action['handler'];
+}): RouteMessenger<Actions['type']> {
+  const messenger = new Messenger<
+    MockAnyNamespace,
+    UIMessengerActions,
+    UIMessengerEvents
+  >({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+  for (const [actionType, handler] of Object.entries(actionHandlers ?? {})) {
+    messenger.registerActionHandler(
+      actionType as Actions['type'],
+      handler as ActionHandler<Actions, Actions['type']>,
+    );
+  }
+
+  return messenger;
+}

--- a/app/util/test/mock-ui-messenger.ts
+++ b/app/util/test/mock-ui-messenger.ts
@@ -1,8 +1,8 @@
 import {
+  ActionConstraint,
   ActionHandler,
+  EventConstraint,
   Messenger,
-  MOCK_ANY_NAMESPACE,
-  MockAnyNamespace,
 } from '@metamask/messenger';
 import type {
   UIMessenger,
@@ -10,12 +10,16 @@ import type {
   UIMessengerEvents,
 } from '../../messengers/ui-messenger';
 
-/**
- * Maps each UIMessenger action type string to its handler function type.
- */
-export type UIMessengerActionHandlersByType = {
-  [Action in UIMessengerActions as Action['type']]: Action['handler'];
-};
+type DelegateeMessenger = Messenger<string, ActionConstraint, EventConstraint>;
+
+interface DelegateArgs<
+  Actions extends UIMessengerActions,
+  Events extends UIMessengerEvents,
+> {
+  actions?: Actions['type'][];
+  events?: Events['type'][];
+  messenger: DelegateeMessenger;
+}
 
 /**
  * Create a UI messenger for testing with the specified action handlers.
@@ -35,26 +39,33 @@ export type UIMessengerActionHandlersByType = {
  */
 export function createMockUIMessenger<
   Actions extends UIMessengerActions = never,
+  Events extends UIMessengerEvents = never,
 >(actionHandlers?: {
   [Action in Actions as Action['type']]: Action['handler'];
 }): UIMessenger {
-  const messenger = new Messenger<
-    MockAnyNamespace,
-    UIMessengerActions,
-    UIMessengerEvents
-  >({
-    namespace: MOCK_ANY_NAMESPACE,
-  });
+  return {
+    async delegate({ actions = [], messenger }: DelegateArgs<Actions, Events>) {
+      for (const actionType of actions) {
+        const handler = actionHandlers?.[actionType];
+        if (!handler) {
+          throw new Error(
+            `No handler registered for action "${String(actionType)}".`,
+          );
+        }
 
-  for (const [actionType, handler] of Object.entries(actionHandlers ?? {})) {
-    messenger.registerActionHandler(
-      actionType as Actions['type'],
-      handler as ActionHandler<Actions, Actions['type']>,
-    );
-  }
+        messenger._internalRegisterDelegatedActionHandler(
+          actionType,
+          handler as ActionHandler<ActionConstraint, Actions['type']>,
+        );
+      }
 
-  // UIMessenger is a subclass of Messenger that includes private fields.
-  // We don't want to create a real UIMessenger instance above, we want to make
-  // a "fake" one, but we want TypeScript to think this is a real one.
-  return messenger as UIMessenger;
+      // No background connection in tests — events are not subscribed to.
+    },
+
+    async revoke({ actions = [], messenger }: DelegateArgs<Actions, Events>) {
+      for (const actionType of actions) {
+        messenger._internalUnregisterDelegatedActionHandler(actionType);
+      }
+    },
+  } as unknown as UIMessenger;
 }

--- a/app/util/test/mock-ui-messenger.ts
+++ b/app/util/test/mock-ui-messenger.ts
@@ -1,0 +1,60 @@
+import {
+  ActionHandler,
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import type {
+  UIMessenger,
+  UIMessengerActions,
+  UIMessengerEvents,
+} from '../../messengers/ui-messenger';
+
+/**
+ * Maps each UIMessenger action type string to its handler function type.
+ */
+export type UIMessengerActionHandlersByType = {
+  [Action in UIMessengerActions as Action['type']]: Action['handler'];
+};
+
+/**
+ * Create a UI messenger for testing with the specified action handlers.
+ *
+ * This creates a real Messenger instance with a fake namespace and registers
+ * the provided action handlers on it.
+ *
+ * @param actionHandlers - A map of action type strings to handler functions.
+ * @returns A messenger with the specified action handlers registered.
+ * @example
+ * ```typescript
+ * const addNetwork = jest.fn().mockResolvedValue({ chainId: '0x1' });
+ * const messenger = createMockUIMessenger({
+ *   'NetworkController:addNetwork': addNetwork,
+ * });
+ * ```
+ */
+export function createMockUIMessenger<
+  Actions extends UIMessengerActions = never,
+>(actionHandlers?: {
+  [Action in Actions as Action['type']]: Action['handler'];
+}): UIMessenger {
+  const messenger = new Messenger<
+    MockAnyNamespace,
+    UIMessengerActions,
+    UIMessengerEvents
+  >({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+  for (const [actionType, handler] of Object.entries(actionHandlers ?? {})) {
+    messenger.registerActionHandler(
+      actionType as Actions['type'],
+      handler as ActionHandler<Actions, Actions['type']>,
+    );
+  }
+
+  // UIMessenger is a subclass of Messenger that includes private fields.
+  // We don't want to create a real UIMessenger instance above, we want to make
+  // a "fake" one, but we want TypeScript to think this is a real one.
+  return messenger as UIMessenger;
+}

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -136,13 +136,36 @@ export function renderHookWithProvider<Result, Props>(
   hook: (props: Props) => Result,
   providerValues?: ProviderValues,
 ) {
-  const { state = {} } = providerValues ?? {};
+  const {
+    state = {},
+    uiMessenger = createMockUIMessenger(),
+    routeMessenger = null,
+  } = providerValues ?? {};
+
   const store = configureStore(state);
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   require('../../store')._updateMockState(state);
-  const Providers = ({ children }: { children: React.ReactElement }) => (
-    <Provider store={store}>{children}</Provider>
-  );
+
+  const Providers = ({ children }: { children: React.ReactElement }) => {
+    let wrappedChildren = children;
+    if (routeMessenger) {
+      wrappedChildren = (
+        <RouteMessengerContext.Provider value={routeMessenger}>
+          <LegacyRouteMessengerProvider>
+            {wrappedChildren}
+          </LegacyRouteMessengerProvider>
+        </RouteMessengerContext.Provider>
+      );
+    }
+
+    return (
+      <Provider store={store}>
+        <UIMessengerProvider value={uiMessenger}>
+          {wrappedChildren}
+        </UIMessengerProvider>
+      </Provider>
+    );
+  };
 
   return {
     ...renderHook(hook, { wrapper: Providers } as RenderHookOptions<Props>),

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -23,6 +23,8 @@ import {
   RouteMessengerContext,
   LegacyRouteMessengerProvider,
 } from '../../contexts/route-messenger';
+import { RouteMessenger } from '../../messengers/route-messenger';
+import { UIMessenger } from '../../messengers/ui-messenger';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -36,9 +38,12 @@ export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
         { [K in keyof T]?: DeepPartial<T[K]> }
       : // Otherwise, return T or undefined.
         T | undefined;
+
 export interface ProviderValues {
   state?: DeepPartial<RootState>;
   theme?: Theme;
+  uiMessenger?: UIMessenger;
+  routeMessenger?: RouteMessenger;
 }
 
 export default function renderWithProvider(
@@ -46,10 +51,14 @@ export default function renderWithProvider(
   providerValues?: ProviderValues,
   includeNavigationContainer = true,
   includeFeatureFlagOverrideProvider = true,
-  uiMessenger = createMockUIMessenger(),
-  routeMessenger = null,
 ) {
-  const { state = {}, theme = mockTheme } = providerValues ?? {};
+  const {
+    state = {},
+    theme = mockTheme,
+    uiMessenger = createMockUIMessenger(),
+    routeMessenger = null,
+  } = providerValues ?? {};
+
   const store = configureStore(state);
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   require('../../store')._updateMockState(state);

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -17,6 +17,12 @@ import { Theme } from '../theme/models';
 import configureStore from './configureStore';
 import { RootState } from '../../reducers';
 import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
+import { UIMessengerProvider } from '../../contexts/ui-messenger';
+import { createMockUIMessenger } from './mock-ui-messenger';
+import {
+  RouteMessengerContext,
+  LegacyRouteMessengerProvider,
+} from '../../contexts/route-messenger';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -40,6 +46,8 @@ export default function renderWithProvider(
   providerValues?: ProviderValues,
   includeNavigationContainer = true,
   includeFeatureFlagOverrideProvider = true,
+  uiMessenger = createMockUIMessenger(),
+  routeMessenger = null,
 ) {
   const { state = {}, theme = mockTheme } = providerValues ?? {};
   const store = configureStore(state);
@@ -55,11 +63,24 @@ export default function renderWithProvider(
         </FeatureFlagOverrideProvider>
       );
     }
+
+    if (routeMessenger) {
+      wrappedChildren = (
+        <RouteMessengerContext.Provider value={routeMessenger}>
+          <LegacyRouteMessengerProvider>
+            {children}
+          </LegacyRouteMessengerProvider>
+        </RouteMessengerContext.Provider>
+      );
+    }
+
     return (
       <Provider store={store}>
-        <ThemeContext.Provider value={theme}>
-          {wrappedChildren}
-        </ThemeContext.Provider>
+        <UIMessengerProvider value={uiMessenger}>
+          <ThemeContext.Provider value={theme}>
+            {wrappedChildren}
+          </ThemeContext.Provider>
+        </UIMessengerProvider>
       </Provider>
     );
   };

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -19,10 +19,7 @@ import { RootState } from '../../reducers';
 import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
 import { UIMessengerProvider } from '../../contexts/ui-messenger';
 import { createMockUIMessenger } from './mock-ui-messenger';
-import {
-  RouteMessengerContext,
-  LegacyRouteMessengerProvider,
-} from '../../contexts/route-messenger';
+import { RouteMessengerContext } from '../../contexts/route-messenger';
 import { RouteMessenger } from '../../messengers/route-messenger';
 import { UIMessenger } from '../../messengers/ui-messenger';
 
@@ -76,9 +73,7 @@ export default function renderWithProvider(
     if (routeMessenger) {
       wrappedChildren = (
         <RouteMessengerContext.Provider value={routeMessenger}>
-          <LegacyRouteMessengerProvider>
-            {wrappedChildren}
-          </LegacyRouteMessengerProvider>
+          {wrappedChildren}
         </RouteMessengerContext.Provider>
       );
     }
@@ -151,9 +146,7 @@ export function renderHookWithProvider<Result, Props>(
     if (routeMessenger) {
       wrappedChildren = (
         <RouteMessengerContext.Provider value={routeMessenger}>
-          <LegacyRouteMessengerProvider>
-            {wrappedChildren}
-          </LegacyRouteMessengerProvider>
+          {wrappedChildren}
         </RouteMessengerContext.Provider>
       );
     }

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -77,7 +77,7 @@ export default function renderWithProvider(
       wrappedChildren = (
         <RouteMessengerContext.Provider value={routeMessenger}>
           <LegacyRouteMessengerProvider>
-            {children}
+            {wrappedChildren}
           </LegacyRouteMessengerProvider>
         </RouteMessengerContext.Provider>
       );

--- a/package.json
+++ b/package.json
@@ -373,6 +373,7 @@
     "@react-native/eslint-config": "^0.82.0",
     "@react-native/typescript-config": "0.76.9",
     "@react-navigation/bottom-tabs": "^6.5.0",
+    "@react-navigation/core": "^6.4.17",
     "@react-navigation/native": "^6.1.0",
     "@react-navigation/native-stack": "^6.0.0",
     "@react-navigation/stack": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -373,7 +373,6 @@
     "@react-native/eslint-config": "^0.82.0",
     "@react-native/typescript-config": "0.76.9",
     "@react-navigation/bottom-tabs": "^6.5.0",
-    "@react-navigation/core": "^6.4.17",
     "@react-navigation/native": "^6.1.0",
     "@react-navigation/native-stack": "^6.0.0",
     "@react-navigation/stack": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35488,6 +35488,7 @@ __metadata:
     "@react-native/metro-config": "npm:0.81.5"
     "@react-native/typescript-config": "npm:0.76.9"
     "@react-navigation/bottom-tabs": "npm:^6.5.0"
+    "@react-navigation/core": "npm:^6.4.17"
     "@react-navigation/native": "npm:^6.1.0"
     "@react-navigation/native-stack": "npm:^6.0.0"
     "@react-navigation/stack": "npm:^6.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35488,7 +35488,6 @@ __metadata:
     "@react-native/metro-config": "npm:0.81.5"
     "@react-native/typescript-config": "npm:0.76.9"
     "@react-navigation/bottom-tabs": "npm:^6.5.0"
-    "@react-navigation/core": "npm:^6.4.17"
     "@react-navigation/native": "npm:^6.1.0"
     "@react-navigation/native-stack": "npm:^6.0.0"
     "@react-navigation/stack": "npm:^6.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Initial implementation of the UI messenger. This sets up the UI messenger, a route messenger, and refactors a Snap page to demonstrate how to use the new route-level messenger.

More details can be found in [the UI messenger ADR](https://github.com/MetaMask/decisions/blob/6760a1616df98f5b8bb7c876fadd7f255a2b8957/decisions/core/0020-integrate-messengers-into-ui.md).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Refs: n/a

## **Manual testing steps**

n/a

## **Screenshots/Recordings**

n/a

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how UI invokes controller actions (snap removal now goes through delegation) and introduces a broad new access-control surface; mitigated by explicit per-route capabilities and KeyringController exclusions, but more routes will need careful capability review as adoption grows.
> 
> **Overview**
> Introduces a **UI messenger layer** so screens can call controller actions through typed, capability-scoped messengers instead of reaching into `Engine` directly.
> 
> **Root** now creates a singleton `UIMessenger` and wraps the app in `UIMessengerProvider`. The UI messenger delegates allowed actions to `Engine.controllerMessenger` and forwards events from the background; a config list (starting with **KeyringController** unsafe/keyring APIs) blocks actions that must not be exposed to the UI.
> 
> **Per-route messengers** are wired via `withMessenger` / `RouteWithMessenger`: on mount they delegate only the declared actions/events, expose them through `RouteMessengerContext`, and revoke on unmount. **Snap Settings** is the first adopter—the navigator wraps `SnapSettings` with `SnapController:removeSnap`, and removal uses `useMessenger().call('SnapController:removeSnap', …)` instead of `Engine.context.SnapController.removeSnap`. Tests and `renderWithProvider` gain optional `uiMessenger` / `routeMessenger` mocks to match this pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbcad3605177adcf32e57408b9e937a3e2a3359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->