### PR TITLE
chore: add AB Test to Market Insights carousel interval

### DIFF
--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
@@ -8,6 +8,12 @@ import MarketInsightsEntryCard from './MarketInsightsEntryCard';
 import { EVENT_NAME } from '../../../../../core/Analytics/MetaMetrics.events';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
 import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
+import {
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS,
+  MarketInsightsCardRotationIntervalVariant,
+} from './abTestConfig';
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
@@ -50,16 +56,20 @@ jest.mock('./AnimatedGradientBorder', () => ({
 }));
 
 let capturedOnSlideStart: (() => void) | null = null;
+let capturedRotateIntervalMs: number | undefined;
 jest.mock('./SlidingTextCarousel', () => {
   const { View, Text } = jest.requireActual('react-native');
   return ({
     texts,
+    rotateIntervalMs,
     onSlideStart,
   }: {
     texts: string[];
+    rotateIntervalMs?: number;
     onSlideStart?: () => void;
   }) => {
     capturedOnSlideStart = onSlideStart ?? null;
+    capturedRotateIntervalMs = rotateIntervalMs;
     return (
       <View>
         <Text>{texts[0]}</Text>
@@ -107,11 +117,25 @@ const mockReport = {
   sources: [{ name: 'CoinDesk', type: 'news', url: 'coindesk.com' }],
 };
 
+const createState = (remoteFeatureFlags: Record<string, unknown>) => ({
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      RemoteFeatureFlagController: {
+        ...(backgroundState as { RemoteFeatureFlagController?: object })
+          .RemoteFeatureFlagController,
+        remoteFeatureFlags,
+      },
+    },
+  },
+});
+
 describe('MarketInsightsEntryCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedOnVisible = null;
     capturedOnSlideStart = null;
+    capturedRotateIntervalMs = undefined;
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
         trackEvent: mockTrackEvent,
@@ -139,6 +163,52 @@ describe('MarketInsightsEntryCard', () => {
 
     fireEvent.press(getByTestId('market-insights-entry-card'));
     expect(mockPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the control rotation interval when assigned control', () => {
+    renderWithProvider(
+      <MarketInsightsEntryCard
+        report={mockReport as never}
+        timeAgo="3m ago"
+        onPress={jest.fn()}
+        testID="market-insights-entry-card"
+      />,
+      {
+        state: createState({
+          [MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY]:
+            MarketInsightsCardRotationIntervalVariant.Control,
+        }),
+      },
+    );
+
+    expect(capturedRotateIntervalMs).toBe(
+      MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS[
+        MarketInsightsCardRotationIntervalVariant.Control
+      ].rotateIntervalMs,
+    );
+  });
+
+  it('uses the extended rotation interval when assigned carouselTimeExtended', () => {
+    renderWithProvider(
+      <MarketInsightsEntryCard
+        report={mockReport as never}
+        timeAgo="3m ago"
+        onPress={jest.fn()}
+        testID="market-insights-entry-card"
+      />,
+      {
+        state: createState({
+          [MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY]:
+            MarketInsightsCardRotationIntervalVariant.CarouselTimeExtended,
+        }),
+      },
+    );
+
+    expect(capturedRotateIntervalMs).toBe(
+      MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS[
+        MarketInsightsCardRotationIntervalVariant.CarouselTimeExtended
+      ].rotateIntervalMs,
+    );
   });
 
   it('renders summary text when there are no trend descriptions', () => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -24,12 +24,17 @@ import {
   generateOpt,
 } from '../../../../../core/Analytics/MetaMetrics.events';
 import { endTrace, TraceName } from '../../../../../util/trace';
+import { useABTest } from '../../../../../hooks/useABTest';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useViewportTracking } from '../../hooks/useViewportTracking';
 import { AnimatedGradientBorder } from './AnimatedGradientBorder';
 import { VISIBILITY_THRESHOLD } from './AnimatedGradientBorder.constants';
 import type { MarketInsightsEntryCardProps } from './MarketInsightsEntryCard.types';
 import SlidingTextCarousel from './SlidingTextCarousel';
+import {
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS,
+} from './abTestConfig';
 import {
   CHROME_GRADIENT_HEAD,
   CHROME_GRADIENT_LINEAR_END,
@@ -136,6 +141,17 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
 }) => {
   const tw = useTailwind();
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const { variant: rotationInterval } = useABTest(
+    MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+    MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS,
+    {
+      experimentName: 'Market Insights Card Rotation Interval',
+      variationNames: {
+        control: '5 second rotation interval',
+        carouselTimeExtended: '6 second rotation interval',
+      },
+    },
+  );
 
   const [cardDimensions, setCardDimensions] = useState<{
     width: number;
@@ -254,6 +270,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
             {/* Body text: rotating trend descriptions */}
             <SlidingTextCarousel
               texts={displayTexts}
+              rotateIntervalMs={rotationInterval.rotateIntervalMs}
               onSlideStart={handleDescriptionSlideStart}
             />
 

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.test.tsx
@@ -72,6 +72,17 @@ describe('SlidingTextCarousel', () => {
     );
   });
 
+  it('uses a custom rotation interval when provided', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    render(
+      <SlidingTextCarousel
+        texts={['First', 'Second']}
+        rotateIntervalMs={6000}
+      />,
+    );
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 6000);
+  });
+
   // ---------------------------------------------------------------------------
   // Slide cycle — requires containerWidth > 0
   // ---------------------------------------------------------------------------

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx
@@ -37,6 +37,8 @@ const styles = StyleSheet.create({
 export interface SlidingTextCarouselProps {
   /** List of text strings to cycle through. */
   texts: string[];
+  /** Interval between text rotations in ms. Defaults to ROTATE_INTERVAL_MS. */
+  rotateIntervalMs?: number;
   /** Called when a slide transition begins (after rotation gates pass). */
   onSlideStart?: () => void;
   /** Called after each slide transition completes. */
@@ -62,6 +64,7 @@ export interface SlidingTextCarouselProps {
  */
 const SlidingTextCarousel: React.FC<SlidingTextCarouselProps> = ({
   texts,
+  rotateIntervalMs = ROTATE_INTERVAL_MS,
   onSlideStart,
   onSlideComplete,
   testID,
@@ -144,9 +147,9 @@ const SlidingTextCarousel: React.FC<SlidingTextCarouselProps> = ({
 
   useEffect(() => {
     if (texts.length <= 1) return undefined;
-    const interval = setInterval(advanceSlide, ROTATE_INTERVAL_MS);
+    const interval = setInterval(advanceSlide, rotateIntervalMs);
     return () => clearInterval(interval);
-  }, [texts.length, advanceSlide]);
+  }, [texts.length, advanceSlide, rotateIntervalMs]);
 
   const handleContainerLayout = useCallback(
     (e: { nativeEvent: { layout: { width: number } } }) => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/abTestConfig.ts
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/abTestConfig.ts
@@ -1,0 +1,35 @@
+import { EVENT_NAME } from '../../../../../core/Analytics/MetaMetrics.events';
+import type { ABTestAnalyticsMapping } from '../../../../../util/analytics/abTestAnalytics.types';
+
+export const MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY =
+  'socialAiTSA495AbtestCardRotationInterval';
+
+export enum MarketInsightsCardRotationIntervalVariant {
+  Control = 'control',
+  CarouselTimeExtended = 'carouselTimeExtended',
+}
+
+export const MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_VARIANTS: Record<
+  MarketInsightsCardRotationIntervalVariant,
+  { rotateIntervalMs: number }
+> = {
+  [MarketInsightsCardRotationIntervalVariant.Control]: {
+    rotateIntervalMs: 5000,
+  },
+  [MarketInsightsCardRotationIntervalVariant.CarouselTimeExtended]: {
+    rotateIntervalMs: 6000,
+  },
+};
+
+export const MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping =
+  {
+    flagKey: MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+    validVariants: Object.values(MarketInsightsCardRotationIntervalVariant),
+    eventNames: [
+      EVENT_NAME.MARKET_INSIGHTS_CARD_SCROLLED_TO_VIEW,
+      EVENT_NAME.MARKET_INSIGHTS_OPENED,
+      EVENT_NAME.MARKET_INSIGHTS_VIEWED,
+      EVENT_NAME.MARKET_INSIGHTS_INTERACTION,
+      EVENT_NAME.MARKET_INSIGHTS_CLOSED,
+    ],
+  };

--- a/app/util/analytics/abTestAnalyticsRegistry.ts
+++ b/app/util/analytics/abTestAnalyticsRegistry.ts
@@ -7,6 +7,7 @@ import {
   HUB_PAGE_DISCOVERY_TABS_AB_TEST_ANALYTICS_MAPPING,
 } from '../../components/Views/Homepage/abTestConfig';
 import { STICKY_FOOTER_SWAP_LABEL_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/TokenDetails/components/abTestConfig';
+import { MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_TEST_ANALYTICS_MAPPING } from '../../components/UI/MarketInsights/components/MarketInsightsEntryCard/abTestConfig';
 
 export const AB_TEST_ANALYTICS_MAPPINGS: readonly ABTestAnalyticsMapping[] = [
   // Card
@@ -22,4 +23,7 @@ export const AB_TEST_ANALYTICS_MAPPINGS: readonly ABTestAnalyticsMapping[] = [
 
   // Token Details
   STICKY_FOOTER_SWAP_LABEL_AB_TEST_ANALYTICS_MAPPING,
+
+  // Market Insights
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_TEST_ANALYTICS_MAPPING,
 ];

--- a/app/util/analytics/enrichWithABTests.test.ts
+++ b/app/util/analytics/enrichWithABTests.test.ts
@@ -1,6 +1,11 @@
 import { AnalyticsEventBuilder } from './AnalyticsEventBuilder';
 import { createActiveABTestAssignment } from './activeABTestAssignments';
 import { enrichWithABTests } from './enrichWithABTests';
+import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
+import {
+  MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+  MarketInsightsCardRotationIntervalVariant,
+} from '../../components/UI/MarketInsights/components/MarketInsightsEntryCard/abTestConfig';
 
 describe('enrichWithABTests', () => {
   it('injects one active assignment for a matching allowlisted event', () => {
@@ -143,6 +148,31 @@ describe('enrichWithABTests', () => {
       ),
     ]);
   });
+
+  it.each([
+    EVENT_NAME.MARKET_INSIGHTS_CARD_SCROLLED_TO_VIEW,
+    EVENT_NAME.MARKET_INSIGHTS_OPENED,
+    EVENT_NAME.MARKET_INSIGHTS_VIEWED,
+    EVENT_NAME.MARKET_INSIGHTS_INTERACTION,
+    EVENT_NAME.MARKET_INSIGHTS_CLOSED,
+  ])(
+    'enriches %s with Market Insights card rotation assignment',
+    (eventName) => {
+      const event = AnalyticsEventBuilder.createEventBuilder(eventName).build();
+
+      const result = enrichWithABTests(event, {
+        [MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY]:
+          MarketInsightsCardRotationIntervalVariant.CarouselTimeExtended,
+      });
+
+      expect(result.properties.active_ab_tests).toEqual([
+        createActiveABTestAssignment(
+          MARKET_INSIGHTS_CARD_ROTATION_INTERVAL_AB_KEY,
+          MarketInsightsCardRotationIntervalVariant.CarouselTimeExtended,
+        ),
+      ]);
+    },
+  );
 
   it('leaves non-A/B properties and sensitive properties unchanged', () => {
     const event = AnalyticsEventBuilder.createEventBuilder('Card Button Viewed')


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adds an AB test to the interval of the Market insights carousel, between 5 and 6 seconds. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: no-changelog

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Market Insights carousel timing via remote feature flags and adds A/B-test attribution for multiple analytics events, which could affect user-visible behavior and metrics if misconfigured.
> 
> **Overview**
> Adds an A/B test to control the `MarketInsightsEntryCard` carousel rotation interval, switching between 5s (control) and 6s (treatment) by passing a new `rotateIntervalMs` prop into `SlidingTextCarousel`.
> 
> Introduces `MarketInsights` A/B-test config (`abTestConfig.ts`) and registers it in the A/B analytics registry so selected Market Insights events are enriched with the active assignment. Updates unit tests to cover the new interval override and event enrichment behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51ef457fddcb08745b6b1749a660f0f3a2fac39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->