### PR TITLE
feat: named-key pause ownership for Perps WS channels

### DIFF
--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -100,10 +100,9 @@ function createMobileMetrics(): PerpsMetrics {
  */
 function createStreamManagerAdapter() {
   return {
-    pauseChannel(channel: string): void {
+    pauseChannel(channel: string, key: string): void {
       const streamManager = getStreamManagerInstance();
       if (streamManager) {
-        // Access the channel by name and call pause on it
         const channelInstance =
           streamManager[channel as keyof typeof streamManager];
         if (
@@ -111,14 +110,13 @@ function createStreamManagerAdapter() {
           typeof channelInstance === 'object' &&
           'pause' in channelInstance
         ) {
-          (channelInstance as { pause: () => void }).pause();
+          (channelInstance as { pause: (k: string) => void }).pause(key);
         }
       }
     },
-    resumeChannel(channel: string): void {
+    resumeChannel(channel: string, key: string): void {
       const streamManager = getStreamManagerInstance();
       if (streamManager) {
-        // Access the channel by name and call resume on it
         const channelInstance =
           streamManager[channel as keyof typeof streamManager];
         if (
@@ -126,7 +124,7 @@ function createStreamManagerAdapter() {
           typeof channelInstance === 'object' &&
           'resume' in channelInstance
         ) {
-          (channelInstance as { resume: () => void }).resume();
+          (channelInstance as { resume: (k: string) => void }).resume(key);
         }
       }
     },

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -3,6 +3,7 @@ import { render, waitFor, act } from '@testing-library/react-native';
 import { Text } from 'react-native';
 import {
   PerpsStreamProvider,
+  PerpsStreamPauseKey,
   usePerpsStream,
   PerpsStreamManager,
 } from './PerpsStreamManager';
@@ -2708,7 +2709,7 @@ describe('PerpsStreamManager', () => {
     });
   });
 
-  describe('StreamChannel pause reference counting', () => {
+  describe('StreamChannel named-key pause ownership', () => {
     let mockOrdersSubscribe: jest.Mock;
     let mockOrdersUnsubscribe: jest.Mock;
     let orderCallback: ((orders: Order[]) => void) | null;
@@ -2748,7 +2749,7 @@ describe('PerpsStreamManager', () => {
         .mockReturnValue(false);
     });
 
-    it('requires all pause holders to resume before emission unblocks', async () => {
+    it('requires all named holders to resume before emission unblocks', async () => {
       const callback = jest.fn();
       const unsubscribe = testStreamManager.orders.subscribe({
         callback,
@@ -2764,10 +2765,10 @@ describe('PerpsStreamManager', () => {
       await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
       callback.mockClear();
 
-      // Two independent callers pause — simulating tab visibility + controller op
+      // Two independent callers pause under distinct keys
       act(() => {
-        testStreamManager.orders.pause(); // caller A: tab
-        testStreamManager.orders.pause(); // caller B: controller
+        testStreamManager.orders.pause(PerpsStreamPauseKey.TAB_LAYER);
+        testStreamManager.orders.pause(PerpsStreamPauseKey.CONTROLLER);
       });
 
       act(() => {
@@ -2778,10 +2779,10 @@ describe('PerpsStreamManager', () => {
       });
       expect(callback).not.toHaveBeenCalled();
 
-      // Caller A releases — count drops to 1, still blocked
+      // tab-layer releases — controller still holds, emission stays blocked
       act(() => {
-        testStreamManager.orders.resume();
-      }); // caller A: tab
+        testStreamManager.orders.resume(PerpsStreamPauseKey.TAB_LAYER);
+      });
       act(() => {
         orderCallback?.([{ ...SAMPLE_ORDER, orderId: '3' }]);
       });
@@ -2790,10 +2791,10 @@ describe('PerpsStreamManager', () => {
       });
       expect(callback).not.toHaveBeenCalled();
 
-      // Caller B releases — count drops to 0, emission resumes
+      // controller releases — set is empty, emission resumes
       act(() => {
-        testStreamManager.orders.resume();
-      }); // caller B: controller
+        testStreamManager.orders.resume(PerpsStreamPauseKey.CONTROLLER);
+      });
       act(() => {
         orderCallback?.([{ ...SAMPLE_ORDER, orderId: '4' }]);
       });
@@ -2807,9 +2808,9 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
-    it('tab resume does not release a concurrent controller pause', async () => {
-      // Regression: the old boolean would allow tab resume to unblock the channel
-      // while a controller operation (e.g. closePosition) was still in-flight.
+    it('tab-layer resume does not release a concurrent controller pause', async () => {
+      // Regression: the old boolean flip would allow the tab resume to unblock
+      // the channel while a controller operation was still in-flight.
       const callback = jest.fn();
       const unsubscribe = testStreamManager.orders.subscribe({
         callback,
@@ -2825,16 +2826,14 @@ describe('PerpsStreamManager', () => {
       callback.mockClear();
 
       act(() => {
-        // Predictions tab becomes active
-        testStreamManager.orders.pause(); // tab: count → 1
-        // Controller starts a trade operation on the same channel
-        testStreamManager.orders.pause(); // controller: count → 2
+        testStreamManager.orders.pause(PerpsStreamPauseKey.TAB_LAYER);
+        testStreamManager.orders.pause(PerpsStreamPauseKey.CONTROLLER);
       });
 
-      // User switches back to Portfolio — tab releases its pause
+      // User switches back to Portfolio — tab-layer releases, controller still holds
       act(() => {
-        testStreamManager.orders.resume();
-      }); // tab: count → 1
+        testStreamManager.orders.resume(PerpsStreamPauseKey.TAB_LAYER);
+      });
 
       // Update arrives while controller op is still running — must be blocked
       act(() => {
@@ -2845,10 +2844,10 @@ describe('PerpsStreamManager', () => {
       });
       expect(callback).not.toHaveBeenCalled();
 
-      // Controller finally block releases — count → 0, emission resumes
+      // Controller finally block releases — set empty, emission resumes
       act(() => {
-        testStreamManager.orders.resume();
-      }); // controller: count → 0
+        testStreamManager.orders.resume(PerpsStreamPauseKey.CONTROLLER);
+      });
       act(() => {
         orderCallback?.([{ ...SAMPLE_ORDER, orderId: 'after-op' }]);
       });
@@ -2863,7 +2862,7 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
-    it('resume() never drives pauseCount below zero (unmatched resume guard)', async () => {
+    it('resume() with an unknown key is a no-op and does not unblock emission', async () => {
       const callback = jest.fn();
       const unsubscribe = testStreamManager.orders.subscribe({
         callback,
@@ -2878,19 +2877,30 @@ describe('PerpsStreamManager', () => {
       await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
       callback.mockClear();
 
-      // Extra resume calls with no matching pause should be no-ops
+      // Pause under one key then call resume with unrelated keys
       act(() => {
-        testStreamManager.orders.resume();
-        testStreamManager.orders.resume();
-        testStreamManager.orders.resume();
+        testStreamManager.orders.pause(PerpsStreamPauseKey.TAB_LAYER);
+        testStreamManager.orders.resume('unknown-a');
+        testStreamManager.orders.resume('unknown-b');
       });
 
-      // Emission must still work — count is 0, not negative
+      // tab-layer still holds — emission must stay blocked
+      act(() => {
+        orderCallback?.([{ ...SAMPLE_ORDER, orderId: 'blocked' }]);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(callback).not.toHaveBeenCalled();
+
+      // Correct key releases — emission resumes
+      act(() => {
+        testStreamManager.orders.resume(PerpsStreamPauseKey.TAB_LAYER);
+      });
       act(() => {
         orderCallback?.([{ ...SAMPLE_ORDER, orderId: 'after-unmatched' }]);
       });
       await waitFor(() => {
-        expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith(
           expect.arrayContaining([
             expect.objectContaining({ orderId: 'after-unmatched' }),
@@ -2901,12 +2911,11 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
-    it('each channel tracks its own pause count independently', () => {
-      // Pausing orders should not affect prices
+    it('each channel tracks its own pause holders independently', () => {
       const orderPauseSpy = jest.spyOn(testStreamManager.orders, 'pause');
       const pricesPauseSpy = jest.spyOn(testStreamManager.prices, 'pause');
 
-      testStreamManager.orders.pause();
+      testStreamManager.orders.pause(PerpsStreamPauseKey.TAB_LAYER);
 
       expect(orderPauseSpy).toHaveBeenCalledTimes(1);
       expect(pricesPauseSpy).not.toHaveBeenCalled();
@@ -2925,27 +2934,31 @@ describe('PerpsStreamManager', () => {
       'candles',
     ] as const;
 
-    it('pauseAllChannels calls pause() on every channel', () => {
+    it('pauseAllChannels forwards the key to pause() on every channel', () => {
       for (const channel of CHANNEL_NAMES) {
         jest.spyOn(testStreamManager[channel], 'pause');
       }
 
-      testStreamManager.pauseAllChannels();
+      testStreamManager.pauseAllChannels(PerpsStreamPauseKey.TAB_LAYER);
 
       for (const channel of CHANNEL_NAMES) {
-        expect(testStreamManager[channel].pause).toHaveBeenCalledTimes(1);
+        expect(testStreamManager[channel].pause).toHaveBeenCalledWith(
+          PerpsStreamPauseKey.TAB_LAYER,
+        );
       }
     });
 
-    it('resumeAllChannels calls resume() on every channel', () => {
+    it('resumeAllChannels forwards the key to resume() on every channel', () => {
       for (const channel of CHANNEL_NAMES) {
         jest.spyOn(testStreamManager[channel], 'resume');
       }
 
-      testStreamManager.resumeAllChannels();
+      testStreamManager.resumeAllChannels(PerpsStreamPauseKey.TAB_LAYER);
 
       for (const channel of CHANNEL_NAMES) {
-        expect(testStreamManager[channel].resume).toHaveBeenCalledTimes(1);
+        expect(testStreamManager[channel].resume).toHaveBeenCalledWith(
+          PerpsStreamPauseKey.TAB_LAYER,
+        );
       }
     });
 
@@ -2953,8 +2966,8 @@ describe('PerpsStreamManager', () => {
       const pauseSpy = jest.spyOn(testStreamManager.marketData, 'pause');
       const resumeSpy = jest.spyOn(testStreamManager.marketData, 'resume');
 
-      testStreamManager.pauseAllChannels();
-      testStreamManager.resumeAllChannels();
+      testStreamManager.pauseAllChannels(PerpsStreamPauseKey.TAB_LAYER);
+      testStreamManager.resumeAllChannels(PerpsStreamPauseKey.TAB_LAYER);
 
       expect(pauseSpy).not.toHaveBeenCalled();
       expect(resumeSpy).not.toHaveBeenCalled();

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -83,10 +83,10 @@ abstract class StreamChannel<T> {
   protected accountAddress: string | null = null;
   // Track WebSocket connection timing for first data measurement
   protected wsConnectionStartTime: number | null = null;
-  // Reference count for pause requests. Emission is blocked whenever > 0,
-  // allowing independent callers (tab visibility, controller operations) to
-  // pause/resume without clobbering each other.
-  protected pauseCount = 0;
+  // Named pause holders. Emission is blocked whenever the set is non-empty,
+  // allowing independent callers (e.g. 'tab-layer', 'controller') to
+  // pause/resume without clobbering each other's hold.
+  protected pauseHolders = new Set<string>();
   // Retry counter for deferred connect() calls
   protected connectRetryCount = 0;
   // Timer handle for deferConnect so it can be cancelled on disconnect
@@ -95,7 +95,7 @@ abstract class StreamChannel<T> {
 
   protected notifySubscribers(updates: T) {
     // Block emission while any pause is held (WebSocket continues receiving updates)
-    if (this.pauseCount > 0) {
+    if (this.pauseHolders.size > 0) {
       return;
     }
 
@@ -311,21 +311,21 @@ abstract class StreamChannel<T> {
   }
 
   /**
-   * Pause emission of updates to subscribers
-   * WebSocket connection stays alive and continues receiving data
-   * Used during batch operations to prevent UI re-renders from stale data
+   * Pause emission of updates to subscribers under a named key.
+   * WebSocket connection stays alive and continues receiving data.
+   * Emission is blocked until every unique key that called pause() has
+   * called resume() — callers cannot release each other's hold.
    */
-  public pause(): void {
-    this.pauseCount += 1;
+  public pause(key: string): void {
+    this.pauseHolders.add(key);
   }
 
   /**
-   * Resume emission of updates to subscribers.
-   * Each pause() call must be matched by exactly one resume(). Emission
-   * resumes only when all callers have released their pause.
+   * Release a named pause hold. Emission resumes only once all holders
+   * have released. Calling resume() with a key that is not held is a no-op.
    */
-  public resume(): void {
-    this.pauseCount = Math.max(0, this.pauseCount - 1);
+  public resume(key: string): void {
+    this.pauseHolders.delete(key);
   }
 
   protected getCachedData(): T | null {
@@ -1742,30 +1742,30 @@ export class PerpsStreamManager {
    * keeping WebSocket subscriptions alive and cache warm. Call when the Perps
    * UI is not visible to avoid unnecessary processing.
    */
-  public pauseAllChannels(): void {
-    this.prices.pause();
-    this.orders.pause();
-    this.positions.pause();
-    this.fills.pause();
-    this.account.pause();
-    this.oiCaps.pause();
-    this.topOfBook.pause();
-    this.candles.pause();
+  public pauseAllChannels(key: string): void {
+    this.prices.pause(key);
+    this.orders.pause(key);
+    this.positions.pause(key);
+    this.fills.pause(key);
+    this.account.pause(key);
+    this.oiCaps.pause(key);
+    this.topOfBook.pause(key);
+    this.candles.pause(key);
   }
 
   /**
    * Resume all stream channels after a pause. Subscribers will receive the
    * next update pushed by the WebSocket.
    */
-  public resumeAllChannels(): void {
-    this.prices.resume();
-    this.orders.resume();
-    this.positions.resume();
-    this.fills.resume();
-    this.account.resume();
-    this.oiCaps.resume();
-    this.topOfBook.resume();
-    this.candles.resume();
+  public resumeAllChannels(key: string): void {
+    this.prices.resume(key);
+    this.orders.resume(key);
+    this.positions.resume(key);
+    this.fills.resume(key);
+    this.account.resume(key);
+    this.oiCaps.resume(key);
+    this.topOfBook.resume(key);
+    this.candles.resume(key);
   }
 
   /**
@@ -1828,10 +1828,17 @@ export const usePerpsStream = () => {
   return context;
 };
 
+// Well-known keys for named pause ownership. Each independent caller uses its
+// own key so releasing one hold never unblocks another caller's pause.
+export const PerpsStreamPauseKey = {
+  TAB_LAYER: 'tab-layer',
+  CONTROLLER: 'controller',
+} as const;
+
 // Type that only includes channel properties (excludes methods like clearAllChannels)
 export type PerpsStreamChannelKey = {
   [K in keyof PerpsStreamManager]: PerpsStreamManager[K] extends {
-    pause(): void;
+    pause(key: string): void;
   }
     ? K
     : never;

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -83,10 +83,12 @@ abstract class StreamChannel<T> {
   protected accountAddress: string | null = null;
   // Track WebSocket connection timing for first data measurement
   protected wsConnectionStartTime: number | null = null;
-  // Named pause holders. Emission is blocked whenever the set is non-empty,
-  // allowing independent callers (e.g. 'tab-layer', 'controller') to
-  // pause/resume without clobbering each other's hold.
-  protected pauseHolders = new Set<string>();
+  // Named ref-counted pause holders. Maps each caller key to the number of
+  // outstanding pause() calls it holds. Emission is blocked whenever the map
+  // is non-empty. Using counts (not a plain Set) allows the same caller to
+  // issue nested pauses (e.g. concurrent #withStreamPause operations) without
+  // the first resume() unblocking a still-in-flight second operation.
+  protected pauseHolders = new Map<string, number>();
   // Retry counter for deferred connect() calls
   protected connectRetryCount = 0;
   // Timer handle for deferConnect so it can be cancelled on disconnect
@@ -311,21 +313,27 @@ abstract class StreamChannel<T> {
   }
 
   /**
-   * Pause emission of updates to subscribers under a named key.
-   * WebSocket connection stays alive and continues receiving data.
-   * Emission is blocked until every unique key that called pause() has
-   * called resume() — callers cannot release each other's hold.
+   * Pause emission under a named key. Each key is ref-counted so the same
+   * caller can nest pauses (e.g. two concurrent controller operations both
+   * using 'controller'). Emission stays blocked until every outstanding
+   * pause() call across all keys has been matched by a resume().
    */
   public pause(key: string): void {
-    this.pauseHolders.add(key);
+    this.pauseHolders.set(key, (this.pauseHolders.get(key) ?? 0) + 1);
   }
 
   /**
-   * Release a named pause hold. Emission resumes only once all holders
-   * have released. Calling resume() with a key that is not held is a no-op.
+   * Release one pause hold for the given key. Decrements the ref-count;
+   * removes the key when it reaches zero. No-op if the key is not held.
    */
   public resume(key: string): void {
-    this.pauseHolders.delete(key);
+    const count = this.pauseHolders.get(key);
+    if (!count) return;
+    if (count <= 1) {
+      this.pauseHolders.delete(key);
+    } else {
+      this.pauseHolders.set(key, count - 1);
+    }
   }
 
   protected getCachedData(): T | null {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -1828,8 +1828,6 @@ export const usePerpsStream = () => {
   return context;
 };
 
-// Well-known keys for named pause ownership. Each independent caller uses its
-// own key so releasing one hold never unblocks another caller's pause.
 export const PerpsStreamPauseKey = {
   TAB_LAYER: 'tab-layer',
   CONTROLLER: 'controller',

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -29,7 +29,7 @@ abstract class StreamChannel<T> {
   protected cache = new Map<string, T>();
   protected subscribers = new Map<string, StreamSubscription<T>>();
   protected wsSubscriptions = new Map<string, () => void>();
-  protected pauseHolders = new Set<string>();
+  protected pauseHolders = new Map<string, number>();
   readonly #onDataPersist?: () => void;
 
   constructor(onDataPersist?: () => void) {
@@ -81,11 +81,17 @@ abstract class StreamChannel<T> {
   }
 
   public pause(key: string): void {
-    this.pauseHolders.add(key);
+    this.pauseHolders.set(key, (this.pauseHolders.get(key) ?? 0) + 1);
   }
 
   public resume(key: string): void {
-    this.pauseHolders.delete(key);
+    const count = this.pauseHolders.get(key);
+    if (!count) return;
+    if (count <= 1) {
+      this.pauseHolders.delete(key);
+    } else {
+      this.pauseHolders.set(key, count - 1);
+    }
   }
 
   public clearCache(): void {

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -29,7 +29,7 @@ abstract class StreamChannel<T> {
   protected cache = new Map<string, T>();
   protected subscribers = new Map<string, StreamSubscription<T>>();
   protected wsSubscriptions = new Map<string, () => void>();
-  protected isPaused = false;
+  protected pauseHolders = new Set<string>();
   readonly #onDataPersist?: () => void;
 
   constructor(onDataPersist?: () => void) {
@@ -41,7 +41,7 @@ abstract class StreamChannel<T> {
   }
 
   protected notifySubscribers(cacheKey: string, updates: T) {
-    if (this.isPaused) {
+    if (this.pauseHolders.size > 0) {
       return;
     }
 
@@ -80,12 +80,12 @@ abstract class StreamChannel<T> {
     });
   }
 
-  public pause(): void {
-    this.isPaused = true;
+  public pause(key: string): void {
+    this.pauseHolders.add(key);
   }
 
-  public resume(): void {
-    this.isPaused = false;
+  public resume(key: string): void {
+    this.pauseHolders.delete(key);
   }
 
   public clearCache(): void {

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -92,6 +92,7 @@ const mockResumeAllChannels = jest.fn();
 jest.mock('../../../../UI/Perps/providers/PerpsStreamManager', () => ({
   PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
     children,
+  PerpsStreamPauseKey: { TAB_LAYER: 'tab-layer', CONTROLLER: 'controller' },
   getStreamManagerInstance: () => ({
     pauseAllChannels: mockPauseAllChannels,
     resumeAllChannels: mockResumeAllChannels,

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -28,6 +28,7 @@ import PredictFeed from '../../../../UI/Predict/views/PredictFeed';
 import { PerpsConnectionProvider } from '../../../../UI/Perps/providers/PerpsConnectionProvider';
 import {
   PerpsStreamProvider,
+  PerpsStreamPauseKey,
   getStreamManagerInstance,
 } from '../../../../UI/Perps/providers/PerpsStreamManager';
 import { PredictPreviewSheetProvider } from '../../../../UI/Predict/contexts';
@@ -232,7 +233,9 @@ const HomepageDiscoveryTabs = forwardRef<
     useEffect(
       () => () => {
         if (tabLayerHoldsPauseRef.current) {
-          getStreamManagerInstance().resumeAllChannels();
+          getStreamManagerInstance().resumeAllChannels(
+            PerpsStreamPauseKey.TAB_LAYER,
+          );
         }
       },
       [],
@@ -301,10 +304,14 @@ const HomepageDiscoveryTabs = forwardRef<
           const isActive = PERPS_WS_TABS.has(i);
 
           if (wasActive && !isActive) {
-            getStreamManagerInstance().pauseAllChannels();
+            getStreamManagerInstance().pauseAllChannels(
+              PerpsStreamPauseKey.TAB_LAYER,
+            );
             tabLayerHoldsPauseRef.current = true;
           } else if (!wasActive && isActive) {
-            getStreamManagerInstance().resumeAllChannels();
+            getStreamManagerInstance().resumeAllChannels(
+              PerpsStreamPauseKey.TAB_LAYER,
+            );
             tabLayerHoldsPauseRef.current = false;
           }
 

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -46,7 +46,6 @@ import {
   PerpsTraceNames,
   PerpsTraceOperations,
   isVersionGatedFeatureFlag,
-  PerpsStreamPauseKey,
   // Platform dependencies interface for core migration (bundles all platform-specific deps)
 } from './types';
 import type {
@@ -130,6 +129,10 @@ import {
 } from './utils/perpsDiskPersistence';
 import type { SortDirection } from './utils/sortMarkets';
 import { wait } from './utils/wait';
+
+// Pause key used when PerpsController holds stream pauses during operations.
+// Must match PerpsStreamPauseKey.CONTROLLER in PerpsStreamManager.tsx.
+const STREAM_PAUSE_KEY_CONTROLLER = 'controller' as const;
 
 /** Derived type for logger options from PerpsLogger interface */
 type PerpsLoggerOptions = Parameters<PerpsLogger['error']>[1];
@@ -1504,7 +1507,7 @@ export class PerpsController extends BaseController<
     // Track which channels successfully paused to ensure proper cleanup
     for (const channel of channels) {
       try {
-        streamManager.pauseChannel(channel, PerpsStreamPauseKey.CONTROLLER);
+        streamManager.pauseChannel(channel, STREAM_PAUSE_KEY_CONTROLLER);
         pausedChannels.push(channel);
       } catch (error) {
         // Log error to Sentry but continue pausing remaining channels
@@ -1526,7 +1529,7 @@ export class PerpsController extends BaseController<
       // Resume only channels that were successfully paused
       for (const channel of pausedChannels) {
         try {
-          streamManager.resumeChannel(channel, PerpsStreamPauseKey.CONTROLLER);
+          streamManager.resumeChannel(channel, STREAM_PAUSE_KEY_CONTROLLER);
         } catch (error) {
           // Log error to Sentry but continue resuming remaining channels
           this.#logError(

--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -46,6 +46,7 @@ import {
   PerpsTraceNames,
   PerpsTraceOperations,
   isVersionGatedFeatureFlag,
+  PerpsStreamPauseKey,
   // Platform dependencies interface for core migration (bundles all platform-specific deps)
 } from './types';
 import type {
@@ -1503,7 +1504,7 @@ export class PerpsController extends BaseController<
     // Track which channels successfully paused to ensure proper cleanup
     for (const channel of channels) {
       try {
-        streamManager.pauseChannel(channel);
+        streamManager.pauseChannel(channel, PerpsStreamPauseKey.CONTROLLER);
         pausedChannels.push(channel);
       } catch (error) {
         // Log error to Sentry but continue pausing remaining channels
@@ -1525,7 +1526,7 @@ export class PerpsController extends BaseController<
       // Resume only channels that were successfully paused
       for (const channel of pausedChannels) {
         try {
-          streamManager.resumeChannel(channel);
+          streamManager.resumeChannel(channel, PerpsStreamPauseKey.CONTROLLER);
         } catch (error) {
           // Log error to Sentry but continue resuming remaining channels
           this.#logError(

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1436,11 +1436,6 @@ export type PerpsDebugLogger = {
  * - Mobile: Wrap existing singleton (streamManager[channel].pause())
  * - Extension: Implement with whatever streaming solution they use
  */
-export const PerpsStreamPauseKey = {
-  TAB_LAYER: 'tab-layer',
-  CONTROLLER: 'controller',
-} as const;
-
 export type PerpsStreamManager = {
   pauseChannel(channel: string, key: string): void;
   resumeChannel(channel: string, key: string): void;

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1436,9 +1436,14 @@ export type PerpsDebugLogger = {
  * - Mobile: Wrap existing singleton (streamManager[channel].pause())
  * - Extension: Implement with whatever streaming solution they use
  */
+export const PerpsStreamPauseKey = {
+  TAB_LAYER: 'tab-layer',
+  CONTROLLER: 'controller',
+} as const;
+
 export type PerpsStreamManager = {
-  pauseChannel(channel: string): void;
-  resumeChannel(channel: string): void;
+  pauseChannel(channel: string, key: string): void;
+  resumeChannel(channel: string, key: string): void;
   clearAllChannels(): void;
 };
 


### PR DESCRIPTION
## **Description**

Replaces the simple boolean isPaused flag on StreamChannel with a named-key ownership model (Set<string>). Each caller, for example the tab layer or the controller, holds its own key, so releasing one hold never unblocks another caller's pause.

Changes:

- `StreamChannel.pause(key)` / `resume(key)` add/remove from `pauseHolders: Set<string>;` emission blocks while `size > 0`
- `PerpsStreamManager.pauseAllChannels(key)` / `resumeAllChannels(key)` propagate key to all 8 channels
- `CandleStreamChannel` - migrated its local base class to the same pattern
- `mobileInfrastructure.ts` - adapter forwards key through `pauseChannel` / `resumeChannel`
- HomepageDiscoveryTabs - pauses/resumes with `PerpsStreamPauseKey.TAB_LAYER` on tab switch; `tabLayerHoldsPauseRef` - guards the unmount cleanup against unmatched resumes
- `PerpsStreamPauseKey` - const exported from `PerpsStreamManager` for all call sites

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-737
 
## **Manual testing steps**

```gherkin
Feature: Perps WS pause ownership

  Scenario: user navigates to Predictions tab
    Given the user is on the Portfolio or Perpetuals tab
    When user taps the Predictions tab
    Then Perps WebSocket channels stop emitting updates to subscribers
    And the WebSocket connection stays alive

  Scenario: user returns from Predictions tab
    Given the user is on the Predictions tab
    When user taps Portfolio or Perpetuals
    Then Perps WebSocket channels resume emitting updates immediately
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the pause/resume semantics for Perps WebSocket channels and updates multiple call sites and interfaces to require pause keys; mistakes could leave streams permanently paused or unintentionally unpaused, impacting UI freshness during trading operations.
> 
> **Overview**
> Implements **named-key, ref-counted pause ownership** for Perps stream channels so multiple callers (e.g. tab visibility vs controller operations) can pause emissions without clobbering each other, and unknown resumes become no-ops.
> 
> Updates the Perps stream APIs to require a `key` for `pause()`/`resume()` and for manager-level `pauseAllChannels(key)`/`resumeAllChannels(key)`, adds `PerpsStreamPauseKey` constants, and propagates the key through the mobile infrastructure adapter and `PerpsController.withStreamPause`.
> 
> Adjusts Homepage tab switching to pause/resume using the tab-layer key with guarded unmount cleanup, and expands tests to cover the new multi-owner pause behavior and key forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001d079f46cb257d191e6bcea6a84eea24c7f430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->