### PR TITLE
Revert "fix(activity): correct EVM rows when non-EVM account selected"

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -26,10 +26,7 @@ import {
 } from '@metamask/transaction-controller';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import { selectTickerByChainId } from '../../../selectors/networkController';
-import {
-  selectSelectedInternalAccount,
-  selectSelectedInternalAccountAddress,
-} from '../../../selectors/accountsController';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectPrimaryCurrency } from '../../../selectors/settings';
 import {
@@ -60,7 +57,7 @@ import {
   selectCurrencyRates,
 } from '../../../selectors/currencyRateController';
 import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
-import { selectTokensByChainIdAndWalletAddress } from '../../../selectors/tokensController';
+import { selectTokensByChainIdAndAddress } from '../../../selectors/tokensController';
 import Routes from '../../../constants/navigation/Routes';
 import {
   hasGasFeeTokenSelected,
@@ -233,10 +230,6 @@ class TransactionElement extends PureComponent {
      */
     txChainId: PropTypes.string,
     /**
-     * Selected wallet address for decoding and token map (optional override from parent)
-     */
-    selectedAddress: PropTypes.string,
-    /**
      * Ticker
      */
     ticker: PropTypes.string,
@@ -290,8 +283,7 @@ class TransactionElement extends PureComponent {
   componentDidUpdate(prevProps) {
     if (
       prevProps.txChainId !== this.props.txChainId ||
-      prevProps.swapsTransactions !== this.props.swapsTransactions ||
-      prevProps.selectedAddress !== this.props.selectedAddress
+      prevProps.swapsTransactions !== this.props.swapsTransactions
     ) {
       this.componentDidMount();
     }
@@ -785,29 +777,21 @@ class TransactionElement extends PureComponent {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const walletAddressForTokens =
-    ownProps.selectedAddress ?? selectSelectedInternalAccountAddress(state);
-  return {
-    selectedInternalAccount: selectSelectedInternalAccount(state),
-    selectSelectedAccountGroupInternalAccounts:
-      selectSelectedAccountGroupInternalAccounts(state),
-    primaryCurrency: selectPrimaryCurrency(state),
-    swapsTransactions: selectSwapsTransactions(state),
-    ticker: selectTickerByChainId(state, ownProps.txChainId),
-    conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
-    currencyRates: selectCurrencyRates(state),
-    contractExchangeRates: selectContractExchangeRatesByChainId(
-      state,
-      ownProps.txChainId,
-    ),
-    tokens: selectTokensByChainIdAndWalletAddress(
-      state,
-      ownProps.txChainId,
-      walletAddressForTokens,
-    ),
-  };
-};
+const mapStateToProps = (state, ownProps) => ({
+  selectedInternalAccount: selectSelectedInternalAccount(state),
+  selectSelectedAccountGroupInternalAccounts:
+    selectSelectedAccountGroupInternalAccounts(state),
+  primaryCurrency: selectPrimaryCurrency(state),
+  swapsTransactions: selectSwapsTransactions(state),
+  ticker: selectTickerByChainId(state, ownProps.txChainId),
+  conversionRate: selectConversionRateByChainId(state, ownProps.txChainId),
+  currencyRates: selectCurrencyRates(state),
+  contractExchangeRates: selectContractExchangeRatesByChainId(
+    state,
+    ownProps.txChainId,
+  ),
+  tokens: selectTokensByChainIdAndAddress(state, ownProps.txChainId),
+});
 
 TransactionElement.contextType = ThemeContext;
 

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -579,9 +579,7 @@ const UnifiedTransactionsView = ({
           i={index}
           navigation={navigation}
           txChainId={getEvmChainId(item.tx)}
-          selectedAddress={
-            selectedAccountGroupEvmAddress || selectedInternalAccount?.address
-          }
+          selectedAddress={selectedInternalAccount?.address}
           onSpeedUpAction={onSpeedUpAction}
           onCancelAction={onCancelAction}
           signQRTransaction={signQRTransaction}

--- a/app/selectors/tokensController.test.ts
+++ b/app/selectors/tokensController.test.ts
@@ -10,7 +10,6 @@ import {
   selectAllDetectedTokensForSelectedAddress,
   selectAllDetectedTokensFlat,
   selectTokensByChainIdAndAddress,
-  selectTokensByChainIdAndWalletAddress,
   getChainIdsToPoll,
   selectSingleTokenByAddressAndChainId,
 } from './tokensController';
@@ -334,34 +333,6 @@ describe('TokensController Selectors', () => {
     it('returns empty object if no tokens exist for chain ID', () => {
       expect(
         selectTokensByChainIdAndAddress(mockRootState, '0x2'),
-      ).toStrictEqual({});
-    });
-  });
-
-  describe('selectTokensByChainIdAndWalletAddress', () => {
-    it('returns tokens for the given chain and explicit wallet address', () => {
-      expect(
-        selectTokensByChainIdAndWalletAddress(
-          mockRootState,
-          '0x1',
-          '0xAddress2',
-        ),
-      ).toStrictEqual({ '0xToken2': mockToken2 });
-    });
-
-    it('returns empty object when wallet address has no tokens on that chain', () => {
-      expect(
-        selectTokensByChainIdAndWalletAddress(
-          mockRootState,
-          '0x2',
-          '0xAddress1',
-        ),
-      ).toStrictEqual({});
-    });
-
-    it('returns empty object when wallet address is undefined', () => {
-      expect(
-        selectTokensByChainIdAndWalletAddress(mockRootState, '0x1', undefined),
       ).toStrictEqual({});
     });
   });

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -53,34 +53,6 @@ export const selectTokensByChainIdAndAddress = createDeepEqualSelector(
     ) ?? {},
 );
 
-/**
- * Like {@link selectTokensByChainIdAndAddress} but uses an explicit account
- * address (e.g. the EVM address for the account group) instead of the globally
- * selected account. Needed when the UI shows EVM activity while a non-EVM
- * account is still selected.
- */
-export const selectTokensByChainIdAndWalletAddress = createDeepEqualSelector(
-  getTokensControllerAllTokens,
-  (_state: RootState, chainId: Hex, _walletAddress: Hex | string | undefined) =>
-    chainId,
-  (_state: RootState, _chainId: Hex, walletAddress: Hex | string | undefined) =>
-    walletAddress,
-  (
-    allTokens: TokensControllerState['allTokens'],
-    chainId: Hex,
-    walletAddress: Hex | string | undefined,
-  ) =>
-    !walletAddress
-      ? {}
-      : (allTokens[chainId]?.[walletAddress as Hex]?.reduce(
-          (tokensMap: { [address: string]: Token }, token: Token) => ({
-            ...tokensMap,
-            [token.address]: token,
-          }),
-          {},
-        ) ?? {}),
-);
-
 export const selectTokensByAddress = createSelector(
   selectTokens,
   (tokens: Token[]) =>


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#29794

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes revert the ability to override the address used for token lookups/decoding in EVM activity rows, which may reintroduce incorrect transaction rendering when a non-EVM account is selected. Impact is user-visible but confined to activity display logic and selectors.
> 
> **Overview**
> Reverts the prior “explicit EVM address” handling for EVM activity rows by removing the `selectedAddress` override path from `TransactionElement` (including its update trigger) and simplifying token lookup to always use the globally selected account via `selectTokensByChainIdAndAddress`.
> 
> `UnifiedTransactionsView` now passes only `selectedInternalAccount?.address` to `TransactionElement`, and the `selectTokensByChainIdAndWalletAddress` selector (and its tests) is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b44ab0304c6efbb47d7c759245ca0fdc2b49c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->