### PR TITLE
test(e2e): mock test-dapp fox SVG and empty ALLOWLISTED_URLS (MMQA-1786)

### DIFF
--- a/tests/api-mocking/mock-e2e-allowlist.ts
+++ b/tests/api-mocking/mock-e2e-allowlist.ts
@@ -15,7 +15,4 @@ export const ALLOWLISTED_HOSTS = [
   'metamask.github.io', // Test-snaps and test-dapp pages loaded in browser
 ];
 
-export const ALLOWLISTED_URLS = [
-  // Temporarily allow existing live requests during migration
-  'https://metamask.github.io/test-dapp/metamask-fox.svg',
-];
+export const ALLOWLISTED_URLS: string[] = [];

--- a/tests/api-mocking/mock-responses/defaults/static-assets.ts
+++ b/tests/api-mocking/mock-responses/defaults/static-assets.ts
@@ -23,5 +23,11 @@ export const STATIC_ASSETS_MOCKS: MockEventsObject = {
       responseCode: 200,
       response: MINIMAL_SVG,
     },
+    {
+      urlEndpoint:
+        /^https:\/\/metamask\.github\.io\/test-dapp\/metamask-fox\.svg$/,
+      responseCode: 200,
+      response: MINIMAL_SVG,
+    },
   ],
 };


### PR DESCRIPTION
## **Description**

Empties `ALLOWLISTED_URLS` in `tests/api-mocking/mock-e2e-allowlist.ts` by mocking the last remaining entry — the test-dapp's hardcoded `metamask-fox.svg` URL.

After [MMQA-1785](https://consensyssoftware.atlassian.net/browse/MMQA-1785), `ALLOWLISTED_URLS` was down to one URL. This PR drops it to zero by adding a default static-assets mock and deleting the entry. Cosmetic milestone for parent epic [MMQA-1364](https://consensyssoftware.atlassian.net/browse/MMQA-1364) (epic AC: *"`ALLOWLISTED_URLS` is empty"*).

**Context — why no runtime change:**

- `metamask.github.io` is still in `ALLOWLISTED_HOSTS` (driven separately by [MMQA-1367](https://consensyssoftware.atlassian.net/browse/MMQA-1367)). Hosts are matched first in `MockServerE2E.ts`, so the URL entry was redundant in practice.
- The local DappServer serves `node_modules/@metamask/test-dapp/dist/`, which contains a local `metamask-fox.svg`. The HTML references it relatively (`<img src="metamask-fox.svg">`), so normal test-dapp loads never hit GitHub.
- The hardcoded `https://metamask.github.io/test-dapp/metamask-fox.svg` only appears inside the test-dapp's `wallet_watchAsset` button (sample token image). Specs that exercise "Add Token" trigger that fetch — the new mock now intercepts it with a minimal SVG response.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

[MMQA-1786](https://consensyssoftware.atlassian.net/browse/MMQA-1786)
Parent epic: [MMQA-1364](https://consensyssoftware.atlassian.net/browse/MMQA-1364)

Fixes:

## **Manual testing steps**

```gherkin
Feature: Empty ALLOWLISTED_URLS via test-dapp fox SVG mock

  Scenario: ALLOWLISTED_URLS is empty after this change
    Given the e2e test infrastructure is running

    When MockServerE2E starts up
    Then ALLOWLISTED_URLS in mock-e2e-allowlist.ts contains zero entries

  Scenario: test-dapp wallet_watchAsset flow uses mocked SVG
    Given a spec exercises the Add Token button on the test-dapp

    When the test-dapp performs wallet_watchAsset with the metamask-fox.svg image URL
    Then the request to https://metamask.github.io/test-dapp/metamask-fox.svg is answered by the static-assets default mock with a minimal SVG
    And no live request leaks per validateLiveRequests()
```

## **Screenshots/Recordings**

### **Before**

`tests/api-mocking/mock-e2e-allowlist.ts`:

```ts
export const ALLOWLISTED_URLS = [
  // Temporarily allow existing live requests during migration
  'https://metamask.github.io/test-dapp/metamask-fox.svg',
];
```

### **After**

`tests/api-mocking/mock-e2e-allowlist.ts`:

```ts
export const ALLOWLISTED_URLS: string[] = [];
```

`tests/api-mocking/mock-responses/defaults/static-assets.ts` — new GET matcher serving `MINIMAL_SVG`:

```ts
{
  urlEndpoint:
    /^https:\/\/metamask\.github\.io\/test-dapp\/metamask-fox\.svg$/,
  responseCode: 200,
  response: MINIMAL_SVG,
},
```

CI verification will be added once smoke tests complete on this PR.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1785]: https://consensyssoftware.atlassian.net/browse/MMQA-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1364]: https://consensyssoftware.atlassian.net/browse/MMQA-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1367]: https://consensyssoftware.atlassian.net/browse/MMQA-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1786]: https://consensyssoftware.atlassian.net/browse/MMQA-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects e2e API-mocking configuration by replacing a previously allowlisted live URL with a deterministic mock response.
> 
> **Overview**
> Removes the last entry from `ALLOWLISTED_URLS` in e2e mocking so *no full URLs are explicitly allowed* to hit live servers.
> 
> Adds a static-assets default GET mock for `https://metamask.github.io/test-dapp/metamask-fox.svg`, returning `MINIMAL_SVG`, so tests that fetch the test-dapp’s token image are handled entirely by the mock server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bb7bc8fa513fbc2fdb056fa41d6def41b024a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->