### PR TITLE
revert: remove CocoaPods specs cache from iOS production build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,16 +333,6 @@ jobs:
           SECRETS_JSON: ${{ toJSON(secrets) }}
         run: node scripts/validate-secrets-from-config.js
 
-      - name: Restore CocoaPods specs cache (iOS)
-        if: matrix.platform == 'ios'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cocoapods/repos
-          key: ${{ runner.os }}-cocoapods-specs-${{ hashFiles('ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-specs-
-        continue-on-error: true
-
       # iOS: Install Pods here so generated paths match this runner (setup-node-modules skips pod install with --no-install-pods).
       - name: Install CocoaPods dependencies (iOS)
         if: matrix.platform == 'ios'


### PR DESCRIPTION
## **Description**

Reverts #29798.

Post-merge measurements showed the CocoaPods specs cache (`~/.cocoapods/repos`) is a net regression for production iOS builds. The ~1.45 GiB compressed cache takes ~2m30s to restore, while the `pod install` step it was meant to accelerate only saved ~3s on average. End-to-end, the CocoaPods area went from 1m 47s (baseline) to 4m 14s (with cache) -- a **2m 27s regression per iOS production build**.

| State | Cache Restore | Pod Install | Combined |
|---|---|---|---|
| Before PR 29798 (n=3) | n/a | 1m 47s | 1m 47s |
| After PR 29798 (n=3, cache hits) | 2m 30s | 1m 44s | 4m 14s |
| **Regression** | | | **+2m 27s** |

Measured run links:
- Before: [25440409992](https://github.com/MetaMask/metamask-mobile/actions/runs/25440409992/job/74633305319), [25440100695](https://github.com/MetaMask/metamask-mobile/actions/runs/25440100695/job/74632004709), [25343223005](https://github.com/MetaMask/metamask-mobile/actions/runs/25343223005/job/74308768997)
- After: [25549182098](https://github.com/MetaMask/metamask-mobile/actions/runs/25549182098/job/74993873213), [25555384675](https://github.com/MetaMask/metamask-mobile/actions/runs/25555384675/job/75014455797), [25558954751](https://github.com/MetaMask/metamask-mobile/actions/runs/25558954751/job/75028686590)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MCWP-574

## **Manual testing steps**

```gherkin
Feature: iOS production build without CocoaPods specs cache

  Scenario: iOS build completes without cache step
    Given a production iOS build is triggered via workflow_dispatch
    When the build job runs for iOS
    Then there is no "Restore CocoaPods specs cache" step
    And "Install CocoaPods dependencies (iOS)" completes at baseline timing (~1m 47s)
    And the build produces a valid IPA artifact
```

## **Screenshots/Recordings**

N/A -- CI workflow change only, no UI impact.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.