### PR TITLE
fix(rewards): remove sign for rebalance events

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/OndoActivityRow.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoActivityRow.test.tsx
@@ -104,6 +104,18 @@ describe('OndoActivityRow', () => {
     expect(getByText('—')).toBeDefined();
   });
 
+  it('renders rebalance entry USD without a plus sign for positive amounts', () => {
+    const { getByText } = render(
+      <OndoActivityRow
+        entry={createEntry({ type: 'REBALANCE', usdAmount: '5000.000000' })}
+      />,
+    );
+
+    expect(getByText('Rebalance')).toBeDefined();
+    // formatUsd (rebalance) has no '+'; deposit/withdraw still use mocked formatSignedUsd
+    expect(getByText(/^\$5,000/)).toBeDefined();
+  });
+
   it('renders external outflow entry with shortened destAddress', () => {
     const { getByText } = render(
       <OndoActivityRow

--- a/app/components/UI/Rewards/components/Campaigns/OndoActivityRow.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoActivityRow.tsx
@@ -29,6 +29,7 @@ import {
   formatRewardsDate,
   formatRewardsTimeOnly,
   formatSignedUsd,
+  formatUsd,
   getChainHex,
   shortenAddress,
 } from '../../utils/formatUtils';
@@ -50,6 +51,24 @@ const LABEL_KEY_MAP: Record<ActivityEntryType, string> = {
 
 const tokenLabel = (token: ActivityTokenDto): string =>
   token.tokenSymbol || token.tokenName;
+
+/** Rebalance USD is not portfolio P&L; omit the '+' used for signed inflows/outflows. */
+const formatActivityUsd = (
+  usdAmount: OndoGmActivityEntryDto['usdAmount'],
+  entryType: ActivityEntryType,
+): string => {
+  if (entryType !== 'REBALANCE') {
+    return formatSignedUsd(usdAmount);
+  }
+  if (usdAmount === null) {
+    return '—';
+  }
+  const num = typeof usdAmount === 'number' ? usdAmount : parseFloat(usdAmount);
+  if (Number.isNaN(num)) {
+    return '—';
+  }
+  return formatUsd(usdAmount);
+};
 
 interface OndoActivityRowProps {
   entry: OndoGmActivityEntryDto;
@@ -123,7 +142,7 @@ const OndoActivityRow: React.FC<OndoActivityRowProps> = ({
             {label}
           </Text>
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-            {formatSignedUsd(entry.usdAmount)}
+            {formatActivityUsd(entry.usdAmount, entryType)}
           </Text>
         </Box>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-1264
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-05-06 at 11 15 48" src="https://github.com/user-attachments/assets/8ed005e3-a515-4a41-872d-05bf1d489a0d" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI formatting change limited to `OndoActivityRow` display logic, with added test coverage; no business logic, persistence, or security-sensitive code impacted.
> 
> **Overview**
> Updates Ondo campaign activity rows so **`REBALANCE` entries display USD amounts without the leading `+` sign**, while deposits/withdrawals/outflows continue to use signed USD formatting.
> 
> Adds a small helper (`formatActivityUsd`) to special-case rebalance values (returning `—` for `null`/non-numeric inputs) and extends the unit test suite to assert the new rebalance formatting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea01cd4054470ff8ac62c375e609a8da57a1657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->