### PR TITLE
fix: e2e liquidation

### DIFF
--- a/tests/flows/perps.flow.ts
+++ b/tests/flows/perps.flow.ts
@@ -5,14 +5,17 @@ import {
   encapsulatedAction,
 } from '../framework';
 import PerpsMarketDetailsView from '../page-objects/Perps/PerpsMarketDetailsView';
+import PerpsHomeView from '../page-objects/Perps/PerpsHomeView';
+import PerpsMarketListView from '../page-objects/Perps/PerpsMarketListView';
 import PerpsOrderView from '../page-objects/Perps/PerpsOrderView';
+import WalletView from '../page-objects/wallet/WalletView';
 
 /**
  * Checks if the position is open by checking if the close button is visible.
  * @returns {Promise<boolean>} True if the position is open, false otherwise.
  */
 export const isPositionOpen = async (timeout = 5000): Promise<boolean> => {
-  let isPositionOpen = false;
+  let positionOpen = false;
   await encapsulatedAction({
     detox: async () => {
       try {
@@ -21,9 +24,9 @@ export const isPositionOpen = async (timeout = 5000): Promise<boolean> => {
           timeout,
           description: 'Close position button',
         });
-        isPositionOpen = true;
+        positionOpen = true;
       } catch {
-        isPositionOpen = false;
+        positionOpen = false;
       }
     },
     appium: async () => {
@@ -31,14 +34,14 @@ export const isPositionOpen = async (timeout = 5000): Promise<boolean> => {
         const closeEl = await asPlaywrightElement(
           PerpsMarketDetailsView.closeButton,
         );
-        isPositionOpen = await closeEl.isVisible();
+        positionOpen = await closeEl.isVisible();
       } catch {
         // Element lookup timed out — position is not open
-        isPositionOpen = false;
+        positionOpen = false;
       }
     },
   });
-  return isPositionOpen;
+  return positionOpen;
 };
 
 export const waitForPositionOpen = async (
@@ -102,4 +105,25 @@ export const waitForOrderScreenVisible = async (
     await new Promise((resolve) => setTimeout(resolve, interval));
   }
   throw new Error(`Order screen not visible after ${timeout}ms`);
+};
+
+export type PerpsPositionDirection = 'long' | 'short';
+
+export const openPosition = async (
+  symbol: string,
+  direction: PerpsPositionDirection,
+): Promise<void> => {
+  await WalletView.scrollAndTapPerpsSection();
+  await PerpsHomeView.tapExploreCryptoIfVisible();
+
+  await PerpsMarketListView.selectMarket(symbol);
+  if (direction === 'long') {
+    await PerpsMarketDetailsView.tapLongButton();
+  } else {
+    await PerpsMarketDetailsView.tapShortButton();
+  }
+
+  await PerpsOrderView.tapPlaceOrderButton();
+  await PerpsMarketDetailsView.waitForScreenReady();
+  await PerpsMarketDetailsView.expectClosePositionButtonVisible();
 };

--- a/tests/page-objects/Perps/PerpsMarketDetailsView.ts
+++ b/tests/page-objects/Perps/PerpsMarketDetailsView.ts
@@ -231,7 +231,9 @@ class PerpsMarketDetailsView {
         await Utilities.waitForElementToBeEnabled(
           this.longButton as DetoxElement,
         );
-        await Gestures.waitAndTap(this.longButton);
+        await Gestures.waitAndTap(this.longButton, {
+          elemDescription: 'Perps Long button',
+        });
       },
       appium: async () => {
         await PlaywrightGestures.waitAndTap(

--- a/tests/smoke/perps/perps-position-liquidation.spec.ts
+++ b/tests/smoke/perps/perps-position-liquidation.spec.ts
@@ -2,14 +2,11 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SmokePerps } from '../../tags';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
 import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
 import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView';
-import PerpsOrderView from '../../page-objects/Perps/PerpsOrderView';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
 import {
   createLogger,
@@ -21,16 +18,38 @@ import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
 import CommandQueueServer from '../../framework/fixtures/CommandQueueServer';
+import {
+  openPosition,
+  type PerpsPositionDirection,
+} from '../../flows/perps.flow';
 
 const logger = createLogger({
   name: 'PerpsPositionLiquidationSpec',
   level: LogLevel.INFO,
 });
 
-const NON_LIQUIDATING_ETH_MARK_PRICE = '2400.00';
-const LIQUIDATING_ETH_MARK_PRICE = '1.00';
+const MARKET_SYMBOL = 'ETH';
+const POSITION_DIRECTION: PerpsPositionDirection = 'long';
+const MARK_PRICE_BY_DIRECTION: Record<
+  PerpsPositionDirection,
+  {
+    nonLiquidating: string;
+    liquidating: string;
+    liquidatingPriceDirection: 'below' | 'above';
+  }
+> = {
+  long: {
+    nonLiquidating: '2400.00',
+    liquidating: '1.00',
+    liquidatingPriceDirection: 'below',
+  },
+  short: {
+    nonLiquidating: '2600.00',
+    liquidating: '100000.00',
+    liquidatingPriceDirection: 'above',
+  },
+};
 
 const setupPerpsMocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
@@ -76,27 +95,17 @@ const expectPositionClosedAfterLiquidation = async () => {
   );
 };
 
-const openEthLongPosition = async () => {
-  await WalletView.scrollAndTapPerpsSection();
-  await PerpsHomeView.tapExploreCryptoIfVisible();
-
-  await PerpsMarketListView.selectMarket('ETH');
-  await PerpsMarketDetailsView.tapLongButton();
-  await PerpsOrderView.tapPlaceOrderButton();
-  await PerpsMarketDetailsView.waitForScreenReady();
-  await PerpsMarketDetailsView.expectClosePositionButtonVisible();
-};
-
-const queueEthLiquidationCheckAtPrice = async (
+const queueLiquidationCheckAtPrice = async (
   commandQueueServer: CommandQueueServer,
+  symbol: string,
   price: string,
 ) => {
   await PerpsE2EModifiers.updateMarketPriceServer(
     commandQueueServer,
-    'ETH',
+    symbol,
     price,
   );
-  await PerpsE2EModifiers.triggerLiquidationServer(commandQueueServer, 'ETH');
+  await PerpsE2EModifiers.triggerLiquidationServer(commandQueueServer, symbol);
 };
 
 const waitForCommandQueueToProcess = async (
@@ -107,7 +116,7 @@ const waitForCommandQueueToProcess = async (
 };
 
 describe(SmokePerps('Perps Position Liquidation'), () => {
-  it('liquidates a long position when mark price falls below liquidation price', async () => {
+  it(`liquidates a ${POSITION_DIRECTION} position when mark price moves ${MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].liquidatingPriceDirection} liquidation price`, async () => {
     await withFixtures(
       {
         fixture: buildPerpsFixture(),
@@ -121,38 +130,42 @@ describe(SmokePerps('Perps Position Liquidation'), () => {
         }
 
         logger.info('Using E2E mock balance - no wallet import needed');
-        logger.info('Opening ETH long position');
+        logger.info(`Opening ${MARKET_SYMBOL} ${POSITION_DIRECTION} position`);
 
         await loginToApp();
         await device.disableSynchronization();
 
-        await openEthLongPosition();
+        await openPosition(MARKET_SYMBOL, POSITION_DIRECTION);
 
         logger.info(
-          'Pushing ETH mark price above liquidation price; long should stay open',
+          `Pushing ${MARKET_SYMBOL} mark price that should keep ${POSITION_DIRECTION} open`,
         );
 
-        await queueEthLiquidationCheckAtPrice(
+        await queueLiquidationCheckAtPrice(
           commandQueueServer,
-          NON_LIQUIDATING_ETH_MARK_PRICE,
+          MARKET_SYMBOL,
+          MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].nonLiquidating,
         );
         await waitForCommandQueueToProcess(commandQueueServer);
 
         logger.info(
-          'Verifying ETH long remains open after non-liquidating price change',
+          `Verifying ${MARKET_SYMBOL} ${POSITION_DIRECTION} remains open after non-liquidating price change`,
         );
         await PerpsMarketDetailsView.expectClosePositionButtonVisible();
 
         logger.info(
-          'Pushing ETH mark price below liquidation price to liquidate long',
+          `Pushing ${MARKET_SYMBOL} mark price ${MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].liquidatingPriceDirection} liquidation price to liquidate ${POSITION_DIRECTION}`,
         );
 
-        await queueEthLiquidationCheckAtPrice(
+        await queueLiquidationCheckAtPrice(
           commandQueueServer,
-          LIQUIDATING_ETH_MARK_PRICE,
+          MARKET_SYMBOL,
+          MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].liquidating,
         );
 
-        logger.info('Verifying ETH long is closed after liquidation');
+        logger.info(
+          `Verifying ${MARKET_SYMBOL} ${POSITION_DIRECTION} is closed after liquidation`,
+        );
         await expectPositionClosedAfterLiquidation();
       },
     );

--- a/tests/smoke/perps/perps-position-liquidation.spec.ts
+++ b/tests/smoke/perps/perps-position-liquidation.spec.ts
@@ -9,116 +9,151 @@ import {
   mockPerpsGeolocation,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
 import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView';
-import PerpsView from '../../page-objects/Perps/PerpsView';
 import PerpsOrderView from '../../page-objects/Perps/PerpsOrderView';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
-import { createLogger, LogLevel, type TestSuiteParams } from '../../framework';
+import {
+  createLogger,
+  LogLevel,
+  Utilities,
+  type TestSuiteParams,
+} from '../../framework';
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
+import CommandQueueServer from '../../framework/fixtures/CommandQueueServer';
 
 const logger = createLogger({
   name: 'PerpsPositionLiquidationSpec',
   level: LogLevel.INFO,
 });
 
-// Skipped until liquidation mock + assertions are verified stable on iOS and Android in CI.
-describe.skip(SmokePerps('Perps Position Liquidation'), () => {
-  it('opens a long position and gets liquidated', async () => {
+const NON_LIQUIDATING_ETH_MARK_PRICE = '2400.00';
+const LIQUIDATING_ETH_MARK_PRICE = '1.00';
+
+const setupPerpsMocks = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
+  });
+  await PERPS_ARBITRUM_MOCKS(mockServer);
+  await mockPerpsGeolocation(mockServer, RampsRegions[RampsRegionsEnum.SPAIN]);
+};
+
+const buildPerpsFixture = () =>
+  new FixtureBuilder()
+    .withPerpsProfile('no-positions')
+    .withPerpsFirstTimeUser(false)
+    .withNetworkController({
+      type: 'rpc',
+      chainId: '0xa4b1',
+      rpcUrl: 'https://arb1.arbitrum.io/rpc',
+      nickname: 'Arbitrum One',
+      ticker: 'ETH',
+    })
+    .withTokensForAllPopularNetworks([
+      {
+        address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+        symbol: 'USDC',
+        decimals: 6,
+        name: 'USD Coin',
+        type: 'erc20',
+      },
+    ])
+    .withPopularNetworks()
+    .build();
+
+const expectPositionClosedAfterLiquidation = async () => {
+  await Utilities.executeWithRetry(
+    async () => {
+      await PerpsMarketDetailsView.expectClosePositionButtonNotVisible();
+    },
+    {
+      interval: 1000,
+      timeout: 30000,
+      description: 'wait for Close position to disappear after liquidation',
+    },
+  );
+};
+
+const openEthLongPosition = async () => {
+  await WalletView.scrollAndTapPerpsSection();
+  await PerpsHomeView.tapExploreCryptoIfVisible();
+
+  await PerpsMarketListView.selectMarket('ETH');
+  await PerpsMarketDetailsView.tapLongButton();
+  await PerpsOrderView.tapPlaceOrderButton();
+  await PerpsMarketDetailsView.waitForScreenReady();
+  await PerpsMarketDetailsView.expectClosePositionButtonVisible();
+};
+
+const queueEthLiquidationCheckAtPrice = async (
+  commandQueueServer: CommandQueueServer,
+  price: string,
+) => {
+  await PerpsE2EModifiers.updateMarketPriceServer(
+    commandQueueServer,
+    'ETH',
+    price,
+  );
+  await PerpsE2EModifiers.triggerLiquidationServer(commandQueueServer, 'ETH');
+};
+
+const waitForCommandQueueToProcess = async (
+  commandQueueServer: CommandQueueServer,
+) => {
+  commandQueueServer.requestStateExport();
+  await commandQueueServer.getExportedState();
+};
+
+describe(SmokePerps('Perps Position Liquidation'), () => {
+  it('liquidates a long position when mark price falls below liquidation price', async () => {
     await withFixtures(
       {
-        fixture: new FixtureBuilder()
-          .withPerpsProfile('no-positions')
-          .withPerpsFirstTimeUser(false)
-          .withNetworkController({
-            type: 'rpc',
-            chainId: '0xa4b1',
-            rpcUrl: 'https://arb1.arbitrum.io/rpc',
-            nickname: 'Arbitrum One',
-            ticker: 'ETH',
-          })
-          .withTokensForAllPopularNetworks([
-            {
-              address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
-              symbol: 'USDC',
-              decimals: 6,
-              name: 'USD Coin',
-              type: 'erc20',
-            },
-          ])
-          .withPopularNetworks()
-          .build(),
+        fixture: buildPerpsFixture(),
         restartDevice: true,
-        testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
-          await PERPS_ARBITRUM_MOCKS(mockServer);
-          await mockPerpsGeolocation(
-            mockServer,
-            RampsRegions[RampsRegionsEnum.SPAIN],
-          );
-        },
+        testSpecificMock: setupPerpsMocks,
         useCommandQueueServer: true,
       },
       async ({ commandQueueServer }: TestSuiteParams) => {
         if (!commandQueueServer) {
           throw new Error('Command queue server not found');
         }
-        logger.info('💰 Using E2E mock balance - no wallet import needed');
-        logger.info('🎯 Mock account: $10,000 total, $8,000 available');
+
+        logger.info('Using E2E mock balance - no wallet import needed');
+        logger.info('Opening ETH long position');
+
         await loginToApp();
         await device.disableSynchronization();
 
-        // Navigate to Perps via homepage section (same click path as smoke perps tests)
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsMarketListView.selectMarket('ETH');
-        await PerpsMarketDetailsView.tapLongButton();
-        await PerpsOrderView.tapPlaceOrderButton();
+        await openEthLongPosition();
 
-        // Wait for market details like perps-position.spec: a price push before the
-        // sheet finishes closing can redraw the chart and leave the scroll view
-        // under the 75% visible / not-obscured threshold on Android.
-        await PerpsMarketDetailsView.waitForScreenReady();
+        logger.info(
+          'Pushing ETH mark price above liquidation price; long should stay open',
+        );
+
+        await queueEthLiquidationCheckAtPrice(
+          commandQueueServer,
+          NON_LIQUIDATING_ETH_MARK_PRICE,
+        );
+        await waitForCommandQueueToProcess(commandQueueServer);
+
+        logger.info(
+          'Verifying ETH long remains open after non-liquidating price change',
+        );
         await PerpsMarketDetailsView.expectClosePositionButtonVisible();
 
-        logger.info('📈 E2E Mock: Order placed successfully');
-        logger.info('💎 E2E Mock: Position created with mock data');
-
-        await PerpsE2EModifiers.updateMarketPriceServer(
-          commandQueueServer,
-          'ETH',
-          '2125.00',
-        );
-        await PerpsE2EModifiers.triggerLiquidationServer(
-          commandQueueServer,
-          'ETH',
-        );
         logger.info(
-          'E2E Mock: First liquidation attempt at 2125 — position expected to stay open until a lower mark',
+          'Pushing ETH mark price below liquidation price to liquidate long',
         );
 
-        await PerpsView.tapBackButtonPositionSheet();
-        await PerpsE2EModifiers.updateMarketPriceServer(
+        await queueEthLiquidationCheckAtPrice(
           commandQueueServer,
-          'ETH',
-          '1200.00',
-        );
-        await PerpsE2EModifiers.triggerLiquidationServer(
-          commandQueueServer,
-          'ETH',
+          LIQUIDATING_ETH_MARK_PRICE,
         );
 
-        logger.info(
-          'E2E Mock: Second liquidation attempt at 1200 — position expected to clear',
-        );
-
-        await PerpsView.expectPositionRowNotVisibleAnyLeverage(
-          'ETH',
-          'long',
-          0,
-        );
+        logger.info('Verifying ETH long is closed after liquidation');
+        await expectPositionClosedAfterLiquidation();
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fix perps e2e liquidation test

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E test flows and selectors; low product risk but could affect CI stability if timing/mocks are still flaky.
> 
> **Overview**
> Refactors the perps liquidation smoke test to be deterministic and less flaky by extracting shared setup (fixtures/mocks), parameterizing mark prices by `long`/`short` direction, and adding explicit waits/retries to confirm the position closes after liquidation.
> 
> Adds a reusable `openPosition(symbol, direction)` helper in `perps.flow.ts` (including optional “Explore crypto” handling) and improves tap logging for the perps long button to aid debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd10775a80ac6f0a500ba0cc42007026d20e5bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->