### PR TITLE
fix: handle update position tpsl error handling, dedupe flipPosition trace

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsFlipPosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsFlipPosition.test.ts
@@ -199,7 +199,7 @@ describe('usePerpsFlipPosition', () => {
     expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
   });
 
-  it('handles exceptions and logs via Logger.error', async () => {
+  it('surfaces exception via toast and onError without double-reporting to Sentry', async () => {
     const testError = new Error('Network error');
     mockFlipPosition.mockRejectedValue(testError);
     const mockOnError = jest.fn();
@@ -212,31 +212,13 @@ describe('usePerpsFlipPosition', () => {
       await result.current.handleFlipPosition(mockLongPosition);
     });
 
-    expect(Logger.error).toHaveBeenCalledWith(
-      testError,
-      expect.objectContaining({
-        tags: expect.objectContaining({
-          feature: 'perps',
-          component: 'usePerpsFlipPosition',
-          action: 'flip_position',
-          operation: 'position_management',
-        }),
-        context: expect.objectContaining({
-          name: 'usePerpsFlipPosition',
-          data: expect.objectContaining({
-            symbol: 'ETH',
-            size: '2.5',
-            currentDirection: 'long',
-            targetDirection: 'short',
-            positionSize: 2.5,
-          }),
-        }),
-      }),
-    );
+    // Sentry reporting is handled at the controller layer; the UI hook must not duplicate it
+    expect(Logger.error).not.toHaveBeenCalled();
+    expect(mockShowToast).toHaveBeenCalled();
     expect(mockOnError).toHaveBeenCalledWith('Network error');
   });
 
-  it('handles non-Error exceptions', async () => {
+  it('handles non-Error exceptions with fallback message without double-reporting to Sentry', async () => {
     mockFlipPosition.mockRejectedValue('String error');
     const mockOnError = jest.fn();
 
@@ -248,19 +230,9 @@ describe('usePerpsFlipPosition', () => {
       await result.current.handleFlipPosition(mockLongPosition);
     });
 
-    const [loggedError, loggerContext] = (Logger.error as jest.Mock).mock
-      .calls[0];
-    expect(loggedError).toBeInstanceOf(Error);
-    expect((loggedError as Error).message).toBe('String error');
-    expect(loggerContext).toEqual(
-      expect.objectContaining({
-        context: expect.objectContaining({
-          data: expect.objectContaining({
-            rawError: 'String error',
-          }),
-        }),
-      }),
-    );
+    // Sentry reporting is handled at the controller layer; the UI hook must not duplicate it
+    expect(Logger.error).not.toHaveBeenCalled();
+    expect(mockShowToast).toHaveBeenCalled();
     expect(mockOnError).toHaveBeenCalledWith('perps.errors.unknown');
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsFlipPosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsFlipPosition.ts
@@ -1,12 +1,9 @@
 import { useCallback, useState } from 'react';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import Logger from '../../../../util/Logger';
-import { ensureError } from '../../../../util/errorUtils';
 import { usePerpsTrading } from './usePerpsTrading';
 import {
   getPerpsDisplaySymbol,
-  PERPS_CONSTANTS,
   type Position,
   type OrderDirection,
 } from '@metamask/perps-controller';
@@ -80,34 +77,6 @@ export function usePerpsFlipPosition(options?: UsePerpsFlipPositionOptions) {
         }
       } catch (error) {
         DevLogger.log('Error flipping position:', error);
-
-        Logger.error(ensureError(error, 'usePerpsFlipPosition.handle'), {
-          tags: {
-            feature: PERPS_CONSTANTS.FeatureName,
-            component: 'usePerpsFlipPosition',
-            action: 'flip_position',
-            operation: 'position_management',
-          },
-          context: {
-            name: 'usePerpsFlipPosition',
-            data: {
-              symbol: position.symbol,
-              size: position.size,
-              currentDirection,
-              targetDirection: oppositeDirection,
-              positionSize,
-              entryPrice: position.entryPrice,
-              unrealizedPnl: position.unrealizedPnl,
-              leverage: position.leverage,
-              rawError:
-                error instanceof Error
-                  ? undefined
-                  : error === undefined
-                    ? 'undefined'
-                    : String(error),
-            },
-          },
-        });
 
         const errorMessage =
           error instanceof Error

--- a/app/controllers/perps/services/TradingService.test.ts
+++ b/app/controllers/perps/services/TradingService.test.ts
@@ -1822,6 +1822,39 @@ describe('TradingService', () => {
         undefined,
       );
     });
+
+    it('logs error with message and context when provider throws', async () => {
+      const params: UpdatePositionTPSLParams = {
+        symbol: 'BTC',
+        takeProfitPrice: '55000',
+        stopLossPrice: '45000',
+      };
+
+      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockProvider.updatePositionTPSL.mockRejectedValue(
+        new Error('TPSL provider failure'),
+      );
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await expect(
+        tradingService.updatePositionTPSL({
+          provider: mockProvider,
+          params,
+          context: { ...mockContext, getPositions: mockGetPositions },
+        }),
+      ).rejects.toThrow('TPSL provider failure');
+
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'TPSL provider failure' }),
+        expect.objectContaining({
+          controller: 'TradingService',
+          method: 'updatePositionTPSL',
+          symbol: 'BTC',
+        }),
+      );
+    });
   });
 
   describe('updateMargin', () => {

--- a/app/controllers/perps/services/TradingService.test.ts
+++ b/app/controllers/perps/services/TradingService.test.ts
@@ -1002,6 +1002,33 @@ describe('TradingService', () => {
       expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalled();
     });
 
+    it('logs error when provider returns a failure result without throwing', async () => {
+      const cancelParams: CancelOrderParams = {
+        orderId: 'order-123',
+        symbol: 'BTC',
+      };
+      mockProvider.cancelOrder.mockResolvedValue({
+        success: false,
+        error: 'Order already filled',
+      });
+
+      const result = await tradingService.cancelOrder({
+        provider: mockProvider,
+        params: cancelParams,
+        context: mockContext,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Order already filled' }),
+        expect.objectContaining({
+          controller: 'TradingService',
+          method: 'cancelOrder',
+          symbol: 'BTC',
+        }),
+      );
+    });
+
     it('handles provider exception during order cancel', async () => {
       const cancelParams: CancelOrderParams = {
         orderId: 'order-123',
@@ -1258,6 +1285,80 @@ describe('TradingService', () => {
       expect(result.results).toHaveLength(2);
       expect(mockProvider.cancelOrder).toHaveBeenCalledTimes(2);
     });
+
+    it('logs batch error when provider.cancelOrders returns partial/full failure', async () => {
+      const params: CancelOrdersParams = { cancelAll: true };
+      mockGetOpenOrders.mockResolvedValue(mockOrders);
+      mockWithStreamPause.mockImplementation(
+        async (callback) => await callback(),
+      );
+      (mockProvider.cancelOrders as jest.Mock).mockResolvedValue({
+        success: false,
+        successCount: 0,
+        failureCount: 2,
+        results: [
+          {
+            orderId: 'order-1',
+            symbol: 'BTC',
+            success: false,
+            error: 'rate limit',
+          },
+          {
+            orderId: 'order-2',
+            symbol: 'ETH',
+            success: false,
+            error: 'not found',
+          },
+        ],
+      });
+
+      const result = await tradingService.cancelOrders({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getOpenOrders: mockGetOpenOrders },
+        withStreamPause: mockWithStreamPause,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'cancelOrders batch failure: 2/2 failed',
+          ),
+        }),
+        expect.objectContaining({
+          controller: 'TradingService',
+          method: 'cancelOrders',
+        }),
+      );
+    });
+
+    it('does NOT log batch error when using fallback path (provider.cancelOrders undefined)', async () => {
+      const params: CancelOrdersParams = { cancelAll: true };
+      mockGetOpenOrders.mockResolvedValue(mockOrders);
+      mockWithStreamPause.mockImplementation(
+        async (callback) => await callback(),
+      );
+      delete mockProvider.cancelOrders;
+      mockProvider.cancelOrder.mockResolvedValue({ success: true });
+
+      await tradingService.cancelOrders({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getOpenOrders: mockGetOpenOrders },
+        withStreamPause: mockWithStreamPause,
+      });
+
+      // Batch-level log must not fire; individual leaf logs cover per-order failures
+      const batchErrorCalls = (
+        mockDeps.logger.error as jest.Mock
+      ).mock.calls.filter(
+        ([err]: [Error]) =>
+          err instanceof Error &&
+          err.message.includes('cancelOrders batch failure'),
+      );
+      expect(batchErrorCalls).toHaveLength(0);
+    });
   });
 
   describe('closePosition', () => {
@@ -1462,6 +1563,37 @@ describe('TradingService', () => {
         }),
       );
     });
+
+    it('logs error when provider returns a failure result without throwing', async () => {
+      const params: ClosePositionParams = { symbol: 'BTC' };
+      const mockFailureResult: OrderResult = {
+        success: false,
+        error: 'Insufficient liquidity',
+      };
+
+      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockProvider.closePosition.mockResolvedValue(mockFailureResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      const result = await tradingService.closePosition({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getPositions: mockGetPositions },
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(result).toEqual(mockFailureResult);
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Insufficient liquidity' }),
+        expect.objectContaining({
+          controller: 'TradingService',
+          method: 'closePosition',
+          symbol: 'BTC',
+        }),
+      );
+    });
   });
 
   describe('closePositions', () => {
@@ -1622,6 +1754,70 @@ describe('TradingService', () => {
 
       expect(result.results).toHaveLength(1);
       expect(mockProvider.closePosition).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs batch error when provider.closePositions returns partial/full failure', async () => {
+      const params: ClosePositionsParams = { closeAll: true };
+      (mockProvider.closePositions as jest.Mock).mockResolvedValue({
+        success: false,
+        successCount: 0,
+        failureCount: 2,
+        results: [
+          { symbol: 'BTC', success: false, error: 'insufficient liquidity' },
+          { symbol: 'ETH', success: false, error: 'min size' },
+        ],
+      });
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      const result = await tradingService.closePositions({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getPositions: mockGetPositions },
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'closePositions batch failure: 2/2 failed',
+          ),
+        }),
+        expect.objectContaining({
+          controller: 'TradingService',
+          method: 'closePositions',
+        }),
+      );
+    });
+
+    it('does NOT log batch error when using fallback path (provider.closePositions undefined)', async () => {
+      const params: ClosePositionsParams = { symbols: ['BTC'] };
+      mockGetPositions.mockResolvedValue(mockPositions);
+      delete mockProvider.closePositions;
+      mockProvider.closePosition.mockResolvedValue({
+        success: true,
+        orderId: 'close-1',
+      });
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.closePositions({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getPositions: mockGetPositions },
+      });
+
+      // Batch-level log must not fire; individual leaf logs cover per-position failures
+      const batchErrorCalls = (
+        mockDeps.logger.error as jest.Mock
+      ).mock.calls.filter(
+        ([err]: [Error]) =>
+          err instanceof Error &&
+          err.message.includes('closePositions batch failure'),
+      );
+      expect(batchErrorCalls).toHaveLength(0);
     });
   });
 

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -1123,6 +1123,15 @@ export class TradingService {
           },
         );
 
+        this.#deps.logger.error(
+          ensureError(result.error, 'TradingService.cancelOrder'),
+          this.#getErrorContext('cancelOrder', {
+            symbol: params.symbol,
+            orderId: params.orderId,
+            providerError: result.error ?? 'Unknown error',
+          }),
+        );
+
         traceData = { success: false, error: result.error ?? 'Unknown error' };
       }
 
@@ -1298,6 +1307,31 @@ export class TradingService {
         };
       }, ['orders']); // Disconnect orders stream during operation
 
+      if (
+        provider.cancelOrders &&
+        operationResult &&
+        operationResult.failureCount > 0
+      ) {
+        const failureSummary = operationResult.results
+          .filter((result) => !result.success)
+          .map(
+            (result) =>
+              `${result.symbol}/${result.orderId}: ${result.error ?? 'Unknown error'}`,
+          )
+          .join('; ');
+
+        this.#deps.logger.error(
+          new Error(
+            `cancelOrders batch failure: ${operationResult.failureCount}/${operationResult.results.length} failed - ${failureSummary}`,
+          ),
+          this.#getErrorContext('cancelOrders', {
+            successCount: operationResult.successCount,
+            failureCount: operationResult.failureCount,
+            cancelAll: params.cancelAll,
+          }),
+        );
+      }
+
       return operationResult;
     } catch (error) {
       operationError =
@@ -1416,6 +1450,14 @@ export class TradingService {
         this.#deps.cacheInvalidator.invalidate({ cacheType: 'accountState' });
       } else {
         traceData = { success: false, error: result.error ?? 'Unknown error' };
+
+        this.#deps.logger.error(
+          ensureError(result.error, 'TradingService.closePosition'),
+          this.#getErrorContext('closePosition', {
+            symbol: params.symbol,
+            providerError: result.error ?? 'Unknown error',
+          }),
+        );
       }
 
       // Track analytics (success or failure, includes partial fills)
@@ -1600,6 +1642,31 @@ export class TradingService {
             };
           }),
         };
+      }
+
+      if (
+        provider.closePositions &&
+        operationResult &&
+        operationResult.failureCount > 0
+      ) {
+        const failureSummary = operationResult.results
+          .filter((result) => !result.success)
+          .map(
+            (result) => `${result.symbol}: ${result.error ?? 'Unknown error'}`,
+          )
+          .join('; ');
+
+        this.#deps.logger.error(
+          new Error(
+            `closePositions batch failure: ${operationResult.failureCount}/${operationResult.results.length} failed - ${failureSummary}`,
+          ),
+          this.#getErrorContext('closePositions', {
+            successCount: operationResult.successCount,
+            failureCount: operationResult.failureCount,
+            symbols: params.symbols?.length ?? 0,
+            closeAll: params.closeAll,
+          }),
+        );
       }
 
       return operationResult;

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -1722,6 +1722,16 @@ export class TradingService {
     } catch (error) {
       errorMessage = error instanceof Error ? error.message : 'Unknown error';
       traceData = { success: false, error: errorMessage };
+
+      this.#deps.logger.error(
+        ensureError(error, 'TradingService.updatePositionTPSL'),
+        this.#getErrorContext('updatePositionTPSL', {
+          symbol: params.symbol,
+          hasTakeProfit: Boolean(params.takeProfitPrice),
+          hasStopLoss: Boolean(params.stopLossPrice),
+        }),
+      );
+
       throw error;
     } finally {
       const completionDuration = this.#deps.performance.now() - startTime;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fixes two Perps error-reporting gaps to make Sentry monitoring consistent across all trading write paths in TradingService:

- updatePositionTPSL was silently missing controller-level logging. When a TP/SL update threw, the controller's catch block set traceData and rethrew but never called this.#deps.logger.error. Every other write method in TradingService (cancelOrder, cancelOrders, closePositions, updateMargin) calls logger.error in its catch. This gap is now closed.

- flipPosition errors were double-reported to Sentry. The controller already calls this.#deps.logger.error (which routes to Sentry.captureException) when flipPosition throws. The UI hook usePerpsFlipPosition was catching the rethrown error and calling Logger.error again — sending the same event to Sentry twice. The redundant Logger.error call has been removed from the hook; the controller remains the single source of truth. User-facing feedback (error toast and onError callback) is preserved.

- Fixed Perps trading errors (position close, order cancel) being silently swallowed when the provider reports failure — they now appear in Sentry with the underlying cause message

This will need to be synced with core to include changes to TradingService in order to propagate to extension

## **Changelog**

CHANGELOG entry: Fixed missing controller-level Sentry reporting for TP/SL update failures in the Perps trading service
CHANGELOG entry: Fixed duplicate Sentry reports when a `flipPosition` call throws
Fixed missing Sentry logging when trading operations return a failure result without throwing: `closePosition`, `cancelOrder`, `closePositions`, and `cancelOrders` now call `logger.error` at the controller level

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps trading write paths to change when/where errors are logged and surfaced; low functional risk but could impact Sentry noise and observability if context or failure conditions are incorrect.
> 
> **Overview**
> Improves Perps error reporting consistency by **moving/adding controller-level `logger.error` calls** when providers return failure results (not just when they throw), including single `cancelOrder`/`closePosition` failures and batch `cancelOrders`/`closePositions` partial/full failures.
> 
> Adds missing exception logging for `updatePositionTPSL` so thrown errors are captured with method/symbol context.
> 
> Removes `Logger.error` Sentry reporting from the UI `usePerpsFlipPosition` hook to avoid double-reporting exceptions (toast + `onError` behavior remains), and updates tests to assert the deduped behavior and the new controller logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62304108d348f1005c003bb67f4ab3ee3f8a9cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->