### PR TITLE
fix(android): inject webview script at document start

### DIFF
--- a/patches/@metamask+react-native-webview+14.6.0.patch
+++ b/patches/@metamask+react-native-webview+14.6.0.patch
@@ -1,0 +1,68 @@
+diff --git a/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java b/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+index 3f9aa9c998..62acefe282 100644
+--- a/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
++++ b/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+@@ -26,0 +27 @@ import androidx.webkit.JavaScriptReplyProxy;
++import androidx.webkit.ScriptHandler;
+@@ -61,0 +63 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
++    protected @Nullable ScriptHandler injectedJSBeforeContentLoadedScriptHandler;
+@@ -371,0 +374,4 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
++        if (isDocumentStartJavaScriptSupported()) {
++            return;
++        }
++
+@@ -379,0 +386,39 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
++    public boolean isDocumentStartJavaScriptSupported() {
++        return WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT);
++    }
++
++    public void resetDocumentStartJavaScript() {
++        if (!isDocumentStartJavaScriptSupported()) {
++            return;
++        }
++
++        removeDocumentStartJavaScript();
++
++        if (getSettings().getJavaScriptEnabled() &&
++                injectedJSBeforeContentLoaded != null &&
++                !TextUtils.isEmpty(injectedJSBeforeContentLoaded)) {
++            injectedJSBeforeContentLoadedScriptHandler = WebViewCompat.addDocumentStartJavaScript(
++                    this,
++                    getWrappedInjectedJavaScriptBeforeContentLoaded(),
++                    Set.of("*"));
++        }
++    }
++
++    protected void removeDocumentStartJavaScript() {
++        if (injectedJSBeforeContentLoadedScriptHandler != null) {
++            injectedJSBeforeContentLoadedScriptHandler.remove();
++            injectedJSBeforeContentLoadedScriptHandler = null;
++        }
++    }
++
++    protected String getWrappedInjectedJavaScriptBeforeContentLoaded() {
++        if (!injectedJavaScriptBeforeContentLoadedForMainFrameOnly) {
++            return "(function() {\n" + injectedJSBeforeContentLoaded + ";\n})();";
++        }
++
++        return "(function() {\n" +
++                "  try { if (window.self !== window.top) { return; } } catch (_) { return; }\n" +
++                injectedJSBeforeContentLoaded + ";\n" +
++                "})();";
++    }
++
+@@ -473,0 +519 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
++        removeDocumentStartJavaScript();
+diff --git a/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt b/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+index b19f456155..3dfb567f17 100644
+--- a/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
++++ b/node_modules/@metamask/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+@@ -325,0 +326,2 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
++        viewWrapper.webView.resetDocumentStartJavaScript()
++
+@@ -551,0 +554 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
++        view.resetDocumentStartJavaScript()
+@@ -561,0 +565 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
++        view.resetDocumentStartJavaScript()
+@@ -601,0 +606 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
++        view.resetDocumentStartJavaScript()

--- a/scripts/react-native-webview-document-start-patch.test.ts
+++ b/scripts/react-native-webview-document-start-patch.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const patchPath = resolve(
+  __dirname,
+  '..',
+  'patches',
+  '@metamask+react-native-webview+14.6.0.patch',
+);
+
+const patch = readFileSync(patchPath, 'utf8');
+
+describe('@metamask/react-native-webview document-start patch', () => {
+  it('registers AndroidX document-start injection before loading the source', () => {
+    expect(patch).toContain('WebViewFeature.DOCUMENT_START_SCRIPT');
+    expect(patch).toContain('WebViewCompat.addDocumentStartJavaScript');
+    expect(patch).toContain('viewWrapper.webView.resetDocumentStartJavaScript()');
+  });
+
+  it('keeps the legacy evaluateJavascript path as an unsupported-device fallback', () => {
+    expect(patch).toContain('if (isDocumentStartJavaScriptSupported()) {');
+    expect(patch).not.toContain('-            evaluateJavascriptWithFallback');
+    expect(patch).toContain('window.self !== window.top');
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Patches `@metamask/react-native-webview@14.6.0` on Android so `injectedJavaScriptBeforeContentLoaded` uses AndroidX `WebViewCompat.addDocumentStartJavaScript` when `WebViewFeature.DOCUMENT_START_SCRIPT` is supported.

The patch registers the document-start script before `loadSource`, refreshes the registration when relevant props change, preserves the existing `evaluateJavascript` path as the unsupported-device fallback, and keeps the default main-frame-only behavior with a small frame guard.

Validation so far:

- `patch -d /tmp/rnw-mm-doc-start-verify -p4 --dry-run -i patches/@metamask+react-native-webview+14.6.0.patch`
- Static Node invariant check for the patch contents
- `yarn jest scripts/react-native-webview-document-start-patch.test.ts --runInBand` could not run locally because this checkout has no `node_modules` state file

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Android WebView document-start provider injection

  Scenario: dapp inline script checks the provider during document start
    Given the Android WebView implementation supports DOCUMENT_START_SCRIPT
    And a browser tab loads a dapp whose first inline script checks window.ethereum

    When the dapp document begins loading
    Then the injected provider script runs before the dapp inline script continues
```

## **Screenshots/Recordings**

<!-- Not applicable: this is a native WebView injection timing change with no direct visual UI. -->

### **Before**

<!-- Not applicable. -->

### **After**

<!-- Not applicable. -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I have followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I have completed the PR template to the best of my ability
- [ ] I have included tests if applicable
- [ ] I have documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I have applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

<!-- Not applicable for this draft until native Android device validation is available. -->

- [ ] I have tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I have tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I have instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I have manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
