### PR TITLE
fix(Rewards): error when visiting rewards tab cp-7.76.0

### DIFF
--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -146,13 +146,13 @@ function setupDefaults({
   subscriptionId = SUBSCRIPTION_ID,
   outcome = null,
 }: {
-  campaigns?: ReturnType<typeof makeCompletedCampaign>[];
+  campaigns?: ReturnType<typeof makeCompletedCampaign>[] | undefined;
   dismissed?: Record<string, boolean>;
   subscriptionId?: string | null;
   outcome?: BaseCampaignParticipantOutcomeDto | null;
 } = {}) {
   mockUseSelector.mockImplementation((selector) => {
-    if (selector === selectCampaigns) return campaigns;
+    if (selector === selectCampaigns) return campaigns ?? [];
     if (selector === selectDismissedCampaignOutcomeToasts) return dismissed;
     if (selector === selectRewardsSubscriptionId) return subscriptionId;
     return undefined;
@@ -190,6 +190,14 @@ describe('useCampaignOutcomeToast', () => {
     it('no campaigns match the campaignType', () => {
       setupDefaults({ campaigns: [] });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('campaigns are missing from persisted state', () => {
+      setupDefaults({ campaigns: undefined });
+      expect(() =>
+        renderHook(() => useCampaignOutcomeToast(mockConfig)),
+      ).not.toThrow();
       expect(mockShowToast).not.toHaveBeenCalled();
     });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -52,6 +52,10 @@ import {
   BASE32_REGEX,
   CampaignType,
 } from './types';
+import {
+  defaultRewardsControllerState,
+  getRewardsControllerDefaultState,
+} from './defaultState';
 import type { RewardsControllerMessenger } from '../../messengers/rewards-controller-messenger';
 import {
   storeSubscriptionToken,
@@ -308,36 +312,7 @@ const metadata: StateMetadata<RewardsControllerState> = {
   },
 };
 
-/**
- * Get the default state for the RewardsController
- */
-export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
-  activeAccount: null,
-  accounts: {},
-  subscriptions: {},
-  subscriptionBenefits: {},
-  seasons: {},
-  subscriptionReferralDetails: {},
-  seasonStatuses: {},
-  activeBoosts: {},
-  unlockedRewards: {},
-  pointsEvents: {},
-  offDeviceSubscriptionAccounts: {},
-  campaigns: {},
-  campaignParticipantStatus: {},
-  ondoCampaignLeaderboard: {},
-  ondoCampaignLeaderboardPositions: {},
-  ondoCampaignPortfolio: {},
-  ondoCampaignActivity: {},
-  ondoCampaignDeposits: {},
-  perpsTradingCampaignLeaderboard: {},
-  perpsTradingCampaignLeaderboardPositions: {},
-  perpsTradingCampaignVolume: {},
-  pointsEstimateHistory: [],
-  rewardsEnvUrl: null,
-});
-
-export const defaultRewardsControllerState = getRewardsControllerDefaultState();
+export { defaultRewardsControllerState, getRewardsControllerDefaultState };
 
 type CacheReader<T> = (
   key: string,

--- a/app/core/Engine/controllers/rewards-controller/defaultState.ts
+++ b/app/core/Engine/controllers/rewards-controller/defaultState.ts
@@ -1,0 +1,32 @@
+import type { RewardsControllerState } from './types';
+
+/**
+ * Get the default state for the RewardsController.
+ */
+export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
+  activeAccount: null,
+  accounts: {},
+  subscriptions: {},
+  subscriptionBenefits: {},
+  seasons: {},
+  subscriptionReferralDetails: {},
+  seasonStatuses: {},
+  activeBoosts: {},
+  unlockedRewards: {},
+  pointsEvents: {},
+  offDeviceSubscriptionAccounts: {},
+  campaigns: {},
+  campaignParticipantStatus: {},
+  ondoCampaignLeaderboard: {},
+  ondoCampaignLeaderboardPositions: {},
+  ondoCampaignPortfolio: {},
+  ondoCampaignActivity: {},
+  ondoCampaignDeposits: {},
+  perpsTradingCampaignLeaderboard: {},
+  perpsTradingCampaignLeaderboardPositions: {},
+  perpsTradingCampaignVolume: {},
+  pointsEstimateHistory: [],
+  rewardsEnvUrl: null,
+});
+
+export const defaultRewardsControllerState = getRewardsControllerDefaultState();

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -2681,6 +2681,21 @@ describe('rewardsReducer', () => {
 
       expect(state.ondoCampaignActivity).toEqual({});
     });
+
+    it('should default campaigns to [] when absent from persisted state (upgrade path)', () => {
+      const persistedRewardsStateWithoutField = {
+        ...initialState,
+        campaigns: undefined,
+      } as unknown as RewardsState;
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: { rewards: persistedRewardsStateWithoutField },
+      };
+
+      const state = rewardsReducer(initialState, rehydrateAction);
+
+      expect(state.campaigns).toEqual([]);
+    });
   });
 
   describe('unknown actions', () => {

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -2328,6 +2328,27 @@ describe('rewardsReducer', () => {
       );
     });
 
+    it('should default persisted season arrays to empty arrays when absent', () => {
+      const persistedRewardsStateWithoutFields = {
+        ...initialState,
+        seasonTiers: undefined,
+        seasonActivityTypes: undefined,
+        seasonWaysToEarn: undefined,
+      } as unknown as RewardsState;
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsStateWithoutFields,
+        },
+      };
+
+      const state = rewardsReducer(initialState, rehydrateAction);
+
+      expect(state.seasonTiers).toEqual([]);
+      expect(state.seasonActivityTypes).toEqual([]);
+      expect(state.seasonWaysToEarn).toEqual([]);
+    });
+
     it('should preserve all persisted UI state fields', () => {
       // Arrange
       const persistedRewardsState: RewardsState = {
@@ -4636,6 +4657,17 @@ describe('setBenefits', () => {
     const state = rewardsReducer(initialState, action);
 
     expect(state.benefits).toEqual(mockBenefitsPayload.benefits);
+  });
+
+  it('sets benefits to empty array when payload benefits are missing', () => {
+    const action = setBenefits({
+      ...mockBenefitsPayload,
+      benefits: undefined,
+    } as unknown as typeof mockBenefitsPayload);
+
+    const state = rewardsReducer(initialState, action);
+
+    expect(state.benefits).toEqual([]);
   });
 
   it('replaces existing benefits with new payload benefits', () => {

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -687,7 +687,7 @@ const rewardsSlice = createSlice({
     },
 
     setBenefits: (state, action: PayloadAction<SubscriptionBenefitsState>) => {
-      state.benefits = action.payload.benefits;
+      state.benefits = action.payload.benefits ?? [];
     },
 
     setBenefitsLoading: (state, action: PayloadAction<boolean>) => {
@@ -897,9 +897,10 @@ const rewardsSlice = createSlice({
               seasonName: action.payload.rewards.seasonName,
               seasonStartDate: action.payload.rewards.seasonStartDate,
               seasonEndDate: action.payload.rewards.seasonEndDate,
-              seasonTiers: action.payload.rewards.seasonTiers,
-              seasonActivityTypes: action.payload.rewards.seasonActivityTypes,
-              seasonWaysToEarn: action.payload.rewards.seasonWaysToEarn,
+              seasonTiers: action.payload.rewards.seasonTiers ?? [],
+              seasonActivityTypes:
+                action.payload.rewards.seasonActivityTypes ?? [],
+              seasonWaysToEarn: action.payload.rewards.seasonWaysToEarn ?? [],
               referralCode: action.payload.rewards.referralCode,
               refereeCount: action.payload.rewards.refereeCount,
               currentTier: action.payload.rewards.currentTier,

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -912,7 +912,7 @@ const rewardsSlice = createSlice({
               activeBoosts: action.payload.rewards.activeBoosts,
               pointsEvents: action.payload.rewards.pointsEvents,
               unlockedRewards: action.payload.rewards.unlockedRewards,
-              campaigns: action.payload.rewards.campaigns,
+              campaigns: action.payload.rewards.campaigns ?? [],
               campaignParticipantStatuses:
                 action.payload.rewards.campaignParticipantStatuses ?? {},
               ondoCampaignLeaderboardPositions:

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -46,6 +46,7 @@ import {
   selectBulkLinkFailedAccounts,
   selectBulkLinkWasInterrupted,
   selectBulkLinkAccountProgress,
+  selectBenefits,
   selectCampaigns,
   selectCampaignsLoading,
   selectCampaignsError,
@@ -85,6 +86,7 @@ import {
   SeasonWayToEarnDto,
   PointsEventDto,
   OndoGmActivityEntryDto,
+  SubscriptionBenefitDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { RootState } from '..';
 import { RewardsState, AccountOptInBannerInfoStatus } from '.';
@@ -550,6 +552,16 @@ describe('Rewards selectors', () => {
       expect(result.current).toEqual([]);
     });
 
+    it('returns empty array when season tiers are undefined', () => {
+      const mockState = {
+        rewards: { seasonTiers: undefined },
+      } as unknown as RootState;
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonTiers));
+      expect(result.current).toEqual([]);
+    });
+
     it('returns season tiers when set', () => {
       const mockTiers: SeasonTierDto[] = [
         {
@@ -605,6 +617,18 @@ describe('Rewards selectors', () => {
       expect(result.current).toEqual([]);
     });
 
+    it('returns empty array when season activity types are undefined', () => {
+      const mockState = {
+        rewards: { seasonActivityTypes: undefined },
+      } as unknown as RootState;
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectSeasonActivityTypes),
+      );
+      expect(result.current).toEqual([]);
+    });
+
     it('returns season activity types when set', () => {
       const mockActivityTypes: SeasonActivityTypeDto[] = [
         {
@@ -633,6 +657,16 @@ describe('Rewards selectors', () => {
   describe('selectSeasonWaysToEarn', () => {
     it('returns empty array when season ways to earn are not set', () => {
       const mockState = { rewards: { seasonWaysToEarn: [] } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonWaysToEarn));
+      expect(result.current).toEqual([]);
+    });
+
+    it('returns empty array when season ways to earn are undefined', () => {
+      const mockState = {
+        rewards: { seasonWaysToEarn: undefined },
+      } as unknown as RootState;
       mockedUseSelector.mockImplementation((selector) => selector(mockState));
 
       const { result } = renderHook(() => useSelector(selectSeasonWaysToEarn));
@@ -1031,6 +1065,18 @@ describe('Rewards selectors', () => {
       );
       expect(result.current).toEqual([]);
       expect(result.current).toHaveLength(0);
+    });
+
+    it('returns empty array when account banner config is undefined', () => {
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: undefined },
+      } as unknown as RootState;
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual([]);
     });
 
     it('returns single account configuration when set', () => {
@@ -3120,6 +3166,37 @@ describe('Rewards selectors', () => {
     showUpcomingDate: false,
   };
 
+  describe('selectBenefits', () => {
+    const mockBenefit: SubscriptionBenefitDto = {
+      id: 101,
+      longTitle: 'Premium Access',
+      shortDescription: 'Get premium perks',
+      longDescription: 'Unlock premium partner benefits.',
+      thumbnail: 'https://example.com/benefits/premium.png',
+      validFrom: '2026-01-01T00:00:00.000Z',
+      validTo: '2026-12-31T00:00:00.000Z',
+      actionDate: '2026-06-01T00:00:00.000Z',
+      url: 'https://example.com/claim',
+      chain: 'ethereum',
+      type: {
+        id: 1,
+        name: 'Partner',
+      },
+    };
+
+    it('returns empty array when benefits are undefined', () => {
+      const state = createMockRootState({
+        benefits: undefined as unknown as SubscriptionBenefitDto[],
+      });
+      expect(selectBenefits(state)).toEqual([]);
+    });
+
+    it('returns benefits when they exist', () => {
+      const state = createMockRootState({ benefits: [mockBenefit] });
+      expect(selectBenefits(state)).toEqual([mockBenefit]);
+    });
+  });
+
   describe('selectCampaigns', () => {
     it('returns empty array when campaigns is empty', () => {
       const mockState = { rewards: { campaigns: [] } };
@@ -3875,6 +3952,16 @@ describe('Rewards selectors', () => {
   describe('selectDismissedCampaignOutcomeToasts', () => {
     it('returns empty object when no toasts have been dismissed', () => {
       const state = createMockRootState({ dismissedCampaignOutcomeToasts: {} });
+      expect(selectDismissedCampaignOutcomeToasts(state)).toEqual({});
+    });
+
+    it('returns empty object when dismissed toasts are undefined', () => {
+      const state = createMockRootState({
+        dismissedCampaignOutcomeToasts: undefined as unknown as Record<
+          string,
+          boolean
+        >,
+      });
       expect(selectDismissedCampaignOutcomeToasts(state)).toEqual({});
     });
 

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3129,6 +3129,16 @@ describe('Rewards selectors', () => {
       expect(result.current).toEqual([]);
     });
 
+    it('returns empty array when campaigns is undefined', () => {
+      const mockState = {
+        rewards: { campaigns: undefined },
+      } as unknown as RootState;
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectCampaigns));
+      expect(result.current).toEqual([]);
+    });
+
     it('returns campaigns array when campaigns exist', () => {
       const mockState = { rewards: { campaigns: [mockCampaign] } };
       mockedUseSelector.mockImplementation((selector) => selector(mockState));
@@ -3140,6 +3150,13 @@ describe('Rewards selectors', () => {
     describe('Direct selector calls', () => {
       it('returns empty array when campaigns is empty', () => {
         const state = createMockRootState({ campaigns: [] });
+        expect(selectCampaigns(state)).toEqual([]);
+      });
+
+      it('returns empty array when campaigns is undefined', () => {
+        const state = createMockRootState({
+          campaigns: undefined as unknown as CampaignDto[],
+        });
         expect(selectCampaigns(state)).toEqual([]);
       });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -1,11 +1,8 @@
 import { createSelector } from 'reselect';
-import { RootState } from '..';
+import type { RootState } from '..';
+import { initialState } from '.';
 import { RewardsTab, OnboardingStep } from './types';
 import { hasMinimumRequiredVersion } from '../../util/remoteFeatureFlag';
-import {
-  CampaignDto,
-  SubscriptionBenefitDto,
-} from '../../core/Engine/controllers/rewards-controller/types.ts';
 
 export const selectActiveTab = (state: RootState): RewardsTab =>
   state.rewards.activeTab;
@@ -52,14 +49,20 @@ export const selectSeasonStartDate = (state: RootState) =>
 export const selectSeasonEndDate = (state: RootState) =>
   state.rewards.seasonEndDate;
 
-export const selectSeasonTiers = (state: RootState) =>
-  state.rewards.seasonTiers;
+export const selectSeasonTiers = (
+  state: RootState,
+): RootState['rewards']['seasonTiers'] =>
+  state.rewards.seasonTiers ?? initialState.seasonTiers;
 
-export const selectSeasonActivityTypes = (state: RootState) =>
-  state.rewards.seasonActivityTypes;
+export const selectSeasonActivityTypes = (
+  state: RootState,
+): RootState['rewards']['seasonActivityTypes'] =>
+  state.rewards.seasonActivityTypes ?? initialState.seasonActivityTypes;
 
-export const selectSeasonWaysToEarn = (state: RootState) =>
-  state.rewards.seasonWaysToEarn;
+export const selectSeasonWaysToEarn = (
+  state: RootState,
+): RootState['rewards']['seasonWaysToEarn'] =>
+  state.rewards.seasonWaysToEarn ?? initialState.seasonWaysToEarn;
 
 export const selectOnboardingActiveStep = (state: RootState): OnboardingStep =>
   state.rewards.onboardingActiveStep;
@@ -93,7 +96,9 @@ export const selectHideUnlinkedAccountsBanner = (state: RootState) =>
 
 export const selectHideCurrentAccountNotOptedInBannerArray = (
   state: RootState,
-) => state.rewards.hideCurrentAccountNotOptedInBanner;
+): RootState['rewards']['hideCurrentAccountNotOptedInBanner'] =>
+  state.rewards.hideCurrentAccountNotOptedInBanner ??
+  initialState.hideCurrentAccountNotOptedInBanner;
 
 export const selectActiveBoosts = (state: RootState) =>
   state.rewards.activeBoosts;
@@ -155,16 +160,19 @@ export const selectBulkLinkAccountProgress = (state: RootState) => {
 };
 
 // Benefits selectors
-export const selectBenefits = (state: RootState): SubscriptionBenefitDto[] =>
-  state.rewards.benefits;
+export const selectBenefits = (
+  state: RootState,
+): RootState['rewards']['benefits'] =>
+  state.rewards.benefits ?? initialState.benefits;
 
 export const selectBenefitsLoading = (state: RootState): boolean =>
   state.rewards.benefitsLoading;
 
 // Campaigns selectors
-const EMPTY_CAMPAIGNS: CampaignDto[] = [];
-export const selectCampaigns = (state: RootState): CampaignDto[] =>
-  state.rewards.campaigns ?? EMPTY_CAMPAIGNS;
+export const selectCampaigns = (
+  state: RootState,
+): RootState['rewards']['campaigns'] =>
+  state.rewards.campaigns ?? initialState.campaigns;
 
 export const selectCampaignById = (campaignId: string) => (state: RootState) =>
   state.rewards.campaigns?.find((c) => c.id === campaignId) ?? null;
@@ -322,8 +330,11 @@ export const selectOndoCampaignDepositsError = (state: RootState) =>
 export const selectPendingDeeplink = (state: RootState) =>
   state.rewards.pendingDeeplink;
 
-export const selectDismissedCampaignOutcomeToasts = (state: RootState) =>
-  state.rewards.dismissedCampaignOutcomeToasts;
+export const selectDismissedCampaignOutcomeToasts = (
+  state: RootState,
+): RootState['rewards']['dismissedCampaignOutcomeToasts'] =>
+  state.rewards.dismissedCampaignOutcomeToasts ??
+  initialState.dismissedCampaignOutcomeToasts;
 
 // Perps Trading Campaign leaderboard selectors
 export const selectPerpsTradingCampaignLeaderboard = (state: RootState) =>

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -2,7 +2,10 @@ import { createSelector } from 'reselect';
 import { RootState } from '..';
 import { RewardsTab, OnboardingStep } from './types';
 import { hasMinimumRequiredVersion } from '../../util/remoteFeatureFlag';
-import { SubscriptionBenefitDto } from '../../core/Engine/controllers/rewards-controller/types.ts';
+import {
+  CampaignDto,
+  SubscriptionBenefitDto,
+} from '../../core/Engine/controllers/rewards-controller/types.ts';
 
 export const selectActiveTab = (state: RootState): RewardsTab =>
   state.rewards.activeTab;
@@ -159,7 +162,9 @@ export const selectBenefitsLoading = (state: RootState): boolean =>
   state.rewards.benefitsLoading;
 
 // Campaigns selectors
-export const selectCampaigns = (state: RootState) => state.rewards.campaigns;
+const EMPTY_CAMPAIGNS: CampaignDto[] = [];
+export const selectCampaigns = (state: RootState): CampaignDto[] =>
+  state.rewards.campaigns ?? EMPTY_CAMPAIGNS;
 
 export const selectCampaignById = (campaignId: string) => (state: RootState) =>
   state.rewards.campaigns?.find((c) => c.id === campaignId) ?? null;

--- a/app/selectors/rewards/index.test.ts
+++ b/app/selectors/rewards/index.test.ts
@@ -65,7 +65,13 @@ describe('Rewards Selectors', () => {
       const result = selectRewardsControllerState(state);
 
       // Assert
-      expect(result).toBeUndefined();
+      expect(result).toEqual(
+        expect.objectContaining({
+          activeAccount: null,
+          accounts: {},
+          subscriptions: {},
+        }),
+      );
     });
   });
 
@@ -177,6 +183,24 @@ describe('Rewards Selectors', () => {
       // Assert
       expect(result).toBeNull();
     });
+
+    it('returns null when RewardsController is undefined', () => {
+      // Arrange
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: undefined,
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      // Act
+      const result = selectRewardsSubscriptionId(state);
+
+      // Assert
+      expect(result).toBeNull();
+    });
   });
 
   describe('selectRewardsActiveAccountAddress', () => {
@@ -241,6 +265,23 @@ describe('Rewards Selectors', () => {
     it('returns null when no active account exists', () => {
       // Arrange
       const state = createMockRootState({ activeAccount: null });
+
+      // Act
+      const result = selectRewardsActiveAccountAddress(state);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('returns null when RewardsController is undefined', () => {
+      // Arrange
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: undefined,
+          },
+        },
+      } as unknown as RootState;
 
       // Act
       const result = selectRewardsActiveAccountAddress(state);
@@ -393,6 +434,49 @@ describe('Rewards Selectors', () => {
 
       const result = selectCurrentSubscriptionAccounts(state);
       expect(result).toHaveLength(0);
+    });
+
+    it('returns empty array when controller accounts are missing', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: {
+              activeAccount: { subscriptionId: 'sub-1' },
+              accounts: undefined,
+              subscriptions: {
+                'sub-1': { id: 'sub-1' },
+              },
+            },
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      const result = selectCurrentSubscriptionAccounts(state);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when controller subscriptions are missing', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RewardsController: {
+              activeAccount: { subscriptionId: 'sub-1' },
+              accounts: {
+                'acct-1': {
+                  subscriptionId: 'sub-1',
+                  account: 'eip155:1:0x123',
+                },
+              },
+              subscriptions: undefined,
+            },
+          },
+        },
+        rewards: { candidateSubscriptionId: null },
+      } as unknown as RootState;
+
+      const result = selectCurrentSubscriptionAccounts(state);
+      expect(result).toEqual([]);
     });
 
     it('returns empty array when no accounts match subscription', () => {

--- a/app/selectors/rewards/index.ts
+++ b/app/selectors/rewards/index.ts
@@ -1,14 +1,21 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../../reducers';
-import { RewardsAccountState } from '../../core/Engine/controllers/rewards-controller/types';
+import type {
+  RewardsAccountState,
+  RewardsControllerState,
+} from '../../core/Engine/controllers/rewards-controller/types';
+import { defaultRewardsControllerState } from '../../core/Engine/controllers/rewards-controller/defaultState';
 
 /**
  *
  * @param state - Root redux state
  * @returns - AccountsController state
  */
-export const selectRewardsControllerState = (state: RootState) =>
-  state.engine.backgroundState.RewardsController;
+export const selectRewardsControllerState = (
+  state: RootState,
+): RewardsControllerState =>
+  state.engine.backgroundState.RewardsController ??
+  defaultRewardsControllerState;
 
 export const selectRewardsActiveAccountSubscriptionId = createSelector(
   selectRewardsControllerState,
@@ -57,14 +64,14 @@ export const selectCurrentSubscription = createSelector(
   [selectRewardsSubscriptionId, selectRewardsControllerState],
   (subscriptionId, rewardsState) =>
     subscriptionId
-      ? (rewardsState.subscriptions[subscriptionId] ?? null)
+      ? (rewardsState.subscriptions?.[subscriptionId] ?? null)
       : null,
 );
 
 export const selectCurrentSubscriptionAccounts = createSelector(
   [selectRewardsControllerState, selectCurrentSubscription],
   (rewardsState, subscription) =>
-    Object.values(rewardsState.accounts).filter(
+    Object.values(rewardsState.accounts ?? {}).filter(
       (account: RewardsAccountState) =>
         account.subscriptionId === subscription?.id,
     ),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-1267
The Rewards crash likely came from an older persisted Rewards Redux state that did not have newer array fields, especially campaigns. On affected devices, selectCampaigns could return undefined.

It was account/device dependent because persisted state differs per user/install.

Fix Applied: hardened both the restore path and selector path to fallback to initial state (empty array or object instead of undefined)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-1267

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are defensive fallbacks for missing/undefined persisted state and selector inputs, with added tests; behavior should only differ for legacy/partial states.
> 
> **Overview**
> Prevents Rewards tab crashes caused by older/partial persisted Redux/controller state by **defaulting missing fields to safe empty values**.
> 
> Selectors and rehydrate logic now coalesce `undefined` arrays/objects (e.g., `campaigns`, season arrays, `benefits`, dismissed-toasts map, controller `accounts`/`subscriptions`) to empty defaults, and `RewardsController` default state was extracted into `defaultState.ts` and reused. Test coverage was expanded to lock in these upgrade/undefined-state behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b351d0a795e0016dc2f4a686382955d3b4336b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->