### PR TITLE
test: add unit tests for Turkish locale placeholder validation

### DIFF
--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -1134,7 +1134,7 @@
       "edit_button": "Düzenle"
     },
     "stop_loss_prompt": {
-      "near_liquidation_title": "Likidasyona yalnızca %%{distance} uzaktasınız",
+      "near_liquidation_title": "Likidasyona yalnızca {{distance}}% uzaktasınız",
       "near_liquidation_subtitle": "Pozisyonunuzun riskini azaltmak için marj ekleyin",
       "add_margin_button": "Ekle",
       "protect_losses_title": "Daha fazla zarara karşı korunun",
@@ -1386,7 +1386,7 @@
         "current_price": "Mevcut fiyat",
         "liquidation_price": "Likidasyon fiyatı",
         "liquidation_distance": "Likidasyon mesafesi",
-        "liquidation_warning": "Fiyat %%{percentage} {{direction}} yaşarsa pozisyonunuz likidasyona uğrar",
+        "liquidation_warning": "Fiyat {{percentage}} {{direction}} yaşarsa pozisyonunuz likidasyona uğrar",
         "drops": "düşüş",
         "rises": "yükseliş",
         "set_leverage": "{{leverage}} kaldıraç ayarla"
@@ -1816,7 +1816,7 @@
         "provider_fee": "Sağlayıcı ücreti",
         "bridge_fee": "Köprü ücreti",
         "total": "Toplam ücretler",
-        "discount_message": "MetaMask Ödülleri ile %%{percentage} tasarruf ediyorsunuz."
+        "discount_message": "MetaMask Ödülleri ile {{percentage}}% tasarruf ediyorsunuz."
       },
       "closing_fees": {
         "title": "Kapatma ücretleri",
@@ -2515,7 +2515,7 @@
       "slippage": "Kayma",
       "price_details": "Fiyat bilgileri",
       "prediction_order": "Tahmin emri",
-      "prediction_order_description": "Her biri {{price}} fiyatta ~{{count}} sözleşme. Son tutar, emir defteri kullanılabilirliğe göre değişiklik gösterebilir (%%{slippage} orana kadar).",
+      "prediction_order_description": "Her biri {{price}} fiyatta ~{{count}} sözleşme. Son tutar, emir defteri kullanılabilirliğe göre değişiklik gösterebilir ({{slippage}}% orana kadar).",
       "metamask_fee_description": "Bu tahmin işlemine yönelik hizmet ücreti",
       "exchange_fee": "Borsa ücreti",
       "exchange_fee_description": "Borsaya veya piyasaya ödenen ücret",
@@ -5735,8 +5735,8 @@
     "included": "dahil",
     "max_gas_fee": "Maks. gaz ücreti",
     "edit": "Düzenle",
-    "quotes_include_fee": "%%{fee} MetaMask ücreti tekliflere dahildir",
-    "quotes_include_gas_and_metamask_fee": "Gaz ve %%{fee} MetaMask ücreti teklife dahildir",
+    "quotes_include_fee": "{{fee}}% MetaMask ücreti tekliflere dahildir",
+    "quotes_include_gas_and_metamask_fee": "Gaz ve {{fee}}% MetaMask ücreti teklife dahildir",
     "tap_to_swap": "Takas işlemi gerçekleştirmek için dokunun",
     "swipe_to_swap": "Swap gerçekleştirmek için kaydır",
     "swipe_to": "Swap gerçekleştirmek için",
@@ -6340,16 +6340,16 @@
   },
   "earn": {
     "claimable_bonus_tooltip": "mUSD tuttuğunuz için kazandığınız yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
-    "earn_a_percentage_bonus": "%%{percentage} bonus kazanın",
-    "percentage_bonus": "%%{percentage} bonus",
+    "earn_a_percentage_bonus": "{{percentage}}% bonus kazanın",
+    "percentage_bonus": "{{percentage}}% bonus",
     "claimable_bonus": "Alınabilir bonus",
     "claim_bonus": "Bonusu al",
     "claim_bonus_with_fiat": "{{amount}} al",
     "claim_bonus_subtitle": "Bonus, {{networkName}} üzerinde ödenecektir.",
-    "percentage_bonus_on_linea": "Linea üzerinde %%{percentage} bonus",
+    "percentage_bonus_on_linea": "Linea üzerinde {{percentage}}% bonus",
     "claim": "Al",
     "sounds_good": "Kulağa hoş geliyor",
-    "claimable_bonus_tooltip_with_percentage": "mUSD tuttuğunuz için kazandığınız %%{percentage} yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
+    "claimable_bonus_tooltip_with_percentage": "mUSD tuttuğunuz için kazandığınız {{percentage}}% yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz.",
     "your_bonus": "Bonusunuz",
     "estimated_annual_bonus": "Tahmini yıllık bonus",
     "lifetime_bonus_claimed": "Toplam bonus alındı",
@@ -6357,7 +6357,7 @@
     "no_accruing_bonus": "Biriken bonus yok",
     "claim_amount_bonus": "{{amount}}$ bonus al",
     "your_bonus_tooltip_your_bonus": "Bonusunuz",
-    "your_bonus_tooltip_your_bonus_desc": ":  Yalnızca mUSD tutarak kazandığınız %%{percentage} yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz. ",
+    "your_bonus_tooltip_your_bonus_desc": ":  Yalnızca mUSD tutarak kazandığınız {{percentage}}% yıllıklandırılmış bonus. Bonusunuzu Linea üzerinde günlük olarak alabilirsiniz. ",
     "your_bonus_tooltip_annual_bonus": "Tahmini yıllık bonus: ",
     "your_bonus_tooltip_annual_bonus_desc": "Mevcut bakiyenize ve oranınıza göre bir yıl içinde kazanabileceğiniz tahmini tutar. Oran değişkendir ve farklılık gösterebilir.",
     "your_bonus_tooltip_lifetime_bonus": "Alınan toplam bonus: ",
@@ -6448,14 +6448,14 @@
     "musd_conversion": {
       "ok": "Tamam",
       "continue": "Devam et",
-      "convert_and_get_percentage_bonus": "Dönüştür ve %%{percentage} al",
+      "convert_and_get_percentage_bonus": "Dönüştür ve {{percentage}}% al",
       "your_musd": "mUSD bakiyeniz",
       "balance_breakdown_title": "Ağa göre mUSD bakiyeleriniz",
       "balance_amount": "{{amount}} mUSD",
       "balance_amount_with_symbol": "{{amount}} {{symbol}}",
       "balance_fiat_unavailable": "—",
       "convert_to_musd": "mUSD'ye dönüştür",
-      "get_a_percentage_musd_bonus": "%%{percentage} mUSD bonus al",
+      "get_a_percentage_musd_bonus": "{{percentage}}% mUSD bonus al",
       "convert": "Dönüştür",
       "fetching_quote": "Teklif alınıyor...",
       "you_convert": "Dönüştürdüğünüz tutar",
@@ -6471,16 +6471,16 @@
         "failed": "mUSD dönüştürme işlemi başarısız oldu"
       },
       "education": {
-        "heading": "STABİL KRİPTO PARALARDA\n%%{percentage} AL",
-        "description": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz %%{percentage} oranına varan yıllıklandırılmış bonus kazanın.",
+        "heading": "STABİL KRİPTO PARALARDA\n{{percentage}}% AL",
+        "description": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz {{percentage}}% oranına varan yıllıklandırılmış bonus kazanın.",
         "terms_apply": "Şartlar uygulanır.",
         "primary_button": "Başlarken",
         "secondary_button": "Şimdi değil"
       },
       "buy_musd": "mUSD al",
       "get_musd": "mUSD kazan",
-      "bonus_title": "Stabil kripto paranızda %%{percentage} bonus kazanın",
-      "bonus_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve %%{percentage} oranında yıllıklandırılmış bonus alın.",
+      "bonus_title": "Stabil kripto paranızda {{percentage}}% bonus kazanın",
+      "bonus_description": "Stabil kripto paranızı mUSD'ye dönüştürün ve {{percentage}}% oranında yıllıklandırılmış bonus alın.",
       "powered_by_relay": "Destekleyen Relay",
       "max": "Maksimum",
       "quick_convert_button": "Dönüştür",
@@ -6488,15 +6488,15 @@
       "tooltip_title": "mUSD ile getiri elde et",
       "tooltip_content": "USDC, USDT veya DAI'nizi MetaMask'in dolar destekli stabil kripto parası olan mUSD'ye dönüştürün. Tuttuğunuz her dolar için {{apy}} getiri elde edin.",
       "quick_convert": {
-        "title": "Dönüştür ve %%{percentage} al",
-        "subtitle": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz %%{percentage} oranına varan yıllıklandırılmış bonus alın.",
+        "title": "Dönüştür ve {{percentage}}% al",
+        "subtitle": "Stabil kripto paralarınızı mUSD'ye dönüştürün ve günlük olarak alabileceğiniz {{percentage}}% oranına varan yıllıklandırılmış bonus alın.",
         "inline_failed_message": "Dönüştürme işlemi başarısız oldu. Tekrar deneyin.",
         "confirmation": {
           "title": "Maksimumu dönüştür"
         }
       },
-      "percentage_bonus": "%%{percentage} bonus",
-      "claim_percentage_bonus": "%%{percentage} bonus al",
+      "percentage_bonus": "{{percentage}}% bonus",
+      "claim_percentage_bonus": "{{percentage}}% bonus al",
       "rate": "Oran"
     },
     "bonus_claim": {
@@ -6519,7 +6519,7 @@
   },
   "money": {
     "title": "Para",
-    "apy_label": "%%{percentage} Yıllık Bileşik Getiri",
+    "apy_label": "{{percentage}}% Yıllık Bileşik Getiri",
     "apy_info_label": "Yıllık Yüzde Getiri (APY) bilgisi",
     "onboarding": {
       "step_progress": "Adım {{current}}/{{total}}",
@@ -6565,12 +6565,12 @@
       "subtitle": "Paranızı dilediğiniz yerde harcayın.",
       "virtual_card": "Sanal kart",
       "metal_card": "Metal kart",
-      "cashback": "%%{percentage} para iadesi",
+      "cashback": "{{percentage}}% para iadesi",
       "get_now": "Hemen alın",
       "link_title": "MetaMask Card'ı bağla",
       "link_subtitle": "Para bakiyenizi harcayın ve kazanın.",
       "link_bullet_cashback": "%3'e kadar para iadesi",
-      "link_bullet_apy": "%%{apy} APY'ye varan",
+      "link_bullet_apy": "{{apy}}% APY'ye varan",
       "link_card": "Kartı bağla"
     },
     "what_you_get": {
@@ -6834,7 +6834,7 @@
     "you_could_earn_up_to": "Yılda",
     "per_year_on_your_tokens": "kazanabilirsiniz",
     "deposit": "Para Yatır",
-    "gas_cost_impact_warning": "Uyarı: İşlemin gaz maliyeti yatırdığınız paranın %%{percentOverDeposit} fazlası olacaktır.",
+    "gas_cost_impact_warning": "Uyarı: İşlemin gaz maliyeti yatırdığınız paranın {{percentOverDeposit}}% fazlası olacaktır.",
     "earnings_history_title": "{{ticker}} kazançları",
     "apr": "APR",
     "interactive_chart": {
@@ -7202,7 +7202,7 @@
     "title": "Köprü",
     "submitting_transaction": "Gönderiliyor",
     "fetching_quote": "Teklif alınıyor",
-    "fee_disclaimer": "%%{feePercentage} MetaMask ücreti dahildir.",
+    "fee_disclaimer": "{{feePercentage}}% MetaMask ücreti dahildir.",
     "no_mm_fee": "MM ücreti yok",
     "token_suspicious": "Şüpheli",
     "token_malicious": "Kötü amaçlı",
@@ -7248,8 +7248,8 @@
     "confirm": "Onayla",
     "exceeding_upper_slippage_warning": "Yüksek kayma; bu durum istenmeyen bir takas ile sonuçlanabilir",
     "exceeding_lower_slippage_warning": "Düşük kayma; bu durum istenmeyen bir takas ile sonuçlanabilir",
-    "exceeding_lower_slippage_error": "%%{value} değerin üzerinde olan bir değer girin",
-    "exceeding_upper_slippage_error": "%%{value} değerin üzerinde olan bir değer giremezsiniz",
+    "exceeding_lower_slippage_error": "{{value}}% değerin üzerinde olan bir değer girin",
+    "exceeding_upper_slippage_error": "{{value}}% değerin üzerinde olan bir değer giremezsiniz",
     "custom": "Özel",
     "invalid_recipient_address": "Geçersiz adres",
     "select_quote": "Teklif Seç",
@@ -8984,7 +8984,7 @@
       },
       "cash_filled_state": {
         "add": "Ekle",
-        "apy": "%%{percentage} Yıllık Bileşik Getiri"
+        "apy": "{{percentage}}% Yıllık Bileşik Getiri"
       },
       "tokens": "tokenlar",
       "perpetuals": "Sürekli Vadeli İşlemler",

--- a/locales/tr.placeholders.test.js
+++ b/locales/tr.placeholders.test.js
@@ -1,0 +1,39 @@
+import tr from './languages/tr.json';
+
+/**
+ * Recursively collects leaf string values from nested locale objects.
+ *
+ * @param {unknown} node - Current JSON node.
+ * @param {string} path - Dot/bracket path for failure messages.
+ * @param {Array<{ path: string; value: string }>} acc - Collected strings.
+ */
+function collectStrings(node, path, acc) {
+  if (typeof node === 'string') {
+    acc.push({ path, value: node });
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((item, index) => {
+      collectStrings(item, `${path}[${index}]`, acc);
+    });
+    return;
+  }
+  if (node !== null && typeof node === 'object') {
+    for (const [key, child] of Object.entries(node)) {
+      const nextPath = path ? `${path}.${key}` : key;
+      collectStrings(child, nextPath, acc);
+    }
+  }
+}
+
+describe('Turkish locale (tr.json)', () => {
+  it('contains no %{{ substrings in any translation value', () => {
+    /** @type {Array<{ path: string; value: string }>} */
+    const strings = [];
+    collectStrings(tr, '', strings);
+
+    const offenders = strings.filter(({ value }) => value.includes('%{{'));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/locales/tr.placeholders.test.js
+++ b/locales/tr.placeholders.test.js
@@ -27,12 +27,26 @@ function collectStrings(node, path, acc) {
 }
 
 describe('Turkish locale (tr.json)', () => {
-  it('contains no %{{ substrings in any translation value', () => {
+  /** @type {() => Array<{ path: string; value: string }>} */
+  function getAllLeafStrings() {
     /** @type {Array<{ path: string; value: string }>} */
     const strings = [];
     collectStrings(tr, '', strings);
+    return strings;
+  }
 
-    const offenders = strings.filter(({ value }) => value.includes('%{{'));
+  it('contains no %{{ substrings in any translation value', () => {
+    const offenders = getAllLeafStrings().filter(({ value }) =>
+      value.includes('%{{'),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not use %%{…} (literal % before placeholder); use {{…}}% like other locales', () => {
+    const offenders = getAllLeafStrings().filter(({ value }) =>
+      value.includes('%%{'),
+    );
 
     expect(offenders).toEqual([]);
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Crowdin sometimes emits Turkish copy as %{{name}} next to ICU-style {{…}}. In i18n-js, % + { starts a %{…} placeholder, so %{{…}} breaks interpolation and users see missing-placeholder text.

Changes: locales/languages/tr.json — replace the old %%{placeholder} pattern with {{placeholder}}% where values are plain numbers (aligned with English). Keep perps.order.leverage_modal.liquidation_warning as {{percentage}} only (no extra % in the string), because the app already passes a value that includes %.

Tests: locales/tr.placeholders.test.js walks every string in tr.json and fails if any value contains %{{ or %%{, so CI catches bad Crowdin exports quickly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Turkish translation strings and a Jest test that validates placeholder formatting, with no runtime logic changes beyond string interpolation behavior.
> 
> **Overview**
> Fixes Turkish `tr.json` percent placeholders by replacing `%%{...}`/`%{{...}}`-style patterns with `{{...}}%` so interpolation works correctly.
> 
> Adds `locales/tr.placeholders.test.js`, which recursively scans all leaf strings in `tr.json` and fails CI if any translation contains `%{{` or `%%{` to catch bad Crowdin exports early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb8b9c03a62a8e11e09f04c2f0769b139ef14ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->