### PR TITLE
fix: repack prod babel

### DIFF
--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -15,7 +15,8 @@ jobs:
       github.event.label.name == 'skip-smart-e2e-selection' ||
       github.event.label.name == 'skip-e2e' ||
       github.event.label.name == 'skip-e2e-flakiness-detection' ||
-      github.event.label.name == 'pr-not-ready-for-e2e'
+      github.event.label.name == 'pr-not-ready-for-e2e' ||
+      github.event.label.name == 'force-builds'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/scripts/repack.js
+++ b/scripts/repack.js
@@ -3,6 +3,24 @@
  * App Repack Script using @expo/repack-app
  */
 
+// Force production NODE_ENV / BABEL_ENV BEFORE requiring anything that may
+// touch process.env. @expo/repack-app calls a helper at the start of every
+// repack that does `process.env.NODE_ENV = process.env.NODE_ENV || 'development'`
+// and `process.env.BABEL_ENV = process.env.BABEL_ENV || NODE_ENV`. That env
+// is then inherited by the spawned `npx expo export:embed --dev false` child,
+// where `setNodeEnv('production')` is a no-op because both are already set.
+// Babel's React JSX transform reads BABEL_ENV/NODE_ENV (not metro's --dev
+// flag) to choose between `jsx` (production) and `jsxDEV` (development), so
+// without this guard the rebundled JS contains `jsxDEV(...)` calls while
+// metro emits `__DEV__ = false`. The dev-only React runtime then references
+// helpers that are tree-shaken when `__DEV__` is false, crashing the app at
+// the first render with `TypeError: undefined is not a function` inside
+// AppContainer. The native build path is immune because RN's community CLI
+// hard-assigns NODE_ENV from --dev. Pre-setting here makes both paths
+// produce equivalent production bundles.
+process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = 'production';
+
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Problem

After [#29247](https://github.com/MetaMask/metamask-mobile/pull/29247) (`da19bad`) replaced the branch-keyed `cirruslabs/cache` reuse layer with a content-addressable cross-PR/cross-commit lookup, virtually every E2E job on `main` and on PRs based off `main` started consuming a *reused* native shell and re-bundling JS through `scripts/repack.js` (`@expo/repack-app`). The repacked apps then crashed at the very first React render with:

```
RCTFatalException: Unhandled JS Exception: TypeError: undefined is not a function
at AppContainer (...bundle.../jsxDEVImpl@1:1034530)
@Thread expo-updates-error-recovery
```

Forcing the heavy native build path (`force-builds` label) produced working artifacts, isolating the issue to the repack/bundle path itself.

Bisecting `@expo/repack-app` showed it ships a helper that runs at the top of every `repackApp*Async` call:

```js
// @expo/repack-app
process.env.NODE_ENV = process.env.NODE_ENV || 'development';
process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
```

That env is then inherited by the spawned `npx expo export:embed --dev false` child. Inside the child, `@expo/cli`'s own `setNodeEnv('production')` is a *no-op* because of the `||` short-circuit:

```js
// @expo/cli/build/src/utils/nodeEnv.js
process.env.NODE_ENV = process.env.NODE_ENV || mode;
process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
```

The native build path (`yarn build:android:main:e2e` → `react-native bundle --dev false`) is immune because RN's community CLI hard-assigns the value:

```js
// @react-native/community-cli-plugin/.../buildBundle.js:48
process.env.NODE_ENV = args.dev ? "development" : "production";
```

Babel's React JSX transform reads `BABEL_ENV` / `NODE_ENV` (not metro's `--dev` flag) to choose between `jsx`/`jsxs` (production) and `jsxDEV` (development). With the above, the repacked bundle is compiled as **dev-mode JSX while metro emits `__DEV__ = false`**. The dev React JSX runtime then dereferences helpers that get tree-shaken under `__DEV__ === false`, causing the `TypeError` at first render. With React 19 (RN 0.81 upgrade in [#29195](https://github.com/MetaMask/metamask-mobile/pull/29195)) this combination became a hard crash; under older React it was tolerated.

Empirical confirmation by diffing the actual Hermes bytecode of a known-good native APK (run [`25570067714`](https://github.com/MetaMask/metamask-mobile/actions/runs/25570067714)) against the broken repacked APK from the first failing run after merge ([`25572812533`](https://github.com/MetaMask/metamask-mobile/actions/runs/25572812533)):

| Marker (string-table count)              | Native (working) | Repack (failing) |
| ---------------------------------------- | ---------------: | ---------------: |
| Bundle size                              |          64.9 MB |  68.1 MB (+4.9%) |
| `__DEV__` literal references             |                5 |               10 |
| `jsxDEVImpl` (dev JSX runtime internal)  |                0 |                1 |
| `react-devtools`                         |                0 |                1 |
| `devtools`                               |                2 |                9 |
| `console.warn` (post `transform-remove-console`) | 4 | 7 |
| `TypeError` (dev-only assertion strings) |               10 |               14 |

Every marker is amplified in the repacked bundle, consistent with babel's `production` env not firing. Same source SHA range, same workflow, same `repack.js` source — only the bundling tool differs.

### Why this only surfaced now

The repack path itself is older than this regression (added in [#20454](https://github.com/MetaMask/metamask-mobile/pull/20454), Oct 2024) and the env-poisoning bug has very likely existed since then. Pre-`da19bad`, the reuse cache was branch-keyed: the first commit on any branch always built natively (correct bundle), and only intra-branch follow-up commits could repack — a small fraction of CI runs. After `da19bad`, content-addressable cross-PR reuse made repack the *dominant* path, exposing the latent defect on essentially every build. The user-visible "this started after #29247" timing is correct, but the underlying defect is not in `da19bad`'s code.

### Solution

Two scoped changes, no new dependencies:

- **`scripts/repack.js`** — Pre-set `NODE_ENV=production` and `BABEL_ENV=production` as the very first executable lines of the script, *before* any `require()`. This neutralizes `@expo/repack-app`'s `Td("development")` and `@expo/cli`'s `setNodeEnv("production")` (both use `||` and become no-ops once the env is set), so babel's React JSX transform picks the production runtime and the bundle matches the native build path exactly. A long block comment in the file documents why this assignment must stay.
- **`.github/workflows/rerun-ci-on-skipped-e2e-labels.yml`** — Add `force-builds` to the set of labels that cancel the running `ci.yml` and re-trigger it. This makes the existing `force-builds` mitigation usable on its own (apply the label and CI reruns into the heavy-build path) without needing an empty commit, which is the prescribed escape hatch while artifacts produced before this fix are still in cache.

The `@expo/repack-app` upstream behavior is genuinely surprising for a tool whose only purpose is to ship production binaries — opening an issue against the package is a sensible follow-up.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

No issue: CI regression fix — reused E2E builds were shipping dev-mode JS bundles, crashing the app at first render with `TypeError: undefined is not a function`. Surfaced after [#29247](https://github.com/MetaMask/metamask-mobile/pull/29247) (`da19bad`) made the repack path dominant. First failing run: [actions/runs/25572812533](https://github.com/MetaMask/metamask-mobile/actions/runs/25572812533).

## **Manual testing steps**

```gherkin
Feature: Reused E2E builds produce a working production JS bundle

  Scenario: PR built on top of main hits the repack path
    Given main has a build artifact for the current source-fingerprint
    And this PR's commit has the same fingerprint (no native-source changes)
    When ci.yml runs build-ios-e2e and build-android-e2e
    Then the gate selects the repack path (no full native rebuild)
    And the resulting app installs and reaches the wallet UI in E2E tests
    And no `TypeError: undefined is not a function` is reported by Detox

  Scenario: force-builds label cancels and reruns CI into the native path
    Given a PR has a running or completed ci.yml
    When the `force-builds` label is applied to the PR
    Then rerun-ci-on-skipped-e2e-labels cancels the in-flight ci.yml
    And the latest ci.yml run is re-triggered
    And the rerun selects the native build path (no repack)

  Scenario: produced bundle is not dev-mode (regression sanity check)
    Given an Android E2E APK from the build job
    When the embedded `assets/index.android.bundle` is inspected
    Then it contains zero `jsxDEVImpl` string references
    And it contains zero `react-devtools` string references
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — CI fix, no UI change. Failure signature in [actions/runs/25572812533](https://github.com/MetaMask/metamask-mobile/actions/runs/25572812533): every iOS and Android E2E job crashes with `RCTFatalException: Unhandled JS Exception: TypeError: undefined is not a function at AppContainer ... jsxDEVImpl@...`.

### **After**

N/A — verified by running this branch through CI on the repack path; bundles produced are bytecode-equivalent to native production bundles (no `jsxDEVImpl` / `react-devtools` markers, `__DEV__` literal counts and bundle size match the native baseline).

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
