### PR TITLE
fix: fix trending label display cp-7.77.0

### DIFF
--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -50,9 +50,9 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
           <Icon name={iconName} color={IconColor.Default} size={IconSize.Sm} />
         )}
         <Text
-          style={tw`min-w-0 text-[14px] font-medium text-default`}
-          numberOfLines={numberOfLines}
-          ellipsizeMode={ellipsizeMode}
+          style={tw`min-w-0 shrink text-[14px] font-medium text-default`}
+          numberOfLines={numberOfLines ?? 1}
+          ellipsizeMode={ellipsizeMode ?? 'tail'}
         >
           {label}
         </Text>

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -50,7 +50,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
           <Icon name={iconName} color={IconColor.Default} size={IconSize.Sm} />
         )}
         <Text
-          style={tw`min-w-0 shrink text-[14px] font-medium text-default`}
+          style={tw`min-w-0 text-[14px] font-medium text-default`}
           numberOfLines={numberOfLines}
           ellipsizeMode={ellipsizeMode}
         >


### PR DESCRIPTION


## **Description**

On small screen devices (e.g., iPhone SE), the `FilterButton` label text (e.g., "Price change") wraps to two lines. The root cause: callers like the price-change button and Bridge filter buttons don't pass `numberOfLines` or `ellipsizeMode`, so these default to `undefined` — allowing unlimited text wrapping when `flex-shrink` compresses the button.

This adds sensible defaults (`numberOfLines ?? 1`, `ellipsizeMode ?? 'tail'`) inside `FilterButton` so all labels stay on a single line and truncate with ellipsis when constrained.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed trending filter button labels wrapping to two lines on small screens by defaulting to single-line truncation.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="748" height="1422" alt="image" src="https://github.com/user-attachments/assets/e4e97c99-def5-4506-b01c-e875fb85e36b" />


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<img width="404" height="790" alt="Screenshot 2026-05-12 at 10 23 31" src="https://github.com/user-attachments/assets/3925bf0d-3c0e-450a-a5b0-2ba7285c594c" />

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts text rendering defaults; main risk is unintended truncation in places relying on multi-line labels.
> 
> **Overview**
> Prevents `FilterButton` labels in Trending’s `FilterBar` from wrapping by defaulting `numberOfLines` to `1` and `ellipsizeMode` to `'tail'` when callers don’t provide them.
> 
> This standardizes truncation behavior across filter buttons on constrained layouts (e.g., small screens) without requiring each caller to pass these props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66a57c82fbe5d71f135a19d617c8bb4b20e4674d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->