### PR TITLE
feat(predict): add Deposit Wallet order flow

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -12,6 +12,7 @@ import type { OrderPreview } from '../types';
 import { Side } from '../../types';
 import type { PredictFeatureFlags } from '../../types/flags';
 import { PolymarketProvider } from './PolymarketProvider';
+import { OrderType, SignatureType } from './types';
 import {
   deriveDepositWalletAddress,
   executeDepositWalletBatch,
@@ -471,6 +472,9 @@ describe('PolymarketProvider', () => {
       expect.any(Object),
       SignTypedDataVersion.V4,
     );
+    expect(mockGetL2Headers).toHaveBeenCalledWith(
+      expect.objectContaining({ address: signer.address }),
+    );
     expect(mockSubmitProtocolClobOrder).toHaveBeenCalledWith(
       expect.objectContaining({
         protocol: expect.objectContaining({
@@ -480,10 +484,86 @@ describe('PolymarketProvider', () => {
             clobVersionHeader: '2',
           }),
         }),
+        clobOrder: expect.objectContaining({
+          order: expect.objectContaining({
+            maker: legacySafeAddress,
+            signer: signer.address,
+            signatureType: SignatureType.POLY_GNOSIS_SAFE,
+          }),
+        }),
         allowancesTx: {
           to: '0x9999999999999999999999999999999999999999',
           data: '0xallowances',
         },
+      }),
+    );
+  });
+
+  it('submits deposit-wallet orders with POLY_1271 payload and no Safe preflight fields', async () => {
+    const innerSignature = `0x${'11'.repeat(65)}`;
+    signer.signTypedMessage.mockResolvedValueOnce(innerSignature);
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const provider = createProvider({
+      fakOrdersEnabled: true,
+      feeCollection: {
+        ...DEFAULT_FEE_COLLECTION_FLAG,
+        permit2Enabled: true,
+        executors: ['0x4444444444444444444444444444444444444444'],
+      },
+    });
+
+    const result = await provider.placeOrder({
+      signer,
+      preview: {
+        ...basePreview,
+        fees: {
+          metamaskFee: 0.05,
+          providerFee: 0.05,
+          totalFee: 0.1,
+          totalFeePercentage: 1,
+          collector: '0x3333333333333333333333333333333333333333',
+          executors: ['0x4444444444444444444444444444444444444444'],
+          permit2Enabled: true,
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockCreateApiKey).toHaveBeenCalledWith({ address: signer.address });
+    expect(mockBuildTradeAllowancesTx).not.toHaveBeenCalled();
+    expect(mockCreatePermit2FeeAuthorization).not.toHaveBeenCalled();
+    expect(mockGetL2Headers).toHaveBeenCalledWith(
+      expect.objectContaining({ address: signer.address }),
+    );
+    expect(signer.signTypedMessage).toHaveBeenCalledWith(
+      {
+        from: signer.address,
+        data: expect.objectContaining({
+          primaryType: 'TypedDataSign',
+          message: expect.objectContaining({
+            verifyingContract: depositWalletAddress,
+          }),
+        }),
+      },
+      SignTypedDataVersion.V4,
+    );
+    expect(mockSubmitProtocolClobOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clobOrder: expect.objectContaining({
+          orderType: OrderType.FAK,
+          order: expect.objectContaining({
+            maker: depositWalletAddress,
+            signer: depositWalletAddress,
+            signatureType: SignatureType.POLY_1271,
+            signature: expect.stringMatching(/^0x11+/u),
+          }),
+        }),
+        feeAuthorization: undefined,
+        executor: undefined,
+        allowancesTx: undefined,
       }),
     );
   });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -499,7 +499,7 @@ describe('PolymarketProvider', () => {
     );
   });
 
-  it('submits deposit-wallet orders with POLY_1271 payload and no Safe preflight fields', async () => {
+  it('submits deposit-wallet orders with POLY_1271 payload and no Safe trade preflight fields', async () => {
     const innerSignature = `0x${'11'.repeat(65)}`;
     signer.signTypedMessage.mockResolvedValueOnce(innerSignature);
     mockIsSmartContractAddress
@@ -564,6 +564,108 @@ describe('PolymarketProvider', () => {
         feeAuthorization: undefined,
         executor: undefined,
         allowancesTx: undefined,
+      }),
+    );
+  });
+
+  it('runs deposit-wallet setup before submitting deposit-wallet orders', async () => {
+    const repairTransaction = {
+      to: '0x4444444444444444444444444444444444444444',
+      data: '0xrepair',
+      operation: OperationType.Call,
+      value: '0',
+    };
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    mockPlanDepositWalletPreflight.mockResolvedValue({
+      missingRequirements: [
+        {
+          type: 'erc20-allowance',
+          tokenAddress: repairTransaction.to,
+          spender: '0x5555555555555555555555555555555555555555',
+        },
+      ],
+      transactions: [repairTransaction],
+    });
+
+    const result = await createProvider().placeOrder({
+      signer,
+      preview: basePreview,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockRequestDepositWalletCreate).toHaveBeenCalledWith({
+      ownerAddress: signer.address,
+    });
+    expect(mockExecuteDepositWalletBatch).toHaveBeenCalledWith({
+      signer,
+      walletAddress: depositWalletAddress,
+      calls: [
+        {
+          target: repairTransaction.to,
+          data: repairTransaction.data,
+          value: repairTransaction.value,
+        },
+      ],
+    });
+    expect(
+      mockSyncDepositWalletCollateralBalanceAllowance,
+    ).toHaveBeenCalledWith({
+      protocol: expect.objectContaining({ key: 'v2' }),
+      signerAddress: signer.address,
+      apiKey: expect.objectContaining({ apiKey: 'api-key' }),
+    });
+    expect(
+      mockExecuteDepositWalletBatch.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockSubmitProtocolClobOrder.mock.invocationCallOrder[0]);
+  });
+
+  it('passes legacy Safe migration sweep as allowancesTx for deposit-wallet orders', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    const sweepTransaction: SignedSafeExecution = {
+      params: {
+        to: legacySafeAddress as `0x${string}`,
+        data: '0xsweep' as `0x${string}`,
+      },
+      type: TransactionType.contractInteraction,
+    };
+    mockBuildLegacySafeMigrationSweepTransaction.mockResolvedValue(
+      sweepTransaction,
+    );
+
+    const result = await createProvider().placeOrder({
+      signer,
+      preview: basePreview,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockBuildLegacySafeMigrationSweepTransaction).toHaveBeenCalledWith({
+      signer,
+      legacySafeAddress,
+      depositWalletAddress,
+      protocol: expect.objectContaining({ key: 'v2' }),
+    });
+    expect(mockSubmitProtocolClobOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clobOrder: expect.objectContaining({
+          order: expect.objectContaining({
+            maker: depositWalletAddress,
+            signer: depositWalletAddress,
+            signatureType: SignatureType.POLY_1271,
+          }),
+        }),
+        allowancesTx: sweepTransaction.params,
       }),
     );
   });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -80,6 +80,7 @@ import { Permit2FeeAuthorization } from './safe/types';
 import {
   ApiKeyCreds,
   OrderType,
+  SignatureType,
   PolymarketApiActivity,
   PolymarketApiEvent,
   PolymarketApiTeam,
@@ -119,9 +120,9 @@ import {
 import {
   buildProtocolUnsignedOrder,
   getPreviewFeeRateBpsForProtocol,
-  getProtocolOrderTypedData,
   getProtocolVerifyingContract,
   serializeProtocolRelayerOrder,
+  signProtocolOrder,
 } from './protocol/orderCodec';
 import { submitProtocolClobOrder } from './protocol/transport';
 import { buildClaimTransaction } from './preflight/claim';
@@ -412,12 +413,14 @@ export class PolymarketProvider implements PredictProvider {
     fakOrdersEnabled,
     permit2FeeReady,
     permit2AllowanceReady,
+    manualFeeCollectionSupported = true,
   }: {
     preview: OrderPreview;
     feeCollection: PredictFeatureFlags['feeCollection'];
     fakOrdersEnabled: boolean;
     permit2FeeReady: boolean;
     permit2AllowanceReady: boolean;
+    manualFeeCollectionSupported?: boolean;
   }): OrderType {
     if (
       !this.#shouldUseFakOrderType({
@@ -431,7 +434,11 @@ export class PolymarketProvider implements PredictProvider {
 
     const hasFees = preview.fees !== undefined && preview.fees.totalFee > 0;
 
-    if (!hasFees || (permit2FeeReady && permit2AllowanceReady)) {
+    if (
+      !hasFees ||
+      !manualFeeCollectionSupported ||
+      (permit2FeeReady && permit2AllowanceReady)
+    ) {
       return OrderType.FAK;
     }
 
@@ -472,9 +479,15 @@ export class PolymarketProvider implements PredictProvider {
     preview: OrderPreview;
     protocol: PolymarketProtocolDefinition;
   }) {
-    const safeAddress =
-      this.#getCachedAccountState(signer.address)?.address ??
-      computeProxyAddress(signer.address);
+    const accountState = await this.getAccountState({
+      ownerAddress: signer.address,
+    });
+    const isDepositWallet = accountState.walletType === 'deposit-wallet';
+    const tradingWalletAddress = accountState.address;
+    const verifyingContract = getProtocolVerifyingContract({
+      protocol,
+      negRisk: preview.negRisk,
+    });
 
     const order = buildProtocolUnsignedOrder({
       protocol,
@@ -482,23 +495,21 @@ export class PolymarketProvider implements PredictProvider {
         ...preview,
         feeRateBps: getPreviewFeeRateBpsForProtocol(),
       },
-      makerAddress: safeAddress,
-      signerAddress: getAddress(signer.address),
+      makerAddress: tradingWalletAddress,
+      signerAddress: isDepositWallet
+        ? tradingWalletAddress
+        : getAddress(signer.address),
+      signatureType: isDepositWallet
+        ? SignatureType.POLY_1271
+        : SignatureType.POLY_GNOSIS_SAFE,
     });
 
-    const typedData = getProtocolOrderTypedData({
+    const signature = await signProtocolOrder({
+      signer,
       protocol,
       order,
-      verifyingContract: getProtocolVerifyingContract({
-        protocol,
-        negRisk: preview.negRisk,
-      }),
+      verifyingContract,
     });
-
-    const signature = await signer.signTypedMessage(
-      { data: typedData, from: signer.address },
-      SignTypedDataVersion.V4,
-    );
 
     const signedOrder = {
       ...order,
@@ -508,10 +519,12 @@ export class PolymarketProvider implements PredictProvider {
       address: signer.address,
     });
     const { feeCollection, fakOrdersEnabled } = this.#getFeatureFlags();
-    const shouldUsePermit2 = this.#hasPermit2Config({
-      permit2Enabled: preview.fees?.permit2Enabled,
-      executors: preview.fees?.executors,
-    });
+    const shouldUsePermit2 =
+      !isDepositWallet &&
+      this.#hasPermit2Config({
+        permit2Enabled: preview.fees?.permit2Enabled,
+        executors: preview.fees?.executors,
+      });
 
     let feeAuthorization: Permit2FeeAuthorization | undefined;
     let executor: string | undefined;
@@ -527,7 +540,7 @@ export class PolymarketProvider implements PredictProvider {
       );
       executor = this.#pickExecutor(preview.fees.executors ?? []);
       feeAuthorization = await createPermit2FeeAuthorization({
-        safeAddress,
+        safeAddress: tradingWalletAddress,
         signer,
         amount: feeAmount,
         spender: executor,
@@ -539,32 +552,34 @@ export class PolymarketProvider implements PredictProvider {
     let allowancesTx: { to: string; data: string } | undefined;
     let permit2AllowanceReady = false;
 
-    try {
-      const safeLegacyUsdceBalance = await this.#getLegacyUsdceBalance({
-        safeAddress,
-        protocol,
-      });
-      allowancesTx = await buildTradeAllowancesTx({
-        signer,
-        safeAddress,
-        protocol,
-        safeUsdceBalance: safeLegacyUsdceBalance,
-      });
-      permit2AllowanceReady = true;
-    } catch (allowanceError) {
-      DevLogger.log(
-        'PolymarketProvider: Failed to generate v2 allowances transaction',
-        { error: allowanceError },
-      );
-      Logger.error(
-        allowanceError instanceof Error
-          ? allowanceError
-          : new Error(String(allowanceError)),
-        this.getErrorContext('placeOrder:v2AllowancesTx', {
-          operation: 'generate_allowances_tx_v2',
-        }),
-      );
-      throw new Error('Failed to prepare v2 trade preflight');
+    if (!isDepositWallet) {
+      try {
+        const safeLegacyUsdceBalance = await this.#getLegacyUsdceBalance({
+          safeAddress: tradingWalletAddress,
+          protocol,
+        });
+        allowancesTx = await buildTradeAllowancesTx({
+          signer,
+          safeAddress: tradingWalletAddress,
+          protocol,
+          safeUsdceBalance: safeLegacyUsdceBalance,
+        });
+        permit2AllowanceReady = true;
+      } catch (allowanceError) {
+        DevLogger.log(
+          'PolymarketProvider: Failed to generate v2 allowances transaction',
+          { error: allowanceError },
+        );
+        Logger.error(
+          allowanceError instanceof Error
+            ? allowanceError
+            : new Error(String(allowanceError)),
+          this.getErrorContext('placeOrder:v2AllowancesTx', {
+            operation: 'generate_allowances_tx_v2',
+          }),
+        );
+        throw new Error('Failed to prepare v2 trade preflight');
+      }
     }
 
     const orderType = this.#getPlaceOrderType({
@@ -573,6 +588,7 @@ export class PolymarketProvider implements PredictProvider {
       fakOrdersEnabled,
       permit2FeeReady,
       permit2AllowanceReady,
+      manualFeeCollectionSupported: !isDepositWallet,
     });
 
     const clobOrder = serializeProtocolRelayerOrder({
@@ -588,7 +604,7 @@ export class PolymarketProvider implements PredictProvider {
         requestPath: `/order`,
         body,
       },
-      address: clobOrder.order.signer ?? '',
+      address: signer.address,
       apiKey: signerApiKey,
     });
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -489,6 +489,17 @@ export class PolymarketProvider implements PredictProvider {
       negRisk: preview.negRisk,
     });
 
+    let depositWalletSetupUpdatedState = false;
+    if (isDepositWallet) {
+      depositWalletSetupUpdatedState = await this.ensureDepositWalletReady({
+        ownerAddress: signer.address,
+        depositWalletAddress: tradingWalletAddress,
+        protocol,
+        getSigner: () => signer,
+        operation: 'deposit_wallet_order_preflight',
+      });
+    }
+
     const order = buildProtocolUnsignedOrder({
       protocol,
       preview: {
@@ -518,6 +529,15 @@ export class PolymarketProvider implements PredictProvider {
     const signerApiKey = await this.getApiKey({
       address: signer.address,
     });
+
+    if (isDepositWallet && depositWalletSetupUpdatedState) {
+      await this.syncDepositWalletBalanceAllowanceForOrderIfNeeded({
+        protocol,
+        signerAddress: signer.address,
+        apiKey: signerApiKey,
+      });
+    }
+
     const { feeCollection, fakOrdersEnabled } = this.#getFeatureFlags();
     const shouldUsePermit2 =
       !isDepositWallet &&
@@ -552,7 +572,26 @@ export class PolymarketProvider implements PredictProvider {
     let allowancesTx: { to: string; data: string } | undefined;
     let permit2AllowanceReady = false;
 
-    if (!isDepositWallet) {
+    if (isDepositWallet) {
+      const legacySafeAddress = computeProxyAddress(signer.address);
+      const legacySafeDeployed = await isSmartContractAddress(
+        legacySafeAddress,
+        numberToHex(POLYGON_MAINNET_CHAIN_ID),
+      );
+
+      if (legacySafeDeployed) {
+        const sweepTransaction = await buildLegacySafeMigrationSweepTransaction(
+          {
+            signer,
+            legacySafeAddress,
+            depositWalletAddress: tradingWalletAddress,
+            protocol,
+          },
+        );
+
+        allowancesTx = sweepTransaction?.params;
+      }
+    } else {
       try {
         const safeLegacyUsdceBalance = await this.#getLegacyUsdceBalance({
           safeAddress: tradingWalletAddress,
@@ -2305,6 +2344,145 @@ export class PolymarketProvider implements PredictProvider {
     return Boolean(this.getDepositWalletDepositTransaction(transactionMeta));
   }
 
+  private async ensureDepositWalletReady({
+    ownerAddress,
+    depositWalletAddress,
+    protocol,
+    getSigner,
+    operation = 'deposit_wallet_preflight',
+  }: {
+    ownerAddress: string;
+    depositWalletAddress: Hex;
+    protocol: PolymarketProtocolDefinition;
+    getSigner: (address?: string) => Signer;
+    operation?: string;
+  }): Promise<boolean> {
+    let updatedState = false;
+    let depositWalletDeploymentConfirmed = false;
+
+    DevLogger.log('PolymarketProvider: Deposit wallet preflight started', {
+      operation,
+      walletType: 'deposit-wallet',
+      from: ownerAddress,
+      depositWalletAddress,
+    });
+
+    const depositWalletIsDeployed = await isSmartContractAddress(
+      depositWalletAddress,
+      numberToHex(POLYGON_MAINNET_CHAIN_ID),
+    );
+
+    if (!depositWalletIsDeployed) {
+      const createResponse = await requestDepositWalletCreate({
+        ownerAddress,
+      });
+      const transactionID =
+        getDepositWalletRelayerTransactionId(createResponse);
+
+      if (!transactionID) {
+        throw new Error(
+          'Polymarket deposit wallet creation response missing transactionID',
+        );
+      }
+
+      DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
+        operation: 'deposit_wallet_create',
+        walletType: 'deposit-wallet',
+        transactionID,
+        from: ownerAddress,
+        depositWalletAddress,
+      });
+
+      await waitForDepositWalletTransaction({
+        transactionID,
+        requireCompletion: true,
+      });
+
+      DevLogger.log(
+        'PolymarketProvider: Waiting for deposit wallet relayer registry',
+        {
+          operation: 'deposit_wallet_relayer_registry',
+          walletType: 'deposit-wallet',
+          from: ownerAddress,
+          depositWalletAddress,
+        },
+      );
+
+      await waitForDepositWalletDeployed({
+        walletAddress: depositWalletAddress,
+      });
+      depositWalletDeploymentConfirmed = true;
+
+      this.#setCachedAccountState(ownerAddress, {
+        address: depositWalletAddress,
+        isDeployed: true,
+        walletType: 'deposit-wallet',
+      });
+      this.setPolymarketAccountCreatedTrait();
+      updatedState = true;
+    }
+
+    const preflightPlan = await planDepositWalletPreflight({
+      walletAddress: depositWalletAddress,
+      protocol,
+    });
+
+    DevLogger.log('PolymarketProvider: Deposit wallet preflight planned', {
+      operation: 'deposit_wallet_allowance_preflight',
+      walletType: 'deposit-wallet',
+      from: ownerAddress,
+      depositWalletAddress,
+      missingRequirementsCount: preflightPlan.missingRequirements.length,
+    });
+
+    if (preflightPlan.transactions.length > 0) {
+      if (!depositWalletDeploymentConfirmed) {
+        await waitForDepositWalletDeployed({
+          walletAddress: depositWalletAddress,
+        });
+      }
+
+      const signer = getSigner(ownerAddress);
+      const executeResponse = await executeDepositWalletBatch({
+        signer,
+        walletAddress: depositWalletAddress,
+        calls: toDepositWalletCalls(preflightPlan.transactions),
+      });
+      const transactionID =
+        getDepositWalletRelayerTransactionId(executeResponse);
+
+      if (!transactionID) {
+        throw new Error(
+          'Polymarket deposit wallet batch response missing transactionID',
+        );
+      }
+
+      DevLogger.log('PolymarketProvider: Waiting for deposit wallet batch', {
+        operation: 'deposit_wallet_batch',
+        walletType: 'deposit-wallet',
+        transactionID,
+        from: ownerAddress,
+        depositWalletAddress,
+        missingRequirementsCount: preflightPlan.missingRequirements.length,
+      });
+
+      await waitForDepositWalletTransaction({
+        transactionID,
+        requireCompletion: true,
+      });
+      updatedState = true;
+    }
+
+    DevLogger.log('PolymarketProvider: Deposit wallet preflight completed', {
+      operation,
+      walletType: 'deposit-wallet',
+      from: ownerAddress,
+      depositWalletAddress,
+    });
+
+    return updatedState;
+  }
+
   public async beforePublishDepositWalletDeposit({
     transactionMeta,
     getSigner,
@@ -2323,123 +2501,11 @@ export class PolymarketProvider implements PredictProvider {
     const protocol = this.#getProtocol();
 
     try {
-      DevLogger.log('PolymarketProvider: Deposit wallet preflight started', {
-        operation: 'deposit_wallet_preflight',
-        walletType: 'deposit-wallet',
-        from: ownerAddress,
+      await this.ensureDepositWalletReady({
+        ownerAddress,
         depositWalletAddress,
-      });
-
-      const depositWalletIsDeployed = await isSmartContractAddress(
-        depositWalletAddress,
-        numberToHex(POLYGON_MAINNET_CHAIN_ID),
-      );
-      let depositWalletDeploymentConfirmed = false;
-
-      if (!depositWalletIsDeployed) {
-        const createResponse = await requestDepositWalletCreate({
-          ownerAddress,
-        });
-        const transactionID =
-          getDepositWalletRelayerTransactionId(createResponse);
-
-        if (!transactionID) {
-          throw new Error(
-            'Polymarket deposit wallet creation response missing transactionID',
-          );
-        }
-
-        DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
-          operation: 'deposit_wallet_create',
-          walletType: 'deposit-wallet',
-          transactionID,
-          from: ownerAddress,
-          depositWalletAddress,
-        });
-
-        await waitForDepositWalletTransaction({
-          transactionID,
-          requireCompletion: true,
-        });
-
-        DevLogger.log(
-          'PolymarketProvider: Waiting for deposit wallet relayer registry',
-          {
-            operation: 'deposit_wallet_relayer_registry',
-            walletType: 'deposit-wallet',
-            from: ownerAddress,
-            depositWalletAddress,
-          },
-        );
-
-        await waitForDepositWalletDeployed({
-          walletAddress: depositWalletAddress,
-        });
-        depositWalletDeploymentConfirmed = true;
-
-        this.#setCachedAccountState(ownerAddress, {
-          address: depositWalletAddress,
-          isDeployed: true,
-          walletType: 'deposit-wallet',
-        });
-        this.setPolymarketAccountCreatedTrait();
-      }
-
-      const preflightPlan = await planDepositWalletPreflight({
-        walletAddress: depositWalletAddress,
         protocol,
-      });
-
-      DevLogger.log('PolymarketProvider: Deposit wallet preflight planned', {
-        operation: 'deposit_wallet_allowance_preflight',
-        walletType: 'deposit-wallet',
-        from: ownerAddress,
-        depositWalletAddress,
-        missingRequirementsCount: preflightPlan.missingRequirements.length,
-      });
-
-      if (preflightPlan.transactions.length > 0) {
-        if (!depositWalletDeploymentConfirmed) {
-          await waitForDepositWalletDeployed({
-            walletAddress: depositWalletAddress,
-          });
-        }
-
-        const signer = getSigner(ownerAddress);
-        const executeResponse = await executeDepositWalletBatch({
-          signer,
-          walletAddress: depositWalletAddress,
-          calls: toDepositWalletCalls(preflightPlan.transactions),
-        });
-        const transactionID =
-          getDepositWalletRelayerTransactionId(executeResponse);
-
-        if (!transactionID) {
-          throw new Error(
-            'Polymarket deposit wallet batch response missing transactionID',
-          );
-        }
-
-        DevLogger.log('PolymarketProvider: Waiting for deposit wallet batch', {
-          operation: 'deposit_wallet_batch',
-          walletType: 'deposit-wallet',
-          transactionID,
-          from: ownerAddress,
-          depositWalletAddress,
-          missingRequirementsCount: preflightPlan.missingRequirements.length,
-        });
-
-        await waitForDepositWalletTransaction({
-          transactionID,
-          requireCompletion: true,
-        });
-      }
-
-      DevLogger.log('PolymarketProvider: Deposit wallet preflight completed', {
-        operation: 'deposit_wallet_preflight',
-        walletType: 'deposit-wallet',
-        from: ownerAddress,
-        depositWalletAddress,
+        getSigner,
       });
 
       return true;
@@ -2459,6 +2525,39 @@ export class PolymarketProvider implements PredictProvider {
         }),
       );
       throw error;
+    }
+  }
+
+  private async syncDepositWalletBalanceAllowanceForOrderIfNeeded({
+    protocol,
+    signerAddress,
+    apiKey,
+  }: {
+    protocol: PolymarketProtocolDefinition;
+    signerAddress: string;
+    apiKey: ApiKeyCreds;
+  }): Promise<void> {
+    try {
+      await syncDepositWalletCollateralBalanceAllowance({
+        protocol,
+        signerAddress,
+        apiKey,
+      });
+    } catch (error) {
+      DevLogger.log(
+        'PolymarketProvider: Deposit wallet order balance-allowance sync failed',
+        {
+          operation: 'deposit_wallet_order_balance_allowance_sync',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
+      Logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        this.getErrorContext('placeOrder:depositWalletBalanceAllowanceSync', {
+          operation: 'deposit_wallet_order_balance_allowance_sync',
+          walletType: 'deposit-wallet',
+        }),
+      );
     }
   }
 

--- a/app/components/UI/Predict/providers/polymarket/protocol/orderCodec.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/orderCodec.test.ts
@@ -1,5 +1,9 @@
+import { SignTypedDataVersion } from '@metamask/keyring-controller';
+import { hexlify, toUtf8Bytes } from 'ethers/lib/utils';
 import { Side, type OrderPreview } from '../../../types';
-import { OrderType } from '../types';
+import type { Signer } from '../../types';
+import { HASH_ZERO_BYTES32, POLYGON_MAINNET_CHAIN_ID } from '../constants';
+import { OrderType, SignatureType } from '../types';
 import { POLYMARKET_V2_PROTOCOL } from './definitions';
 import {
   buildProtocolUnsignedOrder,
@@ -8,6 +12,7 @@ import {
   getProtocolOrderTypedData,
   getProtocolVerifyingContract,
   serializeProtocolRelayerOrder,
+  signProtocolOrder,
 } from './orderCodec';
 
 const preview: OrderPreview = {
@@ -26,6 +31,24 @@ const preview: OrderPreview = {
   feeRateBps: '77',
 };
 
+const ORDER_TYPE_STRING =
+  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
+const rawSignature = `0x${'11'.repeat(65)}`;
+const ownerAddress = '0x1111111111111111111111111111111111111111';
+const safeAddress = '0x2222222222222222222222222222222222222222';
+const depositWalletAddress = '0x3333333333333333333333333333333333333333';
+
+function createMockSigner(signature = rawSignature) {
+  const signTypedMessage = jest.fn().mockResolvedValue(signature);
+  const signer: Signer = {
+    address: ownerAddress,
+    signTypedMessage,
+    signPersonalMessage: jest.fn(),
+  };
+
+  return { signer, signTypedMessage };
+}
+
 describe('polymarket protocol order codec', () => {
   const protocol = {
     ...POLYMARKET_V2_PROTOCOL,
@@ -36,12 +59,12 @@ describe('polymarket protocol order codec', () => {
     },
   };
 
-  it('builds a v2 order with timestamp, metadata, and builder', () => {
+  it('builds a v2 order with timestamp, metadata, builder, and Safe signature type', () => {
     const order = buildProtocolUnsignedOrder({
       protocol,
       preview,
-      makerAddress: '0x1111111111111111111111111111111111111111',
-      signerAddress: '0x2222222222222222222222222222222222222222',
+      makerAddress: ownerAddress,
+      signerAddress: safeAddress,
       nowInSeconds: 456,
     });
 
@@ -54,6 +77,7 @@ describe('polymarket protocol order codec', () => {
       'builder',
       '0x3333333333333333333333333333333333333333333333333333333333333333',
     );
+    expect(order.signatureType).toBe(SignatureType.POLY_GNOSIS_SAFE);
     expect(order).not.toHaveProperty('taker');
     expect(order).not.toHaveProperty('nonce');
     expect(order).not.toHaveProperty('feeRateBps');
@@ -73,12 +97,28 @@ describe('polymarket protocol order codec', () => {
     ]);
   });
 
+  it('builds a deposit-wallet order with POLY_1271 signature type', () => {
+    const order = buildProtocolUnsignedOrder({
+      protocol,
+      preview,
+      makerAddress: depositWalletAddress,
+      signerAddress: depositWalletAddress,
+      signatureType: SignatureType.POLY_1271,
+      nowInSeconds: 456,
+    });
+
+    expect(SignatureType.POLY_1271).toBe(3);
+    expect(order.maker).toBe(depositWalletAddress);
+    expect(order.signer).toBe(depositWalletAddress);
+    expect(order.signatureType).toBe(SignatureType.POLY_1271);
+  });
+
   it('builds v2 typed data with domain version 2 and bytes32 fields', () => {
     const order = buildProtocolUnsignedOrder({
       protocol,
       preview,
-      makerAddress: '0x1111111111111111111111111111111111111111',
-      signerAddress: '0x2222222222222222222222222222222222222222',
+      makerAddress: ownerAddress,
+      signerAddress: safeAddress,
       nowInSeconds: 456,
     });
 
@@ -103,12 +143,112 @@ describe('polymarket protocol order codec', () => {
     );
   });
 
+  it('signs Safe orders with the raw CLOB Order typed data', async () => {
+    const { signer, signTypedMessage } = createMockSigner();
+    const order = buildProtocolUnsignedOrder({
+      protocol,
+      preview,
+      makerAddress: safeAddress,
+      signerAddress: ownerAddress,
+      nowInSeconds: 456,
+    });
+    const verifyingContract = getProtocolVerifyingContract({
+      protocol,
+      negRisk: false,
+    });
+
+    await expect(
+      signProtocolOrder({ signer, protocol, order, verifyingContract }),
+    ).resolves.toBe(rawSignature);
+
+    expect(signTypedMessage).toHaveBeenCalledWith(
+      {
+        from: ownerAddress,
+        data: expect.objectContaining({
+          primaryType: 'Order',
+          domain: expect.objectContaining({
+            name: 'Polymarket CTF Exchange',
+            version: '2',
+            verifyingContract,
+          }),
+          message: order,
+        }),
+      },
+      SignTypedDataVersion.V4,
+    );
+  });
+
+  it('signs deposit-wallet orders with an ERC-7739 TypedDataSign wrapper', async () => {
+    const { signer, signTypedMessage } = createMockSigner();
+    const order = buildProtocolUnsignedOrder({
+      protocol,
+      preview,
+      makerAddress: depositWalletAddress,
+      signerAddress: depositWalletAddress,
+      signatureType: SignatureType.POLY_1271,
+      nowInSeconds: 456,
+    });
+    const verifyingContract = getProtocolVerifyingContract({
+      protocol,
+      negRisk: false,
+    });
+
+    const signature = await signProtocolOrder({
+      signer,
+      protocol,
+      order,
+      verifyingContract,
+    });
+
+    const expectedContentsTypeSuffix = `${hexlify(
+      toUtf8Bytes(ORDER_TYPE_STRING),
+    ).slice(2)}${ORDER_TYPE_STRING.length.toString(16).padStart(4, '0')}`;
+
+    expect(signature.startsWith(rawSignature)).toBe(true);
+    expect(signature.endsWith(expectedContentsTypeSuffix)).toBe(true);
+    expect(signature.length).toBe(
+      rawSignature.length + 32 * 2 + 32 * 2 + expectedContentsTypeSuffix.length,
+    );
+    expect(signTypedMessage).toHaveBeenCalledWith(
+      {
+        from: ownerAddress,
+        data: expect.objectContaining({
+          primaryType: 'TypedDataSign',
+          domain: expect.objectContaining({
+            name: 'Polymarket CTF Exchange',
+            version: '2',
+            chainId: POLYGON_MAINNET_CHAIN_ID,
+            verifyingContract,
+          }),
+          types: expect.objectContaining({
+            TypedDataSign: expect.arrayContaining([
+              { name: 'contents', type: 'Order' },
+              { name: 'verifyingContract', type: 'address' },
+            ]),
+            Order: expect.arrayContaining([
+              { name: 'signatureType', type: 'uint8' },
+            ]),
+          }),
+          message: {
+            contents: order,
+            name: 'DepositWallet',
+            version: '1',
+            chainId: POLYGON_MAINNET_CHAIN_ID,
+            verifyingContract: depositWalletAddress,
+            salt: HASH_ZERO_BYTES32,
+          },
+        }),
+      },
+      SignTypedDataVersion.V4,
+    );
+  });
+
   it('serializes signed orders into the relayer body shape', () => {
     const order = buildProtocolUnsignedOrder({
       protocol,
       preview,
-      makerAddress: '0x1111111111111111111111111111111111111111',
-      signerAddress: '0x2222222222222222222222222222222222222222',
+      makerAddress: ownerAddress,
+      signerAddress: safeAddress,
       nowInSeconds: 456,
     });
 
@@ -133,6 +273,8 @@ describe('polymarket protocol order codec', () => {
         }),
       }),
     );
+    expect(serialized).not.toHaveProperty('deferExec');
+    expect(serialized).not.toHaveProperty('postOnly');
   });
 
   it('forces preview fee rate to zero', () => {
@@ -143,7 +285,7 @@ describe('polymarket protocol order codec', () => {
     expect(
       encodeWrap({
         asset: protocol.collateral.legacyUsdceToken,
-        to: '0x1111111111111111111111111111111111111111',
+        to: ownerAddress,
         amount: 42n,
       }),
     ).toMatch(/^0x[0-9a-f]+$/u);

--- a/app/components/UI/Predict/providers/polymarket/protocol/orderCodec.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/orderCodec.ts
@@ -1,8 +1,18 @@
+import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import { Hex } from '@metamask/utils';
-import { Interface, parseUnits } from 'ethers/lib/utils';
+import {
+  defaultAbiCoder,
+  hexlify,
+  Interface,
+  keccak256,
+  parseUnits,
+  toUtf8Bytes,
+} from 'ethers/lib/utils';
 import { Side, type OrderPreview } from '../../../types';
+import type { Signer } from '../../types';
 import {
   EIP712Domain,
+  HASH_ZERO_BYTES32,
   POLYGON_MAINNET_CHAIN_ID,
   ROUNDING_CONFIG,
 } from '../constants';
@@ -51,10 +61,32 @@ export type ProtocolRelayerOrder = ClobOrderObjectV2;
 
 const ORDER_PRIMARY_TYPE = 'Order';
 const ORDER_DOMAIN_NAME = 'Polymarket CTF Exchange';
+const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
+const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
+const ORDER_TYPE_STRING =
+  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
+const ORDER_TYPE_HASH = keccak256(toUtf8Bytes(ORDER_TYPE_STRING));
+const DOMAIN_TYPE_HASH = keccak256(
+  toUtf8Bytes(
+    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
+  ),
+);
 const ORDER_DOMAIN_TYPES = [
   ...EIP712Domain,
   { name: 'verifyingContract', type: 'address' },
 ];
+const TYPED_DATA_SIGN_STRUCT = [
+  { name: 'contents', type: ORDER_PRIMARY_TYPE },
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+  { name: 'salt', type: 'bytes32' },
+];
+
+function withoutHexPrefix(value: string): string {
+  return value.startsWith('0x') ? value.slice(2) : value;
+}
 
 function buildProtocolOrderDomain({
   protocol,
@@ -120,12 +152,14 @@ export function buildProtocolUnsignedOrder({
   preview,
   makerAddress,
   signerAddress,
+  signatureType = SignatureType.POLY_GNOSIS_SAFE,
   nowInSeconds = Math.floor(Date.now() / 1000),
 }: {
   protocol: PolymarketProtocolDefinition;
   preview: OrderPreview;
   makerAddress: string;
   signerAddress: string;
+  signatureType?: SignatureType;
   nowInSeconds?: number;
 }): ProtocolUnsignedOrder {
   // NOTE: Field order matters for EIP-712 signing. Do NOT use object spread
@@ -140,7 +174,6 @@ export function buildProtocolUnsignedOrder({
   ).toString();
   const takerAmount = getTakerAmountWithSlippage(preview);
   const side = preview.side === Side.BUY ? UtilsSide.BUY : UtilsSide.SELL;
-  const signatureType = SignatureType.POLY_GNOSIS_SAFE;
   const builder = protocol.order.getBuilderCode();
 
   if (!builder) {
@@ -196,6 +229,147 @@ export function getProtocolOrderTypedData({
     types: getProtocolOrderTypes(),
     message: order,
   };
+}
+
+function getProtocolAppDomainSeparator({
+  protocol,
+  verifyingContract,
+  chainId,
+}: {
+  protocol: PolymarketProtocolDefinition;
+  verifyingContract: string;
+  chainId: number;
+}): string {
+  return keccak256(
+    defaultAbiCoder.encode(
+      ['bytes32', 'bytes32', 'bytes32', 'uint256', 'address'],
+      [
+        DOMAIN_TYPE_HASH,
+        keccak256(toUtf8Bytes(ORDER_DOMAIN_NAME)),
+        keccak256(toUtf8Bytes(protocol.order.domainVersion)),
+        chainId,
+        verifyingContract,
+      ],
+    ),
+  );
+}
+
+function getProtocolOrderContentsHash(order: ProtocolUnsignedOrder): string {
+  if (!order.signer) {
+    throw new Error('Missing Polymarket CLOB order signer');
+  }
+
+  if (order.signatureType === undefined) {
+    throw new Error('Missing Polymarket CLOB order signature type');
+  }
+
+  return keccak256(
+    defaultAbiCoder.encode(
+      [
+        'bytes32',
+        'uint256',
+        'address',
+        'address',
+        'uint256',
+        'uint256',
+        'uint256',
+        'uint8',
+        'uint8',
+        'uint256',
+        'bytes32',
+        'bytes32',
+      ],
+      [
+        ORDER_TYPE_HASH,
+        BigInt(order.salt).toString(),
+        order.maker,
+        order.signer,
+        BigInt(order.tokenId).toString(),
+        BigInt(order.makerAmount).toString(),
+        BigInt(order.takerAmount).toString(),
+        order.side,
+        order.signatureType,
+        BigInt(order.timestamp).toString(),
+        order.metadata,
+        order.builder,
+      ],
+    ),
+  );
+}
+
+export async function signProtocolOrder({
+  signer,
+  protocol,
+  order,
+  verifyingContract,
+  chainId = POLYGON_MAINNET_CHAIN_ID,
+}: {
+  signer: Signer;
+  protocol: PolymarketProtocolDefinition;
+  order: ProtocolUnsignedOrder;
+  verifyingContract: string;
+  chainId?: number;
+}): Promise<string> {
+  const typedData = getProtocolOrderTypedData({
+    protocol,
+    order,
+    verifyingContract,
+    chainId,
+  });
+
+  if (order.signatureType !== SignatureType.POLY_1271) {
+    return signer.signTypedMessage(
+      { data: typedData, from: signer.address },
+      SignTypedDataVersion.V4,
+    );
+  }
+
+  if (!order.signer) {
+    throw new Error('Missing Polymarket deposit wallet signer');
+  }
+
+  const innerSignature = await signer.signTypedMessage(
+    {
+      from: signer.address,
+      data: {
+        primaryType: 'TypedDataSign',
+        domain: typedData.domain,
+        types: {
+          EIP712Domain: ORDER_DOMAIN_TYPES,
+          TypedDataSign: TYPED_DATA_SIGN_STRUCT,
+          Order: typedData.types.Order,
+        },
+        message: {
+          contents: typedData.message,
+          name: DEPOSIT_WALLET_DOMAIN_NAME,
+          version: DEPOSIT_WALLET_DOMAIN_VERSION,
+          chainId,
+          verifyingContract: order.signer,
+          salt: HASH_ZERO_BYTES32,
+        },
+      },
+    },
+    SignTypedDataVersion.V4,
+  );
+
+  const appDomainSeparator = getProtocolAppDomainSeparator({
+    protocol,
+    verifyingContract,
+    chainId,
+  });
+  const contentsHash = getProtocolOrderContentsHash(order);
+  const contentsTypeHex = withoutHexPrefix(
+    hexlify(toUtf8Bytes(ORDER_TYPE_STRING)),
+  );
+  const contentsTypeLengthHex = ORDER_TYPE_STRING.length
+    .toString(16)
+    .padStart(4, '0');
+
+  return `0x${withoutHexPrefix(innerSignature)}${withoutHexPrefix(
+    appDomainSeparator,
+  )}${withoutHexPrefix(
+    contentsHash,
+  )}${contentsTypeHex}${contentsTypeLengthHex}`;
 }
 
 export function serializeProtocolRelayerOrder({

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -172,6 +172,11 @@ export enum SignatureType {
    * EIP712 signatures signed by EOAs that own Polymarket Gnosis safes
    */
   POLY_GNOSIS_SAFE,
+
+  /**
+   * ERC-1271 signatures validated by Polymarket deposit wallets
+   */
+  POLY_1271,
 }
 
 // Simplified market order for users


### PR DESCRIPTION
## **Description**

Adds Predict order placement support for Polymarket Deposit Wallet accounts on top of the Deposit Wallet deposit foundation.

This PR:
- Adds the `POLY_1271` Polymarket signature type.
- Adds Deposit Wallet / ERC-1271 order signing via the `TypedDataSign` wrapper.
- Routes order maker/signer fields from active Predict account state.
- Uses Deposit Wallet maker/signer for Deposit Wallet users.
- Preserves legacy Safe order signing for grandfathered Safe users.
- Runs Deposit Wallet create/setup preflight before submitting Deposit Wallet orders.
- Passes an optional signed legacy Safe migration sweep as `allowancesTx` for Deposit Wallet orders, so stranded pUSD/USDC.e can be swept before the backend relays the order.
- Skips Safe trade allowance and Permit2 fee preflight for Deposit Wallet orders.
- Continues signing CLOB L2 headers with the EOA owner address.

This PR is temporarily stacked on `predict/dw-deposit-foundation` while PRs 1 and 2 are under review, and should be rebased/retargeted after those merge.

Validation run locally:

```bash
yarn jest app/components/UI/Predict/providers/polymarket/protocol/orderCodec.test.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts --runInBand
yarn lint:tsc
```

## **Changelog**

CHANGELOG entry: Fixed Predict order placement for Polymarket Deposit Wallet accounts

## **Related issues**

Fixes: [PRED-860](https://consensyssoftware.atlassian.net/browse/PRED-860)

## **Manual testing steps**

```gherkin
Feature: Predict Deposit Wallet order flow

  Scenario: Deposit Wallet user places a Predict order
    Given a Predict user is routed to a Polymarket Deposit Wallet
      And the Deposit Wallet has enough pUSD balance and required setup from the deposit flow
    When the user places a Predict buy or sell order
    Then the order is signed with POLY_1271 semantics
      And the order is submitted successfully to the Polymarket CLOB

  Scenario: Deposit Wallet user places first order before wallet setup
    Given a Predict user is routed to a Polymarket Deposit Wallet
      And the Deposit Wallet still needs creation or allowance setup
    When the user places a Predict buy or sell order
    Then the app creates/sets up the Deposit Wallet before order submission
      And the order is submitted successfully to the Polymarket CLOB

  Scenario: Deposit Wallet user has funds stranded in legacy Safe
    Given a Predict user is routed to a Polymarket Deposit Wallet
      And the deterministic legacy Safe has sweepable pUSD or USDC.e
    When the user places a Predict buy or sell order
    Then the signed legacy Safe sweep is included as allowancesTx
      And the backend can submit the sweep before relaying the order

  Scenario: Legacy Safe user places a Predict order
    Given a Predict user is grandfathered to the legacy Safe wallet
    When the user places a Predict buy or sell order
    Then the order continues to use legacy Safe signing and preflight behavior
```

## **Screenshots/Recordings**

### **Before**

N/A - provider/order-signing change only.

### **After**

N/A - provider/order-signing change only.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-860]: https://consensyssoftware.atlassian.net/browse/PRED-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Predict order submission/signing paths, adding a new ERC-1271 signing format and deposit-wallet preflight flows; mistakes could cause failed or incorrectly-signed orders. Legacy Safe behavior is preserved but now shares more conditional branching.
> 
> **Overview**
> Adds end-to-end order placement support for Polymarket **Deposit Wallet** accounts.
> 
> Order submission now derives maker/signer from the resolved account state and, for deposit-wallet users, performs a create/allowance batch preflight before signing/submitting. Deposit-wallet orders use the new `SignatureType.POLY_1271` and are signed via `signProtocolOrder` using an ERC-7739 `TypedDataSign` wrapper, while Safe users keep legacy Safe signing.
> 
> Fee collection and Safe trade preflight steps (Permit2 fee authorization + allowances tx) are skipped for deposit-wallet orders; instead an optional legacy Safe migration sweep can be attached as `allowancesTx`. L2 CLOB headers are consistently signed using the EOA owner address. Tests were expanded to cover both Safe and deposit-wallet order flows and the new signing payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bf1ee701cd156ff795a99dcfb80bb95e4944a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->