### PR TITLE
test: fixes several bugs in update-fixtures workflow

### DIFF
--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -226,47 +226,17 @@ jobs:
       - name: Download iOS app artifact from CI
         run: |
           RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
-          REPO="${{ github.repository }}"
-          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempt --jq '.attempt') || {
-            echo "::error ::Failed to determine attempt count for run ${RUN_ID}. Ensure the RUN_ID is valid and the token has 'actions: read' permission."
+          echo "Downloading iOS artifact from CI run ${RUN_ID}..."
+
+          # gh run download uses the ListArtifacts API, which includes artifacts from all
+          # attempts of a run — including earlier attempts when only failed jobs were re-run.
+          if ! gh run download "${RUN_ID}" \
+              -n main-qa-MetaMask.app \
+              -D artifacts/main-qa-MetaMask.app; then
+            echo "::error title=iOS artifact not found::Failed to download 'main-qa-MetaMask.app' artifact from run ${RUN_ID}. Possible causes:%0A- The 'Build iOS Apps' job has not completed%0A- The iOS build was skipped (no iOS-impacting changes)%0A- The iOS build failed%0A%0ACheck the CI workflow: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
             exit 1
-          }
-          echo "Run ${RUN_ID} has ${ATTEMPT_COUNT} attempt(s). Searching for iOS artifact..."
-
-          # Search from newest to oldest attempt via the REST API — the artifact may live
-          # in an earlier attempt when only failed jobs were re-run and the iOS build was not.
-          # `|| true` prevents `-eo pipefail` from exiting when gh api exits non-zero (e.g. 404
-          # for an attempt that predates the artifact upload) before the loop tries the next one.
-          for ATTEMPT in $(seq "${ATTEMPT_COUNT}" -1 1); do
-            echo "Trying attempt ${ATTEMPT}..."
-
-            ARTIFACT_ID=$(gh api \
-              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/artifacts" \
-              2>/dev/null \
-              | jq -r '.artifacts[]? | select(.name == "main-qa-MetaMask.app") | .id' \
-              2>/dev/null \
-              | head -1) || true
-
-            if [[ "$ARTIFACT_ID" =~ ^[0-9]+$ ]]; then
-              echo "Found artifact (ID=${ARTIFACT_ID}) in attempt ${ATTEMPT}. Downloading..."
-              mkdir -p artifacts/main-qa-MetaMask.app
-              if ! curl -L -s -f \
-                  -H "Authorization: Bearer $GITHUB_TOKEN" \
-                  -H "Accept: application/vnd.github+json" \
-                  "https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" \
-                  -o /tmp/ios-artifact.zip; then
-                echo "::error title=iOS artifact download failed::curl exited non-zero for artifact ID ${ARTIFACT_ID}. The artifact may have expired or the token may lack permissions."
-                exit 1
-              fi
-              unzip -q /tmp/ios-artifact.zip -d artifacts/main-qa-MetaMask.app
-              rm /tmp/ios-artifact.zip
-              echo "✅ Downloaded iOS artifact from attempt ${ATTEMPT}."
-              exit 0
-            fi
-          done
-
-          echo "::error title=iOS artifact not found::Could not find 'main-qa-MetaMask.app' in any of the ${ATTEMPT_COUNT} attempt(s) for run ${RUN_ID}. Possible causes:%0A- The 'Build iOS Apps' job has not completed%0A- The iOS build was skipped (no iOS-impacting changes)%0A- The iOS build failed%0A%0ACheck the CI workflow: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
-          exit 1
+          fi
+          echo "✅ Downloaded iOS artifact."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -101,6 +101,7 @@ jobs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
       BRANCH: ${{ steps.branch.outputs.BRANCH }}
       PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
+      RUN_ID: ${{ steps.validate-ci.outputs.RUN_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -121,7 +122,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
 
-      - name: Download iOS build artifact from CI
+      - name: Validate CI run and resolve RUN_ID
+        id: validate-ci
         run: |
           COMMIT_SHA_FULL=$(git rev-parse HEAD)
           BRANCH="${{ steps.branch.outputs.BRANCH }}"
@@ -140,6 +142,7 @@ jobs:
           RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
           RUN_HEAD_SHA=$(echo "$RUN_INFO" | jq -r '.headSha')
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+          echo "RUN_ID=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
           echo "CI workflow run: ${RUN_URL}"
           echo "Status: ${RUN_STATUS}, Conclusion: ${RUN_CONCLUSION}"
@@ -161,29 +164,14 @@ jobs:
             echo "::warning title=CI did not succeed::The CI workflow concluded with '${RUN_CONCLUSION}'. The iOS build artifact may not be available. View CI: ${RUN_URL}"
           fi
 
-          echo "::group::Downloading iOS app artifact"
-          echo "Attempting to download iOS app artifact from CI run ${RUN_ID}..."
-
-          if ! gh run download "${RUN_ID}" -n main-qa-MetaMask.app -D ios-app-artifact; then
-            echo "::endgroup::"
-            echo "::error title=iOS artifact not found::Failed to download 'main-qa-MetaMask.app' artifact. Possible causes:%0A- The 'Build iOS Apps' job has not completed%0A- The iOS build was skipped (no iOS-impacting changes)%0A- The iOS build failed%0A%0ACheck the CI workflow: ${RUN_URL}"
-            exit 1
-          fi
-
-          echo "::endgroup::"
-          echo "✅ Successfully downloaded iOS app artifact."
+          echo "✅ CI run validated. RUN_ID=${RUN_ID}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache iOS app artifact
-        uses: actions/cache/save@v4
-        with:
-          path: ios-app-artifact
-          key: ios-app-${{ steps.commit-sha.outputs.COMMIT_SHA }}
-
   update-fixtures:
     name: Export & update fixtures
-    needs: [prepare]
+    needs: [is-fork-pull-request, prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     runs-on: ${{ startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]') }}
     timeout-minutes: 30
 
@@ -235,19 +223,13 @@ jobs:
           yarn detox clean-framework-cache
           yarn detox build-framework-cache
 
-      - name: Restore iOS app artifact
-        uses: actions/cache/restore@v4
-        with:
-          path: ios-app-artifact
-          key: ios-app-${{ needs.prepare.outputs.COMMIT_SHA }}
-          fail-on-cache-miss: true
-
-      - name: Place iOS app artifact
+      - name: Download iOS app artifact from CI
         run: |
-          mkdir -p artifacts/main-qa-MetaMask.app
-          cp -R ios-app-artifact/* artifacts/main-qa-MetaMask.app/
+          gh run download "${{ needs.prepare.outputs.RUN_ID }}" \
+            -n main-qa-MetaMask.app \
+            -D artifacts/
         env:
-          PREBUILT_IOS_APP_PATH: artifacts/main-qa-MetaMask.app
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run fixture validation spec
         timeout-minutes: 30
@@ -259,7 +241,6 @@ jobs:
           PREBUILT_IOS_APP_PATH: artifacts/main-qa-MetaMask.app
 
       - name: Cache updated fixture
-        if: ${{ !cancelled() }}
         uses: actions/cache/save@v4
         with:
           path: tests/framework/fixtures/json/default-fixture.json
@@ -276,7 +257,7 @@ jobs:
       - prepare
       - is-fork-pull-request
       - update-fixtures
-    if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ !cancelled() && needs.update-fixtures.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -293,17 +293,20 @@ jobs:
             echo "HAS_CHANGES=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Node.js for prettier
+      - name: Set up Node.js
         if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install dependencies
+        if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
+        run: yarn install --immutable
 
       - name: Format updated fixture with prettier
         if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
-        run: |
-          npm install --no-save --ignore-scripts prettier@^3.6.2
-          ./node_modules/.bin/prettier --write tests/framework/fixtures/json/default-fixture.json
+        run: yarn prettier --write tests/framework/fixtures/json/default-fixture.json
 
       # Note: Commits pushed with the default GITHUB_TOKEN do not trigger
       # downstream CI workflows (GitHub anti-loop protection). This is

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -227,25 +227,37 @@ jobs:
         run: |
           RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
           REPO="${{ github.repository }}"
-          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempt --jq '.attempt')
+          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempt --jq '.attempt') || {
+            echo "::error ::Failed to determine attempt count for run ${RUN_ID}. Ensure the RUN_ID is valid and the token has 'actions: read' permission."
+            exit 1
+          }
           echo "Run ${RUN_ID} has ${ATTEMPT_COUNT} attempt(s). Searching for iOS artifact..."
 
           # Search from newest to oldest attempt via the REST API — the artifact may live
           # in an earlier attempt when only failed jobs were re-run and the iOS build was not.
-          # Note: `gh run download` has no --attempt flag; per-attempt lookup requires the API.
+          # `|| true` prevents `-eo pipefail` from exiting when gh api exits non-zero (e.g. 404
+          # for an attempt that predates the artifact upload) before the loop tries the next one.
           for ATTEMPT in $(seq "${ATTEMPT_COUNT}" -1 1); do
             echo "Trying attempt ${ATTEMPT}..."
 
             ARTIFACT_ID=$(gh api \
               "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/artifacts" \
-              --jq '.artifacts[] | select(.name == "main-qa-MetaMask.app") | .id' \
-              2>/dev/null | head -1)
+              2>/dev/null \
+              | jq -r '.artifacts[]? | select(.name == "main-qa-MetaMask.app") | .id' \
+              2>/dev/null \
+              | head -1) || true
 
-            if [ -n "$ARTIFACT_ID" ]; then
+            if [[ "$ARTIFACT_ID" =~ ^[0-9]+$ ]]; then
               echo "Found artifact (ID=${ARTIFACT_ID}) in attempt ${ATTEMPT}. Downloading..."
               mkdir -p artifacts/main-qa-MetaMask.app
-              gh api --output /tmp/ios-artifact.zip \
-                "repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip"
+              if ! curl -L -s -f \
+                  -H "Authorization: Bearer $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" \
+                  -o /tmp/ios-artifact.zip; then
+                echo "::error title=iOS artifact download failed::curl exited non-zero for artifact ID ${ARTIFACT_ID}. The artifact may have expired or the token may lack permissions."
+                exit 1
+              fi
               unzip -q /tmp/ios-artifact.zip -d artifacts/main-qa-MetaMask.app
               rm /tmp/ios-artifact.zip
               echo "✅ Downloaded iOS artifact from attempt ${ATTEMPT}."

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -227,7 +227,7 @@ jobs:
         run: |
           gh run download "${{ needs.prepare.outputs.RUN_ID }}" \
             -n main-qa-MetaMask.app \
-            -D artifacts/
+            -D artifacts/main-qa-MetaMask.app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -225,9 +225,25 @@ jobs:
 
       - name: Download iOS app artifact from CI
         run: |
-          gh run download "${{ needs.prepare.outputs.RUN_ID }}" \
-            -n main-qa-MetaMask.app \
-            -D artifacts/main-qa-MetaMask.app
+          RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
+          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempts --jq '.attempts | length')
+          echo "Run ${RUN_ID} has ${ATTEMPT_COUNT} attempt(s). Searching for iOS artifact..."
+
+          # Search from newest to oldest attempt — the artifact may be in an earlier
+          # attempt if only failed jobs were re-run and the iOS build was not among them.
+          for ATTEMPT in $(seq "${ATTEMPT_COUNT}" -1 1); do
+            echo "Trying attempt ${ATTEMPT}..."
+            if gh run download "${RUN_ID}" \
+                -n main-qa-MetaMask.app \
+                -D artifacts/main-qa-MetaMask.app \
+                --attempt "${ATTEMPT}" 2>/dev/null; then
+              echo "✅ Downloaded iOS artifact from attempt ${ATTEMPT}."
+              exit 0
+            fi
+          done
+
+          echo "::error title=iOS artifact not found::Could not find 'main-qa-MetaMask.app' in any of the ${ATTEMPT_COUNT} attempt(s) for run ${RUN_ID}. Possible causes:%0A- The 'Build iOS Apps' job has not completed%0A- The iOS build was skipped (no iOS-impacting changes)%0A- The iOS build failed%0A%0ACheck the CI workflow: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -226,17 +226,28 @@ jobs:
       - name: Download iOS app artifact from CI
         run: |
           RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
-          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempts --jq '.attempts | length')
+          REPO="${{ github.repository }}"
+          ATTEMPT_COUNT=$(gh run view "${RUN_ID}" --json attempt --jq '.attempt')
           echo "Run ${RUN_ID} has ${ATTEMPT_COUNT} attempt(s). Searching for iOS artifact..."
 
-          # Search from newest to oldest attempt — the artifact may be in an earlier
-          # attempt if only failed jobs were re-run and the iOS build was not among them.
+          # Search from newest to oldest attempt via the REST API — the artifact may live
+          # in an earlier attempt when only failed jobs were re-run and the iOS build was not.
+          # Note: `gh run download` has no --attempt flag; per-attempt lookup requires the API.
           for ATTEMPT in $(seq "${ATTEMPT_COUNT}" -1 1); do
             echo "Trying attempt ${ATTEMPT}..."
-            if gh run download "${RUN_ID}" \
-                -n main-qa-MetaMask.app \
-                -D artifacts/main-qa-MetaMask.app \
-                --attempt "${ATTEMPT}" 2>/dev/null; then
+
+            ARTIFACT_ID=$(gh api \
+              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/artifacts" \
+              --jq '.artifacts[] | select(.name == "main-qa-MetaMask.app") | .id' \
+              2>/dev/null | head -1)
+
+            if [ -n "$ARTIFACT_ID" ]; then
+              echo "Found artifact (ID=${ARTIFACT_ID}) in attempt ${ATTEMPT}. Downloading..."
+              mkdir -p artifacts/main-qa-MetaMask.app
+              gh api --output /tmp/ios-artifact.zip \
+                "repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip"
+              unzip -q /tmp/ios-artifact.zip -d artifacts/main-qa-MetaMask.app
+              rm /tmp/ios-artifact.zip
               echo "✅ Downloaded iOS artifact from attempt ${ATTEMPT}."
               exit 0
             fi


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Three bugs were identified and fixed in the `update-e2e-fixtures.yml` workflow, which is triggered by commenting `@metamaskbot update-mobile-fixture` on a PR.

**1. `dispatch` job failed with HTTP 403 when triggering `workflow_dispatch`**

`issue_comment` events run from the default branch (`main`) with a `GITHUB_TOKEN` that has read-only permissions by default. Calling `gh workflow run` (which requires `actions: write`) and `gh pr comment` (which requires `pull-requests: write`) with that token caused a 403. Fixed by adding an explicit `permissions` block to the `dispatch` job (`actions: write`, `contents: read`, `pull-requests: write`).

**2. iOS app artifact consistently failed to restore from cache**

The `prepare` job (running on `ubuntu-latest`) was saving the iOS `.app` artifact to GitHub Actions cache, and the `update-fixtures` job (running on `ghcr.io/cirruslabs/macos-runner:tahoe`) was trying to restore it. The Cirrus Labs macOS runner does not reliably support GitHub Actions cache restoration across jobs, causing a persistent `fail-on-cache-miss` failure. Fixed by removing the cache entirely: `prepare` now validates the CI run and exposes the `RUN_ID` as a job output; `update-fixtures` downloads the artifact directly using `gh run download` with the `GITHUB_TOKEN`, which uses the GitHub API and works on any runner with network access.

**3. Misleading "No E2E fixture changes detected" comment posted on failure**

When `update-fixtures` failed (e.g., at the cache restore step), the `Cache updated fixture` step still ran due to its `if: ${{ !cancelled() }}` condition, saving the unmodified fixture to cache. `commit-updated-fixtures` then restored that stale fixture, saw no diff, and posted a false success comment. Fixed by:
- Removing `if: ${{ !cancelled() }}` from `Cache updated fixture` so it only runs when all prior steps succeed.
- Adding `needs.update-fixtures.result == 'success'` to `commit-updated-fixtures`'s condition so it skips entirely when the fixture job failed, allowing `failure-comment` to post the correct error message instead.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the `update-e2e-fixtures` GitHub Actions workflow execution and artifact retrieval logic; failures could block or misreport fixture updates, but changes are confined to CI automation.
> 
> **Overview**
> Fixes the `update-e2e-fixtures` workflow so the bot-triggered run has the required GitHub token permissions and more reliably targets the correct CI artifacts.
> 
> `prepare` now validates the latest `ci` run for the PR branch/HEAD and exposes its `RUN_ID`, and `update-fixtures` downloads the iOS `.app` artifact directly from that run (removing the cross-runner cache-based artifact transfer).
> 
> Tightens job gating so fixture caching/committing only happens after a successful `update-fixtures` run, and switches fixture formatting to use repo `yarn prettier` (with Node/yarn cache + install) instead of installing `prettier` ad-hoc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03ce80ddd611e9278cd13daea81e3121805f6910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->