### PR TITLE
chore: disable external TestFlight distribution for RC and production builds

### DIFF
--- a/.github/workflows/auto-rc-ota-build-core.yml
+++ b/.github/workflows/auto-rc-ota-build-core.yml
@@ -142,4 +142,5 @@ jobs:
       build_commit_sha: ${{ needs.trigger-build.outputs.built_commit_sha }}
       build_version: ${{ needs.trigger-build.outputs.semantic_version }}
       build_number: ${{ needs.trigger-build.outputs.ios_version_code }}
+      distribute_external: false
     secrets: inherit

--- a/.github/workflows/runway-production-builds.yml
+++ b/.github/workflows/runway-production-builds.yml
@@ -65,4 +65,5 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
+      distribute_external: false
     secrets: inherit

--- a/.github/workflows/runway-rc-builds.yml
+++ b/.github/workflows/runway-rc-builds.yml
@@ -65,6 +65,7 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
+      distribute_external: false
     secrets: inherit
 
   slack-notification:


### PR DESCRIPTION
---

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

RC and production iOS builds were not explicitly setting `distribute_external` when calling `upload-to-testflight.yml`, which meant they relied on the callee's default. This made the behaviour implicit and fragile.

This PR explicitly passes `distribute_external: false` in the three workflows that trigger a TestFlight upload for RC and production builds:

- `auto-rc-ota-build-core.yml` (Auto-RC flow)
- `runway-rc-builds.yml` (Runway manual RC trigger)
- `runway-production-builds.yml` (Runway manual production trigger)

By pinning the flag to `false`, each new RC or production binary is uploaded to TestFlight for **internal testers only**. External distribution remains a deliberate, separate step — preventing accidental early exposure of builds to external groups and allowing multiple RC builds to be uploaded without immediately surfacing them externally.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

No issue: CI/build workflow maintenance — makes external distribution behaviour explicit and consistent across all RC and production upload paths.

## **Manual testing steps**

```gherkin
Feature: TestFlight distribution gating for RC and production builds

  Scenario: RC build is uploaded without external distribution
    Given a release branch exists and a build is triggered via runway-rc-builds.yml
    When the upload-ios-testflight job completes
    Then the IPA is available to internal testers on TestFlight
    And the build is NOT distributed to external testing groups

  Scenario: Production build is uploaded without external distribution
    Given a release branch exists and a build is triggered via runway-production-builds.yml
    When the upload-ios-testflight job completes
    Then the IPA is available to internal testers on TestFlight
    And the build is NOT distributed to external testing groups
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only adjusts CI/TestFlight upload configuration, but it affects who receives RC/prod builds so misconfiguration could block intended external distribution.
> 
> **Overview**
> Makes RC and production iOS TestFlight uploads **explicitly internal-only** by passing `distribute_external: false` to `upload-to-testflight.yml` in the Auto-RC core flow and both Runway RC/production build workflows.
> 
> This removes reliance on the callee workflow’s default behavior and reduces the chance of accidentally distributing RC/prod builds to external tester groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c9966c5e1b858bab38eeb5309f14b75473bd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->