### PR TITLE
feat(rewards): expose VIP perps fee discount via getPerpsDiscountForAccount

### DIFF
--- a/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
@@ -215,12 +215,14 @@ describe('createMobileInfrastructure', () => {
       const caipAccountId =
         'eip155:42161:0x1234' as `${string}:${string}:${string}`;
 
-      const result =
-        await infra.rewards.getPerpsDiscountForAccount(caipAccountId);
+      const result = await infra.rewards.getPerpsDiscountForAccount(
+        caipAccountId,
+        10,
+      );
 
       expect(
         Engine.context.RewardsController.getPerpsDiscountForAccount,
-      ).toHaveBeenCalledWith(caipAccountId);
+      ).toHaveBeenCalledWith(caipAccountId, 10);
       expect(result).toBe(5);
     });
   });

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -302,9 +302,11 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
     rewards: {
       getPerpsDiscountForAccount(
         caipAccountId: `${string}:${string}:${string}`,
+        baseFeeBips: number,
       ) {
         return Engine.context.RewardsController.getPerpsDiscountForAccount(
           caipAccountId,
+          baseFeeBips,
         );
       },
     },

--- a/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.test.ts
@@ -490,6 +490,47 @@ describe('usePerpsCloseAllCalculations', () => {
       expect(result.current.avgFeeDiscountPercentage).toBe(65);
     });
 
+    it('does not apply a discount and allows retry when controller returns null (unhydrated)', async () => {
+      // Arrange: subscription state not hydrated yet
+      mockGetPerpsDiscount.mockResolvedValue(null);
+
+      const positions = [createMockPosition({ symbol: 'BTC' })];
+      const priceData = { BTC: { price: '51000' } };
+
+      mockCalculateFees.mockResolvedValue(
+        createMockFeeResult({
+          feeAmount: 275,
+          metamaskFeeRate: 0.01,
+          metamaskFeeAmount: 250,
+          protocolFeeRate: 0.001,
+          protocolFeeAmount: 25,
+        }),
+      );
+
+      // Act
+      const { result, rerender } = renderHook(
+        ({ pos }: { pos: Position[] }) =>
+          usePerpsCloseAllCalculations({ positions: pos, priceData }),
+        { initialProps: { pos: positions } },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // No discount applied; original rate matches base rate
+      expect(result.current.avgFeeDiscountPercentage).toBeUndefined();
+      expect(result.current.avgMetamaskFeeRate).toBeCloseTo(0.01, 4);
+      expect(result.current.totalFees).toBe(275);
+
+      // Hydration completes and a positions change retries the fetch
+      mockGetPerpsDiscount.mockResolvedValueOnce(6500);
+      rerender({ pos: [...positions] });
+
+      await waitFor(() =>
+        expect(result.current.avgFeeDiscountPercentage).toBe(65),
+      );
+      expect(mockGetPerpsDiscount).toHaveBeenCalledTimes(2);
+    });
+
     it('handles discount fetch errors gracefully', async () => {
       // Arrange: Discount API fails
       mockGetPerpsDiscount.mockRejectedValue(new Error('API error'));

--- a/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.ts
@@ -14,6 +14,7 @@ import type {
 import Engine from '../../../../core/Engine';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectChainId } from '../../../../selectors/networkController';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 
 /**
  * Aggregated calculations result for closing all positions
@@ -107,6 +108,9 @@ export function usePerpsCloseAllCalculations({
   const isComponentMountedRef = useRef(true);
   const discountFetchCounterRef = useRef(0);
   const calculationCounterRef = useRef(0);
+  // Tracks the account the freeze was set for, so position changes don't
+  // spuriously reset it but account switches do.
+  const discountAccountKeyRef = useRef<string | undefined>(undefined);
 
   // State for per-position calculations
   const [perPositionResults, setPerPositionResults] = useState<
@@ -145,12 +149,19 @@ export function usePerpsCloseAllCalculations({
   );
 
   // Fetch account-level fee discount (applies uniformly to all positions)
-  // Freeze mechanism prevents refetching when only positions change
+  // Freeze mechanism prevents refetching once we have a hydrated answer.
+  // Positions are included in deps so an unhydrated result (null) gets a
+  // retry on the next positions change instead of locking in no-discount.
   useEffect(() => {
     // Increment counter to invalidate any in-flight requests
     const currentFetchId = ++discountFetchCounterRef.current;
-    // Reset freeze when account changes (allow refetch for new account)
-    hasValidDiscountRef.current = false;
+    // Only reset freeze when the account actually changes — keep it across
+    // positions changes so a successful fetch isn't re-run on every tick.
+    const accountKey = `${selectedAddress ?? ''}-${currentChainId ?? ''}`;
+    if (discountAccountKeyRef.current !== accountKey) {
+      hasValidDiscountRef.current = false;
+      discountAccountKeyRef.current = accountKey;
+    }
 
     async function fetchFeeDiscount() {
       // Skip if already have valid discount for this account (freeze guard)
@@ -198,8 +209,20 @@ export function usePerpsCloseAllCalculations({
           discountFetchCounterRef.current === currentFetchId &&
           isComponentMountedRef.current
         ) {
-          setFeeDiscountBips(discountBips);
-          hasValidDiscountRef.current = true;
+          if (discountBips === null) {
+            // Subscription state hasn't hydrated yet — don't cache the
+            // no-discount value. Freeze stays off so the next positions
+            // change retries the fetch.
+            DevLogger.log(
+              'Rewards: fee discount unhydrated for close-all flow, will retry on next positions change',
+              { selectedAddress, currentChainId },
+            );
+            setFeeDiscountBips(0);
+            hasValidDiscountRef.current = false;
+          } else {
+            setFeeDiscountBips(discountBips);
+            hasValidDiscountRef.current = true;
+          }
         }
       } catch (error) {
         console.warn('Failed to fetch fee discount:', error);
@@ -217,7 +240,7 @@ export function usePerpsCloseAllCalculations({
     fetchFeeDiscount().catch((error) => {
       console.error('Unhandled error in fetchFeeDiscount:', error);
     });
-  }, [selectedAddress, currentChainId]);
+  }, [selectedAddress, currentChainId, positions]);
 
   // Per-position fee and rewards calculation
   // This ensures accurate coin-specific rewards calculation

--- a/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCloseAllCalculations.ts
@@ -1,6 +1,8 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
+  BASIS_POINTS_DIVISOR,
+  BUILDER_FEE_CONFIG,
   formatAccountToCaipAccountId,
   type Position,
   type FeeCalculationResult,
@@ -188,6 +190,7 @@ export function usePerpsCloseAllCalculations({
         const discountBips =
           await Engine.context.RewardsController.getPerpsDiscountForAccount(
             caipAccountId,
+            BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR,
           );
 
         // Only update state if this is still the latest fetch and component is mounted

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
@@ -497,6 +497,38 @@ describe('usePerpsOrderFees', () => {
       expect(result.current.originalMetamaskFeeRate).toBe(0.01);
       // The hook should apply discount internally
     });
+
+    it('does not apply a discount when controller returns null discountBips', async () => {
+      mockEngineContext.RewardsController.getPerpsDiscountForAccount.mockResolvedValueOnce(
+        null,
+      );
+
+      const mockFeeResult: FeeCalculationResult = {
+        feeRate: 0.01045,
+        feeAmount: 1045,
+        protocolFeeRate: 0.00045,
+        metamaskFeeRate: 0.01,
+      };
+      mockCalculateFees.mockResolvedValue(mockFeeResult);
+
+      const { result } = renderHook(
+        () =>
+          usePerpsOrderFees({
+            orderType: 'market',
+            amount: '100000',
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoadingMetamaskFee).toBe(false);
+      });
+
+      expect(result.current.feeDiscountPercentage).toBeUndefined();
+      expect(result.current.metamaskFeeRate).toBe(0.01);
+      expect(result.current.originalMetamaskFeeRate).toBe(0.01);
+      expect(result.current.metamaskFee).toBe(1000); // 100000 * 0.01, undiscounted
+    });
   });
 
   describe('Loading states', () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
@@ -188,6 +188,13 @@ export function usePerpsOrderFees({
           caipAccountId,
           BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR,
         );
+        if (discountBips === null) {
+          DevLogger.log('Rewards: No fee discount available', {
+            address,
+            caipAccountId,
+          });
+          return { discountBips: undefined };
+        }
         const feeDiscountDuration = performance.now() - feeDiscountStartTime;
 
         // Measure fee discount API call performance

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
@@ -12,6 +12,8 @@ import {
   EstimatedPointsDto,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
 import {
+  BASIS_POINTS_DIVISOR,
+  BUILDER_FEE_CONFIG,
   PerpsMeasurementName,
   PERFORMANCE_CONFIG,
   formatAccountToCaipAccountId,
@@ -182,8 +184,10 @@ export function usePerpsOrderFees({
 
         const { RewardsController } = Engine.context;
         const feeDiscountStartTime = performance.now();
-        const discountBips =
-          await RewardsController.getPerpsDiscountForAccount(caipAccountId);
+        const discountBips = await RewardsController.getPerpsDiscountForAccount(
+          caipAccountId,
+          BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR,
+        );
         const feeDiscountDuration = performance.now() - feeDiscountStartTime;
 
         // Measure fee discount API call performance

--- a/app/controllers/perps/services/RewardsIntegrationService.test.ts
+++ b/app/controllers/perps/services/RewardsIntegrationService.test.ts
@@ -68,6 +68,7 @@ describe('RewardsIntegrationService', () => {
       expect(result).toBe(6500);
       expect(mockDeps.rewards.getPerpsDiscountForAccount).toHaveBeenCalledWith(
         expect.stringMatching(/^eip155:1:0x/),
+        10,
       );
       expect(mockDeps.debugLogger.log).toHaveBeenCalledWith(
         'RewardsIntegrationService: Fee discount calculated',

--- a/app/controllers/perps/services/RewardsIntegrationService.test.ts
+++ b/app/controllers/perps/services/RewardsIntegrationService.test.ts
@@ -90,6 +90,23 @@ describe('RewardsIntegrationService', () => {
       expect(result).toBe(0);
     });
 
+    it('returns undefined when rewards subscription state has not hydrated yet', async () => {
+      setupMessengerDefaults();
+      (
+        mockDeps.rewards.getPerpsDiscountForAccount as jest.Mock
+      ).mockResolvedValue(null);
+
+      const result = await service.calculateUserFeeDiscount();
+
+      expect(result).toBeUndefined();
+      expect(mockDeps.debugLogger.log).toHaveBeenCalledWith(
+        'RewardsIntegrationService: Fee discount unavailable (subscription state not hydrated)',
+        expect.objectContaining({
+          caipAccountId: expect.any(String),
+        }),
+      );
+    });
+
     it('returns undefined when no EVM account found', async () => {
       setupMessengerDefaults({
         'AccountTreeController:getAccountsFromSelectedAccountGroup': [],

--- a/app/controllers/perps/services/RewardsIntegrationService.ts
+++ b/app/controllers/perps/services/RewardsIntegrationService.ts
@@ -130,6 +130,16 @@ export class RewardsIntegrationService {
         BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR,
       );
 
+      // null = subscription state not hydrated yet; surface as undefined so
+      // callers don't treat it as a definitive "no discount" answer.
+      if (discountBips === null) {
+        this.#deps.debugLogger.log(
+          'RewardsIntegrationService: Fee discount unavailable (subscription state not hydrated)',
+          { address: evmAccount.address, caipAccountId },
+        );
+        return undefined;
+      }
+
       this.#deps.debugLogger.log(
         'RewardsIntegrationService: Fee discount calculated',
         {

--- a/app/controllers/perps/services/RewardsIntegrationService.ts
+++ b/app/controllers/perps/services/RewardsIntegrationService.ts
@@ -1,3 +1,7 @@
+import {
+  BASIS_POINTS_DIVISOR,
+  BUILDER_FEE_CONFIG,
+} from '../constants/hyperLiquidConfig';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { PerpsPlatformDependencies } from '../types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
@@ -118,9 +122,13 @@ export class RewardsIntegrationService {
         return undefined;
       }
 
-      // Use rewards via DI (no RewardsController in Core yet)
-      const discountBips =
-        await this.#deps.rewards.getPerpsDiscountForAccount(caipAccountId);
+      // Use rewards via DI (no RewardsController in Core yet).
+      // The rewards controller needs the perps MetaMask builder base fee in
+      // bips to convert an absolute VIP fee into a discount fraction.
+      const discountBips = await this.#deps.rewards.getPerpsDiscountForAccount(
+        caipAccountId,
+        BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR,
+      );
 
       this.#deps.debugLogger.log(
         'RewardsIntegrationService: Fee discount calculated',

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1589,7 +1589,9 @@ export type PerpsPlatformDependencies = {
   rewards: {
     /**
      * Get fee discount for an account from the RewardsController.
-     * Returns discount in basis points (e.g., 6500 = 65% discount).
+     * Returns discount in basis points (e.g., 6500 = 65% discount), or null
+     * when subscription state hasn't hydrated yet — callers should skip
+     * caching null results and retry on the next fee calculation.
      *
      * Pass the perps MetaMask builder base fee in bips so the rewards
      * controller can convert an absolute VIP fee into a discount fraction.
@@ -1597,7 +1599,7 @@ export type PerpsPlatformDependencies = {
     getPerpsDiscountForAccount(
       caipAccountId: `${string}:${string}:${string}`,
       baseFeeBips: number,
-    ): Promise<number>;
+    ): Promise<number | null>;
   };
 };
 

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -1589,10 +1589,14 @@ export type PerpsPlatformDependencies = {
   rewards: {
     /**
      * Get fee discount for an account from the RewardsController.
-     * Returns discount in basis points (e.g., 6500 = 65% discount)
+     * Returns discount in basis points (e.g., 6500 = 65% discount).
+     *
+     * Pass the perps MetaMask builder base fee in bips so the rewards
+     * controller can convert an absolute VIP fee into a discount fraction.
      */
     getPerpsDiscountForAccount(
       caipAccountId: `${string}:${string}:${string}`,
+      baseFeeBips: number,
     ): Promise<number>;
   };
 };

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -171,10 +171,19 @@ export type RewardsControllerGetOptInStatusAction = {
 };
 
 /**
- * Get perps fee discount for an account with caching and threshold logic
+ * Get perps fee discount for an account.
+ *
+ * When the account's active subscription has VIP enabled, this calls the
+ * authenticated `/vip/fees` endpoint and converts the absolute VIP builder
+ * fee into a discount fraction relative to `baseFeeBips`. Non-VIP accounts
+ * receive no discount.
  *
  * @param account - The account address in CAIP-10 format
- * @returns Promise<number> - The discount in basis points
+ * @param baseFeeBips - The perps MetaMask builder base fee in basis points
+ * that the caller would apply absent any discount. Used to convert the VIP
+ * absolute fee into a discount fraction (caller owns the source of truth
+ * for the base fee; the controller is a pure transformer).
+ * @returns Promise<number> - The discount in basis points (0-10000)
  */
 export type RewardsControllerGetPerpsDiscountForAccountAction = {
   type: `RewardsController:getPerpsDiscountForAccount`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -183,7 +183,7 @@ export type RewardsControllerGetOptInStatusAction = {
  * that the caller would apply absent any discount. Used to convert the VIP
  * absolute fee into a discount fraction (caller owns the source of truth
  * for the base fee; the controller is a pure transformer).
- * @returns Promise<number> - The discount in basis points (0-10000)
+ * @returns Promise resolving to the discount in basis points (0-10000), or null when we can't determine the discount.
  */
 export type RewardsControllerGetPerpsDiscountForAccountAction = {
   type: `RewardsController:getPerpsDiscountForAccount`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -3542,7 +3542,7 @@ describe('RewardsController', () => {
   });
 
   describe('getPerpsDiscountForAccount', () => {
-    it('returns 0 when disabled via isDisabled callback', async () => {
+    it('returns null when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
         messenger: mockMessenger,
@@ -3555,19 +3555,19 @@ describe('RewardsController', () => {
         10,
       );
 
-      expect(result).toBe(0);
+      expect(result).toBeNull();
     });
 
-    it('returns 0 for accounts the controller has never seen', async () => {
+    it('returns null for accounts the controller has never seen (unhydrated)', async () => {
       const result = await controller.getPerpsDiscountForAccount(
         CAIP_ACCOUNT_2,
         10,
       );
-      expect(result).toBe(0);
+      expect(result).toBeNull();
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('returns 0 when the account has no linked subscription', async () => {
+    it('returns null when the account has no linked subscription (unhydrated)', async () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: true,
@@ -3590,7 +3590,7 @@ describe('RewardsController', () => {
         10,
       );
 
-      expect(result).toBe(0);
+      expect(result).toBeNull();
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
@@ -3778,8 +3778,8 @@ describe('RewardsController', () => {
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is negative (discount > 10000)', async () => {
-        buildController('-5'); // negative backend value → discount would be 15000
+      it('returns 0 and logs when the VIP builder fee is negative', async () => {
+        buildController('-5'); // caught by the <= 0 guard before range check
 
         const result = await controller.getPerpsDiscountForAccount(
           VIP_COERCED_ACCOUNT,
@@ -3788,16 +3788,12 @@ describe('RewardsController', () => {
 
         expect(result).toBe(0);
         expect(Logger.log).toHaveBeenCalledWith(
-          'RewardsController: VIP builder fee out of valid range; returning no discount',
-          expect.objectContaining({
-            builderFeeBips: -5,
-            baseFeeBips: 10,
-            rawDiscountBips: 15000,
-          }),
+          'RewardsController: VIP fees returned an invalid builderFeeBips:',
+          '-5',
         );
       });
 
-      it('returns 10000 when the VIP builder fee is 0 (full discount, boundary)', async () => {
+      it('returns 0 and logs when the VIP builder fee is 0 (closes 100%-discount loophole)', async () => {
         buildController('0');
 
         const result = await controller.getPerpsDiscountForAccount(
@@ -3805,7 +3801,41 @@ describe('RewardsController', () => {
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(10000);
+        expect(result).toBe(0);
+        expect(Logger.log).toHaveBeenCalledWith(
+          'RewardsController: VIP fees returned an invalid builderFeeBips:',
+          '0',
+        );
+      });
+
+      it('returns 0 and logs when the VIP builder fee is an empty string', async () => {
+        buildController('');
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+        expect(Logger.log).toHaveBeenCalledWith(
+          'RewardsController: VIP fees returned an invalid builderFeeBips:',
+          '',
+        );
+      });
+
+      it('returns 0 and logs when the VIP builder fee is non-numeric', async () => {
+        buildController('abc');
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+        expect(Logger.log).toHaveBeenCalledWith(
+          'RewardsController: VIP fees returned an invalid builderFeeBips:',
+          'abc',
+        );
       });
 
       it('returns 0 with no warning when the VIP builder fee equals the base (boundary)', async () => {
@@ -3823,7 +3853,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('returns 0 when /vip/fees errors (no legacy fallback)', async () => {
+      it('returns null when /vip/fees errors (so callers skip caching and retry)', async () => {
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
@@ -3848,10 +3878,10 @@ describe('RewardsController', () => {
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(0);
+        expect(result).toBeNull();
       });
 
-      it('returns 0 when /vip/fees returns tier 0 (fees=null)', async () => {
+      it('returns 0 when /vip/fees returns no builder fee (fees=null)', async () => {
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
@@ -3881,6 +3911,35 @@ describe('RewardsController', () => {
         );
 
         expect(result).toBe(0);
+      });
+
+      it('returns null when accountState references a subscriptionId that is not in state', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            // subscriptions intentionally empty — covers the defensive
+            // `if (!subscription) return null` branch in #getVipPerpsDiscountBips.
+          },
+          isDisabled: () => false,
+        });
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBeNull();
+        expect(mockMessenger.call).not.toHaveBeenCalled();
       });
 
       it('returns 0 when the subscription is not VIP-enabled', async () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -25,6 +25,8 @@ import {
   type SubscriptionBenefitDto,
   type VipDashboardDto,
   type VipDashboardState,
+  type VipFeesResponseDto,
+  type SubscriptionDto,
 } from './types';
 import type { CaipAccountId, Json } from '@metamask/utils';
 import { base58 } from 'ethers/lib/utils';
@@ -361,6 +363,7 @@ describe('RewardsController', () => {
       login: jest.fn(),
       getBenefits: jest.fn(),
       getVIPDashboard: jest.fn(),
+      getVipFees: jest.fn(),
       postBenefitImpression: jest.fn(),
     }));
 
@@ -631,21 +634,15 @@ describe('RewardsController', () => {
         await disabledController.getHasAccountOptedIn(CAIP_ACCOUNT_1);
 
       expect(result).toBe(false);
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        expect.anything(),
-      );
     });
 
-    it('returns cached hasOptedIn value when cache is fresh', async () => {
-      const recentTime = Date.now() - 60000; // 1 minute ago
+    it('returns true when cached account state shows the account has opted in', async () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: true,
         subscriptionId: 'test',
-        lastCheckedAuth: Date.now(),
-        perpsFeeDiscount: 5.0,
-        lastPerpsDiscountRateFetched: recentTime,
+        perpsFeeDiscount: null,
+        lastPerpsDiscountRateFetched: null,
       };
 
       controller = new RewardsController({
@@ -661,179 +658,9 @@ describe('RewardsController', () => {
       const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
 
       expect(result).toBe(true);
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        expect.anything(),
-      );
     });
 
-    it('returns false from cached data when account has not opted in', async () => {
-      const recentTime = Date.now() - 60000; // 1 minute ago
-      const accountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        lastCheckedAuth: Date.now(),
-        perpsFeeDiscount: 0,
-        lastPerpsDiscountRateFetched: recentTime,
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
-          subscriptions: {},
-        },
-        isDisabled: () => false,
-      });
-
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
-
-      expect(result).toBe(false);
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        expect.anything(),
-      );
-    });
-
-    it('fetches fresh data when cache is stale', async () => {
-      const staleTime = Date.now() - 600000; // 10 minutes ago (stale)
-      const accountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: 0,
-        lastPerpsDiscountRateFetched: staleTime,
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
-          subscriptions: {},
-        },
-        isDisabled: () => false,
-      });
-
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 500,
-      });
-
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
-
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_1 },
-      );
-      expect(result).toBe(true);
-    });
-
-    it('updates store state with new hasOptedIn value when fetching fresh data', async () => {
-      const staleTime = Date.now() - 600000; // 10 minutes ago (stale)
-      const accountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: 0,
-        lastPerpsDiscountRateFetched: staleTime,
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
-        },
-        isDisabled: () => false,
-      });
-
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 850,
-      });
-
-      // Act
-      await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
-
-      // Assert - verify state has been updated
-      const updatedAccountState =
-        controller.state.accounts[
-          CAIP_ACCOUNT_1.replace('eip155:1:', 'eip155:0:') as CaipAccountId
-        ];
-      expect(updatedAccountState).toBeDefined();
-      expect(updatedAccountState.hasOptedIn).toBe(true);
-      expect(updatedAccountState.perpsFeeDiscount).toBe(850);
-      expect(updatedAccountState.lastPerpsDiscountRateFetched).toBeGreaterThan(
-        staleTime,
-      );
-    });
-
-    it('updates store state when creating new account on first opt-in check', async () => {
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 1200,
-      });
-
-      // Act - check account that doesn't exist in state
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
-
-      // Assert - verify new account state was created
-      expect(result).toBe(true);
-      const newAccountState =
-        controller.state.accounts[
-          CAIP_ACCOUNT_2.replace('eip155:1:', 'eip155:0:') as CaipAccountId
-        ];
-      expect(newAccountState).toBeDefined();
-      expect(newAccountState.hasOptedIn).toBe(true);
-      expect(newAccountState.perpsFeeDiscount).toBe(1200);
-      expect(newAccountState.subscriptionId).toBeNull();
-      expect(newAccountState.lastPerpsDiscountRateFetched).toBeLessThanOrEqual(
-        Date.now(),
-      );
-    });
-
-    it('calls data service for unknown accounts', async () => {
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: false,
-        discountBips: 500,
-      });
-
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
-
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_2 },
-      );
-      expect(result).toBe(false);
-    });
-
-    it('returns true when data service indicates opted in', async () => {
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 1000,
-      });
-
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
-
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_2 },
-      );
-      expect(result).toBe(true);
-    });
-
-    it('handles data service errors and return false', async () => {
-      mockMessenger.call.mockRejectedValue(new Error('Network error'));
-
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
-
-      expect(result).toBe(false);
-    });
-
-    it('fetches fresh data when no cache timestamp exists', async () => {
+    it('returns false when cached account state shows the account has not opted in', async () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -852,18 +679,14 @@ describe('RewardsController', () => {
         isDisabled: () => false,
       });
 
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 750,
-      });
-
       const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
 
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_1 },
-      );
-      expect(result).toBe(true);
+      expect(result).toBe(false);
+    });
+
+    it('returns false for accounts the controller has never seen', async () => {
+      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_2);
+      expect(result).toBe(false);
     });
   });
 
@@ -3727,87 +3550,31 @@ describe('RewardsController', () => {
         isDisabled,
       });
 
-      const result =
-        await disabledController.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
+      const result = await disabledController.getPerpsDiscountForAccount(
+        CAIP_ACCOUNT_1,
+        10,
+      );
 
       expect(result).toBe(0);
     });
 
-    it('returns cached discount when available and fresh', async () => {
-      const recentTime = Date.now() - 60000; // 1 minute ago
-      const accountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: 750,
-        lastPerpsDiscountRateFetched: recentTime,
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
-          subscriptions: {},
-        },
-        isDisabled: () => false,
-      });
-
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
-
-      expect(result).toBe(750);
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        expect.anything(),
+    it('returns 0 for accounts the controller has never seen', async () => {
+      const result = await controller.getPerpsDiscountForAccount(
+        CAIP_ACCOUNT_2,
+        10,
       );
+      expect(result).toBe(0);
+      expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    it('fetches fresh discount when cache is stale', async () => {
-      const staleTime = Date.now() - 600000; // 10 minutes ago
-      const accountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: 750,
-        lastPerpsDiscountRateFetched: staleTime,
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
-          subscriptions: {},
-        },
-        isDisabled: () => false,
-      });
-
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: false,
-        discountBips: 1000,
-      });
-
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
-
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_1 },
-      );
-      expect(result).toBe(1000);
-    });
-
-    it('updates store state with new discount value when fetching fresh data', async () => {
-      const staleTime = Date.now() - 600000; // 10 minutes ago
+    it('returns 0 when the account has no linked subscription', async () => {
       const accountState = {
         account: CAIP_ACCOUNT_1,
         hasOptedIn: true,
-        subscriptionId: 'test',
-        perpsFeeDiscount: 750,
-        lastPerpsDiscountRateFetched: staleTime,
+        subscriptionId: null,
+        perpsFeeDiscount: null,
+        lastPerpsDiscountRateFetched: null,
       };
-
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -3818,307 +3585,335 @@ describe('RewardsController', () => {
         isDisabled: () => false,
       });
 
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: true,
-        discountBips: 1500,
-      });
-
-      // Act
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
-
-      // Assert - verify state has been updated
-      expect(result).toBe(1500);
-      const updatedAccountState =
-        controller.state.accounts[
-          CAIP_ACCOUNT_1.replace('eip155:1:', 'eip155:0:') as CaipAccountId
-        ];
-      expect(updatedAccountState).toBeDefined();
-      expect(updatedAccountState.perpsFeeDiscount).toBe(1500);
-      expect(updatedAccountState.hasOptedIn).toBe(true);
-      expect(updatedAccountState.lastPerpsDiscountRateFetched).toBeGreaterThan(
-        staleTime,
+      const result = await controller.getPerpsDiscountForAccount(
+        CAIP_ACCOUNT_1,
+        10,
       );
-    });
-
-    it('fetches discount for new accounts', async () => {
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: false,
-        discountBips: 1500,
-      });
-
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_2);
-
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        { account: CAIP_ACCOUNT_2 },
-      );
-      expect(result).toBe(1500);
-    });
-
-    it('updates store state when creating new account on first discount check', async () => {
-      mockMessenger.call.mockResolvedValue({
-        hasOptedIn: false,
-        discountBips: 2000,
-      });
-
-      // Act - check discount for account that doesn't exist in state
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_3);
-
-      // Assert - verify new account state was created with correct values
-      expect(result).toBe(2000);
-      const newAccountState =
-        controller.state.accounts[
-          CAIP_ACCOUNT_3.replace('eip155:1:', 'eip155:0:') as CaipAccountId
-        ];
-      expect(newAccountState).toBeDefined();
-      expect(newAccountState.hasOptedIn).toBe(false);
-      expect(newAccountState.perpsFeeDiscount).toBe(2000);
-      expect(newAccountState.subscriptionId).toBeNull();
-      expect(newAccountState.lastPerpsDiscountRateFetched).toBeLessThanOrEqual(
-        Date.now(),
-      );
-    });
-
-    it('returns 0 on data service error', async () => {
-      mockMessenger.call.mockRejectedValue(new Error('Network error'));
-
-      const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_2);
 
       expect(result).toBe(0);
+      expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
-    describe('CAIP account ID coercion', () => {
-      it('coerces eip155:1:0xABC to eip155:0:0xabc format when storing state', async () => {
-        // Arrange - account with chain ID 1 (needs coercion to chain ID 0)
-        const nonCoercedAccount = 'eip155:1:0xABCDEF' as CaipAccountId;
-        const expectedCoercedAccount = 'eip155:0:0xabcdef' as CaipAccountId;
+    describe('VIP subscription path', () => {
+      const SUB_VIP = 'sub-vip-1';
+      const BASE_FEE_BIPS = 10;
+      const VIP_COERCED_ACCOUNT = 'eip155:0:0xabcdef' as CaipAccountId;
 
-        mockMessenger.call.mockResolvedValue({
-          hasOptedIn: false,
-          discountBips: 1500,
-        });
+      const vipSubscription: SubscriptionDto = {
+        id: SUB_VIP,
+        referralCode: 'ref',
+        accounts: [],
+        features: { vip: { enabled: true } },
+      };
 
-        // Act - fetch discount for account that needs coercion
-        const result =
-          await controller.getPerpsDiscountForAccount(nonCoercedAccount);
-
-        // Assert - verify result is correct
-        expect(result).toBe(1500);
-
-        // Verify state was stored with coerced account key (not the original)
-        const coercedAccountState =
-          controller.state.accounts[expectedCoercedAccount];
-        expect(coercedAccountState).toBeDefined();
-        expect(coercedAccountState.account).toBe(expectedCoercedAccount);
-        expect(coercedAccountState.perpsFeeDiscount).toBe(1500);
-
-        // Verify state was NOT stored with non-coerced account key
-        const nonCoercedAccountState =
-          controller.state.accounts[nonCoercedAccount];
-        expect(nonCoercedAccountState).toBeUndefined();
-      });
-
-      it('updates existing account with coerced key when hasOptedIn changes to false', async () => {
-        // Arrange - existing account with coerced format, currently opted in with subscription
-        const coercedAccount = 'eip155:0:0xabcdef' as CaipAccountId;
-        const accountState = {
-          account: coercedAccount,
-          hasOptedIn: true,
-          subscriptionId: 'sub-123',
-          perpsFeeDiscount: 750,
-          lastPerpsDiscountRateFetched: Date.now() - 600000, // Stale cache
-        };
-
-        controller = new RewardsController({
-          messenger: mockMessenger,
-          state: {
-            activeAccount: null,
-            accounts: { [coercedAccount]: accountState as RewardsAccountState },
-            subscriptions: {},
+      const buildVipFeesResponse = (
+        builderFeeBips: string,
+      ): VipFeesResponseDto => ({
+        vipTier: 1,
+        fees: {
+          hyperliquid: {
+            builderCode: '0xbuilder',
+            builderFeeBips,
           },
-          isDisabled: () => false,
-        });
-
-        // Mock API response shows user has opted out
-        mockMessenger.call.mockResolvedValue({
-          hasOptedIn: false,
-          discountBips: 1000,
-        });
-
-        // Act - fetch discount for non-coerced account format (should coerce to same key)
-        const nonCoercedAccount = 'eip155:1:0xABCDEF' as CaipAccountId;
-        const result =
-          await controller.getPerpsDiscountForAccount(nonCoercedAccount);
-
-        // Assert
-        expect(result).toBe(1000);
-
-        // Verify state was updated using the coerced key
-        const updatedAccountState = controller.state.accounts[coercedAccount];
-        expect(updatedAccountState).toBeDefined();
-        expect(updatedAccountState.hasOptedIn).toBe(false);
-        expect(updatedAccountState.subscriptionId).toBeNull(); // This is the critical fix - should use coerced key
-        expect(updatedAccountState.perpsFeeDiscount).toBe(1000);
+          swaps: { feeBips: '50' },
+        },
+        updatedAt: '2026-05-01T00:00:00.000Z',
       });
 
-      it('handles eip155:0:0xABC format without coercion (already correct format)', async () => {
-        // Arrange - account already in correct format (eip155:0:...)
-        const correctAccount = 'eip155:0:0xDEF123' as CaipAccountId;
-
-        mockMessenger.call.mockResolvedValue({
-          hasOptedIn: true,
-          discountBips: 2000,
-        });
-
-        // Act
-        const result =
-          await controller.getPerpsDiscountForAccount(correctAccount);
-
-        // Assert - should store with same key (lowercased)
-        expect(result).toBe(2000);
-        const accountState =
-          controller.state.accounts['eip155:0:0xdef123' as CaipAccountId];
-        expect(accountState).toBeDefined();
-        expect(accountState.account).toBe('eip155:0:0xdef123' as CaipAccountId);
-        expect(accountState.perpsFeeDiscount).toBe(2000);
-      });
-
-      it('consistently use coerced account when updating existing account that opted out', async () => {
-        // Arrange - existing account stored with different chain ID format
-        const existingAccount = 'eip155:0:0xabc123' as CaipAccountId;
-        const accountState = {
-          account: existingAccount,
-          hasOptedIn: true,
-          subscriptionId: 'existing-sub',
-          perpsFeeDiscount: 500,
-          lastPerpsDiscountRateFetched: Date.now() - 700000, // Stale
-        };
-
+      const buildController = (builderFeeBips: string) => {
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
-            activeAccount: null,
+            ...getRewardsControllerDefaultState(),
             accounts: {
-              [existingAccount]: accountState as RewardsAccountState,
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
             },
-            subscriptions: {},
+            subscriptions: { [SUB_VIP]: vipSubscription },
           },
           isDisabled: () => false,
         });
-
-        // Mock response indicates user opted out
-        mockMessenger.call.mockResolvedValue({
-          hasOptedIn: false,
-          discountBips: 800,
+        mockMessenger.call.mockImplementation((method, ..._args): any => {
+          if (method === 'RewardsDataService:getVipFees') {
+            return Promise.resolve(buildVipFeesResponse(builderFeeBips));
+          }
+          return Promise.resolve({ hasOptedIn: false, discountBips: 0 });
         });
+      };
 
-        // Act - query with different chain ID format (should coerce to same key)
-        const queryAccount = 'eip155:137:0xABC123' as CaipAccountId; // Different chain ID, uppercase
-        await controller.getPerpsDiscountForAccount(queryAccount);
+      it('converts the absolute VIP builder fee into a discount fraction', async () => {
+        buildController('5'); // VIP rate 5 bps, base 10 bps → 50% discount
 
-        // Assert - verify the CORRECT coerced account was updated
-        const updatedState = controller.state.accounts[existingAccount];
-        expect(updatedState).toBeDefined();
-        expect(updatedState.hasOptedIn).toBe(false);
-        expect(updatedState.subscriptionId).toBeNull(); // Should use coerced key to set null
-        expect(updatedState.perpsFeeDiscount).toBe(800);
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
 
-        // Ensure no duplicate entries were created with wrong keys
-        const wrongKeyEntry = controller.state.accounts[queryAccount];
-        expect(wrongKeyEntry).toBeUndefined();
+        expect(result).toBe(5000);
+        expect(mockMessenger.call).toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          SUB_VIP,
+        );
       });
 
-      it('sets subscriptionId to null using coerced account when hasOptedIn becomes false', async () => {
-        // This test specifically verifies the bug fix on line 988
-        // where state.accounts[account] should be state.accounts[coercedAccount]
+      it('persists the raw VIP builder fee to the per-subscription cache', async () => {
+        buildController('5');
 
-        // Arrange - account with subscription that will opt out
-        const coercedFormat = 'eip155:0:0x999888' as CaipAccountId;
-        const existingState = {
-          account: coercedFormat,
-          hasOptedIn: true,
-          subscriptionId: 'should-be-nulled',
-          perpsFeeDiscount: 1200,
-          lastPerpsDiscountRateFetched: Date.now() - 800000,
-        };
+        await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
 
+        expect(controller.state.vipPerpsFees[SUB_VIP]).toEqual({
+          hyperliquidBuilderFeeBips: '5',
+          lastFetched: 123,
+        });
+        // VIP path must not pollute the per-account legacy cache slot.
+        expect(
+          controller.state.accounts[VIP_COERCED_ACCOUNT].perpsFeeDiscount,
+        ).toBeNull();
+        expect(
+          controller.state.accounts[VIP_COERCED_ACCOUNT]
+            .lastPerpsDiscountRateFetched,
+        ).toBeNull();
+      });
+
+      it('reuses the per-subscription cache within the TTL without re-fetching', async () => {
+        buildController('5');
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
-            activeAccount: null,
+            ...getRewardsControllerDefaultState(),
             accounts: {
-              [coercedFormat]: existingState as RewardsAccountState,
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
             },
-            subscriptions: {},
+            subscriptions: { [SUB_VIP]: vipSubscription },
+            vipPerpsFees: {
+              [SUB_VIP]: {
+                hyperliquidBuilderFeeBips: '5',
+                lastFetched: 100, // mocked Date.now()=123, TTL=5min → fresh
+              },
+            },
           },
           isDisabled: () => false,
         });
 
-        // Mock opt-out response
-        mockMessenger.call.mockResolvedValue({
-          hasOptedIn: false,
-          discountBips: 100,
-        });
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
 
-        // Act - query with format that needs coercion
-        const queryFormat = 'eip155:1:0x999888' as CaipAccountId;
-        await controller.getPerpsDiscountForAccount(queryFormat);
-
-        // Assert - the coerced account should have subscriptionId set to null
-        const finalState = controller.state.accounts[coercedFormat];
-        expect(finalState).toBeDefined();
-        expect(finalState.subscriptionId).toBeNull();
-        expect(finalState.hasOptedIn).toBe(false);
-        expect(finalState.perpsFeeDiscount).toBe(100);
-
-        // Verify no state was created or modified under the wrong key
-        expect(Object.keys(controller.state.accounts).length).toBe(1);
-        expect(controller.state.accounts[queryFormat]).toBeUndefined();
+        expect(result).toBe(5000);
+        expect(mockMessenger.call).not.toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          expect.anything(),
+        );
       });
 
-      it('preserves subscriptionId when hasOptedIn remains true', async () => {
-        // Arrange - account with subscription that stays opted in
-        const coercedFormat = 'eip155:0:0xffffff' as CaipAccountId;
-        const existingState = {
-          account: coercedFormat,
-          hasOptedIn: true,
-          subscriptionId: 'keep-this-sub',
-          perpsFeeDiscount: 500,
-          lastPerpsDiscountRateFetched: Date.now() - 900000,
-        };
-
+      it('re-derives the discount from cache when baseFeeBips changes', async () => {
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
-            activeAccount: null,
+            ...getRewardsControllerDefaultState(),
             accounts: {
-              [coercedFormat]: existingState as RewardsAccountState,
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
             },
-            subscriptions: {},
+            subscriptions: { [SUB_VIP]: vipSubscription },
+            vipPerpsFees: {
+              [SUB_VIP]: {
+                hyperliquidBuilderFeeBips: '5',
+                lastFetched: 100,
+              },
+            },
           },
           isDisabled: () => false,
         });
 
-        // Mock response with hasOptedIn: true
+        const a = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          10, // base 10 → 50% discount
+        );
+        const b = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          20, // base 20 → 75% discount, same cached raw 5 bps
+        );
+
+        expect(a).toBe(5000);
+        expect(b).toBe(7500);
+      });
+
+      it('returns 0 and logs when the VIP builder fee exceeds the base (negative discount)', async () => {
+        buildController('15'); // VIP 15 bps > base 10 bps → discount would be -5000
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+        expect(Logger.log).toHaveBeenCalledWith(
+          'RewardsController: VIP builder fee out of valid range; returning no discount',
+          expect.objectContaining({
+            builderFeeBips: 15,
+            baseFeeBips: 10,
+            rawDiscountBips: -5000,
+          }),
+        );
+      });
+
+      it('returns 0 and logs when the VIP builder fee is negative (discount > 10000)', async () => {
+        buildController('-5'); // negative backend value → discount would be 15000
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+        expect(Logger.log).toHaveBeenCalledWith(
+          'RewardsController: VIP builder fee out of valid range; returning no discount',
+          expect.objectContaining({
+            builderFeeBips: -5,
+            baseFeeBips: 10,
+            rawDiscountBips: 15000,
+          }),
+        );
+      });
+
+      it('returns 10000 when the VIP builder fee is 0 (full discount, boundary)', async () => {
+        buildController('0');
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(10000);
+      });
+
+      it('returns 0 with no warning when the VIP builder fee equals the base (boundary)', async () => {
+        buildController('10');
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+        expect(Logger.log).not.toHaveBeenCalledWith(
+          'RewardsController: VIP builder fee out of valid range; returning no discount',
+          expect.anything(),
+        );
+      });
+
+      it('returns 0 when /vip/fees errors (no legacy fallback)', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: { [SUB_VIP]: vipSubscription },
+          },
+          isDisabled: () => false,
+        });
+        mockMessenger.call.mockRejectedValue(new Error('boom'));
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+      });
+
+      it('returns 0 when /vip/fees returns tier 0 (fees=null)', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: { [SUB_VIP]: vipSubscription },
+          },
+          isDisabled: () => false,
+        });
         mockMessenger.call.mockResolvedValue({
-          hasOptedIn: true,
-          discountBips: 1500,
+          vipTier: 0,
+          fees: null,
+          updatedAt: null,
+        } as VipFeesResponseDto);
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(0);
+      });
+
+      it('returns 0 when the subscription is not VIP-enabled', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: {
+              [SUB_VIP]: {
+                ...vipSubscription,
+                features: { vip: { enabled: false } },
+              },
+            },
+          },
+          isDisabled: () => false,
         });
 
-        // Act
-        const queryFormat = 'eip155:5:0xFFFFFF' as CaipAccountId;
-        await controller.getPerpsDiscountForAccount(queryFormat);
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
 
-        // Assert - subscriptionId should be preserved (not set to null)
-        const finalState = controller.state.accounts[coercedFormat];
-        expect(finalState).toBeDefined();
-        expect(finalState.subscriptionId).toBe('keep-this-sub');
-        expect(finalState.hasOptedIn).toBe(true);
-        expect(finalState.perpsFeeDiscount).toBe(1500);
+        expect(result).toBe(0);
+        expect(mockMessenger.call).not.toHaveBeenCalled();
       });
     });
   });
@@ -16538,6 +16333,7 @@ describe('RewardsController', () => {
       subscriptions: {},
       unlockedRewards: {},
       vipDashboard: {},
+      vipPerpsFees: {},
     });
   });
 
@@ -16569,6 +16365,7 @@ describe('RewardsController', () => {
       subscriptions: {},
       unlockedRewards: {},
       vipDashboard: {},
+      vipPerpsFees: {},
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -4,7 +4,6 @@ import {
   type RewardsControllerState,
   type RewardsAccountState,
   type LoginResponseDto,
-  type PerpsDiscountData,
   type EstimatePointsDto,
   type EstimatedPointsDto,
   type SeasonDtoState,
@@ -51,6 +50,8 @@ import {
   type SubscriptionBenefitsState,
   type VipDashboardDto,
   type VipDashboardState,
+  type VipFeesResponseDto,
+  type VipPerpsFeesState,
   BASE32_REGEX,
   CampaignType,
 } from './types';
@@ -99,9 +100,6 @@ export const DEFAULT_BLOCKED_REGIONS = ['UK', 'GB', 'GI'];
 
 const controllerName = 'RewardsController';
 
-// Perps discount refresh threshold
-const PERPS_DISCOUNT_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
-
 // Season status cache threshold
 const SEASON_STATUS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
@@ -116,6 +114,10 @@ const BENEFITS_DETAILS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minutes
 
 // VIP dashboard cache threshold — disabled while backend still serves hardcoded data
 const VIP_DASHBOARD_CACHE_THRESHOLD_MS = 0;
+
+// VIP perps fees cache threshold — read on every perps trade UI render, so
+// cache for the same 5-minute window as the legacy public-discount path.
+const VIP_PERPS_FEES_CACHE_THRESHOLD_MS = 1000 * 60 * 5;
 
 // Active boosts cache threshold
 const ACTIVE_BOOSTS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
@@ -323,6 +325,12 @@ const metadata: StateMetadata<RewardsControllerState> = {
     persist: true,
     includeInDebugSnapshot: false,
     usedInUi: true,
+  },
+  vipPerpsFees: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: false,
   },
 };
 
@@ -1396,83 +1404,6 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Update perps fee discount for a given address
-   * @param address - The account address in CAIP-10 format
-   */
-  async #getPerpsFeeDiscountData(
-    account: CaipAccountId,
-  ): Promise<PerpsDiscountData | null> {
-    const accountState = this.#getAccountState(account);
-
-    // Check if we have a cached discount and if threshold hasn't been reached
-    if (
-      accountState?.perpsFeeDiscount !== null &&
-      accountState?.lastPerpsDiscountRateFetched !== null &&
-      accountState?.lastPerpsDiscountRateFetched &&
-      Date.now() - accountState.lastPerpsDiscountRateFetched <
-        PERPS_DISCOUNT_CACHE_THRESHOLD_MS
-    ) {
-      return {
-        hasOptedIn: !!accountState?.hasOptedIn,
-        discountBips: accountState?.perpsFeeDiscount,
-      };
-    }
-
-    try {
-      Logger.log(
-        'RewardsController: Fetching fresh perps discount data via API call for',
-        account,
-      );
-      const perpsDiscountData = await this.messenger.call(
-        'RewardsDataService:getPerpsDiscount',
-        { account },
-      );
-
-      // Make sure all account caip indexes are stored the same way
-      let coercedAccount: CaipAccountId;
-      if (account?.startsWith('eip155') && !account?.startsWith('eip155:0')) {
-        coercedAccount =
-          `eip155:0:${account.split(':')[2]?.toLowerCase()}` as CaipAccountId;
-      } else if (account?.startsWith('eip155')) {
-        coercedAccount = account.toLowerCase() as CaipAccountId;
-      } else {
-        coercedAccount = account;
-      }
-
-      this.update((state) => {
-        // Create account state if it doesn't exist
-        if (!state.accounts[coercedAccount]) {
-          state.accounts[coercedAccount] = {
-            account: coercedAccount,
-            hasOptedIn: perpsDiscountData.hasOptedIn,
-            subscriptionId: null,
-            perpsFeeDiscount: perpsDiscountData.discountBips ?? 0,
-            lastPerpsDiscountRateFetched: Date.now(),
-          };
-        } else {
-          // Update account state
-          state.accounts[coercedAccount].hasOptedIn =
-            perpsDiscountData.hasOptedIn;
-          if (!perpsDiscountData.hasOptedIn) {
-            state.accounts[coercedAccount].subscriptionId = null;
-          }
-          state.accounts[coercedAccount].perpsFeeDiscount =
-            perpsDiscountData.discountBips ?? 0;
-          state.accounts[coercedAccount].lastPerpsDiscountRateFetched =
-            Date.now();
-        }
-      });
-      return perpsDiscountData;
-    } catch (error) {
-      Logger.log(
-        'RewardsController: Failed to update perps fee discount:',
-        error instanceof Error ? error.message : String(error),
-      );
-      return null;
-    }
-  }
-
-  /**
    * Check if the given account (caip-10 format) has opted in to rewards
    * @param account - The account address in CAIP-10 format
    * @returns Promise<boolean> - True if the account has opted in, false otherwise
@@ -1481,11 +1412,7 @@ export class RewardsController extends BaseController<
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) return false;
     const accountState = this.#getAccountState(account);
-    if (accountState?.hasOptedIn) return accountState.hasOptedIn;
-
-    // Right now we'll derive this from either cached map state or perps fee discount api call.
-    const perpsDiscountData = await this.#getPerpsFeeDiscountData(account);
-    return !!perpsDiscountData?.hasOptedIn;
+    return !!accountState?.hasOptedIn;
   }
 
   checkOptInStatusAgainstCache(
@@ -1684,15 +1611,117 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Get perps fee discount for an account with caching and threshold logic
+   * Get perps fee discount for an account.
+   *
+   * When the account's active subscription has VIP enabled, this calls the
+   * authenticated `/vip/fees` endpoint and converts the absolute VIP builder
+   * fee into a discount fraction relative to `baseFeeBips`. Non-VIP accounts
+   * receive no discount.
+   *
    * @param account - The account address in CAIP-10 format
-   * @returns Promise<number> - The discount in basis points
+   * @param baseFeeBips - The perps MetaMask builder base fee in basis points
+   * that the caller would apply absent any discount. Used to convert the VIP
+   * absolute fee into a discount fraction (caller owns the source of truth
+   * for the base fee; the controller is a pure transformer).
+   * @returns Promise<number> - The discount in basis points (0-10000)
    */
-  async getPerpsDiscountForAccount(account: CaipAccountId): Promise<number> {
+  async getPerpsDiscountForAccount(
+    account: CaipAccountId,
+    baseFeeBips: number,
+  ): Promise<number> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) return 0;
-    const perpsDiscountData = await this.#getPerpsFeeDiscountData(account);
-    return perpsDiscountData?.discountBips || 0;
+
+    const vipDiscountBips = await this.#getVipPerpsDiscountBips(
+      account,
+      baseFeeBips,
+    );
+    return vipDiscountBips ?? 0;
+  }
+
+  /**
+   * Resolve a VIP-driven perps discount for the given account. Returns null
+   * when the account isn't on a VIP-enabled subscription, the backend returns
+   * tier 0 (no fees), or the fetch fails — callers should treat null as "no
+   * discount" (0).
+   */
+  async #getVipPerpsDiscountBips(
+    account: CaipAccountId,
+    baseFeeBips: number,
+  ): Promise<number | null> {
+    if (!Number.isFinite(baseFeeBips) || baseFeeBips <= 0) return null;
+
+    const accountState = this.#getAccountState(account);
+    const subscriptionId = accountState?.subscriptionId;
+    if (!subscriptionId) return null;
+
+    const subscription = this.state.subscriptions[subscriptionId];
+    if (!subscription?.features?.vip?.enabled) return null;
+
+    let builderFeeBipsRaw: string;
+    const cached = this.state.vipPerpsFees[subscriptionId];
+    if (
+      cached &&
+      Date.now() - cached.lastFetched < VIP_PERPS_FEES_CACHE_THRESHOLD_MS
+    ) {
+      builderFeeBipsRaw = cached.hyperliquidBuilderFeeBips;
+    } else {
+      try {
+        const vipFeeResponse: VipFeesResponseDto = await this.#withAuthRetry(
+          () =>
+            this.messenger.call(
+              'RewardsDataService:getVipFees',
+              subscriptionId,
+            ),
+          subscriptionId,
+        );
+        // Tier 0 returns fees=null; treat as no discount.
+        if (!vipFeeResponse?.fees?.hyperliquid?.builderFeeBips) return null;
+        builderFeeBipsRaw = vipFeeResponse.fees.hyperliquid.builderFeeBips;
+        const next: VipPerpsFeesState = {
+          hyperliquidBuilderFeeBips: builderFeeBipsRaw,
+          lastFetched: Date.now(),
+        };
+        this.update((state) => {
+          state.vipPerpsFees[subscriptionId] = next;
+        });
+      } catch (error) {
+        Logger.log(
+          'RewardsController: VIP fees fetch failed; returning no discount:',
+          error instanceof Error ? error.message : String(error),
+        );
+        return null;
+      }
+    }
+
+    const builderFeeBips = parseFloat(builderFeeBipsRaw);
+    if (!Number.isFinite(builderFeeBips)) {
+      Logger.log(
+        'RewardsController: VIP fees returned a non-numeric builderFeeBips:',
+        builderFeeBipsRaw,
+      );
+      return null;
+    }
+
+    // Valid range is [0, 10000]: 0 means VIP fee equals base (no discount),
+    // 10000 means VIP fee is 0 (100% discount). Anything outside that range
+    // would require a negative builder fee or one larger than the base —
+    // both indicate backend misconfig, so log and return 0.
+    const rawDiscountBips = Math.round(
+      10000 * (1 - builderFeeBips / baseFeeBips),
+    );
+    if (rawDiscountBips < 0 || rawDiscountBips > 10000) {
+      Logger.log(
+        'RewardsController: VIP builder fee out of valid range; returning no discount',
+        {
+          builderFeeBips,
+          baseFeeBips,
+          rawDiscountBips,
+        },
+      );
+      return 0;
+    }
+    return rawDiscountBips;
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1623,27 +1623,27 @@ export class RewardsController extends BaseController<
    * that the caller would apply absent any discount. Used to convert the VIP
    * absolute fee into a discount fraction (caller owns the source of truth
    * for the base fee; the controller is a pure transformer).
-   * @returns Promise<number> - The discount in basis points (0-10000)
+   * @returns Promise resolving to the discount in basis points (0-10000), or null when we can't determine the discount.
    */
   async getPerpsDiscountForAccount(
     account: CaipAccountId,
     baseFeeBips: number,
-  ): Promise<number> {
+  ): Promise<number | null> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
-    if (!rewardsEnabled) return 0;
+    if (!rewardsEnabled) return null;
 
     const vipDiscountBips = await this.#getVipPerpsDiscountBips(
       account,
       baseFeeBips,
     );
-    return vipDiscountBips ?? 0;
+    return vipDiscountBips;
   }
 
   /**
    * Resolve a VIP-driven perps discount for the given account. Returns null
-   * when the account isn't on a VIP-enabled subscription, the backend returns
-   * tier 0 (no fees), or the fetch fails — callers should treat null as "no
-   * discount" (0).
+   * when the account isn't on a VIP-enabled subscription or the fetch fails
+   * — callers should treat null as "no discount" (0). Returns 0 when the
+   * backend returns no builder fee (fees=null) or an invalid builderFeeBips.
    */
   async #getVipPerpsDiscountBips(
     account: CaipAccountId,
@@ -1656,7 +1656,8 @@ export class RewardsController extends BaseController<
     if (!subscriptionId) return null;
 
     const subscription = this.state.subscriptions[subscriptionId];
-    if (!subscription?.features?.vip?.enabled) return null;
+    if (!subscription) return null;
+    if (!subscription?.features?.vip?.enabled) return 0;
 
     let builderFeeBipsRaw: string;
     const cached = this.state.vipPerpsFees[subscriptionId];
@@ -1675,9 +1676,9 @@ export class RewardsController extends BaseController<
             ),
           subscriptionId,
         );
-        // Tier 0 returns fees=null; treat as no discount.
-        if (!vipFeeResponse?.fees?.hyperliquid?.builderFeeBips) return null;
-        builderFeeBipsRaw = vipFeeResponse.fees.hyperliquid.builderFeeBips;
+        const rawBuilderFee = vipFeeResponse?.fees?.hyperliquid?.builderFeeBips;
+        if (rawBuilderFee == null) return 0;
+        builderFeeBipsRaw = rawBuilderFee;
         const next: VipPerpsFeesState = {
           hyperliquidBuilderFeeBips: builderFeeBipsRaw,
           lastFetched: Date.now(),
@@ -1695,12 +1696,12 @@ export class RewardsController extends BaseController<
     }
 
     const builderFeeBips = parseFloat(builderFeeBipsRaw);
-    if (!Number.isFinite(builderFeeBips)) {
+    if (!Number.isFinite(builderFeeBips) || builderFeeBips <= 0) {
       Logger.log(
-        'RewardsController: VIP fees returned a non-numeric builderFeeBips:',
+        'RewardsController: VIP fees returned an invalid builderFeeBips:',
         builderFeeBipsRaw,
       );
-      return null;
+      return 0;
     }
 
     // Valid range is [0, 10000]: 0 means VIP fee equals base (no discount),

--- a/app/core/Engine/controllers/rewards-controller/defaultState.ts
+++ b/app/core/Engine/controllers/rewards-controller/defaultState.ts
@@ -9,6 +9,7 @@ export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
   subscriptions: {},
   subscriptionBenefits: {},
   vipDashboard: {},
+  vipPerpsFees: {},
   seasons: {},
   subscriptionReferralDetails: {},
   seasonStatuses: {},

--- a/app/core/Engine/controllers/rewards-controller/services/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/index.ts
@@ -4,7 +4,6 @@ export type {
   RewardsDataServiceGetPointsEventsAction,
   RewardsDataServiceLoginAction,
   RewardsDataServiceEstimatePointsAction,
-  RewardsDataServiceGetPerpsDiscountAction,
   RewardsDataServiceMessenger,
   RewardsDataServiceGetSeasonStatusAction,
   RewardsDataServiceGetReferralDetailsAction,
@@ -19,6 +18,7 @@ export type {
   RewardsDataServiceGetUnlockedRewardsAction,
   RewardsDataServiceClaimRewardAction,
   RewardsDataServiceGetVIPDashboardAction,
+  RewardsDataServiceGetVipFeesAction,
 } from './rewards-data-service';
 
 export { RewardsDataService } from './rewards-data-service';

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -22,13 +22,13 @@ import type {
   LineaTokenRewardDto,
   CampaignDto,
   VipDashboardDto,
+  VipFeesResponseDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import {
   canChangeRewardsEnvUrl,
   getDefaultRewardsApiBaseUrlForMetaMaskEnv,
 } from '../utils/rewards-api-url';
-import type { CaipAccountId } from '@metamask/utils';
 import AppConstants from '../../../../AppConstants';
 
 // Mock dependencies
@@ -121,10 +121,6 @@ describe('RewardsDataService', () => {
         expect.any(Function),
       );
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
-        'RewardsDataService:getPerpsDiscount',
-        expect.any(Function),
-      );
-      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
         'RewardsDataService:mobileOptin',
         expect.any(Function),
       );
@@ -210,6 +206,10 @@ describe('RewardsDataService', () => {
       );
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
         'RewardsDataService:getVIPDashboard',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getVipFees',
         expect.any(Function),
       );
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
@@ -1003,76 +1003,6 @@ describe('RewardsDataService', () => {
 
       await expect(service.estimatePoints(mockEstimateRequest)).rejects.toThrow(
         'Points estimation failed: 400',
-      );
-    });
-  });
-
-  describe('getPerpsDiscount', () => {
-    const testAddress = 'eip155:1:0x123456789' as CaipAccountId;
-
-    it('should successfully get perps discount', async () => {
-      const mockResponse = {
-        ok: true,
-        text: jest.fn().mockResolvedValue('1,550'),
-      } as unknown as Response;
-      mockFetch.mockResolvedValue(mockResponse);
-
-      const result = await service.getPerpsDiscount({
-        account: testAddress as CaipAccountId,
-      });
-
-      expect(result).toEqual({
-        hasOptedIn: true,
-        discountBips: 550,
-      });
-      expect(mockFetch).toHaveBeenCalledWith(
-        `https://uat.rewards.test/public/rewards/perps-fee-discount/${testAddress}`,
-        expect.objectContaining({
-          method: 'GET',
-        }),
-      );
-    });
-
-    it('should parse not opted in response', async () => {
-      const mockResponse = {
-        ok: true,
-        text: jest.fn().mockResolvedValue('0,1000'),
-      } as unknown as Response;
-      mockFetch.mockResolvedValue(mockResponse);
-
-      const result = await service.getPerpsDiscount({
-        account: testAddress as CaipAccountId,
-      });
-
-      expect(result).toEqual({
-        hasOptedIn: false,
-        discountBips: 1000,
-      });
-    });
-
-    it('should handle perps discount errors', async () => {
-      const mockResponse = {
-        ok: false,
-        status: 404,
-      } as Response;
-      mockFetch.mockResolvedValue(mockResponse);
-
-      await expect(
-        service.getPerpsDiscount({ account: testAddress as CaipAccountId }),
-      ).rejects.toThrow('Get Perps discount failed: 404');
-    });
-
-    it('should handle invalid response format', async () => {
-      const mockResponse = {
-        ok: true,
-        text: jest.fn().mockResolvedValue('invalid_format'),
-      } as unknown as Response;
-      mockFetch.mockResolvedValue(mockResponse);
-
-      await expect(
-        service.getPerpsDiscount({ account: testAddress as CaipAccountId }),
-      ).rejects.toThrow(
-        'Invalid perps discount response format: invalid_format',
       );
     });
   });
@@ -4574,6 +4504,63 @@ describe('RewardsDataService', () => {
 
       await expect(service.getVIPDashboard(mockSubscriptionId)).rejects.toThrow(
         'Get VIP dashboard failed: 500',
+      );
+    });
+  });
+
+  describe('getVipFees', () => {
+    const mockSubscriptionId = 'sub-vip-fees';
+    const mockToken = 'test-bearer-token';
+    const mockVipFees: VipFeesResponseDto = {
+      vipTier: 1,
+      fees: {
+        hyperliquid: {
+          builderCode: '0xbuilder',
+          builderFeeBips: '5',
+        },
+        swaps: { feeBips: '50' },
+      },
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    };
+
+    beforeEach(() => {
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token: mockToken,
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(mockVipFees),
+      } as unknown as Response);
+    });
+
+    it('fetches VIP fees using the expected endpoint and auth headers', async () => {
+      const result = await service.getVipFees(mockSubscriptionId);
+
+      expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://uat.rewards.test/vip/fees',
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'omit',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'rewards-access-token': mockToken,
+          }),
+        }),
+      );
+      expect(result).toEqual(mockVipFees);
+    });
+
+    it('throws when the VIP fees response is not ok', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      await expect(service.getVipFees(mockSubscriptionId)).rejects.toThrow(
+        'Get VIP fees failed: 500',
       );
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -4,8 +4,6 @@ import type {
   LoginResponseDto,
   EstimatePointsDto,
   EstimatedPointsDto,
-  GetPerpsDiscountDto,
-  PerpsDiscountData,
   SubscriptionSeasonReferralDetailsDto,
   PaginatedPointsEventsDto,
   GetPointsEventsDto,
@@ -40,6 +38,7 @@ import type {
   PerpsTradingCampaignVolumeDto,
   PerpsTradingCampaignParticipantOutcomeDto,
   VipDashboardDto,
+  VipFeesResponseDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import Logger from '../../../../../util/Logger';
@@ -116,11 +115,6 @@ export interface RewardsDataServiceGetPointsEventsLastUpdatedAction {
 export interface RewardsDataServiceEstimatePointsAction {
   type: `${typeof SERVICE_NAME}:estimatePoints`;
   handler: RewardsDataService['estimatePoints'];
-}
-
-export interface RewardsDataServiceGetPerpsDiscountAction {
-  type: `${typeof SERVICE_NAME}:getPerpsDiscount`;
-  handler: RewardsDataService['getPerpsDiscount'];
 }
 
 export interface RewardsDataServiceMobileOptinAction {
@@ -317,6 +311,11 @@ export interface RewardsDataServiceGetVIPDashboardAction {
   handler: RewardsDataService['getVIPDashboard'];
 }
 
+export interface RewardsDataServiceGetVipFeesAction {
+  type: `${typeof SERVICE_NAME}:getVipFees`;
+  handler: RewardsDataService['getVipFees'];
+}
+
 export interface RewardsDataServicePostBenefitImpressionAction {
   type: `${typeof SERVICE_NAME}:postBenefitImpression`;
   handler: RewardsDataService['postBenefitImpression'];
@@ -328,7 +327,6 @@ export type RewardsDataServiceActions =
   | RewardsDataServiceGetPointsEventsLastUpdatedAction
   | RewardsDataServiceGetSubscriptionAccountsAction
   | RewardsDataServiceEstimatePointsAction
-  | RewardsDataServiceGetPerpsDiscountAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceGetReferralDetailsAction
   | RewardsDataServiceMobileOptinAction
@@ -355,6 +353,7 @@ export type RewardsDataServiceActions =
   | RewardsDataServiceOptInToCampaignAction
   | RewardsDataServiceGetBenefitsAction
   | RewardsDataServiceGetVIPDashboardAction
+  | RewardsDataServiceGetVipFeesAction
   | RewardsDataServicePostBenefitImpressionAction
   | RewardsDataServiceGetCampaignParticipantStatusAction
   | RewardsDataServiceGetClientVersionRequirementsAction
@@ -426,10 +425,6 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:estimatePoints`,
       this.estimatePoints.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getPerpsDiscount`,
-      this.getPerpsDiscount.bind(this),
     );
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:mobileOptin`,
@@ -582,6 +577,10 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:getVIPDashboard`,
       this.getVIPDashboard.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getVipFees`,
+      this.getVipFees.bind(this),
     );
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:postBenefitImpression`,
@@ -868,56 +867,6 @@ export class RewardsDataService {
     }
 
     return (await response.json()) as EstimatedPointsDto;
-  }
-
-  /**
-   * Get Perps fee discount in bips for a given address.
-   * @param params - The request parameters containing the CAIP-10 address.
-   * @returns The parsed Perps discount data containing opt-in status and discount percentage.
-   */
-  async getPerpsDiscount(
-    params: GetPerpsDiscountDto,
-  ): Promise<PerpsDiscountData> {
-    const response = await this.makeRequest(
-      `/public/rewards/perps-fee-discount/${params.account}`,
-      {
-        method: 'GET',
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`Get Perps discount failed: ${response.status}`);
-    }
-
-    const responseText = await response.text();
-
-    // Parse the X,Y format where X is opt-in status (0 or 1) and Y is discount
-    const parts = responseText.split(',');
-    if (parts.length !== 2) {
-      throw new Error(
-        `Invalid perps discount response format: ${responseText}`,
-      );
-    }
-
-    const optInStatus = parseInt(parts[0]);
-    const discountBips = parseFloat(parts[1]);
-
-    if (isNaN(optInStatus) || isNaN(discountBips)) {
-      throw new Error(
-        `Invalid perps discount values: optIn=${parts[0]}, discount=${parts[1]}`,
-      );
-    }
-
-    if (optInStatus !== 0 && optInStatus !== 1) {
-      throw new Error(
-        `Invalid opt-in status: ${optInStatus}. Expected 0 or 1.`,
-      );
-    }
-
-    return {
-      hasOptedIn: optInStatus === 1,
-      discountBips,
-    };
   }
 
   /**
@@ -1592,6 +1541,27 @@ export class RewardsDataService {
     }
 
     return (await response.json()) as VipDashboardDto;
+  }
+
+  /**
+   * Get the VIP fee table for the current subscription.
+   * @param subscriptionId - The subscription ID for authentication.
+   * @returns The VIP fee response (tier 0 will have fees=null).
+   */
+  async getVipFees(subscriptionId: string): Promise<VipFeesResponseDto> {
+    const response = await this.makeRequest(
+      '/vip/fees',
+      {
+        method: 'GET',
+      },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      throw new Error(`Get VIP fees failed: ${response.status}`);
+    }
+
+    return (await response.json()) as VipFeesResponseDto;
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -137,6 +137,42 @@ export type VipDashboardState = VipDashboardDto & {
   lastFetched: number;
 };
 
+// Backend wire format for GET /vip/fees — mirrors va-mmcx-rewards
+// src/main/vip/dto/vip-fees.dto.ts (PR #546). Fee bips are returned as
+// strings; the controller parses them as needed.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type HyperliquidVipFeesDto = {
+  builderCode: string;
+  builderFeeBips: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SwapsVipFeesDto = {
+  feeBips: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipFeesGroupDto = {
+  hyperliquid: HyperliquidVipFeesDto;
+  swaps: SwapsVipFeesDto;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipFeesResponseDto = {
+  vipTier: number;
+  fees: VipFeesGroupDto | null;
+  updatedAt: string | null;
+};
+
+// Per-subscription cache for VIP perps builder fee.
+// We store the raw bips string from the backend rather than a derived
+// discount so the cache stays valid if the perps base fee constant changes.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipPerpsFeesState = {
+  hyperliquidBuilderFeeBips: string;
+  lastFetched: number;
+};
+
 export interface MobileLoginDto {
   /**
    * The account of the user
@@ -2042,6 +2078,9 @@ export type RewardsControllerState = {
   vipDashboard: {
     [subscriptionId: string]: VipDashboardState;
   };
+  vipPerpsFees: {
+    [subscriptionId: string]: VipPerpsFeesState;
+  };
   seasonStatuses: { [compositeId: string]: SeasonStatusState };
   activeBoosts: { [compositeId: string]: ActiveBoostsState };
   unlockedRewards: { [compositeId: string]: UnlockedRewardsState };
@@ -2214,32 +2253,6 @@ export interface Patch {
   op: 'replace' | 'add' | 'remove';
   path: string[];
   value?: unknown;
-}
-
-/**
- * Request for getting Perps discount
- */
-export interface GetPerpsDiscountDto {
-  /**
-   * Account address in CAIP-10 format
-   * @example 'eip155:1:0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
-   */
-  account: CaipAccountId;
-}
-
-/**
- * Parsed response for Perps discount data
- */
-export interface PerpsDiscountData {
-  /**
-   * Whether the account has opted in (0 = not opted in, 1 = opted in)
-   */
-  hasOptedIn: boolean;
-  /**
-   * The discount percentage in basis points
-   * @example 550
-   */
-  discountBips: number;
 }
 
 /**

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -14,7 +14,6 @@ import type { GeolocationControllerGetGeolocationAction } from '@metamask/geoloc
 import {
   RewardsDataServiceLoginAction,
   RewardsDataServiceEstimatePointsAction,
-  RewardsDataServiceGetPerpsDiscountAction,
   RewardsDataServiceGetSeasonStatusAction,
   RewardsDataServiceGetReferralDetailsAction,
   RewardsDataServiceMobileOptinAction,
@@ -60,6 +59,7 @@ import {
   RewardsDataServiceGetCampaignParticipantStatusAction,
   RewardsDataServiceGetBenefitsAction,
   RewardsDataServiceGetVIPDashboardAction,
+  RewardsDataServiceGetVipFeesAction,
   RewardsDataServicePostBenefitImpressionAction,
   RewardsDataServiceGetClientVersionRequirementsAction,
   RewardsDataServiceGetOndoCampaignLeaderboardAction,
@@ -90,7 +90,6 @@ type AllowedActions =
   | RewardsDataServiceGetPointsEventsAction
   | RewardsDataServiceGetPointsEventsLastUpdatedAction
   | RewardsDataServiceEstimatePointsAction
-  | RewardsDataServiceGetPerpsDiscountAction
   | RewardsDataServiceGetSeasonStatusAction
   | RewardsDataServiceGetReferralDetailsAction
   | RewardsDataServiceMobileOptinAction
@@ -130,6 +129,7 @@ type AllowedActions =
   | RewardsDataServiceGetPerpsTradingCampaignLeaderboardPositionAction
   | RewardsDataServiceGetPerpsTradingCampaignVolumeAction
   | RewardsDataServiceGetVIPDashboardAction
+  | RewardsDataServiceGetVipFeesAction
   | RewardsDataServiceGetPerpsTradingCampaignParticipantOutcomeAction;
 
 // Don't reexport as per guidelines
@@ -182,7 +182,6 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getPointsEvents',
       'RewardsDataService:getPointsEventsLastUpdated',
       'RewardsDataService:estimatePoints',
-      'RewardsDataService:getPerpsDiscount',
       'RewardsDataService:getSeasonStatus',
       'RewardsDataService:getReferralDetails',
       'RewardsDataService:mobileOptin',
@@ -210,6 +209,7 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getDefaultRewardsEnvUrl',
       'RewardsDataService:getBenefits',
       'RewardsDataService:getVIPDashboard',
+      'RewardsDataService:getVipFees',
       'RewardsDataService:postBenefitImpression',
       'RewardsDataService:getClientVersionRequirements',
       'RewardsDataService:getOndoCampaignLeaderboard',

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -754,6 +754,7 @@
     "seasons": {},
     "subscriptionBenefits": {},
     "vipDashboard": {},
+    "vipPerpsFees": {},
     "subscriptionReferralDetails": {},
     "subscriptions": {},
     "rewardsEnvUrl": null


### PR DESCRIPTION
## Summary

Keep the existing `RewardsController.getPerpsDiscountForAccount` contract (still returns a discount in basis points; perps still applies it via `metamaskFeeRate = base * (1 - discount/10000)`), and only swap *how* the discount is derived. When the account's active subscription has `features.vip.enabled === true`, the controller calls the new authenticated `GET /vip/fees`, reads `hyperliquid.builderFeeBips`, and converts it to a discount fraction using the base fee the caller passes in. Non-VIP accounts now receive a 0 discount; the legacy `/public/rewards/perps-fee-discount` endpoint and its data-service method are removed.

Targets [#29888 (`vip-feature-icon-menu`)](https://github.com/MetaMask/metamask-mobile/pull/29888) because it relies on the new `SubscriptionDto.features.vip.enabled` flag and the per-subscription VIP state introduced there.

- Adds `RewardsDataService.getVipFees` (auth'd, mirrors [va-mmcx-rewards#546](https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/546) DTOs)
- Adds per-subscription cache slot `RewardsControllerState.vipPerpsFees` (5-min TTL; stores raw bips so the cache is independent of `baseFeeBips`)
- Extends `getPerpsDiscountForAccount(account, baseFeeBips)` — perps callers pass `BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR` so the controller stays a pure transformer (no perps constant import inside rewards)
- Removes `getPerpsDiscount` data service method, `RewardsDataServiceGetPerpsDiscountAction`, `#getPerpsFeeDiscountData`, `GetPerpsDiscountDto`, `PerpsDiscountData`
- Simplifies `getHasAccountOptedIn` to rely on cached state only
- Updates the three perps call sites (`RewardsIntegrationService`, `usePerpsOrderFees`, `usePerpsCloseAllCalculations`) and the mobile infrastructure adapter

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## Screenshots



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the perps fee-discount source and contract (adds `baseFeeBips`, introduces `null` for unhydrated/failed VIP lookups), which can affect fee calculations and caching behavior across perps UI flows.
> 
> **Overview**
> Perps fee discounts are now derived from VIP subscription data: `RewardsController.getPerpsDiscountForAccount(account, baseFeeBips)` calls a new authenticated `GET /vip/fees`, converts the returned absolute VIP builder fee into a discount fraction vs the caller-provided base fee, and caches the raw VIP builder fee per subscription (`vipPerpsFees`, 5‑min TTL).
> 
> The legacy public perps-discount endpoint and related data-service/action/types/caching logic are removed, and `getHasAccountOptedIn` no longer falls back to perps-discount API calls.
> 
> All perps call sites (`RewardsIntegrationService`, `usePerpsOrderFees`, `usePerpsCloseAllCalculations`, `mobileInfrastructure`) are updated to pass `baseFeeBips` and to treat `null` as *unhydrated/unavailable* (don’t cache; retry on subsequent calculations), with new tests covering these cases and VIP fee edge-condition handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9ccbcfc8afabfa1094599262eb70a48749fa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->