### PR TITLE
feat(predict): update liveline chart foundation

### DIFF
--- a/app/components/UI/Charts/LivelineChart/LivelineChart.tsx
+++ b/app/components/UI/Charts/LivelineChart/LivelineChart.tsx
@@ -1,6 +1,8 @@
 import React, {
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -15,195 +17,265 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import Logger from '../../../../util/Logger';
 import { useTheme } from '../../../../util/theme';
 import { createLivelineChartTemplate } from './LivelineChartTemplate';
 import { REACT_LIB, REACT_DOM_LIB, LIVELINE_LIB } from './LivelineChartAssets';
 import {
   parseWebViewMessage,
   type LivelineChartProps,
+  type LivelineChartRef,
   type RNToWebViewMessage,
 } from './LivelineChart.types';
 
 export const DEFAULT_CHART_HEIGHT = 250;
 
-const LivelineChart: React.FC<LivelineChartProps> = ({
-  height = DEFAULT_CHART_HEIGHT,
-  onChartReady,
-  onError,
-  onHover,
-  onWindowChange,
-  onModeChange,
-  onSeriesToggle,
-  ...chartProps
-}) => {
-  const tw = useTailwind();
-  const theme = useTheme();
-  const webViewRef = useRef<WebView>(null);
-  const [isChartReady, setIsChartReady] = useState(false);
-  const [webViewError, setWebViewError] = useState<string | null>(null);
-
-  const htmlContent = useMemo(
-    () =>
-      createLivelineChartTemplate(
-        theme,
-        REACT_LIB,
-        REACT_DOM_LIB,
-        LIVELINE_LIB,
-      ),
-    [theme],
-  );
-
-  const postMessage = useCallback((message: RNToWebViewMessage) => {
-    webViewRef.current?.postMessage(JSON.stringify(message));
-  }, []);
-
-  // When htmlContent changes (e.g. theme switch) the WebView reloads.
-  // Reset both isChartReady and webViewError so the WebView re-mounts
-  // cleanly: if only isChartReady were reset, a prior error state would keep
-  // the error UI visible (early return at the error render branch), preventing
-  // the WebView from mounting and CHART_READY from ever firing — a deadlock.
-  useEffect(() => {
-    setIsChartReady(false);
-    setWebViewError(null);
-  }, [htmlContent]);
-
-  // Send the full props snapshot to the WebView whenever any chart prop
-  // changes. The WebView calls root.render(<Liveline {...props} />) on receipt,
-  // letting React's own reconciler diff and update.
-  //
-  // chartProps is destructured from the component props so it is a new object
-  // on every render; we JSON-serialise it to get a stable dep-comparable value.
-  const chartPropsJson = JSON.stringify({
-    ...chartProps,
-    theme: theme.themeAppearance,
-  });
-  useEffect(() => {
-    if (!isChartReady) return;
-    // chartPropsJson is the stable dep; parse it back so the payload is a
-    // plain object (avoids sending the stale chartProps closure value).
-    postMessage({
-      type: 'SET_PROPS',
-      payload: JSON.parse(chartPropsJson),
-    });
-  }, [isChartReady, postMessage, chartPropsJson]);
-
-  const handleMessage = useCallback(
-    (event: WebViewMessageEvent) => {
-      let raw;
-      try {
-        raw = JSON.parse(event.nativeEvent.data);
-      } catch {
-        return;
-      }
-
-      const message = parseWebViewMessage(raw);
-      if (!message) return;
-
-      switch (message.type) {
-        case 'CHART_READY':
-          setIsChartReady(true);
-          setWebViewError(null);
-          onChartReady?.();
-          break;
-        case 'ERROR':
-          setWebViewError(message.payload.message);
-          onError?.(message.payload.message);
-          break;
-        case 'HOVER':
-          onHover?.(message.payload);
-          break;
-        case 'WINDOW_CHANGE':
-          onWindowChange?.(message.payload.secs);
-          break;
-        case 'MODE_CHANGE':
-          onModeChange?.(message.payload.mode);
-          break;
-        case 'SERIES_TOGGLE':
-          onSeriesToggle?.(message.payload.id, message.payload.visible);
-          break;
-        default:
-          break;
-      }
-    },
-    [
+const LivelineChart = forwardRef<LivelineChartRef, LivelineChartProps>(
+  (
+    {
+      height = DEFAULT_CHART_HEIGHT,
       onChartReady,
       onError,
       onHover,
       onWindowChange,
       onModeChange,
       onSeriesToggle,
-    ],
-  );
-
-  const handleWebViewError = useCallback(
-    (syntheticEvent: { nativeEvent: { description: string } }) => {
-      const { description } = syntheticEvent.nativeEvent;
-      setWebViewError(description);
-      onError?.(description);
+      ...chartProps
     },
-    [onError],
-  );
+    ref,
+  ) => {
+    const tw = useTailwind();
+    const theme = useTheme();
+    const webViewRef = useRef<WebView>(null);
+    const [isChartReady, setIsChartReady] = useState(false);
+    const [webViewError, setWebViewError] = useState<string | null>(null);
+    const isChartReadyRef = useRef(false);
+    const pendingRef = useRef<RNToWebViewMessage[]>([]);
+    const hasFlushedRef = useRef(false);
+    const callbacksRef = useRef({
+      onChartReady,
+      onError,
+      onHover,
+      onWindowChange,
+      onModeChange,
+      onSeriesToggle,
+    });
 
-  if (webViewError) {
-    return (
-      <Box
-        testID="liveline-chart-error"
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
-        style={tw.style('w-full bg-background-default', { height })}
-        twClassName="px-5"
-      >
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="text-error-default text-center"
-        >
-          Failed to load chart: {webViewError}
-        </Text>
-      </Box>
+    callbacksRef.current = {
+      onChartReady,
+      onError,
+      onHover,
+      onWindowChange,
+      onModeChange,
+      onSeriesToggle,
+    };
+
+    const htmlContent = useMemo(
+      () =>
+        createLivelineChartTemplate(
+          theme,
+          REACT_LIB,
+          REACT_DOM_LIB,
+          LIVELINE_LIB,
+        ),
+      [theme],
     );
-  }
 
-  return (
-    <Box style={tw.style('w-full bg-background-default', { height })}>
-      <WebView
-        testID="liveline-chart-webview"
-        ref={webViewRef}
-        source={{ html: htmlContent }}
-        style={tw.style('flex-1 bg-background-default')}
-        onMessage={handleMessage}
-        onError={handleWebViewError}
-        originWhitelist={['about:*', 'file:*']}
-        javaScriptEnabled
-        domStorageEnabled
-        scrollEnabled={false}
-        bounces={false}
-        showsHorizontalScrollIndicator={false}
-        showsVerticalScrollIndicator={false}
-        allowsInlineMediaPlayback
-        androidLayerType="hardware"
-      />
+    const postMessage = useCallback((message: RNToWebViewMessage) => {
+      webViewRef.current?.postMessage(JSON.stringify(message));
+    }, []);
 
-      {!isChartReady && (
+    const flushPendingMessages = useCallback(() => {
+      if (hasFlushedRef.current) return;
+      hasFlushedRef.current = true;
+      const queued = pendingRef.current;
+      pendingRef.current = [];
+      if (queued.length === 0) return;
+      queued.forEach((msg) => postMessage(msg));
+    }, [postMessage]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        appendPoint: (point, value) => {
+          const msg: RNToWebViewMessage = {
+            type: 'APPEND_POINT',
+            payload: { point, value },
+          };
+          if (!isChartReadyRef.current) {
+            pendingRef.current.push(msg);
+            return;
+          }
+          postMessage(msg);
+        },
+        clearData: () => {
+          if (!isChartReadyRef.current) {
+            pendingRef.current = pendingRef.current.filter(
+              (message) =>
+                message.type !== 'APPEND_POINT' &&
+                message.type !== 'CLEAR_DATA',
+            );
+            pendingRef.current.push({ type: 'CLEAR_DATA' });
+            return;
+          }
+          postMessage({ type: 'CLEAR_DATA' });
+        },
+      }),
+      [postMessage],
+    );
+
+    useEffect(() => {
+      setIsChartReady(false);
+      isChartReadyRef.current = false;
+      hasFlushedRef.current = false;
+      pendingRef.current = [];
+      setWebViewError(null);
+    }, [htmlContent]);
+
+    const chartPropsJson = JSON.stringify({
+      ...chartProps,
+      theme: theme.themeAppearance,
+    });
+    const shouldShowNativeLoading = !isChartReady || chartProps.loading;
+
+    useEffect(() => {
+      if (!isChartReady) return;
+      postMessage({
+        type: 'SET_PROPS',
+        payload: JSON.parse(chartPropsJson),
+      });
+    }, [isChartReady, postMessage, chartPropsJson]);
+
+    useEffect(() => {
+      if (!isChartReady || hasFlushedRef.current) return;
+      flushPendingMessages();
+    }, [flushPendingMessages, isChartReady]);
+
+    const handleMessage = useCallback(
+      (event: WebViewMessageEvent) => {
+        let raw;
+        try {
+          raw = JSON.parse(event.nativeEvent.data);
+        } catch {
+          return;
+        }
+
+        const message = parseWebViewMessage(raw);
+        if (!message) return;
+
+        switch (message.type) {
+          case 'CHART_READY':
+            setIsChartReady(true);
+            isChartReadyRef.current = true;
+            setWebViewError(null);
+            flushPendingMessages();
+            callbacksRef.current.onChartReady?.();
+            break;
+          case 'ERROR':
+            setWebViewError(message.payload.message);
+            callbacksRef.current.onError?.(message.payload.message);
+            break;
+          case 'HOVER':
+            callbacksRef.current.onHover?.(message.payload);
+            break;
+          case 'WINDOW_CHANGE':
+            callbacksRef.current.onWindowChange?.(message.payload.secs);
+            break;
+          case 'MODE_CHANGE':
+            callbacksRef.current.onModeChange?.(message.payload.mode);
+            break;
+          case 'SERIES_TOGGLE':
+            callbacksRef.current.onSeriesToggle?.(
+              message.payload.id,
+              message.payload.visible,
+            );
+            break;
+          case 'PERF':
+            if (__DEV__) {
+              Logger.log('LivelineChart render', message.payload);
+            }
+            break;
+          default:
+            break;
+        }
+      },
+      [flushPendingMessages],
+    );
+
+    const handleWebViewError = useCallback(
+      (syntheticEvent: { nativeEvent: { description: string } }) => {
+        const { description } = syntheticEvent.nativeEvent;
+        setWebViewError(description);
+        callbacksRef.current.onError?.(description);
+      },
+      [],
+    );
+
+    if (webViewError) {
+      return (
         <Box
-          testID="liveline-chart-loading"
+          testID="liveline-chart-error"
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Center}
-          style={tw.style(
-            'absolute top-0 left-0 right-0 bottom-0 bg-background-default',
-          )}
+          style={tw.style('w-full bg-background-default', { height })}
+          twClassName="px-5"
         >
-          <ActivityIndicator
-            size="large"
-            color={theme.colors.primary.default}
-          />
-          <Text variant={TextVariant.BodySm} twClassName="mt-3 text-text-muted">
-            Loading chart...
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-error-default text-center"
+          >
+            Failed to load chart: {webViewError}
           </Text>
         </Box>
-      )}
-    </Box>
-  );
-};
+      );
+    }
+
+    return (
+      <Box style={tw.style('w-full bg-background-default', { height })}>
+        <WebView
+          testID="liveline-chart-webview"
+          ref={webViewRef}
+          source={{ html: htmlContent }}
+          style={tw.style('flex-1 bg-background-default')}
+          onMessage={handleMessage}
+          onError={handleWebViewError}
+          originWhitelist={['about:*', 'file:*']}
+          javaScriptEnabled
+          domStorageEnabled
+          scrollEnabled={false}
+          bounces={false}
+          showsHorizontalScrollIndicator={false}
+          showsVerticalScrollIndicator={false}
+          allowsInlineMediaPlayback
+          androidLayerType="hardware"
+        />
+
+        {/* TODO: Clean up Liveline loading so the WebView empty state never appears between native loading and chart data. */}
+        {shouldShowNativeLoading && (
+          <Box
+            testID="liveline-chart-loading"
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+            style={tw.style(
+              'absolute top-0 left-0 right-0 bottom-0 bg-background-default',
+            )}
+          >
+            <ActivityIndicator
+              size="large"
+              color={theme.colors.primary.default}
+            />
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="mt-3 text-text-muted"
+            >
+              Loading chart...
+            </Text>
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
 
 LivelineChart.displayName = 'LivelineChart';
 

--- a/app/components/UI/Charts/LivelineChart/LivelineChart.types.ts
+++ b/app/components/UI/Charts/LivelineChart/LivelineChart.types.ts
@@ -112,6 +112,7 @@ export interface LivelineChartProps {
 
   // -- Feature flags --
   grid?: boolean;
+  hideControls?: boolean;
   badge?: boolean;
   badgeTail?: boolean;
   badgeVariant?: BadgeVariant;
@@ -179,30 +180,31 @@ export interface LivelineChartProps {
   onError?: (message: string) => void;
 }
 
+// ---- Ref API (imperative updates) ----
+
+export interface LivelineChartRef {
+  /** O(1) bridge cost — sends only the new point instead of the full array. */
+  appendPoint: (point: LivelinePoint, value: number) => void;
+  clearData: () => void;
+}
+
 // ---- WebView ↔ RN message protocol ----
 
-/**
- * Single message type sent from React Native → WebView.
- * The full props snapshot is sent on every change; the WebView calls
- * `root.render(createElement(Liveline, props))` on receipt.
- *
- * Callback props (onHover, onWindowChange, onModeChange, onSeriesToggle) are
- * omitted — they cannot cross the JSON bridge and are wired inside the WebView,
- * posting messages back to RN instead.
- */
-export interface RNToWebViewMessage {
-  type: 'SET_PROPS';
-  payload: Omit<
-    LivelineChartProps,
-    | 'height'
-    | 'onChartReady'
-    | 'onError'
-    | 'onHover'
-    | 'onWindowChange'
-    | 'onModeChange'
-    | 'onSeriesToggle'
-  >;
-}
+type ChartPropsPayload = Omit<
+  LivelineChartProps,
+  | 'height'
+  | 'onChartReady'
+  | 'onError'
+  | 'onHover'
+  | 'onWindowChange'
+  | 'onModeChange'
+  | 'onSeriesToggle'
+>;
+
+export type RNToWebViewMessage =
+  | { type: 'SET_PROPS'; payload: ChartPropsPayload }
+  | { type: 'APPEND_POINT'; payload: { point: LivelinePoint; value: number } }
+  | { type: 'CLEAR_DATA' };
 
 /** Messages sent from WebView → React Native. */
 export type WebViewToRNMessage =
@@ -211,7 +213,22 @@ export type WebViewToRNMessage =
   | { type: 'HOVER'; payload: HoverPoint | null }
   | { type: 'WINDOW_CHANGE'; payload: { secs: number } }
   | { type: 'MODE_CHANGE'; payload: { mode: 'line' | 'candle' } }
-  | { type: 'SERIES_TOGGLE'; payload: { id: string; visible: boolean } };
+  | { type: 'SERIES_TOGGLE'; payload: { id: string; visible: boolean } }
+  | { type: 'PERF'; payload: { renderMs: number; points: number } };
+
+const parsePerfPayload = (payload: unknown): WebViewToRNMessage => {
+  const perfPayload = payload as
+    | { renderMs?: number; points?: number }
+    | undefined;
+
+  return {
+    type: 'PERF',
+    payload: {
+      renderMs: perfPayload?.renderMs ?? 0,
+      points: perfPayload?.points ?? 0,
+    },
+  };
+};
 
 /**
  * Type-safe parser for incoming WebView → RN messages.
@@ -260,6 +277,8 @@ export const parseWebViewMessage = (
         payload: { id: payload?.id ?? '', visible: payload?.visible ?? true },
       };
     }
+    case 'PERF':
+      return parsePerfPayload(obj.payload);
     default:
       return null;
   }

--- a/app/components/UI/Charts/LivelineChart/LivelineChartTemplate.ts
+++ b/app/components/UI/Charts/LivelineChart/LivelineChartTemplate.ts
@@ -53,6 +53,7 @@ export const createLivelineChartTemplate = (
        natural height. Using last-child covers all combinations. */
     #root>*{flex-shrink:0}
     #root>*:last-child{flex:1;min-height:0}
+    body.liveline-hide-controls #root>*:not(:last-child){display:none!important}
   </style>
 </head>
 <body>
@@ -123,21 +124,56 @@ export const createLivelineChartTemplate = (
 
     var root = createRoot(document.getElementById('root'));
     var currentProps = null;
+    var liveData = [];
+    var liveValue = 0;
+    var inLiveMode = false;
+    var lastPerfTs = 0;
+
+    function mergeLivelineData(base, incoming) {
+      var byTime = new Map();
+      (base || []).forEach(function(point) {
+        if (point && typeof point.time === 'number') {
+          byTime.set(point.time, point);
+        }
+      });
+      (incoming || []).forEach(function(point) {
+        if (point && typeof point.time === 'number') {
+          byTime.set(point.time, point);
+        }
+      });
+      return Array.from(byTime.values()).sort(function(a, b) {
+        return a.time - b.time;
+      });
+    }
+
+    function trimLivelineData(data, windowSecs) {
+      if (!windowSecs || data.length === 0) {
+        return data;
+      }
+
+      var latestTime = data[data.length - 1].time;
+      var cutoff = latestTime - windowSecs * 2;
+      return data.filter(function(point) {
+        return point.time >= cutoff;
+      });
+    }
 
     function render() {
       if (!currentProps) return;
-      // Reconstruct formatValue / formatTime from their serialised bodies.
       var formatValue = currentProps.formatValue;
       var formatTime  = currentProps.formatTime;
       var rest = Object.assign({}, currentProps);
       delete rest.formatValue;
       delete rest.formatTime;
+      var hideControls = !!rest.hideControls;
+      delete rest.hideControls;
+      document.body.classList.toggle('liveline-hide-controls', hideControls);
+      var effectiveData  = inLiveMode ? liveData : (rest.data || []);
+      var effectiveValue = inLiveMode ? liveValue : (rest.value || 0);
       var props = Object.assign({}, rest, callbacks, {
-        // width:100% ensures the canvas fills the flex item horizontally.
-        // height is intentionally omitted — the CSS flex layout gives the
-        // canvas-wrapper div flex:1 so it grows to fill all remaining space
-        // after any showValue / control-bar siblings have taken their height.
         style: { width: '100%' },
+        data: effectiveData,
+        value: effectiveValue,
       });
       if (formatValue) { props.formatValue = new Function('v', formatValue); }
       if (formatTime)  { props.formatTime  = new Function('t', formatTime);  }
@@ -149,9 +185,57 @@ export const createLivelineChartTemplate = (
         var msg = typeof event.data === 'string'
           ? JSON.parse(event.data)
           : event.data;
-        if (msg.type === 'SET_PROPS') {
-          currentProps = msg.payload;
-          render();
+        switch (msg.type) {
+          case 'SET_PROPS':
+            if (inLiveMode) {
+              var incoming = Object.assign({}, msg.payload);
+              if (Array.isArray(incoming.data) && incoming.data.length > 0) {
+                liveData = mergeLivelineData(liveData, incoming.data);
+                liveData = trimLivelineData(liveData, incoming.window);
+              }
+              delete incoming.data;
+              delete incoming.value;
+              currentProps = incoming;
+            } else {
+              currentProps = msg.payload;
+            }
+            render();
+            break;
+          case 'APPEND_POINT':
+            if (!inLiveMode) {
+              liveData = (currentProps && Array.isArray(currentProps.data))
+                ? currentProps.data.slice()
+                : [];
+            }
+            inLiveMode = true;
+            liveData = mergeLivelineData(liveData, [msg.payload.point]);
+            liveValue = msg.payload.value;
+            if (currentProps && currentProps.window) {
+              liveData = trimLivelineData(liveData, currentProps.window);
+            }
+            if (!currentProps) {
+              break;
+            }
+            var t0 = performance.now();
+            render();
+            var t1 = performance.now();
+            if (t1 - t0 > 16 && t1 - lastPerfTs > 5000) {
+              lastPerfTs = t1;
+              sendToRN('PERF', { renderMs: Math.round(t1 - t0), points: liveData.length });
+            }
+            break;
+          case 'CLEAR_DATA':
+            liveData = [];
+            liveValue = 0;
+            inLiveMode = false;
+            if (currentProps) {
+              currentProps = Object.assign({}, currentProps, {
+                data: [],
+                value: 0,
+              });
+            }
+            render();
+            break;
         }
       } catch (e) {
         sendToRN('ERROR', { message: e.message });

--- a/app/components/UI/Charts/LivelineChart/__tests__/LivelineChart.test.tsx
+++ b/app/components/UI/Charts/LivelineChart/__tests__/LivelineChart.test.tsx
@@ -6,6 +6,7 @@ import {
   type LivelinePoint,
   type CandlePoint,
   type HoverPoint,
+  type LivelineChartRef,
 } from '../LivelineChart.types';
 
 // Mock the generated asset file — it contains ~200 KB of minified JS strings
@@ -67,6 +68,34 @@ const makeReady = (webView: { props: Record<string, unknown> }) => {
   fireMessage(webView, { type: 'CHART_READY' });
 };
 
+describe('LivelineChartTemplate', () => {
+  it('lets incoming SET_PROPS data replace matching live timestamps', () => {
+    const { createLivelineChartTemplate } = jest.requireActual(
+      '../LivelineChartTemplate',
+    );
+    const theme = {
+      colors: { background: { default: 'white' } },
+    };
+
+    expect(createLivelineChartTemplate(theme, '', '', '')).toContain(
+      'mergeLivelineData(liveData, incoming.data)',
+    );
+  });
+
+  it('does not render appended points before SET_PROPS initializes props', () => {
+    const { createLivelineChartTemplate } = jest.requireActual(
+      '../LivelineChartTemplate',
+    );
+    const theme = {
+      colors: { background: { default: 'white' } },
+    };
+
+    expect(createLivelineChartTemplate(theme, '', '', '')).toContain(
+      'if (!currentProps) {',
+    );
+  });
+});
+
 // ---- component tests ----
 
 describe('LivelineChart', () => {
@@ -99,6 +128,16 @@ describe('LivelineChart', () => {
       makeReady(getByTestId('liveline-chart-webview'));
 
       expect(queryByTestId('liveline-chart-loading')).not.toBeOnTheScreen();
+    });
+
+    it('keeps the native loading overlay while chart data is loading', () => {
+      const { getByTestId } = render(
+        <LivelineChart data={[]} value={0} loading />,
+      );
+
+      makeReady(getByTestId('liveline-chart-webview'));
+
+      expect(getByTestId('liveline-chart-loading')).toBeOnTheScreen();
     });
   });
 
@@ -164,6 +203,32 @@ describe('LivelineChart', () => {
       });
 
       expect(onHover).toHaveBeenCalledWith(null);
+    });
+
+    it('keeps onMessage stable while using the latest callback props', () => {
+      const firstOnHover = jest.fn();
+      const secondOnHover = jest.fn();
+      const { getByTestId, rerender } = render(
+        <LivelineChart data={MOCK_DATA} value={43.1} onHover={firstOnHover} />,
+      );
+      const webView = getByTestId('liveline-chart-webview');
+      const initialOnMessage = webView.props.onMessage;
+
+      rerender(
+        <LivelineChart data={MOCK_DATA} value={43.1} onHover={secondOnHover} />,
+      );
+
+      expect(getByTestId('liveline-chart-webview').props.onMessage).toBe(
+        initialOnMessage,
+      );
+
+      fireMessage(getByTestId('liveline-chart-webview'), {
+        type: 'HOVER',
+        payload: null,
+      });
+
+      expect(firstOnHover).not.toHaveBeenCalled();
+      expect(secondOnHover).toHaveBeenCalledWith(null);
     });
 
     it('calls onWindowChange when WINDOW_CHANGE message arrives', () => {
@@ -399,6 +464,66 @@ describe('LivelineChart', () => {
       expect(onError).not.toHaveBeenCalled();
     });
   });
+
+  describe('imperative messages', () => {
+    it('flushes queued messages before onChartReady messages', () => {
+      const chartRef = React.createRef<LivelineChartRef>();
+      const queuedPoint = { time: 1700000060, value: 44 };
+      const readyPoint = { time: 1700000090, value: 45 };
+      const onChartReady = jest.fn(() => {
+        chartRef.current?.appendPoint(readyPoint, readyPoint.value);
+      });
+      const { getByTestId } = render(
+        <LivelineChart
+          ref={chartRef}
+          data={MOCK_DATA}
+          value={43.1}
+          onChartReady={onChartReady}
+        />,
+      );
+
+      act(() => {
+        chartRef.current?.appendPoint(queuedPoint, queuedPoint.value);
+      });
+      makeReady(getByTestId('liveline-chart-webview'));
+
+      const appendMessages = mockPostMessage.mock.calls
+        .map(([message]) => JSON.parse(message as string))
+        .filter((message) => message.type === 'APPEND_POINT');
+      expect(appendMessages.map((message) => message.payload.point)).toEqual([
+        queuedPoint,
+        readyPoint,
+      ]);
+    });
+
+    it('keeps appendPoint calls after a queued clearData reset', () => {
+      const chartRef = React.createRef<LivelineChartRef>();
+      const stalePoint = { time: 1700000060, value: 44 };
+      const freshPoint = { time: 1700000090, value: 45 };
+      const { getByTestId } = render(
+        <LivelineChart ref={chartRef} data={MOCK_DATA} value={43.1} />,
+      );
+
+      act(() => {
+        chartRef.current?.appendPoint(stalePoint, stalePoint.value);
+        chartRef.current?.clearData();
+        chartRef.current?.appendPoint(freshPoint, freshPoint.value);
+      });
+      makeReady(getByTestId('liveline-chart-webview'));
+
+      const flushedMessages = mockPostMessage.mock.calls
+        .map(([message]) => JSON.parse(message as string))
+        .filter((message) => message.type !== 'SET_PROPS');
+
+      expect(flushedMessages).toEqual([
+        { type: 'CLEAR_DATA' },
+        {
+          type: 'APPEND_POINT',
+          payload: { point: freshPoint, value: freshPoint.value },
+        },
+      ]);
+    });
+  });
 });
 
 // ---- parseWebViewMessage unit tests ----
@@ -491,6 +616,18 @@ describe('parseWebViewMessage', () => {
     expect(result).toEqual({
       type: 'SERIES_TOGGLE',
       payload: { id: 'series-1', visible: false },
+    });
+  });
+
+  it('parses PERF message', () => {
+    const result = parseWebViewMessage({
+      type: 'PERF',
+      payload: { renderMs: 24, points: 10 },
+    });
+
+    expect(result).toEqual({
+      type: 'PERF',
+      payload: { renderMs: 24, points: 10 },
     });
   });
 });

--- a/app/components/UI/Charts/LivelineChart/index.ts
+++ b/app/components/UI/Charts/LivelineChart/index.ts
@@ -3,6 +3,7 @@ export {
   DEFAULT_CHART_HEIGHT,
 } from './LivelineChart';
 export type {
+  LivelineChartRef,
   LivelineChartProps,
   LivelinePoint,
   CandlePoint,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
This PR updates the shared Liveline chart foundation used by the Predict crypto up/down work. It makes the React Native wrapper and WebView template support imperative live-point updates, queued messages before chart readiness, native loading behavior, and safer callback handling.

# TODO
1. This PR is stack item 1/3 and should merge before #30004 and #30005.
2. Keep this PR as draft until the stacked PRs are validated and all required checks are passing.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - stacked Predict crypto up/down implementation split from #29436.

## **Manual testing steps**

```gherkin
Feature: Liveline chart foundation

  Scenario: chart initializes and accepts live data updates
    Given a Predict screen renders a Liveline chart with historical data

    When the chart WebView becomes ready and live price points arrive
    Then the chart remains mounted and updates without showing an error state
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the RN↔WebView messaging contract and rendering flow (adds queued imperative updates and live-mode state), which could affect chart correctness, loading states, and performance.
> 
> **Overview**
> Updates `LivelineChart` to support an imperative ref API (`appendPoint`, `clearData`) that sends incremental WebView messages, queues them until `CHART_READY`, and flushes deterministically before firing `onChartReady`.
> 
> Extends the RN↔WebView protocol and template to handle `APPEND_POINT`/`CLEAR_DATA`, maintain a live-mode data buffer with merge/trim behavior, and optionally hide in-chart controls via the new `hideControls` prop (CSS body class).
> 
> Adjusts loading and callback handling: keeps a native loading overlay while `loading` is true, stabilizes `onMessage` while always using latest callback props, and adds dev-only `PERF` telemetry logging plus expanded unit tests for the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2a7e238962efa6beed173ae793764b93d444a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->