### PR TITLE
fix(activity): correct EVM rows when non-EVM account selected

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -26,7 +26,10 @@ import {
 } from '@metamask/transaction-controller';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { selectTickerByChainId } from '../../../selectors/networkController';
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
+import {
+  selectSelectedInternalAccount,
+  selectSelectedInternalAccountAddress,
+} from '../../../selectors/accountsController';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectPrimaryCurrency } from '../../../selectors/settings';
 import {
@@ -56,7 +59,7 @@ import {
   selectCurrencyRates,
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
-import { selectTokensByChainIdAndAddress } from '../../../selectors/tokensController';
+import { selectTokensByChainIdAndWalletAddress } from '../../../selectors/tokensController';
 import Routes from '../../../constants/navigation/Routes';
 import {
   hasGasFeeTokenSelected,
@@ -225,6 +228,10 @@ class TransactionElement extends PureComponent {
      */
     txChainId: PropTypes.string,
     /**
+     * Selected wallet address for decoding and token map (optional override from parent)
+     */
+    selectedAddress: PropTypes.string,
+    /**
      * Ticker
      */
     ticker: PropTypes.string,
@@ -278,7 +285,8 @@ class TransactionElement extends PureComponent {
   componentDidUpdate(prevProps) {
     if (
       prevProps.txChainId !== this.props.txChainId ||
-      prevProps.swapsTransactions !== this.props.swapsTransactions
+      prevProps.swapsTransactions !== this.props.swapsTransactions ||
+      prevProps.selectedAddress !== this.props.selectedAddress
     ) {
       this.componentDidMount();
     }
@@ -738,21 +746,29 @@ class TransactionElement extends PureComponent {
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  selectedInternalAccount: selectSelectedInternalAccount(state),
-  selectSelectedAccountGroupInternalAccounts:
-    selectSelectedAccountGroupInternalAccounts(state),
-  primaryCurrency: selectPrimaryCurrency(state),
-  swapsTransactions: selectSwapsTransactions(state),
-  ticker: selectTickerByChainId(state, ownProps.txChainId),
-  conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
-  currencyRates: selectCurrencyRates(state),
-  contractExchangeRates: selectContractExchangeRatesByChainId(
-    state,
-    ownProps.txChainId,
-  ),
-  tokens: selectTokensByChainIdAndAddress(state, ownProps.txChainId),
-});
+const mapStateToProps = (state, ownProps) => {
+  const walletAddressForTokens =
+    ownProps.selectedAddress ?? selectSelectedInternalAccountAddress(state);
+  return {
+    selectedInternalAccount: selectSelectedInternalAccount(state),
+    selectSelectedAccountGroupInternalAccounts:
+      selectSelectedAccountGroupInternalAccounts(state),
+    primaryCurrency: selectPrimaryCurrency(state),
+    swapsTransactions: selectSwapsTransactions(state),
+    ticker: selectTickerByChainId(state, ownProps.txChainId),
+    conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
+    currencyRates: selectCurrencyRates(state),
+    contractExchangeRates: selectContractExchangeRatesByChainId(
+      state,
+      ownProps.txChainId,
+    ),
+    tokens: selectTokensByChainIdAndWalletAddress(
+      state,
+      ownProps.txChainId,
+      walletAddressForTokens,
+    ),
+  };
+};
 
 TransactionElement.contextType = ThemeContext;
 

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -632,7 +632,9 @@ const UnifiedTransactionsView = ({
           i={index}
           navigation={navigation}
           txChainId={getEvmChainId(item.tx)}
-          selectedAddress={selectedInternalAccount?.address}
+          selectedAddress={
+            selectedAccountGroupEvmAddress || selectedInternalAccount?.address
+          }
           onSpeedUpAction={onSpeedUpAction}
           onCancelAction={onCancelAction}
           signQRTransaction={signQRTransaction}

--- a/app/selectors/tokensController.test.ts
+++ b/app/selectors/tokensController.test.ts
@@ -10,6 +10,7 @@ import {
   selectAllDetectedTokensForSelectedAddress,
   selectAllDetectedTokensFlat,
   selectTokensByChainIdAndAddress,
+  selectTokensByChainIdAndWalletAddress,
   getChainIdsToPoll,
   selectSingleTokenByAddressAndChainId,
 } from './tokensController';
@@ -333,6 +334,34 @@ describe('TokensController Selectors', () => {
     it('returns empty object if no tokens exist for chain ID', () => {
       expect(
         selectTokensByChainIdAndAddress(mockRootState, '0x2'),
+      ).toStrictEqual({});
+    });
+  });
+
+  describe('selectTokensByChainIdAndWalletAddress', () => {
+    it('returns tokens for the given chain and explicit wallet address', () => {
+      expect(
+        selectTokensByChainIdAndWalletAddress(
+          mockRootState,
+          '0x1',
+          '0xAddress2',
+        ),
+      ).toStrictEqual({ '0xToken2': mockToken2 });
+    });
+
+    it('returns empty object when wallet address has no tokens on that chain', () => {
+      expect(
+        selectTokensByChainIdAndWalletAddress(
+          mockRootState,
+          '0x2',
+          '0xAddress1',
+        ),
+      ).toStrictEqual({});
+    });
+
+    it('returns empty object when wallet address is undefined', () => {
+      expect(
+        selectTokensByChainIdAndWalletAddress(mockRootState, '0x1', undefined),
       ).toStrictEqual({});
     });
   });

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -53,6 +53,34 @@ export const selectTokensByChainIdAndAddress = createDeepEqualSelector(
     ) ?? {},
 );
 
+/**
+ * Like {@link selectTokensByChainIdAndAddress} but uses an explicit account
+ * address (e.g. the EVM address for the account group) instead of the globally
+ * selected account. Needed when the UI shows EVM activity while a non-EVM
+ * account is still selected.
+ */
+export const selectTokensByChainIdAndWalletAddress = createDeepEqualSelector(
+  getTokensControllerAllTokens,
+  (_state: RootState, chainId: Hex, _walletAddress: Hex | string | undefined) =>
+    chainId,
+  (_state: RootState, _chainId: Hex, walletAddress: Hex | string | undefined) =>
+    walletAddress,
+  (
+    allTokens: TokensControllerState['allTokens'],
+    chainId: Hex,
+    walletAddress: Hex | string | undefined,
+  ) =>
+    !walletAddress
+      ? {}
+      : (allTokens[chainId]?.[walletAddress as Hex]?.reduce(
+          (tokensMap: { [address: string]: Token }, token: Token) => ({
+            ...tokensMap,
+            [token.address]: token,
+          }),
+          {},
+        ) ?? {}),
+);
+
 export const selectTokensByAddress = createSelector(
   selectTokens,
   (tokens: Token[]) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity’s unified transaction list passes `selectedAddress` into `TransactionElement` and Redux token selectors keyed by account. Those paths previously used the **globally selected** internal account. After switching the Activity network filter from a non-EVM network (e.g. Bitcoin) back to **all popular networks**, the selected account could still be non-EVM while EVM transactions remained in the list. EVM sends were compared against a non-EVM address (wrong direction / “Received”), and token metadata was looked up under the wrong account key on each chain (“Not available”).

This change passes the account group’s **EVM** address for EVM rows (`UnifiedTransactionsView`), re-decodes when `selectedAddress` changes (`TransactionElement`), and adds `selectTokensByChainIdAndWalletAddress` so token maps match the same wallet address used for decoding.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Activity showing incorrect Sent/Received labels and "Not available" amounts after switching from a non-EVM network filter back to all popular networks.

## **Related issues**

Fixes: #28035

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-602

## **Manual testing steps**

```gherkin
Feature: Activity unified list after network filter change

  Scenario: EVM sends stay correct after non-EVM filter then popular networks
    Given the user has confirmed token sends on an EVM network (e.g. Linea)
    And Activity Transactions tab is open with the network filter set to that EVM chain

    When the user switches the filter to a non-EVM network (e.g. Bitcoin)
    And the user switches the filter back to all popular networks

    Then top EVM transactions still show Sent (not Received) with token amounts and fiat where applicable (not "Not available")
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

see video on [this comment](https://github.com/MetaMask/metamask-mobile/issues/28035#issuecomment-4387402519) from #28035 

### **After**


https://github.com/user-attachments/assets/6e44a38c-9830-4aa4-a08d-63439533e74c



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Activity derives the address used to classify EVM transactions and fetch per-chain token metadata, which can alter Sent/Received labeling and displayed amounts across the unified list. Risk is limited to UI/state selection logic and is covered by added selector tests.
> 
> **Overview**
> Fixes unified Activity rendering when a non-EVM account remains selected by ensuring EVM list rows use the account group’s **EVM address** for direction/decoding and token metadata.
> 
> `UnifiedTransactionsView` now passes the account group EVM address into `TransactionElement`, `TransactionElement` re-decodes when `selectedAddress` changes, and token lookup is switched to a new selector `selectTokensByChainIdAndWalletAddress` (with tests) so token maps are keyed by the same explicit wallet address rather than the globally selected account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7910a161e98ead65ebe6c2f6c5cd7b5aa4652a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->