### PR TITLE
ci: skip smart e2e ai selection for cherry-pick PRs targeting release branch

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: 'false'
   base-ref:
-    description: 'PR base branch ref passed to the AI analysis script for diff comparison'
+    description: 'PR base branch ref passed to the AI analysis script for diff comparison. When release/*, AI selection is skipped and the full E2E suite is selected.'
     required: false
     default: ''
 outputs:
@@ -57,21 +57,32 @@ runs:
           echo "⏭️ SKIP=true due to 'skip-smart-e2e-selection' label on PR"
         fi
 
+    - name: Check release target branch (full E2E, no AI selection)
+      id: check-release-target
+      shell: bash
+      run: |
+        echo "SKIP=false" >> "$GITHUB_OUTPUT"
+        BASE='${{ inputs.base-ref }}'
+        if [[ -n "$BASE" && "$BASE" == release/* ]]; then
+          echo "SKIP=true" >> "$GITHUB_OUTPUT"
+          echo "⏭️ Base branch is release/* — skipping AI E2E selection; full E2E suite will run"
+        fi
+
     - name: Checkout for PR analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       uses: actions/checkout@v6
       with:
         fetch-depth: 1 # Shallow clone for speed; unshallowed below for diff comparison
 
     - name: Disable sparse checkout and restore all files
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       shell: bash
       run: |
         git sparse-checkout disable
         git checkout HEAD -- .
 
     - name: Fetch base branch for comparison
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       shell: bash
       run: |
         # Unshallow the repository first (if it's shallow)
@@ -80,13 +91,13 @@ runs:
         git fetch origin "${{ inputs.base-ref || 'main' }}" 2>/dev/null || true
 
     - name: Setup Node.js
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
 
     - name: Install minimal dependencies for AI analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       shell: bash
       run: |
         echo "📦 Installing only required packages for AI analysis..."
@@ -98,7 +109,7 @@ runs:
         echo "✅ AI analysis dependencies installed in /tmp/ai-deps"
 
     - name: Copy AI dependencies to workspace
-      if: steps.check-skip-label.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
       shell: bash
       run: |
         echo "📋 Copying AI dependencies to workspace..."
@@ -129,6 +140,11 @@ runs:
           echo "⏭️ Skipping AI analysis - skip-smart-e2e-selection label found"
           echo "SKIPPED=true" >> "$GITHUB_OUTPUT"
           echo "SKIP_REASON=skip-smart-e2e-selection label found" >> "$GITHUB_OUTPUT"
+          echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ steps.check-release-target.outputs.SKIP }}" == "true" ]]; then
+          echo "⏭️ Skipping AI analysis - PR targets a release branch (release/*)"
+          echo "SKIPPED=true" >> "$GITHUB_OUTPUT"
+          echo "SKIP_REASON=PR targets a release branch (release/*)" >> "$GITHUB_OUTPUT"
           echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         else
           echo "✅ Running AI analysis for PR #$PR_NUMBER"


### PR DESCRIPTION
## **Description**

Re-introduces the release-branch skip in `.github/actions/smart-e2e-selection/action.yml`.

The original logic was added in #28331 and accidentally removed by #29305 ("ci: add automated E2E readiness label and CI checks - Part1"), which refactored the action and didn't carry the release-branch handling forward. Since the merge of #29305, every cherry-pick PR targeting `release/*` runs the AI-based reduced E2E selection — same as a `main` PR — instead of running the full suite.

Why release branches deserve different handling (same reasoning as #28331):

- On `main`, iterating quickly with a risk-scored subset is a reasonable trade-off — we accept some residual risk for speed and catch the rest in follow-up PRs.
- A PR into `release/*` is effectively "this build is a candidate to ship." Release cherry-picks are low-volume and high-impact, and we cannot afford to merge a cherry-pick that breaks CI on the release branch under release urgency.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3464 

## **Manual testing steps**


## **Screenshots/Recordings**

### **Before**


### **After**

> ⏭️ **Smart E2E selection skipped** - PR targets a release branch (release/\*)
>
> All E2E tests pre-selected.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just alters when the composite action runs AI selection vs defaulting to the full E2E suite; main risk is unintentionally skipping AI selection if `base-ref` is mis-set.
> 
> **Overview**
> **Smart E2E selection now skips AI for PRs targeting `release/*`.** The `smart-e2e-selection` composite action adds a `check-release-target` gate using `inputs.base-ref`; when it matches `release/*`, the action bypasses checkout/deps/analysis and keeps the default `ai_e2e_test_tags=["ALL"]` with `ai_confidence=100`.
> 
> The action’s `base-ref` input description is updated to document this behavior, and the AI analysis step now reports a specific skip reason for release-branch targets (in addition to the existing skip-label behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94855dc225078898d72832af76658cb9b1b0113a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->