### PR TITLE
fix(ci): only pass TestFlight groups when distributing externally

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -98,19 +98,18 @@ platform :ios do
     # uploads the IPA binary. This avoids TestFlight management API calls that
     # require an App Manager (or higher) role API key — a Developer role key
     # can upload builds but cannot manage distribution.
+    # Groups are only passed when distributing externally — passing groups with
+    # skip_submission triggers unnecessary TestFlight group management API calls.
     testflight_options = {
       api_key: api_key,
       ipa: ipa_path,
       reject_build_waiting_for_review: true,
       distribute_external: distribute_external,
-      groups: groups,
       notify_external_testers: notify_external_testers,
       changelog: changelog_message
     }
 
     if distribute_external
-      testflight_options[:distribute_external] = true
-      testflight_options[:notify_external_testers] = true
       testflight_options[:groups] = groups
     else
       testflight_options[:skip_submission] = true

--- a/scripts/upload-to-testflight.sh
+++ b/scripts/upload-to-testflight.sh
@@ -49,7 +49,11 @@ fi
 
 echo "🚀 Uploading to TestFlight..."
 echo "IPA: $IPA_PATH"
-echo "Group: $TESTFLIGHT_GROUP"
+if [ "$DISTRIBUTE_EXTERNAL" = "true" ]; then
+  echo "Group: $TESTFLIGHT_GROUP"
+else
+  echo "Group: (not set — distribute_external is false)"
+fi
 
 # Extract environment from pipeline name for changelog
 # GitHub Actions passes "github_actions_<build_name>" (e.g. github_actions_main-exp); use segment after first "-" (e.g. exp).
@@ -73,9 +77,15 @@ echo "Changelog: $CHANGELOG"
 # Change to ios directory where fastlane folder is located
 cd ios
 
-bundle exec fastlane upload_to_testflight_only \
-  ipa_path:"$IPA_PATH" \
-  groups:"$TESTFLIGHT_GROUP" \
-  changelog:"$CHANGELOG" \
+FASTLANE_ARGS=(
+  ipa_path:"$IPA_PATH"
+  changelog:"$CHANGELOG"
   distribute_external:"$DISTRIBUTE_EXTERNAL"
+)
+
+if [ "$DISTRIBUTE_EXTERNAL" = "true" ]; then
+  FASTLANE_ARGS+=(groups:"$TESTFLIGHT_GROUP")
+fi
+
+bundle exec fastlane upload_to_testflight_only "${FASTLANE_ARGS[@]}"
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `groups` was unconditionally included in `testflight_options` in the Fastfile, meaning every internal-only upload (Runway RC/prod builds, auto-RC builds) was making a TestFlight group management API call even with `skip_submission: true`. This requires an **App Manager** role API key — a Developer-role key will fail on that call.
- Removed `groups` from the base `testflight_options` hash in `Fastfile`; it is now only added inside the `if distribute_external` branch.
- Removed the redundant double-assignment of `distribute_external` and `notify_external_testers` in the `if distribute_external` branch (they were already set in the base hash).
- Updated `upload-to-testflight.sh` to not pass `groups:` as an argument to Fastlane when `distribute_external=false`, as a defensive/consistent layer matching the Fastfile fix.

## Changes

- `ios/fastlane/Fastfile`: `groups` only added to `testflight_options` when `distribute_external` is `true`
- `scripts/upload-to-testflight.sh`: `groups:` argument only passed to Fastlane when `distribute_external=true`

## Affected workflows

Callers that set `distribute_external: false` (and were previously triggering the spurious group API call):
- `runway-rc-builds.yml`
- `runway-production-builds.yml`
- `auto-rc-ota-build-core.yml`

Callers that set `distribute_external: true` (nightly builds) are unaffected — groups continue to be passed as before.

## Manual testing steps

```gherkin
Scenario: Internal upload does not attempt group assignment
  Given distribute_external is false
  When upload-to-testflight.sh is invoked
  Then groups: argument is NOT passed to Fastlane
  And skip_submission: true is set in testflight_options
  And no TestFlight group management API call is made

Scenario: External upload still assigns the group
  Given distribute_external is true
  When upload-to-testflight.sh is invoked
  Then groups: argument IS passed to Fastlane
  And testflight_options includes groups: [group_name]
```

Made with [Cursor](https://cursor.com)