### PR TITLE
feat: gas sponsorship improve alerts and remove gas alert

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.test.ts
@@ -10,6 +10,7 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
+import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 
 const MOCK_TRANSACTION_META = {
   id: '1',
@@ -30,14 +31,20 @@ const MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS = {
 } as unknown as TransactionMeta;
 
 jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../gas/useIsGaslessSupported');
 
 describe('useGasEstimateFailedAlert', () => {
   const mockUseTransactionMetadataRequest = jest.mocked(
     useTransactionMetadataRequest,
   );
-
+  const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
   beforeEach(() => {
     jest.clearAllMocks();
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSmartTransaction: false,
+      isSupported: false,
+      pending: false,
+    });
   });
 
   it('returns alert when simulationFails is truthy', () => {
@@ -104,5 +111,37 @@ describe('useGasEstimateFailedAlert', () => {
     );
 
     expect(result.current).toEqual([]);
+  });
+
+  it('returns no alerts if simulation fails but transaction is gasless or sponsored', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
+    );
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSmartTransaction: false,
+      isSupported: true,
+      pending: false,
+    });
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current[0]).toBe(undefined);
+  });
+
+  it('returns no alerts when gasless support check is pending', () => {
+    mockUseTransactionMetadataRequest.mockReturnValue(
+      MOCK_TRANSACTION_META_WITH_SIMULATION_FAILS,
+    );
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSmartTransaction: false,
+      isSupported: false,
+      pending: true,
+    });
+    const { result } = renderHookWithProvider(() =>
+      useGasEstimateFailedAlert(),
+    );
+
+    expect(result.current[0]).toBe(undefined);
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasEstimateFailedAlert.ts
@@ -5,12 +5,21 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { Alert, Severity } from '../../types/alerts';
 import { useEstimationFailed } from '../gas/useEstimationFailed';
+import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 
 export const useGasEstimateFailedAlert = (): Alert[] => {
   const estimationFailed = useEstimationFailed();
+  const {
+    isSupported: isGaslessSupported,
+    pending: isGaslessSupportCheckPending,
+  } = useIsGaslessSupported();
 
   return useMemo(() => {
-    if (!estimationFailed) {
+    if (
+      !estimationFailed ||
+      isGaslessSupportCheckPending ||
+      isGaslessSupported
+    ) {
       return [];
     }
 
@@ -24,5 +33,5 @@ export const useGasEstimateFailedAlert = (): Alert[] => {
         severity: Severity.Warning,
       },
     ];
-  }, [estimationFailed]);
+  }, [estimationFailed, isGaslessSupportCheckPending, isGaslessSupported]);
 };

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
@@ -13,7 +13,13 @@ import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
+import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { useConfirmActions } from '../useConfirmActions';
 
+jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: jest.fn(),
+}));
+jest.mock('../useConfirmActions');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../gas/useIsGaslessSupported');
 
@@ -53,6 +59,8 @@ describe('useGasSponsorshipWarningAlert', () => {
     useTransactionMetadataRequest,
   );
   const mockUseIsGaslessSupported = jest.mocked(useIsGaslessSupported);
+  const mockUseRampNavigation = jest.mocked(useRampNavigation);
+  const mockUseConfirmActions = jest.mocked(useConfirmActions);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,6 +68,16 @@ describe('useGasSponsorshipWarningAlert', () => {
       isSupported: true,
       isSmartTransaction: false,
       pending: false,
+    });
+    mockUseConfirmActions.mockReturnValue({
+      onReject: jest.fn(),
+      onConfirm: jest.fn(),
+    });
+    mockUseRampNavigation.mockReturnValue({
+      goToBuy: jest.fn(),
+      goToAggregator: jest.fn(),
+      goToSell: jest.fn(),
+      goToDeposit: jest.fn(),
     });
   });
 
@@ -80,11 +98,11 @@ describe('useGasSponsorshipWarningAlert', () => {
 
       expect(result.current).toHaveLength(1);
       expect(result.current[0]).toMatchObject({
-        isBlocking: false,
+        isBlocking: true,
         key: AlertKeys.GasSponsorshipReserveBalance,
         field: RowAlertKey.EstimatedFee,
-        severity: Severity.Warning,
-        title: 'Gas sponsorship unavailable',
+        severity: Severity.Danger,
+        title: 'Reserve balance is required',
       });
     });
 

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
@@ -9,6 +9,8 @@ import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
+import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { useConfirmActions } from '../useConfirmActions';
 
 /**
  * Configuration for gas sponsorship warning rules per chain.
@@ -17,6 +19,8 @@ import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
 interface SponsorshipWarningRule {
   /** The localization message key for the warning */
   messageKey: string;
+  /** The localization title key for the warning */
+  titleKey: string;
   /** The minimum balance required for sponsorship */
   minBalance: string;
   /** The native token symbol for this chain (e.g., 'MON' for Monad) */
@@ -42,6 +46,7 @@ const GAS_SPONSORSHIP_WARNING_RULES: Partial<
 > = {
   [NETWORKS_CHAIN_ID.MONAD as Hex]: {
     messageKey: 'alert_system.gas_sponsorship_reserve_balance.message',
+    titleKey: 'alert_system.gas_sponsorship_reserve_balance.title',
     minBalance: '10',
     nativeCurrency: 'MON',
     matchers: ['reserve balance violation'],
@@ -88,6 +93,8 @@ function hasGasSponsorshipWarning(
 export const useGasSponsorshipWarningAlert = (): Alert[] => {
   const transactionMetadata = useTransactionMetadataRequest();
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
+  const { goToBuy } = useRampNavigation();
+  const { onReject } = useConfirmActions();
 
   const { chainId, isGasFeeSponsored, simulationData } =
     transactionMetadata ?? {};
@@ -121,18 +128,30 @@ export const useGasSponsorshipWarningAlert = (): Alert[] => {
       return [];
     }
 
+    const { titleKey, messageKey, nativeCurrency, minBalance } = rule;
+
     return [
       {
-        isBlocking: false,
+        action: {
+          label: strings('alert_system.insufficient_balance.buy_action', {
+            nativeCurrency,
+          }),
+          callback: () => {
+            goToBuy();
+            onReject(undefined, true);
+          },
+        },
+        isBlocking: true,
         field: RowAlertKey.EstimatedFee,
         key: AlertKeys.GasSponsorshipReserveBalance,
-        message: strings(rule.messageKey, {
-          minBalance: rule.minBalance,
-          nativeTokenSymbol: rule.nativeCurrency,
+        message: strings(messageKey, {
+          minBalance,
+          nativeTokenSymbol: nativeCurrency,
         }),
-        title: strings('alert_system.gas_sponsorship_reserve_balance.title'),
-        severity: Severity.Warning,
+        title: strings(titleKey),
+        severity: Severity.Danger,
+        skipConfirmation: true,
       },
     ];
-  }, [shouldShow, chainId]);
+  }, [shouldShow, chainId, goToBuy, onReject]);
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -133,8 +133,8 @@
       "message": "The recipient address may not support direct token transfers, which could result in fund loss. Only continue if you're certain this contract can receive your transfer."
     },
     "gas_sponsorship_reserve_balance": {
-      "message": "Gas sponsorship isn't available for this transaction. You'll need to keep at least %{minBalance} %{nativeTokenSymbol} in your account.",
-      "title": "Gas sponsorship unavailable"
+      "message": "This specific network requires to maintain a reserve of %{minBalance} %{nativeTokenSymbol} in your account.",
+      "title": "Reserve balance is required"
     },
     "token_trust_signal": {
       "malicious": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR contains two fixes related to Gas Sponsorship alerts:
- Removes a gas-estimate-related alert for when a transaction will fail in a gasless transaction. Avoids the "double alert" and drops the modal prompting user to change their "gas limit" which doesn't make sense in gasless flows.
- Changes the copy and severity of the specific 10 MON reserve alert - when a tx would bring the balance of the user below the 10 MON minimum imposed by the Monad network - making sure the user is aware when this condition happens and cannot proceed with the tx - which will always fail in those conditions. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove gas alerts from confirmation modal in gasless flows
CHANGELOG entry: update copy of 10 MON minimal reserve confirmation alert

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-951?atlOrigin=eyJpIjoiMDBmNDlhY2E5ZDZiNGQ0NGIwYzNkZGEwMWQ4Y2QxZjYiLCJwIjoiaiJ9

## **Manual testing steps**

Test 1, send MON beyond `10 MON` reserve:

On Monad (gas sponsored, but 10 MON reserve limit), try to send:
- Max `MON`.
- Max `MON` - 1.
- Max `MON` - 10.
- Max `MON` -9.999

Observe that the 10 MON error message is always displayed first, as opposed as before, and that user cannot proceed with the transaction. 

Test 2, removal of network fee warnings:
1. On Monad or SEI network, open a transaction confirmation for a transaction that will fail - for example call "pause" on USDC (will fail since you are not admin of the token) -> https://monadscan.com/token/0x754704bc059f8c67012fed69bc8a327a5aafb603#writeProxyContract
3. Observe presence or absence of irrelevant warnings: "Transaction likely to fail" should show up, but not the "Network fee" alert since it is irrelevant in gasless. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
Failing tx:
<img width="300" alt="Screenshot_2026-05-07-09-20-25-179_io metamask" src="https://github.com/user-attachments/assets/63b71c0d-89a3-4e0f-b767-6d9fc477f75b" />

Send MON beyond 10 MON reserve:
<img width="300" alt="Screenshot_2026-05-07-08-54-43-804_io metamask" src="https://github.com/user-attachments/assets/a9d2f9bc-22be-4b93-aa1b-9821ed3a8bdb" />


### **After**

Failing tx:
<img width="300" alt="Screenshot_2026-05-07-08-39-48-064_io metamask" src="https://github.com/user-attachments/assets/ca9a20ee-8aa8-46d7-b28b-40b46ac86b4d" />


Send MON beyond 10 MON reserve:

<img width="300" alt="Screenshot_2026-05-07-07-19-05-301_io metamask" src="https://github.com/user-attachments/assets/cd8eff38-5b4b-4b02-99b2-8028d59f375e" />
(note: the grayed "Got it" is already flagged as a general separate issue)

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation alert gating and makes the Monad gas sponsorship reserve-balance warning blocking with a buy-flow action, which can affect whether users can proceed with transactions. Risk is limited to the confirmations alert layer but could impact conversion/flow if conditions are misdetected.
> 
> **Overview**
> Prevents the `GasEstimateFailed` warning from showing during gasless/sponsored flows (or while gasless support is still being determined) to avoid redundant/irrelevant gas-limit guidance.
> 
> Updates the Monad gas sponsorship reserve-balance alert to be **blocking** and **Danger** severity, revises its localized copy/title, and adds a CTA that routes to `goToBuy()` and rejects the confirmation (`skipConfirmation: true`). Tests were expanded/updated to cover the new gasless gating and blocking alert behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a423cdbda09603e7b5aaaceb191c654b14464106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->