### PR TITLE
ci: align fingerprint checkout with E2E merge ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -115,9 +115,7 @@ jobs:
         uses: ./.github/actions/post-build-source-hash
         with:
           github-token: ${{ github.token }}
-          # .head.sha = PR head (pull_request events); github.sha fallback = pushed/scheduled commit
-          # (push to main, merge_group, schedule) where no PR payload exists.
-          target-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          target-sha: ${{ github.sha }}
 
   dedupe:
     name: Dedupe


### PR DESCRIPTION
## Summary

The `post-build-source-hash` job in `ci.yml` was checking out and computing the fingerprint from the **PR head SHA** (`github.event.pull_request.head.sha`), while the E2E build workflows (`build-ios-e2e.yml`, `build-android-e2e.yml`) use the default `pull_request` checkout ref, which resolves to the **merge commit SHA** (`github.sha` = `refs/pull/<N>/merge`, i.e. branch + main).

This mismatch meant:
- Fingerprint/status was tied to a different source tree than the actual built artifacts
- Reuse lookups could match a fingerprint that doesn't represent what was built/tested
- E2E signal was ambiguous — unclear which commit state was actually validated

## Changes

- `ci.yml` `post-build-source-hash` job: checkout `ref` changed from `github.event.pull_request.head.sha || github.sha` → `github.sha`
- `target-sha` input to the `post-build-source-hash` action changed from `github.event.pull_request.head.sha || github.sha` → `github.sha`

This ensures fingerprint identity always matches the same source tree that E2E jobs build and test (branch + main on `pull_request` events).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing guidelines**](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented on my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Made with [Cursor](https://cursor.com)