### PR TITLE
fix: replace repository-dispatch with direct API call

### DIFF
--- a/.github/workflows/triage-forwarder.yml
+++ b/.github/workflows/triage-forwarder.yml
@@ -35,17 +35,17 @@ jobs:
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch to triage-agent
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.exchange.outputs.token }}
-          repository: MetaMask/triage-agent
-          event-type: triage-issue
-          client-payload: |-
-            {
-              "repo_owner": "${{ github.repository_owner }}",
-              "repo_name": "${{ github.event.repository.name }}",
-              "issue_number": "${{ github.event.issue.number }}",
-              "event_action": "${{ github.event.action }}",
-              "event_label_name": "${{ github.event.label.name }}",
-              "trigger_mode": "label"
-            }
+        env:
+          TOKEN: ${{ steps.exchange.outputs.token }}
+        run: |
+          curl -sSf -X POST \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/MetaMask/triage-agent/dispatches" \
+            -d "$(jq -cn \
+              --arg owner "${{ github.repository_owner }}" \
+              --arg name "${{ github.event.repository.name }}" \
+              --arg number "${{ github.event.issue.number }}" \
+              --arg action "${{ github.event.action }}" \
+              --arg label "${{ github.event.label.name }}" \
+              '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: $action, event_label_name: $label, trigger_mode: "label"}}')"


### PR DESCRIPTION
## **Description**

The `peter-evans/repository-dispatch@v3` action is not on the MetaMask org's GitHub Actions allowlist, causing the triage forwarder workflow to fail.

### Fix
Replace the third-party action with a direct `curl` call to the GitHub REST API (`POST /repos/{owner}/{repo}/dispatches`). This is consistent with how `metamask-extension` does cross-repo dispatch in `main.yml`.

### Changes
- Remove `peter-evans/repository-dispatch@v3` usage
- Replace with `curl` to `https://api.github.com/repos/MetaMask/triage-agent/dispatches`
- Payload is constructed via `jq` to match the existing `triage-issue` event contract

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `triage-forwarder` GitHub Actions workflow dispatch mechanism; a malformed request or auth header could break cross-repo triage dispatching, but scope is limited to automation.
> 
> **Overview**
> Replaces the `peter-evans/repository-dispatch@v3` step in `.github/workflows/triage-forwarder.yml` with a direct `curl` call to `POST /repos/MetaMask/triage-agent/dispatches` using the exchanged installation token.
> 
> The dispatch payload is now constructed via `jq` and sent as `event_type: "triage-issue"` with the same `client_payload` fields as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c8909e4e21fd03eb0ff276c2fba740b53531f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->