### PR TITLE
chore(INFRA-3591): temp Bitrise RN cache + iOS E2E smoke POC

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,6 +15,10 @@ self-hosted-runner:
     - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"
     - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xl"
     - "low-priority"
+    # Bitrise GHA runner pool labels (self-hosted runner group temp-bitrise-runners)
+    - "bitrise_pool_name:DemoFA"
+    - "bitrise_pool_name:DemoFAL"
+    - "bitrise_pool_name:DemoFAXL"
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -78,6 +78,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   perps-ios-smoke:
@@ -115,6 +116,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   identity-ios-smoke:
@@ -228,6 +230,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   multichain-api-ios-smoke:

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ''
+      use_bitrise_runner:
+        description: "Route iOS E2E jobs to Bitrise self-hosted runner group."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,6 +40,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   swap-ios-smoke:
@@ -53,6 +59,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   stake-ios-smoke:
@@ -89,6 +96,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   wallet-platform-ios-smoke:
@@ -125,6 +133,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   accounts-ios-smoke:
@@ -143,6 +152,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   network-abstraction-ios-smoke:
@@ -161,6 +171,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   network-expansion-ios-smoke:
@@ -179,6 +190,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   prediction-market-ios-smoke:
@@ -197,6 +209,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   money-ios-smoke:
@@ -233,6 +246,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   seedless-onboarding-ios-smoke:
@@ -251,6 +265,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   browser-ios-smoke:
@@ -269,6 +284,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   snaps-ios-smoke:
@@ -287,6 +303,7 @@ jobs:
       changed_files: ${{ inputs.changed_files }}
       build_type: 'main'
       metamask_environment: 'qa'
+      use_bitrise_runner: ${{ inputs.use_bitrise_runner }}
     secrets: inherit
 
   report-ios-smoke-tests:

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -53,11 +53,16 @@ on:
         required: false
         type: string
         default: 'main-'
+      use_bitrise_runner:
+        description: 'Route iOS E2E jobs to Bitrise self-hosted runner group.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test-e2e-mobile:
     name: ${{ inputs.test-suite-name }}
-    runs-on: ${{ inputs.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' }}
+    runs-on: ${{ inputs.platform == 'ios' && (inputs.use_bitrise_runner && fromJSON('{"group":"temp-bitrise-runners","labels":["bitrise_pool_name:DemoFAL"]}') || 'ghcr.io/cirruslabs/macos-runner:tahoe') || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' }}
     outputs:
       apk-target-path: ${{ steps.determine-target-paths.outputs.apk-target-path }}
       test-apk-target-path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
@@ -101,6 +106,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # TEMPORARY: Bitrise runners use Vagrant (user=vagrant, HOME=/Users/vagrant).
+      # GitHub Actions tools hardcode /Users/runner paths, so create the symlink.
+      - name: Fix Vagrant environment paths (Bitrise runners)
+        if: ${{ inputs.use_bitrise_runner && inputs.platform == 'ios' }}
+        run: |
+          if [ -L /Users/runner ]; then
+            current_target="$(readlink /Users/runner)"
+            if [ "$current_target" = "/Users/vagrant" ]; then
+              echo "Symlink already correct: /Users/runner -> /Users/vagrant"
+            else
+              echo "Replacing incorrect symlink /Users/runner -> $current_target"
+              sudo rm /Users/runner
+              sudo ln -s /Users/vagrant /Users/runner
+              echo "Recreated symlink: /Users/runner -> /Users/vagrant"
+            fi
+          elif [ -e /Users/runner ]; then
+            echo "Error: /Users/runner exists but is not a symlink"
+            ls -ld /Users/runner
+            exit 1
+          else
+            sudo ln -s /Users/vagrant /Users/runner
+            echo "Created symlink /Users/runner -> /Users/vagrant"
+          fi
+          mkdir -p "$HOME/hostedtoolcache" "$HOME/tmp"
+          echo "RUNNER_TOOL_CACHE=$HOME/hostedtoolcache" >> "$GITHUB_ENV"
+          echo "RUNNER_TEMP=$HOME/tmp" >> "$GITHUB_ENV"
+        shell: bash
 
       - name: Restore .metamask folder
         uses: actions/cache@v4

--- a/.github/workflows/temp-bitrise-ios-kv.yml
+++ b/.github/workflows/temp-bitrise-ios-kv.yml
@@ -1,0 +1,361 @@
+name: "[TEMP] Bitrise iOS KV cache POC"
+
+# TEMPORARY WORKFLOW for INFRA-3591
+# Purpose: KV cache POC — GitHub Actions cache (actions/cache) for Xcode/DerivedData + iOS app on Bitrise runners.
+# This workflow is not part of the CI gate and should be removed after the POC.
+#
+# Triggers: workflow_dispatch (Actions tab — pick branch under "Use workflow from"),
+# pull_request (label bitrise-poc), and hourly schedule (:30 UTC, staggered from temp-bitrise-ios-rn.yml).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ labeled, synchronize ]
+  schedule:
+    - cron: "30 * * * *"
+
+concurrency:
+  group: bitrise-ios-kv-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-ios-on-bitrise:
+    name: Build iOS E2E App (KV cache)
+    if: >-
+      github.event_name != 'pull_request' ||
+      (contains(github.event.pull_request.labels.*.name, 'bitrise-poc') &&
+       !github.event.pull_request.head.repo.fork)
+    runs-on:
+      group: temp-bitrise-runners
+      labels: [ "bitrise_pool_name:DemoFAXL" ]
+    timeout-minutes: 60
+    outputs:
+      artifacts-url: ${{ steps.set-artifacts-url.outputs.artifacts-url }}
+    env:
+      XCODE_CACHE_VERSION: 1
+      IOS_APP_CACHE_VERSION: 2
+      RCT_NO_LAUNCH_PACKAGER: 1
+      XCODE_BUILD_SETTINGS: "COMPILER_INDEX_STORE_ENABLE=NO"
+      GITHUB_CI: "true"
+      PLATFORM: ios
+      METAMASK_ENVIRONMENT: qa
+      METAMASK_BUILD_TYPE: main
+      IS_TEST: true
+      E2E: "true"
+      IGNORE_BOXLOGS_DEVELOPMENT: true
+      CI: "true"
+      NODE_OPTIONS: "--max-old-space-size=8192"
+      BRIDGE_USE_DEV_APIS: "true"
+      RAMP_INTERNAL_BUILD: "true"
+      SEEDLESS_ONBOARDING_ENABLED: "true"
+      MM_NOTIFICATIONS_UI_ENABLED: "true"
+      MM_SECURITY_ALERTS_API_ENABLED: "true"
+      YARN_ENABLE_GLOBAL_CACHE: "true"
+      FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+      FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+      SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+      SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+      SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+      SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+      MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+      MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+      MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+      MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+      MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+      MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+      MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+      GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+      GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+      MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+      MM_PREDICT_GTM_MODAL_ENABLED: "false"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Print runner environment diagnostics
+        run: |
+          echo "=== Runner Diagnostics ==="
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Runner Arch: ${{ runner.arch }}"
+          echo "macOS version: $(sw_vers -productVersion)"
+          echo "Memory: $(sysctl -n hw.memsize | awk '{print $1/1024/1024/1024 " GB"}')"
+          echo "Disk free: $(df -h / | tail -1 | awk '{print $4}')"
+          echo "CPU cores: $(sysctl -n hw.ncpu)"
+          echo "=== Xcode ==="
+          xcode-select -p 2>/dev/null | sed "s|$HOME|~|g" || echo "No Xcode selected"
+          xcodebuild -version 2>/dev/null | head -2 || echo "xcodebuild not available"
+          echo "=== Ruby ==="
+          ruby --version 2>/dev/null || echo "No ruby"
+          echo "=== Node ==="
+          node --version 2>/dev/null || echo "No node"
+        shell: bash
+
+      - name: Fix Vagrant environment paths
+        run: |
+          if [ -L /Users/runner ]; then
+            current_target="$(readlink /Users/runner)"
+            if [ "$current_target" = "/Users/vagrant" ]; then
+              echo "Symlink already correct: /Users/runner -> /Users/vagrant"
+            else
+              echo "Replacing incorrect symlink /Users/runner -> $current_target"
+              sudo rm /Users/runner
+              sudo ln -s /Users/vagrant /Users/runner
+              echo "Recreated symlink: /Users/runner -> /Users/vagrant"
+            fi
+          elif [ -e /Users/runner ]; then
+            echo "Error: /Users/runner exists but is not a symlink"
+            ls -ld /Users/runner
+            exit 1
+          else
+            sudo ln -s /Users/vagrant /Users/runner
+            echo "Created symlink: /Users/runner -> /Users/vagrant"
+          fi
+          mkdir -p "$HOME/hostedtoolcache" "$HOME/tmp"
+          echo "RUNNER_TOOL_CACHE=$HOME/hostedtoolcache" >> "$GITHUB_ENV"
+          echo "RUNNER_TEMP=$HOME/tmp" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Restore Xcode derived data from branch cache
+        id: xcode-restore-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ios/build
+          key: bitrise-${{ runner.os }}-xcode-${{ github.ref_name }}-${{
+            env.XCODE_CACHE_VERSION }}-${{ hashFiles('ios/**/*.{h,m,mm,swift}',
+            'ios/**/Podfile.lock', 'yarn.lock') }}
+
+      - name: Restore Xcode derived data from main cache
+        if: ${{ steps.xcode-restore-cache.outputs.cache-hit != 'true' && github.ref_name
+          != 'main' }}
+        id: xcode-restore-cache-main
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ios/build
+          key: bitrise-${{ runner.os }}-xcode-main-${{ env.XCODE_CACHE_VERSION }}-${{
+            hashFiles('ios/**/*.{h,m,mm,swift}', 'ios/**/Podfile.lock',
+            'yarn.lock') }}
+
+      - name: Installing iOS Environment Setup
+        timeout-minutes: 15
+        uses: ./.github/actions/setup-e2e-env
+        with:
+          platform: ios
+          setup-simulator: false
+          configure-keystores: false
+
+      - name: Print iOS tool versions
+        run: |
+          echo "Node.js Version: $(node -v || echo 'not found')"
+          echo "Yarn Version: $(yarn -v || echo 'not found')"
+          echo "CocoaPods Version: $(pod --version || echo 'not found')"
+          echo "Xcode Path: $(xcode-select -p || echo 'not found')"
+          echo "Ruby Version: $(ruby --version || echo 'not found')"
+          echo "Booted iOS Simulators:"
+          xcrun simctl list | grep Booted || echo "No booted simulators found"
+        shell: bash
+
+      - name: Clean iOS plist files
+        run: find ios -name "*.plist" -exec xattr -c {} \;
+
+      - name: Restore .metamask folder
+        id: restore-metamask
+        uses: actions/cache@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
+      - name: Install Foundry if cache missed
+        if: steps.restore-metamask.outputs.cache-hit != 'true'
+        run: yarn install:foundryup
+
+      - name: Setup project dependencies with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "Setting up project..."
+            yarn setup:github-ci --build-ios --no-build-android
+
+      - name: Generate current fingerprint
+        id: generate-fingerprint
+        run: |
+          FINGERPRINT=$(yarn fingerprint:generate)
+          echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Current fingerprint: ${FINGERPRINT}"
+
+      - name: Restore iOS app matching fingerprint from branch cache
+        id: cache-restore
+        uses: actions/cache@v4
+        with:
+          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          key: bitrise-ios-app-${{ github.ref_name }}-v${{ env.IOS_APP_CACHE_VERSION
+            }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
+
+      - name: Restore iOS app matching fingerprint from main cache
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name !=
+          'main' }}
+        id: cache-restore-main
+        uses: actions/cache/restore@v4
+        with:
+          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          key: bitrise-ios-app-main-v${{ env.IOS_APP_CACHE_VERSION }}-${{
+            steps.generate-fingerprint.outputs.fingerprint }}
+
+      - name: Build iOS E2E App
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' &&
+          steps.cache-restore-main.outputs.cache-hit != 'true' }}
+        run: |
+          echo "Building iOS E2E App on Bitrise runner with KV cache only..."
+          yarn build:ios:main:e2e
+        shell: bash
+        env:
+          PLATFORM: ios
+          METAMASK_ENVIRONMENT: qa
+          METAMASK_BUILD_TYPE: main
+          IS_TEST: true
+          IS_SIM_BUILD: "true"
+          IGNORE_BOXLOGS_DEVELOPMENT: true
+          GITHUB_CI: "true"
+          CI: "true"
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+
+      - name: Repack iOS app with JS updates
+        if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
+          steps.cache-restore-main.outputs.cache-hit == 'true' }}
+        run: |
+          echo "Repacking iOS app with updated JavaScript bundle..."
+          yarn build:repack:ios
+          echo "Final app size: $(du -sh "ios/build/Build/Products/Release-iphonesimulator/MetaMask.app" | cut -f1)"
+        env:
+          PLATFORM: ios
+          METAMASK_ENVIRONMENT: qa
+          METAMASK_BUILD_TYPE: main
+          IS_TEST: true
+          E2E: "true"
+          IGNORE_BOXLOGS_DEVELOPMENT: true
+          GITHUB_CI: "true"
+          CI: "true"
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          BRIDGE_USE_DEV_APIS: "true"
+          RAMP_INTERNAL_BUILD: "true"
+          SEEDLESS_ONBOARDING_ENABLED: "true"
+          MM_NOTIFICATIONS_UI_ENABLED: "true"
+          MM_SECURITY_ALERTS_API_ENABLED: "true"
+          FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+          FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+
+      - name: Fix iOS bundle executable case and permissions before upload
+        run: |
+          APP_PATH="ios/build/Build/Products/Release-iphonesimulator/MetaMask.app"
+          BUNDLE_EXEC=$(/usr/libexec/PlistBuddy -c "Print CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null)
+          if [ -z "$BUNDLE_EXEC" ]; then
+            echo "Could not read CFBundleExecutable from Info.plist"
+            exit 1
+          fi
+          ACTUAL_PATH=$(find "$APP_PATH" -maxdepth 1 -iname "$BUNDLE_EXEC" -type f | head -1)
+          if [ -z "$ACTUAL_PATH" ]; then
+            echo "Bundle executable not found: $BUNDLE_EXEC"
+            exit 1
+          fi
+          if [ "$(basename "$ACTUAL_PATH")" != "$BUNDLE_EXEC" ]; then
+            mv "$ACTUAL_PATH" "$APP_PATH/${BUNDLE_EXEC}_fix"
+            mv "$APP_PATH/${BUNDLE_EXEC}_fix" "$APP_PATH/$BUNDLE_EXEC"
+          fi
+          chmod +x "$APP_PATH/$BUNDLE_EXEC"
+        shell: bash
+
+      - name: Upload iOS APP Artifact (Simulator)
+        id: upload-app
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-qa-MetaMask.app
+          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload iOS Source Map
+        id: upload-sourcemap
+        if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
+          steps.cache-restore-main.outputs.cache-hit == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-qa-index.js.map
+          path: sourcemaps/ios/index.js.map
+          retention-days: 7
+          if-no-files-found: error
+        continue-on-error: true
+
+      - name: Set Artifacts URL and Status
+        id: set-artifacts-url
+        run: |
+          ARTIFACTS_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "artifacts-url=${ARTIFACTS_URL}" >> "$GITHUB_OUTPUT"
+          echo "Artifacts available at: ${ARTIFACTS_URL}"
+          echo ""
+          echo "Upload Status Summary:"
+          echo "- APP (Simulator): ${{ steps.upload-app.outcome }}"
+          echo "- Source Map: ${{ steps.upload-sourcemap.outcome }}"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      - name: Record build timing summary
+        if: always()
+        run: |
+          echo "=== Bitrise iOS KV cache — build timing summary ==="
+          echo "Runner platform: ${{ runner.os }}/${{ runner.arch }}"
+          echo "Build outcome: ${{ steps.upload-app.outcome }}"
+          echo "Xcode cache hit (branch): ${{ steps.xcode-restore-cache.outputs.cache-hit }}"
+          echo "Xcode cache hit (main): ${{ steps.xcode-restore-cache-main.outputs.cache-hit || 'N/A' }}"
+          echo "App cache hit (branch): ${{ steps.cache-restore.outputs.cache-hit }}"
+          echo "App cache hit (main): ${{ steps.cache-restore-main.outputs.cache-hit || 'N/A' }}"
+          echo "Cache mode: Bitrise KV cache via actions/cache only"
+          echo "Record CPU and memory utilization from the VM monitoring CSV for this job."
+        shell: bash
+  # e2e-smoke-tests-ios:
+  #   name: iOS E2E Smoke Tests (Bitrise)
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   needs: [build-ios-on-bitrise]
+  #   uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
+  #   with:
+  #     use_bitrise_runner: true
+  #   secrets: inherit

--- a/.github/workflows/temp-bitrise-ios-rn-e2e.yml
+++ b/.github/workflows/temp-bitrise-ios-rn-e2e.yml
@@ -1,21 +1,19 @@
-name: "[TEMP] Bitrise iOS KV cache POC"
+name: "[TEMP] Bitrise iOS RN cache + E2E POC"
 
 # TEMPORARY WORKFLOW for INFRA-3591
-# Purpose: KV cache POC — GitHub Actions cache (actions/cache) for Xcode/DerivedData + iOS app on Bitrise runners.
-# This workflow is not part of the CI gate and should be removed after the POC.
-#
-# Triggers: workflow_dispatch (Actions tab — pick branch under "Use workflow from"),
-# pull_request (label bitrise-poc), and hourly schedule (:30 UTC, staggered from temp-bitrise-ios-rn.yml).
+# Purpose: Same as temp-bitrise-ios-rn.yml (Bitrise RN build cache + iOS E2E app build), then runs
+# iOS E2E smoke tests on Bitrise. Not part of the CI gate; remove when benchmarking is complete.
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [ labeled, synchronize ]
+  # Hourly at :30 UTC — staggered from temp-bitrise-ios-rn.yml (:00). Note: temp-bitrise-ios-kv.yml
+  # also schedules at :30; expect concurrent Bitrise load unless offsets change.
   schedule:
     - cron: "30 * * * *"
 
 concurrency:
-  group: bitrise-ios-kv-${{ github.head_ref || github.ref }}
+  group: bitrise-ios-rn-e2e-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -24,11 +22,11 @@ permissions:
 
 jobs:
   build-ios-on-bitrise:
-    name: Build iOS E2E App (KV cache)
+    name: Build iOS E2E App (RN cache)
     if: >-
-      github.event_name != 'pull_request' ||
-      (contains(github.event.pull_request.labels.*.name, 'bitrise-poc') &&
-       !github.event.pull_request.head.repo.fork)
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'bitrise-poc')) &&
+      !github.event.pull_request.head.repo.fork
     runs-on:
       group: temp-bitrise-runners
       labels: [ "bitrise_pool_name:DemoFAXL" ]
@@ -36,7 +34,6 @@ jobs:
     outputs:
       artifacts-url: ${{ steps.set-artifacts-url.outputs.artifacts-url }}
     env:
-      XCODE_CACHE_VERSION: 1
       IOS_APP_CACHE_VERSION: 2
       RCT_NO_LAUNCH_PACKAGER: 1
       XCODE_BUILD_SETTINGS: "COMPILER_INDEX_STORE_ENABLE=NO"
@@ -72,6 +69,8 @@ jobs:
       GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
       MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
       MM_PREDICT_GTM_MODAL_ENABLED: "false"
+      BITRISE_BUILD_CACHE_WORKSPACE_ID: ${{ vars.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
+      BITRISE_BUILD_CACHE_AUTH_TOKEN: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
 
     steps:
       - name: Checkout repo
@@ -120,29 +119,17 @@ jobs:
           echo "RUNNER_TEMP=$HOME/tmp" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Restore Xcode derived data from branch cache
-        id: xcode-restore-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/Library/Developer/Xcode/DerivedData
-            ios/build
-          key: bitrise-${{ runner.os }}-xcode-${{ github.ref_name }}-${{
-            env.XCODE_CACHE_VERSION }}-${{ hashFiles('ios/**/*.{h,m,mm,swift}',
-            'ios/**/Podfile.lock', 'yarn.lock') }}
-
-      - name: Restore Xcode derived data from main cache
-        if: ${{ steps.xcode-restore-cache.outputs.cache-hit != 'true' && github.ref_name
-          != 'main' }}
-        id: xcode-restore-cache-main
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/Library/Developer/Xcode/DerivedData
-            ios/build
-          key: bitrise-${{ runner.os }}-xcode-main-${{ env.XCODE_CACHE_VERSION }}-${{
-            hashFiles('ios/**/*.{h,m,mm,swift}', 'ios/**/Podfile.lock',
-            'yarn.lock') }}
+      # ──────────────────────────────────────────────────────────────────────
+      # REMOVED: "Restore Xcode derived data from branch cache" step
+      #   Was: cirruslabs/cache for ~/Library/Developer/Xcode/DerivedData + ios/build
+      #   Reason: Replaced by Bitrise React Native Build Cache which provides
+      #           granular, build-system-level caching (Xcode via LLVM CAS,
+      #           C++ via ccache) instead of coarse tar-and-restore of DerivedData.
+      #
+      # REMOVED: "Restore Xcode derived data from main cache" step
+      #   Was: cirruslabs/cache/restore (restore-only fallback to main branch)
+      #   Reason: Same as above.
+      # ──────────────────────────────────────────────────────────────────────
 
       - name: Installing iOS Environment Setup
         timeout-minutes: 15
@@ -187,6 +174,30 @@ jobs:
             echo "Setting up project..."
             yarn setup:github-ci --build-ios --no-build-android
 
+      # ──────────────────────────────────────────────────────────────────────
+      # NEW: Activate Bitrise Build Cache for React Native
+      #   Configures build-system-level remote caching for:
+      #   - Xcode compilation outputs (LLVM CAS via Xcelerate)
+      #   - C++ native modules (ccache backed by Bitrise ABCS)
+      #   Must run BEFORE any step that triggers a native build (xcodebuild).
+      #   Does NOT cache Metro JS bundling or node_modules.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Activate Bitrise Build Cache for React Native
+        env:
+          BITRISE_BUILD_CACHE_AUTH_TOKEN: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
+          BITRISE_BUILD_CACHE_WORKSPACE_ID: ${{ vars.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
+        run: |
+          #!/usr/bin/env bash
+          set -euxo pipefail
+
+          # Download Bitrise Build Cache CLI
+          curl --retry 5 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d
+
+          # Activate React Native build cache (configures Xcode + ccache)
+          /tmp/bin/bitrise-build-cache activate react-native
+          echo "/tmp/bin" >> "$GITHUB_PATH"
+        shell: bash
+
       - name: Generate current fingerprint
         id: generate-fingerprint
         run: |
@@ -194,30 +205,35 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
           echo "Current fingerprint: ${FINGERPRINT}"
 
+      # ── Changed: cirruslabs/cache → actions/cache@v5 ──
       - name: Restore iOS app matching fingerprint from branch cache
         id: cache-restore
         uses: actions/cache@v5
         with:
-          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          path: |
+            ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
           key: bitrise-ios-app-${{ github.ref_name }}-v${{ env.IOS_APP_CACHE_VERSION
             }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
 
+      # ── Changed: cirruslabs/cache/restore → actions/cache/restore@v5 ──
       - name: Restore iOS app matching fingerprint from main cache
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name !=
           'main' }}
         id: cache-restore-main
         uses: actions/cache/restore@v5
         with:
-          path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
+          path: |
+            ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
           key: bitrise-ios-app-main-v${{ env.IOS_APP_CACHE_VERSION }}-${{
             steps.generate-fingerprint.outputs.fingerprint }}
 
+      # ── Changed: Wrapped with bitrise-build-cache react-native run ──
       - name: Build iOS E2E App
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' &&
           steps.cache-restore-main.outputs.cache-hit != 'true' }}
         run: |
-          echo "Building iOS E2E App on Bitrise runner with KV cache only..."
-          yarn build:ios:main:e2e
+          echo "Building iOS E2E App on Bitrise runner..."
+          bitrise-build-cache react-native run yarn build:ios:main:e2e
         shell: bash
         env:
           PLATFORM: ios
@@ -242,6 +258,7 @@ jobs:
           GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
 
+      # Repack is JS-only bundling (no native build) — no wrapping needed
       - name: Repack iOS app with JS updates
         if: ${{ steps.cache-restore.outputs.cache-hit == 'true' ||
           steps.cache-restore-main.outputs.cache-hit == 'true' }}
@@ -336,26 +353,26 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
 
+      # Record timing data for benchmarking
       - name: Record build timing summary
         if: always()
         run: |
-          echo "=== Bitrise iOS KV cache — build timing summary ==="
+          echo "=== Bitrise iOS RN cache — build timing summary ==="
           echo "Runner platform: ${{ runner.os }}/${{ runner.arch }}"
           echo "Build outcome: ${{ steps.upload-app.outcome }}"
-          echo "Xcode cache hit (branch): ${{ steps.xcode-restore-cache.outputs.cache-hit }}"
-          echo "Xcode cache hit (main): ${{ steps.xcode-restore-cache-main.outputs.cache-hit || 'N/A' }}"
-          echo "App cache hit (branch): ${{ steps.cache-restore.outputs.cache-hit }}"
-          echo "App cache hit (main): ${{ steps.cache-restore-main.outputs.cache-hit || 'N/A' }}"
-          echo "Cache mode: Bitrise KV cache via actions/cache only"
-          echo "Record CPU and memory utilization from the VM monitoring CSV for this job."
+          echo "Cache hit (branch): ${{ steps.cache-restore.outputs.cache-hit }}"
+          echo "Cache hit (main): ${{ steps.cache-restore-main.outputs.cache-hit || 'N/A' }}"
+          echo "Build cache: Bitrise React Native Build Cache (Xcode LLVM CAS + ccache)"
+          echo "Record this data in the benchmark tracker referenced by the related ticket or PR description."
         shell: bash
-  # e2e-smoke-tests-ios:
-  #   name: iOS E2E Smoke Tests (Bitrise)
-  #   permissions:
-  #     contents: read
-  #     id-token: write
-  #   needs: [build-ios-on-bitrise]
-  #   uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
-  #   with:
-  #     use_bitrise_runner: true
-  #   secrets: inherit
+
+  e2e-smoke-tests-ios:
+    name: iOS E2E Smoke Tests (Bitrise)
+    permissions:
+      contents: read
+      id-token: write
+    needs: [ build-ios-on-bitrise ]
+    uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
+    with:
+      use_bitrise_runner: true
+    secrets: inherit


### PR DESCRIPTION
## **Description**

Adds **temp-bitrise-ios-rn-e2e.yml**: Bitrise iOS build using the same React Native / Bitrise Build Cache path as the RN-only POC, then runs **iOS E2E smoke** via `run-e2e-smoke-tests-ios.yml` with `use_bitrise_runner: true`. Schedule is **:30 UTC** hourly to stagger from the RN-only workflow (**:00**). Also aligns **temp-bitrise-ios-kv.yml** with `actions/checkout@v6`, `actions/cache@v5`, `actions/cache/restore@v5`, and `actions/upload-artifact@v6`, and passes **`use_bitrise_runner`** through **stake-ios-smoke**, **wallet-platform-ios-smoke**, and **money-ios-smoke** so Bitrise benchmarking is consistent when the flag is set.

**Branch:** `chore/INFRA-3591-bitrise-rn-cache-e2e-poc` (separate from the RN-only and KV-only POC branches.)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3591](https://consensyssoftware.atlassian.net/browse/INFRA-3591)

## **Manual testing steps**

```gherkin
Feature: Bitrise RN cache + E2E temp workflow

  Scenario: Workflow runs on label or schedule
    Given a non-fork PR has label bitrise-poc or the hourly :30 UTC schedule fires
    When the temp Bitrise RN+E2E workflow runs
    Then the build job completes and E2E smoke jobs can consume the uploaded iOS artifact
```

## **Screenshots/Recordings**

N/A — CI / workflow-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3591]: https://consensyssoftware.atlassian.net/browse/INFRA-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes where iOS E2E jobs run (Bitrise self-hosted runner group) and introduces new scheduled POC workflows that could impact CI capacity or job behavior when enabled.
> 
> **Overview**
> **Adds an opt-in Bitrise execution path for iOS E2E smoke tests.** `run-e2e-smoke-tests-ios.yml` and the shared `run-e2e-workflow.yml` now accept `use_bitrise_runner` and, when enabled, run iOS shards on the `temp-bitrise-runners` runner group (with a Bitrise pool label) instead of the Cirrus macOS runner.
> 
> **Improves Bitrise runner compatibility.** When `use_bitrise_runner` is set, the E2E workflow adds a step to fix Bitrise/Vagrant home/toolcache paths by creating `/Users/runner -> /Users/vagrant` and setting `RUNNER_TOOL_CACHE`/`RUNNER_TEMP`.
> 
> **Adds temporary Bitrise POC workflows for benchmarking.** Introduces `temp-bitrise-ios-rn-e2e.yml` (Bitrise React Native build cache + iOS E2E app build, then runs iOS smoke tests on Bitrise) and `temp-bitrise-ios-kv.yml` (KV-cache-only build POC), and updates `actionlint` config to allow Bitrise runner labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af54674cb06fdfbd42643ad067cf690bac624140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->