### PR TITLE
fix: sponsored hardware wallet send max native

### DIFF
--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -5,6 +5,7 @@ import { isTestNet } from '../../../../../util/networks';
 import { stakingDepositConfirmationState } from '../../../../../util/test/confirm-data-helpers';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useFeeCalculations } from './useFeeCalculations';
+import { useIsGaslessSupported } from './useIsGaslessSupported';
 import { toHex } from '@metamask/controller-utils';
 
 jest.mock('../../../../../util/networks', () => ({
@@ -28,11 +29,21 @@ jest.mock('../../utils/token', () => ({
   fetchErc20Decimals: jest.fn().mockResolvedValue(18),
 }));
 
+jest.mock('./useIsGaslessSupported', () => ({
+  useIsGaslessSupported: jest.fn(),
+}));
+
 describe('useFeeCalculations', () => {
   const mockIsTestNet = jest.mocked(isTestNet);
+  const mockUseIsGaslessSupported = jest.mocked(useIsGaslessSupported);
 
   beforeEach(() => {
     jest.resetAllMocks();
+    mockUseIsGaslessSupported.mockReturnValue({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
+    });
   });
 
   const transactionMeta =
@@ -55,6 +66,11 @@ describe('useFeeCalculations', () => {
   });
 
   it('returns zero fee when gas is sponsored', () => {
+    mockUseIsGaslessSupported.mockReturnValue({
+      isSupported: true,
+      isSmartTransaction: false,
+      pending: false,
+    });
     const { result } = renderHookWithProvider(
       () =>
         useFeeCalculations({
@@ -71,6 +87,29 @@ describe('useFeeCalculations', () => {
     expect(result.current.preciseNativeFeeInHex).toBe('0x0');
     expect(result.current.maxFeeFiat).toBe('$0');
     expect(result.current.maxFeeNative).toBe('0');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns correct fee calculations when gas is sponsored but gasless not supported', () => {
+    mockUseIsGaslessSupported.mockReturnValue({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
+    });
+    const { result } = renderHookWithProvider(
+      () =>
+        useFeeCalculations({
+          ...transactionMeta,
+          isGasFeeSponsored: true,
+        }),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+    expect(result.current.estimatedFeeFiat).toBe('$0.34');
+    expect(result.current.estimatedFeeNative).toBe('0.0001');
+    expect(result.current.estimatedFeeFiatPrecise).toBe('0.337875011');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -19,6 +19,7 @@ import {
 import { useSupportsEIP1559 } from '../transactions/useSupportsEIP1559';
 import { useEIP1559TxFees } from './useEIP1559TxFees';
 import { useGasFeeEstimates } from './useGasFeeEstimates';
+import { useIsGaslessSupported } from './useIsGaslessSupported';
 
 const HEX_ZERO = '0x0';
 
@@ -99,6 +100,7 @@ export const useFeeCalculations = (
   const estimatedBaseFee = (gasFeeEstimates as GasFeeEstimates)
     ?.estimatedBaseFee;
 
+  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const txParamsGasPrice = transactionMeta.txParams?.gasPrice ?? HEX_ZERO;
   const receiptGasPriceHex = txReceipt?.effectiveGasPrice;
 
@@ -144,9 +146,13 @@ export const useFeeCalculations = (
     [estimatedBaseFee, layer1GasFee, getFeesFromHexCallback],
   );
 
+  const isSponsorshipEnabledForTx = Boolean(
+    transactionMeta?.isGasFeeSponsored && isGaslessSupported,
+  );
+
   // Estimated fee
   const estimatedFees = useMemo(() => {
-    if (transactionMeta.isGasFeeSponsored) {
+    if (isSponsorshipEnabledForTx) {
       return {
         currentCurrencyFee: fiatFormatter(new BigNumber('0')),
         preciseCurrentCurrencyFee: '0',
@@ -170,13 +176,13 @@ export const useFeeCalculations = (
     supportsEIP1559,
     txParamsGasPrice,
     receiptGasPriceHex,
-    transactionMeta.isGasFeeSponsored,
+    isSponsorshipEnabledForTx,
     fiatFormatter,
   ]);
 
   // Max fee
   const maxFee = useMemo(() => {
-    if (transactionMeta.isGasFeeSponsored) {
+    if (isSponsorshipEnabledForTx) {
       return HEX_ZERO;
     }
     return addHexes(
@@ -194,7 +200,7 @@ export const useFeeCalculations = (
     txParamsGasPrice,
     transactionMeta.txParams.gas,
     transactionMeta.layer1GasFee,
-    transactionMeta.isGasFeeSponsored,
+    isSponsorshipEnabledForTx,
   ]);
 
   const {

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
@@ -14,6 +14,7 @@ import { usePercentageAmount } from './usePercentageAmount';
 import { useBalance } from './useBalance';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useIsNetworkGasSponsored } from '../../../../UI/Bridge/hooks/useIsNetworkGasSponsored';
+import { isHardwareAccount } from '../../../../../util/address';
 
 jest.mock('@metamask/assets-controllers', () => ({
   getNativeTokenAddress: () => '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
@@ -41,6 +42,10 @@ jest.mock('../../../../UI/Bridge/hooks/useIsNetworkGasSponsored', () => ({
   useIsNetworkGasSponsored: jest.fn(),
 }));
 
+jest.mock('../../../../../util/address', () => ({
+  isHardwareAccount: jest.fn(),
+}));
+
 const mockState = {
   state: evmSendStateMock,
 };
@@ -58,11 +63,16 @@ const mockUseIsNetworkGasSponsored =
     typeof useIsNetworkGasSponsored
   >;
 
+const mockIsHardwareAccount = isHardwareAccount as jest.MockedFunction<
+  typeof isHardwareAccount
+>;
+
 describe('usePercentageAmount', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseParams.mockReturnValue(undefined);
     mockUseIsNetworkGasSponsored.mockReturnValue(false);
+    mockIsHardwareAccount.mockReturnValue(false);
   });
 
   it('return required fields', () => {
@@ -128,6 +138,33 @@ describe('usePercentageAmount', () => {
     mockUseSendContext.mockReturnValue({
       asset: {
         chainId: '0x1',
+        address: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
+        decimals: 2,
+        isNative: true,
+      },
+    } as unknown as ReturnType<typeof useSendContext>);
+    mockUseBalance.mockReturnValue({
+      balance: '1000000000000000',
+      decimals: 2,
+      rawBalanceBN: new BN('1000000000000000'),
+    });
+
+    const { result } = renderHookWithProvider(
+      () => usePercentageAmount(),
+      mockState,
+    );
+    expect(result.current.isMaxAmountSupported).toBeTruthy();
+    expect(result.current.getPercentageAmount(100)).toEqual('9685000000000');
+  });
+
+  it('return correct calculated max value for native asset if gas sponsored with hardware wallets', () => {
+    mockUseIsNetworkGasSponsored.mockReturnValue(true);
+    mockIsHardwareAccount.mockReturnValue(true);
+    mockUseSendContext.mockReturnValue({
+      // Field required for HW wallet detection
+      from: '0x0EA854bC5E08eb20E1fCD83Bf21F529268687C52',
+      asset: {
+        chainId: '0x531',
         address: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
         decimals: 2,
         isNative: true,

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
@@ -12,6 +12,7 @@ import { useBalance } from './useBalance';
 import { useGasFeeEstimatesForSend } from './useGasFeeEstimatesForSend';
 import { useSendType } from './useSendType';
 import { useIsNetworkGasSponsored } from '../../../../UI/Bridge/hooks/useIsNetworkGasSponsored';
+import { isHardwareAccount } from '../../../../../util/address';
 
 export interface GasFeeEstimatesType {
   medium: {
@@ -81,7 +82,9 @@ export const usePercentageAmount = () => {
   const { isEvmNativeSendType, isNonEvmNativeSendType } = useSendType();
   const { rawBalanceBN } = useBalance();
   const { gasFeeEstimates } = useGasFeeEstimatesForSend();
-  const isGasSponsored = useIsNetworkGasSponsored(chainId);
+  const isHardwareWallet = Boolean(from && isHardwareAccount(from));
+  const isNetworkGasSponsored = useIsNetworkGasSponsored(chainId);
+  const isGasSponsored = Boolean(isNetworkGasSponsored && !isHardwareWallet);
 
   const { value: layer1GasFee } = useAsyncResult(async () => {
     if (!isEvmNativeSendType || asset?.chainId === CHAIN_IDS.MAINNET || !from) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

On sponsored networks, the "send max native" feature wrongly tries to send 100% of user's balance on Hardware Wallets despite Gas Sponsorship being disabled for those. This creates an out of gas situation.
The PR restores the legacy behavior of the "max" button for such specific cases (HW + gas sponsorship + send max native).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: sponsored hardware wallet send max native

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-1132?atlOrigin=eyJpIjoiYjFiZWVkNWJlMTI5NDk5NmE4OTA2NTM5NjkzM2RlMzQiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

0. Use a HW wallet account - ex: QR Code wallet
1. Go on SEI token page on SEI network
2. Click on "Send"
3. Click on the "max" / "100%" button
4. Continue to Confirmation view. Notice that no error appear and that the tx executes without sponsorship.

Non-reg on regular accounts to check that sending max on SEI still sends the full balance - not Monad because of the 10 MON constraint. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="Screenshot_2026-05-07-16-09-18-393_io metamask" src="https://github.com/user-attachments/assets/f29f7b95-318e-4f01-9b78-3bc7a1ff1b38" />


### **After**

<img width="300" alt="Screenshot_2026-05-07-16-08-45-146_io metamask" src="https://github.com/user-attachments/assets/0ed97b31-a17a-4afb-b2d0-3600058ee881" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fee and max-send calculations for gas sponsorship, which can affect how much users attempt to send and what fees are displayed; incorrect logic could reintroduce out-of-gas or under-send behavior on sponsored networks.
> 
> **Overview**
> Updates gas sponsorship handling to only apply when the app confirms gasless/sponsorship is actually supported.
> 
> In `useFeeCalculations`, sponsored transactions now show `0` fees *only* when `useIsGaslessSupported().isSupported` is true; otherwise normal fee/max-fee computation is used, with tests covering both cases.
> 
> In `usePercentageAmount`, hardware-wallet accounts are treated as **not gas-sponsored** even on sponsored networks, restoring legacy “send max native” behavior (subtracting estimated gas) to prevent out-of-gas sends; tests add coverage for the HW-sponsored-network scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d8f577247f1a3c7192af37aef46792c07e54c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->