### PR TITLE
fix(agentic): match RN 0.81 Bridgeless inspector targets

### DIFF
--- a/scripts/perps/agentic/lib/target-discovery.js
+++ b/scripts/perps/agentic/lib/target-discovery.js
@@ -94,8 +94,12 @@ async function discoverTarget(port) {
   let candidates = targets.filter(
     (t) =>
       t.webSocketDebuggerUrl &&
-      t.title &&
-      (/react/i.test(t.title) || /hermes/i.test(t.title)),
+      // Pre-RN-0.81 titles say "React Native"/"Hermes". RN 0.81+ Bridgeless
+      // titles are bundle-id-only (e.g. "io.metamask.MetaMask (mm-5)") and
+      // the runtime kind is in `description` instead.
+      ((t.title &&
+        (/react/i.test(t.title) || /hermes/i.test(t.title))) ||
+        /bridgeless|hermes/i.test(t.description || '')),
   );
 
   // Filter by device name if IOS_SIMULATOR is set
@@ -167,8 +171,12 @@ async function discoverAllTargets(port) {
   const candidates = (targets || []).filter(
     (t) =>
       t.webSocketDebuggerUrl &&
-      t.title &&
-      (/react/i.test(t.title) || /hermes/i.test(t.title)),
+      // Pre-RN-0.81 titles say "React Native"/"Hermes". RN 0.81+ Bridgeless
+      // titles are bundle-id-only (e.g. "io.metamask.MetaMask (mm-5)") and
+      // the runtime kind is in `description` instead.
+      ((t.title &&
+        (/react/i.test(t.title) || /hermes/i.test(t.title))) ||
+        /bridgeless|hermes/i.test(t.description || '')),
   );
 
   // Sort by page number descending (JS runtime has higher page number)


### PR DESCRIPTION
## **Description**

`yarn a:ios` was failing at the CDP-wait step on RN 0.81+ builds with `Still waiting... app may still be loading JS bundle` followed by a timeout, even when the simulator was booted, the app was running, and `__AGENTIC__` was actually exposed and reachable on Metro's inspector port.

Root cause: `scripts/perps/agentic/lib/target-discovery.js` filters Metro `/json/list` results by `t.title` matching `/react|hermes/i`. With RN 0.81 + Hermes Bridgeless the inspector titles are bundle-id-only (e.g. `io.metamask.MetaMask (mm-5)`) and the runtime kind moved into `description` (`React Native Bridgeless [C++ connection]`). The old filter excluded every Bridgeless target — `discoverAllTargets()` returned `[]`, `cdp-bridge.js status` returned empty, the preflight loop timed out.

Verified on a freshly built RN 0.81.5 simulator session before the patch:

- `curl http://localhost:<port>/json/list` returned a Bridgeless target whose `appId` was `io.metamask.MetaMask` and `description` was `React Native Bridgeless [C++ connection]`.
- Manually opening a WS to that target and running `Runtime.evaluate("typeof __AGENTIC__")` returned `object` (the bridge was there the whole time).
- `node scripts/perps/agentic/cdp-bridge.js status` returned `[]` (empty), confirming the agentic discovery filter dropped the target.

After the patch, `cdp-bridge.js status` on the same session returns:
```
{
  "account": { "address": "0x8dc623...9003", "id": "0285a92b-...", "name": "" },
  "route": { "key": "Wallet-...", "name": "Wallet" },
  "deviceName": "mm-5",
  "platform": "ios"
}
```

The fix relaxes the candidate filter in both `discoverTarget` and `discoverAllTargets` to also accept targets whose `description` contains `bridgeless` or `hermes`. Pre-0.81 behavior is unchanged because the legacy title-based clause still matches first; the new branch only fires when the title doesn't match. No behavior change on Android or older RN builds.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Agentic CDP discovery works on RN 0.81 Bridgeless inspector

  Scenario: yarn a:ios on RN 0.81+ build
    Given the engineer has a clean RN 0.81+ debug build of MetaMask installed on a simulator
    And the app is running and exposes __AGENTIC__ via Metro's inspector
    When the engineer runs "yarn a:ios"
    Then the preflight CDP wait passes within a few seconds (rather than timing out)
    And "node scripts/perps/agentic/cdp-bridge.js status" returns a non-empty payload with the running route and selected account

  Scenario: Pre-RN-0.81 builds remain unaffected
    Given a pre-0.81 RN debug build whose inspector titles still say "React Native (...)" or "Hermes (...)"
    When the engineer runs "yarn a:ios"
    Then target discovery still picks the legacy title match (no behavior change)

  Scenario: Probe still gates by __AGENTIC__
    Given a non-MetaMask Hermes target appears on the same Metro
    When discoverAllTargets runs
    Then the probe step still rejects targets that don't expose __AGENTIC__ (the filter only widens the candidate set; the __AGENTIC__ probe is unchanged)
```

## **Screenshots/Recordings**

### **Before**

N/A — agentic CDP-wait failure mode is text-only:
```
[4/5] Connecting CDP
  Waiting for app to expose debug target
  Still waiting... app may still be loading JS bundle
  Taking longer than usual — check device
  CDP timeout — diagnostic probe:
    port <port>: 2 targets
      - io.metamask.MetaMask (mm-5) (device=mm-5)
      - io.metamask.MetaMask (mm-5) (device=mm-5)
```

### **After**

N/A — same path now succeeds without timing out (`yarn a:ios` proceeds to the wallet setup step).

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to debug-target discovery heuristics, only broadening candidate matching to include RN 0.81+ Bridgeless targets; primary risk is accidentally matching an extra non-RN CDP target in unusual Metro setups.
> 
> **Overview**
> Fixes Agentic CDP target discovery on RN 0.81+ *Bridgeless* by widening the Metro `/json/list` candidate filter to accept targets identified via `description` (e.g., containing `bridgeless`/`hermes`) when `title` no longer contains "React Native"/"Hermes".
> 
> This update is applied consistently in both `discoverTarget()` and `discoverAllTargets()`, preserving the legacy title-based matching for pre-0.81 builds while allowing Bridgeless sessions to be selected and probed for `__AGENTIC__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcd99a658287d9ab8a6c1ce83431b88292f185d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->