### PR TITLE
fix: allow money account controller init to include local overrides

### DIFF
--- a/app/core/Engine/controllers/money-account-controller-init.test.ts
+++ b/app/core/Engine/controllers/money-account-controller-init.test.ts
@@ -73,7 +73,7 @@ function publishStateChange(
 ) {
   baseMessenger.publish(
     'RemoteFeatureFlagController:stateChange',
-    { remoteFeatureFlags: {}, cacheTimestamp: 0 },
+    { remoteFeatureFlags: {}, localOverrides: {}, cacheTimestamp: 0 },
     [],
   );
 }

--- a/app/core/Engine/controllers/money-account-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-controller-init.ts
@@ -29,9 +29,12 @@ export const moneyAccountControllerInit: MessengerClientInitFunction<
   // Re-check the Money account feature flag whenever remote flags are updated.
   initMessenger.subscribe(
     'RemoteFeatureFlagController:stateChange',
-    async ({ remoteFeatureFlags }) => {
+    async ({ remoteFeatureFlags, localOverrides }) => {
       try {
-        const isEnabled = isMoneyAccountEnabled(remoteFeatureFlags);
+        const isEnabled = isMoneyAccountEnabled({
+          ...remoteFeatureFlags,
+          ...localOverrides,
+        });
         const hasMoneyAccount =
           Object.keys(controller.state.moneyAccounts).length > 0;
 


### PR DESCRIPTION
## **Description**

The `RemoteFeatureFlagController:stateChange` subscriber in `moneyAccountControllerInit` was only reading `remoteFeatureFlags` from the event payload, ignoring `localOverrides`. This meant that enabling the Money account flag via the local overrides menu in developer settings had no effect — the override lived in `localOverrides` but was never merged before being evaluated.

The fix destructures both `remoteFeatureFlags` and `localOverrides` from the event payload and merges them (with local overrides taking precedence) before passing to `isMoneyAccountEnabled`, matching the behaviour of the `selectRemoteFeatureFlags` Redux selector used elsewhere in the app.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Money account local override
  Scenario: user enables Money account via local overrides
    Given the Money account remote feature flag is disabled in LaunchDarkly
    And the user has opened Settings > Advanced > Feature Flag Overrides
    When the user enables the moneyEnableMoneyAccount local override
    Then the Money account controller initialises successfully
    And the Money account is visible in the app
```

## **Screenshots/Recordings**

### **Before**

Local override had no effect — Money account controller did not initialise.

### **After**

Local override correctly enables Money account initialisation.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to feature-flag evaluation by merging `localOverrides` into remote flags, plus a matching test update. Behavior change is limited to Money account initialization/clearing when developer overrides are set.
> 
> **Overview**
> Updates `moneyAccountControllerInit` to consider `RemoteFeatureFlagController` `localOverrides` (merged over `remoteFeatureFlags`) when evaluating `isMoneyAccountEnabled`, so developer override toggles can trigger Money account init/cleanup.
> 
> Adjusts the init test helper to publish the updated `stateChange` payload including `localOverrides`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f412e97d3a2d091cf7b6e6f24df690f97af386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->