### PR TITLE
fix: show sort direction in filter bar in trending list

### DIFF
--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -50,7 +50,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
           <Icon name={iconName} color={IconColor.Default} size={IconSize.Sm} />
         )}
         <Text
-          style={tw`min-w-0 text-[14px] font-medium text-default`}
+          style={tw`min-w-0 shrink text-[14px] font-medium text-default`}
           numberOfLines={numberOfLines}
           ellipsizeMode={ellipsizeMode}
         >

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -46,15 +46,20 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
       disabled={disabled}
     >
       <View style={tw`flex-row items-center justify-center gap-1`}>
+        <Icon
+          name={iconName}
+          color={IconColor.Alternative}
+          size={IconSize.Xs}
+        />
         <Text
-          style={tw`min-w-0 shrink text-[14px] font-medium text-default`}
+          style={tw`min-w-0 text-[14px] font-medium text-default`}
           numberOfLines={numberOfLines}
           ellipsizeMode={ellipsizeMode}
         >
           {label}
         </Text>
         <Icon
-          name={iconName}
+          name={IconName.ArrowDown}
           color={IconColor.Alternative}
           size={IconSize.Xs}
         />

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -17,7 +17,7 @@ export interface FilterButtonProps {
   ellipsizeMode?: 'tail' | 'head' | 'middle' | 'clip';
   /** Optional Tailwind class overrides for layout in custom contexts */
   twClassName?: string;
-  /** Optional icon name to replace the default ArrowDown icon */
+  /** Optional icon name to show before the label (e.g., for sort direction indicators) */
   iconName?: IconName;
 }
 
@@ -29,7 +29,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
   numberOfLines,
   ellipsizeMode,
   twClassName,
-  iconName = IconName.ArrowDown,
+  iconName,
 }) => {
   const tw = useTailwind();
 
@@ -46,11 +46,13 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
       disabled={disabled}
     >
       <View style={tw`flex-row items-center justify-center gap-1`}>
-        <Icon
-          name={iconName}
-          color={IconColor.Alternative}
-          size={IconSize.Xs}
-        />
+        {iconName && (
+          <Icon
+            name={iconName}
+            color={IconColor.Alternative}
+            size={IconSize.Xs}
+          />
+        )}
         <Text
           style={tw`min-w-0 text-[14px] font-medium text-default`}
           numberOfLines={numberOfLines}

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -47,11 +47,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
     >
       <View style={tw`flex-row items-center justify-center gap-1`}>
         {iconName && (
-          <Icon
-            name={iconName}
-            color={IconColor.Alternative}
-            size={IconSize.Xs}
-          />
+          <Icon name={iconName} color={IconColor.Default} size={IconSize.Sm} />
         )}
         <Text
           style={tw`min-w-0 text-[14px] font-medium text-default`}

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -17,6 +17,8 @@ export interface FilterButtonProps {
   ellipsizeMode?: 'tail' | 'head' | 'middle' | 'clip';
   /** Optional Tailwind class overrides for layout in custom contexts */
   twClassName?: string;
+  /** Optional icon name to replace the default ArrowDown icon */
+  iconName?: IconName;
 }
 
 export const FilterButton: React.FC<FilterButtonProps> = ({
@@ -27,6 +29,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
   numberOfLines,
   ellipsizeMode,
   twClassName,
+  iconName = IconName.ArrowDown,
 }) => {
   const tw = useTailwind();
 
@@ -51,7 +54,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
           {label}
         </Text>
         <Icon
-          name={IconName.ArrowDown}
+          name={iconName}
           color={IconColor.Alternative}
           size={IconSize.Xs}
         />
@@ -64,6 +67,8 @@ export interface FilterBarProps {
   priceChangeButtonText: string;
   onPriceChangePress: () => void;
   isPriceChangeDisabled?: boolean;
+  /** Optional icon name for the price change button */
+  priceChangeIconName?: IconName;
 
   networkName: string;
   onNetworkPress: () => void;
@@ -81,6 +86,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
   priceChangeButtonText,
   onPriceChangePress,
   isPriceChangeDisabled = false,
+  priceChangeIconName,
   networkName,
   onNetworkPress,
   extraFilters,
@@ -95,6 +101,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           label={priceChangeButtonText}
           onPress={onPriceChangePress}
           disabled={isPriceChangeDisabled}
+          iconName={priceChangeIconName}
         />
         <View style={tw`ml-2 min-w-0 shrink flex-row items-center gap-2`}>
           <FilterButton

--- a/app/components/UI/Trending/components/TokenListPageLayout/TokenListPageLayout.tsx
+++ b/app/components/UI/Trending/components/TokenListPageLayout/TokenListPageLayout.tsx
@@ -88,6 +88,7 @@ const TokenListPageLayout: React.FC<TokenListPageLayoutProps> = ({
           priceChangeButtonText={filters.priceChangeButtonText}
           onPriceChangePress={filters.handlePriceChangePress}
           isPriceChangeDisabled={searchResults.length === 0}
+          priceChangeIconName={filters.priceChangeSortDirectionIcon}
           networkName={filters.selectedNetworkName}
           onNetworkPress={filters.handleAllNetworksPress}
           extraFilters={extraFilters}

--- a/app/components/UI/Trending/hooks/useTokenListFilters/useTokenListFilters.test.ts
+++ b/app/components/UI/Trending/hooks/useTokenListFilters/useTokenListFilters.test.ts
@@ -7,6 +7,7 @@ import {
   TimeOption,
 } from '../../components/TrendingTokensBottomSheet';
 import type { CaipChainId } from '@metamask/utils';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
 
 const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -281,6 +282,50 @@ describe('useTokenListFilters', () => {
       );
 
       expect(result.current.priceChangeButtonText).toBe('Market cap');
+    });
+  });
+
+  describe('priceChangeSortDirectionIcon', () => {
+    it('returns Arrow2Down for descending sort direction', () => {
+      const { result } = renderFilters();
+
+      expect(result.current.priceChangeSortDirectionIcon).toBe(
+        IconName.Arrow2Down,
+      );
+    });
+
+    it('returns Arrow2Up for ascending sort direction', () => {
+      const { result } = renderFilters();
+
+      act(() =>
+        result.current.handlePriceChangeSelect(
+          PriceChangeOption.Volume,
+          SortDirection.Ascending,
+        ),
+      );
+
+      expect(result.current.priceChangeSortDirectionIcon).toBe(
+        IconName.Arrow2Up,
+      );
+    });
+
+    it('updates when sort direction changes', () => {
+      const { result } = renderFilters();
+
+      expect(result.current.priceChangeSortDirectionIcon).toBe(
+        IconName.Arrow2Down,
+      );
+
+      act(() =>
+        result.current.handlePriceChangeSelect(
+          PriceChangeOption.PriceChange,
+          SortDirection.Ascending,
+        ),
+      );
+
+      expect(result.current.priceChangeSortDirectionIcon).toBe(
+        IconName.Arrow2Up,
+      );
     });
   });
 

--- a/app/components/UI/Trending/hooks/useTokenListFilters/useTokenListFilters.ts
+++ b/app/components/UI/Trending/hooks/useTokenListFilters/useTokenListFilters.ts
@@ -11,6 +11,7 @@ import {
 import type { TrendingFilterContext } from '../../components/TrendingTokensList/TrendingTokensList';
 import TrendingFeedSessionManager from '../../services/TrendingFeedSessionManager';
 import { useNetworkName } from '../useNetworkName/useNetworkName';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
 
 interface UseTokenListFiltersOptions {
   /**
@@ -49,6 +50,7 @@ export interface TokenListFilters {
   ) => void;
   handlePriceChangePress: () => void;
   priceChangeButtonText: string;
+  priceChangeSortDirectionIcon: IconName;
 
   // Time
   selectedTimeOption: TimeOption;
@@ -189,6 +191,14 @@ export const useTokenListFilters = (
     }
   }, [selectedPriceChangeOption]);
 
+  const priceChangeSortDirectionIcon = useMemo(
+    () =>
+      priceChangeSortDirection === SortDirection.Ascending
+        ? IconName.Arrow2Up
+        : IconName.Arrow2Down,
+    [priceChangeSortDirection],
+  );
+
   const filterContext: TrendingFilterContext = useMemo(
     () => ({
       timeFilter: selectedTimeOption,
@@ -226,6 +236,7 @@ export const useTokenListFilters = (
     handlePriceChangeSelect,
     handlePriceChangePress,
     priceChangeButtonText,
+    priceChangeSortDirectionIcon,
     selectedTimeOption,
     setSelectedTimeOption,
     refreshing,


### PR DESCRIPTION


## **Description**

Add sort direction indicators to trending token filter buttons to improve UX by making the current sort order immediately visible.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds sort icons on filter bar in trending list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3152

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/2b7ac0c1-fe27-4ec8-bcd3-2bcd459ce306



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI enhancement that only adds derived state and icon rendering for the sort button; minimal chance of regressions outside the Trending filter bar layout.
> 
> **Overview**
> Adds a sort-direction indicator to the Trending token list price-change filter.
> 
> `FilterButton`/`FilterBar` now accept an optional `iconName`/`priceChangeIconName` and render that icon before the label. `useTokenListFilters` exposes a new `priceChangeSortDirectionIcon` (up/down) derived from `priceChangeSortDirection`, `TokenListPageLayout` wires it into the `FilterBar`, and tests cover the new icon mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6e9263a72ba62f0e94d500ff3ba36832a20a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->