### PR TITLE
fix(activity): align EVM activity with account group and network filter cp-7.77.0

### DIFF
--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -2,7 +2,10 @@ import React, { ComponentType } from 'react';
 import { RefreshControl } from 'react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { V1TransactionByHashResponse } from '@metamask/core-backend';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import UnifiedTransactionsView from './UnifiedTransactionsView';
 import _renderWithProvider from '../../../util/test/renderWithProvider';
@@ -618,10 +621,32 @@ describe('UnifiedTransactionsView with transactions', () => {
 describe('UnifiedTransactionsView - EVM network filter for unified list', () => {
   const WALLET = '0xabc';
 
+  /** Required so selectLocalTransactions includes pending txs for UnifiedTransactionsView filtering. */
+  const accountsControllerForWallet = {
+    ...backgroundState.AccountsController,
+    internalAccounts: {
+      accounts: {
+        'wallet-evm-id': {
+          id: 'wallet-evm-id',
+          type: 'eip155:eoa' as const,
+          address: WALLET,
+          options: {},
+          methods: [],
+          metadata: {
+            name: 'Account 1',
+            keyring: { type: 'HD Key Tree' },
+          },
+        },
+      },
+      selectedAccount: 'wallet-evm-id',
+    },
+  };
+
   const emptyEvmChainsState = {
     engine: {
       backgroundState: {
         ...backgroundState,
+        AccountsController: accountsControllerForWallet,
         NetworkEnablementController: {
           ...backgroundState.NetworkEnablementController,
           enabledNetworkMap: {
@@ -637,6 +662,7 @@ describe('UnifiedTransactionsView - EVM network filter for unified list', () => 
     engine: {
       backgroundState: {
         ...backgroundState,
+        AccountsController: accountsControllerForWallet,
         NetworkEnablementController: {
           ...backgroundState.NetworkEnablementController,
           enabledNetworkMap: {
@@ -652,6 +678,7 @@ describe('UnifiedTransactionsView - EVM network filter for unified list', () => 
     engine: {
       backgroundState: {
         ...backgroundState,
+        AccountsController: accountsControllerForWallet,
         NetworkEnablementController: {
           ...backgroundState.NetworkEnablementController,
           enabledNetworkMap: {
@@ -754,6 +781,7 @@ describe('UnifiedTransactionsView - EVM network filter for unified list', () => 
       engine: {
         backgroundState: {
           ...backgroundState,
+          AccountsController: accountsControllerForWallet,
           NetworkEnablementController:
             stateOnlyOptimism.engine.backgroundState
               .NetworkEnablementController,
@@ -780,6 +808,82 @@ describe('UnifiedTransactionsView - EVM network filter for unified list', () => 
 
     const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
       state: stateWithPendingMainnet,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
+  });
+
+  it('hides pending EVM transactions when no EVM chains are enabled', () => {
+    mockUseTransactionsQuery(emptyTransactionsQueryData);
+
+    const stateWithPendingButNoEvmNetworks = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          AccountsController: accountsControllerForWallet,
+          NetworkEnablementController:
+            emptyEvmChainsState.engine.backgroundState
+              .NetworkEnablementController,
+          TransactionController: {
+            ...backgroundState.TransactionController,
+            transactions: [
+              {
+                id: 'pending-no-enabled-evm',
+                chainId: '0x1' as const,
+                status: TransactionStatus.submitted,
+                time: Date.now(),
+                txParams: {
+                  from: WALLET,
+                  to: '0x1111111111111111111111111111111111111111',
+                  value: '0x0',
+                  nonce: '0x1',
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: stateWithPendingButNoEvmNetworks,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
+  });
+
+  it('hides pending EVM transactions when chainId is missing', () => {
+    mockUseTransactionsQuery(emptyTransactionsQueryData);
+
+    const pendingWithoutChainId = {
+      id: 'pending-missing-chain',
+      status: TransactionStatus.submitted,
+      time: Date.now(),
+      txParams: {
+        from: WALLET,
+        to: '0x1111111111111111111111111111111111111111',
+        value: '0x0',
+        nonce: '0x1',
+      },
+    } as unknown as TransactionMeta;
+
+    const stateWithPendingMissingChainId = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          AccountsController: accountsControllerForWallet,
+          NetworkEnablementController:
+            stateOnlyMainnet.engine.backgroundState.NetworkEnablementController,
+          TransactionController: {
+            ...backgroundState.TransactionController,
+            transactions: [pendingWithoutChainId],
+          },
+        },
+      },
+    };
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: stateWithPendingMissingChainId,
     });
 
     expect(getByText('You have no transactions')).toBeOnTheScreen();

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -615,6 +615,177 @@ describe('UnifiedTransactionsView with transactions', () => {
   });
 });
 
+describe('UnifiedTransactionsView - EVM network filter for unified list', () => {
+  const WALLET = '0xabc';
+
+  const emptyEvmChainsState = {
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        NetworkEnablementController: {
+          ...backgroundState.NetworkEnablementController,
+          enabledNetworkMap: {
+            ...backgroundState.NetworkEnablementController.enabledNetworkMap,
+            eip155: {},
+          },
+        },
+      },
+    },
+  };
+
+  const stateOnlyOptimism = {
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        NetworkEnablementController: {
+          ...backgroundState.NetworkEnablementController,
+          enabledNetworkMap: {
+            ...backgroundState.NetworkEnablementController.enabledNetworkMap,
+            eip155: { '0xa': true },
+          },
+        },
+      },
+    },
+  };
+
+  const stateOnlyMainnet = {
+    engine: {
+      backgroundState: {
+        ...backgroundState,
+        NetworkEnablementController: {
+          ...backgroundState.NetworkEnablementController,
+          enabledNetworkMap: {
+            ...backgroundState.NetworkEnablementController.enabledNetworkMap,
+            eip155: { '0x1': true },
+          },
+        },
+      },
+    },
+  };
+
+  const createOutgoingMainnetConfirmed = (): V1TransactionByHashResponse =>
+    ({
+      accountId: `eip155:1:${WALLET}`,
+      blockHash: '0xblock',
+      blockNumber: 1,
+      chainId: 1,
+      cumulativeGasUsed: 21000,
+      effectiveGasPrice: '1',
+      from: WALLET,
+      gas: 21000,
+      gasPrice: '1',
+      gasUsed: 21000,
+      hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      isError: false,
+      logs: [],
+      methodId: '0x',
+      nonce: 1,
+      readable: 'Transfer',
+      timestamp: '2026-04-29T19:28:41.000Z',
+      to: '0x1111111111111111111111111111111111111111',
+      transactionCategory: 'TRANSFER',
+      transactionType: 'SIMPLE_SEND',
+      value: '1',
+      valueTransfers: [],
+    }) as V1TransactionByHashResponse;
+
+  const queryDataMainnetConfirmed = selectTransactions({
+    address: WALLET,
+  })({
+    pageParams: [undefined],
+    pages: [
+      {
+        data: [createOutgoingMainnetConfirmed()],
+        unprocessedNetworks: [],
+        pageInfo: {
+          count: 1,
+          endCursor: undefined,
+          hasNextPage: false,
+        },
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTransactionsQuery();
+    (useUnifiedTxActions as jest.Mock).mockImplementation(
+      () => mockDefaultUnifiedTxActionsReturn,
+    );
+  });
+
+  it('hides confirmed EVM rows when no EVM chains are enabled', () => {
+    mockUseTransactionsQuery(queryDataMainnetConfirmed);
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: emptyEvmChainsState,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
+  });
+
+  it('hides confirmed EVM rows when their chain is not in the enabled filter', () => {
+    mockUseTransactionsQuery(queryDataMainnetConfirmed);
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: stateOnlyOptimism,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
+  });
+
+  it('shows confirmed EVM rows when their chain matches the enabled filter', () => {
+    mockUseTransactionsQuery(queryDataMainnetConfirmed);
+
+    const { UNSAFE_queryAllByType } = renderWithProvider(
+      <UnifiedTransactionsView />,
+      { state: stateOnlyMainnet },
+    );
+
+    expect(
+      UNSAFE_queryAllByType(asComponentType('TransactionElement')).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('hides pending EVM transactions when their chain is not in the enabled filter', () => {
+    mockUseTransactionsQuery(emptyTransactionsQueryData);
+
+    const stateWithPendingMainnet = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          NetworkEnablementController:
+            stateOnlyOptimism.engine.backgroundState
+              .NetworkEnablementController,
+          TransactionController: {
+            ...backgroundState.TransactionController,
+            transactions: [
+              {
+                id: 'pending-mainnet',
+                chainId: '0x1' as const,
+                status: TransactionStatus.submitted,
+                time: Date.now(),
+                txParams: {
+                  from: WALLET,
+                  to: '0x1111111111111111111111111111111111111111',
+                  value: '0x0',
+                  nonce: '0x1',
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { getByText } = renderWithProvider(<UnifiedTransactionsView />, {
+      state: stateWithPendingMainnet,
+    });
+
+    expect(getByText('You have no transactions')).toBeOnTheScreen();
+  });
+});
+
 describe('UnifiedTransactionsView - Speed up / Cancel modal', () => {
   const initialState = {
     engine: {

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -167,6 +167,20 @@ const UnifiedTransactionsView = ({
     [enabledNonEVMNetworks],
   );
 
+  /** Drop confirmed rows not on currently enabled EVM chains (guards stale query pages). */
+  const allConfirmedForEnabledChains = useMemo<TransactionViewModel[]>(() => {
+    const chains = enabledEVMChainIds ?? [];
+    if (chains.length === 0) {
+      return [];
+    }
+    const allowed = new Set(chains.map((c) => c.toLowerCase()));
+    return allConfirmedFiltered.filter(
+      (tx) =>
+        typeof tx.hexChainId === 'string' &&
+        allowed.has(tx.hexChainId.toLowerCase()),
+    );
+  }, [allConfirmedFiltered, enabledEVMChainIds]);
+
   const { maliciousTokenKeys } =
     useMultichainActivityMaliciousTokenKeys(nonEvmTransactions);
 
@@ -183,6 +197,9 @@ const UnifiedTransactionsView = ({
     chainFilteredNonEvmTransactionsForSelectedChain: NonEvmTransaction[];
   }>(() => {
     const bridgeHistoryValues = Object.values(bridgeHistory ?? {});
+    const enabledEvmSet = new Set(
+      (enabledEVMChainIds ?? []).map((id) => id.toLowerCase()),
+    );
     const submittedTxsFiltered = submittedTxs.filter(
       (tx): tx is EvmTransaction => {
         if (!isTransactionMetaLike(tx)) {
@@ -190,6 +207,12 @@ const UnifiedTransactionsView = ({
         }
 
         const { chainId: _chainId, txParams } = tx;
+        if (!enabledEvmSet.size) {
+          return false;
+        }
+        if (!_chainId || !enabledEvmSet.has(String(_chainId).toLowerCase())) {
+          return false;
+        }
         const isBridgeTransaction = isBridgeHistoryForEvmTransaction(
           tx,
           bridgeHistoryValues,
@@ -198,17 +221,17 @@ const UnifiedTransactionsView = ({
         const { from, nonce } = txParams || {};
         const hasNonce = nonce !== undefined && nonce !== null;
 
-        const matchingConfirmedByHash = allConfirmedFiltered.some(
+        const matchingConfirmedByHash = allConfirmedForEnabledChains.some(
           (confirmedTx) =>
             typeof hash === 'string' &&
             confirmedTx.hash.toLowerCase() === hash.toLowerCase() &&
-            confirmedTx.hexChainId === _chainId,
+            confirmedTx.hexChainId?.toLowerCase() === _chainId?.toLowerCase(),
         );
-        const matchingConfirmedByNonce = allConfirmedFiltered.some(
+        const matchingConfirmedByNonce = allConfirmedForEnabledChains.some(
           (confirmedTx) =>
             hasNonce &&
             confirmedTx.nonce === nonce &&
-            confirmedTx.hexChainId === _chainId &&
+            confirmedTx.hexChainId?.toLowerCase() === _chainId?.toLowerCase() &&
             Boolean(from) &&
             areAddressesEqual(confirmedTx.from, from),
         );
@@ -250,11 +273,11 @@ const UnifiedTransactionsView = ({
 
     return {
       evmPendingTxs: evmPendingFirst,
-      evmConfirmedTxs: allConfirmedFiltered,
+      evmConfirmedTxs: allConfirmedForEnabledChains,
       chainFilteredNonEvmTransactionsForSelectedChain,
     };
   }, [
-    allConfirmedFiltered,
+    allConfirmedForEnabledChains,
     submittedTxs,
     nonEvmTransactions,
     enabledEVMChainIds,
@@ -609,7 +632,9 @@ const UnifiedTransactionsView = ({
           i={index}
           navigation={navigation}
           txChainId={item.tx.hexChainId}
-          selectedAddress={selectedInternalAccount?.address}
+          selectedAddress={
+            selectedAccountGroupEvmAddress || selectedInternalAccount?.address
+          }
           currentCurrency={currentCurrency}
           showBottomBorder
           location={location}

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
@@ -179,4 +179,20 @@ describe('useTransactionsQuery', () => {
       includeTxMetadata: true,
     });
   });
+
+  it('does not use global EVM address when group account has an empty string address', () => {
+    setupSelectors({
+      evmAddress: ADDRESS_MOCK,
+      groupEvmAccount: { address: '' },
+    });
+
+    renderHook(() => useTransactionsQuery());
+
+    expect(getQueryOptionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accountAddresses: [] }),
+    );
+    expect(useInfiniteQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
 });

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
@@ -164,4 +164,19 @@ describe('useTransactionsQuery', () => {
       expect.objectContaining({ enabled: false }),
     );
   });
+
+  it('prefers the account group EVM address over the global EVM address when both are set', () => {
+    setupSelectors({
+      evmAddress: ADDRESS_MOCK,
+      groupEvmAccount: { address: GROUP_EVM_ADDRESS_MOCK },
+    });
+
+    renderHook(() => useTransactionsQuery());
+
+    expect(getQueryOptionsMock).toHaveBeenCalledWith({
+      accountAddresses: [`eip155:0:${GROUP_EVM_ADDRESS_MOCK}`],
+      networks: NETWORKS_MOCK,
+      includeTxMetadata: true,
+    });
+  });
 });

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 import { apiClient } from '../../../core/apiClient';
 import { selectEvmAddress } from '../../../selectors/accountsController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectEvmEnabledCaipNetworks } from '../../../selectors/networkEnablementController';
 import { useTransactionsQuery } from './useTransactionsQuery';
 import { MINUTE } from '../../../constants/time';
@@ -28,6 +29,13 @@ jest.mock('../../../selectors/accountsController', () => ({
   selectEvmAddress: jest.fn(),
 }));
 
+jest.mock(
+  '../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupEvmInternalAccount: jest.fn(),
+  }),
+);
+
 jest.mock('../../../selectors/networkEnablementController', () => ({
   selectEvmEnabledCaipNetworks: jest.fn(),
 }));
@@ -37,6 +45,7 @@ jest.mock('../../../selectors/transactionController', () => ({
 }));
 
 const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
+const GROUP_EVM_ADDRESS_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const NETWORKS_MOCK = ['eip155:1', 'eip155:137'];
 const QUERY_OPTIONS_MOCK = {
   queryKey: ['transactions'],
@@ -53,12 +62,17 @@ describe('useTransactionsQuery', () => {
 
   function setupSelectors({
     evmAddress = ADDRESS_MOCK,
+    groupEvmAccount = null as { address: string } | null,
     networks = NETWORKS_MOCK,
   }: {
     evmAddress?: string;
+    groupEvmAccount?: { address: string } | null;
     networks?: string[];
   } = {}) {
     useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
+        return groupEvmAccount;
+      }
       if (selector === selectEvmAddress) {
         return evmAddress;
       }
@@ -111,7 +125,7 @@ describe('useTransactionsQuery', () => {
   });
 
   it('disables the query and sends no account addresses when there is no EVM address', () => {
-    setupSelectors({ evmAddress: '' });
+    setupSelectors({ evmAddress: '', groupEvmAccount: null });
 
     renderHook(() => useTransactionsQuery());
 
@@ -120,6 +134,24 @@ describe('useTransactionsQuery', () => {
     );
     expect(useInfiniteQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('uses account group EVM address when globally selected account has no EVM address', () => {
+    setupSelectors({
+      evmAddress: '',
+      groupEvmAccount: { address: GROUP_EVM_ADDRESS_MOCK },
+    });
+
+    renderHook(() => useTransactionsQuery());
+
+    expect(getQueryOptionsMock).toHaveBeenCalledWith({
+      accountAddresses: [`eip155:0:${GROUP_EVM_ADDRESS_MOCK}`],
+      networks: NETWORKS_MOCK,
+      includeTxMetadata: true,
+    });
+    expect(useInfiniteQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
     );
   });
 

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.ts
@@ -4,13 +4,19 @@ import { useSelector } from 'react-redux';
 import { KnownCaipNamespace, toCaipAccountId } from '@metamask/utils';
 import { apiClient } from '../../../core/apiClient';
 import { selectEvmAddress } from '../../../selectors/accountsController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectEvmEnabledCaipNetworks } from '../../../selectors/networkEnablementController';
 import { selectTransactions } from './helpers/transformations';
 import { MINUTE } from '../../../constants/time';
 import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 
 export const useTransactionsQuery = () => {
-  const evmAddress = useSelector(selectEvmAddress) || '';
+  const groupEvmAccount = useSelector(
+    selectSelectedAccountGroupEvmInternalAccount,
+  );
+  const globalEvmAddress = useSelector(selectEvmAddress);
+  /** Activity must load EVM history for the group's EVM account when e.g. Bitcoin is selected. */
+  const evmAddress = (groupEvmAccount?.address ?? globalEvmAddress ?? '') || '';
   const networks = useSelector(selectEvmEnabledCaipNetworks);
   const excludedTxHashes = useSelector(selectRequiredTransactionHashes);
   const accountAddresses = evmAddress


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity’s unified transaction list used the globally selected account for the Accounts API infinite query (`selectEvmAddress`). When a **non-EVM** account stayed selected (e.g. Bitcoin) but the network filter returned to **all popular networks**, the query had no EVM address and stayed disabled, so the UI showed **only non-EVM** rows.

This PR resolves the query to the **selected account group’s EVM internal account** when present, falling back to the global EVM address otherwise. It also **filters confirmed and pending EVM** rows to the currently **enabled EVM chain IDs** so the list matches the Activity network filter (including single-chain vs multi-chain). **ConfirmedEvm** rows use the same **group EVM `selectedAddress`** as pending EVM rows for consistent decode/display with multichain selection.

This builds on the earlier Activity fixes in [#29794](https://github.com/MetaMask/metamask-mobile/pull/29794) (TransactionElement / token map); this branch carries the remaining **UnifiedTransactionsView** and **useTransactionsQuery** alignment.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Activity transaction list not showing EVM history after switching back from a non-EVM network filter to all popular networks, and tightened EVM rows to the enabled network filter.

## **Related issues**

Fixes #29952
Refs:  #28035

## **Manual testing steps**

```gherkin
Feature: Activity unified transactions and network filter

  Scenario: EVM history returns when non-EVM account is selected and filter is all popular networks
    Given the user has an account group with both EVM and non-EVM accounts
    And the globally selected account is non-EVM (e.g. Bitcoin)

    When the user opens Activity then sets the network filter to all popular networks

    Then EVM and non-EVM transactions appear in the unified list as expected

  Scenario: Single EVM chain filter only shows that chain
    Given Activity Transactions is open with multiple EVM networks available

    When the user sets the filter to one EVM chain (e.g. Linea) then to another (e.g. Ethereum)

    Then the list updates to transactions for the selected chain only

  Scenario: Pending EVM rows respect enabled chains
    Given the user has a submitted EVM transaction on one chain

    When the user filters Activity to a different single EVM chain

    Then pending rows for other chains do not appear at the top of the list
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/de557bf5-4caf-4ba2-bcf4-8a4459e53b3d



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Activity selects the EVM account/address for history queries and tightens EVM pending/confirmed filtering by enabled chain IDs, which can affect transaction visibility in the main Activity list.
> 
> **Overview**
> Fixes unified Activity EVM history loading by resolving the Accounts API query address from the *selected account group’s* EVM internal account (falling back to the global `selectEvmAddress`), so EVM activity still loads when a non-EVM account is selected.
> 
> Aligns the unified list with the network filter by **filtering both confirmed (API) and pending (local) EVM transactions** to the currently enabled EVM chain IDs (including guarding against stale paged results), and ensures confirmed EVM rows pass the same group-based `selectedAddress` into `TransactionElement` as pending rows.
> 
> Adds targeted tests covering EVM chain-filter behavior for pending/confirmed rows and the new address-selection precedence rules in `useTransactionsQuery`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fb3e17cad8b7a000ed37e420ae3ae3606fa090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->