### PR TITLE
refactor(tabs): rename collapseBy → collapseHeightOffset

### DIFF
--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.test.tsx
@@ -366,7 +366,7 @@ describe('TabsIconBar', () => {
       expect(getByTestId('icon-bar')).toBeOnTheScreen();
     });
 
-    it('renders without throwing when collapseBy is provided', () => {
+    it('renders without throwing when collapseHeightOffset is provided', () => {
       const collapseAnim = new Animated.Value(0);
       expect(() =>
         render(
@@ -375,14 +375,14 @@ describe('TabsIconBar', () => {
             activeIndex={0}
             onTabPress={jest.fn()}
             collapseAnim={collapseAnim}
-            collapseBy={28}
+            collapseHeightOffset={28}
             testID="icon-bar"
           />,
         ),
       ).not.toThrow();
     });
 
-    it('renders without throwing when collapseBy exceeds tabRowHeight', () => {
+    it('renders without throwing when collapseHeightOffset exceeds tabRowHeight', () => {
       const collapseAnim = new Animated.Value(0);
       const { getByTestId } = render(
         <TabsIconBar
@@ -390,7 +390,7 @@ describe('TabsIconBar', () => {
           activeIndex={0}
           onTabPress={jest.fn()}
           collapseAnim={collapseAnim}
-          collapseBy={9999}
+          collapseHeightOffset={9999}
           testID="icon-bar"
         />,
       );

--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.tsx
@@ -23,7 +23,7 @@ const TabsIconBar: React.FC<TabsIconBarProps> = ({
   twClassName,
   fillWidth = false,
   collapseAnim,
-  collapseBy,
+  collapseHeightOffset,
   ...boxProps
 }) => {
   const tw = useTailwind();
@@ -35,7 +35,9 @@ const TabsIconBar: React.FC<TabsIconBarProps> = ({
   // Height collapse animation — icon tabs always have a border-b row
   const [tabRowHeight, setTabRowHeight] = useState(0);
   const collapsedHeight =
-    collapseBy !== undefined ? Math.max(0, tabRowHeight - collapseBy) : 0;
+    collapseHeightOffset !== undefined
+      ? Math.max(0, tabRowHeight - collapseHeightOffset)
+      : 0;
   const animatedHeight =
     collapseAnim && tabRowHeight > 0
       ? collapseAnim.interpolate({

--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.types.ts
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.types.ts
@@ -61,9 +61,10 @@ export interface TabsIconBarProps extends BoxComponentProps {
    */
   collapseAnim?: Animated.Value;
   /**
-   * When provided alongside `collapseAnim`, the tab row collapses BY this many pixels at the
-   * fully-hidden state (1.0) instead of collapsing all the way to 0. Use this to shrink the
-   * row by just the icon area (for example) while keeping labels visible.
+   * Optional height offset (in px) used when `collapseAnim` reaches its fully-collapsed
+   * state (value 1). Instead of shrinking the row to 0, the row shrinks BY this many px —
+   * use this to reclaim the icon area while keeping labels visible. Defaults to the full
+   * row height (full collapse).
    */
-  collapseBy?: number;
+  collapseHeightOffset?: number;
 }


### PR DESCRIPTION
## **Description**


Following up from feedback on the [Hub Page Discovery Tabs PR](https://github.com/MetaMask/metamask-mobile/pull/29889): the new `collapseBy` prop on `TabsIconBar` was too vague. Renamed to `collapseHeightOffset` and clarified the JSDoc. No behavior change, no consumers currently use the prop.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TabsIconBar collapseHeightOffset prop

  Scenario: existing consumers unaffected
    Given a TabsIconBar without collapseHeightOffset
    Then it collapses to height 0 (existing behavior)

  Scenario: partial collapse
    Given a TabsIconBar with collapseAnim and collapseHeightOffset={28}
    When collapseAnim animates to 1
    Then the row shrinks by 28px (not all the way to 0)
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a prop rename plus doc/test updates in a single component, with no behavioral logic change beyond using the new prop name; risk is limited to any external callers still passing the old prop.
> 
> **Overview**
> Renames the `TabsIconBar` partial-collapse prop from `collapseBy` to `collapseHeightOffset` and updates the component implementation to use the new name when computing collapsed height.
> 
> Updates the related TypeScript types/JSDoc and adjusts the `TabsIconBar` tests to pass and describe `collapseHeightOffset` (including clamping behavior when the offset exceeds the measured row height).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243b05d786208790e6c26002e788c7624ec0a244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->