### PR TITLE
ci: gate Auto RC builds on auto-rc-builds label

### DIFF
--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -83,6 +83,16 @@ jobs:
             exit 0
           fi
 
+          # Gate on the auto-rc-builds label so release managers can opt out of the
+          # version-bump force-push (which becomes the new HEAD and skips CI on the
+          # release PR) by removing the label before merging.
+          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | contains(["auto-rc-builds"])')
+          if [[ "$HAS_LABEL" != "true" ]]; then
+            echo "PR #$PR_NUMBER does not have the auto-rc-builds label. Skipping RC build."
+            echo "has-pr=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Found PR #$PR_NUMBER - proceeding with RC build"
           echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "has-pr=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -125,6 +125,23 @@ jobs:
           github-token: ${{ github.event_name == 'workflow_dispatch' && secrets.PR_TOKEN || secrets.github-token }}
           google-application-creds-base64: ${{ github.event_name == 'workflow_dispatch' && secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 || secrets.google-application-creds-base64 }}
 
+      # Apply the auto-rc-builds label so the build-rc-auto workflow runs by default
+      # on pushes to this release branch. Release managers remove the label when ready
+      # to merge so the [skip ci] version-bump force-push doesn't land on top.
+      - name: Apply auto-rc-builds label to native release PR
+        if: needs.resolve-bases.outputs.is_ota != 'true'
+        shell: bash
+        env:
+          SEMVER: ${{ inputs.semver-version }}
+          RELEASE_BASE: ${{ needs.resolve-bases.outputs.release_base }}
+          GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && secrets.PR_TOKEN || secrets.github-token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "release/${SEMVER}" --base "$RELEASE_BASE" --json number --jq '.[0].number // ""')
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label auto-rc-builds
+          fi
+
       # Check PR before checkout/bump/push so retries do not overwrite OTA_VERSION again when a PR already exists.
       - name: Check for existing OTA release PR
         id: ota_release_pr
@@ -226,5 +243,6 @@ jobs:
           BODY="${BODY}"$'\n'"- CHANGELOG.md header and production git tag both use bare \`${SEMVER}\` / \`v${SEMVER}\`; the \`-ota\` suffix is branch-only."
           gh pr create --repo "$GITHUB_REPOSITORY" --draft \
             --base "$RELEASE_BASE" --head "$BRANCH" \
+            --label auto-rc-builds \
             --title "release: ${SEMVER} (OTA)" \
             --body "$BODY"


### PR DESCRIPTION
## **Description**

Make the `Auto RC builds` workflow opt-in via the existing `auto-rc-builds` label, so release managers can stop the build (and the `[skip ci] Bump version number` force-push that lands as the new HEAD) by removing the label when they're ready to merge the release PR.

### Why

Today every push to a `release/*` branch with an open PR triggers `Auto RC builds`, which calls `update-latest-build-version.yml` to force-push a `[skip ci] Bump version number to NNNN` commit on top of the user's commit. That `[skip ci]` HEAD suppresses the `pull_request` synchronize CI run, so `Check all jobs pass` / `All jobs pass` never appear on the latest SHA and the release PR's merge button stays disabled.

Concrete impact: during merge of release/7.76.0 (PR #29584), the release manager has had to manually cancel each `Auto RC builds` run racing every push, and CI still doesn't show green because the bump-version commit wins the force-push race. 

### What

**`build-rc-auto.yml`** — in the `Validate branch and find PR` job, additionally check that the PR carries the `auto-rc-builds` label. If missing, short-circuit by setting `has-pr=false`, which already gates every downstream job (`update_rc_build_version`, `trigger-ios-rc-build`, `trigger-android-rc-build`, and the comment / Slack notification jobs that depend on them). Smallest possible change — no new outputs, no `if:` updates anywhere else.

**`create-release-pr.yml`** — apply the `auto-rc-builds` label to the release PR right after it is created, so the **default behaviour is preserved** (build on every push during the validation period). Release manager only needs to remove the label when they're ready to merge.

- Native: new post-step that finds the PR by head branch and runs `gh pr edit --add-label auto-rc-builds`. The upstream `MetaMask/github-tools/.github/actions/create-release-pr@v1` action has no label input, so we apply it from this side.
- OTA: inline `--label auto-rc-builds` on the existing `gh pr create` call.

### New release-manager flow

| Step | Today | After this PR |
| --- | --- | --- |
| PR opens | RC builds auto-run | RC builds auto-run (label auto-applied) |
| Validation period | RC builds on every push | RC builds on every push (unchanged) |
| Ready to merge | Cancel `Auto RC builds` workflow on every push, race the bump-version force-push | Remove `auto-rc-builds` label once. No more force-pushes. |

### Trade-off / known edge

If `create-release-pr.yml` is re-run after the release manager has intentionally removed the label, the label would be re-added. In practice the workflow runs on `create:` (one-shot per branch) or `workflow_dispatch` (rare), and the OTA path additionally short-circuits on `steps.ota_release_pr.outputs.exists`. Re-runs after PR creation are not part of the normal flow, so this is acceptable.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #29584 (release/7.76.0 PR currently blocked by this same race)

No GitHub issue: release-engineering ergonomics fix.

## **Manual testing steps**

```gherkin
Feature: auto-rc-builds label gates the build-rc-auto workflow

  Scenario: A release PR with the label runs RC builds (default)
    Given a release/X.Y.Z branch with an open PR labeled auto-rc-builds
    When a commit is pushed to that branch
    Then Auto RC builds proceeds (validate-and-find-pr -> update_rc_build_version -> trigger-ios-rc-build / trigger-android-rc-build)

  Scenario: Removing the label stops further RC builds
    Given a release/X.Y.Z branch with an open PR
    And the auto-rc-builds label has been removed from the PR
    When a commit is pushed to that branch
    Then validate-and-find-pr logs "PR #N does not have the auto-rc-builds label. Skipping RC build."
    And update_rc_build_version, trigger-ios-rc-build, trigger-android-rc-build, post-rc-build-comment and slack-notification all show as skipped

  Scenario: Native release PR is auto-labeled on creation
    Given a release/X.Y.0 branch is created (auto-create-release-pr triggered)
    When create-release-pr.yml finishes
    Then the new release PR has the auto-rc-builds label

  Scenario: OTA release PR is auto-labeled on creation
    Given a release/X.Y.Z-ota branch is created
    When create-release-pr.yml creates the OTA PR
    Then the new OTA release PR has the auto-rc-builds label
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)