### PR TITLE
refactor: add central convertTransactionToRedeemDelegations matching extension

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -697,7 +697,6 @@ describe('Transaction Controller Init', () => {
         expect(Delegation7702PublishHookMock).toHaveBeenCalledWith({
           isAtomicBatchSupported: expect.any(Function),
           messenger: expect.any(Object),
-          getNextNonce: expect.any(Function),
         });
         expect(mockDelegation7702Hook).toHaveBeenCalled();
         expect(result).toEqual({ transactionHash: '0xde702' });
@@ -1011,48 +1010,6 @@ describe('Transaction Controller Init', () => {
 
       expect(await optionFn?.(mockTransactionMeta)).toBe(true);
     });
-  });
-
-  it('calls getNonceLock and releaseLock via Delegation7702PublishHook getNextNonce', async () => {
-    accountSupports7702Mock.mockResolvedValue(true);
-    const releaseLockMock = jest.fn();
-    const getNonceLockMock = jest.fn().mockResolvedValue({
-      nextNonce: 99,
-      releaseLock: releaseLockMock,
-    });
-
-    isSendBundleSupportedMock.mockResolvedValue(false);
-    transactionControllerClassMock.mockImplementation(
-      () =>
-        ({
-          getNonceLock: getNonceLockMock,
-          isAtomicBatchSupported: jest.fn().mockResolvedValue([]),
-        }) as unknown as TransactionController,
-    );
-
-    let capturedGetNextNonce:
-      | ((address: string, networkClientId: string) => Promise<Hex>)
-      | undefined;
-    jest.mocked(Delegation7702PublishHook).mockImplementation((opts) => {
-      capturedGetNextNonce = opts.getNextNonce;
-      return {
-        getHook: () => async () => ({ transactionHash: '0xde702' }),
-      } as unknown as InstanceType<typeof Delegation7702PublishHook>;
-    });
-
-    const hooks = testConstructorOption('hooks', {
-      getNonceLock: getNonceLockMock,
-    });
-
-    await hooks?.publish?.({
-      ...MOCK_TRANSACTION_META,
-      chainId: '0x13',
-    });
-
-    const resultNonce = await capturedGetNextNonce?.('0xabc', 'testNetwork');
-    expect(getNonceLockMock).toHaveBeenCalledWith('0xabc', 'testNetwork');
-    expect(releaseLockMock).toHaveBeenCalled();
-    expect(resultNonce).toBe(toHex(99));
   });
 
   it('calls 7702 publish hook if isExternalSign', async () => {

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -15,7 +15,9 @@ import {
   TransactionControllerAddTransactionAction,
   TransactionControllerAddTransactionBatchAction,
   TransactionControllerEstimateGasBatchAction,
+  TransactionControllerGetNonceLockAction,
   TransactionControllerGetStateAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
   TransactionControllerMessenger,
   TransactionControllerStateChangeEvent,
   TransactionControllerTransactionApprovedEvent,
@@ -131,7 +133,9 @@ type InitMessengerActions =
   | TransactionControllerAddTransactionAction
   | TransactionControllerAddTransactionBatchAction
   | TransactionControllerEstimateGasBatchAction
+  | TransactionControllerGetNonceLockAction
   | TransactionControllerGetStateAction
+  | TransactionControllerIsAtomicBatchSupportedAction
   | TransactionControllerUpdateTransactionAction
   | TransactionPayControllerActions
   | AnalyticsControllerActions
@@ -198,7 +202,9 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:addTransaction',
       'TransactionController:addTransactionBatch',
       'TransactionController:estimateGasBatch',
+      'TransactionController:getNonceLock',
       'TransactionController:getState',
+      'TransactionController:isAtomicBatchSupported',
       'TransactionController:updateTransaction',
       'TransactionPayController:getAmountData',
       'TransactionPayController:getDelegationTransaction',

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -1,5 +1,4 @@
 import {
-  IsAtomicBatchSupportedRequest,
   TransactionController,
   TransactionMeta,
 } from '@metamask/transaction-controller';
@@ -12,18 +11,6 @@ const mockGetNonceLock = jest.fn();
 const mockIsAtomicBatchSupported: jest.MockedFn<
   TransactionController['isAtomicBatchSupported']
 > = jest.fn();
-
-jest.spyOn(Math, 'random').mockReturnValue(0);
-
-jest.mock('../../core/Engine', () => ({
-  context: {
-    TransactionController: {
-      getNonceLock: () => mockGetNonceLock(),
-      isAtomicBatchSupported: (request: IsAtomicBatchSupportedRequest) =>
-        mockIsAtomicBatchSupported(request),
-    },
-  },
-}));
 
 const DELEGATION_SIGNATURE_MOCK = '0x111222333';
 const UPGRADE_CONTRACT_ADDRESS_MOCK = '0x456' as Hex;
@@ -68,6 +55,16 @@ describe('Transaction Delegation Utils', () => {
     messengerMock.registerActionHandler(
       'KeyringController:signEip7702Authorization',
       sign7702Mock,
+    );
+
+    messengerMock.registerActionHandler(
+      'TransactionController:getNonceLock',
+      mockGetNonceLock,
+    );
+
+    messengerMock.registerActionHandler(
+      'TransactionController:isAtomicBatchSupported',
+      mockIsAtomicBatchSupported,
     );
 
     signDelegationMock.mockResolvedValue(DELEGATION_SIGNATURE_MOCK);

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -1,5 +1,8 @@
 import {
   AuthorizationList,
+  TransactionControllerGetNonceLockAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
+  TransactionEnvelopeType,
   TransactionMeta,
   decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
@@ -16,17 +19,16 @@ import {
 import {
   ANY_BENEFICIARY,
   Delegation,
+  ROOT_AUTHORITY,
   UnsignedDelegation,
-  createDelegation,
   encodeRedeemDelegations,
 } from '../../core/Delegation/delegation';
-import { Hex, createProjectLogger } from '@metamask/utils';
+import { Hex, bytesToHex, createProjectLogger } from '@metamask/utils';
 import { limitedCalls } from '../../core/Delegation/caveatBuilder/limitedCallsBuilder';
 import { Messenger } from '@metamask/messenger';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
 import { toHex } from '@metamask/controller-utils';
-import Engine from '../../core/Engine';
 import { exactExecutionBatch } from '../../core/Delegation/caveatBuilder/exactExecutionBatchBuilder';
 import { exactExecution } from '../../core/Delegation/caveatBuilder/exactExecutionBuilder';
 
@@ -35,9 +37,34 @@ const log = createProjectLogger('transaction-delegation');
 export type SignMessenger = Messenger<
   string,
   | DelegationControllerSignDelegationAction
-  | KeyringControllerSignEip7702AuthorizationAction,
+  | KeyringControllerSignEip7702AuthorizationAction
+  | TransactionControllerGetNonceLockAction
+  | TransactionControllerIsAtomicBatchSupportedAction,
   never
 >;
+
+export interface AuthorizationRequest {
+  minimal?: boolean;
+  upgradeContractAddress?: Hex;
+  upgradeExistingDelegation?: boolean;
+}
+
+export interface ConvertTransactionToRedeemDelegationsRequest {
+  additionalExecutions?: ExecutionStruct[];
+  authorization?: AuthorizationRequest;
+  caveats?: Caveat[];
+  delegatee?: Hex;
+  delegationSignature?: Hex;
+  messenger: SignMessenger;
+  transaction: TransactionMeta;
+}
+
+export interface ConvertTransactionToRedeemDelegationsResult {
+  authorizationList?: AuthorizationList;
+  data: Hex;
+  to: Hex;
+  type: TransactionEnvelopeType;
+}
 
 export interface DelegationTransaction {
   authorizationList?: AuthorizationList;
@@ -46,95 +73,217 @@ export interface DelegationTransaction {
   value: Hex;
 }
 
+export async function convertTransactionToRedeemDelegations(
+  request: ConvertTransactionToRedeemDelegationsRequest,
+): Promise<ConvertTransactionToRedeemDelegationsResult> {
+  const { transaction, messenger } = request;
+  const { chainId } = transaction;
+  const environment = getDeleGatorEnvironment(parseInt(chainId, 16));
+
+  const defaultExecutions = getDefaultTransactionExecutions(transaction);
+  const additionalExecutions = request.additionalExecutions ?? [];
+  const executions: ExecutionStruct[][] = [
+    [...defaultExecutions, ...additionalExecutions],
+  ];
+
+  const caveats =
+    request.caveats ?? buildDefaultCaveats(environment, executions[0]);
+
+  const modes: ExecutionMode[] = [
+    executions[0].length > 1 ? BATCH_DEFAULT_MODE : SINGLE_DEFAULT_MODE,
+  ];
+
+  const delegations = await signAndWrapDelegation({
+    transaction,
+    caveats,
+    messenger,
+    delegatee: request.delegatee,
+    delegationSignature: request.delegationSignature,
+  });
+
+  log('Built delegations', { delegations, modes, executions });
+
+  const data = encodeRedeemDelegations({
+    delegations,
+    modes,
+    executions,
+  });
+
+  const authorizationList = request.authorization
+    ? await buildAuthorizationList(transaction, messenger, request.authorization)
+    : undefined;
+
+  return {
+    authorizationList,
+    data,
+    to: environment.DelegationManager as Hex,
+    type: authorizationList
+      ? TransactionEnvelopeType.setCode
+      : (transaction.txParams.type as TransactionEnvelopeType),
+  };
+}
+
 export async function getDelegationTransaction<
   MessengerType extends SignMessenger,
 >(
   messenger: MessengerType,
   transaction: TransactionMeta,
 ): Promise<DelegationTransaction> {
-  const { chainId } = transaction;
-  const delegationEnvironment = getDeleGatorEnvironment(parseInt(chainId, 16));
-
-  const delegationManagerAddress =
-    delegationEnvironment.DelegationManager as Hex;
-
-  const delegations = await buildDelegation(
-    delegationEnvironment,
-    transaction,
-    messenger,
-  );
-
-  const executions = buildExecutions(transaction);
-
-  const modes: ExecutionMode[] = [
-    executions[0].length > 1 ? BATCH_DEFAULT_MODE : SINGLE_DEFAULT_MODE,
-  ];
-
-  log('Built delegations', { delegations, modes, executions });
-
-  const transactionData = encodeRedeemDelegations({
-    delegations,
-    modes,
-    executions,
-  });
-
-  const authorizationList = await buildAuthorizationList(
-    transaction,
-    messenger,
-  );
+  const { authorizationList, data, to } =
+    await convertTransactionToRedeemDelegations({
+      transaction,
+      messenger,
+      authorization: {},
+    });
 
   return {
     authorizationList,
-    data: transactionData,
-    to: delegationManagerAddress,
+    data,
+    to,
     value: '0x0',
   };
 }
 
-async function buildAuthorizationList<MessengerType extends SignMessenger>(
-  transactionMeta: TransactionMeta,
-  messenger: MessengerType,
-): Promise<AuthorizationList | undefined> {
-  const { TransactionController } = Engine.context;
-  const { chainId, networkClientId, txParams } = transactionMeta;
-  const { from } = txParams;
-
-  const atomicBatchResult = await TransactionController.isAtomicBatchSupported({
-    address: from as Hex,
-    chainIds: [chainId],
-  });
-
-  const chainResult = atomicBatchResult.find(
-    (r) => r.chainId.toLowerCase() === chainId.toLowerCase(),
-  );
-
-  if (!chainResult) {
-    throw new Error('Chain does not support EIP-7702');
+function normalizeCallData(data: unknown): Hex {
+  if (typeof data !== 'string' || data.length === 0) {
+    return '0x';
   }
 
-  const { delegationAddress, isSupported, upgradeContractAddress } =
-    chainResult;
+  const hasHexPrefix = data.slice(0, 2).toLowerCase() === '0x';
+  const lower = data.toLowerCase();
+  const prefixed = hasHexPrefix ? `0x${lower.slice(2)}` : `0x${lower}`;
+  const hexBody = prefixed.slice(2);
 
-  if (isSupported) {
-    log('Skipping authorization as already upgraded');
+  if (hexBody.length === 0) {
+    return '0x';
+  }
+
+  if (hexBody.length % 2 !== 0) {
+    return normalizeCallData(`0x0${hexBody}`);
+  }
+
+  return prefixed as Hex;
+}
+
+function getDefaultTransactionExecutions(
+  transactionMeta: TransactionMeta,
+): ExecutionStruct[] {
+  const { nestedTransactions, txParams } = transactionMeta;
+
+  if (nestedTransactions?.length && nestedTransactions[0].to) {
+    return nestedTransactions.map((tx) => ({
+      target: tx.to as Hex,
+      value: BigInt(tx.value ?? '0x0'),
+      callData: normalizeCallData(tx.data),
+    }));
+  }
+
+  if (!txParams.to) {
+    return [];
+  }
+
+  return [
+    {
+      target: txParams.to as Hex,
+      value: BigInt((txParams.value as Hex) ?? '0x0'),
+      callData: normalizeCallData(txParams.data),
+    },
+  ];
+}
+
+function buildDefaultCaveats(
+  environment: DeleGatorEnvironment,
+  executions: ExecutionStruct[],
+): Caveat[] {
+  const caveatBuilder = createCaveatBuilder(environment);
+
+  caveatBuilder.addCaveat(limitedCalls, 1);
+
+  if (executions.length > 1) {
+    const executionParams = executions.map((ex) => ({
+      to: ex.target as string,
+      value: toHex(ex.value),
+      data: ex.callData as string | undefined,
+    }));
+    caveatBuilder.addCaveat(exactExecutionBatch, executionParams);
+  } else if (executions.length === 1) {
+    const ex = executions[0];
+    caveatBuilder.addCaveat(
+      exactExecution,
+      ex.target as string,
+      toHex(ex.value),
+      ex.callData as string | undefined,
+    );
+  }
+
+  return caveatBuilder.build();
+}
+
+async function signAndWrapDelegation({
+  transaction,
+  caveats,
+  messenger,
+  delegatee,
+  delegationSignature,
+}: {
+  transaction: TransactionMeta;
+  caveats: Caveat[];
+  messenger: SignMessenger;
+  delegatee?: Hex;
+  delegationSignature?: Hex;
+}): Promise<Delegation[][]> {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const salt = bytesToHex(bytes);
+
+  const unsignedDelegation: UnsignedDelegation = {
+    delegator: transaction.txParams.from as Hex,
+    delegate: delegatee ?? ANY_BENEFICIARY,
+    authority: ROOT_AUTHORITY,
+    salt,
+    caveats,
+  };
+
+  log('Signing delegation', unsignedDelegation);
+
+  const signature =
+    delegationSignature ??
+    ((await messenger.call('DelegationController:signDelegation', {
+      chainId: transaction.chainId,
+      delegation: unsignedDelegation,
+    })) as Hex);
+
+  log('Delegation signature', signature);
+
+  return [[{ ...unsignedDelegation, signature }]];
+}
+
+async function buildAuthorizationList(
+  transactionMeta: TransactionMeta,
+  messenger: SignMessenger,
+  authorization: AuthorizationRequest,
+): Promise<AuthorizationList | undefined> {
+  const upgradeContractAddress = await resolveUpgradeContractAddress(
+    transactionMeta,
+    messenger,
+    authorization,
+  );
+
+  if (!upgradeContractAddress) {
     return undefined;
   }
 
-  if (!delegationAddress) {
-    log('Upgrading account to EIP-7702', { from, upgradeContractAddress });
-  } else {
-    log('Overwriting authorization as already upgraded', {
-      from,
-      current: delegationAddress,
-      new: upgradeContractAddress,
-    });
+  if (authorization.minimal) {
+    return [{ address: upgradeContractAddress }];
   }
 
-  if (!upgradeContractAddress) {
-    throw new Error('Upgrade contract address not found');
-  }
+  const { chainId, networkClientId, txParams } = transactionMeta;
+  const { from } = txParams;
 
-  const nonceLock = await TransactionController.getNonceLock(
+  log('Upgrading account to EIP-7702', { from, upgradeContractAddress });
+
+  const nonceLock = await messenger.call(
+    'TransactionController:getNonceLock',
     from,
     networkClientId,
   );
@@ -176,99 +325,60 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
   ];
 }
 
-async function buildDelegation<MessengerType extends SignMessenger>(
-  delegationEnvironment: DeleGatorEnvironment,
+async function resolveUpgradeContractAddress(
   transactionMeta: TransactionMeta,
-  messenger: MessengerType,
-): Promise<Delegation[][]> {
-  const unsignedDelegation = buildUnsignedDelegation(
-    delegationEnvironment,
-    transactionMeta,
+  messenger: SignMessenger,
+  authorization: AuthorizationRequest,
+): Promise<Hex | undefined> {
+  if (authorization.upgradeContractAddress) {
+    return authorization.upgradeContractAddress;
+  }
+
+  const { chainId, txParams } = transactionMeta;
+  const { from } = txParams;
+
+  const atomicBatchResult = await messenger.call(
+    'TransactionController:isAtomicBatchSupported',
+    {
+      address: from as Hex,
+      chainIds: [chainId],
+    },
   );
 
-  log('Signing delegation');
+  const chainResult = atomicBatchResult.find(
+    (r) => r.chainId.toLowerCase() === chainId.toLowerCase(),
+  );
 
-  const delegationSignature = (await messenger.call(
-    'DelegationController:signDelegation',
-    {
-      chainId: transactionMeta.chainId,
-      delegation: unsignedDelegation,
-    },
-  )) as Hex;
+  if (!chainResult) {
+    throw new Error('Chain does not support EIP-7702');
+  }
 
-  log('Delegation signature', delegationSignature);
+  const { delegationAddress, isSupported, upgradeContractAddress } =
+    chainResult;
 
-  const delegations: Delegation[][] = [
-    [
-      {
-        ...unsignedDelegation,
+  if (isSupported) {
+    log('Skipping authorization as already upgraded');
+    return undefined;
+  }
 
-        signature: delegationSignature,
-      },
-    ],
-  ];
-
-  return delegations;
-}
-
-function buildExecutions(
-  transactionMeta: TransactionMeta,
-): ExecutionStruct[][] {
-  const { nestedTransactions } = transactionMeta;
-
-  return [
-    (nestedTransactions ?? []).map((tx) => ({
-      target: tx.to as Hex,
-      value: BigInt(tx.value ?? '0x0'),
-      callData: tx.data as Hex,
-    })),
-  ];
-}
-
-function buildUnsignedDelegation(
-  environment: DeleGatorEnvironment,
-  transactionMeta: TransactionMeta,
-): UnsignedDelegation {
-  const caveats = buildCaveats(environment, transactionMeta);
-
-  log('Caveats', caveats);
-
-  const delegation = createDelegation({
-    from: transactionMeta.txParams.from as Hex,
-    to: ANY_BENEFICIARY,
-    caveats,
-  });
-
-  log('Delegation', delegation);
-
-  return delegation;
-}
-
-function buildCaveats(
-  environment: DeleGatorEnvironment,
-  transaction: TransactionMeta,
-): Caveat[] {
-  const caveatBuilder = createCaveatBuilder(environment);
-  const { nestedTransactions } = transaction;
-
-  const executions = (transaction.nestedTransactions ?? []).map((tx) => ({
-    to: tx.to as string,
-    value: tx.value ?? '0x0',
-    data: tx.data as string | undefined,
-  }));
-
-  if ((nestedTransactions ?? []).length > 1) {
-    caveatBuilder.addCaveat(exactExecutionBatch, executions);
-  } else {
-    caveatBuilder.addCaveat(
-      exactExecution,
-      executions[0].to,
-      executions[0].value,
-      executions[0].data,
+  if (delegationAddress && authorization.upgradeExistingDelegation === false) {
+    throw new Error(
+      `Account is already upgraded to a different delegation address: ${delegationAddress}`,
     );
   }
 
-  caveatBuilder.addCaveat(limitedCalls, 1);
+  if (!upgradeContractAddress) {
+    throw new Error('Upgrade contract address not found');
+  }
 
-  return caveatBuilder.build();
+  if (delegationAddress) {
+    log('Overwriting existing delegation', {
+      current: delegationAddress,
+      new: upgradeContractAddress,
+    });
+  }
+
+  return upgradeContractAddress;
 }
+
+

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -12,14 +12,21 @@ import {
 } from '@metamask/keyring-controller';
 import {
   GasFeeToken,
+  IsAtomicBatchSupportedRequest,
   TransactionController,
+  TransactionControllerGetNonceLockAction,
+  TransactionControllerGetStateAction,
   TransactionControllerState,
+  TransactionControllerUpdateTransactionAction,
   TransactionMeta,
   TransactionType,
-  TransactionControllerGetStateAction,
-  TransactionControllerUpdateTransactionAction,
 } from '@metamask/transaction-controller';
 import { getDeleGatorEnvironment } from '../../../core/Delegation';
+import {
+  encodePermissionContexts,
+  encodeRedeemDelegations,
+} from '../../../core/Delegation/delegation';
+import { encodeExecutionCalldatas } from '../../../core/Delegation/execution';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
 import {
   RelayStatus,
@@ -27,14 +34,20 @@ import {
   waitForRelayResult,
 } from '../transaction-relay';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
-import { NetworkClientId } from '@metamask/network-controller';
 import { Hex } from '@metamask/utils';
+
+const mockGetNonceLock = jest.fn();
 
 jest.mock('../transaction-relay');
 jest.mock('../../../core/Delegation/delegation', () => ({
   ...jest.requireActual('../../../core/Delegation/delegation'),
-  encodeRedeemDelegations: jest.fn(() => '0xdeadbeef'),
-  signDelegation: jest.fn(async () => '0xsignature'),
+  encodeRedeemDelegations: jest.fn(),
+  encodePermissionContexts: jest.fn(),
+  signDelegation: jest.fn(),
+}));
+jest.mock('../../../core/Delegation/execution', () => ({
+  ...jest.requireActual('../../../core/Delegation/execution'),
+  encodeExecutionCalldatas: jest.fn(),
 }));
 
 const SIGNED_TX_MOCK = '0x1234';
@@ -45,6 +58,7 @@ const AUTHORIZATION_SIGNATURE_MOCK =
   '0xf85c827a6994663f3ad617193148711d28f5334ee4ed070166028080a040e292da533253143f134643a03405f1af1de1d305526f44ed27e62061368d4ea051cfb0af34e491aa4d6796dececf95569088322e116c4b2f312bb23f20699269';
 const UPGRADE_CONTRACT_ADDRESS_MOCK =
   '0x12345678901234567890123456789012345678a4';
+const NONCE_MOCK = 7;
 
 const TRANSACTION_META_MOCK = {
   chainId: '0x1',
@@ -105,9 +119,6 @@ describe('Delegation 7702 Publish Hook', () => {
   const signDelegationControllerMock: jest.MockedFn<
     DelegationControllerSignDelegationAction['handler']
   > = jest.fn();
-  const getNextNonceMock: jest.MockedFn<
-    (address: string, networkClientId: NetworkClientId) => Promise<Hex>
-  > = jest.fn();
   const getStateMock: jest.MockedFn<
     TransactionControllerGetStateAction['handler']
   > = jest.fn();
@@ -118,6 +129,10 @@ describe('Delegation 7702 Publish Hook', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    jest.mocked(encodeRedeemDelegations).mockReturnValue('0xdeadbeef' as Hex);
+    jest.mocked(encodePermissionContexts).mockReturnValue([]);
+    jest.mocked(encodeExecutionCalldatas).mockReturnValue([]);
+
     const rootMessenger = getRootMessenger();
 
     messenger = new Messenger<
@@ -126,6 +141,7 @@ describe('Delegation 7702 Publish Hook', () => {
       | DelegationControllerSignDelegationAction
       | KeyringControllerSignEip7702AuthorizationAction
       | KeyringControllerSignTypedMessageAction
+      | TransactionControllerGetNonceLockAction
       | TransactionControllerGetStateAction
       | TransactionControllerUpdateTransactionAction,
       never,
@@ -141,6 +157,7 @@ describe('Delegation 7702 Publish Hook', () => {
         'KeyringController:signTypedMessage',
         'BridgeStatusController:getState',
         'DelegationController:signDelegation',
+        'TransactionController:getNonceLock',
         'TransactionController:getState',
         'TransactionController:updateTransaction',
       ],
@@ -161,6 +178,10 @@ describe('Delegation 7702 Publish Hook', () => {
       signDelegationControllerMock,
     );
     rootMessenger.registerActionHandler(
+      'TransactionController:getNonceLock',
+      mockGetNonceLock,
+    );
+    rootMessenger.registerActionHandler(
       'TransactionController:getState',
       getStateMock,
     );
@@ -172,10 +193,13 @@ describe('Delegation 7702 Publish Hook', () => {
     hookClass = new Delegation7702PublishHook({
       isAtomicBatchSupported: isAtomicBatchSupportedMock,
       messenger,
-      getNextNonce: getNextNonceMock,
     });
 
     isAtomicBatchSupportedMock.mockResolvedValue([]);
+    mockGetNonceLock.mockResolvedValue({
+      nonceDetails: { params: { nextNetworkNonce: NONCE_MOCK } },
+      releaseLock: jest.fn(),
+    });
     signTypedMessageMock.mockResolvedValue(DELEGATION_SIGNATURE_MOCK);
     signDelegationControllerMock.mockResolvedValue(DELEGATION_SIGNATURE_MOCK);
     submitRelayTransactionMock.mockResolvedValue({
@@ -505,8 +529,7 @@ describe('Delegation 7702 Publish Hook', () => {
 
       expect(signDelegationControllerMock).toHaveBeenCalledTimes(1);
       const signArgs = signDelegationControllerMock.mock.calls[0][0];
-      // Should only have limitedCalls caveat, no execution caveats for deployment
-      expect(signArgs.delegation.caveats).toHaveLength(1);
+      expect(signArgs.delegation.caveats).toHaveLength(2);
     });
 
     it('handles contract deployment (no "to" address) for gasless flow', async () => {
@@ -532,8 +555,8 @@ describe('Delegation 7702 Publish Hook', () => {
 
       expect(signDelegationControllerMock).toHaveBeenCalledTimes(1);
       const signArgs = signDelegationControllerMock.mock.calls[0][0];
-      // Should only have limitedCalls caveat for deployment
       expect(signArgs.delegation.caveats).toHaveLength(1);
+      expect(submitRelayTransactionMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -645,7 +668,7 @@ describe('Delegation 7702 Publish Hook', () => {
           {
             address: UPGRADE_CONTRACT_ADDRESS_MOCK,
             chainId: TRANSACTION_META_MOCK.chainId,
-            nonce: TRANSACTION_META_MOCK.txParams.nonce,
+            nonce: toHex(NONCE_MOCK),
             r: expect.any(String),
             s: expect.any(String),
             yParity: expect.any(String),

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -1,7 +1,6 @@
 import { Interface } from '@ethersproject/abi';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import {
-  AuthorizationList,
   GasFeeToken,
   IsAtomicBatchSupportedRequest,
   IsAtomicBatchSupportedResult,
@@ -9,29 +8,9 @@ import {
   PublishHookResult,
   TransactionMeta,
   TransactionType,
-  decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger } from '@metamask/utils';
-import {
-  ANY_BENEFICIARY,
-  BATCH_DEFAULT_MODE,
-  Caveat,
-  DeleGatorEnvironment,
-  ExecutionMode,
-  ExecutionStruct,
-  SINGLE_DEFAULT_MODE,
-  UnsignedDelegation,
-  createCaveatBuilder,
-  createDelegation,
-  getDeleGatorEnvironment,
-} from '../../../core/Delegation';
-import { exactExecution } from '../../../core/Delegation/caveatBuilder/exactExecutionBuilder';
-import { limitedCalls } from '../../../core/Delegation/caveatBuilder/limitedCallsBuilder';
-import { specificActionERC20TransferBatch } from '../../../core/Delegation/caveatBuilder/specificActionERC20TransferBatchBuilder';
-import {
-  Delegation,
-  encodeRedeemDelegations,
-} from '../../../core/Delegation/delegation';
+import { ExecutionStruct } from '../../../core/Delegation';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
 import {
   RelayStatus,
@@ -39,18 +18,14 @@ import {
   submitRelayTransaction,
   waitForRelayResult,
 } from '../transaction-relay';
-import { NetworkClientId } from '@metamask/network-controller';
-import { isE2ETest } from '../util';
 import {
   getClientForTransactionMetadata,
   getClientVersionForTransactionMetadata,
   sanitizeOrigin,
 } from '../../../constants/smartTransactions';
+import { convertTransactionToRedeemDelegations } from '../delegation';
 
-// Test chain ID (Sepolia) used in E2E tests to match the delegation package's test contract configuration
-const SEPOLIA_CHAIN_ID = '0xaa36a7';
-const EMPTY_HEX = '0x';
-const POLLING_INTERVAL_MS = 1000; // 1 Second
+const POLLING_INTERVAL_MS = 1000;
 
 const EMPTY_RESULT = {
   transactionHash: undefined,
@@ -65,28 +40,17 @@ export class Delegation7702PublishHook {
 
   #messenger: TransactionControllerInitMessenger;
 
-  #getNextNonce: (
-    address: string,
-    networkClientId: NetworkClientId,
-  ) => Promise<Hex>;
-
   constructor({
     isAtomicBatchSupported,
     messenger,
-    getNextNonce,
   }: {
     isAtomicBatchSupported: (
       request: IsAtomicBatchSupportedRequest,
     ) => Promise<IsAtomicBatchSupportedResult>;
     messenger: TransactionControllerInitMessenger;
-    getNextNonce: (
-      address: string,
-      networkClientId: NetworkClientId,
-    ) => Promise<Hex>;
   }) {
     this.#isAtomicBatchSupported = isAtomicBatchSupported;
     this.#messenger = messenger;
-    this.#getNextNonce = getNextNonce;
   }
 
   getHook(): PublishHook {
@@ -142,7 +106,6 @@ export class Delegation7702PublishHook {
       atomicBatchChainSupport;
 
     const isGaslessBridge = transactionMeta.isGasFeeIncluded;
-
     const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
 
     if (
@@ -167,10 +130,6 @@ export class Delegation7702PublishHook {
       throw new Error('Selected gas fee token not found');
     }
 
-    const delegationEnvironment = getDeleGatorEnvironment(
-      parseInt(isE2ETest(chainId) ? SEPOLIA_CHAIN_ID : chainId, 16),
-    );
-    const delegationManagerAddress = delegationEnvironment.DelegationManager;
     const includeTransfer =
       !isGaslessBridge && !transactionMeta.isGasFeeSponsored;
 
@@ -178,32 +137,31 @@ export class Delegation7702PublishHook {
       throw new Error('Gas fee token not found');
     }
 
-    const delegations = await this.#buildDelegation(
-      delegationEnvironment,
-      transactionMeta,
-      gasFeeToken,
-      includeTransfer,
-    );
+    const additionalExecutions: ExecutionStruct[] =
+      includeTransfer && gasFeeToken
+        ? [this.#buildTransferExecution(gasFeeToken)]
+        : [];
 
-    const modes: ExecutionMode[] = [
-      includeTransfer ? BATCH_DEFAULT_MODE : SINGLE_DEFAULT_MODE,
-    ];
-    const executions = this.#buildExecutions(
-      transactionMeta,
-      gasFeeToken,
-      includeTransfer,
-    );
+    let authorization;
+    if (!delegationAddress) {
+      if (!upgradeContractAddress) {
+        throw new Error('Upgrade contract address not found');
+      }
+      authorization = { upgradeContractAddress: upgradeContractAddress as Hex };
+    }
 
-    const transactionData = encodeRedeemDelegations({
-      delegations,
-      modes,
-      executions,
-    });
+    const { data, to, authorizationList } =
+      await convertTransactionToRedeemDelegations({
+        transaction: transactionMeta,
+        messenger: this.#messenger,
+        additionalExecutions,
+        authorization,
+      });
 
     const relayRequest: RelaySubmitRequest = {
       chainId,
-      data: transactionData,
-      to: delegationManagerAddress,
+      data,
+      to,
       metadata: {
         txType: transactionMeta.type,
         client: getClientForTransactionMetadata(),
@@ -212,11 +170,8 @@ export class Delegation7702PublishHook {
       },
     };
 
-    if (!delegationAddress) {
-      relayRequest.authorizationList = await this.#buildAuthorizationList(
-        transactionMeta,
-        upgradeContractAddress,
-      );
+    if (authorizationList) {
+      relayRequest.authorizationList = authorizationList;
     }
 
     log('Relay request', relayRequest);
@@ -251,8 +206,6 @@ export class Delegation7702PublishHook {
       throw new Error(`Transaction relay error - ${status}`);
     }
 
-    // Mark 7702 relay transaction as intent complete so PendingTransactionTracker
-    // skips dropped checks
     log('Setting isIntentComplete after relay success', transactionMeta.id);
     const finalTxMeta = this.#messenger
       .call('TransactionController:getState')
@@ -274,221 +227,14 @@ export class Delegation7702PublishHook {
     };
   }
 
-  async #buildDelegation(
-    delegationEnvironment: DeleGatorEnvironment,
-    transactionMeta: TransactionMeta,
-    gasFeeToken: GasFeeToken | undefined,
-    includeTransfer: boolean,
-  ): Promise<Delegation[][]> {
-    const { chainId } = transactionMeta;
-    const unsignedDelegation = this.#buildUnsignedDelegation(
-      delegationEnvironment,
-      transactionMeta,
-      gasFeeToken,
-      includeTransfer,
-    );
-
-    log('Signing delegation');
-
-    const delegationSignature = (await this.#messenger.call(
-      'DelegationController:signDelegation',
-      {
-        chainId: isE2ETest(chainId) ? SEPOLIA_CHAIN_ID : chainId,
-        delegation: unsignedDelegation,
-      },
-    )) as Hex;
-
-    log('Delegation signature', delegationSignature);
-
-    const delegations: Delegation[][] = [
-      [
-        {
-          ...unsignedDelegation,
-
-          signature: delegationSignature,
-        },
-      ],
-    ];
-
-    return delegations;
-  }
-
-  #buildExecutions(
-    transactionMeta: TransactionMeta,
-    gasFeeToken: GasFeeToken | undefined,
-    includeTransfer: boolean,
-  ): ExecutionStruct[][] {
-    const { txParams } = transactionMeta;
-    const { data, to, value } = txParams;
-    const normalizedData = this.#normalizeCallData(data);
-    const userExecution: ExecutionStruct = {
-      target: to as Hex,
-      value: BigInt((value as Hex) ?? '0x0'),
-      callData: normalizedData,
-    };
-
-    if (!includeTransfer) {
-      return [[userExecution]];
-    }
-
-    if (!gasFeeToken) {
-      throw new Error('Selected gas fee token not found');
-    }
-
-    const transferExecution: ExecutionStruct = {
+  #buildTransferExecution(gasFeeToken: GasFeeToken): ExecutionStruct {
+    return {
       target: gasFeeToken.tokenAddress,
       value: BigInt('0x0'),
-      callData: this.#buildTokenTransferData(
+      callData: new Interface(abiERC20).encodeFunctionData('transfer', [
         gasFeeToken.recipient,
         gasFeeToken.amount,
-      ),
+      ]) as Hex,
     };
-    return [[userExecution, transferExecution]];
-  }
-
-  #buildUnsignedDelegation(
-    environment: DeleGatorEnvironment,
-    transactionMeta: TransactionMeta,
-    gasFeeToken: GasFeeToken | undefined,
-    includeTransfer: boolean,
-  ): UnsignedDelegation {
-    const caveats = this.#buildCaveats(
-      environment,
-      transactionMeta,
-      gasFeeToken,
-      includeTransfer,
-    );
-
-    log('Caveats', caveats);
-
-    const delegation = createDelegation({
-      from: transactionMeta.txParams.from as Hex,
-      to: ANY_BENEFICIARY,
-      caveats,
-    });
-
-    log('Delegation', delegation);
-
-    return delegation;
-  }
-
-  #buildCaveats(
-    environment: DeleGatorEnvironment,
-    transactionMeta: TransactionMeta,
-    gasFeeToken: GasFeeToken | undefined,
-    includeTransfer: boolean,
-  ): Caveat[] {
-    const caveatBuilder = createCaveatBuilder(environment);
-
-    const { txParams } = transactionMeta;
-    const { to, value, data } = txParams;
-    const normalizedData = this.#normalizeCallData(data);
-
-    if (includeTransfer && gasFeeToken !== undefined) {
-      const { tokenAddress, recipient, amount } = gasFeeToken;
-
-      // contract deployments can't be delegated
-      if (to !== undefined) {
-        caveatBuilder.addCaveat(
-          specificActionERC20TransferBatch,
-          tokenAddress,
-          recipient,
-          amount,
-          to,
-          (value as Hex) ?? '0x0',
-          normalizedData,
-        );
-      }
-    } else if (to !== undefined) {
-      // contract deployments can't be delegated
-      caveatBuilder.addCaveat(
-        exactExecution,
-        to,
-        value ?? '0x0',
-        normalizedData,
-      );
-    }
-
-    // the relay may only execute this delegation once for security reasons
-    caveatBuilder.addCaveat(limitedCalls, 1);
-
-    return caveatBuilder.build();
-  }
-
-  async #buildAuthorizationList(
-    transactionMeta: TransactionMeta,
-    upgradeContractAddress?: Hex,
-  ): Promise<AuthorizationList> {
-    const { chainId, txParams, networkClientId } = transactionMeta;
-    const { from, nonce: txNonce } = txParams;
-    const nextNonce = await this.#getNextNonce(from, networkClientId);
-
-    const nonce = txNonce ?? nextNonce;
-
-    log('Including authorization as not upgraded');
-
-    if (!upgradeContractAddress) {
-      throw new Error('Upgrade contract address not found');
-    }
-
-    const authorizationSignature = (await this.#messenger.call(
-      'KeyringController:signEip7702Authorization',
-      {
-        chainId: parseInt(chainId, 16),
-        contractAddress: upgradeContractAddress,
-        from,
-        nonce: parseInt(nonce as string, 16),
-      },
-    )) as Hex;
-
-    const { r, s, yParity } = decodeAuthorizationSignature(
-      authorizationSignature,
-    );
-
-    log('Authorization signature', { authorizationSignature, r, s, yParity });
-
-    return [
-      {
-        address: upgradeContractAddress,
-        chainId,
-        nonce: nonce as Hex,
-        r,
-        s,
-        yParity,
-      },
-    ];
-  }
-
-  #buildTokenTransferData(recipient: Hex, amount: Hex): Hex {
-    return new Interface(abiERC20).encodeFunctionData('transfer', [
-      recipient,
-      amount,
-    ]) as Hex;
-  }
-
-  #normalizeCallData(data: unknown): Hex {
-    if (typeof data !== 'string' || data.length === 0) {
-      return EMPTY_HEX;
-    }
-
-    const hasHexPrefix = data.slice(0, 2).toLowerCase() === '0x';
-    const normalizedData = data.toLowerCase();
-    const prefixed = hasHexPrefix
-      ? `0x${normalizedData.slice(2)}`
-      : `0x${normalizedData}`;
-    const hexBody = prefixed.slice(2);
-
-    if (hexBody.length === 0) {
-      return EMPTY_HEX;
-    }
-
-    if (hexBody.length % 2 !== 0) {
-      // The EVM works with byte arrays, and each byte is represented by exactly
-      // two hexadecimal characters. Ensure the hex string is byte-aligned by
-      // prefixing a leading zero.
-      return this.#normalizeCallData(`0x0${hexBody}`);
-    }
-
-    return prefixed as Hex;
   }
 }


### PR DESCRIPTION
## **Description**

Introduces a single `convertTransactionToRedeemDelegations` entry point in `app/util/transactions/delegation.ts`, mirroring the pattern in `metamask-extension`. All delegation flows now route through this central function.

### Changes

- **`convertTransactionToRedeemDelegations`** added to `delegation.ts`, matching the extension's implementation. Accepts optional `caveats`, `additionalExecutions`, `delegatee`, `delegationSignature`, and `authorization` so each caller keeps its own semantics while sharing one assembly path.
- **`getDelegationTransaction`** reduced to a thin wrapper that calls the central function with `authorization: {}` and adds `value: '0x0'`.
- **`Delegation7702PublishHook`** refactored to relay-submission only — builds `additionalExecutions` (transfer) and `authorization`, then delegates all delegation/caveat/encoding logic to the central function. Removes ~100 lines of duplicated assembly code.
- **`getNextNonce`** removed from `transaction-controller-init` — authorization nonce is now obtained inside `convertTransactionToRedeemDelegations` via `Engine.context.TransactionController.getNonceLock` directly.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Perform a gasless 7702 swap with a gas fee token selected — transaction should relay successfully.
2. Perform a sponsored flow — transaction should relay successfully.
3. Perform a pay-controller delegated transaction — authorization list and delegation data should be correct.
4. Perform a transaction on a chain where the account is already upgraded (isSupported: true) — no authorization list should be included.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.