### PR TITLE
fix(rewards): remove client cache for Ondo portfolio positions

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -530,7 +530,10 @@ export type RewardsControllerGetPerpsTradingCampaignParticipantOutcomeAction = {
 /**
  * Get the current user's position on the campaign leaderboard.
  * This is an authenticated endpoint.
- * Results are cached for 5 minutes.
+ * Always fetches fresh from the API so the user's rank stays in sync with
+ * their latest trades; the result is mirrored to
+ * `state.ondoCampaignLeaderboardPositions` so selectors can read the latest
+ * snapshot.
  *
  * @param campaignId - The campaign ID to get position for.
  * @param subscriptionId - The subscription ID for authentication.
@@ -549,9 +552,10 @@ export type RewardsControllerGetOndoCampaignParticipantOutcomeAction = {
 /**
  * Get the current user's Ondo GM portfolio for a campaign.
  * This is an authenticated endpoint.
- * Results are cached for 5 minutes under
+ * Always fetches fresh from the API; the result is mirrored to
  * `state.ondoCampaignPortfolio[subscriptionId:campaignId]` as
- * {@link OndoGmPortfolioState}. Null API responses are not written to the cache.
+ * {@link OndoGmPortfolioState} so selectors can read the latest snapshot.
+ * Null API responses are not written to the cache.
  *
  * @param campaignId - The campaign ID to get portfolio for.
  * @param subscriptionId - The subscription ID for authentication.
@@ -564,9 +568,11 @@ export type RewardsControllerGetOndoCampaignPortfolioPositionAction = {
 
 /**
  * Get paginated activity for an Ondo GM campaign.
- * First page is cached for 1 minute; subsequent pages are always fetched fresh.
- * When `forceFresh` is true the cache is bypassed but a last-updated check
- * avoids redundant fetches if the server data hasn't changed.
+ * Always fetches fresh from the API; the first-page result is mirrored to
+ * `state.ondoCampaignActivity` so selectors can read the latest snapshot.
+ * Subsequent pages (cursor provided) are fetched directly without going
+ * through the cache. When `forceFresh` is true a last-updated check avoids
+ * redundant fetches if the server data hasn't changed.
  *
  * @param params - Campaign ID, subscription ID, pagination cursor, and optional forceFresh flag.
  * @returns Paginated activity entries.
@@ -731,7 +737,10 @@ export type RewardsControllerGetPerpsTradingCampaignLeaderboardAction = {
 /**
  * Get the current user's position on the perps trading campaign leaderboard.
  * This is an authenticated endpoint.
- * Results are cached for 5 minutes.
+ * Always fetches fresh from the API so the user's rank stays in sync with
+ * their latest trades; the result is mirrored to
+ * `state.perpsTradingCampaignLeaderboardPositions` so selectors can read the
+ * latest snapshot.
  *
  * @param campaignId - The campaign ID to get position for.
  * @param subscriptionId - The subscription ID for authentication.

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -19805,9 +19805,13 @@ describe('RewardsController', () => {
       ).toBeDefined();
     });
 
-    it('returns cached position when cache is fresh', async () => {
-      const recentTime = Date.now() - 30000; // 30 seconds ago (within 1 minute threshold)
+    it('always fetches fresh leaderboard position even when a recent cache entry exists', async () => {
+      const recentTime = Date.now() - 30000; // 30 seconds ago
       const cacheKey = `${mockSubscriptionId}:${mockCampaignId}`;
+      const freshPosition = {
+        ...mockPosition,
+        rank: (mockPosition.rank ?? 0) + 1,
+      };
       const ctrl = new RewardsController({
         messenger: ondoLeaderboardPositionMessenger,
         state: {
@@ -19821,13 +19825,19 @@ describe('RewardsController', () => {
         },
       });
 
+      ondoLeaderboardPositionMessenger.call.mockResolvedValue(freshPosition);
+
       const result = await ctrl.getOndoCampaignLeaderboardPosition(
         mockCampaignId,
         mockSubscriptionId,
       );
 
-      expect(result).toEqual(mockPosition);
-      expect(ondoLeaderboardPositionMessenger.call).not.toHaveBeenCalled();
+      expect(ondoLeaderboardPositionMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getOndoCampaignLeaderboardPosition',
+        mockCampaignId,
+        mockSubscriptionId,
+      );
+      expect(result).toEqual(freshPosition);
     });
 
     it('returns null and caches a not-found sentinel when API returns null (user not on leaderboard)', async () => {
@@ -19853,7 +19863,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('does not re-fetch when a fresh not-found sentinel is cached (TTL respected)', async () => {
+    it('re-fetches even when a fresh not-found sentinel is cached', async () => {
       const cacheKey = `${mockSubscriptionId}:${mockCampaignId}`;
       const ctrl = new RewardsController({
         messenger: ondoLeaderboardPositionMessenger,
@@ -19862,19 +19872,25 @@ describe('RewardsController', () => {
           ondoCampaignLeaderboardPositions: {
             [cacheKey]: {
               notFound: true as const,
-              lastFetched: Date.now() - 30000, // 30 seconds ago (within 1 minute threshold)
+              lastFetched: Date.now() - 30000, // 30 seconds ago
             },
           },
         },
       });
+
+      ondoLeaderboardPositionMessenger.call.mockResolvedValue(mockPosition);
 
       const result = await ctrl.getOndoCampaignLeaderboardPosition(
         mockCampaignId,
         mockSubscriptionId,
       );
 
-      expect(result).toBeNull();
-      expect(ondoLeaderboardPositionMessenger.call).not.toHaveBeenCalled();
+      expect(result).toEqual(mockPosition);
+      expect(ondoLeaderboardPositionMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getOndoCampaignLeaderboardPosition',
+        mockCampaignId,
+        mockSubscriptionId,
+      );
     });
 
     it('logs when fetching fresh position', async () => {
@@ -19982,9 +19998,13 @@ describe('RewardsController', () => {
       expect(ctrl.state.ondoCampaignPortfolio[cacheKey]).toBeDefined();
     });
 
-    it('returns cached portfolio when cache is fresh', async () => {
-      const recentTime = Date.now() - 30000; // 30 seconds ago (within 1 minute threshold)
+    it('always fetches fresh portfolio even when a recent cache entry exists', async () => {
+      const recentTime = Date.now() - 30000; // 30 seconds ago
       const cacheKey = `${mockSubscriptionId}:${mockCampaignId}`;
+      const freshPortfolio = {
+        ...mockPortfolio,
+        computedAt: '2024-03-20T12:05:00.000Z',
+      };
       const ctrl = new RewardsController({
         messenger: ondoPortfolioMessenger,
         state: {
@@ -19998,13 +20018,19 @@ describe('RewardsController', () => {
         },
       });
 
+      ondoPortfolioMessenger.call.mockResolvedValue(freshPortfolio);
+
       const result = await ctrl.getOndoCampaignPortfolioPosition(
         mockCampaignId,
         mockSubscriptionId,
       );
 
-      expect(result).toEqual(mockPortfolio);
-      expect(ondoPortfolioMessenger.call).not.toHaveBeenCalled();
+      expect(ondoPortfolioMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getOndoCampaignPortfolioPosition',
+        mockCampaignId,
+        mockSubscriptionId,
+      );
+      expect(result).toEqual(freshPortfolio);
     });
 
     it('returns null when API returns null and does not cache', async () => {
@@ -20195,21 +20221,29 @@ describe('RewardsController', () => {
       );
     });
 
-    it('returns cached activity when cache is fresh', async () => {
+    it('always re-checks activity freshness even when a recent cache entry exists', async () => {
       const recentTime = Date.now() - 30000;
       const cacheKey = `${mockSubscriptionId}:${mockCampaignId}`;
+      const freshActivity = {
+        ...mockActivity,
+        cursor: 'fresh-cursor',
+      };
       const ctrl = new RewardsController({
         messenger: ondoActivityMessenger,
         state: {
           ...getRewardsControllerDefaultState(),
           ondoCampaignActivity: {
             [cacheKey]: {
-              ...mockActivity,
+              has_more: false,
+              cursor: null,
+              results: [],
               lastFetched: recentTime,
             },
           },
         },
       });
+
+      ondoActivityMessenger.call.mockResolvedValue(freshActivity as any);
 
       const result = await ctrl.getOndoCampaignActivity({
         campaignId: mockCampaignId,
@@ -20217,8 +20251,13 @@ describe('RewardsController', () => {
         cursor: null,
       });
 
-      expect(result).toEqual(mockActivity);
-      expect(ondoActivityMessenger.call).not.toHaveBeenCalled();
+      expect(ondoActivityMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getOndoCampaignActivity',
+        mockCampaignId,
+        mockSubscriptionId,
+        null,
+      );
+      expect(result).toEqual(freshActivity);
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -132,10 +132,12 @@ const CAMPAIGN_PARTICIPANT_STATUS_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minut
 const ONDO_CAMPAIGN_LEADERBOARD_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
 
 // Campaign leaderboard position cache threshold
-const ONDO_CAMPAIGN_LEADERBOARD_POSITION_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
+// Disabled to keep the user's rank in sync with their latest trades.
+const ONDO_CAMPAIGN_LEADERBOARD_POSITION_CACHE_THRESHOLD_MS = 0;
 
 // Campaign portfolio position cache threshold
-const ONDO_CAMPAIGN_PORTFOLIO_POSITION_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
+// Disabled to keep positions in sync with the activity list after rebalances.
+const ONDO_CAMPAIGN_PORTFOLIO_POSITION_CACHE_THRESHOLD_MS = 0;
 
 // Campaign deposits cache threshold
 const ONDO_CAMPAIGN_DEPOSITS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
@@ -144,7 +146,8 @@ const ONDO_CAMPAIGN_DEPOSITS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 const POINTS_EVENTS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute cache
 
 // Campaign activity cache threshold (first page only)
-const ONDO_CAMPAIGN_ACTIVITY_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute cache
+// Disabled to keep the activity feed in sync with the user's latest trades.
+const ONDO_CAMPAIGN_ACTIVITY_CACHE_THRESHOLD_MS = 0;
 
 // Campaign participant outcome cache threshold
 const ONDO_CAMPAIGN_PARTICIPANT_OUTCOME_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
@@ -153,8 +156,8 @@ const ONDO_CAMPAIGN_PARTICIPANT_OUTCOME_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 
 const PERPS_TRADING_CAMPAIGN_LEADERBOARD_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
 
 // Perps Trading Campaign leaderboard position cache threshold
-const PERPS_TRADING_CAMPAIGN_LEADERBOARD_POSITION_CACHE_THRESHOLD_MS =
-  1000 * 60 * 5; // 5 minutes
+// Disabled to keep the user's rank in sync with their latest trades.
+const PERPS_TRADING_CAMPAIGN_LEADERBOARD_POSITION_CACHE_THRESHOLD_MS = 0;
 
 // Perps Trading Campaign volume cache threshold
 const PERPS_TRADING_CAMPAIGN_VOLUME_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
@@ -3737,7 +3740,10 @@ export class RewardsController extends BaseController<
   /**
    * Get the current user's position on the campaign leaderboard.
    * This is an authenticated endpoint.
-   * Results are cached for 5 minutes.
+   * Always fetches fresh from the API so the user's rank stays in sync with
+   * their latest trades; the result is mirrored to
+   * `state.ondoCampaignLeaderboardPositions` so selectors can read the latest
+   * snapshot.
    * @param campaignId - The campaign ID to get position for.
    * @param subscriptionId - The subscription ID for authentication.
    * @returns The user's leaderboard position, or null if not found.
@@ -3864,9 +3870,10 @@ export class RewardsController extends BaseController<
   /**
    * Get the current user's Ondo GM portfolio for a campaign.
    * This is an authenticated endpoint.
-   * Results are cached for 5 minutes under
+   * Always fetches fresh from the API; the result is mirrored to
    * `state.ondoCampaignPortfolio[subscriptionId:campaignId]` as
-   * {@link OndoGmPortfolioState}. Null API responses are not written to the cache.
+   * {@link OndoGmPortfolioState} so selectors can read the latest snapshot.
+   * Null API responses are not written to the cache.
    * @param campaignId - The campaign ID to get portfolio for.
    * @param subscriptionId - The subscription ID for authentication.
    * @returns The portfolio, or null if not found.
@@ -3935,9 +3942,11 @@ export class RewardsController extends BaseController<
 
   /**
    * Get paginated activity for an Ondo GM campaign.
-   * First page is cached for 1 minute; subsequent pages are always fetched fresh.
-   * When `forceFresh` is true the cache is bypassed but a last-updated check
-   * avoids redundant fetches if the server data hasn't changed.
+   * Always fetches fresh from the API; the first-page result is mirrored to
+   * `state.ondoCampaignActivity` so selectors can read the latest snapshot.
+   * Subsequent pages (cursor provided) are fetched directly without going
+   * through the cache. When `forceFresh` is true a last-updated check avoids
+   * redundant fetches if the server data hasn't changed.
    * @param params - Campaign ID, subscription ID, pagination cursor, and optional forceFresh flag.
    * @returns Paginated activity entries.
    */
@@ -4562,7 +4571,10 @@ export class RewardsController extends BaseController<
   /**
    * Get the current user's position on the perps trading campaign leaderboard.
    * This is an authenticated endpoint.
-   * Results are cached for 5 minutes.
+   * Always fetches fresh from the API so the user's rank stays in sync with
+   * their latest trades; the result is mirrored to
+   * `state.perpsTradingCampaignLeaderboardPositions` so selectors can read the
+   * latest snapshot.
    * @param campaignId - The campaign ID to get position for.
    * @param subscriptionId - The subscription ID for authentication.
    * @returns The user's leaderboard position, or null if not found.


### PR DESCRIPTION
## **Description**

After a rebalance, the Ondo positions list could remain stale for up to 60 seconds while the activity list (which is not cached on the client) showed the up-to-date trade. Both views read the same upstream data, so the divergence was purely a client-side cache artifact in `RewardsController.getOndoCampaignPortfolioPosition`.

This PR sets `ONDO_CAMPAIGN_PORTFOLIO_POSITION_CACHE_THRESHOLD_MS` to `0`, which makes `wrapWithCache` always treat the entry as stale and fetch fresh from the API. The mirrored Redux state (`state.ondoCampaignPortfolio[…]`) is still written on each fetch, so selectors continue to render the latest snapshot — only the staleness window is removed.

Agreed on the approach with @jonathan.deyoung and @christian.montoya in [this Slack thread](https://consensys.slack.com/archives/C09372GAN59/p1778101253654439); flagged as a quick win for today's RC. Jonathan's call: low-risk because traffic to this endpoint is low and hits read-only servers, and the longer-term fix (timestamp-aligning positions and activity, à la S1) is parked as Perps follow-up work.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — driven by Slack thread linked above.

## **Manual testing steps**

```gherkin
Feature: Ondo positions stay in sync with activity after a rebalance

  Scenario: user rebalances and immediately reopens the campaign details
    Given the user has an active Ondo GM portfolio with at least one position
    When the user performs a rebalance (e.g. swap GE for MSFT)
    And the user navigates back into the Ondo campaign details screen within 60s
    Then the positions list reflects the post-rebalance holdings (MSFT present, GE absent)
    And the positions list matches the activity list
```

## **Screenshots/Recordings**

### **Before**

<!-- Stale positions list immediately after rebalance — see attached images in the Slack thread. -->

### **After**

<!-- Positions list matches activity list immediately after rebalance. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables several short-lived client caches, increasing request frequency for authenticated rewards endpoints; main risk is performance/network impact and potential rate-limiting, not data integrity.
> 
> **Overview**
> Removes the client-side TTL for several rewards “live snapshot” reads by setting their cache thresholds to `0`, forcing fresh API fetches while still mirroring responses into controller state for selectors.
> 
> This applies to Ondo leaderboard position, Ondo portfolio position, Ondo first-page activity, and Perps trading leaderboard position, and updates unit tests and generated action-type docs to reflect the new always-fresh behavior (including re-fetching even when a recent not-found sentinel exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77be6100fb7da80625073d6270effaa0d5c1468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->