### PR TITLE
feat(predict): add deposit wallet claim flow

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -44,7 +44,10 @@ import {
 import type { PredictFeatureFlags } from '../types/flags';
 
 import { PREDICT_ERROR_CODES } from '../constants/errors';
-import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
+import {
+  MATIC_CONTRACTS_V2,
+  POLYMARKET_PROVIDER_ID,
+} from '../providers/polymarket/constants';
 // Mock the PolymarketProvider and its dependencies
 jest.mock('../providers/polymarket/PolymarketProvider');
 
@@ -280,6 +283,8 @@ describe('PredictController', () => {
       getCryptoTargetPrice: jest.fn(),
       invalidateAccountState: jest.fn(),
       beforePublishDepositWalletDeposit: jest.fn(),
+      beforeSignClaim: jest.fn(),
+      publishClaim: jest.fn(),
       syncDepositWalletBalanceAllowanceForDepositTransaction: jest.fn(),
     } as unknown as jest.Mocked<PolymarketProvider>;
 
@@ -289,6 +294,9 @@ describe('PredictController', () => {
     mockPolymarketProvider.syncDepositWalletBalanceAllowanceForDepositTransaction.mockResolvedValue(
       undefined,
     );
+    mockPolymarketProvider.publishClaim?.mockResolvedValue({
+      transactionHash: undefined,
+    });
 
     // Default safe mocks for async fire-and-forget methods
     // (prevents unhandled rejections when payWithAnyTokenConfirmation is
@@ -2732,7 +2740,14 @@ describe('PredictController', () => {
             address: '0x1234567890123456789012345678901234567890',
           }),
         });
-        expect(addTransactionBatch).toHaveBeenCalled();
+        expect(addTransactionBatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            disableHook: true,
+            disableSequential: true,
+            gasFeeToken: MATIC_CONTRACTS_V2.collateral,
+            skipInitialGasEstimate: true,
+          }),
+        );
       });
     });
 
@@ -6206,6 +6221,24 @@ describe('PredictController', () => {
   });
 
   describe('publish', () => {
+    const claimTransactionMeta = {
+      id: 'tx-claim',
+      batchId: 'batch-claim',
+      txParams: {
+        from: MOCK_ADDRESS,
+        to: '0xTarget',
+        data: '0xdata',
+        value: '0x0',
+      },
+      nestedTransactions: [
+        {
+          id: 'nested-claim',
+          type: TransactionType.predictClaim,
+          data: '0xclaim' as `0x${string}`,
+        },
+      ],
+    } as unknown as TransactionMeta;
+
     it('passes through by default', async () => {
       await withController(async ({ controller }) => {
         const result = await controller.publish({
@@ -6218,6 +6251,58 @@ describe('PredictController', () => {
         });
 
         expect(result).toEqual({ transactionHash: undefined });
+        expect(mockPolymarketProvider.publishClaim).not.toHaveBeenCalled();
+      });
+    });
+
+    it('delegates pending claims to provider.publishClaim', async () => {
+      mockPolymarketProvider.publishClaim?.mockResolvedValue({
+        transactionHash:
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      });
+
+      await withController(async ({ controller }) => {
+        const claimablePositions = [createMockPosition({ claimable: true })];
+        controller.updateStateForTesting((state) => {
+          state.pendingClaims[MOCK_ADDRESS.toUpperCase()] = 'batch-claim';
+          state.claimablePositions[MOCK_ADDRESS.toUpperCase()] =
+            claimablePositions;
+        });
+
+        const result = await controller.publish({
+          transactionMeta: claimTransactionMeta,
+        });
+
+        expect(result).toEqual({
+          transactionHash:
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+        expect(mockPolymarketProvider.publishClaim).toHaveBeenCalledWith({
+          transactionMeta: claimTransactionMeta,
+          signer: expect.objectContaining({ address: MOCK_ADDRESS }),
+          positions: claimablePositions,
+        });
+        expect(
+          (mockPolymarketProvider.publishClaim as jest.Mock).mock.calls[0][0]
+            .positions,
+        ).not.toBe(claimablePositions);
+      });
+    });
+
+    it('throws on pending claim batch mismatch', async () => {
+      await withController(async ({ controller }) => {
+        controller.updateStateForTesting((state) => {
+          state.pendingClaims[MOCK_ADDRESS] = 'different-batch';
+          state.claimablePositions[MOCK_ADDRESS] = [
+            createMockPosition({ claimable: true }),
+          ];
+        });
+
+        await expect(
+          controller.publish({ transactionMeta: claimTransactionMeta }),
+        ).rejects.toThrow(
+          'Pending claim batch does not match transaction batch',
+        );
       });
     });
   });
@@ -6538,6 +6623,70 @@ describe('PredictController', () => {
         });
 
         expect(result).toBeUndefined();
+      });
+    });
+
+    it('delegates pending claim beforeSign even when no withdraw state exists', async () => {
+      const updateTransaction = jest.fn();
+      mockPolymarketProvider.beforeSignClaim?.mockResolvedValue({
+        updateTransaction,
+      });
+
+      await withController(async ({ controller }) => {
+        const claimablePositions = [createMockPosition({ claimable: true })];
+        controller.updateStateForTesting((state) => {
+          state.pendingClaims[MOCK_ADDRESS] = 'batch-claim';
+          state.claimablePositions[MOCK_ADDRESS] = claimablePositions;
+        });
+
+        const transactionMeta = {
+          ...mockTransactionMeta,
+          batchId: 'batch-claim',
+          nestedTransactions: [
+            {
+              id: 'nested-claim',
+              type: TransactionType.predictClaim,
+              data: '0xclaim' as `0x${string}`,
+            },
+          ],
+        } as unknown as TransactionMeta;
+
+        const result = await controller.beforeSign({ transactionMeta });
+
+        expect(result).toEqual({ updateTransaction });
+        expect(mockPolymarketProvider.beforeSignClaim).toHaveBeenCalledWith({
+          transactionMeta,
+          signer: expect.objectContaining({ address: MOCK_ADDRESS }),
+          positions: claimablePositions,
+        });
+        expect(
+          (mockPolymarketProvider.beforeSignClaim as jest.Mock).mock.calls[0][0]
+            .positions,
+        ).not.toBe(claimablePositions);
+      });
+    });
+
+    it('throws when pending claim has no claimable positions', async () => {
+      await withController(async ({ controller }) => {
+        controller.updateStateForTesting((state) => {
+          state.pendingClaims[MOCK_ADDRESS] = 'batch-claim';
+          state.claimablePositions[MOCK_ADDRESS] = [];
+        });
+
+        await expect(
+          controller.beforeSign({
+            transactionMeta: {
+              ...mockTransactionMeta,
+              batchId: 'batch-claim',
+              nestedTransactions: [
+                {
+                  type: TransactionType.predictClaim,
+                  data: '0xclaim' as `0x${string}`,
+                },
+              ],
+            } as unknown as TransactionMeta,
+          }),
+        ).rejects.toThrow('No claimable positions found for pending claim');
       });
     });
   });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1454,6 +1454,7 @@ export class PredictController extends BaseController<
         networkClientId,
         disableHook: true,
         disableSequential: true,
+        skipInitialGasEstimate: true,
         // Temporarily breaking abstraction, can instead be abstracted via provider.
         gasFeeToken: MATIC_CONTRACTS_V2.collateral as Hex,
         transactions,
@@ -2680,7 +2681,62 @@ export class PredictController extends BaseController<
     });
   }
 
-  public async beforeSign(request: {
+  private getPendingClaimContext(transactionMeta: TransactionMeta):
+    | {
+        senderAddress: string;
+        matchedAddress: string;
+        pendingValue: string;
+        positions: PredictPosition[];
+        signer: Signer;
+      }
+    | undefined {
+    const isClaim = transactionMeta.nestedTransactions?.some(
+      (tx) => tx.type === TransactionType.predictClaim,
+    );
+
+    if (!isClaim) {
+      return undefined;
+    }
+
+    const senderAddress = transactionMeta.txParams.from as string | undefined;
+    if (!senderAddress) {
+      return undefined;
+    }
+
+    const normalizedAddress = senderAddress.toLowerCase();
+    const matchedAddress = Object.keys(this.state.pendingClaims).find(
+      (addressKey) => addressKey.toLowerCase() === normalizedAddress,
+    );
+
+    if (!matchedAddress) {
+      return undefined;
+    }
+
+    const pendingValue = this.state.pendingClaims[matchedAddress];
+
+    if (
+      pendingValue !== 'pending' &&
+      transactionMeta.batchId &&
+      pendingValue !== transactionMeta.batchId
+    ) {
+      throw new Error('Pending claim batch does not match transaction batch');
+    }
+
+    const claimablePositions = this.state.claimablePositions[matchedAddress];
+    if (!claimablePositions || claimablePositions.length === 0) {
+      throw new Error('No claimable positions found for pending claim');
+    }
+
+    return {
+      senderAddress,
+      matchedAddress,
+      pendingValue,
+      positions: [...claimablePositions],
+      signer: this.getSigner(senderAddress),
+    };
+  }
+
+  private async beforeSignWithdrawIfNeeded(request: {
     transactionMeta: TransactionMeta;
   }): Promise<
     | {
@@ -2783,10 +2839,49 @@ export class PredictController extends BaseController<
     };
   }
 
-  public async publish(_request: {
+  public async beforeSign(request: {
+    transactionMeta: TransactionMeta;
+  }): Promise<
+    | {
+        updateTransaction?: (transaction: TransactionMeta) => void;
+      }
+    | undefined
+  > {
+    const withdrawResult = await this.beforeSignWithdrawIfNeeded(request);
+    if (withdrawResult) {
+      return withdrawResult;
+    }
+
+    const claimContext = this.getPendingClaimContext(request.transactionMeta);
+    if (!claimContext) {
+      return undefined;
+    }
+
+    return this.provider.beforeSignClaim?.({
+      transactionMeta: request.transactionMeta,
+      signer: claimContext.signer,
+      positions: claimContext.positions,
+    });
+  }
+
+  public async publish(request: {
     transactionMeta: TransactionMeta;
   }): Promise<{ transactionHash?: string }> {
-    return { transactionHash: undefined };
+    const claimContext = this.getPendingClaimContext(request.transactionMeta);
+
+    if (!claimContext) {
+      return { transactionHash: undefined };
+    }
+
+    if (!this.provider.publishClaim) {
+      return { transactionHash: undefined };
+    }
+
+    return this.provider.publishClaim({
+      transactionMeta: request.transactionMeta,
+      signer: claimContext.signer,
+      positions: claimContext.positions,
+    });
   }
 
   public clearWithdrawTransaction(): void {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -9,7 +9,7 @@ import { analytics } from '../../../../../util/analytics/analytics';
 import { UserProfileProperty } from '../../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { DEFAULT_FEE_COLLECTION_FLAG } from '../../constants/flags';
 import type { OrderPreview } from '../types';
-import { Side } from '../../types';
+import { Side, type PredictPosition } from '../../types';
 import type { PredictFeatureFlags } from '../../types/flags';
 import { PolymarketProvider } from './PolymarketProvider';
 import { OrderType, SignatureType } from './types';
@@ -47,6 +47,10 @@ import {
   previewOrder,
 } from './utils';
 import { submitProtocolClobOrder } from './protocol/transport';
+import {
+  buildClaimTransaction,
+  planDepositWalletClaim,
+} from './preflight/claim';
 import { buildDepositMaintenanceTransaction } from './preflight/deposit';
 import type { SignedSafeExecution } from './preflight/core';
 import { planDepositWalletPreflight } from './preflight/depositWallet';
@@ -126,6 +130,11 @@ jest.mock('./depositWallet', () => ({
   waitForDepositWalletTransaction: jest.fn(),
 }));
 
+jest.mock('./preflight/claim', () => ({
+  buildClaimTransaction: jest.fn(),
+  planDepositWalletClaim: jest.fn(),
+}));
+
 jest.mock('./preflight/deposit', () => ({
   buildDepositMaintenanceTransaction: jest.fn(),
 }));
@@ -171,6 +180,8 @@ const mockIsSmartContractAddress = jest.mocked(isSmartContractAddress);
 const mockParsePolymarketPositions = jest.mocked(parsePolymarketPositions);
 const mockPreviewOrder = jest.mocked(previewOrder);
 const mockSubmitProtocolClobOrder = jest.mocked(submitProtocolClobOrder);
+const mockBuildClaimTransaction = jest.mocked(buildClaimTransaction);
+const mockPlanDepositWalletClaim = jest.mocked(planDepositWalletClaim);
 const mockBuildDepositMaintenanceTransaction = jest.mocked(
   buildDepositMaintenanceTransaction,
 );
@@ -229,6 +240,40 @@ function createDepositTransactionMeta({
       },
     ],
   } as TransactionMeta;
+}
+
+function createClaimPosition(
+  overrides: Partial<PredictPosition> = {},
+): PredictPosition {
+  return {
+    id: 'position-1',
+    providerId: POLYMARKET_PROVIDER_ID,
+    marketId: 'market-1',
+    outcomeId:
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    outcome: 'Yes',
+    outcomeTokenId: 'token-1',
+    currentValue: 1,
+    title: 'Market',
+    icon: '',
+    amount: 1,
+    price: 1,
+    status: 'open',
+    size: 1,
+    outcomeIndex: 0,
+    percentPnl: 0,
+    cashPnl: 0,
+    claimable: true,
+    initialValue: 1,
+    avgPrice: 1,
+    endDate: new Date(0).toISOString(),
+    negRisk: false,
+    ...overrides,
+  } as PredictPosition;
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 const basePreview: OrderPreview = {
@@ -322,6 +367,20 @@ describe('PolymarketProvider', () => {
       params: { to: '0xFactory', data: '0xdeploy' },
       type: TransactionType.contractInteraction,
     });
+    mockBuildClaimTransaction.mockResolvedValue({
+      params: {
+        to: legacySafeAddress as `0x${string}`,
+        data: '0xsignedClaim' as `0x${string}`,
+      },
+      type: TransactionType.predictClaim,
+    });
+    mockPlanDepositWalletClaim.mockResolvedValue([
+      {
+        target: MATIC_CONTRACTS_V2.collateral,
+        value: '0',
+        data: '0xclaim',
+      },
+    ]);
     mockBuildDepositMaintenanceTransaction.mockResolvedValue(undefined);
     mockBuildLegacySafeMigrationSweepTransaction.mockResolvedValue(undefined);
     mockGetDepositWalletRelayerTransactionId.mockImplementation(
@@ -957,6 +1016,178 @@ describe('PolymarketProvider', () => {
     expect(result).toBe(true);
     expect(mockRequestDepositWalletCreate).not.toHaveBeenCalled();
     expect(mockPlanDepositWalletPreflight).not.toHaveBeenCalled();
+  });
+
+  it('marks deposit-wallet claim transactions as externally signed before signing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    const provider = createProvider();
+    const transactionMeta = {
+      id: 'claim-tx',
+      txParams: {
+        from: signer.address,
+        nonce: '0x1',
+      },
+    } as TransactionMeta;
+
+    const result = await provider.beforeSignClaim({
+      transactionMeta,
+      signer,
+      positions: [createClaimPosition()],
+    });
+
+    expect(result?.updateTransaction).toBeDefined();
+
+    result?.updateTransaction?.(transactionMeta);
+    expect(transactionMeta.isExternalSign).toBe(true);
+    expect(transactionMeta.isGasFeeTokenIgnoredIfBalance).toBe(false);
+    expect(transactionMeta.selectedGasFeeToken).toBeUndefined();
+    expect(transactionMeta.txParams.nonce).toBeUndefined();
+  });
+
+  it('passes through Safe claims before signing', async () => {
+    const result = await createProvider().beforeSignClaim({
+      transactionMeta: {
+        id: 'claim-tx',
+        txParams: { from: signer.address },
+      } as TransactionMeta,
+      signer,
+      positions: [createClaimPosition()],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('passes through Safe claim publishing', async () => {
+    const result = await createProvider().publishClaim({
+      transactionMeta: {
+        id: 'claim-tx',
+        isExternalSign: true,
+        txParams: { from: signer.address },
+      } as TransactionMeta,
+      signer,
+      positions: [createClaimPosition()],
+    });
+
+    expect(result).toEqual({ transactionHash: undefined });
+    expect(mockPlanDepositWalletClaim).not.toHaveBeenCalled();
+    expect(mockExecuteDepositWalletBatch).not.toHaveBeenCalled();
+  });
+
+  it('publishes deposit-wallet claims through the relayer batch and returns once a hash is available', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    mockWaitForDepositWalletTransaction.mockResolvedValue(
+      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    );
+
+    const positions = [createClaimPosition()];
+    const result = await createProvider().publishClaim({
+      transactionMeta: {
+        id: 'claim-tx',
+        isExternalSign: true,
+        txParams: { from: signer.address },
+      } as TransactionMeta,
+      signer,
+      positions,
+    });
+
+    expect(mockPlanDepositWalletClaim).toHaveBeenCalledWith({
+      positions,
+      walletAddress: depositWalletAddress,
+      protocol: expect.objectContaining({ key: 'v2' }),
+    });
+    expect(mockExecuteDepositWalletBatch).toHaveBeenCalledWith({
+      signer,
+      walletAddress: depositWalletAddress,
+      calls: [
+        {
+          target: MATIC_CONTRACTS_V2.collateral,
+          value: '0',
+          data: '0xclaim',
+        },
+      ],
+    });
+    expect(mockWaitForDepositWalletTransaction).toHaveBeenCalledWith({
+      transactionID: 'batch-1',
+    });
+    expect(result).toEqual({
+      transactionHash:
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    });
+  });
+
+  it('requires external-sign metadata before publishing deposit-wallet claims', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+
+    await expect(
+      createProvider().publishClaim({
+        transactionMeta: {
+          id: 'claim-tx',
+          txParams: { from: signer.address },
+        } as TransactionMeta,
+        signer,
+        positions: [createClaimPosition()],
+      }),
+    ).rejects.toThrow(
+      'Deposit wallet claim publish requires external-sign transaction',
+    );
+  });
+
+  it('syncs deposit-wallet CLOB balance allowance after confirmed claims', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+
+    createProvider().confirmClaim({
+      positions: [createClaimPosition()],
+      signer,
+    });
+    await flushPromises();
+
+    expect(
+      mockSyncDepositWalletCollateralBalanceAllowance,
+    ).toHaveBeenCalledWith({
+      protocol: expect.objectContaining({ key: 'v2' }),
+      signerAddress: signer.address,
+      apiKey: {
+        apiKey: 'api-key',
+        secret: 'secret',
+        passphrase: 'passphrase',
+      },
+    });
+  });
+
+  it('does not sync claim balance allowance for Safe users', async () => {
+    createProvider().confirmClaim({
+      positions: [createClaimPosition()],
+      signer,
+    });
+    await flushPromises();
+
+    expect(
+      mockSyncDepositWalletCollateralBalanceAllowance,
+    ).not.toHaveBeenCalled();
   });
 
   it('syncs deposit-wallet CLOB balance allowance after matching deposits', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -39,6 +39,8 @@ import {
 } from '../../types';
 import {
   AccountState,
+  BeforeSignClaimParams,
+  BeforeSignClaimResult,
   ClaimOrderParams,
   ClaimOrderResponse,
   ConnectionStatus,
@@ -59,6 +61,8 @@ import {
   PrepareWithdrawResponse,
   PreviewOrderParams,
   PriceUpdateCallback,
+  PublishClaimParams,
+  PublishClaimResult,
   Signer,
   SignWithdrawParams,
   SignWithdrawResponse,
@@ -125,7 +129,10 @@ import {
   signProtocolOrder,
 } from './protocol/orderCodec';
 import { submitProtocolClobOrder } from './protocol/transport';
-import { buildClaimTransaction } from './preflight/claim';
+import {
+  buildClaimTransaction,
+  planDepositWalletClaim,
+} from './preflight/claim';
 import { buildDepositMaintenanceTransaction } from './preflight/deposit';
 import { planDepositWalletPreflight } from './preflight/depositWallet';
 import { buildLegacySafeMigrationSweepTransaction } from './preflight/legacySafeMigration';
@@ -1930,6 +1937,165 @@ export class PolymarketProvider implements PredictProvider {
     }
   }
 
+  public async beforeSignClaim({
+    transactionMeta,
+    signer,
+    positions,
+  }: BeforeSignClaimParams): Promise<BeforeSignClaimResult | undefined> {
+    if (!positions || positions.length === 0) {
+      throw new Error('No claimable positions found for claim signing');
+    }
+
+    const accountState = await this.getAccountState({
+      ownerAddress: signer.address,
+    });
+
+    if (accountState.walletType !== 'deposit-wallet') {
+      return undefined;
+    }
+
+    DevLogger.log('PolymarketProvider: Deposit wallet claim beforeSign', {
+      operation: 'deposit_wallet_claim_before_sign',
+      walletType: 'deposit-wallet',
+      signerAddress: signer.address,
+      depositWalletAddress: accountState.address,
+      transactionId: transactionMeta.id,
+      positionCount: positions.length,
+    });
+
+    return {
+      updateTransaction: (transaction: TransactionMeta) => {
+        transaction.isExternalSign = true;
+        transaction.selectedGasFeeToken = undefined;
+        transaction.isGasFeeTokenIgnoredIfBalance = false;
+        delete transaction.txParams.nonce;
+      },
+    };
+  }
+
+  public async publishClaim({
+    transactionMeta,
+    signer,
+    positions,
+  }: PublishClaimParams): Promise<PublishClaimResult> {
+    if (!positions || positions.length === 0) {
+      throw new Error('No claimable positions found for claim publish');
+    }
+
+    const protocol = this.#getProtocol();
+    const accountState = await this.getAccountState({
+      ownerAddress: signer.address,
+    });
+
+    if (accountState.walletType !== 'deposit-wallet') {
+      return { transactionHash: undefined };
+    }
+
+    if (transactionMeta.isExternalSign !== true) {
+      throw new Error(
+        'Deposit wallet claim publish requires external-sign transaction',
+      );
+    }
+
+    try {
+      const calls = await planDepositWalletClaim({
+        positions,
+        walletAddress: accountState.address,
+        protocol,
+      });
+
+      DevLogger.log(
+        'PolymarketProvider: Deposit wallet claim publish started',
+        {
+          operation: 'deposit_wallet_claim_publish',
+          walletType: 'deposit-wallet',
+          signerAddress: signer.address,
+          depositWalletAddress: accountState.address,
+          transactionId: transactionMeta.id,
+          positionCount: positions.length,
+          callCount: calls.length,
+        },
+      );
+
+      const executeResponse = await executeDepositWalletBatch({
+        signer,
+        walletAddress: accountState.address,
+        calls,
+      });
+      const transactionID =
+        getDepositWalletRelayerTransactionId(executeResponse);
+
+      if (!transactionID) {
+        throw new Error(
+          'Polymarket deposit wallet claim response missing transactionID',
+        );
+      }
+
+      const transactionHash = await waitForDepositWalletTransaction({
+        transactionID,
+      });
+
+      DevLogger.log(
+        'PolymarketProvider: Deposit wallet claim publish submitted',
+        {
+          operation: 'deposit_wallet_claim_publish',
+          walletType: 'deposit-wallet',
+          signerAddress: signer.address,
+          depositWalletAddress: accountState.address,
+          transactionId: transactionMeta.id,
+          relayerTransactionID: transactionID,
+          positionCount: positions.length,
+          callCount: calls.length,
+          transactionHash,
+        },
+      );
+
+      return { transactionHash };
+    } catch (error) {
+      DevLogger.log('PolymarketProvider: Deposit wallet claim publish failed', {
+        operation: 'deposit_wallet_claim_publish',
+        walletType: 'deposit-wallet',
+        signerAddress: signer.address,
+        depositWalletAddress: accountState.address,
+        transactionId: transactionMeta.id,
+        positionCount: positions.length,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+
+      Logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        this.getErrorContext('publishClaim', {
+          operation: 'deposit_wallet_claim_publish',
+          walletType: 'deposit-wallet',
+          positionCount: positions.length,
+        }),
+      );
+
+      throw error;
+    }
+  }
+
+  private async syncDepositWalletBalanceAllowanceForSignerIfNeeded({
+    signerAddress,
+  }: {
+    signerAddress: string;
+  }): Promise<void> {
+    const accountState = await this.getAccountState({
+      ownerAddress: signerAddress,
+    });
+
+    if (accountState.walletType !== 'deposit-wallet') {
+      return;
+    }
+
+    const apiKey = await this.getApiKey({ address: signerAddress });
+    await syncDepositWalletCollateralBalanceAllowance({
+      protocol: this.#getProtocol(),
+      signerAddress,
+      apiKey,
+    });
+  }
+
   public confirmClaim({
     positions,
     signer,
@@ -1945,6 +2111,26 @@ export class PolymarketProvider implements PredictProvider {
         outcomeTokenId: position.outcomeTokenId,
         marketId: position.marketId,
       });
+    });
+
+    this.syncDepositWalletBalanceAllowanceForSignerIfNeeded({
+      signerAddress: signer.address,
+    }).catch((error) => {
+      DevLogger.log(
+        'PolymarketProvider: Deposit wallet claim balance-allowance sync failed',
+        {
+          operation: 'deposit_wallet_claim_balance_allowance_sync',
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+      );
+
+      Logger.error(
+        error instanceof Error ? error : new Error(String(error)),
+        this.getErrorContext('confirmClaim', {
+          operation: 'deposit_wallet_claim_balance_allowance_sync',
+          walletType: 'deposit-wallet',
+        }),
+      );
     });
   }
 

--- a/app/components/UI/Predict/providers/polymarket/preflight/claim.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/preflight/claim.test.ts
@@ -1,0 +1,185 @@
+import type { PredictPosition } from '../../../types';
+import { POLYMARKET_V2_PROTOCOL } from '../protocol/definitions';
+import { PERMIT2_ADDRESS } from '../safe/constants';
+import { planDepositWalletClaim } from './claim';
+import { compileRequirementTransactions } from './compileRequirementTransactions';
+import { inspectMissingRequirements } from './inspectMissingRequirements';
+
+jest.mock('./inspectMissingRequirements', () => ({
+  inspectMissingRequirements: jest.fn(),
+}));
+
+jest.mock('./compileRequirementTransactions', () => ({
+  compileRequirementTransactions: jest.fn((requirements) =>
+    requirements.map(
+      (requirement: { tokenAddress: string }, index: number) => ({
+        to: requirement.tokenAddress,
+        data: `0x${String(index + 1).padStart(64, '0')}`,
+        operation: 0,
+        value: '0',
+      }),
+    ),
+  ),
+}));
+
+const mockInspectMissingRequirements = jest.mocked(inspectMissingRequirements);
+const mockCompileRequirementTransactions = jest.mocked(
+  compileRequirementTransactions,
+);
+
+const walletAddress = '0x1111111111111111111111111111111111111111';
+
+function createPosition(
+  overrides: Partial<PredictPosition> = {},
+): PredictPosition {
+  return {
+    id: 'position-1',
+    providerId: 'polymarket',
+    marketId: 'market-1',
+    outcomeId:
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    outcome: 'Yes',
+    outcomeTokenId: 'token-1',
+    currentValue: 1,
+    title: 'Market',
+    icon: '',
+    amount: 1,
+    price: 1,
+    status: 'open',
+    size: 1,
+    outcomeIndex: 0,
+    percentPnl: 0,
+    cashPnl: 0,
+    claimable: true,
+    initialValue: 1,
+    avgPrice: 1,
+    endDate: new Date(0).toISOString(),
+    negRisk: false,
+    ...overrides,
+  } as PredictPosition;
+}
+
+describe('planDepositWalletClaim', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInspectMissingRequirements.mockResolvedValue([]);
+  });
+
+  it('throws for empty positions', async () => {
+    await expect(
+      planDepositWalletClaim({ positions: [], walletAddress }),
+    ).rejects.toThrow('No positions provided for deposit wallet claim');
+
+    expect(mockInspectMissingRequirements).not.toHaveBeenCalled();
+  });
+
+  it('inspects active claim requirements without legacy sweep requirements', async () => {
+    await planDepositWalletClaim({
+      positions: [createPosition()],
+      walletAddress,
+    });
+
+    expect(mockInspectMissingRequirements).toHaveBeenCalledWith({
+      address: walletAddress,
+      requirements: expect.not.arrayContaining([
+        expect.objectContaining({
+          tokenAddress: POLYMARKET_V2_PROTOCOL.collateral.legacyUsdceToken,
+        }),
+      ]),
+    });
+  });
+
+  it('filters Permit2 while preserving allowed deposit-wallet claim requirements', async () => {
+    await planDepositWalletClaim({
+      positions: [createPosition()],
+      walletAddress,
+    });
+
+    expect(mockInspectMissingRequirements).toHaveBeenCalledWith({
+      address: walletAddress,
+      requirements: expect.not.arrayContaining([
+        expect.objectContaining({
+          type: 'erc20-allowance',
+          spender: PERMIT2_ADDRESS,
+        }),
+      ]),
+    });
+    expect(mockInspectMissingRequirements).toHaveBeenCalledWith({
+      address: walletAddress,
+      requirements: expect.arrayContaining([
+        expect.objectContaining({
+          type: 'erc20-allowance',
+          spender: POLYMARKET_V2_PROTOCOL.contracts.exchange,
+        }),
+        expect.objectContaining({
+          type: 'erc1155-operator',
+          operator: POLYMARKET_V2_PROTOCOL.claim.standardTarget,
+        }),
+      ]),
+    });
+  });
+
+  it('includes missing requirement calls before redeem calls', async () => {
+    const missingRequirement = {
+      type: 'erc20-allowance' as const,
+      tokenAddress: POLYMARKET_V2_PROTOCOL.collateral.tradingToken,
+      spender: POLYMARKET_V2_PROTOCOL.contracts.exchange,
+    };
+    mockInspectMissingRequirements.mockResolvedValue([missingRequirement]);
+
+    const calls = await planDepositWalletClaim({
+      positions: [createPosition()],
+      walletAddress,
+    });
+
+    expect(mockCompileRequirementTransactions).toHaveBeenCalledWith([
+      missingRequirement,
+    ]);
+    expect(calls[0]).toEqual({
+      target: missingRequirement.tokenAddress,
+      value: '0',
+      data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    });
+    expect(calls[1]).toEqual(
+      expect.objectContaining({
+        target: POLYMARKET_V2_PROTOCOL.claim.standardTarget,
+        value: '0',
+      }),
+    );
+  });
+
+  it('uses the neg-risk redeem target for neg-risk positions', async () => {
+    const calls = await planDepositWalletClaim({
+      positions: [createPosition({ negRisk: true })],
+      walletAddress,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(
+      expect.objectContaining({
+        target: POLYMARKET_V2_PROTOCOL.claim.negRiskTarget,
+        value: '0',
+      }),
+    );
+  });
+
+  it('preserves redeem call order for multiple positions', async () => {
+    const calls = await planDepositWalletClaim({
+      positions: [
+        createPosition({ id: 'standard', negRisk: false }),
+        createPosition({
+          id: 'neg-risk',
+          outcomeId:
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          negRisk: true,
+        }),
+      ],
+      walletAddress,
+    });
+
+    expect(calls.map((call) => call.target)).toEqual([
+      POLYMARKET_V2_PROTOCOL.claim.standardTarget,
+      POLYMARKET_V2_PROTOCOL.claim.negRiskTarget,
+    ]);
+  });
+});

--- a/app/components/UI/Predict/providers/polymarket/preflight/claim.ts
+++ b/app/components/UI/Predict/providers/polymarket/preflight/claim.ts
@@ -10,6 +10,7 @@ import {
   POLYMARKET_V2_PROTOCOL,
   type PolymarketProtocolDefinition,
 } from '../protocol/definitions';
+import { toDepositWalletCalls, type DepositWalletCall } from '../depositWallet';
 import { OperationType, type SafeTransaction } from '../safe/types';
 import { encodeErc20Transfer, encodeRedeemPositions } from '../utils';
 import {
@@ -17,8 +18,10 @@ import {
   compileAllowanceMaintenanceTransactions,
   getRawTokenBalance,
 } from './core';
+import { compileRequirementTransactions } from './compileRequirementTransactions';
 import { inspectMissingRequirements } from './inspectMissingRequirements';
 import {
+  filterDepositWalletUnsupportedRequirements,
   getActiveV2AllowanceRequirements,
   getLegacySweepAllowanceRequirements,
   type V2AllowanceRequirement,
@@ -203,6 +206,44 @@ function compileClaimTransactions({
   }
 
   return transactions;
+}
+
+export async function planDepositWalletClaim({
+  positions,
+  walletAddress,
+  protocol = POLYMARKET_V2_PROTOCOL,
+}: {
+  positions: PredictPosition[];
+  walletAddress: string;
+  protocol?: PolymarketV2ProtocolDefinition;
+}): Promise<DepositWalletCall[]> {
+  if (!positions || positions.length === 0) {
+    throw new Error('No positions provided for deposit wallet claim');
+  }
+
+  const requirements = filterDepositWalletUnsupportedRequirements(
+    getClaimRequirements({
+      positions,
+      protocol,
+      includeLegacySweep: false,
+    }),
+  );
+
+  const missingRequirements = await inspectMissingRequirements({
+    address: walletAddress,
+    requirements,
+  });
+
+  const transactions = [
+    ...compileRequirementTransactions(missingRequirements),
+    ...buildClaimSubtransactions({ positions, protocol }),
+  ];
+
+  if (transactions.length === 0) {
+    throw new Error('No deposit wallet claim calls generated');
+  }
+
+  return toDepositWalletCalls(transactions);
 }
 
 export async function buildClaimTransaction({

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -26,7 +26,10 @@ import {
   UnrealizedPnL,
 } from '../types';
 import { Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import { PredictFeatureFlags } from '../types/flags';
 
 // Re-export shared types so existing provider-layer imports continue to work
@@ -99,6 +102,26 @@ export interface ClaimOrderParams {
   signer: Signer;
 }
 
+export interface BeforeSignClaimParams {
+  transactionMeta: TransactionMeta;
+  signer: Signer;
+  positions: PredictPosition[];
+}
+
+export interface BeforeSignClaimResult {
+  updateTransaction?: (transaction: TransactionMeta) => void;
+}
+
+export interface PublishClaimParams {
+  transactionMeta: TransactionMeta;
+  signer: Signer;
+  positions: PredictPosition[];
+}
+
+export interface PublishClaimResult {
+  transactionHash?: string;
+}
+
 export interface ClaimOrderResponse {
   chainId: number;
   transactions: {
@@ -154,6 +177,10 @@ export interface PredictProvider {
   ): Promise<OrderResult>;
 
   prepareClaim(params: ClaimOrderParams): Promise<ClaimOrderResponse>;
+  beforeSignClaim?(
+    params: BeforeSignClaimParams,
+  ): Promise<BeforeSignClaimResult | undefined>;
+  publishClaim?(params: PublishClaimParams): Promise<PublishClaimResult>;
   confirmClaim?(params: { positions: PredictPosition[]; signer: Signer }): void;
 
   isEligible(): Promise<GeoBlockResponse>;


### PR DESCRIPTION
## **Description**

Adds Deposit Wallet support for the Predict claim flow.

Polymarket Deposit Wallet users still create a normal MetaMask claim confirmation so the transaction is visible in activity, but the signed confirmation transaction is not published directly. Instead, Predict intercepts pending claim transactions in the publish hook, submits the actual claim calls as a Polymarket Deposit Wallet relayer `WALLET` batch, waits only until the relayer returns a transaction hash, and returns that hash to TransactionController.

This PR preserves legacy Safe claim behavior: Safe users continue to sign and publish the existing Safe claim transaction path.

Key changes:
- Add Deposit Wallet claim planning that builds relayer calls from claimable positions.
- Mark Deposit Wallet claim confirmation transactions as externally signed before signing.
- Publish Deposit Wallet claims through the relayer batch and return as soon as a transaction hash is available.
- Trigger best-effort CLOB balance-allowance sync after confirmed claims.
- Wire Predict pending-claim context into `beforeSign` and `publish`.
- Add `skipInitialGasEstimate` to claim confirmation batch creation.

## **Changelog**

CHANGELOG entry: Fixed Predict claims for Polymarket Deposit Wallet users.

## **Related issues**

Fixes: [PRED-859](https://consensyssoftware.atlassian.net/browse/PRED-859)

## **Manual testing steps**

```gherkin
Feature: Predict Deposit Wallet claim flow

  Scenario: Deposit Wallet user claims resolved positions
    Given a Predict user is routed to a Polymarket Deposit Wallet
    And the user has claimable positions
    When the user starts the claim flow
    Then MetaMask shows the normal claim confirmation
    When the user approves the confirmation
    Then the claim is submitted through the Polymarket Deposit Wallet relayer
    And MetaMask activity tracks the returned transaction hash

  Scenario: legacy Safe user claims resolved positions
    Given a Predict user is routed to a legacy Safe wallet
    And the user has claimable positions
    When the user approves the claim confirmation
    Then the existing Safe claim publish path is used
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-859]: https://consensyssoftware.atlassian.net/browse/PRED-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes claim transaction `beforeSign`/`publish` behavior and introduces a new relayer-based submission path for deposit-wallet users, which could affect transaction lifecycle and activity tracking if metadata or batch matching is wrong.
> 
> **Overview**
> Adds **deposit-wallet support for Predict claims** by intercepting pending `predictClaim` transactions in `PredictController` and delegating `beforeSign`/`publish` to new provider hooks (`beforeSignClaim`, `publishClaim`). Deposit-wallet claims are now marked as *externally signed* before signing and are published via a Polymarket relayer `WALLET` batch (planned by new `planDepositWalletClaim`) while legacy Safe claims continue to pass through.
> 
> Claim batch submission is tweaked to set `skipInitialGasEstimate` and include the MATIC collateral gas token, and `confirmClaim` now triggers a best-effort deposit-wallet collateral allowance sync after claim confirmation. Tests are expanded/added across `PredictController`, `PolymarketProvider`, and new `preflight/claim` coverage for requirement filtering and call ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11a3c626a9639cfed55e9627de7ec5116b37fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->