### PR TITLE
test: adds a retry to transaction finalized event checks

### DIFF
--- a/tests/smoke/confirmations/send/metricsValidationHelper.ts
+++ b/tests/smoke/confirmations/send/metricsValidationHelper.ts
@@ -1,7 +1,10 @@
 import { Mockttp } from 'mockttp';
 import { AnvilManager } from '../../../seeder/anvil-manager';
 import { LocalNode } from '../../../framework';
-import { getEventsPayloads } from '../../../helpers/analytics/helpers';
+import {
+  EventPayload,
+  getEventsPayloads,
+} from '../../../helpers/analytics/helpers';
 
 /**
  * Validates the transaction hash in the Transaction Finalized Event.
@@ -35,10 +38,20 @@ export const validateTransactionHashInTransactionFinalizedEvent = async (
     );
   }
 
-  const events = await getEventsPayloads(mockServer);
-  const transactionFinalizedEvent = events.find(
-    (event) => event.event === 'Transaction Finalized',
-  );
+  // The transaction finalized event may not be sent immediately, so we safely retry up to 5 times.
+  const MAX_ATTEMPTS = 5;
+  const delay = 1000;
+  let transactionFinalizedEvent: EventPayload | undefined;
+  for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    const events = await getEventsPayloads(mockServer);
+    transactionFinalizedEvent = events.find(
+      (event) => event.event === 'Transaction Finalized',
+    );
+    if (transactionFinalizedEvent) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
 
   if (!transactionFinalizedEvent) {
     throw new Error(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
The Transaction Finalized event may not be fired immediately so there is a race condition between the E2E check and the timing for the event to be fired. This PR adds a retry mechanism to want a maximum of 5s before actually throwing the error when the event is not fired at all. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1778143821257179

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds polling before failing when the analytics event arrives late; no production logic is affected.
> 
> **Overview**
> Reduces flakiness in the send confirmation smoke test by **polling for the `Transaction Finalized` MetaMetrics event** (up to 5 attempts with a 1s delay) before failing the transaction-hash validation.
> 
> Also updates the helper to import and use the `EventPayload` type for the retried lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d151e3688bb6c139baa94fa23cfaf42b25bd16fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->