### PR TITLE
fix(money): scroll 'Your balance' heading with content (MUSD-779)

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenList.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenList.tsx
@@ -40,6 +40,7 @@ interface TokenListProps {
   setShowScamWarningModal: (chainId: string | null) => void;
   maxItems?: number;
   isFullView?: boolean;
+  listHeaderComponent?: React.ReactElement;
   listFooterComponent?: React.ReactElement;
   /**
    * Optional external RefreshControl. When provided, overrides the internal
@@ -54,6 +55,11 @@ interface TokenListProps {
   hideSecondaryPriceRow?: boolean;
 }
 
+const wrapEdgeNode = (
+  node: React.ReactElement | undefined,
+  isFullView: boolean,
+) => (isFullView && node ? <Box twClassName="-mx-4">{node}</Box> : node);
+
 const TokenListComponent = ({
   tokenKeys,
   refreshing,
@@ -63,6 +69,7 @@ const TokenListComponent = ({
   setShowScamWarningModal,
   maxItems,
   isFullView = false,
+  listHeaderComponent,
   listFooterComponent,
   refreshControl,
   hideSecondaryPriceRow = false,
@@ -180,6 +187,7 @@ const TokenListComponent = ({
       twClassName={'bg-default'}
       testID={WalletViewSelectorsIDs.TOKENS_CONTAINER_LIST}
     >
+      {listHeaderComponent}
       {displayTokenKeys.map((item, index) => (
         <TokenListItem
           key={`${getTokenKey(item)}-${index}`}
@@ -227,13 +235,8 @@ const TokenListComponent = ({
         }
         extraData={{ isTokenNetworkFilterEqualCurrentNetwork }}
         contentContainerStyle={!isFullView ? undefined : tw`px-4`}
-        ListFooterComponent={
-          isFullView && listFooterComponent ? (
-            <Box twClassName="-mx-4">{listFooterComponent}</Box>
-          ) : (
-            listFooterComponent
-          )
-        }
+        ListHeaderComponent={wrapEdgeNode(listHeaderComponent, isFullView)}
+        ListFooterComponent={wrapEdgeNode(listFooterComponent, isFullView)}
       />
     </Box>
   );

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -303,13 +303,14 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
         </Box>
       );
 
-      if (listFooterComponent || refreshControl) {
+      if (listHeaderComponent || listFooterComponent || refreshControl) {
         return (
           <ScrollView
             style={tw`flex-1`}
             showsVerticalScrollIndicator={false}
             refreshControl={refreshControl}
           >
+            {listHeaderComponent}
             {emptyState}
             {listFooterComponent}
           </ScrollView>

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -56,6 +56,7 @@ interface TokensProps {
    * (e.g. network filter set to a chain without mUSD).
    */
   hasMusdBalanceOnAnyChain?: boolean;
+  listHeaderComponent?: React.ReactElement;
   listFooterComponent?: React.ReactElement;
   /**
    * Optional external RefreshControl. When provided, overrides the internal
@@ -82,6 +83,7 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
       isFullView = false,
       showOnlyMusd = false,
       hasMusdBalanceOnAnyChain: hasMusdBalanceOnAnyChainProp,
+      listHeaderComponent,
       listFooterComponent,
       refreshControl,
       hideLoadingSkeleton = false,
@@ -275,6 +277,7 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
               setShowScamWarningModal={handleScamWarningModal}
               maxItems={maxItems}
               isFullView={isFullView}
+              listHeaderComponent={listHeaderComponent}
               listFooterComponent={listFooterComponent}
               refreshControl={refreshControl}
               hideSecondaryPriceRow={hideSecondaryPriceRow}
@@ -329,6 +332,7 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
       handleScamWarningModal,
       maxItems,
       isGeoEligible,
+      listHeaderComponent,
       listFooterComponent,
       refreshControl,
       hideSecondaryPriceRow,

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.test.tsx
@@ -128,9 +128,11 @@ jest.mock('../../UI/Tokens', () => {
   const MockTokens = ({
     isFullView,
     showOnlyMusd,
+    listHeaderComponent,
   }: {
     isFullView?: boolean;
     showOnlyMusd?: boolean;
+    listHeaderComponent?: React.ReactElement;
   }) =>
     createElement(
       View,
@@ -140,6 +142,7 @@ jest.mock('../../UI/Tokens', () => {
         { testID: 'tokens-props' },
         `isFullView=${isFullView} showOnlyMusd=${showOnlyMusd}`,
       ),
+      listHeaderComponent,
     );
   return { __esModule: true, default: MockTokens };
 });

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
@@ -216,6 +216,21 @@ const CashTokensFullView = () => {
     });
   }, [createEventBuilder, goToBuy, trackEvent]);
 
+  const balanceHeading = useMemo(
+    () => (
+      <Box twClassName="px-4 pt-2 pb-3">
+        <Text
+          variant={TextVariant.HeadingLg}
+          fontWeight={FontWeight.Bold}
+          testID={CashTokensFullViewTestIds.HEADING}
+        >
+          {strings('money.your_balance')}
+        </Text>
+      </Box>
+    ),
+    [],
+  );
+
   const bonusAndConvertSections = useMemo(
     () => (
       <>
@@ -246,17 +261,6 @@ const CashTokensFullView = () => {
       >
         {strings('money.title')}
       </HeaderBase>
-      {isMoneyHubEnabled && (
-        <Box twClassName="px-4 pt-2 pb-3">
-          <Text
-            variant={TextVariant.HeadingLg}
-            fontWeight={FontWeight.Bold}
-            testID={CashTokensFullViewTestIds.HEADING}
-          >
-            {strings('money.your_balance')}
-          </Text>
-        </Box>
-      )}
       {hasMusdBalanceOnAnyChain ? (
         isTokenListReady ? (
           <Tokens
@@ -268,6 +272,7 @@ const CashTokensFullView = () => {
             // mUSD entries inside Money Hub so the row reads as a balance
             // entry under the new "Your balance" heading.
             hideSecondaryPriceRow={isMoneyHubEnabled}
+            listHeaderComponent={isMoneyHubEnabled ? balanceHeading : undefined}
             listFooterComponent={
               isMoneyHubEnabled ? bonusAndConvertSections : undefined
             }
@@ -280,6 +285,7 @@ const CashTokensFullView = () => {
             numChainsWithMusdBalance={numChainsWithMusdBalance}
             isMoneyHubEnabled={isMoneyHubEnabled}
             conversionTokenCount={conversionTokens.length}
+            listHeaderComponent={isMoneyHubEnabled ? balanceHeading : undefined}
           />
         )
       ) : (
@@ -290,6 +296,7 @@ const CashTokensFullView = () => {
             <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
           }
         >
+          {isMoneyHubEnabled && balanceHeading}
           {isMoneyHubEnabled ? (
             // MUSD-729 empty state: mirror the "Your balance" funded layout
             // (mUSD avatar + network badge + $0.00 / 0 mUSD). The standard

--- a/app/components/Views/CashTokensFullView/CashTokensFullViewSkeleton.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullViewSkeleton.tsx
@@ -21,6 +21,7 @@ interface CashTokensFullViewSkeletonProps {
   numChainsWithMusdBalance: number;
   isMoneyHubEnabled: boolean;
   conversionTokenCount: number;
+  listHeaderComponent?: React.ReactElement;
 }
 
 /**
@@ -193,6 +194,7 @@ const CashTokensFullViewSkeleton = ({
   numChainsWithMusdBalance,
   isMoneyHubEnabled,
   conversionTokenCount,
+  listHeaderComponent,
 }: CashTokensFullViewSkeletonProps) => {
   const tw = useTailwind();
 
@@ -202,6 +204,7 @@ const CashTokensFullViewSkeleton = ({
       showsVerticalScrollIndicator={false}
       testID={CashTokensFullViewSkeletonTestIds.CONTAINER}
     >
+      {listHeaderComponent}
       {numChainsWithMusdBalance > 0 ? (
         <>
           {Array.from({ length: numChainsWithMusdBalance }, (_, index) => (


### PR DESCRIPTION
## **Description**

The "Your balance" heading on the Money Hub screen (`CashTokensFullView`) was rendered between the screen header and the scrollable list, leaving it pinned at the top while content scrolled beneath it. This created a visually disconnected UX between the heading and the list.

The heading is now moved into each scrollable container so it scrolls naturally with the rest of the page:

- Funded path: passed as `ListHeaderComponent` of the FlashList inside `<TokenList>`.
- Empty-state path: rendered as the first child of the existing `ScrollView`.
- Skeleton path: rendered as the first child of the skeleton's `ScrollView`.

To reach FlashList's header slot from the screen, an additive `listHeaderComponent` prop was added to `<Tokens>` and `<TokenList>`, mirroring the existing `listFooterComponent` pattern (opt-in, no behavior change for existing callers). A small `wrapEdgeNode` helper deduplicates the `-mx-4` padding-compensation that header and footer both need in `isFullView` mode.

Note: `<Tokens>` / `<TokenList>` belong to the wallet team. Touching them was the minimal way to reach FlashList's header slot — flagging for wallet-team awareness during review.

## **Changelog**

CHANGELOG entry: Fixed a bug where the "Your balance" heading on the Money Hub stayed pinned to the top of the screen instead of scrolling with the content.

## **Related issues**

Fixes: [MUSD-779](https://consensyssoftware.atlassian.net/browse/MUSD-779)

## **Manual testing steps**

\`\`\`gherkin
Feature: Money Hub Your balance heading scrolls with content

  Scenario: user with mUSD scrolls the Money Hub
    Given the user has mUSD balance on at least one chain
    And the user is on the Money Hub
    When the user scrolls down
    Then the "Your balance" heading scrolls off-screen with the rest of the content
    When the user scrolls back to the top
    Then the "Your balance" heading reappears in flow above the mUSD list

  Scenario: user without mUSD scrolls the Money Hub empty state
    Given the user has no mUSD balance
    And the user is on the Money Hub
    When the user scrolls down
    Then the "Your balance" heading scrolls off-screen with the empty-state content
\`\`\`

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/51a85271-a4da-465f-9d65-0491bcd1831a


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-779]: https://consensyssoftware.atlassian.net/browse/MUSD-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change that threads a new optional `listHeaderComponent` prop through `Tokens`/`TokenList`; main risk is minor rendering/padding regressions in full-view/empty-state paths.
> 
> **Overview**
> Fixes Money Hub (CashTokensFullView) so the **"Your balance"** heading scrolls with the token content instead of staying pinned.
> 
> This adds an optional `listHeaderComponent` prop to `Tokens` and `TokenList`, wiring it through both the map-rendered list and the FlashList `ListHeaderComponent`, and updates the empty-state and skeleton ScrollViews to render the header at the top. It also deduplicates full-view edge padding compensation for both header and footer via `wrapEdgeNode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab8ff133d591d79a57fc831e02f9cb0b4a4acce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->