### PR TITLE
fix: Patch detox to handle errors when injecting into WebViews

### DIFF
--- a/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch
+++ b/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch
@@ -1,0 +1,22 @@
+diff --git a/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt b/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
+index 564838a10114b3dd929b0742d1a99ae28b08717f..8e3dbfa23906e2c02b6d44f273a689670c288272 100644
+--- a/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
++++ b/android/detox/src/full/java/com/wix/detox/espresso/hierarchy/ViewHierarchyGenerator.kt
+@@ -19,6 +19,7 @@ import kotlin.coroutines.resume
+ 
+ private const val GET_HTML_SCRIPT = """
+ (function() {
++  try {
+     const blacklistedTags = ['script', 'style', 'head', 'meta'];
+     const blackListedTagsSelector = blacklistedTags.join(',');
+ 
+@@ -39,6 +40,9 @@ private const val GET_HTML_SCRIPT = """
+ 
+     // Return the serialized HTML as a string
+     return serializedHtml;
++  } catch {
++    return '<html xmlns="http://www.w3.org/1999/xhtml"><body></body></html>';
++  }
+ })();
+ """
+ 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -191,6 +191,7 @@ android {
         versionCode 4532
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        missingDimensionStrategy 'detox', 'full'
         manifestPlaceholders.MM_BRANCH_KEY_TEST = "$System.env.MM_BRANCH_KEY_TEST"
         manifestPlaceholders.MM_BRANCH_KEY_LIVE = "$System.env.MM_BRANCH_KEY_LIVE"
 
@@ -423,7 +424,7 @@ dependencies {
     }
     // Detox's AAR still reflects Espresso UiControllerImpl.eventInjector, but its POM pulls
     // espresso-* 3.6.x where that field was removed. Exclude Espresso from Detox and pin 3.5.1.
-    androidTestImplementation('com.wix:detox:+') {
+    androidTestImplementation(project(path: ":detox")) {
         exclude module: 'protobuf-lite'
         exclude group: 'androidx.test.espresso', module: 'espresso-core'
         exclude group: 'androidx.test.espresso', module: 'espresso-web'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,9 +27,6 @@ buildscript {
 	}
 	allprojects {
     repositories {
-        maven {
-          url("$rootDir/../node_modules/detox/Detox-android")
-        }
 		        // Notifee repository
         maven {
             url(new File(['node', '--print', "require.resolve('@notifee/react-native/package.json')"].execute(null, rootDir).text.trim(), '../android/libs'))

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -58,5 +58,9 @@ includeBuild('../node_modules/react-native') {
     }
 }
 
+// Build Detox from source to ensure our patches are applied
+include ':detox'
+project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')
+
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
 useExpoModules()

--- a/package.json
+++ b/package.json
@@ -636,7 +636,7 @@
     "chromedriver": "^123.0.1",
     "depcheck": "^1.4.7",
     "deprecated-react-native-prop-types": "^5.0.0",
-    "detox": "^20.43.0",
+    "detox": "patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch",
     "dotenv": "^16.0.3",
     "dpdm": "^3.14.0",
     "eas-cli": "^12.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26812,7 +26812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detox@npm:^20.43.0":
+"detox@npm:20.51.0":
   version: 20.51.0
   resolution: "detox@npm:20.51.0"
   dependencies:
@@ -26861,6 +26861,58 @@ __metadata:
   bin:
     detox: local-cli/cli.js
   checksum: 10/23941160076e3746cba9861a9c0e218913c218ad11489e7954ab761b2ab3346950a72d6f9d0ca339ddf18dce966e9e04c94758b79a403c65c0126ac40adee97b
+  languageName: node
+  linkType: hard
+
+"detox@patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch":
+  version: 20.51.0
+  resolution: "detox@patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch::version=20.51.0&hash=12af19"
+  dependencies:
+    "@wix-pilot/core": "npm:^3.4.2"
+    "@wix-pilot/detox": "npm:^1.0.13"
+    ajv: "npm:^8.6.3"
+    bunyan: "npm:^1.8.12"
+    bunyan-debug-stream: "npm:^3.1.0"
+    caf: "npm:^15.0.1"
+    chalk: "npm:^4.0.0"
+    execa: "npm:^5.1.1"
+    find-up: "npm:^5.0.0"
+    fs-extra: "npm:^11.0.0"
+    funpermaproxy: "npm:^1.1.0"
+    glob: "npm:^8.0.3"
+    ini: "npm:^1.3.4"
+    jest-environment-emit: "npm:^1.2.0"
+    json-cycle: "npm:^1.3.0"
+    lodash: "npm:^4.17.11"
+    multi-sort-stream: "npm:^1.0.3"
+    multipipe: "npm:^4.0.0"
+    node-ipc: "npm:9.2.1"
+    promisify-child-process: "npm:^4.1.2"
+    proper-lockfile: "npm:^3.0.2"
+    resolve-from: "npm:^5.0.0"
+    sanitize-filename: "npm:^1.6.1"
+    semver: "npm:^7.0.0"
+    serialize-error: "npm:^8.0.1"
+    shell-quote: "npm:^1.7.2"
+    signal-exit: "npm:^3.0.3"
+    stream-json: "npm:^1.7.4"
+    strip-ansi: "npm:^6.0.1"
+    telnet-client: "npm:1.2.8"
+    tmp: "npm:^0.2.1"
+    trace-event-lib: "npm:^1.3.1"
+    which: "npm:^1.3.1"
+    ws: "npm:^7.0.0"
+    yargs: "npm:^17.0.0"
+    yargs-parser: "npm:^21.0.0"
+    yargs-unparser: "npm:^2.0.0"
+  peerDependencies:
+    jest: 30.x.x || 29.x.x || 28.x.x || ^27.2.5
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  bin:
+    detox: local-cli/cli.js
+  checksum: 10/7adee890378e5f2da21ea3fbef49589eb54c12f611b67d862802aa8272368240fcd3f10cf82c9f872c61dd84f364671342ee6a12b5e5f6184778befc7adaf2de
   languageName: node
   linkType: hard
 
@@ -36095,7 +36147,7 @@ __metadata:
     dayjs: "npm:^1.11.13"
     depcheck: "npm:^1.4.7"
     deprecated-react-native-prop-types: "npm:^5.0.0"
-    detox: "npm:^20.43.0"
+    detox: "patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch"
     dotenv: "npm:^16.0.3"
     dpdm: "npm:^3.14.0"
     eas-cli: "npm:^12.6.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Android test/build wiring for Detox (dependency resolution, Gradle module inclusion, flavor dimensions), which could break CI/e2e builds even though it shouldn’t affect production runtime.
> 
> **Overview**
> Ensures Detox’s Android WebView HTML extraction doesn’t fail hard by wrapping the injected `GET_HTML_SCRIPT` in a `try/catch` and returning a minimal empty HTML document on error.
> 
> Switches the project to consume a Yarn-patched `detox@20.51.0` and builds Detox from source in Gradle (`include ':detox'` + `androidTestImplementation(project(path: ":detox"))`), removing the old `Detox-android` Maven repo usage. Android app config is updated to resolve Detox’s flavor via `missingDimensionStrategy 'detox', 'full'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e05cb0c0d91014891d21059896b49aa8aad049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->