### PR TITLE
feat: add cycling sort button to trader profile positions

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -15,6 +15,12 @@ const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockToggleFollow = jest.fn();
 const mockRefresh = jest.fn();
+const mockPlaySelection = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../../util/haptics', () => ({
+  ...jest.requireActual('../../../../util/haptics'),
+  playSelection: (...args: unknown[]) => mockPlaySelection(...args),
+}));
 
 jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
   getAssetImageUrl: () => 'https://example.com/token.png',
@@ -178,6 +184,60 @@ const fixtureOpenPositions: Position[] = [
     currentValueUSD: 2259.96,
     pnlValueUsd: 1059.96,
     pnlPercent: 182,
+  },
+];
+
+const fixtureClosedPositions: Position[] = [
+  {
+    positionId: 'cult-eth',
+    tokenSymbol: 'CULT',
+    tokenName: 'Cult',
+    tokenAddress: '0xc01t',
+    chain: 'ethereum',
+    positionAmount: 0,
+    boughtUsd: 100,
+    soldUsd: 300,
+    realizedPnl: 200,
+    costBasis: 100,
+    trades: [],
+    lastTradeAt: 1000,
+    currentValueUSD: 0,
+    pnlValueUsd: 200,
+    pnlPercent: null,
+  },
+  {
+    positionId: 'moonkin-sol',
+    tokenSymbol: 'MOONKIN',
+    tokenName: 'Moonkin',
+    tokenAddress: '0xm00n',
+    chain: 'solana',
+    positionAmount: 0,
+    boughtUsd: 100,
+    soldUsd: 1000,
+    realizedPnl: 900,
+    costBasis: 100,
+    trades: [],
+    lastTradeAt: 3000,
+    currentValueUSD: 0,
+    pnlValueUsd: 900,
+    pnlPercent: null,
+  },
+  {
+    positionId: 'dope-base',
+    tokenSymbol: 'DOPE',
+    tokenName: 'Dope',
+    tokenAddress: '0xd0pe',
+    chain: 'base',
+    positionAmount: 0,
+    boughtUsd: 500,
+    soldUsd: 500,
+    realizedPnl: 0,
+    costBasis: 500,
+    trades: [],
+    lastTradeAt: 2000,
+    currentValueUSD: 0,
+    pnlValueUsd: 0,
+    pnlPercent: null,
   },
 ];
 
@@ -434,6 +494,117 @@ describe('TraderProfileView', () => {
         screen.queryByTestId(TraderProfileViewSelectorsIDs.ERROR_BANNER),
       ).not.toBeOnTheScreen();
       expect(screen.getByText('45 followers')).toBeOnTheScreen();
+    });
+  });
+
+  describe('sort button', () => {
+    it('renders with default Value label on the Open tab', () => {
+      renderWithProvider(<TraderProfileView />);
+
+      expect(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      ).toBeOnTheScreen();
+      expect(screen.getByText('Value')).toBeOnTheScreen();
+    });
+
+    it('cycles Open tab sort Value -> P&L % -> Value on consecutive taps', () => {
+      renderWithProvider(<TraderProfileView />);
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('Value')).toBeOnTheScreen();
+    });
+
+    it('defaults Closed tab sort to Recent and cycles Recent -> Value -> P&L % -> Recent', () => {
+      mockPositionsResult.closedPositions = fixtureClosedPositions;
+      renderWithProvider(<TraderProfileView />);
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TAB_CLOSED),
+      );
+
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('Value')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+    });
+
+    it('preserves independent sort state when switching between tabs', () => {
+      mockPositionsResult.closedPositions = fixtureClosedPositions;
+      renderWithProvider(<TraderProfileView />);
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TAB_CLOSED),
+      );
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('Value')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TAB_OPEN),
+      );
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TAB_CLOSED),
+      );
+      expect(screen.getByText('Value')).toBeOnTheScreen();
+    });
+
+    it('triggers a haptic on each sort tap', () => {
+      renderWithProvider(<TraderProfileView />);
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+
+      expect(mockPlaySelection).toHaveBeenCalledTimes(2);
+    });
+
+    it('hides the sort button when positions list is empty', () => {
+      mockPositionsResult.openPositions = [];
+      renderWithProvider(<TraderProfileView />);
+
+      expect(
+        screen.queryByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides the sort button while positions are loading', () => {
+      mockPositionsResult.isLoadingOpen = true;
+      renderWithProvider(<TraderProfileView />);
+
+      expect(
+        screen.queryByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      ).not.toBeOnTheScreen();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.testIds.ts
@@ -7,6 +7,7 @@ export const TraderProfileViewSelectorsIDs = {
   FOLLOW_BUTTON: 'trader-profile-follow-button',
   TAB_OPEN: 'trader-profile-tab-open',
   TAB_CLOSED: 'trader-profile-tab-closed',
+  SORT_BUTTON: 'trader-profile-sort-button',
   ERROR_BANNER: 'trader-profile-error-banner',
   TWITTER_LINK: 'trader-profile-twitter-link',
 };

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
+import { playSelection } from '../../../../util/haptics';
 import {
   useNavigation,
   useRoute,
@@ -33,6 +34,15 @@ import type { Position } from '@metamask/social-controllers';
 import ProfileHeader from './components/ProfileHeader';
 import StatsRow from './components/StatsRow';
 import PositionRow from './components/PositionRow';
+import SortButton from './components/SortButton';
+import {
+  CLOSED_SORT_CYCLE,
+  OPEN_SORT_CYCLE,
+  sortPositions,
+  type ClosedSortKey,
+  type OpenSortKey,
+  type SortKey,
+} from './utils/sortPositions';
 import {
   ProfileHeaderSkeleton,
   StatsRowSkeleton,
@@ -52,6 +62,12 @@ const POSITION_SKELETON_KEYS = Array.from(
   { length: POSITION_SKELETON_COUNT },
   (_, i) => `position-skeleton-${i}`,
 );
+
+const SORT_LABEL_KEYS: Record<SortKey, string> = {
+  value: 'social_leaderboard.trader_profile.sort.value',
+  pnl: 'social_leaderboard.trader_profile.sort.pnl_percent',
+  recent: 'social_leaderboard.trader_profile.sort.recent',
+};
 
 interface TabButtonProps {
   label: string;
@@ -110,6 +126,8 @@ const TraderProfileView = () => {
   } = useNotificationPreferences();
 
   const [activeTab, setActiveTab] = useState<'open' | 'closed'>('open');
+  const [openSort, setOpenSort] = useState<OpenSortKey>('value');
+  const [closedSort, setClosedSort] = useState<ClosedSortKey>('recent');
 
   const notificationsSheetRef = useRef<TraderNotificationsBottomSheetRef>(null);
   const setupSheetRef =
@@ -146,6 +164,29 @@ const TraderProfileView = () => {
   const positions = activeTab === 'open' ? openPositions : closedPositions;
   const isLoadingPositions =
     activeTab === 'open' ? isLoadingOpen : isLoadingClosed;
+
+  const currentSortKey: SortKey = activeTab === 'open' ? openSort : closedSort;
+
+  const sortedPositions = useMemo(
+    () => sortPositions(positions, currentSortKey, activeTab),
+    [positions, currentSortKey, activeTab],
+  );
+
+  const handleSortPress = useCallback(() => {
+    // Fire-and-forget haptic; ignore rejection (unsupported platforms).
+    playSelection().catch(() => undefined);
+    if (activeTab === 'open') {
+      setOpenSort((current) => {
+        const idx = OPEN_SORT_CYCLE.indexOf(current);
+        return OPEN_SORT_CYCLE[(idx + 1) % OPEN_SORT_CYCLE.length];
+      });
+    } else {
+      setClosedSort((current) => {
+        const idx = CLOSED_SORT_CYCLE.indexOf(current);
+        return CLOSED_SORT_CYCLE[(idx + 1) % CLOSED_SORT_CYCLE.length];
+      });
+    }
+  }, [activeTab]);
 
   return (
     <SafeAreaView
@@ -242,28 +283,44 @@ const TraderProfileView = () => {
 
                 <Box
                   flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  justifyContent={BoxJustifyContent.Between}
                   twClassName="px-4 mb-2"
-                  gap={4}
                 >
-                  <TabButton
-                    label={strings('social_leaderboard.trader_profile.open')}
-                    isActive={activeTab === 'open'}
-                    onPress={() => setActiveTab('open')}
-                    testID={TraderProfileViewSelectorsIDs.TAB_OPEN}
-                  />
-                  <TabButton
-                    label={strings('social_leaderboard.trader_profile.closed')}
-                    isActive={activeTab === 'closed'}
-                    onPress={() => setActiveTab('closed')}
-                    testID={TraderProfileViewSelectorsIDs.TAB_CLOSED}
-                  />
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={4}
+                  >
+                    <TabButton
+                      label={strings('social_leaderboard.trader_profile.open')}
+                      isActive={activeTab === 'open'}
+                      onPress={() => setActiveTab('open')}
+                      testID={TraderProfileViewSelectorsIDs.TAB_OPEN}
+                    />
+                    <TabButton
+                      label={strings(
+                        'social_leaderboard.trader_profile.closed',
+                      )}
+                      isActive={activeTab === 'closed'}
+                      onPress={() => setActiveTab('closed')}
+                      testID={TraderProfileViewSelectorsIDs.TAB_CLOSED}
+                    />
+                  </Box>
+                  {!isLoadingPositions && positions.length > 0 && (
+                    <SortButton
+                      label={strings(SORT_LABEL_KEYS[currentSortKey])}
+                      onPress={handleSortPress}
+                      testID={TraderProfileViewSelectorsIDs.SORT_BUTTON}
+                    />
+                  )}
                 </Box>
 
                 {isLoadingPositions ? (
                   POSITION_SKELETON_KEYS.map((key) => (
                     <PositionRowSkeleton key={key} />
                   ))
-                ) : positions.length === 0 ? (
+                ) : sortedPositions.length === 0 ? (
                   <Box
                     twClassName="px-4 py-8"
                     alignItems={BoxAlignItems.Center}
@@ -278,7 +335,7 @@ const TraderProfileView = () => {
                     </Text>
                   </Box>
                 ) : (
-                  positions.map((position, index) => (
+                  sortedPositions.map((position, index) => (
                     <PositionRow
                       key={`${position.tokenAddress}-${position.chain}-${index}`}
                       position={position}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/SortButton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/SortButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+export interface SortButtonProps {
+  label: string;
+  onPress: () => void;
+  testID?: string;
+}
+
+const SortButton: React.FC<SortButtonProps> = ({ label, onPress, testID }) => {
+  const tw = useTailwind();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      testID={testID}
+      hitSlop={8}
+      style={({ pressed }) =>
+        tw.style('flex-row items-center', pressed && 'opacity-70')
+      }
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+      >
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {label}
+        </Text>
+        <Icon
+          name={IconName.SwapVertical}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+    </Pressable>
+  );
+};
+
+export default SortButton;

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.test.ts
@@ -1,0 +1,172 @@
+import type { Position } from '@metamask/social-controllers';
+import {
+  CLOSED_SORT_CYCLE,
+  OPEN_SORT_CYCLE,
+  sortPositions,
+} from './sortPositions';
+
+const makeOpen = (overrides: Partial<Position> = {}): Position => ({
+  positionId: 'p',
+  tokenSymbol: 'TKN',
+  tokenName: 'Token',
+  tokenAddress: '0x1',
+  chain: 'base',
+  positionAmount: 100,
+  boughtUsd: 100,
+  soldUsd: 0,
+  realizedPnl: 0,
+  costBasis: 100,
+  trades: [],
+  lastTradeAt: 0,
+  currentValueUSD: 0,
+  pnlValueUsd: 0,
+  pnlPercent: 0,
+  ...overrides,
+});
+
+const makeClosed = (overrides: Partial<Position> = {}): Position =>
+  makeOpen({
+    positionAmount: 0,
+    soldUsd: 100,
+    realizedPnl: 0,
+    boughtUsd: 100,
+    currentValueUSD: 0,
+    pnlPercent: null,
+    ...overrides,
+  });
+
+describe('sortPositions', () => {
+  describe('cycles', () => {
+    it('exposes the Open tab cycle as [value, pnl]', () => {
+      expect(OPEN_SORT_CYCLE).toEqual(['value', 'pnl']);
+    });
+
+    it('exposes the Closed tab cycle as [value, pnl, recent]', () => {
+      expect(CLOSED_SORT_CYCLE).toEqual(['value', 'pnl', 'recent']);
+    });
+  });
+
+  describe('open tab', () => {
+    const a = makeOpen({
+      positionId: 'a',
+      currentValueUSD: 100,
+      pnlPercent: 5,
+    });
+    const b = makeOpen({
+      positionId: 'b',
+      currentValueUSD: 300,
+      pnlPercent: 1,
+    });
+    const c = makeOpen({
+      positionId: 'c',
+      currentValueUSD: 200,
+      pnlPercent: 10,
+    });
+
+    it('sorts by currentValueUSD descending when sortKey is value', () => {
+      const result = sortPositions([a, b, c], 'value', 'open');
+
+      expect(result.map((p) => p.positionId)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('sorts by pnlPercent descending when sortKey is pnl', () => {
+      const result = sortPositions([a, b, c], 'pnl', 'open');
+
+      expect(result.map((p) => p.positionId)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('treats null currentValueUSD as 0 for value sort', () => {
+      const nullValue = makeOpen({
+        positionId: 'z',
+        currentValueUSD: null,
+        pnlPercent: 0,
+      });
+
+      const result = sortPositions([a, nullValue], 'value', 'open');
+
+      expect(result.map((p) => p.positionId)).toEqual(['a', 'z']);
+    });
+
+    it('treats null pnlPercent as 0 for pnl sort', () => {
+      const nullPnl = makeOpen({
+        positionId: 'z',
+        currentValueUSD: 0,
+        pnlPercent: null,
+      });
+
+      const result = sortPositions([a, nullPnl], 'pnl', 'open');
+
+      expect(result.map((p) => p.positionId)).toEqual(['a', 'z']);
+    });
+  });
+
+  describe('closed tab', () => {
+    const a = makeClosed({
+      positionId: 'a',
+      soldUsd: 1000,
+      realizedPnl: 100,
+      boughtUsd: 500,
+      lastTradeAt: 1_000,
+    });
+    const b = makeClosed({
+      positionId: 'b',
+      soldUsd: 3000,
+      realizedPnl: 30,
+      boughtUsd: 1000,
+      lastTradeAt: 3_000,
+    });
+    const c = makeClosed({
+      positionId: 'c',
+      soldUsd: 2000,
+      realizedPnl: 500,
+      boughtUsd: 1000,
+      lastTradeAt: 2_000,
+    });
+
+    it('sorts by soldUsd descending when sortKey is value', () => {
+      const result = sortPositions([a, b, c], 'value', 'closed');
+
+      expect(result.map((p) => p.positionId)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('sorts by realized P&L percent descending when sortKey is pnl', () => {
+      const result = sortPositions([a, b, c], 'pnl', 'closed');
+
+      expect(result.map((p) => p.positionId)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('sorts by lastTradeAt descending when sortKey is recent', () => {
+      const result = sortPositions([a, b, c], 'recent', 'closed');
+
+      expect(result.map((p) => p.positionId)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('treats boughtUsd === 0 as 0 P&L', () => {
+      const zeroBought = makeClosed({
+        positionId: 'z',
+        soldUsd: 100,
+        realizedPnl: 100,
+        boughtUsd: 0,
+        lastTradeAt: 5_000,
+      });
+
+      const result = sortPositions([zeroBought, a], 'pnl', 'closed');
+
+      expect(result.map((p) => p.positionId)).toEqual(['a', 'z']);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input array', () => {
+      const input = [
+        makeOpen({ positionId: 'a', currentValueUSD: 1 }),
+        makeOpen({ positionId: 'b', currentValueUSD: 2 }),
+      ];
+      const before = input.map((p) => p.positionId);
+
+      sortPositions(input, 'value', 'open');
+
+      expect(input.map((p) => p.positionId)).toEqual(before);
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.ts
@@ -1,0 +1,54 @@
+import type { Position } from '@metamask/social-controllers';
+
+export type OpenSortKey = 'value' | 'pnl';
+export type ClosedSortKey = 'value' | 'pnl' | 'recent';
+export type SortKey = OpenSortKey | ClosedSortKey;
+
+export const OPEN_SORT_CYCLE: readonly OpenSortKey[] = ['value', 'pnl'];
+export const CLOSED_SORT_CYCLE: readonly ClosedSortKey[] = [
+  'value',
+  'pnl',
+  'recent',
+];
+
+const getOpenValue = (position: Position): number =>
+  position.currentValueUSD ?? 0;
+
+const getClosedValue = (position: Position): number => position.soldUsd;
+
+const getOpenPnl = (position: Position): number => position.pnlPercent ?? 0;
+
+const getClosedPnl = (position: Position): number =>
+  position.boughtUsd > 0
+    ? (position.realizedPnl / position.boughtUsd) * 100
+    : 0;
+
+const getRecency = (position: Position): number => position.lastTradeAt ?? 0;
+
+/**
+ * Sort a list of positions for the trader profile view.
+ *
+ * Pure function — never mutates the input array.
+ *
+ * @param positions - The positions to sort.
+ * @param sortKey - The sort criterion.
+ * @param tab - Which tab the positions belong to (decides which field to read).
+ * @returns A new array sorted in descending order by the chosen criterion.
+ */
+export const sortPositions = (
+  positions: Position[],
+  sortKey: SortKey,
+  tab: 'open' | 'closed',
+): Position[] => {
+  const getScore = (position: Position): number => {
+    if (sortKey === 'recent') {
+      return getRecency(position);
+    }
+    if (sortKey === 'pnl') {
+      return tab === 'open' ? getOpenPnl(position) : getClosedPnl(position);
+    }
+    return tab === 'open' ? getOpenValue(position) : getClosedValue(position);
+  };
+
+  return [...positions].sort((a, b) => getScore(b) - getScore(a));
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1064,7 +1064,12 @@
       "closed": "Closed",
       "no_positions": "No positions yet",
       "error_loading_profile": "Couldn't load profile",
-      "twitter_link": "View on X (Twitter)"
+      "twitter_link": "View on X (Twitter)",
+      "sort": {
+        "value": "Value",
+        "pnl_percent": "P&L %",
+        "recent": "Recent"
+      }
     },
     "trader_position": {
       "market_cap": "Market cap",


### PR DESCRIPTION
---

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

https://github.com/user-attachments/assets/6ba73ed6-8a0f-4825-bcfc-27549290963e


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds an inline cycling sort control to the Top Traders trader profile screen on both the Open and Closed tabs. The button visually mirrors the Perps Markets sort dropdown (label + swap-vertical icon), but tapping cycles through the available options inline instead of opening a bottom sheet. Each tap fires a light selection haptic through the project's `app/util/haptics` utility (Redux-gated, kill-switch-aware).

Sort state is independent per tab and preserved when switching back and forth:

- Open tab: `Value`, `P&L %` — default `Value`
- Closed tab: `Value`, `P&L %`, `Recent` — default `Recent`

The button is hidden while positions are loading or when the list is empty, so the control is only shown when there is something meaningful to sort.

Sorting logic lives in a pure `sortPositions` utility (no React, no Redux) so it is trivial to test and reuse, and keeps domain logic out of the view.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a sort control to a trader's Open and Closed positions on the Top Traders profile screen.

## **Related issues**

Fixes: N/A — product request from design/PM, no linked issue.

## **Manual testing steps**

```gherkin
Feature: Sort trader positions

  Scenario: Open tab cycles between Value and P&L %
    Given I am on a trader profile with Open positions
    Then the sort button shows "Value"
    When I tap the sort button
    Then the sort button shows "P&L %" and the list is sorted by P&L % descending
    When I tap the sort button again
    Then the sort button shows "Value" and the list is sorted by Value descending

  Scenario: Closed tab defaults to Recent and cycles through three options
    Given I am on a trader profile with Closed positions
    When I tap the "Closed" tab
    Then the sort button shows "Recent" and positions are sorted by most recent
    When I tap the sort button
    Then the sort button shows "Value"
    When I tap the sort button
    Then the sort button shows "P&L %"
    When I tap the sort button
    Then the sort button shows "Recent" again

  Scenario: Sort state is independent and preserved per tab
    Given I am on the Open tab and have selected "P&L %"
    When I switch to the Closed tab and select "Value"
    And I switch back to the Open tab
    Then the sort button still shows "P&L %"
    When I switch back to the Closed tab
    Then the sort button still shows "Value"

  Scenario: Sort button is hidden when there is nothing to sort
    Given I am on a trader profile whose Open positions list is loading or empty
    Then the sort button is not visible

  Scenario: Tapping the sort button triggers a haptic
    Given haptics are enabled on the device and in app settings
    When I tap the sort button
    Then a light selection haptic is felt
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no sort control existed on the trader profile positions list.

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects client-side ordering and a non-blocking haptic call; main risk is incorrect sort criteria or state handling across tabs.
> 
> **Overview**
> Adds an inline, cycling **sort button** to `TraderProfileView` that appears when positions are loaded/non-empty and reorders the displayed list via a new pure `sortPositions` utility.
> 
> Introduces independent per-tab sort state (Open: `Value`/`P&L %`; Closed: `Recent`/`Value`/`P&L %`), triggers `playSelection()` haptics on each tap, adds i18n labels, and expands test coverage for sort cycling, visibility rules, and sorting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb7f43c3ec2d5a96275022fec8ad63ec6aeac88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->