### PR TITLE
ci(workflows): ternary GRADLE_USER_HOME for namespace runner

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-build' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' }} # Optimized for lg runner (48GB) with conservative memory settings
     timeout-minutes: 40
     env:
-      GRADLE_USER_HOME: /home/admin/_work/.gradle
+      GRADLE_USER_HOME: ${{ inputs.runner_provider == 'namespace' && '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle' }}
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)
       YARN_ENABLE_GLOBAL_CACHE: 'true' # Enable Yarn global cache for faster installs
     outputs:


### PR DESCRIPTION
Phase 2 follow-up — cross-provider env-var divergence not handled by Phase 0.

`build-android-e2e.yml` hardcodes `GRADLE_USER_HOME: /home/admin/_work/.gradle` — that path is the Cirrus `cirruslabs/ubuntu-runner-amd64` runner's home (user `admin`). On Namespace runners the user is `runner`, so Gradle fails to create the lock-file directory.

This PR ternaries the env var on `runner_provider`, mirroring Phase 0's `runs-on` ternary pattern:

```yaml
GRADLE_USER_HOME: ${{ inputs.runner_provider == 'namespace' && '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle' }}
```

Behaviour on `runner_provider: current` is byte-identical (the second branch returns the original Cirrus path).

Validated end-to-end on the integration-test branch: https://github.com/MetaMask/metamask-mobile/actions/runs/25435437017 (Build Android APKs ✓ in 20m56s, all 26 Android E2E smoke jobs ✓).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts a Gradle cache path to match the user home on Namespace runners; behavior on the existing Cirrus runner remains the same.
> 
> **Overview**
> Updates the `build-android-e2e.yml` workflow to set `GRADLE_USER_HOME` via a `runner_provider` conditional, using `/home/runner/_work/.gradle` on Namespace runners and preserving the existing `/home/admin/_work/.gradle` path on the Cirrus runner.
> 
> This prevents Gradle failures on Namespace due to an incorrect home directory while keeping the current provider behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22e19233bc8c68c18263ba5b3e909abfc16ef99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->