### PR TITLE
fix: Predict withdraw beforeSign handling

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -6308,6 +6308,9 @@ describe('PredictController', () => {
   });
 
   describe('beforeSign', () => {
+    const ERC20_TRANSFER_CALL_DATA =
+      '0xa9059cbb00000000000000000000000012345678901234567890123456789012345678900000000000000000000000000000000000000000000000000000000000011170' as const;
+
     const mockTransactionMeta = {
       id: 'tx-1',
       txParams: {
@@ -6320,7 +6323,7 @@ describe('PredictController', () => {
         {
           id: 'nested-1',
           type: 'predictWithdraw' as const,
-          data: '0xoriginaldata' as `0x${string}`,
+          data: ERC20_TRANSFER_CALL_DATA,
         },
       ],
     };
@@ -6371,6 +6374,63 @@ describe('PredictController', () => {
       });
     });
 
+    it('return undefined when transaction does not match active withdraw transaction id', async () => {
+      await withController(async ({ controller }) => {
+        controller.updateStateForTesting((state) => {
+          state.withdrawTransaction = {
+            chainId: 137,
+            status: PredictWithdrawStatus.IDLE,
+            providerId: POLYMARKET_PROVIDER_ID,
+            predictAddress: '0xPredict' as `0x${string}`,
+            transactionId: 'tx-1',
+            amount: 0,
+          };
+        });
+
+        const result = await controller.beforeSign({
+          transactionMeta: {
+            ...mockTransactionMeta,
+            id: 'tx-2',
+          } as any,
+        });
+
+        expect(result).toBeUndefined();
+        expect(mockPolymarketProvider.signWithdraw).not.toHaveBeenCalled();
+      });
+    });
+
+    it('return undefined when predict withdraw calldata is already signed safe execution data', async () => {
+      await withController(async ({ controller }) => {
+        controller.updateStateForTesting((state) => {
+          state.withdrawTransaction = {
+            chainId: 137,
+            status: PredictWithdrawStatus.IDLE,
+            providerId: POLYMARKET_PROVIDER_ID,
+            predictAddress: '0xPredict' as `0x${string}`,
+            transactionId: 'tx-1',
+            amount: 0,
+          };
+        });
+
+        const result = await controller.beforeSign({
+          transactionMeta: {
+            ...mockTransactionMeta,
+            nestedTransactions: [
+              {
+                id: 'nested-1',
+                type: 'predictWithdraw' as const,
+                data: '0x6a76120200000000' as `0x${string}`,
+              },
+            ],
+          } as any,
+        });
+
+        expect(result).toBeUndefined();
+        expect(mockPolymarketProvider.signWithdraw).not.toHaveBeenCalled();
+        expect(mockInvalidateQueries).not.toHaveBeenCalled();
+      });
+    });
+
     it('return undefined when provider does not support signWithdraw', async () => {
       await withController(async ({ controller }) => {
         controller.updateStateForTesting((state) => {
@@ -6417,7 +6477,7 @@ describe('PredictController', () => {
         });
 
         expect(mockPolymarketProvider.signWithdraw).toHaveBeenCalledWith({
-          callData: '0xoriginaldata',
+          callData: ERC20_TRANSFER_CALL_DATA,
           signer: expect.objectContaining({
             address: '0x1234567890123456789012345678901234567890',
             signTypedMessage: expect.any(Function),

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -389,6 +389,8 @@ const MESSENGER_EXPOSED_METHODS = [
   'trackShareAction',
 ] as const;
 
+const ERC20_TRANSFER_FUNCTION_SELECTOR = '0xa9059cbb';
+
 /**
  * PredictController - Protocol-agnostic prediction markets trading controller
  *
@@ -2744,7 +2746,18 @@ export class PredictController extends BaseController<
       }
     | undefined
   > {
-    if (!this.state.withdrawTransaction) {
+    const activeWithdrawTransaction = this.state.withdrawTransaction;
+
+    if (!activeWithdrawTransaction) {
+      return;
+    }
+
+    if (
+      activeWithdrawTransaction.transactionId &&
+      request.transactionMeta.id !== activeWithdrawTransaction.transactionId
+    ) {
+      // MetaMask Pay creates a follow-up transaction after the original withdraw
+      // is signed. Only the active withdraw transaction should be signed here.
       return;
     }
 
@@ -2765,12 +2778,21 @@ export class PredictController extends BaseController<
 
     const signer = this.getSigner(request.transactionMeta.txParams.from);
 
-    const chainId = this.state.withdrawTransaction.chainId;
+    const chainId = activeWithdrawTransaction.chainId;
 
     const networkClientId = this.messenger.call(
       'NetworkController:findNetworkClientIdByChainId',
       numberToHex(chainId),
     );
+    const withdrawDataPrefix = withdrawTransaction.data?.slice(0, 10);
+
+    if (
+      withdrawDataPrefix?.toLowerCase() !== ERC20_TRANSFER_FUNCTION_SELECTOR
+    ) {
+      // signWithdraw expects the original ERC20 transfer calldata. Pay-created
+      // batches may already contain signed Safe calldata and should pass through.
+      return;
+    }
 
     // Invalidate query cache (to avoid nonce issues)
     await this.invalidateQueryCache(chainId);
@@ -2784,7 +2806,7 @@ export class PredictController extends BaseController<
       ...withdrawTransaction,
       from: request.transactionMeta.txParams.from,
       data: callData,
-      to: this.state.withdrawTransaction?.predictAddress as Hex,
+      to: activeWithdrawTransaction.predictAddress as Hex,
     };
 
     // Attempt to estimate gas for the updated transaction
@@ -2824,8 +2846,8 @@ export class PredictController extends BaseController<
     return {
       updateTransaction: (transaction: TransactionMeta) => {
         transaction.txParams.data = callData;
-        transaction.txParams.to = this.state.withdrawTransaction
-          ?.predictAddress as Hex;
+        transaction.txParams.to =
+          activeWithdrawTransaction.predictAddress as Hex;
         transaction.assetsFiatValues = {
           ...transaction.assetsFiatValues,
           receiving: String(amount),


### PR DESCRIPTION
## Summary

- Guards Predict withdraw `beforeSign` so it only signs the active withdraw transaction.
- Skips signing when the withdraw calldata is already Safe execution calldata produced by the MetaMask Pay follow-up flow.
- Reuses the active withdraw state consistently when updating transaction params.
- Adds unit coverage for stale transaction IDs and already-signed Safe calldata.

## Changelog

CHANGELOG entry: Fixed Predict withdraw signing when withdraw transaction calldata is already prepared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction pre-signing for Predict withdrawals, which can affect what data gets signed and where it is sent. Changes are well-scoped with added unit coverage, but mistakes could block withdrawals or sign incorrect transactions.
> 
> **Overview**
> Predict withdraw `beforeSign` now only runs `signWithdraw` for the **currently active** withdraw transaction (by `transactionId`) and reuses that active state when setting `to`/updating tx params.
> 
> It also **skips signing** when the nested withdraw calldata is not an ERC-20 `transfer` selector (e.g., already-prepared Safe execution calldata from MetaMask Pay), and adds unit tests covering stale transaction IDs, pre-signed calldata pass-through, and updated call-data expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56813813b429dd6c60b94b3ed45f2c483603b18d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

