### PR TITLE
feat(money): polish earnings sections — copy update, deposited-state headline (MUSD-787)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -385,9 +385,9 @@ describe('MoneyHomeView', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
       // Default mock has totalFiatRaw='3' / totalFiatFormatted='$3.00'.
-      expect(
-        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
-      ).toHaveTextContent('$3.00');
+      expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+        '$3.00',
+      );
     });
 
     it('falls back to the projected sum when the user has not deposited', () => {
@@ -409,9 +409,9 @@ describe('MoneyHomeView', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
       // mockMoneyFormatFiat returns '$0.12'; the projected branch wraps it with '+'.
-      expect(
-        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
-      ).toHaveTextContent('+$0.12');
+      expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+        '+$0.12',
+      );
     });
 
     it('falls back to the projected sum when totalFiatRaw is zero', () => {
@@ -439,9 +439,9 @@ describe('MoneyHomeView', () => {
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
-      expect(
-        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
-      ).toHaveTextContent('+$0.12');
+      expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+        '+$0.12',
+      );
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -380,6 +380,71 @@ describe('MoneyHomeView', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.POTENTIAL_EARNINGS);
   });
 
+  describe('potential earnings headline', () => {
+    it('shows the deposited balance when the user has a positive Money balance', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      // Default mock has totalFiatRaw='3' / totalFiatFormatted='$3.00'.
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
+      ).toHaveTextContent('$3.00');
+    });
+
+    it('falls back to the projected sum when the user has not deposited', () => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: undefined,
+        musdFiatFormatted: undefined,
+        musdSHFvdFiatFormatted: undefined,
+        totalFiatRaw: undefined,
+        tokenTotal: undefined,
+        isAggregatedBalanceLoading: false,
+        apyDecimal: 0.04,
+        apyPercent: 4,
+        apyPercentFormatted: '4%',
+        vaultApyQuery: { data: { apy: 0.04 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      } as ReturnType<typeof useMoneyAccountBalance>);
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      // mockMoneyFormatFiat returns '$0.12'; the projected branch wraps it with '+'.
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
+      ).toHaveTextContent('+$0.12');
+    });
+
+    it('falls back to the projected sum when totalFiatRaw is zero', () => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: '$0.00',
+        musdFiatFormatted: '$0.00',
+        musdSHFvdFiatFormatted: '$0.00',
+        totalFiatRaw: '0',
+        tokenTotal: undefined,
+        isAggregatedBalanceLoading: false,
+        apyDecimal: 0.04,
+        apyPercent: 4,
+        apyPercentFormatted: '4%',
+        vaultApyQuery: { data: { apy: 0.04 }, isLoading: false },
+        musdBalanceQuery: { data: { balance: '0' }, isLoading: false },
+        musdEquivalentBalanceQuery: {
+          data: {
+            musdEquivalentValue: '0',
+            musdSHFvdBalance: '0',
+            exchangeRate: '1000000',
+          },
+          isLoading: false,
+        },
+      } as ReturnType<typeof useMoneyAccountBalance>);
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
+      ).toHaveTextContent('+$0.12');
+    });
+  });
+
   it('opens the MUSD learn more URL when learn more is pressed in empty state', () => {
     const mockOpenURL = jest
       .spyOn(Linking, 'openURL')

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -112,6 +112,16 @@ const MoneyHomeView = () => {
     return moneyFormatFiat(new BigNumber(earnings), currentCurrency);
   }, [totalFiatRaw, apyPercent, currentCurrency, formattedZero]);
 
+  // When the user has already deposited (non-zero Money balance), surface the
+  // current total balance in the Earn-on-crypto headline instead of the
+  // aggregate projection of unconverted holdings.
+  const potentialEarningsHeadline = useMemo(() => {
+    if (!totalFiatRaw || !totalFiatFormatted) return undefined;
+    const balance = new BigNumber(totalFiatRaw);
+    if (balance.isNaN() || balance.isLessThanOrEqualTo(0)) return undefined;
+    return totalFiatFormatted;
+  }, [totalFiatRaw, totalFiatFormatted]);
+
   const handleMenuPress = useCallback(() => {
     navigation.navigate(Routes.MONEY.MODALS.ROOT, {
       screen: Routes.MONEY.MODALS.MORE_SHEET,
@@ -294,6 +304,7 @@ const MoneyHomeView = () => {
             <MoneyPotentialEarnings
               tokens={conversionTokens}
               apy={apyPercent}
+              headlineFiat={potentialEarningsHeadline}
               onTokenPress={handleTokenConvertPress}
               onViewAllPress={handleEarnCryptoPress}
               onHeaderPress={handleEarnCryptoPress}

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
@@ -206,12 +206,14 @@ describe('MoneyPotentialEarningsView', () => {
 
   describe('headline gradient', () => {
     it('shows the deposited Money balance when totalFiatRaw is positive', () => {
-      const { getByTestId } = renderWithProvider(<MoneyPotentialEarningsView />);
+      const { getByTestId } = renderWithProvider(
+        <MoneyPotentialEarningsView />,
+      );
 
       // Default mock has totalFiatRaw='10000' / totalFiatFormatted='$10,000.00'.
-      expect(
-        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
-      ).toHaveTextContent('$10,000.00');
+      expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+        '$10,000.00',
+      );
     });
 
     it('falls back to the projected sum when totalFiatRaw is absent', () => {
@@ -230,12 +232,14 @@ describe('MoneyPotentialEarningsView', () => {
         musdSHFvdFiatFormatted: undefined,
       } as ReturnType<typeof useMoneyAccountBalance>);
 
-      const { getByTestId } = renderWithProvider(<MoneyPotentialEarningsView />);
+      const { getByTestId } = renderWithProvider(
+        <MoneyPotentialEarningsView />,
+      );
 
       // Tokens sum: 5000+3000+2000+1500+800+400 = 12,700 × 4% = $508.00.
-      expect(
-        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
-      ).toHaveTextContent('+$508.00');
+      expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+        '+$508.00',
+      );
     });
   });
 });

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
@@ -4,6 +4,7 @@ import MoneyPotentialEarningsView from './MoneyPotentialEarningsView';
 import { MoneyPotentialEarningsViewTestIds } from './MoneyPotentialEarningsView.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { MoneyPotentialEarningsTestIds } from '../../components/MoneyPotentialEarnings/MoneyPotentialEarnings.testIds';
 
 const mockGoBack = jest.fn();
 
@@ -201,5 +202,40 @@ describe('MoneyPotentialEarningsView', () => {
     expect(
       getByTestId(MoneyPotentialEarningsViewTestIds.CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  describe('headline gradient', () => {
+    it('shows the deposited Money balance when totalFiatRaw is positive', () => {
+      const { getByTestId } = renderWithProvider(<MoneyPotentialEarningsView />);
+
+      // Default mock has totalFiatRaw='10000' / totalFiatFormatted='$10,000.00'.
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
+      ).toHaveTextContent('$10,000.00');
+    });
+
+    it('falls back to the projected sum when totalFiatRaw is absent', () => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        apyPercent: 4,
+        apyDecimal: 0.04,
+        apyPercentFormatted: '4%',
+        totalFiatFormatted: undefined,
+        totalFiatRaw: undefined,
+        tokenTotal: undefined,
+        isAggregatedBalanceLoading: false,
+        vaultApyQuery: { data: { apy: 0.04 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        musdFiatFormatted: undefined,
+        musdSHFvdFiatFormatted: undefined,
+      } as ReturnType<typeof useMoneyAccountBalance>);
+
+      const { getByTestId } = renderWithProvider(<MoneyPotentialEarningsView />);
+
+      // Tokens sum: 5000+3000+2000+1500+800+400 = 12,700 × 4% = $508.00.
+      expect(
+        getByTestId(MoneyPotentialEarningsTestIds.TEXT),
+      ).toHaveTextContent('+$508.00');
+    });
   });
 });

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
@@ -47,7 +47,8 @@ const MoneyPotentialEarningsView = () => {
 
   const { tokens } = useMusdConversionTokens();
   const { initiateCustomConversion } = useMusdConversion();
-  const { apyPercent } = useMoneyAccountBalance();
+  const { apyPercent, totalFiatRaw, totalFiatFormatted } =
+    useMoneyAccountBalance();
   const apyPercentForProjection = apyPercent ?? 0;
 
   const eligibleTokens = useMemo(
@@ -69,6 +70,15 @@ const MoneyPotentialEarningsView = () => {
       ),
     [eligibleTokens, apyPercentForProjection],
   );
+
+  // When the user has already deposited, the headline mirrors MoneyHomeView
+  // and shows the current Money balance instead of the projected sum.
+  const headlineFiat = useMemo(() => {
+    if (!totalFiatRaw || !totalFiatFormatted) return undefined;
+    const balance = new BigNumber(totalFiatRaw);
+    if (balance.isNaN() || balance.isLessThanOrEqualTo(0)) return undefined;
+    return totalFiatFormatted;
+  }, [totalFiatRaw, totalFiatFormatted]);
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -114,7 +124,8 @@ const MoneyPotentialEarningsView = () => {
             {strings('money.potential_earnings.title')}
           </Text>
 
-          {isPositiveNumber(projectedAmount) && (
+          {headlineFiat && <MoneyGradientText value={headlineFiat} />}
+          {!headlineFiat && isPositiveNumber(projectedAmount) && (
             <MoneyGradientText
               value={`+${moneyFormatFiat(new BigNumber(projectedAmount), currentCurrency)}`}
             />

--- a/app/components/UI/Money/components/MoneyHowItWorks/MoneyHowItWorks.test.tsx
+++ b/app/components/UI/Money/components/MoneyHowItWorks/MoneyHowItWorks.test.tsx
@@ -16,10 +16,10 @@ describe('MoneyHowItWorks', () => {
 
     const description = getByTestId(MoneyHowItWorksTestIds.DESCRIPTION);
     expect(description).toHaveTextContent(
-      /Hold mUSD in your Money Account and auto-earn/,
+      /Your Money account auto-earns up to/,
     );
     expect(description).toHaveTextContent(
-      /dollar-backed, always liquid, and ready to spend, trade, or send anytime\./,
+      /Your balance is dollar-backed, always liquid, and ready to spend, trade, or send anytime\./,
     );
   });
 

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
@@ -220,6 +220,49 @@ describe('MoneyPotentialEarnings', () => {
     ).not.toBeOnTheScreen();
   });
 
+  it('renders the headlineFiat value in the gradient when provided', () => {
+    const { getByTestId } = render(
+      <MoneyPotentialEarnings
+        apy={4}
+        tokens={[MOCK_USDC]}
+        headlineFiat="$1,234.56"
+      />,
+    );
+
+    expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+      '$1,234.56',
+    );
+  });
+
+  it('uses headlineFiat instead of the projected sum when both are available', () => {
+    const { getByTestId } = render(
+      <MoneyPotentialEarnings
+        apy={4}
+        tokens={[MOCK_USDC, MOCK_USDT]}
+        headlineFiat="$10,000.00"
+      />,
+    );
+
+    const headline = getByTestId(MoneyPotentialEarningsTestIds.TEXT);
+    expect(headline).toHaveTextContent('$10,000.00');
+    // Projected sum would have been +$360.00 with USDC+USDT @ 4% — must not appear.
+    expect(headline).not.toHaveTextContent('+$360.00');
+  });
+
+  it('falls back to the projected sum when headlineFiat is undefined', () => {
+    const { getByTestId } = render(
+      <MoneyPotentialEarnings
+        apy={4}
+        tokens={[MOCK_USDC]}
+        headlineFiat={undefined}
+      />,
+    );
+
+    expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
+      '+$200.00',
+    );
+  });
+
   it('hides the per-token projected earning text when apy is zero', () => {
     const { queryByText } = render(
       <MoneyPotentialEarnings apy={0} tokens={[MOCK_USDC]} />,

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -49,6 +49,13 @@ interface MoneyPotentialEarningsProps {
    * alongside each token and in the gradient headline.
    */
   apy: number | undefined;
+  /**
+   * Pre-formatted fiat string to render in the gradient headline (e.g. the
+   * user's current Money balance). When provided, the headline shows this
+   * value instead of the aggregated projected earnings — used to surface
+   * the deposited balance once a user has any mUSD held.
+   */
+  headlineFiat?: string;
   onTokenPress?: (token: AssetType) => void;
   onViewAllPress?: () => void;
   onHeaderPress?: () => void;
@@ -57,6 +64,7 @@ interface MoneyPotentialEarningsProps {
 const MoneyPotentialEarnings = ({
   tokens,
   apy,
+  headlineFiat,
   onTokenPress,
   onViewAllPress,
   onHeaderPress,
@@ -112,7 +120,8 @@ const MoneyPotentialEarnings = ({
           onPress={onHeaderPress}
         />
 
-        {isPositiveNumber(projectedAmount) && (
+        {headlineFiat && <MoneyGradientText value={headlineFiat} />}
+        {!headlineFiat && isPositiveNumber(projectedAmount) && (
           <MoneyGradientText
             value={`+${moneyFormatFiat(new BigNumber(projectedAmount), currentCurrency)}`}
           />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6577,8 +6577,8 @@
     },
     "how_it_works": {
       "title": "How it works",
-      "description_prefix": "Hold mUSD in your Money Account and auto-earn",
-      "description_suffix": ". It's dollar-backed, always liquid, and ready to spend, trade, or send anytime."
+      "description_prefix": "Your Money account auto-earns up to",
+      "description_suffix": ". Your balance is dollar-backed, always liquid, and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "Add"


### PR DESCRIPTION
## **Description**

Polishes the earnings sections on Money Account Home:

- **Estimated-earnings tooltip** — verified the existing "Got it" CTA matches the design (no code change needed).
- **"How it works" copy** — updated the English description prefix and suffix to match the new copy in Figma; the inline APY tag continues to render between the two halves.
- **Earn-on-crypto headline** — when the user has a positive mUSD balance ("deposited"), the green gradient headline now shows their total balance instead of the projected-earnings sum. Users with no mUSD balance still see the projected sum as before. The mirror "View all" full-screen view follows the same branch.

Re-uses existing utils (`calculateProjectedEarnings`, `moneyFormatFiat`, `tokenFiatValue`) and the existing DSRN button props — no DS overrides, no nested ternaries, no other locales touched.

## **Changelog**

CHANGELOG entry: Polished the Money Account earnings sections, including refreshed "How it works" copy and a deposited-state headline that shows the user's total balance.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-787

## **Manual testing steps**

```gherkin
Feature: Money Account earnings polish

  Scenario: user with no mUSD balance views the earn-on-crypto section
    Given the user has zero mUSD balance and convertible tokens with positive value
    When the user opens the Money Account home
    Then the earn-on-crypto headline shows the projected earnings sum in green

  Scenario: user with a deposited mUSD balance views the earn-on-crypto section
    Given the user has a positive mUSD balance
    When the user opens the Money Account home
    Then the earn-on-crypto headline shows their total balance in green

  Scenario: user views the "How it works" section
    When the user opens the Money Account home
    Then the "How it works" description shows the updated copy with the APY tag inline

  Scenario: user opens the estimated-earnings tooltip
    When the user taps the info icon on the earnings card
    Then the tooltip shows a "Got it" CTA that closes the sheet
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only logic changes that switch which pre-formatted value is displayed based on a non-zero balance, plus copy updates; no auth, storage, or transaction flows changed.
> 
> **Overview**
> **Earn-on-crypto headline now reflects deposited state.** On `MoneyHomeView` and the full-screen `MoneyPotentialEarningsView`, the green gradient headline shows `totalFiatFormatted` when `totalFiatRaw` is a positive number; otherwise it continues to show the `+<projected earnings>` sum.
> 
> **Component/API update.** `MoneyPotentialEarnings` adds an optional `headlineFiat` prop to override the projected headline, and callers pass the computed deposited-balance headline.
> 
> **Copy + tests.** Updates English `money.how_it_works` prefix/suffix copy and expands unit tests to cover the new headline branching and `headlineFiat` override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7640810104f1bf9680062ae20f073e7a7b2a17b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->