### PR TITLE
fix(perps): use limit price for margin calculation in limit orders [NOT-READY]

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
@@ -775,6 +775,104 @@ describe('usePerpsOrderForm', () => {
     });
   });
 
+  describe('limit order maxPossibleAmount', () => {
+    it('uses limit price for maxPossibleAmount when order type is limit', () => {
+      // Use szDecimals: 0 with a balance/leverage combo that causes
+      // rounding overshoot at one price but not another.
+      // balance=999, leverage=3 → theoretical=2997, maxAmount=2997
+      // At price=100: size=2997/100=29.97→30, notional=3000, margin=1000 > 999 → step down by 100 → 2897
+      // buffered = floor(2897*0.995) = 2882
+      // At price=700: size=2997/700=4.28→4, notional=2800, margin=933 < 999 → no step down
+      // But rounding up: 4*700=2800 < 2997, so +1 → 5*700=3500, margin=1167 > 999 → step down by 700 → 2297
+      // buffered = floor(2297*0.995) = 2285
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          availableBalance: '999',
+          marginUsed: '0',
+          unrealizedPnl: '0',
+          returnOnEquity: '0',
+          totalBalance: '999',
+        },
+        isInitialLoading: false,
+      });
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: { price: '100', timestamp: Date.now(), symbol: 'BTC' },
+      });
+      mockUsePerpsMarketData.mockReturnValue({
+        marketData: {
+          szDecimals: 0,
+          name: 'BTC',
+          maxLeverage: 10,
+          marginTableId: 1,
+        },
+        refetch: jest.fn(),
+        isLoading: false,
+        error: null,
+      });
+
+      const { result } = renderHook(
+        () =>
+          usePerpsOrderForm({
+            initialType: 'limit',
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      const maxAtMarketPrice = result.current.maxPossibleAmount;
+
+      // Set limit price to 700 (7x market)
+      act(() => {
+        result.current.setLimitPrice('700');
+      });
+
+      const maxAtLimitPrice = result.current.maxPossibleAmount;
+
+      // The step-down increment differs ($100 vs $700), producing different max
+      expect(maxAtLimitPrice).not.toBe(maxAtMarketPrice);
+    });
+
+    it('uses market price for maxPossibleAmount when order type is market', () => {
+      const { result } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+
+      const maxMarket = result.current.maxPossibleAmount;
+
+      // Set limit price but keep order type as market
+      act(() => {
+        result.current.setLimitPrice('100000');
+      });
+
+      const maxAfterLimitSet = result.current.maxPossibleAmount;
+
+      // For market orders, limit price should be ignored
+      expect(maxMarket).toBe(maxAfterLimitSet);
+    });
+
+    it('falls back to market price when limit order has no limit price set', () => {
+      const { result } = renderHook(
+        () =>
+          usePerpsOrderForm({
+            initialType: 'limit',
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      // Limit order type but no limit price set yet — should use market price
+      const maxNoLimitPrice = result.current.maxPossibleAmount;
+
+      // Switch to market type for comparison
+      act(() => {
+        result.current.setOrderType('market');
+      });
+
+      const maxMarketType = result.current.maxPossibleAmount;
+
+      // Both should use market price, so same result
+      expect(maxNoLimitPrice).toBe(maxMarketType);
+    });
+  });
+
   describe('empty amount handling', () => {
     it('should convert empty string to 0', () => {
       const { result } = renderHook(() => usePerpsOrderForm(), {

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
@@ -184,17 +184,6 @@ export function usePerpsOrderForm(
   const maxPossibleAmount = useMemo(() => {
     const marketPrice = Number.parseFloat(currentPrice?.price) || 0;
     const priceForCalc = marketPrice;
-    // eslint-disable-next-line no-console
-    console.debug(
-      '[PR-29748] BUG_MARKER: maxPossibleAmount uses market price even for limit orders',
-      JSON.stringify({
-        orderType: orderForm.type,
-        limitPrice: orderForm.limitPrice,
-        marketPrice,
-        priceForCalc,
-        leverage: orderForm.leverage,
-      }),
-    );
     return getMaxAllowedAmount({
       availableBalance: balanceForMax,
       assetPrice: priceForCalc,
@@ -206,8 +195,6 @@ export function usePerpsOrderForm(
     currentPrice?.price,
     marketData?.szDecimals,
     orderForm.leverage, // Include current leverage in dependencies
-    orderForm.type,
-    orderForm.limitPrice,
   ]);
 
   // Update amount only once when the hook first calculates the initial value

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
@@ -181,9 +181,15 @@ export function usePerpsOrderForm(
   });
 
   // Calculate the maximum possible amount; when paying with custom token, capped by selected token amount in USD
+  // For limit orders, use the limit price instead of market price so that margin requirements
+  // are correctly calculated at the order's execution price, not the current spot price.
   const maxPossibleAmount = useMemo(() => {
     const marketPrice = Number.parseFloat(currentPrice?.price) || 0;
-    const priceForCalc = marketPrice;
+    const limitPriceNum =
+      orderForm.type === 'limit' && orderForm.limitPrice
+        ? Number.parseFloat(orderForm.limitPrice)
+        : 0;
+    const priceForCalc = limitPriceNum > 0 ? limitPriceNum : marketPrice;
     return getMaxAllowedAmount({
       availableBalance: balanceForMax,
       assetPrice: priceForCalc,
@@ -194,7 +200,9 @@ export function usePerpsOrderForm(
     balanceForMax,
     currentPrice?.price,
     marketData?.szDecimals,
-    orderForm.leverage, // Include current leverage in dependencies
+    orderForm.leverage,
+    orderForm.type,
+    orderForm.limitPrice,
   ]);
 
   // Update amount only once when the hook first calculates the initial value

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
@@ -181,21 +181,34 @@ export function usePerpsOrderForm(
   });
 
   // Calculate the maximum possible amount; when paying with custom token, capped by selected token amount in USD
-  const maxPossibleAmount = useMemo(
-    () =>
-      getMaxAllowedAmount({
-        availableBalance: balanceForMax,
-        assetPrice: Number.parseFloat(currentPrice?.price) || 0,
-        assetSzDecimals: marketData?.szDecimals ?? 6,
-        leverage: orderForm.leverage, // Use current leverage instead of default
+  const maxPossibleAmount = useMemo(() => {
+    const marketPrice = Number.parseFloat(currentPrice?.price) || 0;
+    const priceForCalc = marketPrice;
+    // eslint-disable-next-line no-console
+    console.debug(
+      '[PR-29748] BUG_MARKER: maxPossibleAmount uses market price even for limit orders',
+      JSON.stringify({
+        orderType: orderForm.type,
+        limitPrice: orderForm.limitPrice,
+        marketPrice,
+        priceForCalc,
+        leverage: orderForm.leverage,
       }),
-    [
-      balanceForMax,
-      currentPrice?.price,
-      marketData?.szDecimals,
-      orderForm.leverage, // Include current leverage in dependencies
-    ],
-  );
+    );
+    return getMaxAllowedAmount({
+      availableBalance: balanceForMax,
+      assetPrice: priceForCalc,
+      assetSzDecimals: marketData?.szDecimals ?? 6,
+      leverage: orderForm.leverage,
+    });
+  }, [
+    balanceForMax,
+    currentPrice?.price,
+    marketData?.szDecimals,
+    orderForm.leverage, // Include current leverage in dependencies
+    orderForm.type,
+    orderForm.limitPrice,
+  ]);
 
   // Update amount only once when the hook first calculates the initial value
   // We use a ref to track if we've already set the initial amount to avoid overwriting user input


### PR DESCRIPTION
## **Description**

When placing a limit order, the max order size and margin requirements were calculated using the current market price instead of the user-set limit price. This caused "Order 0: insufficient margin to place order" errors when submitting short limit orders above market price, and silent downsizing for long limit orders below market price.

**Fix:** Updated `maxPossibleAmount` in `usePerpsOrderForm` to use the limit price (when set) instead of market price for `getMaxAllowedAmount` calculation. Added `orderForm.type` and `orderForm.limitPrice` to the useMemo dependency array so the max recalculates when the limit price changes.

## **Changelog**

CHANGELOG entry: Fixed limit order margin calculation to use limit price instead of market price, preventing "insufficient margin" errors

## **Related issues**

Fixes: [TAT-3086](https://consensyssoftware.atlassian.net/browse/TAT-3086)

## **Manual testing steps**

```gherkin
Feature: Limit order margin calculation

  Scenario: User places short limit order above market price
    Given the wallet is unlocked and perps is ready to trade
    And the user navigates to SOL market details

    When the user taps Short and switches to Limit order type
    And sets the limit price to $200 (above SOL market ~$85)
    And enters $11 as the order amount
    And taps Place Order
    Then no "insufficient margin" error appears
    And the limit order is created successfully
```

## **Screenshots/Recordings**

<!-- Evidence will be inserted by the gateway from evidence-manifest.json -->

### **Before**

<!-- Simulator recording unavailable (SimRenderServer error) -->

### **After**

<!-- Screenshots from recipe validation -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "pr": "29748",
  "title": "Verify limit order margin uses limit price, not market price",
  "jira": "TAT-3086",
  "acceptance_criteria": [
    "AC1: Max USD order size accounts for limit price, not spot, when limit price set (covered by unit test)",
    "AC2: Changing limit price recalculates max order size in real time (covered by unit test)",
    "AC3: Submitting limit order at 100% slider with divergent limit price does not produce insufficient margin error (recipe integration)",
    "AC4: Extension-only (UNTESTABLE on mobile)"
  ],
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.ready_to_trade"],
      "entry": "setup-select-account",
      "nodes": {
        "setup-select-account": {
          "action": "select_account",
          "address": "0x316bde155acd07609872a56bc32ccfb0b13201fa",
          "next": "setup-snapshot-orders"
        },
        "setup-snapshot-orders": {
          "action": "eval_async",
          "expression": "Engine.context.PerpsController.getOpenOrders().then(function(os){var f=os.filter(function(o){return o.symbol==='SOL' && !o.isTrigger});return JSON.stringify({preCount:f.length})})",
          "assert": { "operator": "exists", "field": "preCount" },
          "save_as": "preOrders",
          "next": "setup-nav-market"
        },
        "setup-nav-market": {
          "action": "navigate",
          "target": "PerpsMarketDetails",
          "params": {
            "market": {
              "symbol": "SOL",
              "name": "SOL",
              "price": "0",
              "change24h": "0",
              "change24hPercent": "0",
              "volume": "0",
              "maxLeverage": "50"
            }
          },
          "next": "setup-wait-render"
        },
        "setup-wait-render": {
          "action": "wait_for",
          "test_id": "perps-market-details-short-button",
          "timeout_ms": 15000,
          "next": "setup-press-short"
        },
        "setup-press-short": {
          "action": "press",
          "test_id": "perps-market-details-short-button",
          "next": "setup-wait-form"
        },
        "setup-wait-form": {
          "action": "wait_for",
          "test_id": "perps-order-header-order-type-button",
          "next": "setup-press-order-type"
        },
        "setup-press-order-type": {
          "action": "press",
          "test_id": "perps-order-header-order-type-button",
          "next": "setup-wait-type-sheet"
        },
        "setup-wait-type-sheet": {
          "action": "wait_for",
          "test_id": "perps-order-type-limit",
          "next": "setup-press-limit-type"
        },
        "setup-press-limit-type": {
          "action": "press",
          "test_id": "perps-order-type-limit",
          "next": "setup-wait-limit-form"
        },
        "setup-wait-limit-form": {
          "action": "wait_for",
          "test_id": "perps-order-view-limit-price-row",
          "next": "ac3-press-limit-row"
        },
        "ac3-press-limit-row": {
          "action": "press",
          "test_id": "perps-order-view-limit-price-row",
          "next": "ac3-wait-price-sheet"
        },
        "ac3-wait-price-sheet": {
          "action": "wait_for",
          "test_id": "keypad-delete-button",
          "next": "ac3-clear-limit-keypad"
        },
        "ac3-clear-limit-keypad": {
          "action": "clear_keypad",
          "count": 12,
          "next": "ac3-type-high-limit-price"
        },
        "ac3-type-high-limit-price": {
          "action": "type_keypad",
          "value": "200",
          "next": "ac3-press-limit-confirm"
        },
        "ac3-press-limit-confirm": {
          "action": "press",
          "test_id": "perps-limit-price-confirm-button",
          "next": "ac3-wait-amount"
        },
        "ac3-wait-amount": {
          "action": "wait_for",
          "test_id": "perps-amount-display-touchable",
          "next": "ac3-press-amount-display"
        },
        "ac3-press-amount-display": {
          "action": "press",
          "test_id": "perps-amount-display-touchable",
          "next": "ac3-wait-keypad"
        },
        "ac3-wait-keypad": {
          "action": "wait_for",
          "test_id": "keypad-delete-button",
          "next": "ac3-clear-amount-keypad"
        },
        "ac3-clear-amount-keypad": {
          "action": "clear_keypad",
          "count": 8,
          "next": "ac3-type-amount"
        },
        "ac3-type-amount": {
          "action": "type_keypad",
          "value": "11",
          "next": "ac3-press-done"
        },
        "ac3-press-done": {
          "action": "press",
          "test_id": "perps-order-view-keypad-done",
          "next": "ac3-wait-place-button"
        },
        "ac3-wait-place-button": {
          "action": "wait_for",
          "test_id": "perps-order-view-place-order-button",
          "next": "ac3-screenshot-pre-submit"
        },
        "ac3-screenshot-pre-submit": {
          "action": "screenshot",
          "filename": "evidence-ac3-form-at-limit-price.png",
          "note": "AC3: Short limit order form with limit price $200 (above SOL market ~$85) — about to submit",
          "next": "ac3-place-order"
        },
        "ac3-place-order": {
          "action": "press",
          "test_id": "perps-order-view-place-order-button",
          "next": "ac3-watch-no-error"
        },
        "ac3-watch-no-error": {
          "action": "log_watch",
          "window_seconds": 10,
          "must_not_appear": ["insufficient margin", "Insufficient margin", "Order 0: insufficient"],
          "next": "ac3-verify-order-created"
        },
        "ac3-verify-order-created": {
          "action": "wait_for",
          "expression": "Engine.context.PerpsController.getOpenOrders().then(function(os){var f=os.filter(function(o){return o.symbol==='SOL' && !o.isTrigger});return JSON.stringify({count:f.length})})",
          "assert": { "operator": "gt", "field": "count", "value": 0 },
          "timeout_ms": 15000,
          "next": "ac3-screenshot-success"
        },
        "ac3-screenshot-success": {
          "action": "screenshot",
          "filename": "evidence-ac3-order-placed-no-error.png",
          "note": "AC3: Limit order placed successfully — no insufficient margin error",
          "next": "teardown-cancel-order"
        },
        "teardown-cancel-order": {
          "action": "call",
          "ref": "perps/order-limit-cancel",
          "params": { "symbol": "SOL" },
          "next": "teardown-done"
        },
        "teardown-done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
graph TD
  setup-select-account["setup-select-account<br/>select_account"]
  setup-snapshot-orders["setup-snapshot-orders<br/>eval_async"]
  setup-nav-market["setup-nav-market<br/>navigate"]
  setup-wait-render["setup-wait-render<br/>wait_for"]
  setup-press-short["setup-press-short<br/>press"]
  setup-wait-form["setup-wait-form<br/>wait_for"]
  setup-press-order-type["setup-press-order-type<br/>press"]
  setup-wait-type-sheet["setup-wait-type-sheet<br/>wait_for"]
  setup-press-limit-type["setup-press-limit-type<br/>press"]
  setup-wait-limit-form["setup-wait-limit-form<br/>wait_for"]
  ac3-press-limit-row["ac3-press-limit-row<br/>press"]
  ac3-wait-price-sheet["ac3-wait-price-sheet<br/>wait_for"]
  ac3-clear-limit-keypad["ac3-clear-limit-keypad<br/>clear_keypad"]
  ac3-type-high-limit-price["ac3-type-high-limit-price<br/>type_keypad"]
  ac3-press-limit-confirm["ac3-press-limit-confirm<br/>press"]
  ac3-wait-amount["ac3-wait-amount<br/>wait_for"]
  ac3-press-amount-display["ac3-press-amount-display<br/>press"]
  ac3-wait-keypad["ac3-wait-keypad<br/>wait_for"]
  ac3-clear-amount-keypad["ac3-clear-amount-keypad<br/>clear_keypad"]
  ac3-type-amount["ac3-type-amount<br/>type_keypad"]
  ac3-press-done["ac3-press-done<br/>press"]
  ac3-wait-place-button["ac3-wait-place-button<br/>wait_for"]
  ac3-screenshot-pre-submit["ac3-screenshot-pre-submit<br/>screenshot"]
  ac3-place-order["ac3-place-order<br/>press"]
  ac3-watch-no-error["ac3-watch-no-error<br/>log_watch"]
  ac3-verify-order-created["ac3-verify-order-created<br/>wait_for"]
  ac3-screenshot-success["ac3-screenshot-success<br/>screenshot"]
  teardown-cancel-order["teardown-cancel-order<br/>call"]
  teardown-done["teardown-done<br/>end"]

  setup-select-account --> setup-snapshot-orders
  setup-snapshot-orders --> setup-nav-market
  setup-nav-market --> setup-wait-render
  setup-wait-render --> setup-press-short
  setup-press-short --> setup-wait-form
  setup-wait-form --> setup-press-order-type
  setup-press-order-type --> setup-wait-type-sheet
  setup-wait-type-sheet --> setup-press-limit-type
  setup-press-limit-type --> setup-wait-limit-form
  setup-wait-limit-form --> ac3-press-limit-row
  ac3-press-limit-row --> ac3-wait-price-sheet
  ac3-wait-price-sheet --> ac3-clear-limit-keypad
  ac3-clear-limit-keypad --> ac3-type-high-limit-price
  ac3-type-high-limit-price --> ac3-press-limit-confirm
  ac3-press-limit-confirm --> ac3-wait-amount
  ac3-wait-amount --> ac3-press-amount-display
  ac3-press-amount-display --> ac3-wait-keypad
  ac3-wait-keypad --> ac3-clear-amount-keypad
  ac3-clear-amount-keypad --> ac3-type-amount
  ac3-type-amount --> ac3-press-done
  ac3-press-done --> ac3-wait-place-button
  ac3-wait-place-button --> ac3-screenshot-pre-submit
  ac3-screenshot-pre-submit --> ac3-place-order
  ac3-place-order --> ac3-watch-no-error
  ac3-watch-no-error --> ac3-verify-order-created
  ac3-verify-order-created --> ac3-screenshot-success
  ac3-screenshot-success --> teardown-cancel-order
  teardown-cancel-order --> teardown-done
```

</details>


[TAT-3086]: https://consensyssoftware.atlassian.net/browse/TAT-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ