### PR TITLE
fix: use decodeAuthorizationSignature util from transaction-controller

### DIFF
--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -1,6 +1,7 @@
 import {
   AuthorizationList,
   TransactionMeta,
+  decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
 import {
   BATCH_DEFAULT_MODE,
@@ -19,7 +20,7 @@ import {
   createDelegation,
   encodeRedeemDelegations,
 } from '../../core/Delegation/delegation';
-import { Hex, add0x, createProjectLogger } from '@metamask/utils';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import { limitedCalls } from '../../core/Delegation/caveatBuilder/limitedCallsBuilder';
 import { Messenger } from '@metamask/messenger';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
@@ -270,17 +271,4 @@ function buildCaveats(
   caveatBuilder.addCaveat(limitedCalls, 1);
 
   return caveatBuilder.build();
-}
-
-function decodeAuthorizationSignature(signature: Hex) {
-  const r = signature.slice(0, 66) as Hex;
-  const s = add0x(signature.slice(66, 130));
-  const v = parseInt(signature.slice(130, 132), 16);
-  const yParity = toHex(v - 27 === 0 ? 0 : 1);
-
-  return {
-    r,
-    s,
-    yParity,
-  };
 }

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -8,8 +8,9 @@ import {
   PublishHook,
   PublishHookResult,
   TransactionMeta,
+  decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
-import { Hex, add0x, createProjectLogger } from '@metamask/utils';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import {
   ANY_BENEFICIARY,
   BATCH_DEFAULT_MODE,
@@ -38,8 +39,7 @@ import {
   waitForRelayResult,
 } from '../transaction-relay';
 import { NetworkClientId } from '@metamask/network-controller';
-import { toHex } from '@metamask/controller-utils';
-import { isE2ETest, stripSingleLeadingZero } from '../util';
+import { isE2ETest } from '../util';
 import {
   getClientForTransactionMetadata,
   sanitizeOrigin,
@@ -433,7 +433,7 @@ export class Delegation7702PublishHook {
       },
     )) as Hex;
 
-    const { r, s, yParity } = this.#decodeAuthorizationSignature(
+    const { r, s, yParity } = decodeAuthorizationSignature(
       authorizationSignature,
     );
 
@@ -456,19 +456,6 @@ export class Delegation7702PublishHook {
       recipient,
       amount,
     ]) as Hex;
-  }
-
-  #decodeAuthorizationSignature(signature: Hex) {
-    const r = stripSingleLeadingZero(signature.slice(0, 66)) as Hex;
-    const s = stripSingleLeadingZero(add0x(signature.slice(66, 130))) as Hex;
-    const v = parseInt(signature.slice(130, 132), 16);
-    const yParity = toHex(v - 27 === 0 ? 0 : 1);
-
-    return {
-      r,
-      s,
-      yParity,
-    };
   }
 
   #normalizeCallData(data: unknown): Hex {


### PR DESCRIPTION
## **Description**

Replace local EIP-7702 authorization signature decoding with the `decodeAuthorizationSignature` util from `@metamask/transaction-controller` (added in [core#8656](https://github.com/MetaMask/core/pull/8656)). The util produces RLP-canonical hex (no leading zero nibbles, `0x0` for zero), which the Sentinel relay and public RPCs require. The local copies under-canonicalised: `delegation.ts` did nothing, `delegation-7702-publish.ts` only stripped a single leading zero.

## **Changelog**

CHANGELOG entry: Fixed an issue where EIP-7702 authorization signatures with leading zero bytes in `r` or `s` could be rejected by relays and public RPCs.

## **Related issues**

Fixes: [CONF-1133](https://consensyssoftware.atlassian.net/browse/CONF-1133)

<!--
## **Manual testing steps**
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1133]: https://consensyssoftware.atlassian.net/browse/CONF-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches EIP-7702 authorization encoding used for relay/RPC submission; small change but in a transaction-critical path and could affect signature validity if the upstream util behavior differs.
> 
> **Overview**
> Replaces two local EIP-7702 authorization signature parsing implementations with `decodeAuthorizationSignature` from `@metamask/transaction-controller`.
> 
> This removes custom `r`/`s`/`yParity` slicing/normalization (and related helpers/imports) so authorization lists use the shared, canonical decoding expected by relays and public RPCs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8202337500001638ef8eb95625589c79035df0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->