### PR TITLE
chore: cherry-pick fix(homepage): hub page discovery tabs UX & scroll improvements

### DIFF
--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.test.tsx
@@ -365,6 +365,41 @@ describe('TabsIconBar', () => {
       });
       expect(getByTestId('icon-bar')).toBeOnTheScreen();
     });
+
+    it('renders without throwing when collapseBy is provided', () => {
+      const collapseAnim = new Animated.Value(0);
+      expect(() =>
+        render(
+          <TabsIconBar
+            tabs={mockTabs}
+            activeIndex={0}
+            onTabPress={jest.fn()}
+            collapseAnim={collapseAnim}
+            collapseBy={28}
+            testID="icon-bar"
+          />,
+        ),
+      ).not.toThrow();
+    });
+
+    it('renders without throwing when collapseBy exceeds tabRowHeight', () => {
+      const collapseAnim = new Animated.Value(0);
+      const { getByTestId } = render(
+        <TabsIconBar
+          tabs={mockTabs}
+          activeIndex={0}
+          onTabPress={jest.fn()}
+          collapseAnim={collapseAnim}
+          collapseBy={9999}
+          testID="icon-bar"
+        />,
+      );
+      // Tab row height is clamped to 0 (no negative height); should not crash.
+      act(() => {
+        fireEvent(getByTestId('icon-bar'), 'onLayout', mockLayoutEvent(400));
+      });
+      expect(getByTestId('icon-bar')).toBeOnTheScreen();
+    });
   });
 
   describe('Tab Array Changes', () => {

--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.tsx
@@ -23,6 +23,7 @@ const TabsIconBar: React.FC<TabsIconBarProps> = ({
   twClassName,
   fillWidth = false,
   collapseAnim,
+  collapseBy,
   ...boxProps
 }) => {
   const tw = useTailwind();
@@ -33,11 +34,13 @@ const TabsIconBar: React.FC<TabsIconBarProps> = ({
 
   // Height collapse animation — icon tabs always have a border-b row
   const [tabRowHeight, setTabRowHeight] = useState(0);
+  const collapsedHeight =
+    collapseBy !== undefined ? Math.max(0, tabRowHeight - collapseBy) : 0;
   const animatedHeight =
     collapseAnim && tabRowHeight > 0
       ? collapseAnim.interpolate({
           inputRange: [0, 1],
-          outputRange: [tabRowHeight, 0],
+          outputRange: [tabRowHeight, collapsedHeight],
         })
       : undefined;
 

--- a/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.types.ts
+++ b/app/component-library/components-temp/Tabs/TabsIconBar/TabsIconBar.types.ts
@@ -60,4 +60,10 @@ export interface TabsIconBarProps extends BoxComponentProps {
    * Requires useNativeDriver: false on the driving animation.
    */
   collapseAnim?: Animated.Value;
+  /**
+   * When provided alongside `collapseAnim`, the tab row collapses BY this many pixels at the
+   * fully-hidden state (1.0) instead of collapsing all the way to 0. Use this to shrink the
+   * row by just the icon area (for example) while keeping labels visible.
+   */
+  collapseBy?: number;
 }

--- a/app/component-library/components-temp/Tabs/TabsIconList/TabsIconList.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconList/TabsIconList.tsx
@@ -85,7 +85,7 @@ const TabsIconList = forwardRef<TabsIconListRef, TabsIconListProps>(
 
         <GestureDetector gesture={swipeGesture}>
           <Box
-            twClassName={`flex-1 mt-2 px-4 ${tabsListContentTwClassName || ''}`}
+            twClassName={`flex-1 ${tabsListContentTwClassName || ''}`}
             testID={testID ? `${testID}-content` : undefined}
           >
             {tabs.map((tab, index) => {

--- a/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconAnimationContext.ts
+++ b/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconAnimationContext.ts
@@ -1,14 +1,17 @@
 import { createContext } from 'react';
-import { Animated } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
 
 /**
- * Provides an optional RN Animated.Value (0 = icons expanded, 1 = icons collapsed)
- * to Tab components without threading props through TabsList / TabsBar.
- * Consumers that don't provide this context get the default (undefined), which
- * means icons render at full size — preserving existing behaviour.
+ * Provides an optional Reanimated SharedValue (0 = icons expanded, 1 = icons collapsed)
+ * to Tab components without threading props through TabsList / TabsBar. The value drives
+ * the icon's height / marginBottom / opacity via useAnimatedStyle on the UI thread —
+ * no per-frame JS work, no layout reflow on the JS thread.
+ *
+ * Consumers that don't provide this context get the default (undefined), which means
+ * icons render at full size — preserving existing behaviour.
  */
 export interface TabIconAnimationContextValue {
-  iconCollapseAnim?: Animated.Value;
+  iconCollapseProgress?: SharedValue<number>;
 }
 
 export const TabIconAnimationContext =

--- a/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconTab.test.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconTab.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 
 // Internal dependencies.
 import TabsIconTab from './TabsIconTab';
+import { TabIconAnimationContext } from './TabsIconAnimationContext';
 import { IconName } from '../../../components/Icons/Icon/Icon.types';
 
 describe('TabsIconTab', () => {
@@ -119,6 +120,41 @@ describe('TabsIconTab', () => {
           ),
         ).not.toThrow();
       });
+    });
+  });
+
+  describe('Icon collapse animation context', () => {
+    it('renders without throwing when iconCollapseProgress SharedValue is provided', () => {
+      const iconCollapseProgress = { value: 0 } as never;
+      expect(() =>
+        render(
+          <TabIconAnimationContext.Provider value={{ iconCollapseProgress }}>
+            <TabsIconTab {...defaultProps} testID="tab" />
+          </TabIconAnimationContext.Provider>,
+        ),
+      ).not.toThrow();
+    });
+
+    it('renders without throwing when no SharedValue is provided (icons full size)', () => {
+      expect(() =>
+        render(
+          <TabIconAnimationContext.Provider value={{}}>
+            <TabsIconTab {...defaultProps} testID="tab" />
+          </TabIconAnimationContext.Provider>,
+        ),
+      ).not.toThrow();
+    });
+
+    it('renders the label text regardless of collapse progress value', () => {
+      const fullyCollapsed = { value: 1 } as never;
+      const { getByText } = render(
+        <TabIconAnimationContext.Provider
+          value={{ iconCollapseProgress: fullyCollapsed }}
+        >
+          <TabsIconTab {...defaultProps} />
+        </TabIconAnimationContext.Provider>,
+      );
+      expect(getByText('Portfolio')).toBeOnTheScreen();
     });
   });
 });

--- a/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconTab.tsx
+++ b/app/component-library/components-temp/Tabs/TabsIconTab/TabsIconTab.tsx
@@ -1,6 +1,11 @@
 // Third party dependencies.
 import React, { useContext, useRef, useCallback } from 'react';
-import { Animated, Pressable, StyleProp, View, ViewStyle } from 'react-native';
+import { Pressable, StyleProp, View, ViewStyle } from 'react-native';
+import Reanimated, {
+  useAnimatedStyle,
+  interpolate,
+  Extrapolation,
+} from 'react-native-reanimated';
 
 // External dependencies.
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -37,27 +42,31 @@ const TabsIconTab: React.FC<TabsIconTabProps> = ({
 }) => {
   const tw = useTailwind();
   const viewRef = useRef<View>(null);
-  const { iconCollapseAnim } = useContext(TabIconAnimationContext);
+  const { iconCollapseProgress } = useContext(TabIconAnimationContext);
 
-  // translateY slides the icon upward out of the clipping boundary (overflow:hidden
-  // on the outer View) without changing layout — keeps tab bar height fixed so
-  // there is no layout cascade. Both transform and opacity run on the native thread.
-  const iconAnimatedStyle = iconCollapseAnim
-    ? {
-        opacity: iconCollapseAnim.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, 0],
-        }),
-        transform: [
-          {
-            translateY: iconCollapseAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [0, -(ICON_SIZE_LG + ICON_MARGIN_BOTTOM)],
-            }),
-          },
-        ],
-      }
-    : undefined;
+  // Drive icon's layout box (height + marginBottom) and opacity from a Reanimated
+  // SharedValue so the entire transition runs on the UI thread — no per-frame JS work,
+  // no layout reflow on the JS thread.
+  const iconAnimatedStyle = useAnimatedStyle(() => {
+    if (!iconCollapseProgress) {
+      return {
+        height: ICON_SIZE_LG,
+        marginBottom: ICON_MARGIN_BOTTOM,
+        opacity: 1,
+      };
+    }
+    const p = iconCollapseProgress.value;
+    return {
+      height: interpolate(p, [0, 1], [ICON_SIZE_LG, 0], Extrapolation.CLAMP),
+      marginBottom: interpolate(
+        p,
+        [0, 1],
+        [ICON_MARGIN_BOTTOM, 0],
+        Extrapolation.CLAMP,
+      ),
+      opacity: interpolate(p, [0, 1], [1, 0], Extrapolation.CLAMP),
+    };
+  });
 
   const handleOnLayout = useCallback(
     (layoutEvent: Parameters<NonNullable<typeof onLayout>>[0]) => {
@@ -92,12 +101,7 @@ const TabsIconTab: React.FC<TabsIconTabProps> = ({
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Center}
         >
-          <Animated.View
-            style={[
-              { height: ICON_SIZE_LG, marginBottom: ICON_MARGIN_BOTTOM },
-              iconAnimatedStyle,
-            ]}
-          >
+          <Reanimated.View style={iconAnimatedStyle}>
             <Icon
               name={iconName}
               size={IconSize.Lg}
@@ -110,7 +114,7 @@ const TabsIconTab: React.FC<TabsIconTabProps> = ({
               }
               {...iconProps}
             />
-          </Animated.View>
+          </Reanimated.View>
           <Text
             variant={TextVariant.BodySm}
             fontWeight={

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -82,6 +82,12 @@ interface PerpsHomeViewProps {
   tabEnterCallbackRef?: React.MutableRefObject<(() => void) | null>;
   /** Forwarded to useDiscoveryScrollManager to sync icon animations with header hide/show. */
   onHeaderHiddenChange?: (hidden: boolean) => void;
+  /**
+   * Top padding applied inside the scroll content container — used by HomepageDiscoveryTabs
+   * (Hub Page Discovery Tabs feature flag treatment) so the perps gradient extends up
+   * directly under the discovery tab bar instead of leaving a transparent gap.
+   */
+  topInset?: number;
 }
 
 const PerpsHomeView = ({
@@ -90,6 +96,7 @@ const PerpsHomeView = ({
   walletHeaderHeight = 0,
   tabEnterCallbackRef,
   onHeaderHiddenChange,
+  topInset = 0,
 }: PerpsHomeViewProps) => {
   const { styles } = useStyles(styleSheet, {});
   const insets = useSafeAreaInsets();
@@ -483,7 +490,10 @@ const PerpsHomeView = ({
       {/* Main Content - ScrollView with all carousels */}
       <Reanimated.ScrollView
         style={styles.scrollView}
-        contentContainerStyle={styles.scrollViewContent}
+        contentContainerStyle={[
+          styles.scrollViewContent,
+          topInset > 0 ? { paddingTop: topInset } : null,
+        ]}
         showsVerticalScrollIndicator={false}
         onScroll={perpsScrollHandler}
         scrollEventThrottle={16}

--- a/app/components/UI/Predict/hooks/useFeedScrollManager.test.ts
+++ b/app/components/UI/Predict/hooks/useFeedScrollManager.test.ts
@@ -436,6 +436,179 @@ describe('useFeedScrollManager', () => {
     });
   });
 
+  describe('wallet header coordination', () => {
+    interface ScrollHandler {
+      onScroll?: (event: { contentOffset: { y: number } }) => void;
+    }
+
+    const patchReanimatedMock = () => {
+      const reanimated = jest.requireMock('react-native-reanimated');
+      reanimated.withTiming = mockWithTiming;
+      reanimated.runOnJS = mockRunOnJS;
+    };
+
+    it('accepts walletHeaderTranslateY and walletHeaderHeight without error', () => {
+      patchReanimatedMock();
+      const walletHeaderTranslateY = { value: 0 };
+      const props = createDefaultProps({
+        walletHeaderTranslateY,
+        walletHeaderHeight: 100,
+      });
+
+      expect(() => renderHook(() => useFeedScrollManager(props))).not.toThrow();
+    });
+
+    it('hides predict header by combined header + tab bar height when scrolling down past threshold', async () => {
+      patchReanimatedMock();
+      const walletHeaderTranslateY = { value: 0 };
+      const props = createDefaultProps({
+        walletHeaderTranslateY,
+        walletHeaderHeight: 100,
+      });
+
+      const { result } = renderHook(() => useFeedScrollManager(props));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.layoutReady).toBe(true);
+      });
+
+      const handler = result.current.scrollHandler as unknown as ScrollHandler;
+
+      mockWithTiming.mockClear();
+
+      act(() => {
+        handler.onScroll?.({ contentOffset: { y: 0 } });
+        handler.onScroll?.({ contentOffset: { y: 300 } });
+      });
+
+      // withTiming should have been called with -(headerHeight + tabBarHeight) = -(120 + 48) = -168
+      const calledValues = mockWithTiming.mock.calls.map((call) => call[0]);
+      expect(calledValues).toContain(-168);
+    });
+
+    it('animates walletHeaderTranslateY in lock-step with predict header', async () => {
+      patchReanimatedMock();
+      const walletHeaderTranslateY = { value: 0 };
+      const props = createDefaultProps({
+        walletHeaderTranslateY,
+        walletHeaderHeight: 100,
+      });
+
+      const { result } = renderHook(() => useFeedScrollManager(props));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.layoutReady).toBe(true);
+      });
+
+      const handler = result.current.scrollHandler as unknown as ScrollHandler;
+
+      act(() => {
+        handler.onScroll?.({ contentOffset: { y: 0 } });
+        handler.onScroll?.({ contentOffset: { y: 300 } });
+      });
+
+      expect(walletHeaderTranslateY.value).toBe(-100);
+    });
+
+    it('restores walletHeaderTranslateY when scrolling up past threshold', async () => {
+      patchReanimatedMock();
+      const walletHeaderTranslateY = { value: 0 };
+      const props = createDefaultProps({
+        walletHeaderTranslateY,
+        walletHeaderHeight: 100,
+      });
+
+      const { result } = renderHook(() => useFeedScrollManager(props));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.layoutReady).toBe(true);
+      });
+
+      const handler = result.current.scrollHandler as unknown as ScrollHandler;
+
+      // Scroll down to hide
+      act(() => {
+        handler.onScroll?.({ contentOffset: { y: 0 } });
+        handler.onScroll?.({ contentOffset: { y: 300 } });
+      });
+      expect(walletHeaderTranslateY.value).toBe(-100);
+
+      // Scroll up past threshold to restore
+      act(() => {
+        handler.onScroll?.({ contentOffset: { y: 50 } });
+        handler.onScroll?.({ contentOffset: { y: -250 } });
+      });
+
+      expect(walletHeaderTranslateY.value).toBe(0);
+      expect(result.current.headerTranslateY.value).toBe(0);
+    });
+
+    it('hides only by headerHeight (predict tabs stay pinned) when walletHeaderTranslateY is omitted', async () => {
+      patchReanimatedMock();
+      const props = createDefaultProps();
+
+      const { result } = renderHook(() => useFeedScrollManager(props));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.layoutReady).toBe(true);
+      });
+
+      const handler = result.current.scrollHandler as unknown as ScrollHandler;
+
+      mockWithTiming.mockClear();
+
+      act(() => {
+        handler.onScroll?.({ contentOffset: { y: 0 } });
+        handler.onScroll?.({ contentOffset: { y: 300 } });
+      });
+
+      const calledValues = mockWithTiming.mock.calls.map((call) => call[0]);
+      // Standalone path: only -headerHeight (-120), not -(headerHeight + tabBarHeight) (-168)
+      expect(calledValues).toContain(-120);
+      expect(calledValues).not.toContain(-168);
+    });
+
+    it('does not throw when walletHeaderTranslateY is omitted', async () => {
+      patchReanimatedMock();
+      const props = createDefaultProps();
+
+      const { result } = renderHook(() => useFeedScrollManager(props));
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.layoutReady).toBe(true);
+      });
+
+      const handler = result.current.scrollHandler as unknown as ScrollHandler;
+
+      expect(() => {
+        act(() => {
+          handler.onScroll?.({ contentOffset: { y: 0 } });
+          handler.onScroll?.({ contentOffset: { y: 300 } });
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe('onLayout callbacks', () => {
     it('provides onHeaderLayout callback', () => {
       const props = createDefaultProps();

--- a/app/components/UI/Predict/hooks/useFeedScrollManager.ts
+++ b/app/components/UI/Predict/hooks/useFeedScrollManager.ts
@@ -18,6 +18,8 @@ export interface UseFeedScrollManagerParams {
   tabBarRef: React.RefObject<View>;
   setActiveIndex: (index: number) => void;
   onHeaderHiddenChange?: (hidden: boolean) => void;
+  walletHeaderTranslateY?: SharedValue<number>;
+  walletHeaderHeight?: number;
 }
 
 export interface UseFeedScrollManagerReturn {
@@ -71,12 +73,18 @@ export const useFeedScrollManager = ({
   tabBarRef,
   setActiveIndex,
   onHeaderHiddenChange,
+  walletHeaderTranslateY,
+  walletHeaderHeight = 0,
 }: UseFeedScrollManagerParams): UseFeedScrollManagerReturn => {
   const isHeaderHidden = useSharedValue(0);
   const headerTranslateY = useSharedValue(0);
 
   const sharedHeaderHeight = useSharedValue(0);
   const sharedTabBarHeight = useSharedValue(0);
+  const sharedWalletHeaderHeight = useSharedValue(walletHeaderHeight);
+  useLayoutEffect(() => {
+    sharedWalletHeaderHeight.value = walletHeaderHeight;
+  }, [walletHeaderHeight, sharedWalletHeaderHeight]);
   const lastScrollY = useSharedValue(0);
 
   const isTabSwitching = useSharedValue(false);
@@ -185,6 +193,9 @@ export const useFeedScrollManager = ({
       if (atTop && isHeaderHidden.value === 1 && currentDirection === -1) {
         isHeaderHidden.value = 0;
         headerTranslateY.value = withTiming(0, animationConfig);
+        if (walletHeaderTranslateY) {
+          walletHeaderTranslateY.value = withTiming(0, animationConfig);
+        }
         accumulatedDelta.value = 0;
         lastDirection.value = 0;
         runOnJS(setHeaderHidden)(false);
@@ -196,13 +207,23 @@ export const useFeedScrollManager = ({
         return;
       }
 
-      // Scrolling down -> hide header
+      // Scrolling down -> hide header.
+      // When embedded in the Hub Page Discovery Tabs (feature flag treatment), walletHeaderTranslateY
+      // is provided and we slide both the predict header and predict tab bar away together so the
+      // outer discovery tabs become the only navigation row at the top. In the standalone screen
+      // path (no walletHeaderTranslateY), only the balance/carousel hides — predict tabs stay pinned.
       if (currentDirection === 1 && isHeaderHidden.value === 0) {
         isHeaderHidden.value = 1;
-        headerTranslateY.value = withTiming(
-          -sharedHeaderHeight.value,
-          animationConfig,
-        );
+        const hiddenTranslate = walletHeaderTranslateY
+          ? -(sharedHeaderHeight.value + sharedTabBarHeight.value)
+          : -sharedHeaderHeight.value;
+        headerTranslateY.value = withTiming(hiddenTranslate, animationConfig);
+        if (walletHeaderTranslateY) {
+          walletHeaderTranslateY.value = withTiming(
+            -sharedWalletHeaderHeight.value,
+            animationConfig,
+          );
+        }
         accumulatedDelta.value = 0;
         runOnJS(setHeaderHidden)(true);
         if (onHeaderHiddenChange) runOnJS(onHeaderHiddenChange)(true);
@@ -212,6 +233,9 @@ export const useFeedScrollManager = ({
       if (currentDirection === -1 && isHeaderHidden.value === 1) {
         isHeaderHidden.value = 0;
         headerTranslateY.value = withTiming(0, animationConfig);
+        if (walletHeaderTranslateY) {
+          walletHeaderTranslateY.value = withTiming(0, animationConfig);
+        }
         accumulatedDelta.value = 0;
         runOnJS(setHeaderHidden)(false);
         if (onHeaderHiddenChange) runOnJS(onHeaderHiddenChange)(false);

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -604,11 +604,15 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
 interface PredictFeedProps {
   hideHeader?: boolean;
   onHeaderHiddenChange?: (hidden: boolean) => void;
+  walletHeaderTranslateY?: SharedValue<number>;
+  walletHeaderHeight?: number;
 }
 
 const PredictFeed: React.FC<PredictFeedProps> = ({
   hideHeader = false,
   onHeaderHiddenChange,
+  walletHeaderTranslateY,
+  walletHeaderHeight,
 }) => {
   const {
     tabs,
@@ -687,6 +691,8 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
     tabBarRef,
     setActiveIndex,
     onHeaderHiddenChange,
+    walletHeaderTranslateY,
+    walletHeaderHeight,
   });
 
   const handleTabPress = useCallback(
@@ -741,7 +747,7 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
           </Box>
         )}
 
-        <Box twClassName="flex-1 relative">
+        <Box twClassName="flex-1 relative overflow-hidden">
           <AnimatedHeader
             headerTranslateY={headerTranslateY}
             headerHeight={headerHeight}

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.styles.ts
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.styles.ts
@@ -16,6 +16,10 @@ const styleSheet = (_params: { theme: Theme }) =>
     gradientFill: {
       flex: 1,
     },
+    portfolioScrollContent: {
+      paddingTop: 14,
+      gap: 16,
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -69,10 +69,14 @@ jest.mock('../../../../UI/Perps/Views/PerpsHomeView/PerpsHomeView', () => {
   };
 });
 
+const mockPredictFeedProps: { current: Record<string, unknown> | null } = {
+  current: null,
+};
 jest.mock('../../../../UI/Predict/views/PredictFeed', () => {
   const { View } = jest.requireActual('react-native');
   const ReactLib = jest.requireActual('react');
-  return function MockPredictFeed() {
+  return function MockPredictFeed(props: Record<string, unknown>) {
+    mockPredictFeedProps.current = props;
     return ReactLib.createElement(View, { testID: 'predict-feed' });
   };
 });
@@ -209,6 +213,43 @@ describe('HomepageDiscoveryTabs', () => {
 
     it('renders without throwing when walletHeaderOffset is 0', () => {
       expect(() => renderComponent({ walletHeaderOffset: 0 })).not.toThrow();
+    });
+  });
+
+  describe('PredictFeed wallet header forwarding', () => {
+    beforeEach(() => {
+      mockPredictFeedProps.current = null;
+    });
+
+    it('forwards walletHeaderTranslateY and walletHeaderHeight to PredictFeed', async () => {
+      const walletHeaderTranslateY = { value: 0 } as unknown;
+      renderComponent({
+        walletHeaderTranslateY,
+        walletHeaderHeight: 120,
+      });
+      await pressTab('Predictions');
+
+      expect(mockPredictFeedProps.current).not.toBeNull();
+      expect(mockPredictFeedProps.current?.walletHeaderTranslateY).toBe(
+        walletHeaderTranslateY,
+      );
+      expect(mockPredictFeedProps.current?.walletHeaderHeight).toBe(120);
+    });
+
+    it('passes onHeaderHiddenChange to PredictFeed so discovery icons collapse', async () => {
+      renderComponent();
+      await pressTab('Predictions');
+
+      expect(typeof mockPredictFeedProps.current?.onHeaderHiddenChange).toBe(
+        'function',
+      );
+    });
+
+    it('passes hideHeader=true to PredictFeed', async () => {
+      renderComponent();
+      await pressTab('Predictions');
+
+      expect(mockPredictFeedProps.current?.hideHeader).toBe(true);
     });
   });
 

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -5,15 +5,22 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import {
+  Animated,
+  RefreshControlProps,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
 import Reanimated, {
   SharedValue,
   withTiming,
   Easing,
+  useSharedValue,
 } from 'react-native-reanimated';
 import LinearGradient from 'react-native-linear-gradient';
 import TabsIconList from '../../../../../component-library/components-temp/Tabs/TabsIconList/TabsIconList';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { TabsIconListRef } from '../../../../../component-library/components-temp/Tabs/TabsIconList/TabsIconList.types';
 import Homepage from '../../Homepage';
 import PerpsHomeView from '../../../../UI/Perps/Views/PerpsHomeView/PerpsHomeView';
@@ -73,14 +80,16 @@ interface DiscoveryTabViewProps {
   tabLabel: string;
   tabIcon?: IconName;
   keepMounted?: boolean;
+  style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 }
 
 const discoveryTabViewStyles = StyleSheet.create({ root: { flex: 1 } });
 
-const DiscoveryTabView: React.FC<DiscoveryTabViewProps> = ({ children }) => (
-  <View style={discoveryTabViewStyles.root}>{children}</View>
-);
+const DiscoveryTabView: React.FC<DiscoveryTabViewProps> = ({
+  children,
+  style,
+}) => <View style={[discoveryTabViewStyles.root, style]}>{children}</View>;
 
 export interface HomepageDiscoveryTabsProps {
   /**
@@ -145,7 +154,6 @@ const HomepageDiscoveryTabs = forwardRef<
     const tabsRef = useRef<TabsIconListRef>(null);
     const homepageRef = useRef<SectionRefreshHandle>(null);
     const perpsTabEnterRef = useRef<(() => void) | null>(null);
-    const tw = useTailwind();
     const { styles } = useStyles(styleSheet, {});
     const { themeAppearance } = useTheme();
     const isDarkMode = themeAppearance === AppThemeKey.dark;
@@ -158,35 +166,38 @@ const HomepageDiscoveryTabs = forwardRef<
     ).current;
     const activeTabIndexRef = useRef<number>(TAB_INDEX.PORTFOLIO);
 
-    // 0 = icons expanded (header visible), 1 = icons collapsed (header hidden)
+    // 0 = icons expanded (header visible), 1 = icons collapsed (header hidden).
+    // Reanimated SharedValue drives icon height/marginBottom/opacity via useAnimatedStyle
+    // on the UI thread — no per-frame JS work, no JS-thread layout reflow.
+    const iconCollapseProgress = useSharedValue(0);
+    // RN Animated.Value mirror for the gradient overlay's Animated.multiply (which composes
+    // with tabGradientOpacities). Updated alongside the SharedValue at every toggle.
     const iconCollapseAnim = useRef(new Animated.Value(0)).current;
-    // Ref so the animated reaction closure always calls the latest animation starter
     const iconCollapseAnimRef = useRef(iconCollapseAnim);
-
-    // Drives TabsBar height collapse on the Predictions tab only (useNativeDriver: false)
-    const tabBarCollapseAnim = useRef(new Animated.Value(0)).current;
-    const tabBarCollapseAnimRef = useRef(tabBarCollapseAnim);
 
     // Triggered directly from the scroll worklet via onHeaderHiddenChange —
     // fires in the same frame as the hide/show decision, not based on position.
-    const animateIcons = useCallback((hidden: boolean) => {
-      const toValue = hidden ? 1 : 0;
-      const duration = hidden ? 300 : 250;
+    // eslint-disable-next-line react-compiler/react-compiler -- mutating a Reanimated SharedValue is the documented pattern; it does not affect React render
+    const animateIcons = useCallback(
+      (hidden: boolean) => {
+        const toValue = hidden ? 1 : 0;
+        const duration = hidden ? 300 : 250;
 
-      Animated.timing(iconCollapseAnimRef.current, {
-        toValue,
-        duration,
-        useNativeDriver: true,
-      }).start();
+        // UI-thread layout animation via Reanimated.
+        iconCollapseProgress.value = withTiming(toValue, {
+          duration,
+          easing: Easing.out(Easing.cubic),
+        });
 
-      if (activeTabIndexRef.current === TAB_INDEX.PREDICTIONS) {
-        Animated.timing(tabBarCollapseAnimRef.current, {
+        // Mirror onto the Animated.Value for the gradient overlay's Animated.multiply.
+        Animated.timing(iconCollapseAnimRef.current, {
           toValue,
           duration,
-          useNativeDriver: false,
+          useNativeDriver: true,
         }).start();
-      }
-    }, []);
+      },
+      [iconCollapseProgress],
+    );
 
     const { scrollHandler, onTabEnter: portfolioOnTabEnter } =
       useDiscoveryScrollManager({
@@ -229,6 +240,10 @@ const HomepageDiscoveryTabs = forwardRef<
                 duration: 250,
                 easing: Easing.out(Easing.cubic),
               }));
+            iconCollapseProgress.value = withTiming(0, {
+              duration: 250,
+              easing: Easing.out(Easing.cubic),
+            });
             Animated.timing(iconCollapseAnimRef.current, {
               toValue: 0,
               duration: 250,
@@ -242,22 +257,14 @@ const HomepageDiscoveryTabs = forwardRef<
               duration: 250,
               easing: Easing.out(Easing.cubic),
             }));
+          iconCollapseProgress.value = withTiming(0, {
+            duration: 250,
+            easing: Easing.out(Easing.cubic),
+          });
           Animated.timing(iconCollapseAnimRef.current, {
             toValue: 0,
             duration: 250,
             useNativeDriver: true,
-          }).start();
-        }
-
-        // Reset tab bar collapse when leaving Predictions
-        if (
-          prevIndex === TAB_INDEX.PREDICTIONS &&
-          i !== TAB_INDEX.PREDICTIONS
-        ) {
-          Animated.timing(tabBarCollapseAnimRef.current, {
-            toValue: 0,
-            duration: 250,
-            useNativeDriver: false,
           }).start();
         }
 
@@ -288,22 +295,20 @@ const HomepageDiscoveryTabs = forwardRef<
         portfolioOnTabEnter,
         walletHeaderTranslateY,
         trackTabViewed,
+        iconCollapseProgress,
       ],
     );
 
     return (
-      <TabIconAnimationContext.Provider value={{ iconCollapseAnim }}>
+      <TabIconAnimationContext.Provider value={{ iconCollapseProgress }}>
         <View style={styles.flex}>
           <TabsIconList
             ref={tabsRef}
             initialActiveIndex={TAB_INDEX.PORTFOLIO}
             onChangeTab={handleChangeTab}
             tabsListContentTwClassName="px-0"
-            style={tw.style('mt-2')}
             tabsBarProps={{
               fillWidth: true,
-              collapseAnim: tabBarCollapseAnim,
-              style: { zIndex: 2 },
             }}
           >
             <DiscoveryTabView tabLabel="Portfolio" tabIcon={IconName.PieChart}>
@@ -312,8 +317,9 @@ const HomepageDiscoveryTabs = forwardRef<
                 onScroll={scrollHandler}
                 scrollEventThrottle={16}
                 refreshControl={refreshControl}
+                contentContainerStyle={styles.portfolioScrollContent}
               >
-                <View style={tw.style('mt-4 mb-2')}>{portfolioHeader}</View>
+                {portfolioHeader}
                 <Homepage ref={homepageRef} />
               </Reanimated.ScrollView>
             </DiscoveryTabView>
@@ -331,6 +337,7 @@ const HomepageDiscoveryTabs = forwardRef<
                     walletHeaderHeight={walletHeaderHeight}
                     tabEnterCallbackRef={perpsTabEnterRef}
                     onHeaderHiddenChange={animateIcons}
+                    topInset={22}
                   />
                 </PerpsStreamProvider>
               </PerpsConnectionProvider>
@@ -342,7 +349,12 @@ const HomepageDiscoveryTabs = forwardRef<
               keepMounted={false}
             >
               <PredictPreviewSheetProvider>
-                <PredictFeed hideHeader onHeaderHiddenChange={animateIcons} />
+                <PredictFeed
+                  hideHeader
+                  walletHeaderTranslateY={walletHeaderTranslateY}
+                  walletHeaderHeight={walletHeaderHeight}
+                  onHeaderHiddenChange={animateIcons}
+                />
               </PredictPreviewSheetProvider>
             </DiscoveryTabView>
           </TabsIconList>
@@ -353,7 +365,7 @@ const HomepageDiscoveryTabs = forwardRef<
               Outer wrapper fades the entire gradient out when the header/icons collapse. */}
           {walletHeaderOffset > 0 &&
             isDarkMode &&
-            Object.entries(TAB_GRADIENT_COLORS).map(([idx, colors]) => (
+            Object.entries(TAB_GRADIENT_COLORS).map(([idx, gradientColors]) => (
               <Animated.View
                 key={idx}
                 style={[
@@ -373,7 +385,7 @@ const HomepageDiscoveryTabs = forwardRef<
                 pointerEvents="none"
               >
                 <LinearGradient
-                  colors={colors}
+                  colors={gradientColors}
                   locations={[0, 0.6, 1.0]}
                   style={styles.gradientFill}
                 />


### PR DESCRIPTION
## **Description**

- fix(homepage): hub page discovery tabs UX & scroll improvements cp-7.77.0 (https://github.com/MetaMask/metamask-mobile/pull/29889) 

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes header/tab-bar hide/show behavior and animation plumbing across Homepage Discovery Tabs, Predict, and Perps, which can regress layout/scroll interactions on iOS/Android.
> 
> **Overview**
> Improves Hub Page Discovery Tabs UX by moving icon-collapse animation to Reanimated: `TabIconAnimationContext` now provides a `SharedValue` and `TabsIconTab` animates icon height/margin/opacity on the UI thread, while keeping a mirrored `Animated.Value` only for the dark-mode gradient fade.
> 
> Updates the discovery tab content layout (Portfolio scroll container spacing, removing extra `mt-2` in `TabsIconList`, adding `topInset` support to `PerpsHomeView`) and forwards wallet header coordination props into `PredictFeed`.
> 
> Extends `useFeedScrollManager` so, when embedded, it hides Predict’s header *and* its tab bar together and animates `walletHeaderTranslateY` in sync; adds clamped partial-collapse support to `TabsIconBar` via new `collapseBy` prop. Tests are added/updated to cover the new props and non-crashing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1cc4f5a719058df87c1d622e2aa66446aed006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->