### PR TITLE
chore: add shared native-stack modal options

### DIFF
--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -47,7 +47,11 @@ import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 /* eslint-disable-next-line */
 import { NavigationContext } from '@react-navigation/core';
 import { CONFIRMATION_HEADER_CONFIG } from '../constants/perpsConfig';
-import { clearStackNavigatorOptions } from '../../../../constants/navigation/clearStackNavigatorOptions';
+import {
+  clearNativeStackNavigatorOptions,
+  clearStackNavigatorOptions,
+  transparentModalScreenOptions,
+} from '../../../../constants/navigation/clearStackNavigatorOptions';
 
 const Stack = createNativeStackNavigator<PerpsNavigationParamList>();
 const ModalStack = createStackNavigator();
@@ -73,7 +77,7 @@ function getRedesignedConfirmationsHeaderOptions({
     title: '',
     headerBackVisible: false,
     contentStyle: { backgroundColor: 'transparent' },
-    presentation: 'transparentModal',
+    ...transparentModalScreenOptions,
   };
 }
 
@@ -353,9 +357,9 @@ const PerpsScreenStack = () => {
             name={Routes.PERPS.TPSL}
             component={PerpsTPSLView}
             options={{
+              ...transparentModalScreenOptions,
               title: strings('perps.tpsl.title'),
               headerShown: false,
-              presentation: 'transparentModal',
             }}
           />
 
@@ -411,12 +415,8 @@ const PerpsScreenStack = () => {
             name={Routes.PERPS.MODALS.CLOSE_POSITION_MODALS}
             component={PerpsClosePositionBottomSheetStack}
             options={{
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'transparent',
-              },
-              animation: 'none',
-              presentation: 'transparentModal',
+              ...clearNativeStackNavigatorOptions,
+              ...transparentModalScreenOptions,
             }}
           />
 
@@ -425,12 +425,8 @@ const PerpsScreenStack = () => {
             name={Routes.PERPS.MODALS.ROOT}
             component={PerpsModalStack}
             options={{
-              headerShown: false,
-              contentStyle: {
-                backgroundColor: 'transparent',
-              },
-              animation: 'none',
-              presentation: 'transparentModal',
+              ...clearNativeStackNavigatorOptions,
+              ...transparentModalScreenOptions,
             }}
           />
 
@@ -442,7 +438,7 @@ const PerpsScreenStack = () => {
             component={PayWithModal}
             options={{
               headerShown: false,
-              presentation: 'transparentModal',
+              ...transparentModalScreenOptions,
             }}
           />
 

--- a/app/constants/navigation/clearStackNavigatorOptions.ts
+++ b/app/constants/navigation/clearStackNavigatorOptions.ts
@@ -1,3 +1,4 @@
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import type { StackNavigationOptions } from '@react-navigation/stack';
 
 /** Transparent stack with no transition animation; used for modal-style flows. */
@@ -22,3 +23,30 @@ export const clearStackNavigatorOptionsWithTransitionAnimation: StackNavigationO
     }),
     animationEnabled: false,
   };
+
+/**
+ * Native-stack counterpart to {@link clearStackNavigatorOptions}.
+ * Use with `createNativeStackNavigator` only (`contentStyle` / `animation`, not `cardStyle` / `animationEnabled`).
+ *
+ * Includes `animation: 'none'` — omit this preset on screens where you want the default push/modal animation.
+ */
+export const clearNativeStackNavigatorOptions: NativeStackNavigationOptions = {
+  headerShown: false,
+  contentStyle: {
+    backgroundColor: 'transparent',
+  },
+  animation: 'none',
+};
+
+/**
+ * Per-screen options for overlay-style screens on native stack.
+ * Replaces the JS-stack `cardStyleInterpolator` trick (overlay opacity 0) — native stack keeps the
+ * presenting screen mounted and does not dim it when `presentation: 'transparentModal'` is used.
+ *
+ * Often spread **after** {@link clearNativeStackNavigatorOptions} for fully static overlays.
+ * Skip `clearNativeStackNavigatorOptions` when this screen should keep the default stack animation
+ * (it sets `animation: 'none'`).
+ */
+export const transparentModalScreenOptions: NativeStackNavigationOptions = {
+  presentation: 'transparentModal',
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
This PR introduces two shared `NativeStackNavigationOptions` presets in `clearStackNavigatorOptions.ts`:

Perps already uses `createNativeStackNavigator`, but several screens repeated the same option blobs (`presentation: 'transparentModal'`, transparent `contentStyle`, `animation: 'none'`, `headerShown: false`) inline. That duplicated the JS-stack `clearStackNavigatorOptions` idea without a typed, reusable native-stack equivalent.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes React Navigation option presets for native stacks, which can affect modal presentation, animations, and header behavior across Perps flows.
> 
> **Overview**
> Standardizes Perps native-stack overlay behavior by replacing inline `presentation: 'transparentModal'`/transparent styling with shared presets (`transparentModalScreenOptions`, `clearNativeStackNavigatorOptions`).
> 
> Adds native-stack equivalents of the existing clear JS-stack options in `clearStackNavigatorOptions.ts`, and updates Perps screens (TP/SL, close-position/bottom-sheet stacks, and pay-with modal) to use these presets for consistent transparent modals without unwanted animations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0cec5fe529e086dbddbe392eac1418de9804f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->