### PR TITLE
ci: use MetaMask/action-checkout-and-setup for OTA changelog steps

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -185,9 +185,13 @@ jobs:
           path: github-tools
           ref: v1
 
+      # Use the standalone action (MetaMask/action-checkout-and-setup) directly. The previous
+      # `./github-tools/.github/actions/checkout-and-setup` reference broke when MetaMask/github-tools@v1
+      # (a moving major-version tag) rolled forward past the point where that local action existed —
+      # github-tools itself now delegates to this standalone action.
       - name: Setup Node for changelog tooling
         if: needs.resolve-bases.outputs.is_ota == 'true' && steps.ota_release_pr.outputs.exists != 'true'
-        uses: ./github-tools/.github/actions/checkout-and-setup
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
 

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -67,8 +67,12 @@ jobs:
           path: github-tools
           ref: v1
 
+      # Use the standalone action (MetaMask/action-checkout-and-setup) directly. The previous
+      # `./github-tools/.github/actions/checkout-and-setup` reference broke when MetaMask/github-tools@v1
+      # (a moving major-version tag) rolled forward past the point where that local action existed —
+      # github-tools itself now delegates to this standalone action.
       - name: Setup Node for changelog tooling
-        uses: ./github-tools/.github/actions/checkout-and-setup
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
           is-high-risk-environment: true
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
OTA release automation and the “Update Release Changelog PR” workflow referenced `./github-tools/.github/actions/checkout-and-setup` after checking out `MetaMask/github-tools@v1`. That path no longer exists on the current `v1` tag: the composite action was removed from `github-tools` (around the `v1.9.0` line) in favor of the standalone repo `MetaMask/action-checkout-and-setup`.

Native release PR creation was unaffected because it only uses `MetaMask/github-tools/.github/actions/create-release-pr@v1`; the failure showed up on the OTA path (and on any run that hit the changelog workflow’s setup step).

**Changes**
- **`create-release-pr.yml`** — For OTA hotfixes, replace the local `checkout-and-setup` reference with `MetaMask/action-checkout-and-setup@v1` (same `is-high-risk-environment: true` input). Keep the separate `github-tools` checkout so `run-update-release-changelog-mobile.sh` can still run `github-tools/.github/scripts/update-release-changelog.sh`.
- **`update-release-changelog.yml`** — Same replacement so pushes to `release/*` branches can set up Node/Yarn again without relying on a removed path under `github-tools@v1`.

failed workflow: https://github.com/MetaMask/metamask-mobile/actions/runs/25684499507/job/75404595902

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
