### PR TITLE
ci: External distribution configuration with fastlane

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: 'MetaMask BETA & Release Candidates'
+      distribute_external:
+        description: 'Whether to distribute to external testers. Defaults to false; nightly-build.yml relies on the script default (true) so it always distributes externally.'
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       source_branch:
@@ -44,6 +49,11 @@ on:
           - 'MetaMask BETA & Release Candidates'
           - 'MM Card Team'
           - 'Ramp Provider Testing'
+      distribute_external:
+        description: 'Whether to distribute to external testers'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -79,6 +89,7 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
+      distribute_external: ${{ inputs.distribute_external }}
     secrets: inherit
 
   cleanup-build-branch:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,6 +31,7 @@ jobs:
       source_branch: main
       environment: exp
       testflight_group: 'MetaMask BETA & Release Candidates'
+      distribute_external: true
     secrets: inherit
 
   # ── iOS rc: build + TestFlight upload (after exp for sequential versions) ─
@@ -42,6 +43,7 @@ jobs:
       source_branch: main
       environment: rc
       testflight_group: 'MetaMask BETA & Release Candidates'
+      distribute_external: true
     secrets: inherit
 
   # ── Android exp: ephemeral branch + build ──────────────────────────────

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -39,6 +39,11 @@ on:
         description: 'The build number of the app (eg. 4134)'
         required: true
         type: string
+      distribute_external:
+        description: 'Whether to distribute to external testers. Set false for nightly/internal builds to avoid expiring previous TestFlight builds.'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -157,7 +162,8 @@ jobs:
             "github_actions_main-${{ inputs.environment }}" \
             "${{ inputs.source_branch }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "${{ inputs.testflight_group }}"
+            "${{ inputs.testflight_group }}" \
+            "${{ inputs.distribute_external }}"
 
       - name: Cleanup API Key
         if: always()


### PR DESCRIPTION

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Problem

Nightly iOS builds for a given app version (e.g. 7.78.0) were expiring all previous TestFlight builds, leaving only the most recent one active in the external testing group.

As a result, every nightly upload was calling `upload_to_testflight` with `distribute_external: true`, which causes Apple to automatically expire the previous build in the external group each time a new one is submitted.

### Solution

The `distribute_external` parameter is now threaded end-to-end through the full upload chain:

- **`scripts/upload-to-testflight.sh`**: Changed the default for the 5th argument from `true` to `false`, so callers must explicitly opt in to external distribution.
- **`upload-to-testflight.yml`**: Added `distribute_external` as a workflow input (default `true` for backwards compatibility with direct callers) and passes it as the 5th argument to the script.
- **`build-and-upload-to-testflight.yml`**: Added `distribute_external` as a workflow input (default `false` for both `workflow_call` and `workflow_dispatch`), and threads it through to `upload-to-testflight.yml`.
- **`nightly-build.yml`**: Explicitly passes `distribute_external: true` for both `ios-exp` and `ios-rc` jobs, so nightly builds continue to reach the external testing group (needed since the org exceeds the 100-person internal tester limit).

The intent is now explicit and self-documenting: nightly builds always go to the external group, while ad-hoc manual builds (triggered via `workflow_dispatch`) default to internal-only, avoiding accidental expiration of the active nightly build.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

No issue: CI regression fix — the issue's origin hasn't been found yet.

## **Manual testing steps**

```gherkin
Feature: TestFlight external distribution is configurable per caller

  Scenario: nightly build distributes to external testers
    Given the nightly-build.yml workflow is triggered on schedule
    When ios-exp and ios-rc jobs run
    Then distribute_external is true
    And the build is added to the "MetaMask BETA & Release Candidates" external group
    And previous builds for the same version are expired by Apple (expected Apple behaviour for external groups)

  Scenario: manual workflow_dispatch build does not expire the active nightly build
    Given a developer triggers build-and-upload-to-testflight.yml via workflow_dispatch
    And does not explicitly set distribute_external
    When the upload runs
    Then distribute_external defaults to false
    And the build is uploaded to TestFlight as internal-only
    And the active nightly build in the external group is not expired

  Scenario: explicit external distribution via workflow_dispatch
    Given a developer triggers build-and-upload-to-testflight.yml via workflow_dispatch
    And sets distribute_external to true
    When the upload runs
    Then the build is added to the selected external testing group
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
