### PR TITLE
refactor: move activity-specific selectors

### DIFF
--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -28,7 +28,7 @@ import {
   selectEVMEnabledNetworks,
   selectNonEVMEnabledNetworks,
 } from '../../../selectors/networkEnablementController';
-import { selectLocalTransactions } from '../../../selectors/transactionController';
+import { selectLocalTransactions } from '../../../selectors/activity';
 import { baseStyles } from '../../../styles/common';
 import { areAddressesEqual, isHardwareAccount } from '../../../util/address';
 import { getBlockExplorerAddressUrl } from '../../../util/networks';

--- a/app/selectors/activity.test.ts
+++ b/app/selectors/activity.test.ts
@@ -1,0 +1,83 @@
+import { RootState } from '../components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
+import { selectLocalTransactions } from './activity';
+
+jest.mock('./smartTransactionsController', () => ({
+  selectPendingSmartTransactionsForSelectedAccountGroup: (state: {
+    pendingSmartTransactionsForGroup: unknown[];
+  }) => state.pendingSmartTransactionsForGroup || [],
+}));
+
+jest.mock('./accountsController', () => ({
+  selectEvmAddress: (state: {
+    engine: {
+      backgroundState: {
+        AccountsController: {
+          internalAccounts: {
+            selectedAccount: string;
+            accounts: Record<string, { address: string }>;
+          };
+        };
+      };
+    };
+  }) => {
+    const selectedAccountId =
+      state.engine.backgroundState.AccountsController.internalAccounts
+        .selectedAccount;
+    return state.engine.backgroundState.AccountsController.internalAccounts
+      .accounts[selectedAccountId]?.address;
+  },
+}));
+
+describe('activity selectors', () => {
+  describe('selectLocalTransactions', () => {
+    it('filters required child transactions before nonce dedupe', () => {
+      const activeEvmAddress = '0x0000000000000000000000000000000000000001';
+      const state = {
+        engine: {
+          backgroundState: {
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: 'account-1',
+                accounts: {
+                  'account-1': {
+                    id: 'account-1',
+                    address: activeEvmAddress,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'parent',
+                  chainId: '0x1',
+                  time: 1,
+                  txParams: {
+                    from: activeEvmAddress,
+                    nonce: '0x1',
+                  },
+                },
+                {
+                  id: 'child',
+                  chainId: '0x1',
+                  time: 2,
+                  txParams: {
+                    from: activeEvmAddress,
+                    nonce: '0x2',
+                  },
+                  requiredTransactionIds: ['parent'],
+                },
+              ],
+            },
+          },
+        },
+        pendingSmartTransactionsForGroup: [],
+      } as unknown as RootState;
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'parent' }),
+      ]);
+    });
+  });
+});

--- a/app/selectors/activity.test.ts
+++ b/app/selectors/activity.test.ts
@@ -1,7 +1,11 @@
 import { RootState } from '../components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
+import { TransactionType } from '@metamask/transaction-controller';
 import { selectLocalTransactions } from './activity';
 
 jest.mock('./smartTransactionsController', () => ({
+  selectPendingSmartTransactionsBySender: (state: {
+    pendingSmartTransactions?: unknown[];
+  }) => state.pendingSmartTransactions || [],
   selectPendingSmartTransactionsForSelectedAccountGroup: (state: {
     pendingSmartTransactionsForGroup: unknown[];
   }) => state.pendingSmartTransactionsForGroup || [],
@@ -14,7 +18,7 @@ jest.mock('./accountsController', () => ({
         AccountsController: {
           internalAccounts: {
             selectedAccount: string;
-            accounts: Record<string, { address: string }>;
+            accounts: Record<string, { address?: string }>;
           };
         };
       };
@@ -28,55 +32,302 @@ jest.mock('./accountsController', () => ({
   },
 }));
 
-describe('activity selectors', () => {
-  describe('selectLocalTransactions', () => {
-    it('filters required child transactions before nonce dedupe', () => {
-      const activeEvmAddress = '0x0000000000000000000000000000000000000001';
-      const state = {
-        engine: {
-          backgroundState: {
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: 'account-1',
-                accounts: {
-                  'account-1': {
-                    id: 'account-1',
-                    address: activeEvmAddress,
-                    type: 'eip155:eoa',
-                  },
-                },
+const ACTIVE = '0x0000000000000000000000000000000000000001';
+
+function buildState({
+  transactions,
+  pendingSmartTransactionsForGroup = [],
+  accountEvmAddress = ACTIVE,
+  omitAccountEvmAddress = false,
+}: {
+  transactions: Record<string, unknown>[];
+  pendingSmartTransactionsForGroup?: Record<string, unknown>[];
+  accountEvmAddress?: string;
+  omitAccountEvmAddress?: boolean;
+}): RootState {
+  return {
+    engine: {
+      backgroundState: {
+        AccountsController: {
+          internalAccounts: {
+            selectedAccount: 'account-1',
+            accounts: {
+              'account-1': {
+                id: 'account-1',
+                ...(!omitAccountEvmAddress ? { address: accountEvmAddress } : {}),
+                type: 'eip155:eoa',
               },
-            },
-            TransactionController: {
-              transactions: [
-                {
-                  id: 'child',
-                  chainId: '0x1',
-                  time: 2,
-                  txParams: {
-                    from: activeEvmAddress,
-                    nonce: '0x2',
-                  },
-                },
-                {
-                  id: 'parent',
-                  chainId: '0x1',
-                  time: 1,
-                  txParams: {
-                    from: activeEvmAddress,
-                    nonce: '0x1',
-                  },
-                  requiredTransactionIds: ['child'],
-                },
-              ],
             },
           },
         },
-        pendingSmartTransactionsForGroup: [],
-      } as unknown as RootState;
+        TransactionController: {
+          transactions,
+        },
+      },
+    },
+    pendingSmartTransactionsForGroup,
+  } as unknown as RootState;
+}
+
+describe('activity selectors', () => {
+  describe('selectLocalTransactions', () => {
+    it('filters required child transactions before nonce dedupe', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'child',
+            chainId: '0x1',
+            time: 2,
+            txParams: {
+              from: ACTIVE,
+              nonce: '0x2',
+            },
+          },
+          {
+            id: 'parent',
+            chainId: '0x1',
+            time: 1,
+            txParams: {
+              from: ACTIVE,
+              nonce: '0x1',
+            },
+            requiredTransactionIds: ['child'],
+          },
+        ],
+      });
 
       expect(selectLocalTransactions(state)).toStrictEqual([
         expect.objectContaining({ id: 'parent' }),
+      ]);
+    });
+
+    it('returns local transactions for the active account sorted by time descending', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'older',
+            chainId: '0x1',
+            time: 100,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+          {
+            id: 'newer',
+            chainId: '0x1',
+            time: 200,
+            txParams: { from: ACTIVE, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
+        'newer',
+        'older',
+      ]);
+    });
+
+    it('treats missing time as zero when sorting', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'no-time',
+            chainId: '0x1',
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+          {
+            id: 'with-time',
+            chainId: '0x1',
+            time: 50,
+            txParams: { from: ACTIVE, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
+        'with-time',
+        'no-time',
+      ]);
+    });
+
+    it('excludes transactions whose from address does not match the active account', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'other',
+            chainId: '0x1',
+            time: 1,
+            txParams: {
+              from: '0x0000000000000000000000000000000000000002',
+              nonce: '0x1',
+            },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([]);
+    });
+
+    it('returns an empty list when the active account has no EVM address', () => {
+      const state = buildState({
+        omitAccountEvmAddress: true,
+        transactions: [
+          {
+            id: 'a',
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([]);
+    });
+
+    it('merges pending smart transactions for the active address and sorts with controller transactions', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'ctrl',
+            chainId: '0x1',
+            time: 100,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+        ],
+        pendingSmartTransactionsForGroup: [
+          {
+            id: 'smart',
+            chainId: '0x1',
+            time: 300,
+            txParams: { from: ACTIVE, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
+        'smart',
+        'ctrl',
+      ]);
+    });
+
+    it('dedupes two controller transactions that share chain, from, and nonce', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'first',
+            chainId: '0x1',
+            time: 2,
+            txParams: { from: ACTIVE, nonce: '0x5' },
+          },
+          {
+            id: 'second',
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, nonce: '0x5' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'first' }),
+      ]);
+    });
+
+    it('uses bridge hash in the dedupe key for bridge transactions', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'bridge-a',
+            type: TransactionType.bridge,
+            hash: '0xAAA',
+            chainId: '0x1',
+            time: 2,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+          {
+            id: 'bridge-b',
+            type: TransactionType.bridge,
+            hash: '0xAAA',
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'bridge-a' }),
+      ]);
+    });
+
+    it('falls back to nonce dedupe for bridge transactions without a hash', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'bridge-1',
+            type: TransactionType.bridge,
+            chainId: '0x1',
+            time: 2,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+          {
+            id: 'bridge-2',
+            type: TransactionType.bridge,
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, nonce: '0x1' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'bridge-1' }),
+      ]);
+    });
+
+    it('dedupes transactions that share chain, from, and actionId when nonce is absent', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'a',
+            chainId: '0x1',
+            time: 2,
+            txParams: { from: ACTIVE, actionId: 'act-1' },
+          },
+          {
+            id: 'b',
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, actionId: 'act-1' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'a' }),
+      ]);
+    });
+
+    it('dedupes across controller and pending smart transactions using the same nonce key', () => {
+      const state = buildState({
+        transactions: [
+          {
+            id: 'ctrl',
+            chainId: '0x1',
+            time: 1,
+            txParams: { from: ACTIVE, nonce: '0x9' },
+          },
+        ],
+        pendingSmartTransactionsForGroup: [
+          {
+            id: 'smart',
+            chainId: '0x1',
+            time: 2,
+            txParams: { from: ACTIVE, nonce: '0x9' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'ctrl' }),
       ]);
     });
   });

--- a/app/selectors/activity.test.ts
+++ b/app/selectors/activity.test.ts
@@ -121,10 +121,9 @@ describe('activity selectors', () => {
         ],
       });
 
-      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
-        'newer',
-        'older',
-      ]);
+      expect(
+        selectLocalTransactions(state).map((tx) => (tx as { id: string }).id),
+      ).toStrictEqual(['newer', 'older']);
     });
 
     it('treats missing time as zero when sorting', () => {
@@ -144,10 +143,9 @@ describe('activity selectors', () => {
         ],
       });
 
-      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
-        'with-time',
-        'no-time',
-      ]);
+      expect(
+        selectLocalTransactions(state).map((tx) => (tx as { id: string }).id),
+      ).toStrictEqual(['with-time', 'no-time']);
     });
 
     it('excludes transactions whose from address does not match the active account', () => {
@@ -204,10 +202,9 @@ describe('activity selectors', () => {
         ],
       });
 
-      expect(selectLocalTransactions(state).map((tx) => tx.id)).toStrictEqual([
-        'smart',
-        'ctrl',
-      ]);
+      expect(
+        selectLocalTransactions(state).map((tx) => (tx as { id: string }).id),
+      ).toStrictEqual(['smart', 'ctrl']);
     });
 
     it('dedupes two controller transactions that share chain, from, and nonce', () => {

--- a/app/selectors/activity.test.ts
+++ b/app/selectors/activity.test.ts
@@ -54,7 +54,9 @@ function buildState({
             accounts: {
               'account-1': {
                 id: 'account-1',
-                ...(!omitAccountEvmAddress ? { address: accountEvmAddress } : {}),
+                ...(!omitAccountEvmAddress
+                  ? { address: accountEvmAddress }
+                  : {}),
                 type: 'eip155:eoa',
               },
             },

--- a/app/selectors/activity.test.ts
+++ b/app/selectors/activity.test.ts
@@ -50,15 +50,6 @@ describe('activity selectors', () => {
             TransactionController: {
               transactions: [
                 {
-                  id: 'parent',
-                  chainId: '0x1',
-                  time: 1,
-                  txParams: {
-                    from: activeEvmAddress,
-                    nonce: '0x1',
-                  },
-                },
-                {
                   id: 'child',
                   chainId: '0x1',
                   time: 2,
@@ -66,7 +57,16 @@ describe('activity selectors', () => {
                     from: activeEvmAddress,
                     nonce: '0x2',
                   },
-                  requiredTransactionIds: ['parent'],
+                },
+                {
+                  id: 'parent',
+                  chainId: '0x1',
+                  time: 1,
+                  txParams: {
+                    from: activeEvmAddress,
+                    nonce: '0x1',
+                  },
+                  requiredTransactionIds: ['child'],
                 },
               ],
             },

--- a/app/selectors/activity.ts
+++ b/app/selectors/activity.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta, TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
 import { areAddressesEqual } from '../util/address';
 import { createDeepEqualSelector } from './util';

--- a/app/selectors/activity.ts
+++ b/app/selectors/activity.ts
@@ -1,0 +1,86 @@
+import { TransactionMeta, TransactionType } from '@metamask/transaction-controller';
+import { SmartTransaction } from '@metamask/smart-transactions-controller';
+import { areAddressesEqual } from '../util/address';
+import { createDeepEqualSelector } from './util';
+import { selectEvmAddress } from './accountsController';
+import { selectPendingSmartTransactionsForSelectedAccountGroup } from './smartTransactionsController';
+import {
+  selectNonReplacedTransactions,
+  selectRequiredTransactionIds,
+} from './transactionController';
+
+type LocalTransaction = TransactionMeta | SmartTransaction;
+
+function dedupeTransactions(transactions: LocalTransaction[]) {
+  const seenTransactions = new Set<string>();
+
+  return transactions.filter((transaction) => {
+    const { chainId, txParams } = transaction;
+    const { from, nonce, actionId } = txParams || {};
+    const hash = 'hash' in transaction ? transaction.hash : undefined;
+    const isBridgeTransaction = transaction.type === TransactionType.bridge;
+    const hasNonce = nonce !== undefined && nonce !== null;
+
+    if (!from) {
+      return false;
+    }
+
+    const dedupeKeyPrefix = `${chainId}-${String(from).toLowerCase()}`;
+    const dedupeKey =
+      isBridgeTransaction && hash
+        ? `${dedupeKeyPrefix}-bridge-${hash.toLowerCase()}`
+        : hasNonce
+          ? `${dedupeKeyPrefix}-${nonce}`
+          : `${dedupeKeyPrefix}-${actionId}`;
+
+    if (seenTransactions.has(dedupeKey)) {
+      return false;
+    }
+
+    seenTransactions.add(dedupeKey);
+    return true;
+  });
+}
+
+export const selectLocalTransactions = createDeepEqualSelector(
+  [
+    selectNonReplacedTransactions,
+    selectPendingSmartTransactionsForSelectedAccountGroup,
+    selectEvmAddress,
+    selectRequiredTransactionIds,
+  ],
+  (
+    nonReplacedTransactions,
+    pendingSmartTransactions,
+    activeEvmAddress,
+    requiredTransactionIds,
+  ) => {
+    const transactions = nonReplacedTransactions.filter((transaction) => {
+      if (requiredTransactionIds.has(transaction.id)) {
+        return false;
+      }
+
+      const fromAddress = transaction.txParams?.from;
+      if (!fromAddress || !activeEvmAddress) {
+        return false;
+      }
+
+      return areAddressesEqual(fromAddress, activeEvmAddress);
+    });
+
+    const pendingSmartTransactionsForActiveAddress =
+      pendingSmartTransactions.filter((transaction) => {
+        const fromAddress = transaction.txParams?.from;
+        if (!fromAddress || !activeEvmAddress) {
+          return false;
+        }
+
+        return areAddressesEqual(fromAddress, activeEvmAddress);
+      });
+
+    return dedupeTransactions([
+      ...transactions,
+      ...pendingSmartTransactionsForActiveAddress,
+    ]).sort((a, b) => (b?.time ?? 0) - (a?.time ?? 0));
+  },
+);

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -4,8 +4,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import {
   selectTransactions,
   selectLastWithdrawTokenByType,
-  selectLocalTransactions,
-  selectNonReplacedTransactions,
+    selectNonReplacedTransactions,
   selectRequiredTransactionIds,
   selectRequiredTransactionHashes,
   selectRequiredTransactions,
@@ -178,60 +177,6 @@ describe('TransactionController Selectors', () => {
       } as unknown as RootState;
 
       expect(selectRequiredTransactions(state)).toStrictEqual([child]);
-    });
-  });
-
-  describe('selectLocalTransactions', () => {
-    it('filters required child transactions before nonce dedupe', () => {
-      const activeEvmAddress = '0x0000000000000000000000000000000000000001';
-      const state = {
-        engine: {
-          backgroundState: {
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: 'account-1',
-                accounts: {
-                  'account-1': {
-                    id: 'account-1',
-                    address: activeEvmAddress,
-                    type: 'eip155:eoa',
-                  },
-                },
-              },
-            },
-            TransactionController: {
-              transactions: [
-                {
-                  id: 'child',
-                  hash: '0xCHILD',
-                  chainId: '0x1',
-                  time: 200,
-                  txParams: {
-                    from: activeEvmAddress,
-                    nonce: '0x1',
-                  },
-                },
-                {
-                  id: 'parent',
-                  chainId: '0x1',
-                  requiredTransactionIds: ['child'],
-                  time: 100,
-                  type: TransactionType.predictDeposit,
-                  txParams: {
-                    from: activeEvmAddress,
-                    nonce: '0x1',
-                  },
-                },
-              ],
-            },
-          },
-        },
-        pendingSmartTransactionsForGroup: [],
-      } as unknown as RootState;
-
-      expect(selectLocalTransactions(state)).toStrictEqual([
-        expect.objectContaining({ id: 'parent' }),
-      ]);
     });
   });
 

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -4,7 +4,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import {
   selectTransactions,
   selectLastWithdrawTokenByType,
-    selectNonReplacedTransactions,
+  selectNonReplacedTransactions,
   selectRequiredTransactionIds,
   selectRequiredTransactionHashes,
   selectRequiredTransactions,

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -5,54 +5,18 @@ import {
   selectPendingSmartTransactionsBySender,
   selectPendingSmartTransactionsForSelectedAccountGroup,
 } from './smartTransactionsController';
-import { selectEvmAddress } from './accountsController';
 import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { SmartTransaction } from '@metamask/smart-transactions-controller';
-import { areAddressesEqual } from '../util/address';
 
 interface MetaMaskPayToken {
   address: Hex;
   chainId: Hex;
 }
 
-type LocalTransaction = TransactionMeta | SmartTransaction;
-
-// Extracted from UnifiedTransactionsView
-function dedupeTransactions(transactions: LocalTransaction[]) {
-  const seenTransactions = new Set<string>();
-
-  return transactions.filter((transaction) => {
-    const { chainId, txParams } = transaction;
-    const { from, nonce, actionId } = txParams || {};
-    const hash = 'hash' in transaction ? transaction.hash : undefined;
-    const isBridgeTransaction = transaction.type === TransactionType.bridge;
-    const hasNonce = nonce !== undefined && nonce !== null;
-
-    if (!from) {
-      return false;
-    }
-
-    const dedupeKeyPrefix = `${chainId}-${String(from).toLowerCase()}`;
-    const dedupeKey =
-      isBridgeTransaction && hash
-        ? `${dedupeKeyPrefix}-bridge-${hash.toLowerCase()}`
-        : hasNonce
-          ? `${dedupeKeyPrefix}-${nonce}`
-          : `${dedupeKeyPrefix}-${actionId}`;
-
-    // Keep only the first local transaction for each dedupe key
-    if (seenTransactions.has(dedupeKey)) {
-      return false;
-    }
-
-    seenTransactions.add(dedupeKey);
-    return true;
-  });
-}
 
 function getNestedTransactionTypes(
   transaction: TransactionMeta,
@@ -184,49 +148,6 @@ export const selectSortedEVMTransactionsForSelectedAccountGroup =
         (a, b) => (b?.time ?? 0) - (a?.time ?? 0),
       ),
   );
-
-export const selectLocalTransactions = createDeepEqualSelector(
-  [
-    selectNonReplacedTransactions,
-    selectPendingSmartTransactionsForSelectedAccountGroup,
-    selectEvmAddress,
-    selectRequiredTransactionIds,
-  ],
-  (
-    nonReplacedTransactions,
-    pendingSmartTransactions,
-    activeEvmAddress,
-    requiredTransactionIds,
-  ) => {
-    const transactions = nonReplacedTransactions.filter((transaction) => {
-      if (requiredTransactionIds.has(transaction.id)) {
-        return false;
-      }
-
-      const fromAddress = transaction.txParams?.from;
-      if (!fromAddress || !activeEvmAddress) {
-        return false;
-      }
-
-      return areAddressesEqual(fromAddress, activeEvmAddress);
-    });
-
-    const pendingSmartTransactionsForActiveAddress =
-      pendingSmartTransactions.filter((transaction) => {
-        const fromAddress = transaction.txParams?.from;
-        if (!fromAddress || !activeEvmAddress) {
-          return false;
-        }
-
-        return areAddressesEqual(fromAddress, activeEvmAddress);
-      });
-
-    return dedupeTransactions([
-      ...transactions,
-      ...pendingSmartTransactionsForActiveAddress,
-    ]).sort((a, b) => (b?.time ?? 0) - (a?.time ?? 0));
-  },
-);
 
 export const selectSwapsTransactions = createSelector(
   selectTransactionControllerState,

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -17,7 +17,6 @@ interface MetaMaskPayToken {
   chainId: Hex;
 }
 
-
 function getNestedTransactionTypes(
   transaction: TransactionMeta,
 ): TransactionType[] {


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

- Create new app/selectors/activity.ts for activity-specific selectors
- Move selectLocalTransactions and dedupeTransactions from transactionController.ts to activity.ts
- Update imports in UnifiedTransactionsView

This change decouples controller-level selectors from activity and smart transaction specific logic, matching the pattern used in the extension and improving code organization.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mostly moves selector logic and updates imports/tests; behavioral changes are limited to the new selector’s dedupe/sort/filter rules already covered by added unit tests.
> 
> **Overview**
> Creates a new `app/selectors/activity.ts` module and moves the activity-specific `selectLocalTransactions` (and its transaction dedupe helper) out of `transactionController`.
> 
> Updates `UnifiedTransactionsView` to import `selectLocalTransactions` from the new activity selector module, and shifts/expands unit test coverage by removing the old `transactionController` test and adding a dedicated `activity.test.ts` suite covering filtering, deduping (including bridge/hash behavior), smart-tx merging, and sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466c9796a8b6fae0d183b435621500beffb871c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->