### PR TITLE
ci(images): probe metamask-android-build runner image

### DIFF
--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -20,6 +20,36 @@ jobs:
     runs-on: namespace-profile-metamask-android-build
     timeout-minutes: 10
     steps:
+      - name: Diagnostics — Node toolchain layout
+        run: |
+          set +e
+          echo "=== PATH ==="
+          printenv PATH | tr ':' '\n'
+          echo
+          echo "=== which -a node ==="
+          which -a node
+          echo
+          echo "=== default node ==="
+          node --version
+          echo
+          echo "=== /usr/local/bin/node ==="
+          ls -la /usr/local/bin/node 2>&1
+          /usr/local/bin/node --version 2>&1
+          echo
+          echo "=== /usr/bin/node ==="
+          ls -la /usr/bin/node 2>&1
+          /usr/bin/node --version 2>&1
+          echo
+          echo "=== /opt/hostedtoolcache/node ==="
+          ls /opt/hostedtoolcache/node 2>&1
+          echo
+          echo "=== runner shell init ==="
+          ls -la /home/runner/.profile /home/runner/.bashrc /home/runner/.bash_profile 2>&1
+          echo
+          echo "=== nvm? ==="
+          ls -la /home/runner/.nvm 2>&1 | head -5
+          true
+
       - name: Java is Eclipse Temurin 17
         run: |
           set -euo pipefail
@@ -27,12 +57,14 @@ jobs:
           grep -qE 'Temurin-17|temurin.*17' /tmp/java-version.txt
 
       - name: Node is exact 20.18.0
+        continue-on-error: true
         run: |
           set -euo pipefail
           node --version | tee /tmp/node-version.txt
           grep -q '^v20\.18\.0$' /tmp/node-version.txt
 
       - name: Yarn is exact 4.10.3
+        continue-on-error: true
         run: |
           set -euo pipefail
           yarn --version | tee /tmp/yarn-version.txt

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -7,6 +7,9 @@ name: Probe Android image
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/probe-android-image.yml
 
 permissions:
   contents: read

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -2,7 +2,7 @@
 # Asserts the metamask-android-build Namespace runner image contains the
 # toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
 # Temporary: remove or gate behind `if: false` before merging the trial branch.
-# v9 image rerun marker — second attempt after build queue delay.
+# v9 image rerun marker — third attempt, post-optimize ext4 snapshot ready.
 
 name: Probe Android image
 

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -1,0 +1,71 @@
+# INFRA-3594 — Phase 2 verification probe.
+# Asserts the metamask-android-build Namespace runner image contains the
+# toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
+# Temporary: remove or gate behind `if: false` before merging the trial branch.
+
+name: Probe Android image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Assert metamask-android-build image contents
+    runs-on: namespace-profile-metamask-android-build
+    timeout-minutes: 10
+    steps:
+      - name: Java is Eclipse Temurin 17
+        run: |
+          set -euo pipefail
+          java -version 2>&1 | tee /tmp/java-version.txt
+          grep -qE 'Temurin-17|temurin.*17' /tmp/java-version.txt
+
+      - name: Node is exact 20.18.0
+        run: |
+          set -euo pipefail
+          node --version | tee /tmp/node-version.txt
+          grep -q '^v20\.18\.0$' /tmp/node-version.txt
+
+      - name: Yarn is exact 4.10.3
+        run: |
+          set -euo pipefail
+          yarn --version | tee /tmp/yarn-version.txt
+          grep -q '^4\.10\.3$' /tmp/yarn-version.txt
+
+      - name: Android SDK platforms 35 and 34 present
+        run: |
+          set -euo pipefail
+          test -d /opt/android-sdk/platforms/android-35
+          test -d /opt/android-sdk/platforms/android-34
+
+      - name: Build tools 35.0.0 present
+        run: test -d /opt/android-sdk/build-tools/35.0.0
+
+      - name: NDK 26.1.10909125 present
+        run: test -d /opt/android-sdk/ndk/26.1.10909125
+
+      - name: System image android-34 google_apis x86_64 present
+        run: test -d /opt/android-sdk/system-images/android-34/google_apis/x86_64
+
+      - name: AVD test_e2e_avd present
+        run: |
+          set -euo pipefail
+          test -f "$HOME/.android/avd/test_e2e_avd.ini"
+          test -d "$HOME/.android/avd/test_e2e_avd.avd"
+
+      - name: ANDROID_HOME / ANDROID_SDK_ROOT propagated from image
+        run: |
+          set -euo pipefail
+          test "${ANDROID_HOME:-}" = "/opt/android-sdk"
+          test "${ANDROID_SDK_ROOT:-}" = "/opt/android-sdk"
+
+      - name: sdkmanager + avdmanager available on PATH
+        run: |
+          set -euo pipefail
+          which sdkmanager
+          which avdmanager
+          sdkmanager --version
+          avdmanager list avd

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -20,37 +20,50 @@ jobs:
     runs-on: namespace-profile-metamask-android-build
     timeout-minutes: 10
     steps:
-      - name: Diagnostics — Node toolchain layout
+      - name: Diagnostics — runtime environment
         run: |
           set +e
+          echo "=== whoami / pwd ==="
+          whoami
+          pwd
+          echo
           echo "=== PATH ==="
           printenv PATH | tr ':' '\n'
           echo
-          echo "=== which -a node ==="
+          echo "=== ANDROID_* env ==="
+          printenv | grep -iE '^(ANDROID_|JAVA_HOME|NSC_)' | sort
+          echo
+          echo "=== mount table (filtered) ==="
+          mount | grep -E "(/opt|/usr/local|/home/runner)" || true
+          echo
+          echo "=== /opt listing ==="
+          ls -la /opt/ 2>&1
+          echo
+          echo "=== /opt/android-sdk listing ==="
+          ls -la /opt/android-sdk/ 2>&1 | head -20
+          echo
+          echo "=== /opt/android-sdk/platforms ==="
+          ls -la /opt/android-sdk/platforms/ 2>&1
+          echo
+          echo "=== /opt/hostedtoolcache layout ==="
+          ls -la /opt/hostedtoolcache/ 2>&1
+          ls -la /opt/hostedtoolcache/node/ 2>&1 | head -10
+          echo
+          echo "=== Node binaries ==="
           which -a node
+          for bin in /usr/local/bin/node /usr/bin/node; do
+            if [ -e "$bin" ]; then
+              ls -la "$bin"
+              "$bin" --version 2>&1
+            fi
+          done
           echo
-          echo "=== default node ==="
-          node --version
-          echo
-          echo "=== /usr/local/bin/node ==="
-          ls -la /usr/local/bin/node 2>&1
-          /usr/local/bin/node --version 2>&1
-          echo
-          echo "=== /usr/bin/node ==="
-          ls -la /usr/bin/node 2>&1
-          /usr/bin/node --version 2>&1
-          echo
-          echo "=== /opt/hostedtoolcache/node ==="
-          ls /opt/hostedtoolcache/node 2>&1
-          echo
-          echo "=== runner shell init ==="
-          ls -la /home/runner/.profile /home/runner/.bashrc /home/runner/.bash_profile 2>&1
-          echo
-          echo "=== nvm? ==="
-          ls -la /home/runner/.nvm 2>&1 | head -5
+          echo "=== AVD ==="
+          ls -la "$HOME/.android/avd/" 2>&1
           true
 
       - name: Java is Eclipse Temurin 17
+        continue-on-error: true
         run: |
           set -euo pipefail
           java -version 2>&1 | tee /tmp/java-version.txt
@@ -71,33 +84,40 @@ jobs:
           grep -q '^4\.10\.3$' /tmp/yarn-version.txt
 
       - name: Android SDK platforms 35 and 34 present
+        continue-on-error: true
         run: |
           set -euo pipefail
           test -d /opt/android-sdk/platforms/android-35
           test -d /opt/android-sdk/platforms/android-34
 
       - name: Build tools 35.0.0 present
+        continue-on-error: true
         run: test -d /opt/android-sdk/build-tools/35.0.0
 
       - name: NDK 26.1.10909125 present
+        continue-on-error: true
         run: test -d /opt/android-sdk/ndk/26.1.10909125
 
       - name: System image android-34 google_apis x86_64 present
+        continue-on-error: true
         run: test -d /opt/android-sdk/system-images/android-34/google_apis/x86_64
 
       - name: AVD test_e2e_avd present
+        continue-on-error: true
         run: |
           set -euo pipefail
           test -f "$HOME/.android/avd/test_e2e_avd.ini"
           test -d "$HOME/.android/avd/test_e2e_avd.avd"
 
       - name: ANDROID_HOME / ANDROID_SDK_ROOT propagated from image
+        continue-on-error: true
         run: |
           set -euo pipefail
           test "${ANDROID_HOME:-}" = "/opt/android-sdk"
           test "${ANDROID_SDK_ROOT:-}" = "/opt/android-sdk"
 
       - name: sdkmanager + avdmanager available on PATH
+        continue-on-error: true
         run: |
           set -euo pipefail
           which sdkmanager

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -2,7 +2,7 @@
 # Asserts the metamask-android-build Namespace runner image contains the
 # toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
 # Temporary: remove or gate behind `if: false` before merging the trial branch.
-# v9 image rerun marker — third attempt, post-optimize ext4 snapshot ready.
+# v10 image probe — clean auto-build, expect /opt/android-sdk to exist.
 
 name: Probe Android image
 

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -2,6 +2,7 @@
 # Asserts the metamask-android-build Namespace runner image contains the
 # toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
 # Temporary: remove or gate behind `if: false` before merging the trial branch.
+# v9 image rerun marker.
 
 name: Probe Android image
 

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -2,7 +2,7 @@
 # Asserts the metamask-android-build Namespace runner image contains the
 # toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
 # Temporary: remove or gate behind `if: false` before merging the trial branch.
-# v10 image probe — clean auto-build, expect /opt/android-sdk to exist.
+# v10 image probe — dashboard now shows ready, expect /opt/android-sdk to exist.
 
 name: Probe Android image
 

--- a/.github/workflows/probe-android-image.yml
+++ b/.github/workflows/probe-android-image.yml
@@ -2,7 +2,7 @@
 # Asserts the metamask-android-build Namespace runner image contains the
 # toolchain baked by `MetaMask/runner-images/android/Dockerfile`.
 # Temporary: remove or gate behind `if: false` before merging the trial branch.
-# v9 image rerun marker.
+# v9 image rerun marker — second attempt after build queue delay.
 
 name: Probe Android image
 


### PR DESCRIPTION
Phase 2 verification probe (INFRA-3594).

Asserts the metamask-android-build Namespace runner image contains the toolchain baked by the Dockerfile in the runner-images repo: JDK 17 Temurin, Node 20.18.0, Yarn 4.10.3, Android SDK 35+34, build-tools 35.0.0, NDK 26.1.10909125, system-images;android-34;google_apis;x86_64, AVD test_e2e_avd on pixel_5.

Temporary; remove before this branch merges to main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone, non-blocking GitHub Actions workflow to validate runner image contents; it only runs manually or when the workflow file changes, so impact is limited to CI resources and potential runner availability.
> 
> **Overview**
> Introduces a new GitHub Actions workflow, `probe-android-image.yml`, to **verify the `namespace-profile-metamask-android-build` runner image** has the expected Android toolchain and environment.
> 
> The job prints basic diagnostics and then runs a series of *continue-on-error* assertions for Java/Node/Yarn versions, Android SDK/NDK/build-tools/system image presence, a precreated AVD, required `ANDROID_*` env vars, and `sdkmanager`/`avdmanager` availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5850ad788cb3207334c473b83ee6dd717bede6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->