### PR TITLE
chore: Revert "ci: External distribution configuration with fastlane"

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -19,11 +19,6 @@ on:
         required: false
         type: string
         default: 'MetaMask BETA & Release Candidates'
-      distribute_external:
-        description: 'Whether to distribute to external testers. Defaults to false; nightly-build.yml relies on the script default (true) so it always distributes externally.'
-        required: false
-        type: boolean
-        default: false
   workflow_dispatch:
     inputs:
       source_branch:
@@ -49,11 +44,6 @@ on:
           - 'MetaMask BETA & Release Candidates'
           - 'MM Card Team'
           - 'Ramp Provider Testing'
-      distribute_external:
-        description: 'Whether to distribute to external testers'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -89,7 +79,6 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
-      distribute_external: ${{ inputs.distribute_external }}
     secrets: inherit
 
   cleanup-build-branch:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,7 +31,6 @@ jobs:
       source_branch: main
       environment: exp
       testflight_group: 'MetaMask BETA & Release Candidates'
-      distribute_external: true
     secrets: inherit
 
   # ── iOS rc: build + TestFlight upload (after exp for sequential versions) ─
@@ -43,7 +42,6 @@ jobs:
       source_branch: main
       environment: rc
       testflight_group: 'MetaMask BETA & Release Candidates'
-      distribute_external: true
     secrets: inherit
 
   # ── Android exp: ephemeral branch + build ──────────────────────────────

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -39,11 +39,6 @@ on:
         description: 'The build number of the app (eg. 4134)'
         required: true
         type: string
-      distribute_external:
-        description: 'Whether to distribute to external testers. Set false for nightly/internal builds to avoid expiring previous TestFlight builds.'
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -162,8 +157,7 @@ jobs:
             "github_actions_main-${{ inputs.environment }}" \
             "${{ inputs.source_branch }}" \
             "${{ steps.ipa.outputs.path }}" \
-            "${{ inputs.testflight_group }}" \
-            "${{ inputs.distribute_external }}"
+            "${{ inputs.testflight_group }}"
 
       - name: Cleanup API Key
         if: always()


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#29940

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes the ability to toggle TestFlight external distribution from GitHub Actions, defaulting uploads back to the script’s behavior.
> 
> **Overview**
> Reverts the recently-added `distribute_external` plumbing in the iOS TestFlight GitHub Actions workflows.
> 
> `build-and-upload-to-testflight.yml`, `nightly-build.yml`, and `upload-to-testflight.yml` no longer define or pass `distribute_external`, so `scripts/upload-to-testflight.sh` falls back to its default behavior when uploading to TestFlight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b54ce5fe021dbc042a69b1974848fadb9831a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->