### PR TITLE
fix: hide swap gas sponsorship banner for hardware wallets

### DIFF
--- a/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useShouldRenderGasSponsoredBanner } from './index';
 import { useIsNetworkGasSponsored } from '../useIsNetworkGasSponsored';
+import { useIsHardwareWalletForBridge } from '../useIsHardwareWalletForBridge';
 import { useSelector } from 'react-redux';
 import {
   selectSourceToken,
@@ -8,6 +9,7 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 
 jest.mock('../useIsNetworkGasSponsored');
+jest.mock('../useIsHardwareWalletForBridge');
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
@@ -15,6 +17,10 @@ jest.mock('react-redux', () => ({
 const mockUseIsNetworkGasSponsored =
   useIsNetworkGasSponsored as jest.MockedFunction<
     typeof useIsNetworkGasSponsored
+  >;
+const mockUseIsHardwareWalletForBridge =
+  useIsHardwareWalletForBridge as jest.MockedFunction<
+    typeof useIsHardwareWalletForBridge
   >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
@@ -51,6 +57,7 @@ describe('useShouldRenderGasSponsoredBanner', () => {
     jest.clearAllMocks();
     mockTokens({});
     mockUseIsNetworkGasSponsored.mockReturnValue(false);
+    mockUseIsHardwareWalletForBridge.mockReturnValue(false);
   });
 
   describe('returns true when quoteGasSponsored is true', () => {
@@ -146,6 +153,43 @@ describe('useShouldRenderGasSponsoredBanner', () => {
   });
 
   describe('returns false', () => {
+    it('returns false when quote is sponsored but source account is a hardware wallet', () => {
+      // Arrange
+      mockUseIsHardwareWalletForBridge.mockReturnValue(true);
+
+      // Act
+      const { result } = renderHook(() =>
+        useShouldRenderGasSponsoredBanner({
+          quoteGasSponsored: true,
+          hasInsufficientBalance: false,
+        }),
+      );
+
+      // Assert
+      expect(result.current).toBe(false);
+    });
+
+    it('returns false when insufficient balance and network is sponsored but source account is a hardware wallet', () => {
+      // Arrange
+      mockTokens({
+        sourceChainId: SOURCE_CHAIN_ID,
+        destChainId: SAME_CHAIN_DEST_CHAIN_ID,
+      });
+      mockUseIsNetworkGasSponsored.mockReturnValue(true);
+      mockUseIsHardwareWalletForBridge.mockReturnValue(true);
+
+      // Act
+      const { result } = renderHook(() =>
+        useShouldRenderGasSponsoredBanner({
+          quoteGasSponsored: false,
+          hasInsufficientBalance: true,
+        }),
+      );
+
+      // Assert
+      expect(result.current).toBe(false);
+    });
+
     it('returns false when quoteGasSponsored is false and balance is sufficient', () => {
       // Arrange
       mockUseIsNetworkGasSponsored.mockReturnValue(false);

--- a/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.ts
@@ -4,6 +4,7 @@ import {
   selectSourceToken,
   selectDestToken,
 } from '../../../../../core/redux/slices/bridge';
+import { useIsHardwareWalletForBridge } from '../useIsHardwareWalletForBridge';
 
 interface Props {
   quoteGasSponsored?: boolean;
@@ -16,6 +17,7 @@ export const useShouldRenderGasSponsoredBanner = ({
 }: Props) => {
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
+  const isHardwareWallet = useIsHardwareWalletForBridge();
   const isNetworkGasSponsored = useIsNetworkGasSponsored(sourceToken?.chainId);
 
   // Sponsorship only applies to same-chain (swap) flows; cross-chain bridges
@@ -27,8 +29,9 @@ export const useShouldRenderGasSponsoredBanner = ({
   );
 
   const shouldShowGasSponsored =
-    quoteGasSponsored ||
-    (hasInsufficientBalance && isNetworkGasSponsored && isSameChain);
+    !isHardwareWallet &&
+    (quoteGasSponsored ||
+      (hasInsufficientBalance && isNetworkGasSponsored && isSameChain));
 
   return shouldShowGasSponsored;
 };


### PR DESCRIPTION
## Summary
- hide the gas sponsorship banner in bridge/swap quote details when the source account is a hardware wallet
- keep existing sponsorship behavior for non-hardware wallets, including same-chain insufficient-balance fallback logic
- add regression tests covering hardware-wallet paths where sponsorship previously rendered incorrectly

## Test plan
- [x] `yarn jest app/components/UI/Bridge/hooks/useShouldRenderGasSponsoredBanner/index.test.ts`

## Related issue
- Fixes #29870

Made with [Cursor](https://cursor.com)