### PR TITLE
ci(INFRA-3628): Phase 5b - nscloud checkout action

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -91,6 +91,17 @@ inputs:
     description: 'Runner provider forwarded from the caller workflow chain. When set to "namespace", toolchain-install steps short-circuit if the pinned version is already on the image. Default "current" preserves byte-identical behaviour on existing GitHub-hosted / Cirrus runners.'
     required: false
     default: 'current'
+  js-retry-timeout-minutes:
+    description: >-
+      Per-attempt timeout (minutes) for Corepack and yarn install retry steps.
+      Namespace E2E matrix jobs often need more headroom (INFRA-3596).
+    required: false
+    default: '15'
+  pod-install-timeout-minutes:
+    description: >-
+      Per-attempt timeout (minutes) for the CocoaPods install retry step (iOS only).
+    required: false
+    default: '15'
 
 runs:
   using: 'composite'
@@ -289,7 +300,7 @@ runs:
       id: corepack
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
-        timeout_minutes: 15
+        timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
         max_attempts: 3
         retry_wait_seconds: 30
         command: ${{ steps.get-corepack-command.outputs.COREPACK_COMMAND }}
@@ -309,7 +320,7 @@ runs:
       id: yarn-install
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
-        timeout_minutes: 15
+        timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
         max_attempts: 3
         retry_wait_seconds: 30
         on_retry_command: echo "⚠️ yarn install failed — likely a transient network issue on the self-hosted runner. Retrying..."
@@ -413,7 +424,7 @@ runs:
       if: ${{ inputs.platform == 'ios'}}
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
-        timeout_minutes: 15
+        timeout_minutes: ${{ fromJSON(inputs.pod-install-timeout-minutes) }}
         max_attempts: 3
         retry_wait_seconds: 60
         on_retry_command: |

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -51,8 +51,12 @@ jobs:
       artifact_name: ${{ steps.determine-target-paths.outputs.artifact_name }}
 
     steps:
+      - name: Checkout repo (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - name: Checkout repo
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Check force-builds override
         id: force-builds

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -75,8 +75,12 @@ jobs:
 
     steps:
       # Get the source code from the repository
+      - name: Checkout repo (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - name: Checkout repo
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Check force-builds override
         id: force-builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,13 @@ jobs:
       script_name: ${{ steps.config.outputs.script_name }}
       checkout_ref_for_setup: ${{ !inputs.skip_version_bump && needs.update-build-version.outputs.commit-hash || (inputs.source_branch || github.ref_name) }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 1
+          ref: ${{ !inputs.skip_version_bump && needs.update-build-version.outputs.commit-hash || (inputs.source_branch || github.ref_name) }}
       - uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
           ref: ${{ !inputs.skip_version_bump && needs.update-build-version.outputs.commit-hash || (inputs.source_branch || github.ref_name) }}
@@ -204,20 +210,34 @@ jobs:
             exit 1
           fi
           echo "Building at version-bump commit: $COMMIT_HASH"
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' && !inputs.skip_version_bump }}
+        with:
+          ref: ${{ needs.update-build-version.outputs.commit-hash }}
+          submodules: recursive
       - uses: actions/checkout@v4
-        if: ${{ !inputs.skip_version_bump }}
+        if: ${{ inputs.runner_provider != 'namespace' && !inputs.skip_version_bump }}
         with:
           ref: ${{ needs.update-build-version.outputs.commit-hash }}
           submodules: recursive
 
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' && inputs.skip_version_bump && inputs.source_branch != '' }}
+        with:
+          ref: ${{ inputs.source_branch }}
+          submodules: recursive
       - uses: actions/checkout@v4
-        if: ${{ inputs.skip_version_bump && inputs.source_branch != '' }}
+        if: ${{ inputs.runner_provider != 'namespace' && inputs.skip_version_bump && inputs.source_branch != '' }}
         with:
           ref: ${{ inputs.source_branch }}
           submodules: recursive
 
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' && inputs.skip_version_bump && inputs.source_branch == '' }}
+        with:
+          submodules: recursive
       - uses: actions/checkout@v4
-        if: ${{ inputs.skip_version_bump && inputs.source_branch == '' }}
+        if: ${{ inputs.runner_provider != 'namespace' && inputs.skip_version_bump && inputs.source_branch == '' }}
         with:
           submodules: recursive
 
@@ -562,7 +582,13 @@ jobs:
       android_version_code: ${{ steps.meta.outputs.android_version_code }}
       ios_version_code: ${{ steps.meta.outputs.ios_version_code }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 1
+          ref: ${{ needs.prepare.outputs.checkout_ref_for_setup }}
       - uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
           ref: ${{ needs.prepare.outputs.checkout_ref_for_setup }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,10 @@ jobs:
     needs:
       - get_requirements
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
     needs:
       - get_requirements
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -174,7 +177,10 @@ jobs:
     needs:
       - get_requirements
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -221,7 +227,12 @@ jobs:
           - test:depcheck
           - test:tgz-check
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 2
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 2
       - name: Configure Namespace cache
@@ -267,7 +278,10 @@ jobs:
       contents: read
       statuses: write
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -482,7 +496,10 @@ jobs:
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download iOS bundle
         uses: actions/download-artifact@v4
@@ -521,7 +538,10 @@ jobs:
     needs:
       - get_requirements
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/62dc61a45fc95efe8c800af7a557ab0b9165d63b/scripts/download-actionlint.bash) 1.7.1
@@ -540,7 +560,10 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -600,7 +623,10 @@ jobs:
     needs: [unit-tests, component-view-tests]
     if: ${{ !cancelled() && github.event_name != 'merge_group' }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -731,7 +757,10 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -802,8 +831,17 @@ jobs:
       ai_e2e_test_tags: ${{ steps.e2e-selection.outputs.ai_e2e_test_tags }}
       ai_confidence: ${{ steps.e2e-selection.outputs.ai_confidence }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          sparse-checkout: |
+            .github/actions/smart-e2e-selection
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Checkout for action definition
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           sparse-checkout: |
             .github/actions/smart-e2e-selection
@@ -939,7 +977,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download fixture validation results
         continue-on-error: true
@@ -964,7 +1005,12 @@ jobs:
     needs: merge-unit-and-component-view-tests
     if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 0 # SonarCloud needs a full checkout to perform necessary analysis
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 0 # SonarCloud needs a full checkout to perform necessary analysis
       - name: Configure Namespace cache
@@ -1018,8 +1064,11 @@ jobs:
     needs: sonar-cloud
     if: ${{ !cancelled() && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
       - name: Checkout code
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
       - name: SonarCloud Quality Gate Status
         id: sonar-status
         env:
@@ -1090,7 +1139,15 @@ jobs:
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/actions/ci-status-gate
+
       - uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/run-e2e-regression-tests-android.yml
+++ b/.github/workflows/run-e2e-regression-tests-android.yml
@@ -187,8 +187,13 @@ jobs:
       - regression-ux-android
 
     steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download shards test artifacts (XMLs + Screenshots)
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-e2e-regression-tests-ios.yml
+++ b/.github/workflows/run-e2e-regression-tests-ios.yml
@@ -186,8 +186,13 @@ jobs:
       - regression-ux-ios
 
     steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download shards test artifacts (XMLs + Screenshots)
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -300,8 +300,13 @@ jobs:
       - browser-android-smoke
       - snaps-android-smoke
     steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
       - name: Checkout
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -315,8 +315,13 @@ jobs:
       - browser-ios-smoke
       - snaps-ios-smoke
     steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
       - name: Checkout
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -100,8 +100,13 @@ jobs:
       YARN_ENABLE_GLOBAL_CACHE: 'true' # Enable Yarn global cache for faster installs
 
     steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
       - name: Checkout
         uses: actions/checkout@v6
+        if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Restore .metamask folder
         uses: actions/cache@v4

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -115,7 +115,9 @@ jobs:
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Set up E2E environment
-        timeout-minutes: 25
+        # Namespace iOS smoke runs many matrix jobs in parallel; CocoaPods + yarn need more
+        # headroom than the composite default (see INFRA-3596 / run 25755790077 timeouts).
+        timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 45 || 25 }}
         uses: ./.github/actions/setup-e2e-env
         with:
           platform: ${{ inputs.platform }}
@@ -124,6 +126,8 @@ jobs:
           android-api-level: 36
           configure-keystores: false
           runner_provider: ${{ inputs.runner_provider }}
+          js-retry-timeout-minutes: ${{ inputs.runner_provider == 'namespace' && '20' || '15' }}
+          pod-install-timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && '22' || '15' }}
 
       - name: Build Detox framework cache (iOS)
         if: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -83,8 +83,16 @@ jobs:
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
     steps:
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.checkout-submodules && 'recursive' || false }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: ${{ inputs.fetch-depth }}


### PR DESCRIPTION
## **Description**

Adds the Phase 5b `nscloud-checkout-action` pilot to the low-risk `ci.yml` `dedupe` job when `runner_provider == 'namespace'`.

The existing `actions/checkout@v6` fallback remains on the current runner path with only an `if:` condition added, preserving the current checkout version and inputs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3628](https://consensyssoftware.atlassian.net/browse/INFRA-3628)

## **Manual testing steps**

```gherkin
Feature: Namespace checkout pilot

  Scenario: dedupe job uses Namespace checkout on Namespace runners
    Given the ci workflow is dispatched with runner_provider set to namespace
    When the dedupe job starts
    Then the nscloud checkout step runs and actions/checkout is skipped

  Scenario: dedupe job keeps current checkout on current runners
    Given the ci workflow is dispatched with runner_provider set to current
    When the dedupe job starts
    Then actions/checkout@v6 runs and nscloud checkout is skipped
```

## **Screenshots/Recordings**

N/A - CI-only workflow change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[INFRA-3628]: https://consensyssoftware.atlassian.net/browse/INFRA-3628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ