### PR TITLE
feat: add `PayWithBottomSheet` component

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -153,6 +153,7 @@ import useInterval from '../../hooks/useInterval';
 import { Duration } from '@metamask/utils';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 import { PayWithModal } from '../../Views/confirmations/components/modals/pay-with-modal/pay-with-modal';
+import { PayWithBottomSheet } from '../../Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet';
 import MultichainAccountConnect from '../../Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect';
 import { SmartAccountModal } from '../../Views/MultichainAccounts/AccountDetails/components/SmartAccountModal/SmartAccountModal';
 import TradeWalletActions from '../../Views/TradeWalletActions';
@@ -1189,6 +1190,10 @@ const AppFlow = () => {
       <Stack.Screen
         name={Routes.CONFIRMATION_PAY_WITH_MODAL}
         component={PayWithModal}
+      />
+      <Stack.Screen
+        name={Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET}
+        component={PayWithBottomSheet}
       />
     </Stack.Navigator>
   );

--- a/app/components/Views/confirmations/components/UI/pay-with-section/index.ts
+++ b/app/components/Views/confirmations/components/UI/pay-with-section/index.ts
@@ -1,0 +1,2 @@
+export { default } from './pay-with-section';
+export type { PayWithSectionProps } from './pay-with-section';

--- a/app/components/Views/confirmations/components/UI/pay-with-section/pay-with-section.test.tsx
+++ b/app/components/Views/confirmations/components/UI/pay-with-section/pay-with-section.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import PayWithSection from './pay-with-section';
+import { PayWithSectionConfig } from '../../modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+const buildConfig = (
+  overrides: Partial<PayWithSectionConfig> = {},
+): PayWithSectionConfig => ({
+  id: 'crypto',
+  title: 'Crypto',
+  rows: [
+    {
+      id: 'usdc',
+      icon: <Text>USDC-icon</Text>,
+      title: 'USDC',
+      subtitle: '$500.00 available',
+    },
+  ],
+  ...overrides,
+});
+
+describe('PayWithSection', () => {
+  it('renders section title in uppercase', () => {
+    const { getByTestId } = render(<PayWithSection config={buildConfig()} />);
+
+    expect(getByTestId('pay-with-section-crypto-title')).toHaveTextContent(
+      'CRYPTO',
+    );
+  });
+
+  it('renders one row per config entry', () => {
+    const config = buildConfig({
+      rows: [
+        { id: 'usdc', icon: <Text>USDC</Text>, title: 'USDC' },
+        { id: 'pol', icon: <Text>POL</Text>, title: 'POL' },
+      ],
+    });
+
+    const { getByTestId } = render(<PayWithSection config={config} />);
+
+    expect(getByTestId('payment-method-row-usdc')).toBeOnTheScreen();
+    expect(getByTestId('payment-method-row-pol')).toBeOnTheScreen();
+  });
+
+  it('renders empty rows container when section has no rows', () => {
+    const config = buildConfig({ rows: [] });
+
+    const { getByTestId, queryByTestId } = render(
+      <PayWithSection config={config} />,
+    );
+
+    expect(getByTestId('pay-with-section-crypto-rows')).toBeOnTheScreen();
+    expect(queryByTestId('payment-method-row-usdc')).not.toBeOnTheScreen();
+  });
+
+  it('uses custom testID when provided', () => {
+    const config = buildConfig({ testID: 'custom-section' });
+
+    const { getByTestId } = render(<PayWithSection config={config} />);
+
+    expect(getByTestId('custom-section')).toBeOnTheScreen();
+    expect(getByTestId('custom-section-title')).toBeOnTheScreen();
+    expect(getByTestId('custom-section-rows')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/UI/pay-with-section/pay-with-section.tsx
+++ b/app/components/Views/confirmations/components/UI/pay-with-section/pay-with-section.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import PaymentMethodRow from '../payment-method-row';
+import { PayWithSectionConfig } from '../../modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+
+export interface PayWithSectionProps {
+  config: PayWithSectionConfig;
+}
+
+const PayWithSection = ({ config }: PayWithSectionProps) => {
+  const testID = config.testID ?? `pay-with-section-${config.id}`;
+
+  return (
+    <Box twClassName="py-2" testID={testID}>
+      <Text
+        variant={TextVariant.BodyXs}
+        color={TextColor.TextAlternative}
+        testID={`${testID}-title`}
+        twClassName="px-4 pb-2 tracking-wider"
+      >
+        {config.title.toUpperCase()}
+      </Text>
+      <Box twClassName="bg-default" testID={`${testID}-rows`}>
+        {config.rows.map((row) => (
+          <PaymentMethodRow key={row.id} {...row} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default PayWithSection;

--- a/app/components/Views/confirmations/components/UI/payment-method-row/index.ts
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/index.ts
@@ -1,0 +1,2 @@
+export { default } from './payment-method-row';
+export type { PaymentMethodRowProps } from './payment-method-row';

--- a/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.test.tsx
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import PaymentMethodRow from './payment-method-row';
+
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+const baseProps = {
+  id: 'usdc',
+  icon: <Text testID="icon">USDC-icon</Text>,
+  title: 'USDC',
+};
+
+describe('PaymentMethodRow', () => {
+  it('renders title and icon with derived testID', () => {
+    const { getByTestId } = render(<PaymentMethodRow {...baseProps} />);
+
+    expect(getByTestId('payment-method-row-usdc')).toBeOnTheScreen();
+    expect(getByTestId('payment-method-row-usdc-title')).toHaveTextContent(
+      'USDC',
+    );
+    expect(getByTestId('icon')).toBeOnTheScreen();
+  });
+
+  it('renders subtitle when provided', () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow {...baseProps} subtitle="$500.00 available" />,
+    );
+
+    expect(getByTestId('payment-method-row-usdc-subtitle')).toHaveTextContent(
+      '$500.00 available',
+    );
+  });
+
+  it('renders Last used tag when isLastUsed is true', () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow {...baseProps} isLastUsed />,
+    );
+
+    expect(
+      getByTestId('payment-method-row-usdc-last-used-tag'),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not render Last used tag when isLastUsed is false', () => {
+    const { queryByTestId } = render(<PaymentMethodRow {...baseProps} />);
+
+    expect(
+      queryByTestId('payment-method-row-usdc-last-used-tag'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders checkmark when trailingElement is "checkmark"', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PaymentMethodRow {...baseProps} trailingElement="checkmark" />,
+    );
+
+    expect(getByTestId('payment-method-row-checkmark')).toBeOnTheScreen();
+    expect(queryByTestId('payment-method-row-chevron')).not.toBeOnTheScreen();
+  });
+
+  it('renders chevron when trailingElement is "chevron"', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PaymentMethodRow {...baseProps} trailingElement="chevron" />,
+    );
+
+    expect(getByTestId('payment-method-row-chevron')).toBeOnTheScreen();
+    expect(queryByTestId('payment-method-row-checkmark')).not.toBeOnTheScreen();
+  });
+
+  it('renders nothing trailing when trailingElement is "none"', () => {
+    const { queryByTestId } = render(
+      <PaymentMethodRow {...baseProps} trailingElement="none" />,
+    );
+
+    expect(queryByTestId('payment-method-row-checkmark')).not.toBeOnTheScreen();
+    expect(queryByTestId('payment-method-row-chevron')).not.toBeOnTheScreen();
+  });
+
+  it('renders custom ReactNode trailing element when provided', () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        {...baseProps}
+        trailingElement={<Text testID="custom-trailing">Add</Text>}
+      />,
+    );
+
+    expect(getByTestId('custom-trailing')).toHaveTextContent('Add');
+  });
+
+  it('invokes onPress when row is pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PaymentMethodRow {...baseProps} onPress={onPress} />,
+    );
+
+    fireEvent.press(getByTestId('payment-method-row-usdc'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke onPress when disabled', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PaymentMethodRow {...baseProps} onPress={onPress} disabled />,
+    );
+
+    fireEvent.press(getByTestId('payment-method-row-usdc'));
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('uses custom testID when provided', () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow {...baseProps} testID="custom-test-id" />,
+    );
+
+    expect(getByTestId('custom-test-id')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, isValidElement } from 'react';
+import React, { ReactElement } from 'react';
 import { Pressable } from 'react-native';
 import {
   Box,
@@ -17,34 +17,19 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Tag from '../../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../../locales/i18n';
-import {
-  PayWithRowConfig,
-  PayWithRowTrailingVariant,
-} from '../../modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+import { PayWithRowConfig } from '../../modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
 
 export type PaymentMethodRowProps = PayWithRowConfig;
 
-const TRAILING_VARIANTS: readonly PayWithRowTrailingVariant[] = [
-  'checkmark',
-  'chevron',
-  'none',
-];
-
-const isTrailingVariant = (
-  value: PayWithRowConfig['trailingElement'],
-): value is PayWithRowTrailingVariant =>
-  typeof value === 'string' &&
-  (TRAILING_VARIANTS as readonly string[]).includes(value);
-
 const renderTrailing = (
   trailingElement: PayWithRowConfig['trailingElement'],
-): ReactNode => {
+): ReactElement | null => {
   if (trailingElement == null) {
     return null;
   }
 
-  if (isTrailingVariant(trailingElement)) {
-    if (trailingElement === 'checkmark') {
+  switch (trailingElement) {
+    case 'checkmark':
       return (
         <Icon
           name={IconName.Check}
@@ -53,8 +38,7 @@ const renderTrailing = (
           testID="payment-method-row-checkmark"
         />
       );
-    }
-    if (trailingElement === 'chevron') {
+    case 'chevron':
       return (
         <Icon
           name={IconName.ArrowRight}
@@ -63,15 +47,11 @@ const renderTrailing = (
           testID="payment-method-row-chevron"
         />
       );
-    }
-    return null;
+    case 'none':
+      return null;
+    default:
+      return trailingElement;
   }
-
-  if (isValidElement(trailingElement)) {
-    return trailingElement;
-  }
-
-  return null;
 };
 
 const PaymentMethodRow = ({

--- a/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
@@ -1,0 +1,177 @@
+import React, { ReactNode, isValidElement } from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import Tag from '../../../../../../component-library/components/Tags/Tag';
+import { strings } from '../../../../../../../locales/i18n';
+import {
+  PayWithRowConfig,
+  PayWithRowTrailingVariant,
+} from '../../modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+
+export type PaymentMethodRowProps = PayWithRowConfig;
+
+const TRAILING_VARIANTS: readonly PayWithRowTrailingVariant[] = [
+  'checkmark',
+  'chevron',
+  'none',
+];
+
+const isTrailingVariant = (
+  value: PayWithRowConfig['trailingElement'],
+): value is PayWithRowTrailingVariant =>
+  typeof value === 'string' &&
+  (TRAILING_VARIANTS as readonly string[]).includes(value);
+
+const renderTrailing = (
+  trailingElement: PayWithRowConfig['trailingElement'],
+): ReactNode => {
+  if (trailingElement == null) {
+    return null;
+  }
+
+  if (isTrailingVariant(trailingElement)) {
+    if (trailingElement === 'checkmark') {
+      return (
+        <Icon
+          name={IconName.Check}
+          size={IconSize.Md}
+          color={IconColor.IconDefault}
+          testID="payment-method-row-checkmark"
+        />
+      );
+    }
+    if (trailingElement === 'chevron') {
+      return (
+        <Icon
+          name={IconName.ArrowRight}
+          size={IconSize.Md}
+          color={IconColor.IconAlternative}
+          testID="payment-method-row-chevron"
+        />
+      );
+    }
+    return null;
+  }
+
+  if (isValidElement(trailingElement)) {
+    return trailingElement;
+  }
+
+  return null;
+};
+
+const PaymentMethodRow = ({
+  id,
+  icon,
+  title,
+  subtitle,
+  isSelected,
+  isLastUsed,
+  trailingElement,
+  onPress,
+  disabled,
+  testID,
+}: PaymentMethodRowProps) => {
+  const tw = useTailwind();
+  const resolvedTestID = testID ?? `payment-method-row-${id}`;
+
+  const content = (
+    <>
+      <Box
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        twClassName="w-10 h-10 rounded-full bg-section"
+      >
+        {icon}
+      </Box>
+      <Box twClassName="ml-3 flex-1 min-w-0">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-2 flex-wrap"
+        >
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            testID={`${resolvedTestID}-title`}
+          >
+            {title}
+          </Text>
+          {isLastUsed ? (
+            <Tag
+              label={strings('confirm.pay_with_bottom_sheet.last_used')}
+              testID={`${resolvedTestID}-last-used-tag`}
+            />
+          ) : null}
+        </Box>
+        {subtitle ? (
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            testID={`${resolvedTestID}-subtitle`}
+          >
+            {subtitle}
+          </Text>
+        ) : null}
+      </Box>
+      <Box
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        twClassName="min-w-6"
+      >
+        {renderTrailing(trailingElement)}
+      </Box>
+    </>
+  );
+
+  if (!onPress) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName={`px-4 py-3 ${
+          isSelected ? 'bg-section' : 'bg-default'
+        } ${disabled ? 'opacity-50' : ''}`}
+        testID={resolvedTestID}
+      >
+        {content}
+      </Box>
+    );
+  }
+
+  return (
+    <Pressable
+      testID={resolvedTestID}
+      accessibilityRole="button"
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) =>
+        tw.style(
+          'flex-row items-center px-4 py-3',
+          isSelected ? 'bg-section' : 'bg-default',
+          pressed && !disabled ? 'bg-pressed' : '',
+          disabled ? 'opacity-50' : '',
+        )
+      }
+    >
+      {content}
+    </Pressable>
+  );
+};
+
+export default PaymentMethodRow;

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/index.ts
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/index.ts
@@ -1,0 +1,10 @@
+export {
+  PayWithBottomSheet,
+  PAY_WITH_BOTTOM_SHEET_TEST_ID,
+} from './pay-with-bottom-sheet';
+export type {
+  PayWithSectionConfig,
+  PayWithRowConfig,
+  PayWithRowTrailingVariant,
+  PayWithSectionId,
+} from './pay-with-bottom-sheet.types';

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import {
+  PayWithBottomSheet,
+  PAY_WITH_BOTTOM_SHEET_TEST_ID,
+} from './pay-with-bottom-sheet';
+import { usePayWithSections } from '../../../hooks/pay/usePayWithSections';
+import { PayWithSectionConfig } from './pay-with-bottom-sheet.types';
+
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../../hooks/pay/usePayWithSections');
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ goBack: jest.fn() }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View: RNView, Text: RNText } = jest.requireActual('react-native');
+  return {
+    BottomSheet: ReactActual.forwardRef(
+      (
+        { children, testID }: { children: React.ReactNode; testID?: string },
+        _ref: unknown,
+      ) => <RNView testID={testID}>{children}</RNView>,
+    ),
+    BottomSheetHeader: ({ children }: { children: React.ReactNode }) => (
+      <RNView testID="bottom-sheet-header">{children}</RNView>
+    ),
+    Text: ({ children, ...props }: { children: React.ReactNode }) => (
+      <RNText {...props}>{children}</RNText>
+    ),
+    TextVariant: { HeadingSm: 'heading-sm' },
+  };
+});
+
+jest.mock('../../UI/pay-with-section', () => {
+  const { View: RNView, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ config }: { config: PayWithSectionConfig }) => (
+      <RNView testID={`mock-section-${config.id}`}>
+        <RNText>{config.title}</RNText>
+      </RNView>
+    ),
+  };
+});
+
+const usePayWithSectionsMock = jest.mocked(usePayWithSections);
+
+describe('PayWithBottomSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    usePayWithSectionsMock.mockReturnValue({ sections: [] });
+  });
+
+  it('renders the bottom sheet container with title', () => {
+    const { getByTestId, getByText } = render(<PayWithBottomSheet />);
+
+    expect(getByTestId(PAY_WITH_BOTTOM_SHEET_TEST_ID)).toBeOnTheScreen();
+    expect(getByText('confirm.pay_with_bottom_sheet.title')).toBeOnTheScreen();
+  });
+
+  it('renders no sections when usePayWithSections returns empty array', () => {
+    usePayWithSectionsMock.mockReturnValue({ sections: [] });
+
+    const { queryByTestId } = render(<PayWithBottomSheet />);
+
+    expect(queryByTestId('mock-section-crypto')).not.toBeOnTheScreen();
+  });
+
+  it('renders one section per config returned by usePayWithSections', () => {
+    usePayWithSectionsMock.mockReturnValue({
+      sections: [
+        {
+          id: 'crypto',
+          title: 'Crypto',
+          rows: [],
+        },
+        {
+          id: 'bank-card',
+          title: 'Bank and card',
+          rows: [],
+        },
+      ],
+    });
+
+    const { getByTestId } = render(<PayWithBottomSheet />);
+
+    expect(getByTestId('mock-section-crypto')).toBeOnTheScreen();
+    expect(getByTestId('mock-section-bank-card')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useRef } from 'react';
+import { ScrollView } from 'react-native-gesture-handler';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import PayWithSection from '../../UI/pay-with-section';
+import { usePayWithSections } from '../../../hooks/pay/usePayWithSections';
+
+export const PAY_WITH_BOTTOM_SHEET_TEST_ID = 'pay-with-bottom-sheet';
+
+export function PayWithBottomSheet() {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+  const { sections } = usePayWithSections();
+
+  const handleGoBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      goBack={handleGoBack}
+      testID={PAY_WITH_BOTTOM_SHEET_TEST_ID}
+      keyboardAvoidingViewEnabled={false}
+    >
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingSm}>
+          {strings('confirm.pay_with_bottom_sheet.title')}
+        </Text>
+      </BottomSheetHeader>
+      <ScrollView testID={`${PAY_WITH_BOTTOM_SHEET_TEST_ID}-scroll`}>
+        {sections.map((section) => (
+          <PayWithSection key={section.id} config={section} />
+        ))}
+      </ScrollView>
+    </BottomSheet>
+  );
+}
+
+export default PayWithBottomSheet;

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
@@ -1,0 +1,35 @@
+import { ReactNode } from 'react';
+
+export type PayWithSectionId =
+  | 'perps'
+  | 'predict'
+  | 'bank-card'
+  | 'crypto'
+  | (string & {});
+
+export type PayWithRowTrailingVariant = 'checkmark' | 'chevron' | 'none';
+
+export interface PayWithRowConfig {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  subtitle?: string;
+  isSelected?: boolean;
+  isLastUsed?: boolean;
+  trailingElement?: PayWithRowTrailingVariant | ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  testID?: string;
+}
+
+/**
+ * Section hooks return `null` when the section should not render in the
+ * current flow (e.g. the Perps section returns null outside perps txs).
+ * The orchestrator filters nulls out before rendering.
+ */
+export interface PayWithSectionConfig {
+  id: PayWithSectionId;
+  title: string;
+  rows: PayWithRowConfig[];
+  testID?: string;
+}

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 export type PayWithSectionId =
   | 'perps'
@@ -16,7 +16,7 @@ export interface PayWithRowConfig {
   subtitle?: string;
   isSelected?: boolean;
   isLastUsed?: boolean;
-  trailingElement?: PayWithRowTrailingVariant | ReactNode;
+  trailingElement?: PayWithRowTrailingVariant | ReactElement;
   onPress?: () => void;
   disabled?: boolean;
   testID?: string;

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -6,7 +6,6 @@ import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayW
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 import { useMoneyAccountPayToken } from '../../../hooks/pay/useMoneyAccountPayToken';
-import { useMMPayFiatConfig } from '../../../hooks/pay/useMMPayFiatConfig';
 import { type PaymentMethod } from '@metamask/ramps-controller';
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent } from '@testing-library/react-native';
@@ -29,7 +28,6 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod');
 jest.mock('../../../hooks/pay/useMoneyAccountPayToken');
-jest.mock('../../../hooks/pay/useMMPayFiatConfig');
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents');
 jest.mock('@react-navigation/native', () => ({
@@ -52,9 +50,6 @@ jest.mock(
     useTransactionPaySelectedFiatPaymentMethod: jest.fn(),
   }),
 );
-jest.mock('../../../hooks/pay/useMMPayFiatConfig', () => ({
-  useMMPayFiatConfig: jest.fn(),
-}));
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
   useConfirmationMetricEvents: jest.fn(),
@@ -139,8 +134,6 @@ describe('PayWithRow', () => {
       navigate: navigateMock,
     } as never);
 
-    jest.mocked(useMMPayFiatConfig).mockReturnValue({ enabled: false });
-
     isHardwareAccountMock.mockReturnValue(false);
 
     useMoneyAccountPayTokenMock.mockReturnValue({
@@ -165,20 +158,6 @@ describe('PayWithRow', () => {
 
     expect(navigateMock).toHaveBeenCalledWith(
       Routes.CONFIRMATION_PAY_WITH_MODAL,
-    );
-  });
-
-  it('navigates to pay with bottom sheet when fiat config flag enabled', async () => {
-    jest.mocked(useMMPayFiatConfig).mockReturnValue({ enabled: true });
-
-    const { getByText } = render();
-
-    await act(() => {
-      fireEvent.press(getByText(`${ADDRESS_MOCK} ${CHAIN_ID_MOCK}`));
-    });
-
-    expect(navigateMock).toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
     );
   });
 

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -6,6 +6,7 @@ import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayW
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 import { useMoneyAccountPayToken } from '../../../hooks/pay/useMoneyAccountPayToken';
+import { useMMPayFiatConfig } from '../../../hooks/pay/useMMPayFiatConfig';
 import { type PaymentMethod } from '@metamask/ramps-controller';
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent } from '@testing-library/react-native';
@@ -28,6 +29,7 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod');
 jest.mock('../../../hooks/pay/useMoneyAccountPayToken');
+jest.mock('../../../hooks/pay/useMMPayFiatConfig');
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents');
 jest.mock('@react-navigation/native', () => ({
@@ -50,6 +52,9 @@ jest.mock(
     useTransactionPaySelectedFiatPaymentMethod: jest.fn(),
   }),
 );
+jest.mock('../../../hooks/pay/useMMPayFiatConfig', () => ({
+  useMMPayFiatConfig: jest.fn(),
+}));
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
   useConfirmationMetricEvents: jest.fn(),
@@ -134,6 +139,8 @@ describe('PayWithRow', () => {
       navigate: navigateMock,
     } as never);
 
+    jest.mocked(useMMPayFiatConfig).mockReturnValue({ enabled: false });
+
     isHardwareAccountMock.mockReturnValue(false);
 
     useMoneyAccountPayTokenMock.mockReturnValue({
@@ -158,6 +165,20 @@ describe('PayWithRow', () => {
 
     expect(navigateMock).toHaveBeenCalledWith(
       Routes.CONFIRMATION_PAY_WITH_MODAL,
+    );
+  });
+
+  it('navigates to pay with bottom sheet when fiat config flag enabled', async () => {
+    jest.mocked(useMMPayFiatConfig).mockReturnValue({ enabled: true });
+
+    const { getByText } = render();
+
+    await act(() => {
+      fireEvent.press(getByText(`${ADDRESS_MOCK} ${CHAIN_ID_MOCK}`));
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
     );
   });
 

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -13,6 +13,8 @@ import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToke
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
+import { useMMPayFiatConfig } from '../../../hooks/pay/useMMPayFiatConfig';
+import { getFeatureFlagValue } from '../../../../../../selectors/featureFlagController/env';
 import { TouchableOpacity } from 'react-native';
 import { Box } from '../../../../../UI/Box/Box';
 import {
@@ -60,6 +62,15 @@ export function PayWithRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const { styles } = useStyles(styleSheet, {});
   const { setConfirmationMetric } = useConfirmationMetricEvents();
+  const { enabled: isFiatFlagEnabled } = useMMPayFiatConfig();
+  // Local dev override: set MM_DEV_PAY_WITH_BOTTOM_SHEET=true in `.js.env` to
+  // preview the redesigned picker without flipping the shared
+  // `confirmations_pay_fiat` remote flag. Remove once the new picker is the
+  // default.
+  const isPayWithBottomSheetEnabled = getFeatureFlagValue(
+    process.env.MM_DEV_PAY_WITH_BOTTOM_SHEET,
+    isFiatFlagEnabled,
+  );
 
   const {
     txParams: { from },
@@ -76,8 +87,17 @@ export function PayWithRow() {
         mm_pay_token_list_opened: true,
       },
     });
-    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
-  }, [isDisabled, navigation, setConfirmationMetric]);
+    navigation.navigate(
+      isPayWithBottomSheetEnabled
+        ? Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET
+        : Routes.CONFIRMATION_PAY_WITH_MODAL,
+    );
+  }, [
+    isDisabled,
+    isPayWithBottomSheetEnabled,
+    navigation,
+    setConfirmationMetric,
+  ]);
 
   const label = isWithdraw
     ? strings('confirm.label.receive_as')

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -13,8 +13,6 @@ import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToke
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
-import { useMMPayFiatConfig } from '../../../hooks/pay/useMMPayFiatConfig';
-import { getFeatureFlagValue } from '../../../../../../selectors/featureFlagController/env';
 import { TouchableOpacity } from 'react-native';
 import { Box } from '../../../../../UI/Box/Box';
 import {
@@ -62,15 +60,11 @@ export function PayWithRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const { styles } = useStyles(styleSheet, {});
   const { setConfirmationMetric } = useConfirmationMetricEvents();
-  const { enabled: isFiatFlagEnabled } = useMMPayFiatConfig();
   // Local dev override: set MM_DEV_PAY_WITH_BOTTOM_SHEET=true in `.js.env` to
-  // preview the redesigned picker without flipping the shared
-  // `confirmations_pay_fiat` remote flag. Remove once the new picker is the
-  // default.
-  const isPayWithBottomSheetEnabled = getFeatureFlagValue(
-    process.env.MM_DEV_PAY_WITH_BOTTOM_SHEET,
-    isFiatFlagEnabled,
-  );
+  // preview the redesigned picker. Routes to the existing PayWithModal.
+  // Remove once the first section of the redesign is complete.
+  const isPayWithBottomSheetEnabled =
+    process.env.MM_DEV_PAY_WITH_BOTTOM_SHEET === 'true';
 
   const {
     txParams: { from },

--- a/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { usePayWithSections } from './usePayWithSections';
+
+describe('usePayWithSections', () => {
+  it('returns empty sections array as skeleton', () => {
+    const { result } = renderHook(() => usePayWithSections());
+
+    expect(result.current.sections).toEqual([]);
+  });
+
+  it('returns the same sections reference across renders', () => {
+    const { result, rerender } = renderHook(() => usePayWithSections());
+    const first = result.current.sections;
+
+    rerender();
+
+    expect(result.current.sections).toBe(first);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/usePayWithSections.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithSections.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { PayWithSectionConfig } from '../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+
+export interface UsePayWithSectionsResult {
+  sections: PayWithSectionConfig[];
+}
+
+export function usePayWithSections(): UsePayWithSectionsResult {
+  return useMemo<UsePayWithSectionsResult>(() => ({ sections: [] }), []);
+}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -387,6 +387,7 @@ const Routes = {
   CONFIRMATION_REQUEST_MODAL: 'ConfirmationRequestModal',
   CONFIRMATION_SWITCH_ACCOUNT_TYPE: 'ConfirmationSwitchAccountType',
   CONFIRMATION_PAY_WITH_MODAL: 'ConfirmationPayWithModal',
+  CONFIRMATION_PAY_WITH_BOTTOM_SHEET: 'ConfirmationPayWithBottomSheet',
   CONFIRMATION_PAY_WITH_NETWORK_MODAL: 'ConfirmationPayWithNetworkModal',
   NOTIFICATIONS: {
     VIEW: 'NotificationsView',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6953,6 +6953,10 @@
   "confirm": {
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "pay_with_bottom_sheet": {
+      "title": "Pay with",
+      "last_used": "Last used"
+    },
     "staking_footer": {
       "part1": "By continuing, you agree to our ",
       "terms_of_use": "Terms of Use",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Introduces the foundation for the redesigned MMPay payment picker (CONF-1313). When the dev override is enabled, tapping the "Pay with" row on confirmation screens opens a new empty bottom sheet instead of the existing token picker (`PayWithModal`). All subsequent epic PRs (Crypto/Perps/Predict/Bank-Card sections) will plug into this scaffolding.
**What's added:**
- `PayWithBottomSheet` modal at `components/modals/pay-with-bottom-sheet/` using `@metamask/design-system-react-native` BottomSheet
- Generic `PayWithSection` UI primitive at `components/UI/pay-with-section/` — renders a section header + rows from config
- Generic `PaymentMethodRow` UI primitive at `components/UI/payment-method-row/` — icon, title/subtitle, trailing element (checkmark / chevron / custom node), optional `<Tag label="Last used" />`
- `PayWithSectionConfig` and `PayWithRowConfig` TypeScript interfaces — the contract every future section hook will implement
- `usePayWithSections()` orchestrator hook skeleton (returns `[]` for now; PRs 2–7 will plug in section configs)
- New navigation route `Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET` registered in `App.tsx`
- `pay-with-row.tsx` now routes to the new bottom sheet when the dev override is on, falls back to the existing `PayWithModal` otherwise — zero behavior change for users
**Gating:**
- Default behavior is unchanged — users still see the existing `PayWithModal`
- Strict env-only gate: `process.env.MM_DEV_PAY_WITH_BOTTOM_SHEET === 'true'` is the **only** path to the new bottom sheet. routes to the existing `PayWithModal`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1357

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**


Test to confirm that nothing changed on the current flow.

https://github.com/user-attachments/assets/988d2fb1-29aa-477e-9436-1fd49292bb37

Using the dev environment variable it's possible to see the new bottom sheet. Not available to users.
<img width="400" alt="new_bottom_sheet" src="https://github.com/user-attachments/assets/cd76ce2c-ddac-4a00-88a1-debdd20881c4" />

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new confirmation navigation route and new UI primitives used by a redesigned payment picker; while gated behind a dev-only env var, it touches confirmation navigation and interaction flow and could cause routing/render regressions if miswired.
> 
> **Overview**
> Introduces a new `PayWithBottomSheet` confirmation route and bottom-sheet UI scaffold for the upcoming redesigned “Pay with” picker, backed by a new `usePayWithSections()` orchestrator hook (currently returns an empty section list).
> 
> Adds reusable UI primitives (`PayWithSection`, `PaymentMethodRow`) and associated types/tests to render sectioned payment-method rows (subtitle, “Last used” tag, and configurable trailing elements). The existing confirmation `PayWithRow` now conditionally navigates to the bottom sheet when `MM_DEV_PAY_WITH_BOTTOM_SHEET=true`, otherwise it keeps routing to the current `PayWithModal`, and new i18n strings are added for the bottom sheet title/tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb9ae740bebd00a37ae90e95de57608a55fba19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->