### PR TITLE
feat: update client id

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -154,20 +154,6 @@ export E2E_MOCK_OAUTH='false'
 export E2E_BYOA_AUTH_SECRET=''
 export E2E_MOCK_OAUTH_EMAIL=''
 
-# env for seedless onboarding main-dev
-export ANDROID_APPLE_CLIENT_ID='io.metamask.appleloginclient.dev'
-export ANDROID_GOOGLE_CLIENT_ID='8615965109465-i8oeh9kuvl1n6lk1ffkobpvth27bmi41.apps.googleusercontent.com'
-export ANDROID_GOOGLE_SERVER_CLIENT_ID='615965109465-i8oeh9kuvl1n6lk1ffkobpvth27bmi41.apps.googleusercontent.com'
-export IOS_GOOGLE_CLIENT_ID='615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3.apps.googleusercontent.com'
-export IOS_GOOGLE_REDIRECT_URI='com.googleusercontent.apps.615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3:/oauth2redirect/google'
-
-# env for seedless onboarding flask-dev
-#export ANDROID_APPLE_CLIENT_ID="io.metamask.appleloginclient.flask.dev"
-#export ANDROID_GOOGLE_CLIENT_ID="615965109465-ab20kuqbls6fj5s50fvmvbnket8nv1sh.apps.googleusercontent.com"
-#export ANDROID_GOOGLE_SERVER_CLIENT_ID="615965109465-ab20kuqbls6fj5s50fvmvbnket8nv1sh.apps.googleusercontent.com"
-#export IOS_GOOGLE_CLIENT_ID="615965109465-89b2lmqgm5ka8j8t403qhooouv57id9b.apps.googleusercontent.com"
-#export IOS_GOOGLE_REDIRECT_URI="com.googleusercontent.apps.615965109465-89b2lmqgm5ka8j8t403qhooouv57id9b:/oauth2redirect/google"
-
 # Enable send re-designs locally
 export MM_SEND_REDESIGN_ENABLED="true"
 

--- a/app/core/OAuthService/OAuthLoginHandlers/config.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/config.ts
@@ -1,4 +1,10 @@
 interface OAUTH_CONFIG_TYPE {
+  IOS_GOOGLE_CLIENT_ID: string;
+  IOS_GOOGLE_REDIRECT_URI: string;
+  ANDROID_GOOGLE_CLIENT_ID: string;
+  ANDROID_GOOGLE_SERVER_CLIENT_ID: string;
+  ANDROID_APPLE_CLIENT_ID: string;
+
   AUTH_SERVER_URL: string;
   WEB3AUTH_NETWORK: string;
 
@@ -22,6 +28,16 @@ enum BUILD_TYPE {
 
 export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
   development: {
+    IOS_GOOGLE_CLIENT_ID:
+      '615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '615965109465-laapla9g0klg2p7rp5mn66fcl6jc4fes.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '615965109465-i8oeh9kuvl1n6lk1ffkobpvth27bmi41.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.dev',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-seedless-onboarding',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-seedless-onboarding',
     AUTH_SERVER_URL: 'https://api-develop-torus-byoa.web3auth.io',
@@ -33,6 +49,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'byoa-server',
   },
   main_prod: {
+    IOS_GOOGLE_CLIENT_ID:
+      '795351133007-jcaor637tblrlpuj29shdej3co8bu8kv.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.795351133007-47aohp9j9n7r8fef5n6ejeauhu4kfc9e:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '795351133007-jcaor637tblrlpuj29shdej3co8bu8kv.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '795351133007-6d0s31utj13knv440fgjo2ur93241gb6.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.prod',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-main',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-main',
     AUTH_SERVER_URL: 'https://auth-service.api.cx.metamask.io',
@@ -44,6 +70,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'mm-apple-main-common',
   },
   main_uat: {
+    IOS_GOOGLE_CLIENT_ID:
+      '387141446914-5ja3p4dfanfkm8uq238fm1b8t1rkscv4.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.387141446914-5ja3p4dfanfkm8uq238fm1b8t1rkscv4:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '387141446914-7rl5s9s1uv82fgb03f93eqc0n8jq7t6k.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '387141446914-olajr83p1bbvabh1u8tfglt1k4u6jlcb.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.uat',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-uat',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-uat',
     AUTH_SERVER_URL: 'https://auth-service.uat-api.cx.metamask.io',
@@ -55,6 +91,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'mm-apple-uat-common',
   },
   main_dev: {
+    IOS_GOOGLE_CLIENT_ID:
+      '615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.615965109465-h6tp2h3crls6hbggispcgovbvk4vabu3:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '615965109465-laapla9g0klg2p7rp5mn66fcl6jc4fes.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '615965109465-i8oeh9kuvl1n6lk1ffkobpvth27bmi41.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.dev',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-dev',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-dev',
     AUTH_SERVER_URL: 'https://auth-service.dev-api.cx.metamask.io',
@@ -66,6 +112,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'mm-apple-dev-common',
   },
   flask_prod: {
+    IOS_GOOGLE_CLIENT_ID:
+      '795351133007-gvuagr9t7tfkak3sp2cmng4pdhchlfpd.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.795351133007-gvuagr9t7tfkak3sp2cmng4pdhchlfpd:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '795351133007-0po6dfbepae7klaso18qv61f86u4a2ef.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '795351133007-gh67d3hot6ib24htu9d7sh01bg90lpdu.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.flask.prod',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-flask-main',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-flask-main',
     AUTH_SERVER_URL: 'https://auth-service.api.cx.metamask.io',
@@ -77,6 +133,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'mm-apple-flask-main-common',
   },
   flask_uat: {
+    IOS_GOOGLE_CLIENT_ID:
+      '387141446914-1tdlsrare1jtjd2tgal9bi1ilb4qro5d.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.387141446914-1tdlsrare1jtjd2tgal9bi1ilb4qro5d:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '387141446914-ki5586faf9qmlghop8g07f4a10scdevi.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '387141446914-f03k9ivc2jrmi1s53lne88mh529372kj.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.flask.uat',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-flask-uat',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-flask-uat',
     AUTH_SERVER_URL: 'https://auth-service.api.cx.metamask.io',
@@ -88,6 +154,16 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
     IOS_APPLE_AUTH_CONNECTION_ID: 'mm-apple-flask-uat-common',
   },
   flask_dev: {
+    IOS_GOOGLE_CLIENT_ID:
+      '615965109465-89b2lmqgm5ka8j8t403qhooouv57id9b.apps.googleusercontent.com',
+    IOS_GOOGLE_REDIRECT_URI:
+      'com.googleusercontent.apps.615965109465-89b2lmqgm5ka8j8t403qhooouv57id9b:/oauth2redirect/google',
+    ANDROID_GOOGLE_CLIENT_ID:
+      '615965109465-9nn2i74feqs3v9ps4lb61ha0v34eo382.apps.googleusercontent.com',
+    ANDROID_GOOGLE_SERVER_CLIENT_ID:
+      '615965109465-ab20kuqbls6fj5s50fvmvbnket8nv1sh.apps.googleusercontent.com',
+    ANDROID_APPLE_CLIENT_ID: 'io.metamask.appleloginclient.flask.dev',
+
     GOOGLE_GROUPED_AUTH_CONNECTION_ID: 'mm-google-flask-dev',
     APPLE_GROUPED_AUTH_CONNECTION_ID: 'mm-apple-flask-dev',
     AUTH_SERVER_URL: 'https://auth-service.dev-api.cx.metamask.io',

--- a/app/core/OAuthService/OAuthLoginHandlers/config.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/config.ts
@@ -50,7 +50,7 @@ export const OAUTH_CONFIG: Record<BUILD_TYPE, OAUTH_CONFIG_TYPE> = {
   },
   main_prod: {
     IOS_GOOGLE_CLIENT_ID:
-      '795351133007-jcaor637tblrlpuj29shdej3co8bu8kv.apps.googleusercontent.com',
+      '795351133007-47aohp9j9n7r8fef5n6ejeauhu4kfc9e.apps.googleusercontent.com',
     IOS_GOOGLE_REDIRECT_URI:
       'com.googleusercontent.apps.795351133007-47aohp9j9n7r8fef5n6ejeauhu4kfc9e:/oauth2redirect/google',
     ANDROID_GOOGLE_CLIENT_ID:

--- a/app/core/OAuthService/OAuthLoginHandlers/constants.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/constants.test.ts
@@ -47,6 +47,8 @@ jest.mock(
 );
 
 const mockAppRedirectUri = 'metamask://oauth-redirect';
+const CURRENT_OAUTH_CONFIG = OAUTH_CONFIG.main_prod;
+
 describe('OAuth Constants', () => {
   describe('AppRedirectUri', () => {
     it('should generate correct redirect URI', () => {
@@ -55,8 +57,6 @@ describe('OAuth Constants', () => {
   });
 
   describe('Environment-based constants', () => {
-    const CURRENT_OAUTH_CONFIG = OAUTH_CONFIG.main_prod;
-
     it('should have web3AuthNetwork from jest config', () => {
       expect(web3AuthNetwork).toBe('sapphire_mainnet');
     });
@@ -65,9 +65,13 @@ describe('OAuth Constants', () => {
       expect(AuthServerUrl).toBe(CURRENT_OAUTH_CONFIG.AUTH_SERVER_URL);
     });
 
-    it('should have Android configuration from jest config', () => {
-      expect(GoogleWebGID).toBe('androidGoogleWebClientId');
-      expect(AppleWebClientId).toBe('AppleClientId');
+    it('should have Android configuration from config', () => {
+      expect(GoogleWebGID).toBe(
+        CURRENT_OAUTH_CONFIG.ANDROID_GOOGLE_SERVER_CLIENT_ID,
+      );
+      expect(AppleWebClientId).toBe(
+        CURRENT_OAUTH_CONFIG.ANDROID_APPLE_CLIENT_ID,
+      );
     });
 
     it('should generate correct Apple server redirect URI', () => {
@@ -142,8 +146,8 @@ describe('getIosGoogleConfig', () => {
     const config = getIosGoogleConfig();
 
     expect(config).toEqual({
-      clientId: 'iosGoogleClientId',
-      redirectUri: 'iosGoogleRedirectUri',
+      clientId: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_CLIENT_ID,
+      redirectUri: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_REDIRECT_URI,
     });
   });
 
@@ -155,8 +159,8 @@ describe('getIosGoogleConfig', () => {
     const config = getIosGoogleConfig();
 
     expect(config).toEqual({
-      clientId: 'iosGoogleClientId',
-      redirectUri: 'iosGoogleRedirectUri',
+      clientId: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_CLIENT_ID,
+      redirectUri: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_REDIRECT_URI,
     });
   });
 
@@ -166,7 +170,9 @@ describe('getIosGoogleConfig', () => {
 
     const config = getIosGoogleConfig();
 
-    expect(config.clientId).toBe('androidGoogleWebClientId');
+    expect(config.clientId).toBe(
+      CURRENT_OAUTH_CONFIG.ANDROID_GOOGLE_SERVER_CLIENT_ID,
+    );
     expect(config.redirectUri).toContain('link.metamask.io');
   });
 
@@ -188,7 +194,9 @@ describe('getIosGoogleConfig', () => {
 
     const config = getIosGoogleConfig();
 
-    expect(config.clientId).toBe('androidGoogleWebClientId');
+    expect(config.clientId).toBe(
+      CURRENT_OAUTH_CONFIG.ANDROID_GOOGLE_SERVER_CLIENT_ID,
+    );
     expect(config.redirectUri).toContain('link.metamask.io');
   });
 
@@ -200,8 +208,8 @@ describe('getIosGoogleConfig', () => {
     const config = getIosGoogleConfig();
 
     expect(config).toEqual({
-      clientId: 'iosGoogleClientId',
-      redirectUri: 'iosGoogleRedirectUri',
+      clientId: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_CLIENT_ID,
+      redirectUri: CURRENT_OAUTH_CONFIG.IOS_GOOGLE_REDIRECT_URI,
     });
   });
 });

--- a/app/core/OAuthService/OAuthLoginHandlers/constants.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/constants.ts
@@ -64,10 +64,12 @@ export const E2E_QA_MOCK_OAUTH_TOKEN_URL =
 export const AUTH_SERVER_MARKETING_OPT_IN_PATH =
   '/api/v1/oauth/marketing_opt_in_status';
 
-export const IosGID = process.env.IOS_GOOGLE_CLIENT_ID;
-export const IosGoogleRedirectUri = process.env.IOS_GOOGLE_REDIRECT_URI;
-export const GoogleWebGID = process.env.ANDROID_GOOGLE_SERVER_CLIENT_ID;
-export const AppleWebClientId = process.env.ANDROID_APPLE_CLIENT_ID;
+export const IosGID = CURRENT_OAUTH_CONFIG.IOS_GOOGLE_CLIENT_ID;
+export const IosGoogleRedirectUri =
+  CURRENT_OAUTH_CONFIG.IOS_GOOGLE_REDIRECT_URI;
+export const GoogleWebGID =
+  CURRENT_OAUTH_CONFIG.ANDROID_GOOGLE_SERVER_CLIENT_ID;
+export const AppleWebClientId = CURRENT_OAUTH_CONFIG.ANDROID_APPLE_CLIENT_ID;
 
 // Use universal link for OAuth redirect
 export const GoogleRedirectUri = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.OAUTH_REDIRECT}`;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
OAuth client IDs for Google and Apple sign-in (`IOS_GOOGLE_CLIENT_ID`, `IOS_GOOGLE_REDIRECT_URI`, `ANDROID_GOOGLE_CLIENT_ID`, `ANDROID_GOOGLE_SERVER_CLIENT_ID`, `ANDROID_APPLE_CLIENT_ID`) were previously sourced from `process.env`, requiring manual environment variable configuration and risking misconfiguration across different build types.

This PR moves those client IDs into the existing `OAUTH_CONFIG` object in `config.ts`, keyed by build type (development, main_prod, main_uat, main_dev, flask_prod, flask_uat, flask_dev). The constants in `constants.ts` now read from `CURRENT_OAUTH_CONFIG` instead of `process.env`, ensuring the correct client IDs are automatically selected based on the build type. The corresponding environment variable entries have been removed from `.js.env.example`.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Seedless onboarding OAuth login

  Scenario: user signs in with Google on iOS
    Given the app is built with a main production build type
    When user taps "Sign in with Google" during onboarding
    Then the Google OAuth flow uses the correct production client ID
    And the user is authenticated successfully

  Scenario: user signs in with Google on Android
    Given the app is built with a main production build type
    When user taps "Sign in with Google" during onboarding
    Then the Google OAuth flow uses the correct production server client ID
    And the user is authenticated successfully

  Scenario: user signs in with Apple on Android
    Given the app is built with a main production build type
    When user taps "Sign in with Apple" during onboarding
    Then the Apple OAuth flow uses the correct production Apple client ID
    And the user is authenticated successfully
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth configuration used for Google/Apple login; incorrect client IDs/redirect URIs could break authentication in specific build targets despite being mostly a config refactor.
> 
> **Overview**
> OAuth client IDs/redirect URIs are now **defined per build type** in `OAuthLoginHandlers/config.ts` and consumed via `CURRENT_OAUTH_CONFIG` in `constants.ts`, instead of being read from `process.env`.
> 
> The example env file removes the seedless-onboarding client ID entries, and unit tests are updated to assert against `OAUTH_CONFIG.main_prod` values for Android and legacy iOS Google config selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd46114bde615157ccb5c05dccc978ea1130af83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->