### PR TITLE
chore: Upgrade @metamask/delegation-controller from ^2.0.2 to ^3.0.0

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -1369,7 +1369,8 @@ describe('Engine', () => {
             Boolean(controller.state) &&
             (!isEmpty(controller.state) ||
               controllerName === 'ComplianceController' ||
-              controllerName === 'MoneyAccountUpgradeController'),
+              controllerName === 'MoneyAccountUpgradeController' ||
+              controllerName === 'DelegationController'),
         )
         .map(([controllerName]) => controllerName);
 

--- a/app/core/Engine/controllers/delegation/delegation-controller-init.test.ts
+++ b/app/core/Engine/controllers/delegation/delegation-controller-init.test.ts
@@ -7,40 +7,21 @@ import {
   MOCK_ANY_NAMESPACE,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import {
-  type TransactionMeta,
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
-import {
-  DelegationControllerInit,
-  awaitDeleteDelegationEntry,
-} from './delegation-controller-init';
+import { DelegationControllerInit } from './delegation-controller-init';
 import { MessengerClientInitRequest } from '../../types';
-import {
-  DelegationControllerInitMessenger,
-  getDelegationControllerInitMessenger,
-  getDelegationControllerMessenger,
-} from '../../messengers/delegation/delegation-controller-messenger';
+import { getDelegationControllerMessenger } from '../../messengers/delegation/delegation-controller-messenger';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
-import { Hex } from '@metamask/utils';
 
 jest.mock('@metamask/delegation-controller');
 
 function buildInitRequestMock(): jest.Mocked<
-  MessengerClientInitRequest<
-    DelegationControllerMessenger,
-    DelegationControllerInitMessenger
-  >
+  MessengerClientInitRequest<DelegationControllerMessenger, void>
 > {
   const baseControllerMessenger = new Messenger<MockAnyNamespace>({
     namespace: MOCK_ANY_NAMESPACE,
   });
   const controllerMessenger = getDelegationControllerMessenger(
-    baseControllerMessenger,
-  );
-  const initMessenger = getDelegationControllerInitMessenger(
     baseControllerMessenger,
   );
   const extendedControllerMessenger = new ExtendedMessenger<MockAnyNamespace>({
@@ -50,7 +31,9 @@ function buildInitRequestMock(): jest.Mocked<
   return {
     ...buildMessengerClientInitRequestMock(extendedControllerMessenger),
     controllerMessenger,
-    initMessenger,
+    persistedState: {
+      DelegationController: {},
+    },
   };
 }
 
@@ -68,193 +51,21 @@ describe('DelegationControllerInit', () => {
     );
   });
 
-  it('initializes with correct messenger and state', () => {
+  it('initializes with correct messenger, state, and environment resolver', () => {
     const requestMock = buildInitRequestMock();
     DelegationControllerInit(requestMock);
 
     expect(DelegationControllerClassMock).toHaveBeenCalledWith({
       messenger: requestMock.controllerMessenger,
       state: requestMock.persistedState.DelegationController,
-      hashDelegation: expect.any(Function),
       getDelegationEnvironment: expect.any(Function),
     });
   });
 
-  it('returns correct API methods', () => {
+  it('returns only the controller', () => {
     const requestMock = buildInitRequestMock();
     const result = DelegationControllerInit(requestMock);
 
-    expect(result).toEqual(
-      expect.objectContaining({
-        api: {
-          signDelegation: expect.any(Function),
-          storeDelegationEntry: expect.any(Function),
-          listDelegationEntries: expect.any(Function),
-          getDelegationEntry: expect.any(Function),
-          getDelegationEntryChain: expect.any(Function),
-          deleteDelegationEntry: expect.any(Function),
-          awaitDeleteDelegationEntry: expect.any(Function),
-        },
-      }),
-    );
-  });
-});
-
-describe('DelegationController:awaitDeleteDelegationEntry', () => {
-  const mockHash = '0x123' as Hex;
-  let controller: DelegationController;
-  let initMessenger: DelegationControllerInitMessenger;
-  let subscribeHandler:
-    | ((event: { transactionMeta: TransactionMeta }) => void)
-    | undefined;
-
-  const createMockTransactionMeta = (
-    overrides: Partial<TransactionMeta>,
-  ): TransactionMeta => ({
-    id: '123',
-    chainId: '0x1',
-    networkClientId: '1',
-    time: Date.now(),
-    txParams: {
-      from: '0x123',
-      to: '0x456',
-      value: '0x0',
-      data: '0x',
-    },
-    status: TransactionStatus.unapproved,
-    type: TransactionType.contractInteraction,
-    ...overrides,
-  });
-
-  beforeEach(() => {
-    controller = new DelegationController({
-      messenger: getDelegationControllerMessenger(
-        new Messenger<MockAnyNamespace>({
-          namespace: MOCK_ANY_NAMESPACE,
-        }),
-      ),
-      state: {},
-      hashDelegation: () => '0x123' as Hex,
-      getDelegationEnvironment: () => ({
-        DelegationManager: '0x123',
-        EntryPoint: '0x456',
-        SimpleFactory: '0x789',
-        implementations: {},
-        caveatEnforcers: {},
-      }),
-    });
-
-    // Create a mock messenger with jest.fn() for subscribe and unsubscribe
-    initMessenger = {
-      subscribe: jest.fn((_event, handler) => {
-        subscribeHandler = handler;
-      }),
-      unsubscribe: jest.fn(),
-    } as unknown as DelegationControllerInitMessenger;
-  });
-
-  it('subscribes to transaction status updates', () => {
-    const txMeta = createMockTransactionMeta({});
-
-    awaitDeleteDelegationEntry(controller, initMessenger, {
-      hash: mockHash,
-      txMeta,
-    });
-
-    expect(initMessenger.subscribe).toHaveBeenCalledWith(
-      'TransactionController:transactionStatusUpdated',
-      expect.any(Function),
-    );
-  });
-
-  it('deletes delegation when transaction is confirmed', () => {
-    const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
-
-    awaitDeleteDelegationEntry(controller, initMessenger, {
-      hash: mockHash,
-      txMeta,
-    });
-
-    expect(subscribeHandler).toBeDefined();
-    subscribeHandler?.({
-      transactionMeta: createMockTransactionMeta({
-        status: TransactionStatus.confirmed,
-      }),
-    });
-
-    expect(deleteSpy).toHaveBeenCalledWith(mockHash);
-    expect(initMessenger.unsubscribe).toHaveBeenCalled();
-  });
-
-  it('unsubscribes when transaction is dropped', () => {
-    const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
-
-    awaitDeleteDelegationEntry(controller, initMessenger, {
-      hash: mockHash,
-      txMeta,
-    });
-
-    expect(subscribeHandler).toBeDefined();
-    subscribeHandler?.({
-      transactionMeta: createMockTransactionMeta({
-        status: TransactionStatus.dropped,
-      }),
-    });
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-    expect(initMessenger.unsubscribe).toHaveBeenCalled();
-  });
-
-  it('follows transaction chain when replaced', () => {
-    const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
-
-    awaitDeleteDelegationEntry(controller, initMessenger, {
-      hash: mockHash,
-      txMeta,
-    });
-
-    expect(subscribeHandler).toBeDefined();
-
-    // Transaction gets replaced
-    subscribeHandler?.({
-      transactionMeta: createMockTransactionMeta({
-        status: TransactionStatus.dropped,
-        replacedById: '456',
-      }),
-    });
-
-    // New transaction confirms
-    subscribeHandler?.({
-      transactionMeta: createMockTransactionMeta({
-        id: '456',
-        status: TransactionStatus.confirmed,
-      }),
-    });
-
-    expect(deleteSpy).toHaveBeenCalledWith(mockHash);
-    expect(initMessenger.unsubscribe).toHaveBeenCalled();
-  });
-
-  it('unsubscribes when transaction is cancelled', () => {
-    const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
-
-    awaitDeleteDelegationEntry(controller, initMessenger, {
-      hash: mockHash,
-      txMeta,
-    });
-
-    expect(subscribeHandler).toBeDefined();
-    subscribeHandler?.({
-      transactionMeta: createMockTransactionMeta({
-        type: TransactionType.cancel,
-      }),
-    });
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-    expect(initMessenger.unsubscribe).toHaveBeenCalled();
+    expect(Object.keys(result)).toStrictEqual(['controller']);
   });
 });

--- a/app/core/Engine/controllers/delegation/delegation-controller-init.ts
+++ b/app/core/Engine/controllers/delegation/delegation-controller-init.ts
@@ -1,20 +1,10 @@
 import {
   DelegationController,
-  DelegationEntry,
   type DelegationControllerMessenger,
 } from '@metamask/delegation-controller';
-import {
-  type TransactionMeta,
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
-import {
-  getDelegationHashOffchain,
-  getDeleGatorEnvironment,
-} from '../../../Delegation';
+import { getDeleGatorEnvironment } from '../../../Delegation';
 import { Hex } from '@metamask/utils';
 import { MessengerClientInitFunction } from '../../types';
-import { DelegationControllerInitMessenger } from '../../messengers/delegation/delegation-controller-messenger';
 
 const getDelegationEnvironment = (chainId: Hex) =>
   getDeleGatorEnvironment(Number(chainId));
@@ -25,18 +15,15 @@ const getDelegationEnvironment = (chainId: Hex) =>
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
- * @param request.initMessenger - The initialization messenger for the controller.
  * @returns The initialized controller.
  */
 export const DelegationControllerInit: MessengerClientInitFunction<
   DelegationController,
-  DelegationControllerMessenger,
-  DelegationControllerInitMessenger
-> = ({ controllerMessenger, persistedState, initMessenger }) => {
+  DelegationControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
   const controller = new DelegationController({
     messenger: controllerMessenger,
     state: persistedState.DelegationController,
-    hashDelegation: getDelegationHashOffchain,
     getDelegationEnvironment,
   });
 
@@ -47,109 +34,5 @@ export const DelegationControllerInit: MessengerClientInitFunction<
 
   return {
     controller,
-    api: {
-      signDelegation: controller.signDelegation.bind(controller),
-      storeDelegationEntry: controller.store.bind(controller),
-      listDelegationEntries: controller.list.bind(controller),
-      getDelegationEntry: controller.retrieve.bind(controller),
-      getDelegationEntryChain: controller.chain.bind(controller),
-      deleteDelegationEntry: controller.delete.bind(controller),
-      awaitDeleteDelegationEntry: awaitDeleteDelegationEntry.bind(
-        null,
-        controller,
-        initMessenger,
-      ),
-    },
   };
 };
-
-/**
- * Awaits for the transaction with txMeta to be confirmed, then
- * deletes the delegation entry with `hash`.
- *
- * @param controller - The DelegationController.
- * @param initMessenger - The initialization messenger for the controller.
- * @param options
- * @param options.hash - The hash of the delegation entry to delete.
- * @param options.txMeta - The transaction meta of the transaction that confirmed the delegation entry.
- * @param options.entryToStore - The delegation entry to store.
- */
-export async function awaitDeleteDelegationEntry(
-  controller: DelegationController,
-  initMessenger: DelegationControllerInitMessenger,
-  {
-    hash,
-    txMeta,
-    entryToStore,
-  }: { hash: Hex; txMeta: TransactionMeta; entryToStore?: DelegationEntry },
-) {
-  let { id } = txMeta;
-  let action: 'continue' | 'unsubscribe' | 'delete' = 'continue';
-
-  const handleTransactionStatusUpdated = ({
-    transactionMeta,
-  }: {
-    transactionMeta: TransactionMeta;
-  }) => {
-    // If not our transaction, ignore
-    if (transactionMeta.id !== id) {
-      return;
-    }
-
-    // Check if transaction was replaced
-    if (
-      transactionMeta.status === TransactionStatus.dropped &&
-      transactionMeta.replacedById
-    ) {
-      id = transactionMeta.replacedById;
-      return;
-    }
-
-    switch (transactionMeta.type) {
-      case TransactionType.contractInteraction:
-      case TransactionType.retry:
-        switch (transactionMeta.status) {
-          case TransactionStatus.confirmed:
-            action = 'delete';
-            break;
-          case TransactionStatus.dropped:
-          case TransactionStatus.failed:
-          case TransactionStatus.rejected:
-            action = 'unsubscribe';
-            break;
-          default:
-            // Ignore other statuses
-            return;
-        }
-        break;
-      case TransactionType.cancel:
-        action = 'unsubscribe';
-        break;
-      default:
-        console.warn(
-          'awaitDeleteDelegationEntry: Unexpected tx type',
-          transactionMeta.type,
-        );
-        return;
-    }
-
-    if (action === 'delete') {
-      controller.delete(hash);
-      if (entryToStore) {
-        controller.store({ entry: entryToStore });
-      }
-    }
-
-    if (action === 'unsubscribe' || action === 'delete') {
-      initMessenger.unsubscribe(
-        'TransactionController:transactionStatusUpdated',
-        handleTransactionStatusUpdated,
-      );
-    }
-  };
-
-  initMessenger.subscribe(
-    'TransactionController:transactionStatusUpdated',
-    handleTransactionStatusUpdated,
-  );
-}

--- a/app/core/Engine/controllers/delegation/delegation-controller-init.ts
+++ b/app/core/Engine/controllers/delegation/delegation-controller-init.ts
@@ -27,11 +27,6 @@ export const DelegationControllerInit: MessengerClientInitFunction<
     getDelegationEnvironment,
   });
 
-  controllerMessenger.registerActionHandler(
-    'DelegationController:signDelegation',
-    controller.signDelegation.bind(controller),
-  );
-
   return {
     controller,
   };

--- a/app/core/Engine/messengers/delegation/delegation-controller-messenger.ts
+++ b/app/core/Engine/messengers/delegation/delegation-controller-messenger.ts
@@ -4,14 +4,9 @@ import {
   MessengerEvents,
 } from '@metamask/messenger';
 import { type DelegationControllerMessenger } from '@metamask/delegation-controller';
-import { TransactionControllerTransactionStatusUpdatedEvent } from '@metamask/transaction-controller';
 import { RootMessenger } from '../../types';
 
 const name = 'DelegationController' as const;
-
-export type DelegationControllerInitMessenger = ReturnType<
-  typeof getDelegationControllerInitMessenger
->;
 
 export function getDelegationControllerMessenger(
   rootMessenger: RootMessenger,
@@ -26,31 +21,8 @@ export function getDelegationControllerMessenger(
     parent: rootMessenger,
   });
   rootMessenger.delegate({
-    actions: [
-      'AccountsController:getSelectedAccount',
-      'KeyringController:signTypedMessage',
-    ],
+    actions: ['KeyringController:signTypedMessage'],
     events: [],
-    messenger,
-  });
-  return messenger;
-}
-
-export function getDelegationControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'DelegationControllerInit',
-    never,
-    TransactionControllerTransactionStatusUpdatedEvent,
-    RootMessenger
-  >({
-    namespace: 'DelegationControllerInit',
-    parent: rootMessenger,
-  });
-  rootMessenger.delegate({
-    actions: [],
-    events: ['TransactionController:transactionStatusUpdated'],
     messenger,
   });
   return messenger;

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -107,10 +107,7 @@ import { getMoneyAccountBalanceServiceMessenger } from './money-account-balance-
 import { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 import { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
 import { getRewardsDataServiceMessenger } from './rewards-data-service-messenger';
-import {
-  getDelegationControllerInitMessenger,
-  getDelegationControllerMessenger,
-} from './delegation/delegation-controller-messenger';
+import { getDelegationControllerMessenger } from './delegation/delegation-controller-messenger';
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import {
   getRampsControllerMessenger,
@@ -418,7 +415,7 @@ export const MESSENGER_FACTORIES = {
   },
   DelegationController: {
     getMessenger: getDelegationControllerMessenger,
-    getInitMessenger: getDelegationControllerInitMessenger,
+    getInitMessenger: noop,
   },
   BackendWebSocketService: {
     getMessenger: getBackendWebSocketServiceMessenger,

--- a/app/store/migrations/147.test.ts
+++ b/app/store/migrations/147.test.ts
@@ -1,0 +1,88 @@
+import { captureException } from '@sentry/react-native';
+import migrate, { migrationVersion } from './147';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+const mockedCaptureException = jest.mocked(captureException);
+
+interface TestState {
+  engine: {
+    backgroundState: Record<string, unknown>;
+  };
+}
+
+function buildValidState(
+  delegationController?: Record<string, unknown>,
+): TestState {
+  return {
+    engine: {
+      backgroundState: {
+        ...(delegationController !== undefined
+          ? { DelegationController: delegationController }
+          : {}),
+      },
+    },
+  };
+}
+
+describe(`Migration ${migrationVersion}: Strip DelegationController delegations`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
+  });
+
+  it('reports the expected migration version', () => {
+    expect(migrationVersion).toBe(147);
+  });
+
+  it('replaces DelegationController state with {} when delegations key exists', () => {
+    const state = buildValidState({
+      delegations: { '0xabc': { entry: true } },
+    });
+
+    const result = migrate(state) as TestState;
+
+    expect(result.engine.backgroundState.DelegationController).toStrictEqual(
+      {},
+    );
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not change state when DelegationController has no delegations key', () => {
+    const state = buildValidState({});
+
+    const snapshot = JSON.stringify(state);
+    const result = migrate(state);
+
+    expect(JSON.stringify(result)).toBe(snapshot);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not change state when DelegationController is absent', () => {
+    const state = buildValidState();
+    const snapshot = JSON.stringify(state);
+
+    const result = migrate(state);
+
+    expect(JSON.stringify(result)).toBe(snapshot);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns state unchanged when ensureValidState fails', () => {
+    mockedEnsureValidState.mockReturnValue(false);
+    const state = buildValidState({ delegations: {} });
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/app/store/migrations/147.ts
+++ b/app/store/migrations/147.ts
@@ -1,0 +1,53 @@
+import { captureException } from '@sentry/react-native';
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+
+/**
+ * Migration 147: remove legacy `delegations` persisted state from DelegationController.
+ *
+ * `@metamask/delegation-controller` v3 no longer persists delegations; persisted entries are dropped.
+ */
+export const migrationVersion = 147;
+
+const migration = (state: unknown): unknown => {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  try {
+    const { backgroundState } = state.engine;
+    if (
+      !hasProperty(backgroundState, 'DelegationController') ||
+      !isObject(backgroundState.DelegationController)
+    ) {
+      return state;
+    }
+
+    if (!hasProperty(backgroundState.DelegationController, 'delegations')) {
+      return state;
+    }
+
+    return {
+      ...state,
+      engine: {
+        ...state.engine,
+        backgroundState: {
+          ...backgroundState,
+          DelegationController: {},
+        },
+      },
+    };
+  } catch (error) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Failed to strip DelegationController delegations: ${getErrorMessage(
+          error,
+        )}`,
+      ),
+    );
+  }
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -147,6 +147,7 @@ import migration143 from './143';
 import migration144 from './144';
 import migration145 from './145';
 import migration146 from './146';
+import migration147 from './147';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -313,6 +314,7 @@ export const migrationList: MigrationsList = {
   144: migration144,
   145: migration145,
   146: migration146,
+  147: migration147,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -60,9 +60,7 @@
       }
     }
   },
-  "DelegationController": {
-    "delegations": {}
-  },
+  "DelegationController": {},
   "NetworkController": {
     "selectedNetworkClientId": "mainnet",
     "networksMetadata": {

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "@metamask/connectivity-controller": "^0.2.0",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/core-backend": "^6.3.0",
-    "@metamask/delegation-controller": "^2.0.2",
+    "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
     "@metamask/design-system-react-native": "^0.35.0",
     "@metamask/design-system-twrnc-preset": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8605,19 +8605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/delegation-controller@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@metamask/delegation-controller@npm:2.0.2"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^37.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/keyring-controller": "npm:^25.1.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-  checksum: 10/a5bfece3aadbfd2a4b079dc5672b75ef7acbe71e8af92e1c533884d59eadaf4d56cfa89641212cff0776f91964eb2e71d55d45fa0f813dfd9610fd6c0fdff05d
-  languageName: node
-  linkType: hard
-
 "@metamask/delegation-controller@npm:^3.0.2":
   version: 3.0.2
   resolution: "@metamask/delegation-controller@npm:3.0.2"
@@ -35973,7 +35960,7 @@ __metadata:
     "@metamask/connectivity-controller": "npm:^0.2.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/core-backend": "npm:^6.3.0"
-    "@metamask/delegation-controller": "npm:^2.0.2"
+    "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
     "@metamask/design-system-react-native": "npm:^0.35.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.7.0"


### PR DESCRIPTION
## **Description**

@metamask/delegation-controller@3.0.0 removes delegation storage logic, which is unused through both MetaMask clients: https://github.com/MetaMask/core/blob/main/packages/delegation-controller/CHANGELOG.md#300

This PR upgrades @metamask/delegation-controller and removes the related `awaitDeleteDelegationEntry` injected function, and other related cruft.

No longer explicitly register messenger actions as @metamask/delegation-controller@2.1.0 now automatically registers messenger actions, change introduced to controller here https://github.com/MetaMask/core/pull/8205.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

No related issues - just delegation controller bump.

## **Manual testing steps**

No specific testing steps; removal of unused code only.

## **Screenshots/Recordings**

N/A
## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delegation signing integration used by transaction and money-account flows, but changes mostly remove unused storage and duplicate registration rather than alter signing behavior.
> 
> **Overview**
> Upgrades **`@metamask/delegation-controller`** from **^2.0.2** to **^3.0.2**, aligning with v3’s removal of client-side delegation **storage** and related APIs.
> 
> **`DelegationControllerInit`** is slimmed down: it only constructs the controller with **`getDelegationEnvironment`**, persisted state, and the controller messenger—no **`hashDelegation`**, no custom **`registerActionHandler`** for signing, and no returned **`api`** object (init now returns only **`controller`**). The **`awaitDeleteDelegationEntry`** helper and its transaction-status subscription flow are deleted entirely.
> 
> Messenger wiring drops **`DelegationControllerInit`** ( **`getInitMessenger: noop`** ), removes the init messenger that listened to **`TransactionController:transactionStatusUpdated`**, and stops delegating **`AccountsController:getSelectedAccount`** to the delegation messenger. Test fixtures change **`DelegationController`** persisted state from **`{ delegations: {} }`** to **`{}`**, and **`Engine.state`** tests treat **`DelegationController`** like other controllers that may expose empty state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5121ac70bf2d97b084291b71e002ab650b4592ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->