### PR TITLE
chore: add confirmations ownership for messengers and selectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,14 +85,25 @@ app/core/Engine/messengers/card-controller-messenger       @MetaMask/card
 app/selectors/cardController.ts                            @MetaMask/card
 
 # Confirmation Team
-app/components/Views/confirmations                          @MetaMask/confirmations
-app/components/Views/confirmations/external/staking          @MetaMask/confirmations @MetaMask/earn
-app/core/Engine/controllers/approval-controller             @MetaMask/confirmations
-app/core/Engine/controllers/gas-fee-controller              @MetaMask/confirmations
-app/core/Engine/controllers/signature-controller            @MetaMask/confirmations
-app/core/Engine/controllers/transaction-controller          @MetaMask/confirmations
-app/core/Analytics/events/confirmations                     @MetaMask/confirmations
-app/selectors/featureFlagController/confirmations/          @MetaMask/confirmations
+app/components/Views/confirmations                              @MetaMask/confirmations
+app/components/Views/confirmations/external/staking             @MetaMask/confirmations @MetaMask/earn
+app/core/Analytics/events/confirmations                         @MetaMask/confirmations
+app/core/Engine/controllers/approval-controller                 @MetaMask/confirmations
+app/core/Engine/controllers/gas-fee-controller                  @MetaMask/confirmations
+app/core/Engine/controllers/signature-controller                @MetaMask/confirmations
+app/core/Engine/controllers/transaction-controller              @MetaMask/confirmations
+app/core/Engine/controllers/transaction-pay-controller          @MetaMask/confirmations
+app/core/Engine/messengers/approval-controller-messenger        @MetaMask/confirmations
+app/core/Engine/messengers/gas-fee-controller-messenger         @MetaMask/confirmations
+app/core/Engine/messengers/signature-controller-messenger       @MetaMask/confirmations
+app/core/Engine/messengers/transaction-controller-messenger     @MetaMask/confirmations
+app/core/Engine/messengers/transaction-pay-controller-messenger @MetaMask/confirmations
+app/selectors/approvalController.*                              @MetaMask/confirmations
+app/selectors/featureFlagController/confirmations/              @MetaMask/confirmations
+app/selectors/gasFeeController.*                                @MetaMask/confirmations
+app/selectors/signatureController.*                             @MetaMask/confirmations
+app/selectors/transactionController.*                           @MetaMask/confirmations
+app/selectors/transactionPayController.*                        @MetaMask/confirmations
 
 # Wallet integrations Team
 app/actions/sdk/                                            @MetaMask/wallet-integrations


### PR DESCRIPTION
## **Description**

Extends Confirmations team ownership in `CODEOWNERS` to cover the messengers and selectors for the controllers they already own, plus the `transaction-pay-controller` directory. This brings the Confirmation Team section in line with how other teams in this repo (Money Movement, Card, Earn, Accounts, etc.) already own their controllers, messengers, and selectors together.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes `CODEOWNERS` ownership patterns and does not affect runtime behavior.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to **extend Confirmations team ownership** beyond the existing confirmations UI/controllers to also cover the associated `app/core/Engine/messengers/*` entries, selector globs (e.g., `app/selectors/*Controller.*`), and the `transaction-pay-controller` + messenger paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d9d34245c93d2b13d8d4b10ce6d08b82cfcde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->