### PR TITLE
fix(rewards): crown logic in perps leaderboard

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.test.tsx
@@ -39,6 +39,7 @@ jest.mock('./OndoCampaignStatsSummary', () => {
 });
 
 const IDS = CAMPAIGN_LEADERBOARD_SHARED_TEST_IDS;
+const CrownIcon = 'CrownIcon' as unknown as React.ComponentType;
 
 const baseEntry = {
   rank: 7,
@@ -64,6 +65,31 @@ describe('CampaignLeaderboardEntryRow', () => {
     expect(getByText('+12.5%')).toBeDefined();
     expect(formatPrimaryMetric).toHaveBeenCalledWith(baseEntry);
     expect(isPositivePrimaryMetric).toHaveBeenCalledWith(baseEntry);
+  });
+
+  it('shows crown based only on showCrown', () => {
+    const { UNSAFE_queryAllByType } = render(
+      <CampaignLeaderboardEntryRow
+        entry={baseEntry}
+        showCrown
+        formatPrimaryMetric={() => '+12.5%'}
+        isPositivePrimaryMetric={() => true}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(1);
+  });
+
+  it('hides crown when showCrown is false', () => {
+    const { UNSAFE_queryAllByType } = render(
+      <CampaignLeaderboardEntryRow
+        entry={{ ...baseEntry, rank: 1 }}
+        formatPrimaryMetric={() => '+12.5%'}
+        isPositivePrimaryMetric={() => true}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(0);
   });
 
   it('sets row testID from shared ENTRY_ROW and rank', () => {

--- a/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.tsx
@@ -92,9 +92,7 @@ export function CampaignLeaderboardEntryRow<
           >
             {entry.referralCode}
           </Text>
-          {showCrown && entry.rank <= 5 && (
-            <CrownIcon name="crown" width={14} height={14} />
-          )}
+          {showCrown && <CrownIcon name="crown" width={14} height={14} />}
         </Box>
         {showPendingTag && (
           <PendingTag

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.test.tsx
@@ -4,6 +4,7 @@ import OndoLeaderboard, {
   CAMPAIGN_LEADERBOARD_TEST_IDS,
 } from './OndoLeaderboard';
 import type { CampaignLeaderboardEntry } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import { ONDO_GM_TIER_MAX_WINNERS } from '../../utils/ondoCampaignConstants';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import {
   createMockUseAnalyticsHook,
@@ -29,6 +30,8 @@ jest.mock('@metamask/design-system-react-native', () => {
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({ style: (...args: unknown[]) => args }),
 }));
+
+jest.mock('../../../../../images/rewards/crown.svg', () => 'CrownIcon');
 
 jest.mock('../RewardsErrorBanner', () => {
   const ReactActual = jest.requireActual('react');
@@ -86,6 +89,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
     return translations[key] || key;
   },
 }));
+
+const CrownIcon = 'CrownIcon' as unknown as React.ComponentType;
 
 const createMockEntry = (
   overrides: Partial<CampaignLeaderboardEntry> = {},
@@ -334,6 +339,40 @@ describe('OndoLeaderboard', () => {
       );
 
       expect(getByText('No entries in this tier')).toBeDefined();
+    });
+
+    it('shows crown in full view for Ondo winner ranks only', () => {
+      const entries = [
+        createMockEntry({
+          rank: ONDO_GM_TIER_MAX_WINNERS,
+          referralCode: 'WINNER',
+        }),
+        createMockEntry({
+          rank: ONDO_GM_TIER_MAX_WINNERS + 1,
+          referralCode: 'NEXT',
+        }),
+      ];
+      const { UNSAFE_queryAllByType } = render(
+        <OndoLeaderboard {...defaultProps} entries={entries} />,
+      );
+
+      expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(1);
+    });
+
+    it('hides crown in preview mode for Ondo winner ranks', () => {
+      const entries = [
+        createMockEntry({ rank: 1, referralCode: 'AAA111' }),
+        createMockEntry({ rank: 2, referralCode: 'BBB222' }),
+      ];
+      const { UNSAFE_queryAllByType } = render(
+        <OndoLeaderboard
+          {...defaultProps}
+          entries={entries}
+          maxEntries={entries.length}
+        />,
+      );
+
+      expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(0);
     });
   });
 

--- a/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoLeaderboard.tsx
@@ -27,6 +27,7 @@ import {
   formatRateOfReturn,
   formatTierDisplayName,
 } from './OndoLeaderboard.utils';
+import { ONDO_GM_TIER_MAX_WINNERS } from '../../utils/ondoCampaignConstants';
 
 export const CAMPAIGN_LEADERBOARD_TEST_IDS = {
   CONTAINER: 'campaign-leaderboard-container',
@@ -275,7 +276,7 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
               key={`${entry.rank}-${entry.referralCode}`}
               entry={entry}
               isCurrentUser={isCurrentUser(entry)}
-              showCrown={!isPreview}
+              showCrown={!isPreview && entry.rank <= ONDO_GM_TIER_MAX_WINNERS}
               isCampaignComplete={isCampaignComplete}
               formatPrimaryMetric={(e) => formatRateOfReturn(e.rateOfReturn)}
               isPositivePrimaryMetric={(e) => e.rateOfReturn >= 0}
@@ -289,7 +290,9 @@ const OndoLeaderboard: React.FC<CampaignLeaderboardProps> = ({
                   key={`neighbor-${entry.rank}-${entry.referralCode}`}
                   entry={entry}
                   isCurrentUser={isCurrentUser(entry)}
-                  showCrown={!isPreview}
+                  showCrown={
+                    !isPreview && entry.rank <= ONDO_GM_TIER_MAX_WINNERS
+                  }
                   isCampaignComplete={isCampaignComplete}
                   formatPrimaryMetric={(e) =>
                     formatRateOfReturn(e.rateOfReturn)

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
@@ -4,6 +4,7 @@ import PerpsTradingCampaignLeaderboard, {
   PERPS_CAMPAIGN_LEADERBOARD_TEST_IDS,
 } from './PerpsTradingCampaignLeaderboard';
 import type { PerpsTradingCampaignLeaderboardEntry } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import { PERPS_TRADING_MAX_WINNERS } from '../../utils/perpsCampaignConstants';
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -48,6 +49,7 @@ jest.mock('../../../../../constants/navigation/Routes', () => ({
 }));
 
 const TEST_IDS = PERPS_CAMPAIGN_LEADERBOARD_TEST_IDS;
+const CrownIcon = 'CrownIcon' as unknown as React.ComponentType;
 
 const createPerpsEntry = (
   overrides: Partial<PerpsTradingCampaignLeaderboardEntry> = {},
@@ -103,6 +105,40 @@ describe('PerpsTradingCampaignLeaderboard', () => {
         }),
       }),
     );
+  });
+
+  it('shows crown in full view for perps winner ranks only', () => {
+    const entries = [
+      createPerpsEntry({
+        rank: PERPS_TRADING_MAX_WINNERS,
+        referralCode: 'WINNER',
+      }),
+      createPerpsEntry({
+        rank: PERPS_TRADING_MAX_WINNERS + 1,
+        referralCode: 'NEXT',
+      }),
+    ];
+    const { UNSAFE_queryAllByType } = render(
+      <PerpsTradingCampaignLeaderboard {...defaultProps} entries={entries} />,
+    );
+
+    expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(1);
+  });
+
+  it('hides crown in preview mode for perps winner ranks', () => {
+    const entries = [
+      createPerpsEntry({ rank: 1, referralCode: 'AAA111' }),
+      createPerpsEntry({ rank: 2, referralCode: 'BBB222' }),
+    ];
+    const { UNSAFE_queryAllByType } = render(
+      <PerpsTradingCampaignLeaderboard
+        {...defaultProps}
+        entries={entries}
+        maxEntries={entries.length}
+      />,
+    );
+
+    expect(UNSAFE_queryAllByType(CrownIcon)).toHaveLength(0);
   });
 
   describe('split view top count (preview vs full, ranks 21–22 vs other)', () => {

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
@@ -17,7 +17,10 @@ import {
   CAMPAIGN_LEADERBOARD_SHARED_TEST_IDS,
 } from './CampaignLeaderboard';
 import Routes from '../../../../../constants/navigation/Routes';
-import { HYPERTRACKER_ATTRIBUTION_URL } from '../../utils/perpsCampaignConstants';
+import {
+  HYPERTRACKER_ATTRIBUTION_URL,
+  PERPS_TRADING_MAX_WINNERS,
+} from '../../utils/perpsCampaignConstants';
 
 export const PERPS_CAMPAIGN_LEADERBOARD_TEST_IDS = {
   CONTAINER: 'perps-campaign-leaderboard-container',
@@ -191,7 +194,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
             key={`${entry.rank}-${entry.referralCode}`}
             entry={entry}
             isCurrentUser={isCurrentUser(entry)}
-            showCrown={!isPreview}
+            showCrown={!isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS}
             isCampaignComplete={isCampaignComplete}
             formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
             isPositivePrimaryMetric={(e) => e.pnl >= 0}
@@ -205,7 +208,9 @@ const PerpsTradingCampaignLeaderboard: React.FC<
                 key={`neighbor-${entry.rank}-${entry.referralCode}`}
                 entry={entry}
                 isCurrentUser={isCurrentUser(entry)}
-                showCrown={!isPreview}
+                showCrown={
+                  !isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS
+                }
                 isCampaignComplete={isCampaignComplete}
                 formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
                 isPositivePrimaryMetric={(e) => e.pnl >= 0}

--- a/app/components/UI/Rewards/utils/ondoCampaignConstants.ts
+++ b/app/components/UI/Rewards/utils/ondoCampaignConstants.ts
@@ -8,6 +8,9 @@ import { getCampaignStatus } from '../components/Campaigns/CampaignTile.utils';
  */
 export const ONDO_GM_REQUIRED_QUALIFIED_DAYS = 10;
 
+/** Maximum winners per tier for Ondo GM campaigns. */
+export const ONDO_GM_TIER_MAX_WINNERS = 5;
+
 /**
  * Returns true when the active campaign no longer has enough calendar days
  * remaining for the required qualifying-day count to be accumulated.

--- a/app/components/UI/Rewards/utils/perpsCampaignConstants.ts
+++ b/app/components/UI/Rewards/utils/perpsCampaignConstants.ts
@@ -4,6 +4,9 @@
  */
 export const PERPS_QUALIFICATION_NOTIONAL_USD = 25_000;
 
+/** Maximum winners for the perps trading campaign. */
+export const PERPS_TRADING_MAX_WINNERS = 20;
+
 /** HyperTracker attribution URL for the perps trading campaign leaderboard. */
 export const HYPERTRACKER_ATTRIBUTION_URL =
   'https://hypertracker.io?utm_source=metamask&utm_medium=leaderboard&utm_campaign=partner-attribution';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Fix wrong number of crowns shown in Perps leaderboard
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null 

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only affects when the crown icon renders; covered by updated/added unit tests for winner thresholds and preview mode.
> 
> **Overview**
> Fixes crown rendering so leaderboards only show crowns for *actual winner ranks*.
> 
> `CampaignLeaderboardEntryRow` now renders a crown strictly based on the `showCrown` prop (no internal rank check), and `OndoLeaderboard`/`PerpsTradingCampaignLeaderboard` now compute `showCrown` using new constants (`ONDO_GM_TIER_MAX_WINNERS = 5`, `PERPS_TRADING_MAX_WINNERS = 20`) while still disabling crowns in preview mode.
> 
> Adds/updates tests to assert correct crown behavior for winner thresholds and preview vs full views across the shared row, Ondo, and Perps leaderboards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900c4bd6c68b66204b795ea3ec7e5a3a4c1616be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->