### PR TITLE
fix(predict): stabilize crypto up/down e2e tap

### DIFF
--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -905,17 +905,29 @@ class WalletView {
       overshootSwipe?: { direction: 'up' | 'down'; percentage?: number };
     } = {},
   ): Promise<void> {
-    await this.scrollAndTapSection(
-      this.predictionsSectionHeader,
-      'Predictions section',
-      direction,
-      {
-        overshootSwipe: options.overshootSwipe ?? {
-          direction: 'up',
-          percentage: 0.15,
-        },
+    const scrollOptions = {
+      overshootSwipe: options.overshootSwipe ?? {
+        direction: 'up' as const,
+        percentage: 0.15,
       },
-    );
+    };
+
+    try {
+      await this.scrollAndTapSection(
+        this.predictionsSectionHeader,
+        'Predictions section',
+        direction,
+        scrollOptions,
+      );
+    } catch {
+      const fallbackDirection = direction === 'down' ? 'up' : 'down';
+      await this.scrollAndTapSection(
+        this.predictionsSectionHeader,
+        'Predictions section',
+        fallbackDirection,
+        scrollOptions,
+      );
+    }
   }
 
   async scrollAndTapPredictionsPosition(positionName: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Makes the wallet page-object prediction section tap more resilient by retrying in the opposite scroll direction.

## Stack
4/4. Stacked on `predict/crypto-updown-details-ui`.

## Test plan
- yarn eslint tests/page-objects/wallet/WalletView.ts (passed with existing deprecation warning only)
- yarn prettier --check tests/page-objects/wallet/WalletView.ts

Made with [Cursor](https://cursor.com)