### PR TITLE
fix(MUSD-701): use Money Account balance in Add money sheet

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -5,7 +5,7 @@ import MoneyAddMoneySheet from './MoneyAddMoneySheet';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
-import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
+import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
@@ -38,8 +38,9 @@ jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
 }));
 
-jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
-  useMusdBalance: jest.fn(),
+jest.mock('../../hooks/useMoneyAccountBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
 }));
 
 jest.mock('../../hooks/useMoneyAccount', () => ({
@@ -86,8 +87,8 @@ describe('MoneyAddMoneySheet', () => {
     (useRampNavigation as jest.Mock).mockReturnValue({
       goToBuy: mockGoToBuy,
     });
-    (useMusdBalance as jest.Mock).mockReturnValue({
-      fiatBalanceAggregatedFormatted: '$1,203.89',
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      totalFiatFormatted: '$1,203.89',
     });
     (useMoneyAccountDeposit as jest.Mock).mockReturnValue({
       initiateDeposit: mockInitiateDeposit,
@@ -110,8 +111,8 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('preserves the locale fiat prefix in the Move mUSD row', () => {
-    (useMusdBalance as jest.Mock).mockReturnValue({
-      fiatBalanceAggregatedFormatted: 'CA$1,500.00',
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      totalFiatFormatted: 'CA$1,500.00',
     });
     const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 
@@ -119,8 +120,8 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('falls back to the no-amount copy when the mUSD balance is unavailable', () => {
-    (useMusdBalance as jest.Mock).mockReturnValue({
-      fiatBalanceAggregatedFormatted: undefined,
+    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
+      totalFiatFormatted: undefined,
     });
     const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -17,8 +17,8 @@ import {
 import Tag from '../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
-import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
+import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
@@ -40,7 +40,7 @@ const MoneyAddMoneySheet: React.FC = () => {
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
 
-  const { fiatBalanceAggregatedFormatted } = useMusdBalance();
+  const { totalFiatFormatted } = useMoneyAccountBalance();
   const { getChainIdForBuyFlow } = useMusdConversionFlowData();
   const { goToBuy } = useRampNavigation();
   const { initiateDeposit } = useMoneyAccountDeposit();
@@ -94,9 +94,9 @@ const MoneyAddMoneySheet: React.FC = () => {
       testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
     },
     {
-      label: fiatBalanceAggregatedFormatted
+      label: totalFiatFormatted
         ? strings('money.add_money_sheet.move_musd', {
-            amount: fiatBalanceAggregatedFormatted,
+            amount: totalFiatFormatted,
           })
         : strings('money.add_money_sheet.move_musd_no_amount'),
       icon: IconName.Add,


### PR DESCRIPTION
## **Description**

The "Move mUSD" row in the Add money sheet was showing a balance that did not match the Money Account balance displayed at the top of the screen. The two figures were sourced from different places, which surfaced as an obvious mismatch whenever the selected EVM account was not the same as the Money Account.

Root cause: the sheet was reading from `useMusdBalance().fiatBalanceAggregatedFormatted`, which aggregates mUSD across the currently selected EVM account. The screen header, by contrast, uses `useMoneyAccountBalance`, which is the canonical Money Account balance.

Fix: switch the sheet to consume `useMoneyAccountBalance().totalFiatFormatted` so the "Move mUSD" amount and the header always agree. Tests were updated to mock the new hook and assert the same fallback behaviour (no-amount copy when the balance is unavailable, locale fiat prefix preserved).

Credit to Matthew Grainger for diagnosing the source-of-truth mismatch on the Jira ticket.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-701

## **Manual testing steps**

```gherkin
Feature: Add money sheet balance consistency

  Scenario: user opens the Add money sheet with a funded Money Account
    Given the user has a non-zero Money Account balance
    And the selected EVM account is not the Money Account
    When the user opens the Add money sheet
    Then the "Move mUSD" row shows the same fiat amount as the Money Account header

  Scenario: user opens the Add money sheet with no mUSD
    Given the user's Money Account balance is unavailable or zero
    When the user opens the Add money sheet
    Then the "Move mUSD" row shows the no-amount copy
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI data-source swap: the “Move mUSD” row now reads from the canonical Money Account balance, which could only affect displayed copy if the previous EVM-account-aggregated value differed or was undefined.
> 
> **Overview**
> Updates the Add Money bottom sheet so the “Move mUSD” option displays the **Money Account** fiat balance (via `useMoneyAccountBalance().totalFiatFormatted`) instead of the previously EVM-account-aggregated `useMusdBalance()` value, eliminating mismatches with the header balance.
> 
> Adjusts `MoneyAddMoneySheet` tests to mock the new hook and keep the same behaviors for locale-prefixed amounts and the no-amount fallback copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88dd0bcaef1ad5e246c570f95c359900dcb23889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->