### PR TITLE
chore(rewards): fix campaign param extract

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -18,7 +18,7 @@ interface HandleRewardsUrlParams {
 interface RewardsNavigationParams {
   referral?: string;
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1';
+  campaign?: 'ondo' | 'season1' | 'perps-comp';
 }
 
 /**

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -34,7 +34,7 @@ const parseRewardsNavigationParams = (
   );
 
   const pageParam = urlParams.get('page');
-  const campaignParam = urlParams.get('campaign');
+  const campaignParam = urlParams.get('campaign') ?? urlParams.get('~campaign');
 
   return {
     referral:
@@ -43,7 +43,7 @@ const parseRewardsNavigationParams = (
     page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
       ? pageParam
       : undefined) as RewardsNavigationParams['page'],
-    campaign: (['ondo', 'season1'].includes(campaignParam ?? '')
+    campaign: (['ondo', 'season1', 'perps-comp'].includes(campaignParam ?? '')
       ? campaignParam
       : undefined) as RewardsNavigationParams['campaign'],
   };


### PR DESCRIPTION
## **Description**

- "?~campaign=ondo&__branch_flow_id=1580894552734833035&~referring_browser=Chrome" would fail to be parsed correctly, the campaign param we extract would be null, and the user would end up in the rewards dashboard instead of the ondo details campaign page. 

- Added support for upcoming perps trading comp deeplink 

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to rewards deeplink query parsing that may only affect navigation routing for rewards campaign links.
> 
> **Overview**
> Rewards deeplink parsing now falls back to reading Branch-style `~campaign` when `campaign` is missing, preventing campaign links from dropping users onto the generic rewards dashboard.
> 
> It also expands allowed campaign values to include the new `perps-comp` campaign so those deeplinks can route correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddca21a7216ffdf2c615e76cc84b845c016ea403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->