### PR TITLE
chore(card): migrate Card BigInt usage to new library

### DIFF
--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -60,7 +60,7 @@ jest.mock('../../Ramp/Deposit/constants/networks', () => ({
     chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
   },
 }));
-jest.mock('../../../../util/number', () => ({
+jest.mock('../../../../util/number/bigint', () => ({
   balanceToFiatNumber: jest.fn((balance: string, rate: number) => {
     const bal = parseFloat(balance);
     return (bal * rate).toString();

--- a/app/components/UI/Card/hooks/useAssetBalances.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalances.tsx
@@ -8,7 +8,6 @@ import { useTokensWithBalance } from '../../Bridge/hooks/useTokensWithBalance';
 import { isSolanaChainId } from '@metamask/bridge-controller';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import Engine from '../../../../core/Engine';
-import { balanceToFiatNumber } from '../../../../util/number';
 import { safeFormatChainIdToHex } from '../util/safeFormatChainIdToHex';
 import { TokenI } from '../../Tokens/types';
 import { MarketDataDetails } from '@metamask/assets-controllers';
@@ -17,6 +16,7 @@ import I18n from '../../../../../locales/i18n';
 import { deriveBalanceFromAssetMarketDetails } from '../../Tokens/util';
 import { buildTokenIconUrl } from '../util/buildTokenIconUrl';
 import { CARD_CHAIN_IDS } from '../constants';
+import { balanceToFiatNumber } from '../../../../util/number/bigint';
 
 const extractTrailingCurrencyCode = (value: string): string | undefined => {
   const match = value.trim().match(/([A-Za-z]{3})$/);

--- a/app/components/UI/Card/hooks/useCardDelegation.test.ts
+++ b/app/components/UI/Card/hooks/useCardDelegation.test.ts
@@ -9,7 +9,7 @@ import Logger from '../../../../util/Logger';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock';
-import { toTokenMinimalUnit } from '../../../../util/number';
+import { toTokenMinimalUnit } from '../../../../util/number/bigint';
 import { safeToChecksumAddress } from '../../../../util/address';
 import { ARBITRARY_ALLOWANCE } from '../constants';
 import {
@@ -42,7 +42,7 @@ jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
-jest.mock('../../../../util/number', () => ({
+jest.mock('../../../../util/number/bigint', () => ({
   toTokenMinimalUnit: jest.fn(),
 }));
 
@@ -223,7 +223,7 @@ describe('useCardDelegation', () => {
       });
 
     // Setup utility mocks
-    mockToTokenMinimalUnit.mockReturnValue('100000000000000000000');
+    mockToTokenMinimalUnit.mockReturnValue(100000000000000000000n);
     mockSafeToChecksumAddress.mockImplementation(
       (address?: string) => (address as `0x${string}`) || undefined,
     );
@@ -401,7 +401,7 @@ describe('useCardDelegation', () => {
       const mockToken = createMockToken({ decimals: 6 });
       const params = createMockDelegationParams();
 
-      mockToTokenMinimalUnit.mockReturnValue('100000000');
+      mockToTokenMinimalUnit.mockReturnValue(100000000n);
 
       const { result } = renderHook(() => useCardDelegation(mockToken));
 
@@ -1356,7 +1356,7 @@ describe('useCardDelegation', () => {
       };
 
       mockToTokenMinimalUnit.mockReturnValue(
-        '999999999999999999999999999000000000000000000',
+        999999999999999999999999999000000000000000000n,
       );
 
       const { result } = renderHook(() => useCardDelegation(mockToken));

--- a/app/components/UI/Card/hooks/useCardDelegation.ts
+++ b/app/components/UI/Card/hooks/useCardDelegation.ts
@@ -20,7 +20,7 @@ import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { useEnsureCardNetworkExists } from './useEnsureCardNetworkExists';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { ARBITRARY_ALLOWANCE } from '../constants';
-import { toTokenMinimalUnit } from '../../../../util/number';
+import { toTokenMinimalUnit } from '../../../../util/number/bigint';
 import AppConstants from '../../../../core/AppConstants';
 import { safeToChecksumAddress } from '../../../../util/address';
 import { handleSnapRequest } from '../../../../core/Snaps/utils';

--- a/app/components/UI/Card/hooks/useNeedsGasFaucet.ts
+++ b/app/components/UI/Card/hooks/useNeedsGasFaucet.ts
@@ -4,13 +4,12 @@ import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { isNonEvmChainId, isSolanaChainId } from '@metamask/bridge-controller';
 import { Hex, CaipChainId } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
-import BN from 'bnjs4';
 import Engine from '../../../../core/Engine';
 import { useAccountNativeBalance } from '../../../Views/confirmations/hooks/useAccountNativeBalance';
 import { selectMinSolBalance } from '../../../../selectors/bridgeController';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { decGWEIToHexWEI } from '../../../../util/conversions';
-import { hexToBN } from '../../../../util/number';
+import { hexToBigInt } from '../../../../util/number/bigint';
 import { safeFormatChainIdToHex } from '../util/safeFormatChainIdToHex';
 import { CardFundingToken } from '../types';
 import { useLatestBalance } from '../../Bridge/hooks/useLatestBalance';
@@ -93,7 +92,7 @@ export const useNeedsGasFaucet = (
   /**
    * Estimate gas fee for EVM chains
    */
-  const estimateEvmGasFee = useCallback(async (): Promise<BN> => {
+  const estimateEvmGasFee = useCallback(async (): Promise<bigint> => {
     try {
       const { GasFeeController } = Engine.context;
       const result = await GasFeeController.fetchGasFeeEstimates();
@@ -120,16 +119,16 @@ export const useNeedsGasFaucet = (
           break;
       }
 
-      const weiGasPrice = hexToBN(decGWEIToHexWEI(gasPrice));
-      return weiGasPrice.muln(gasLimitWithBuffer);
+      const weiGasPrice = hexToBigInt(decGWEIToHexWEI(gasPrice) as string);
+      return weiGasPrice * BigInt(gasLimitWithBuffer);
     } catch (err) {
       // Return a conservative fallback estimate if gas estimation fails
       // Assume ~20 Gwei gas price as fallback
-      const fallbackGasPrice = new BN('20000000000'); // 20 Gwei in Wei
+      const fallbackGasPrice = 20000000000n; // 20 Gwei in Wei
       const gasLimitWithBuffer = Math.ceil(
         ERC20_APPROVE_GAS_LIMIT * GAS_LIMIT_BUFFER,
       );
-      return fallbackGasPrice.muln(gasLimitWithBuffer);
+      return fallbackGasPrice * BigInt(gasLimitWithBuffer);
     }
   }, []);
 
@@ -144,10 +143,10 @@ export const useNeedsGasFaucet = (
 
     try {
       const estimatedGasFee = await estimateEvmGasFee();
-      const balanceBN = new BN(balanceWeiInHex.replace('0x', ''), 'hex');
+      const balance = hexToBigInt(balanceWeiInHex);
 
       // User needs faucet if balance is less than estimated gas fee
-      return balanceBN.lt(estimatedGasFee);
+      return balance < estimatedGasFee;
     } catch (err) {
       console.error('Error checking EVM faucet need:', err);
       // Assume needs faucet on error


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This change migrates Card feature hooks from the legacy BN.js / `app/util/number` helpers to the native BigInt module at `app/util/number/bigint`, following the repository bigint migration guide.

**Reason:** Reduce BN.js usage, align Card code with the bigint utilities, and keep behavior equivalent for balances, delegation amounts, and gas-faucet checks.

**What changed:**

- `useAssetBalances.tsx` — import `balanceToFiatNumber` from `util/number/bigint`; test mock updated to match.
- `useCardDelegation.ts` — import `toTokenMinimalUnit` from `util/number/bigint`; tests mock `bigint` return values instead of decimal strings.
- `useNeedsGasFaucet.ts` — remove `bnjs4`; use `hexToBigInt` for wei gas price and balance; compare with native `<`; multiply with `BigInt(gasLimitWithBuffer)`; cast `decGWEIToHexWEI` result to `string` for TypeScript (legacy `conversionUtil` union type).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

No issue: internal refactor (Card BigInt burndown / migration guide).

## **Manual testing steps**

```gherkin
Feature: Card hooks BigInt migration

  Scenario: Unit tests cover migrated hooks
    Given the branch is checked out with dependencies installed
    When the developer runs `yarn jest app/components/UI/Card/hooks/useAssetBalances.test.ts app/components/UI/Card/hooks/useCardDelegation.test.ts app/components/UI/Card/hooks/useNeedsGasFaucet.test.ts`
    Then all tests pass

  Scenario: Optional smoke on Card delegation flow
    Given a dev build on a test network with Card funding available
    When the user opens Card home and triggers a flow that uses delegation or gas faucet logic
    Then balances and gas-faucet behavior match expectations (no regression vs prior build)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box means the reviewer consciously assessed that responsibility. See
`docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Card delegation amount conversion and EVM gas-faucet checks by switching from BN/string math to `bigint`, which could change edge-case numeric behavior and transaction approval amounts if not equivalent.
> 
> **Overview**
> Migrates Card hooks off legacy `app/util/number` / BN usage onto `app/util/number/bigint` utilities.
> 
> `useAssetBalances` now uses bigint-based `balanceToFiatNumber` for fiat calculations, `useCardDelegation` switches `toTokenMinimalUnit` to return `bigint` (with tests updated to expect `bigint`), and `useNeedsGasFaucet` removes BN math in favor of `hexToBigInt` and native `bigint` arithmetic/comparisons for EVM gas-fee estimation and balance checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a64d90d99395cbad4152cc71c0a30c15a2146d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->