### PR TITLE
chore: bump @metamask/ramps-controller to 13.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.0.2",
-    "@metamask/ramps-controller": "^13.2.0",
+    "@metamask/ramps-controller": "^13.3.0",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/react-native-acm": "1.2.0",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9620,6 +9620,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ramps-controller@npm:^13.3.0":
+  version: 13.3.0
+  resolution: "@metamask/ramps-controller@npm:13.3.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/messenger": "npm:^1.2.0"
+  checksum: 10/7e90a3e6cd1d7c9921e51b601cccb3df0c6466074153116f3f890582ef101f7b2680e717253a931c322d39099d1ac1a3966113e84ec43a35a36b963e8ec4dc6f
+  languageName: node
+  linkType: hard
+
 "@metamask/react-data-query@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/react-data-query@npm:0.2.0"
@@ -35709,7 +35720,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^13.2.0"
+    "@metamask/ramps-controller": "npm:^13.3.0"
     "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/react-native-acm": "npm:1.2.0"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## Summary

- Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0`.
- Picks up the circuit-breaker error-key fix from [MetaMask/core#8596](https://github.com/MetaMask/core/pull/8596) so clients can localize the fallback copy via the stable `CIRCUIT_BREAKER_OPEN` error key without depending on internal Cockatiel text.
- Released in [MetaMask/core#8698 (Release/959.0.0)](https://github.com/MetaMask/core/pull/8698).

## Test plan

- [ ] CI green (lint, type check, unit tests)
- [ ] Trigger the ramps circuit-breaker on UB2 buy and confirm the new `CIRCUIT_BREAKER_OPEN` error key surfaces in the localizable fallback copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change but it updates ramp/circuit-breaker behavior and error surfaces, which can impact on-ramp/off-ramp user flows and localization.
> 
> **Overview**
> Updates `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` in `package.json` and refreshes `yarn.lock` accordingly.
> 
> The lockfile update pulls in the new `@metamask/ramps-controller` release (including its updated `@metamask/messenger` requirement), aligning the app with the latest ramps controller fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc9150463a6e63db3055af01fd14589d38c9de1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->