### PR TITLE
chore(INFRA-3591): add temp Bitrise iOS RN cache workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,6 +15,10 @@ self-hosted-runner:
     - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"
     - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xl"
     - "low-priority"
+    # Bitrise GHA runner pool labels (self-hosted runner group temp-bitrise-runners)
+    - "bitrise_pool_name:DemoFA"
+    - "bitrise_pool_name:DemoFAL"
+    - "bitrise_pool_name:DemoFAXL"
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/temp-bitrise-ios-rn.yml
+++ b/.github/workflows/temp-bitrise-ios-rn.yml
@@ -1,0 +1,377 @@
+name: "[TEMP] Bitrise iOS RN cache POC"
+
+# TEMPORARY WORKFLOW for INFRA-3591
+# Purpose: RN cache POC (Bitrise React Native build cache) + iOS E2E app build on Bitrise runners.
+# This workflow is NOT part of the CI gate. Remove when benchmarking is complete.
+
+on:
+  pull_request:
+    types: [ labeled, synchronize ]
+  # Hourly on the hour (UTC). Staggered +30m from temp-bitrise-ios-kv.yml (KV cache workflow).
+  schedule:
+    - cron: "0 * * * *"
+
+concurrency:
+  group: bitrise-ios-rn-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-ios-on-bitrise:
+    name: Build iOS E2E App (RN cache)
+    if: >-
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'bitrise-poc')) &&
+      !github.event.pull_request.head.repo.fork
+    runs-on:
+      group: temp-bitrise-runners
+      labels: [ "bitrise_pool_name:DemoFAXL" ]
+    timeout-minutes: 60
+    outputs:
+      artifacts-url: ${{ steps.set-artifacts-url.outputs.artifacts-url }}
+    env:
+      IOS_APP_CACHE_VERSION: 2
+      RCT_NO_LAUNCH_PACKAGER: 1
+      XCODE_BUILD_SETTINGS: "COMPILER_INDEX_STORE_ENABLE=NO"
+      GITHUB_CI: "true"
+      PLATFORM: ios
+      METAMASK_ENVIRONMENT: qa
+      METAMASK_BUILD_TYPE: main
+      IS_TEST: true
+      E2E: "true"
+      IGNORE_BOXLOGS_DEVELOPMENT: true
+      CI: "true"
+      NODE_OPTIONS: "--max-old-space-size=8192"
+      BRIDGE_USE_DEV_APIS: "true"
+      RAMP_INTERNAL_BUILD: "true"
+      SEEDLESS_ONBOARDING_ENABLED: "true"
+      MM_NOTIFICATIONS_UI_ENABLED: "true"
+      MM_SECURITY_ALERTS_API_ENABLED: "true"
+      YARN_ENABLE_GLOBAL_CACHE: "true"
+      FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+      FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+      SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+      SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+      SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+      SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+      MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+      MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+      MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+      MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+      MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+      MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+      MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+      GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+      GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+      MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+      MM_PREDICT_GTM_MODAL_ENABLED: "false"
+      BITRISE_BUILD_CACHE_WORKSPACE_ID: ${{ vars.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
+      BITRISE_BUILD_CACHE_AUTH_TOKEN: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Print runner environment diagnostics
+        run: |
+          echo "=== Runner Diagnostics ==="
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo "macOS version: $(sw_vers -productVersion)"
+          echo "Memory: $(sysctl -n hw.memsize | awk '{print $1/1024/1024/1024 " GB"}')"
+          echo "Disk free: $(df -h / | tail -1 | awk '{print $4}')"
+          echo "CPU cores: $(sysctl -n hw.ncpu)"
+          echo "=== Xcode ==="
+          xcode-select -p 2>/dev/null | sed "s|$HOME|~|g" || echo "No Xcode selected"
+          xcodebuild -version 2>/dev/null | head -2 || echo "xcodebuild not available"
+          echo "=== Ruby ==="
+          ruby --version 2>/dev/null || echo "No ruby"
+          echo "=== Node ==="
+          node --version 2>/dev/null || echo "No node"
+        shell: bash
+
+      - name: Fix Vagrant environment paths
+        run: |
+          if [ -L /Users/runner ]; then
+            current_target="$(readlink /Users/runner)"
+            if [ "$current_target" = "/Users/vagrant" ]; then
+              echo "Symlink already correct: /Users/runner -> /Users/vagrant"
+            else
+              echo "Replacing incorrect symlink /Users/runner -> $current_target"
+              sudo rm /Users/runner
+              sudo ln -s /Users/vagrant /Users/runner
+              echo "Recreated symlink: /Users/runner -> /Users/vagrant"
+            fi
+          elif [ -e /Users/runner ]; then
+            echo "Error: /Users/runner exists but is not a symlink"
+            ls -ld /Users/runner
+            exit 1
+          else
+            sudo ln -s /Users/vagrant /Users/runner
+            echo "Created symlink: /Users/runner -> /Users/vagrant"
+          fi
+          mkdir -p "$HOME/hostedtoolcache" "$HOME/tmp"
+          echo "RUNNER_TOOL_CACHE=$HOME/hostedtoolcache" >> "$GITHUB_ENV"
+          echo "RUNNER_TEMP=$HOME/tmp" >> "$GITHUB_ENV"
+        shell: bash
+
+      # ──────────────────────────────────────────────────────────────────────
+      # REMOVED: "Restore Xcode derived data from branch cache" step
+      #   Was: cirruslabs/cache for ~/Library/Developer/Xcode/DerivedData + ios/build
+      #   Reason: Replaced by Bitrise React Native Build Cache which provides
+      #           granular, build-system-level caching (Xcode via LLVM CAS,
+      #           C++ via ccache) instead of coarse tar-and-restore of DerivedData.
+      #
+      # REMOVED: "Restore Xcode derived data from main cache" step
+      #   Was: cirruslabs/cache/restore (restore-only fallback to main branch)
+      #   Reason: Same as above.
+      # ──────────────────────────────────────────────────────────────────────
+
+      - name: Installing iOS Environment Setup
+        timeout-minutes: 15
+        uses: ./.github/actions/setup-e2e-env
+        with:
+          platform: ios
+          setup-simulator: false
+          configure-keystores: false
+
+      - name: Print iOS tool versions
+        run: |
+          echo "Node.js Version: $(node -v || echo 'not found')"
+          echo "Yarn Version: $(yarn -v || echo 'not found')"
+          echo "CocoaPods Version: $(pod --version || echo 'not found')"
+          echo "Xcode Path: $(xcode-select -p || echo 'not found')"
+          echo "Ruby Version: $(ruby --version || echo 'not found')"
+          echo "Booted iOS Simulators:"
+          xcrun simctl list | grep Booted || echo "No booted simulators found"
+        shell: bash
+
+      - name: Clean iOS plist files
+        run: find ios -name "*.plist" -exec xattr -c {} \;
+
+      - name: Restore .metamask folder
+        id: restore-metamask
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
+      - name: Install Foundry if cache missed
+        if: steps.restore-metamask.outputs.cache-hit != 'true'
+        run: yarn install:foundryup
+
+      - name: Setup project dependencies with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "Setting up project..."
+            yarn setup:github-ci --build-ios --no-build-android
+
+      # ──────────────────────────────────────────────────────────────────────
+      # NEW: Activate Bitrise Build Cache for React Native
+      #   Configures build-system-level remote caching for:
+      #   - Xcode compilation outputs (LLVM CAS via Xcelerate)
+      #   - C++ native modules (ccache backed by Bitrise ABCS)
+      #   Must run BEFORE any step that triggers a native build (xcodebuild).
+      #   Does NOT cache Metro JS bundling or node_modules.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Activate Bitrise Build Cache for React Native
+        env:
+          BITRISE_BUILD_CACHE_AUTH_TOKEN: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
+          BITRISE_BUILD_CACHE_WORKSPACE_ID: ${{ vars.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
+        run: |
+          #!/usr/bin/env bash
+          set -euxo pipefail
+
+          # Download Bitrise Build Cache CLI
+          curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d
+
+          # Activate React Native build cache (configures Xcode + ccache)
+          /tmp/bin/bitrise-build-cache activate react-native
+          echo "/tmp/bin" >> "$GITHUB_PATH"
+        shell: bash
+
+      - name: Generate current fingerprint
+        id: generate-fingerprint
+        run: |
+          FINGERPRINT=$(yarn fingerprint:generate)
+          echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Current fingerprint: ${FINGERPRINT}"
+
+      # ── Changed: cirruslabs/cache → actions/cache@v4 ──
+      - name: Restore iOS app matching fingerprint from branch cache
+        id: cache-restore
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          key: bitrise-ios-app-${{ github.ref_name }}-v${{ env.IOS_APP_CACHE_VERSION
+            }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
+
+      # ── Changed: cirruslabs/cache/restore → actions/cache/restore@v4 ──
+      - name: Restore iOS app matching fingerprint from main cache
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name !=
+          'main' }}
+        id: cache-restore-main
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          key: bitrise-ios-app-main-v${{ env.IOS_APP_CACHE_VERSION }}-${{
+            steps.generate-fingerprint.outputs.fingerprint }}
+
+      # ── Changed: Wrapped with bitrise-build-cache react-native run ──
+      - name: Build iOS E2E App
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' &&
+          steps.cache-restore-main.outputs.cache-hit != 'true' }}
+        run: |
+          echo "Building iOS E2E App on Bitrise runner..."
+          bitrise-build-cache react-native run yarn build:ios:main:e2e
+        shell: bash
+        env:
+          PLATFORM: ios
+          METAMASK_ENVIRONMENT: qa
+          METAMASK_BUILD_TYPE: main
+          IS_TEST: true
+          IS_SIM_BUILD: "true"
+          IGNORE_BOXLOGS_DEVELOPMENT: true
+          GITHUB_CI: "true"
+          CI: "true"
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+
+      # Repack is JS-only bundling (no native build) — no wrapping needed
+      - name: Repack iOS app with JS updates
+        if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
+          steps.cache-restore-main.outputs.cache-hit == 'true' }}
+        run: |
+          echo "Repacking iOS app with updated JavaScript bundle..."
+          yarn build:repack:ios
+          echo "Final app size: $(du -sh "ios/build/Build/Products/Release-iphonesimulator/MetaMask.app" | cut -f1)"
+        env:
+          PLATFORM: ios
+          METAMASK_ENVIRONMENT: qa
+          METAMASK_BUILD_TYPE: main
+          IS_TEST: true
+          E2E: "true"
+          IGNORE_BOXLOGS_DEVELOPMENT: true
+          GITHUB_CI: "true"
+          CI: "true"
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          BRIDGE_USE_DEV_APIS: "true"
+          RAMP_INTERNAL_BUILD: "true"
+          SEEDLESS_ONBOARDING_ENABLED: "true"
+          MM_NOTIFICATIONS_UI_ENABLED: "true"
+          MM_SECURITY_ALERTS_API_ENABLED: "true"
+          FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+          FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+
+      - name: Fix iOS bundle executable case and permissions before upload
+        run: |
+          APP_PATH="ios/build/Build/Products/Release-iphonesimulator/MetaMask.app"
+          BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
+          if [ -z "$BUNDLE_EXEC" ]; then
+            echo "Could not read CFBundleExecutable from Info.plist"
+            exit 1
+          fi
+          ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
+          if [ -z "$ACTUAL_PATH" ]; then
+            echo "Bundle executable not found: $BUNDLE_EXEC"
+            exit 1
+          fi
+          if [ "$(basename "$ACTUAL_PATH")" != "$BUNDLE_EXEC" ]; then
+            mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
+            mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
+          fi
+          chmod +x "$APP_PATH/$BUNDLE_EXEC"
+        shell: bash
+
+      - name: Upload iOS APP Artifact (Simulator)
+        id: upload-app
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-qa-MetaMask.app
+          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload iOS Source Map
+        id: upload-sourcemap
+        if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
+          steps.cache-restore-main.outputs.cache-hit == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-qa-index.js.map
+          path: sourcemaps/ios/index.js.map
+          retention-days: 7
+          if-no-files-found: error
+        continue-on-error: true
+
+      - name: Set Artifacts URL and Status
+        id: set-artifacts-url
+        run: |
+          ARTIFACTS_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "artifacts-url=${ARTIFACTS_URL}" >> "$GITHUB_OUTPUT"
+          echo "Artifacts available at: ${ARTIFACTS_URL}"
+          echo ""
+          echo "Upload Status Summary:"
+          echo "- APP (Simulator): ${{ steps.upload-app.outcome }}"
+          echo "- Source Map: ${{ steps.upload-sourcemap.outcome }}"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      # Record timing data for benchmarking
+      - name: Record build timing summary
+        if: always()
+        run: |
+          echo "=== Bitrise iOS RN cache — build timing summary ==="
+          echo "Runner platform: ${{ runner.os }}/${{ runner.arch }}"
+          echo "Build outcome: ${{ steps.upload-app.outcome }}"
+          echo "Cache hit (branch): ${{ steps.cache-restore.outputs.cache-hit }}"
+          echo "Cache hit (main): ${{ steps.cache-restore-main.outputs.cache-hit || 'N/A' }}"
+          echo "Build cache: Bitrise React Native Build Cache (Xcode LLVM CAS + ccache)"
+          echo "Record this data in the benchmark tracker referenced by the related ticket or PR description."
+        shell: bash
+  # Run iOS E2E smoke tests on Bitrise runners (uses boolean runner toggle)
+  # e2e-smoke-tests-ios:
+  #   name: iOS E2E Smoke Tests (Bitrise)
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   needs: [ build-ios-on-bitrise ]
+  #   uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
+  #   with:
+  #     use_bitrise_runner: true
+  #   secrets: inherit

--- a/.github/workflows/temp-bitrise-ios-rn.yml
+++ b/.github/workflows/temp-bitrise-ios-rn.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Print runner environment diagnostics
         run: |
@@ -154,7 +154,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -204,22 +204,22 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
           echo "Current fingerprint: ${FINGERPRINT}"
 
-      # ── Changed: cirruslabs/cache → actions/cache@v4 ──
+      # ── Changed: cirruslabs/cache → actions/cache@v5 ──
       - name: Restore iOS app matching fingerprint from branch cache
         id: cache-restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
           key: bitrise-ios-app-${{ github.ref_name }}-v${{ env.IOS_APP_CACHE_VERSION
             }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
 
-      # ── Changed: cirruslabs/cache/restore → actions/cache/restore@v4 ──
+      # ── Changed: cirruslabs/cache/restore → actions/cache/restore@v5 ──
       - name: Restore iOS app matching fingerprint from main cache
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name !=
           'main' }}
         id: cache-restore-main
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload iOS APP Artifact (Simulator)
         id: upload-app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: main-qa-MetaMask.app
           path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -330,7 +330,7 @@ jobs:
         id: upload-sourcemap
         if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
           steps.cache-restore-main.outputs.cache-hit == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: main-qa-index.js.map
           path: sourcemaps/ios/index.js.map


### PR DESCRIPTION
## **Description**

Adds a temporary workflow (`.github/workflows/temp-bitrise-ios-rn.yml`) for **INFRA-3591** to benchmark **Bitrise React Native build cache** and produce the **iOS E2E simulator app** on Bitrise GitHub Actions runners. This is **not** part of the merge gate. It runs when a PR has the **`bitrise-poc`** label and on `synchronize`, and uses an hourly **`schedule`** (top of the hour UTC, staggered from the KV cache workflow) once the workflow exists on `main`. Single squashed commit on current `main`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3591](https://consensyssoftware.atlassian.net/browse/INFRA-3591)

## **Manual testing steps**

```gherkin
Feature: Bitrise iOS RN cache workflow (CI)

  Scenario: Workflow runs for a labeled internal PR
    Given a pull request branch includes temp-bitrise-ios-rn.yml
    And the pull request is not from a fork
    When the label bitrise-poc is applied or a new commit is pushed
    Then the workflow "[TEMP] Bitrise iOS RN cache POC" runs on Bitrise runners
    And the build job completes or fails with clear logs
```

## **Screenshots/Recordings**

N/A — CI workflow / infrastructure only (no UI change).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3591]: https://consensyssoftware.atlassian.net/browse/INFRA-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to GitHub Actions config and are gated behind a `bitrise-poc` PR label (and non-fork PRs) plus a schedule, so they don’t affect the main CI gate or app/runtime behavior.
> 
> **Overview**
> Adds a **temporary** GitHub Actions workflow, `[TEMP] Bitrise iOS RN cache POC`, that runs on the `temp-bitrise-runners` self-hosted group to build and upload the iOS E2E simulator `.app`, using Bitrise’s React Native build cache (`bitrise-build-cache activate react-native` and wrapping the native build step).
> 
> The workflow is **not part of the merge gate** and is triggered only for non-fork PRs with the `bitrise-poc` label (plus an hourly schedule on `main`), uses fingerprint-based artifact caching via `actions/cache`, and adds runner labels for Bitrise pools to `.github/actionlint.yaml` so actionlint accepts the new `runs-on` labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f0cdb0b67bc7302cd24656e523c5320f10b673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->