### PR TITLE
fix: validate type of security data in token details and fetch when necessary cp-7.76.0

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenSecurityData.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenSecurityData.test.ts
@@ -109,6 +109,42 @@ describe('useTokenSecurityData', () => {
     expect(result.current.securityData).toBeNull();
   });
 
+  it('ignores prefetchedData with wrong shape and fetches instead', async () => {
+    const assetId = 'eip155:1/erc20:0x1234' as CaipAssetType;
+    mockFetchTokenAssets.mockResolvedValue([
+      {
+        assetId,
+        name: 'Test Token',
+        symbol: 'TEST',
+        decimals: 18,
+        securityData: mockSecurityData,
+      },
+    ]);
+
+    // Bridge SecurityData shape: { type: "Verified" } — missing resultType
+    const wrongShapedData = {
+      type: 'Verified',
+    } as unknown as TokenSecurityData;
+
+    const { result } = renderHook(() =>
+      useTokenSecurityData({
+        assetId,
+        prefetchedData: wrongShapedData,
+      }),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchTokenAssets).toHaveBeenCalledWith([assetId], {
+      includeTokenSecurityData: true,
+    });
+    expect(result.current.securityData).toBe(mockSecurityData);
+  });
+
   it('does not fetch when assetId is null', () => {
     const { result } = renderHook(() =>
       useTokenSecurityData({ assetId: null }),

--- a/app/components/UI/TokenDetails/hooks/useTokenSecurityData.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenSecurityData.ts
@@ -18,10 +18,20 @@ interface UseTokenSecurityDataResult {
   error: Error | null;
 }
 
+const isValidTokenSecurityData = (data: unknown): data is TokenSecurityData =>
+  data != null &&
+  typeof data === 'object' &&
+  typeof (data as TokenSecurityData).resultType === 'string' &&
+  Array.isArray((data as TokenSecurityData).features);
+
 export const useTokenSecurityData = ({
   assetId,
-  prefetchedData,
+  prefetchedData: rawPrefetchedData,
 }: UseTokenSecurityDataOpts): UseTokenSecurityDataResult => {
+  const prefetchedData = isValidTokenSecurityData(rawPrefetchedData)
+    ? rawPrefetchedData
+    : undefined;
+
   const [securityData, setSecurityData] = useState<TokenSecurityData | null>(
     prefetchedData ?? null,
   );


### PR DESCRIPTION


## **Description**

### Bug
When navigating from the Swap/Bridge "Select token" screen to Token Details via the (i) icon, security info (badge, SecurityTrustEntryCard, warning banners) is missing.

### Root Cause
The Bridge `/getTokens/popular` API returns security data in a different shape `({ type: "Verified" })` than what Token Details expects `({ resultType: "Verified", features: [...], ... })`. When navigating, the entire token object — including this wrong-shaped securityData — is spread into route params. `useTokenSecurityData` sees it as `truthy` prefetched data, skips its own API call, and the UI reads resultType / features → undefined → nothing renders.

### Fix
Added a runtime type guard in `useTokenSecurityData` that validates `prefetchedData` has the required `resultType` (string) and features (array) before trusting it. If the shape is invalid, the hook falls through to `fetchTokenAssets()` and gets the full, correctly-shaped data.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed security badges and trust info now display correctly on Token Details when navigating from the Swap token selector.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/1dbc3bbd-293d-4b90-a473-8ce505b8c718


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/61466686-09a6-45db-8961-7fd5d4690ff8


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small runtime type guard and a focused test to ensure `useTokenSecurityData` falls back to fetching when prefetched security data is malformed.
> 
> **Overview**
> Fixes Token Details security UI missing when navigating from Swap/Bridge by **validating `prefetchedData` at runtime** in `useTokenSecurityData` (requires `resultType` string and `features` array) and treating invalid shapes as absent so the hook fetches via `fetchTokenAssets`.
> 
> Adds a regression test covering the Bridge-style wrong-shaped data to ensure the hook ignores it and fetches correct security data instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9c4c841bccbb38677f7c089e4aaac5f1a238d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->