### PR TITLE
fix(predict): stabilize Predict pay-with-any-token quote updates cp-7.77.0

### DIFF
--- a/app/components/UI/Predict/constants/transactions.ts
+++ b/app/components/UI/Predict/constants/transactions.ts
@@ -7,6 +7,15 @@ export const PREDICT_BALANCE_CHAIN_ID = '0x89' as Hex;
 
 export const MINIMUM_BET = 1; // $1 minimum bet
 
+// Keeps the CTA locked long enough for the payment selector to close and the
+// new quote-loading state to arrive, while avoiding a laggy return to the buy
+// sheet after normal blur/focus navigation.
+export const PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS = 1000;
+
+// Fallback recovery if the payment-selector route does not emit the expected
+// blur/focus events, such as transparent modal or interrupted navigation cases.
+export const PAYMENT_SELECTOR_NAVIGATION_SAFETY_UNLOCK_MS = 5000;
+
 export const PREDICT_BALANCE_TOKEN_KEY = 'predict-balance';
 
 export const PREDICTION_ERROR_TRANSACTION_BATCH_ID = 'NA';

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -24,6 +24,13 @@ let mockFakOrdersEnabled = false;
 let mockIsPreviewCalculating = false;
 let mockIsPlacingOrder = false;
 let mockErrorMessage: string | undefined;
+let mockErrorMessageSource:
+  | 'preview'
+  | 'below_minimum'
+  | 'insufficient_balance'
+  | 'blocking_pay_alert'
+  | 'order_error'
+  | undefined;
 let mockBuyErrorBanner: {
   variant: 'price_changed' | 'order_failed';
   title: string;
@@ -178,6 +185,7 @@ jest.mock('./hooks/usePredictBuyConditions', () => ({
 jest.mock('./hooks/usePredictBuyError', () => ({
   usePredictBuyError: () => ({
     errorMessage: mockErrorMessage,
+    errorMessageSource: mockErrorMessageSource,
     buyErrorBanner: mockBuyErrorBanner,
     isOrderNotFilled: false,
     resetOrderNotFilled: mockResetOrderNotFilled,
@@ -422,6 +430,7 @@ describe('PredictBuyWithAnyToken', () => {
     mockIsPreviewCalculating = false;
     mockIsPlacingOrder = false;
     mockErrorMessage = undefined;
+    mockErrorMessageSource = undefined;
     mockBuyErrorBanner = null;
     mockIsCurrentTokenInsufficient = false;
     mockHasAlternativeBalance = false;
@@ -813,10 +822,11 @@ describe('PredictBuyWithAnyToken', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('suppresses error text in Change Payment Method mode', () => {
+    it('suppresses insufficient balance helper text in Change Payment Method mode', () => {
       mockIsCurrentTokenInsufficient = true;
       mockHasAlternativeBalance = true;
       mockErrorMessage = 'Not enough funds';
+      mockErrorMessageSource = 'insufficient_balance';
 
       renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
 
@@ -825,16 +835,49 @@ describe('PredictBuyWithAnyToken', () => {
       );
     });
 
-    it('suppresses error text in Add Funds mode', () => {
+    it('suppresses insufficient balance helper text in Add Funds mode', () => {
       mockIsCurrentTokenInsufficient = true;
       mockHasAlternativeBalance = false;
       mockErrorMessage = 'Not enough funds';
+      mockErrorMessageSource = 'insufficient_balance';
 
       renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
 
       expect(screen.getByTestId('predict-buy-error')).toHaveTextContent(
         'no-error',
       );
+    });
+
+    it('keeps transaction pay alert text visible in Change Payment Method mode', () => {
+      mockIsCurrentTokenInsufficient = true;
+      mockHasAlternativeBalance = true;
+      mockErrorMessage = 'Add less or use a different token';
+      mockErrorMessageSource = 'blocking_pay_alert';
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(screen.getByTestId('predict-buy-error')).toHaveTextContent(
+        'Add less or use a different token',
+      );
+    });
+
+    it('keeps transaction pay alert text visible even when a sheet banner exists', () => {
+      mockErrorMessage = 'Add less or use a different token';
+      mockErrorMessageSource = 'blocking_pay_alert';
+      mockBuyErrorBanner = {
+        variant: 'order_failed',
+        title: 'Order failed',
+        description: 'Please retry',
+      };
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(screen.getByTestId('predict-buy-error')).toHaveTextContent(
+        'Add less or use a different token',
+      );
+      expect(
+        screen.getByTestId('predict-buy-preview-order-failed-banner'),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, screen } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictBuyWithAnyToken from './PredictBuyWithAnyToken';
@@ -37,21 +37,6 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 const mockNavigate = jest.fn();
-const mockNavigationListeners: Record<string, Set<() => void>> = {};
-const mockAddListener = jest.fn((eventName: string, callback: () => void) => {
-  if (!mockNavigationListeners[eventName]) {
-    mockNavigationListeners[eventName] = new Set();
-  }
-
-  mockNavigationListeners[eventName].add(callback);
-
-  return () => {
-    mockNavigationListeners[eventName]?.delete(callback);
-  };
-});
-const mockEmitNavigationEvent = (eventName: string) => {
-  mockNavigationListeners[eventName]?.forEach((callback) => callback());
-};
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -63,10 +48,7 @@ jest.mock('@react-navigation/native', () => ({
       entryPoint: 'market_details',
     },
   }),
-  useNavigation: () => ({
-    addListener: mockAddListener,
-    navigate: mockNavigate,
-  }),
+  useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
 jest.mock('react-redux', () => ({
@@ -174,6 +156,8 @@ jest.mock('./hooks/usePredictBuyInfo', () => ({
 
 let mockIsCurrentTokenInsufficient = false;
 let mockHasAlternativeBalance = false;
+let mockIsPaymentSelectorNavigationLocked = false;
+const mockLockPaymentSelectorNavigation = jest.fn();
 
 jest.mock('./hooks/usePredictBuyConditions', () => ({
   usePredictBuyConditions: () => ({
@@ -185,6 +169,9 @@ jest.mock('./hooks/usePredictBuyConditions', () => ({
     isInsufficientBalance: false,
     isCurrentTokenInsufficient: mockIsCurrentTokenInsufficient,
     hasAlternativeBalance: mockHasAlternativeBalance,
+    maxBetAmount: 50,
+    isPaymentSelectorNavigationLocked: mockIsPaymentSelectorNavigationLocked,
+    lockPaymentSelectorNavigation: mockLockPaymentSelectorNavigation,
   }),
 }));
 
@@ -430,9 +417,6 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 describe('PredictBuyWithAnyToken', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    Object.keys(mockNavigationListeners).forEach((eventName) => {
-      delete mockNavigationListeners[eventName];
-    });
     mockPayWithAnyTokenEnabled = true;
     mockFakOrdersEnabled = false;
     mockIsPreviewCalculating = false;
@@ -441,6 +425,7 @@ describe('PredictBuyWithAnyToken', () => {
     mockBuyErrorBanner = null;
     mockIsCurrentTokenInsufficient = false;
     mockHasAlternativeBalance = false;
+    mockIsPaymentSelectorNavigationLocked = false;
     mockUseSelector.mockImplementation((selector) => {
       if (typeof selector === 'function') {
         return selector({
@@ -454,10 +439,6 @@ describe('PredictBuyWithAnyToken', () => {
 
       return undefined;
     });
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   it('renders the screen, resets user input change after preview calculation, and opens the fee breakdown sheet', () => {
@@ -516,45 +497,23 @@ describe('PredictBuyWithAnyToken', () => {
   });
 
   it('locks the buy button when the payment selector opens and unlocks one second after focus returns', () => {
-    jest.useFakeTimers();
-
     renderWithProvider(<PredictBuyWithAnyToken />);
 
-    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
-      /button-disabled-false/,
-    );
-
     fireEvent.press(screen.getByTestId('predict-pay-with-row'));
+
+    expect(mockLockPaymentSelectorNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the payment selector lock condition to disable the buy button and pay row', () => {
+    mockIsPaymentSelectorNavigationLocked = true;
+
+    renderWithProvider(<PredictBuyWithAnyToken />);
 
     expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
       /button-disabled-true/,
     );
     expect(screen.getByTestId('predict-pay-with-row')).toHaveTextContent(
       /disabled-true/,
-    );
-
-    act(() => {
-      mockEmitNavigationEvent('blur');
-      mockEmitNavigationEvent('focus');
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(999);
-    });
-
-    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
-      /button-disabled-true/,
-    );
-
-    act(() => {
-      jest.advanceTimersByTime(1);
-    });
-
-    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
-      /button-disabled-false/,
-    );
-    expect(screen.getByTestId('predict-pay-with-row')).toHaveTextContent(
-      /disabled-false/,
     );
   });
 
@@ -744,6 +703,7 @@ describe('PredictBuyWithAnyToken', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.CONFIRMATION_PAY_WITH_MODAL,
       );
+      expect(mockLockPaymentSelectorNavigation).toHaveBeenCalledTimes(1);
       expect(mockHandleConfirm).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictBuyWithAnyToken from './PredictBuyWithAnyToken';
@@ -37,6 +37,21 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 }));
 
 const mockNavigate = jest.fn();
+const mockNavigationListeners: Record<string, Set<() => void>> = {};
+const mockAddListener = jest.fn((eventName: string, callback: () => void) => {
+  if (!mockNavigationListeners[eventName]) {
+    mockNavigationListeners[eventName] = new Set();
+  }
+
+  mockNavigationListeners[eventName].add(callback);
+
+  return () => {
+    mockNavigationListeners[eventName]?.delete(callback);
+  };
+});
+const mockEmitNavigationEvent = (eventName: string) => {
+  mockNavigationListeners[eventName]?.forEach((callback) => callback());
+};
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -48,7 +63,10 @@ jest.mock('@react-navigation/native', () => ({
       entryPoint: 'market_details',
     },
   }),
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({
+    addListener: mockAddListener,
+    navigate: mockNavigate,
+  }),
 }));
 
 jest.mock('react-redux', () => ({
@@ -317,16 +335,24 @@ jest.mock('./components/PredictPayWithAnyTokenInfo', () => {
 });
 
 jest.mock('./components/PredictPayWithRow', () => {
-  const { Text } = jest.requireActual('react-native');
+  const { Pressable, Text } = jest.requireActual('react-native');
   return {
     PredictPayWithRow: ({
       disabled,
       variant,
+      onPaymentSelectorOpen,
     }: {
       disabled?: boolean;
       variant?: string;
+      onPaymentSelectorOpen?: () => void;
     }) => (
-      <Text testID="predict-pay-with-row">{`disabled-${String(disabled)} variant-${variant ?? 'default'}`}</Text>
+      <Pressable
+        testID="predict-pay-with-row"
+        disabled={disabled}
+        onPress={onPaymentSelectorOpen}
+      >
+        <Text>{`disabled-${String(disabled)} variant-${variant ?? 'default'}`}</Text>
+      </Pressable>
     ),
   };
 });
@@ -404,6 +430,9 @@ const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 describe('PredictBuyWithAnyToken', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.keys(mockNavigationListeners).forEach((eventName) => {
+      delete mockNavigationListeners[eventName];
+    });
     mockPayWithAnyTokenEnabled = true;
     mockFakOrdersEnabled = false;
     mockIsPreviewCalculating = false;
@@ -425,6 +454,10 @@ describe('PredictBuyWithAnyToken', () => {
 
       return undefined;
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('renders the screen, resets user input change after preview calculation, and opens the fee breakdown sheet', () => {
@@ -479,6 +512,49 @@ describe('PredictBuyWithAnyToken', () => {
     );
     expect(screen.getByTestId('predict-pay-with-row')).toHaveTextContent(
       /disabled-true/,
+    );
+  });
+
+  it('locks the buy button when the payment selector opens and unlocks one second after focus returns', () => {
+    jest.useFakeTimers();
+
+    renderWithProvider(<PredictBuyWithAnyToken />);
+
+    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
+      /button-disabled-false/,
+    );
+
+    fireEvent.press(screen.getByTestId('predict-pay-with-row'));
+
+    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
+      /button-disabled-true/,
+    );
+    expect(screen.getByTestId('predict-pay-with-row')).toHaveTextContent(
+      /disabled-true/,
+    );
+
+    act(() => {
+      mockEmitNavigationEvent('blur');
+      mockEmitNavigationEvent('focus');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+
+    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
+      /button-disabled-true/,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
+      /button-disabled-false/,
+    );
+    expect(screen.getByTestId('predict-pay-with-row')).toHaveTextContent(
+      /disabled-false/,
     );
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -68,6 +68,8 @@ import {
   predictBuyPreviewSessionRef,
 } from '../PredictBuyPreview/PredictBuyPreview';
 
+const PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS = 1000;
+
 const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const tw = useTailwind();
   const keypadRef = useRef<PredictKeypadHandles>(null);
@@ -91,6 +93,15 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const { deposit } = usePredictDeposit();
 
   const [isFeeBreakdownVisible, setIsFeeBreakdownVisible] = useState(false);
+  const [
+    isPaymentSelectorNavigationLocked,
+    setIsPaymentSelectorNavigationLocked,
+  ] = useState(false);
+  const isPaymentSelectorNavigationLockedRef = useRef(false);
+  const didBlurAfterPaymentSelectorOpenRef = useRef(false);
+  const paymentSelectorUnlockTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   const payWithAnyTokenEnabled = useSelector(
     selectPredictWithAnyTokenEnabledFlag,
@@ -143,6 +154,63 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const handleFeeBreakdownClose = useCallback(() => {
     setIsFeeBreakdownVisible(false);
   }, []);
+
+  const clearPaymentSelectorUnlockTimer = useCallback(() => {
+    if (paymentSelectorUnlockTimerRef.current) {
+      clearTimeout(paymentSelectorUnlockTimerRef.current);
+      paymentSelectorUnlockTimerRef.current = null;
+    }
+  }, []);
+
+  const updatePaymentSelectorNavigationLock = useCallback(
+    (isLocked: boolean) => {
+      isPaymentSelectorNavigationLockedRef.current = isLocked;
+      setIsPaymentSelectorNavigationLocked(isLocked);
+    },
+    [],
+  );
+
+  const lockPaymentSelectorNavigation = useCallback(() => {
+    clearPaymentSelectorUnlockTimer();
+    didBlurAfterPaymentSelectorOpenRef.current = false;
+    updatePaymentSelectorNavigationLock(true);
+  }, [clearPaymentSelectorUnlockTimer, updatePaymentSelectorNavigationLock]);
+
+  useEffect(() => {
+    const scheduleUnlock = () => {
+      clearPaymentSelectorUnlockTimer();
+      paymentSelectorUnlockTimerRef.current = setTimeout(() => {
+        didBlurAfterPaymentSelectorOpenRef.current = false;
+        updatePaymentSelectorNavigationLock(false);
+        paymentSelectorUnlockTimerRef.current = null;
+      }, PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS);
+    };
+
+    const unsubscribeBlur = navigation.addListener('blur', () => {
+      if (isPaymentSelectorNavigationLockedRef.current) {
+        didBlurAfterPaymentSelectorOpenRef.current = true;
+      }
+    });
+
+    const unsubscribeFocus = navigation.addListener('focus', () => {
+      if (
+        isPaymentSelectorNavigationLockedRef.current &&
+        didBlurAfterPaymentSelectorOpenRef.current
+      ) {
+        scheduleUnlock();
+      }
+    });
+
+    return () => {
+      unsubscribeBlur();
+      unsubscribeFocus();
+      clearPaymentSelectorUnlockTimer();
+    };
+  }, [
+    clearPaymentSelectorUnlockTimer,
+    navigation,
+    updatePaymentSelectorNavigationLock,
+  ]);
 
   const {
     preview,
@@ -224,8 +292,9 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   );
 
   const handleChangePaymentMethod = useCallback(() => {
+    lockPaymentSelectorNavigation();
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
-  }, [navigation]);
+  }, [lockPaymentSelectorNavigation, navigation]);
 
   const handleAddFunds = useCallback(() => {
     if (isSheetMode) {
@@ -294,6 +363,10 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   }, [isSheetMode, isBannerActive, isInputFocused, setIsInputFocused]);
 
   const handleBuyButtonPress = useCallback(() => {
+    if (isPaymentSelectorNavigationLocked) {
+      return;
+    }
+
     if (isBannerActive) {
       handleRetryWithBestPrice();
       return;
@@ -309,6 +382,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     handleConfirm();
   }, [
     isBannerActive,
+    isPaymentSelectorNavigationLocked,
     isChangePaymentMode,
     isAddFundsMode,
     handleRetryWithBestPrice,
@@ -332,6 +406,22 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const wrapperProps = isSheetMode
     ? { twClassName: 'bg-background-default' }
     : { style: tw.style('flex-1 bg-background-default') };
+
+  const isBuyActionButtonDisabled = isPaymentSelectorNavigationLocked
+    ? true
+    : !isBannerActive && (isChangePaymentMode || isAddFundsMode)
+      ? false
+      : isBannerActive
+        ? isRetrying || !preview
+        : !canPlaceBet;
+
+  const showBuyActionButtonReducedOpacity = isPaymentSelectorNavigationLocked
+    ? true
+    : !isBannerActive && (isChangePaymentMode || isAddFundsMode)
+      ? false
+      : isBannerActive
+        ? !preview
+        : !canPlaceBet;
 
   return (
     <Wrapper {...wrapperProps}>
@@ -393,7 +483,10 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
               hideAvailableBalance={false}
             />
             {payWithAnyTokenEnabled && (
-              <PredictPayWithRow disabled={isPlacingOrder} />
+              <PredictPayWithRow
+                disabled={isPlacingOrder || isPaymentSelectorNavigationLocked}
+                onPaymentSelectorOpen={lockPaymentSelectorNavigation}
+              />
             )}
           </Box>
         </ScrollView>
@@ -428,9 +521,10 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
         )}
         {payWithAnyTokenEnabled && isSheetMode && (
           <PredictPayWithRow
-            disabled={isPlacingOrder}
+            disabled={isPlacingOrder || isPaymentSelectorNavigationLocked}
             variant="row"
             availableBalance={availableBalanceDisplay}
+            onPaymentSelectorOpen={lockPaymentSelectorNavigation}
           />
         )}
         <PredictFeeSummary
@@ -456,20 +550,8 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
         <PredictBuyActionButton
           isLoading={isPlacingOrder || (isBannerActive && isRetrying)}
           onPress={handleBuyButtonPress}
-          disabled={
-            !isBannerActive && (isChangePaymentMode || isAddFundsMode)
-              ? false
-              : isBannerActive
-                ? isRetrying || !preview
-                : !canPlaceBet
-          }
-          showReducedOpacity={
-            !isBannerActive && (isChangePaymentMode || isAddFundsMode)
-              ? false
-              : isBannerActive
-                ? !preview
-                : !canPlaceBet
-          }
+          disabled={isBuyActionButtonDisabled}
+          showReducedOpacity={showBuyActionButtonReducedOpacity}
           outcomeTokenTitle={outcomeToken?.title}
           sharePrice={preview?.sharePrice ?? outcomeToken?.price ?? 0}
           isSheetMode={isSheetMode}

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -68,8 +68,6 @@ import {
   predictBuyPreviewSessionRef,
 } from '../PredictBuyPreview/PredictBuyPreview';
 
-const PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS = 1000;
-
 const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const tw = useTailwind();
   const keypadRef = useRef<PredictKeypadHandles>(null);
@@ -93,15 +91,6 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const { deposit } = usePredictDeposit();
 
   const [isFeeBreakdownVisible, setIsFeeBreakdownVisible] = useState(false);
-  const [
-    isPaymentSelectorNavigationLocked,
-    setIsPaymentSelectorNavigationLocked,
-  ] = useState(false);
-  const isPaymentSelectorNavigationLockedRef = useRef(false);
-  const didBlurAfterPaymentSelectorOpenRef = useRef(false);
-  const paymentSelectorUnlockTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
 
   const payWithAnyTokenEnabled = useSelector(
     selectPredictWithAnyTokenEnabledFlag,
@@ -155,63 +144,6 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     setIsFeeBreakdownVisible(false);
   }, []);
 
-  const clearPaymentSelectorUnlockTimer = useCallback(() => {
-    if (paymentSelectorUnlockTimerRef.current) {
-      clearTimeout(paymentSelectorUnlockTimerRef.current);
-      paymentSelectorUnlockTimerRef.current = null;
-    }
-  }, []);
-
-  const updatePaymentSelectorNavigationLock = useCallback(
-    (isLocked: boolean) => {
-      isPaymentSelectorNavigationLockedRef.current = isLocked;
-      setIsPaymentSelectorNavigationLocked(isLocked);
-    },
-    [],
-  );
-
-  const lockPaymentSelectorNavigation = useCallback(() => {
-    clearPaymentSelectorUnlockTimer();
-    didBlurAfterPaymentSelectorOpenRef.current = false;
-    updatePaymentSelectorNavigationLock(true);
-  }, [clearPaymentSelectorUnlockTimer, updatePaymentSelectorNavigationLock]);
-
-  useEffect(() => {
-    const scheduleUnlock = () => {
-      clearPaymentSelectorUnlockTimer();
-      paymentSelectorUnlockTimerRef.current = setTimeout(() => {
-        didBlurAfterPaymentSelectorOpenRef.current = false;
-        updatePaymentSelectorNavigationLock(false);
-        paymentSelectorUnlockTimerRef.current = null;
-      }, PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS);
-    };
-
-    const unsubscribeBlur = navigation.addListener('blur', () => {
-      if (isPaymentSelectorNavigationLockedRef.current) {
-        didBlurAfterPaymentSelectorOpenRef.current = true;
-      }
-    });
-
-    const unsubscribeFocus = navigation.addListener('focus', () => {
-      if (
-        isPaymentSelectorNavigationLockedRef.current &&
-        didBlurAfterPaymentSelectorOpenRef.current
-      ) {
-        scheduleUnlock();
-      }
-    });
-
-    return () => {
-      unsubscribeBlur();
-      unsubscribeFocus();
-      clearPaymentSelectorUnlockTimer();
-    };
-  }, [
-    clearPaymentSelectorUnlockTimer,
-    navigation,
-    updatePaymentSelectorNavigationLock,
-  ]);
-
   const {
     preview,
     error: previewError,
@@ -252,6 +184,8 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     isCurrentTokenInsufficient,
     hasAlternativeBalance,
     isPaySystemSettling,
+    isPaymentSelectorNavigationLocked,
+    lockPaymentSelectorNavigation,
   } = usePredictBuyConditions({
     currentValue,
     preview,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -68,6 +68,52 @@ import {
   predictBuyPreviewSessionRef,
 } from '../PredictBuyPreview/PredictBuyPreview';
 
+interface BuyActionButtonStateParams {
+  isPaymentSelectorNavigationLocked: boolean;
+  isBannerActive: boolean;
+  isChangePaymentMode: boolean;
+  isAddFundsMode: boolean;
+  isRetrying: boolean;
+  hasPreview: boolean;
+  canPlaceBet: boolean;
+}
+
+const getBuyActionButtonState = ({
+  isPaymentSelectorNavigationLocked,
+  isBannerActive,
+  isChangePaymentMode,
+  isAddFundsMode,
+  isRetrying,
+  hasPreview,
+  canPlaceBet,
+}: BuyActionButtonStateParams) => {
+  if (isPaymentSelectorNavigationLocked) {
+    return {
+      disabled: true,
+      reducedOpacity: true,
+    };
+  }
+
+  if (!isBannerActive && (isChangePaymentMode || isAddFundsMode)) {
+    return {
+      disabled: false,
+      reducedOpacity: false,
+    };
+  }
+
+  if (isBannerActive) {
+    return {
+      disabled: isRetrying || !hasPreview,
+      reducedOpacity: !hasPreview,
+    };
+  }
+
+  return {
+    disabled: !canPlaceBet,
+    reducedOpacity: !canPlaceBet,
+  };
+};
+
 const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const tw = useTailwind();
   const keypadRef = useRef<PredictKeypadHandles>(null);
@@ -342,21 +388,18 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     ? { twClassName: 'bg-background-default' }
     : { style: tw.style('flex-1 bg-background-default') };
 
-  const isBuyActionButtonDisabled = isPaymentSelectorNavigationLocked
-    ? true
-    : !isBannerActive && (isChangePaymentMode || isAddFundsMode)
-      ? false
-      : isBannerActive
-        ? isRetrying || !preview
-        : !canPlaceBet;
-
-  const showBuyActionButtonReducedOpacity = isPaymentSelectorNavigationLocked
-    ? true
-    : !isBannerActive && (isChangePaymentMode || isAddFundsMode)
-      ? false
-      : isBannerActive
-        ? !preview
-        : !canPlaceBet;
+  const {
+    disabled: isBuyActionButtonDisabled,
+    reducedOpacity: showBuyActionButtonReducedOpacity,
+  } = getBuyActionButtonState({
+    isPaymentSelectorNavigationLocked,
+    isBannerActive,
+    isChangePaymentMode,
+    isAddFundsMode,
+    isRetrying,
+    hasPreview: Boolean(preview),
+    canPlaceBet,
+  });
   const shouldSuppressInlineError =
     (isChangePaymentMode || isAddFundsMode) &&
     errorMessageSource === 'insufficient_balance';

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -199,6 +199,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
 
   const {
     errorMessage,
+    errorMessageSource,
     buyErrorBanner,
     isOrderNotFilled,
     resetOrderNotFilled,
@@ -356,6 +357,13 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
       : isBannerActive
         ? !preview
         : !canPlaceBet;
+  const shouldSuppressInlineError =
+    (isChangePaymentMode || isAddFundsMode) &&
+    errorMessageSource === 'insufficient_balance';
+  const shouldRenderInlineError =
+    !isSheetMode ||
+    !buyErrorBanner ||
+    errorMessageSource === 'blocking_pay_alert';
 
   return (
     <Wrapper {...wrapperProps}>
@@ -425,11 +433,9 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
           </Box>
         </ScrollView>
       )}
-      {!(isSheetMode && buyErrorBanner) && (
+      {shouldRenderInlineError && (
         <PredictBuyError
-          errorMessage={
-            isChangePaymentMode || isAddFundsMode ? undefined : errorMessage
-          }
+          errorMessage={shouldSuppressInlineError ? undefined : errorMessage}
         />
       )}
       {!isSheetMode && (

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -239,7 +239,6 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     isUserInputChange,
     isConfirming,
     totalPayForPredictBalance,
-    isInputFocused,
     hasBlockingPayAlerts,
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -682,6 +682,62 @@ describe('PredictPayWithAnyTokenInfo', () => {
     });
   });
 
+  describe('payment token transitions', () => {
+    it('does not re-emit the same token amount after Predict balance', () => {
+      mockIsPredictBalanceSelected = false;
+      mockSelectedPaymentToken = {
+        address: '0xabc123',
+        chainId: '0x1',
+      };
+      mockActiveTransactionMeta = { id: 'tx-1' };
+      mockAmountHuman = '100';
+
+      const { rerender } = render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100');
+
+      jest.clearAllMocks();
+      mockIsPredictBalanceSelected = true;
+      mockSelectedPaymentToken = undefined;
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+      expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
+
+      jest.clearAllMocks();
+      mockIsPredictBalanceSelected = false;
+      mockSelectedPaymentToken = {
+        address: '0xAbC123',
+        chainId: '0X1',
+      };
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
+      expect(mockUpdateTokenAmountCallback).not.toHaveBeenCalled();
+    });
+  });
+
   describe('setPayToken effect', () => {
     it('calls setPayToken when selected token is not applied', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -406,6 +406,37 @@ describe('PredictPayWithAnyTokenInfo', () => {
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
+    it('re-emits the same amount when the active transaction changes', () => {
+      mockActiveTransactionMeta = { id: 'tx-1' };
+      mockAmountHuman = '100';
+
+      const { rerender } = render(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100');
+
+      mockUpdatePendingAmount.mockClear();
+      mockUpdateTokenAmountCallback.mockClear();
+      mockActiveTransactionMeta = { id: 'tx-2' };
+
+      rerender(
+        <PredictPayWithAnyTokenInfo
+          currentValue={100}
+          preview={defaultPreview}
+          isInputFocused={false}
+        />,
+      );
+
+      expect(mockUpdatePendingAmount).toHaveBeenCalledWith('100');
+      expect(mockUpdateTokenAmountCallback).toHaveBeenCalledWith('100');
+    });
+
     it('updates deposit amount when value changes after unfocus', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -88,8 +88,11 @@ function PredictPayWithAnyTokenInfoInner({
   }, [canTriggerDepositAmountCalculation, computedDepositAmount]);
 
   const hasValidDepositAmount = useMemo(
-    () => depositAmount !== '' && Boolean(transactionMeta),
-    [depositAmount, transactionMeta],
+    () =>
+      !isPredictBalanceSelected &&
+      depositAmount !== '' &&
+      Boolean(transactionMeta),
+    [depositAmount, isPredictBalanceSelected, transactionMeta],
   );
 
   const emissionKey = useMemo(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -88,39 +88,65 @@ function PredictPayWithAnyTokenInfoInner({
   }, [canTriggerDepositAmountCalculation, computedDepositAmount]);
 
   const hasValidDepositAmount = useMemo(
-    () => depositAmount !== '' && transactionMeta,
+    () => depositAmount !== '' && Boolean(transactionMeta),
     [depositAmount, transactionMeta],
   );
 
-  const lastEmittedDepositRef = useRef('');
-  const lastEmittedAmountHumanRef = useRef('');
+  const emissionKey = useMemo(() => {
+    const selectedTokenAddress =
+      selectedPaymentToken?.address?.toLowerCase() ?? '';
+    const selectedTokenChainId =
+      selectedPaymentToken?.chainId?.toLowerCase() ?? '';
+
+    return `${transactionMeta?.id ?? ''}:${selectedTokenAddress}:${selectedTokenChainId}`;
+  }, [
+    selectedPaymentToken?.address,
+    selectedPaymentToken?.chainId,
+    transactionMeta?.id,
+  ]);
+
+  const lastEmittedDepositRef = useRef({ key: '', value: '' });
+  const lastEmittedAmountHumanRef = useRef({ key: '', value: '' });
 
   useEffect(() => {
+    const lastEmittedDeposit = lastEmittedDepositRef.current;
+
     if (
       !hasValidDepositAmount ||
-      depositAmount === lastEmittedDepositRef.current
+      (depositAmount === lastEmittedDeposit.value &&
+        emissionKey === lastEmittedDeposit.key)
     ) {
       return;
     }
-    lastEmittedDepositRef.current = depositAmount;
+    lastEmittedDepositRef.current = {
+      key: emissionKey,
+      value: depositAmount,
+    };
     updatePendingAmount(depositAmount);
     EngineService.flushState();
-  }, [depositAmount, hasValidDepositAmount, updatePendingAmount]);
+  }, [depositAmount, emissionKey, hasValidDepositAmount, updatePendingAmount]);
 
   useEffect(() => {
+    const lastEmittedAmountHuman = lastEmittedAmountHumanRef.current;
+
     if (
       !amountHuman ||
       amountHuman === '0' ||
       !hasValidDepositAmount ||
-      amountHuman === lastEmittedAmountHumanRef.current
+      (amountHuman === lastEmittedAmountHuman.value &&
+        emissionKey === lastEmittedAmountHuman.key)
     ) {
       return;
     }
-    lastEmittedAmountHumanRef.current = amountHuman;
+    lastEmittedAmountHumanRef.current = {
+      key: emissionKey,
+      value: amountHuman,
+    };
     updateTokenAmountCallback(amountHuman);
     EngineService.flushState();
   }, [
     amountHuman,
+    emissionKey,
     updateTokenAmountCallback,
     depositAmount,
     hasValidDepositAmount,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
@@ -165,6 +165,24 @@ describe('PredictPayWithRow', () => {
     );
   });
 
+  it('calls onPaymentSelectorOpen before navigating to pay-with modal', () => {
+    const callOrder: string[] = [];
+    const onPaymentSelectorOpen = jest.fn(() => callOrder.push('lock'));
+    mockNavigate.mockImplementation(() => callOrder.push('navigate'));
+
+    renderWithProvider(
+      <PredictPayWithRow onPaymentSelectorOpen={onPaymentSelectorOpen} />,
+    );
+
+    fireEvent.press(screen.getByText('Pay with USDC'));
+
+    expect(onPaymentSelectorOpen).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.CONFIRMATION_PAY_WITH_MODAL,
+    );
+    expect(callOrder).toStrictEqual(['lock', 'navigate']);
+  });
+
   it('does not navigate when disabled prop is true', () => {
     renderWithProvider(<PredictPayWithRow disabled />);
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
@@ -39,6 +39,7 @@ interface PredictPayWithRowProps {
   chevronRight?: boolean;
   variant?: PredictPayWithRowVariant;
   availableBalance?: string;
+  onPaymentSelectorOpen?: () => void;
 }
 
 export function PredictPayWithRow({
@@ -46,6 +47,7 @@ export function PredictPayWithRow({
   chevronRight = false,
   variant = 'pill',
   availableBalance,
+  onPaymentSelectorOpen,
 }: PredictPayWithRowProps) {
   usePredictDefaultPaymentToken();
   const navigation = useNavigation();
@@ -66,8 +68,9 @@ export function PredictPayWithRow({
 
   const handlePress = useCallback(() => {
     if (!canEdit) return;
+    onPaymentSelectorOpen?.();
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
-  }, [canEdit, navigation]);
+  }, [canEdit, navigation, onPaymentSelectorOpen]);
 
   const label = strings('confirm.label.pay_with');
   const displaySymbol = showPredictBalance

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -996,7 +996,7 @@ describe('usePredictBuyConditions', () => {
       expect(result.current.canPlaceBet).toBe(false);
     });
 
-    it('resets settling when switching back to Predict balance', () => {
+    it('keeps the same token settled when switching through Predict balance without changing amount', () => {
       mockIsPredictBalanceSelected = false;
       mockSelectedPaymentToken = { address: '0xUSDC', chainId: '1' };
       mockIsPayQuoteLoading = true;
@@ -1016,7 +1016,7 @@ describe('usePredictBuyConditions', () => {
       rerender({});
       expect(result.current.isPaySystemSettling).toBe(false);
 
-      // Switch back to Predict balance — resets lastSettledTokenKey
+      // Switch back to Predict balance — keeps the settled payment key.
       act(() => {
         mockIsPredictBalanceSelected = true;
         mockSelectedPaymentToken = null;
@@ -1024,13 +1024,59 @@ describe('usePredictBuyConditions', () => {
       rerender({});
       expect(result.current.isPaySystemSettling).toBe(false);
 
-      // Re-select USDC — must settle again (quotes may need re-fetching)
+      // Re-select USDC for the same amount — can reuse the existing quote state.
       act(() => {
         mockIsPredictBalanceSelected = false;
         mockSelectedPaymentToken = { address: '0xUSDC', chainId: '1' };
       });
       rerender({});
+      expect(result.current.isPaySystemSettling).toBe(false);
+      expect(result.current.canPlaceBet).toBe(true);
+    });
+
+    it('settles again when the same token is re-selected after the amount changes', () => {
+      mockIsPredictBalanceSelected = false;
+      mockSelectedPaymentToken = { address: '0xUSDC', chainId: '1' };
+      mockIsPayQuoteLoading = true;
+      mockIsPayTotalsLoading = true;
+      mockQuotes = [];
+
+      const { result, rerender } = renderHook(
+        ({
+          totalPayForPredictBalance,
+        }: {
+          totalPayForPredictBalance: number;
+        }) =>
+          usePredictBuyConditions({
+            ...defaultParams,
+            currentValue: 1,
+            totalPayForPredictBalance,
+          }),
+        { initialProps: { totalPayForPredictBalance: 10.5 } },
+      );
+
+      act(() => {
+        mockIsPayQuoteLoading = false;
+        mockIsPayTotalsLoading = false;
+        mockQuotes = [{ id: 'q1' }];
+      });
+      rerender({ totalPayForPredictBalance: 10.5 });
+      expect(result.current.isPaySystemSettling).toBe(false);
+
+      act(() => {
+        mockIsPredictBalanceSelected = true;
+        mockSelectedPaymentToken = null;
+      });
+      rerender({ totalPayForPredictBalance: 10.5 });
+
+      act(() => {
+        mockIsPredictBalanceSelected = false;
+        mockSelectedPaymentToken = { address: '0xUSDC', chainId: '1' };
+      });
+      rerender({ totalPayForPredictBalance: 11 });
+
       expect(result.current.isPaySystemSettling).toBe(true);
+      expect(result.current.canPlaceBet).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { usePredictBuyConditions } from './usePredictBuyConditions';
 import { ActiveOrderState, OrderPreview } from '../../../types';
+import {
+  PAYMENT_SELECTOR_NAVIGATION_SAFETY_UNLOCK_MS,
+  PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS,
+} from '../../../constants/transactions';
 
 let mockIsBalanceLoading = false;
 let mockAvailableBalance = 100;
@@ -39,12 +43,13 @@ const mockAddListener = jest.fn((eventName: string, callback: () => void) => {
 const mockEmitNavigationEvent = (eventName: string) => {
   mockNavigationListeners[eventName]?.forEach((callback) => callback());
 };
+const mockNavigation = {
+  addListener: mockAddListener,
+};
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
-  useNavigation: () => ({
-    addListener: mockAddListener,
-  }),
+  useNavigation: () => mockNavigation,
 }));
 
 jest.mock('./usePredictBuyAvailableBalance', () => ({
@@ -168,7 +173,39 @@ describe('usePredictBuyConditions', () => {
       });
 
       act(() => {
-        jest.advanceTimersByTime(999);
+        jest.advanceTimersByTime(
+          PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS - 1,
+        );
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(false);
+      expect(result.current.canPlaceBet).toBe(true);
+    });
+
+    it('unlocks after the safety timeout when navigation events do not fire', () => {
+      jest.useFakeTimers();
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      act(() => {
+        result.current.lockPaymentSelectorNavigation();
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(true);
+      expect(result.current.canPlaceBet).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(
+          PAYMENT_SELECTOR_NAVIGATION_SAFETY_UNLOCK_MS - 1,
+        );
       });
 
       expect(result.current.isPaymentSelectorNavigationLocked).toBe(true);

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -119,7 +119,6 @@ const defaultParams = {
   isUserInputChange: false,
   isConfirming: false,
   totalPayForPredictBalance: 10.5,
-  isInputFocused: false,
   hasBlockingPayAlerts: false,
 };
 
@@ -1118,8 +1117,8 @@ describe('usePredictBuyConditions', () => {
     });
   });
 
-  describe('selected payment token reset effect', () => {
-    it('resets the selected token when predict balance covers the total and input is not focused', () => {
+  describe('manual payment token selection', () => {
+    it('does not reset the selected token after initialization, even when Predict balance covers the total', () => {
       mockPredictBalance = 20;
       mockIsPredictBalanceSelected = false;
 
@@ -1127,37 +1126,6 @@ describe('usePredictBuyConditions', () => {
         usePredictBuyConditions({
           ...defaultParams,
           totalPayForPredictBalance: 20,
-          isInputFocused: false,
-        }),
-      );
-
-      expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not reset the selected token while the input is focused', () => {
-      mockPredictBalance = 20;
-      mockIsPredictBalanceSelected = false;
-
-      renderHook(() =>
-        usePredictBuyConditions({
-          ...defaultParams,
-          totalPayForPredictBalance: 20,
-          isInputFocused: true,
-        }),
-      );
-
-      expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
-    });
-
-    it('does not reset the selected token when predict balance is already selected', () => {
-      mockPredictBalance = 20;
-      mockIsPredictBalanceSelected = true;
-
-      renderHook(() =>
-        usePredictBuyConditions({
-          ...defaultParams,
-          totalPayForPredictBalance: 20,
-          isInputFocused: false,
         }),
       );
 
@@ -1172,7 +1140,6 @@ describe('usePredictBuyConditions', () => {
         usePredictBuyConditions({
           ...defaultParams,
           totalPayForPredictBalance: 20,
-          isInputFocused: false,
         }),
       );
 
@@ -1187,7 +1154,6 @@ describe('usePredictBuyConditions', () => {
         usePredictBuyConditions({
           ...defaultParams,
           totalPayForPredictBalance: 0,
-          isInputFocused: false,
         }),
       );
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -24,6 +24,28 @@ let mockAvailableTokens: {
 let mockPredictBalance = 0;
 let mockQuotes: unknown[] = [];
 const mockResetSelectedPaymentToken = jest.fn();
+const mockNavigationListeners: Record<string, Set<() => void>> = {};
+const mockAddListener = jest.fn((eventName: string, callback: () => void) => {
+  if (!mockNavigationListeners[eventName]) {
+    mockNavigationListeners[eventName] = new Set();
+  }
+
+  mockNavigationListeners[eventName].add(callback);
+
+  return () => {
+    mockNavigationListeners[eventName]?.delete(callback);
+  };
+});
+const mockEmitNavigationEvent = (eventName: string) => {
+  mockNavigationListeners[eventName]?.forEach((callback) => callback());
+};
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    addListener: mockAddListener,
+  }),
+}));
 
 jest.mock('./usePredictBuyAvailableBalance', () => ({
   usePredictBuyAvailableBalance: () => ({
@@ -99,6 +121,9 @@ const defaultParams = {
 describe('usePredictBuyConditions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.keys(mockNavigationListeners).forEach((eventName) => {
+      delete mockNavigationListeners[eventName];
+    });
     mockIsBalanceLoading = false;
     mockAvailableBalance = 100;
     mockActiveOrder = null;
@@ -115,7 +140,46 @@ describe('usePredictBuyConditions', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
+  });
+
+  describe('payment selector navigation lock', () => {
+    it('locks immediately and unlocks one second after focus returns from the selector', () => {
+      jest.useFakeTimers();
+
+      const { result } = renderHook(() =>
+        usePredictBuyConditions(defaultParams),
+      );
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(false);
+      expect(result.current.canPlaceBet).toBe(true);
+
+      act(() => {
+        result.current.lockPaymentSelectorNavigation();
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(true);
+      expect(result.current.canPlaceBet).toBe(false);
+
+      act(() => {
+        mockEmitNavigationEvent('blur');
+        mockEmitNavigationEvent('focus');
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(999);
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      expect(result.current.isPaymentSelectorNavigationLocked).toBe(false);
+      expect(result.current.canPlaceBet).toBe(true);
+    });
   });
 
   describe('isBelowMinimum', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.test.ts
@@ -657,7 +657,7 @@ describe('usePredictBuyConditions', () => {
     });
 
     it('is true immediately after an ERC20 token is selected (synchronous — no 1-frame gap)', () => {
-      // isPaySystemSettling is derived synchronously from lastSettledTokenAddress,
+      // isPaySystemSettling is derived synchronously from lastSettledTokenKey,
       // so it is true from the very first render after the token identity changes.
       mockIsPredictBalanceSelected = false;
       mockSelectedPaymentToken = { address: '0xDAI', chainId: '1' };
@@ -852,6 +852,35 @@ describe('usePredictBuyConditions', () => {
       expect(result.current.isPaySystemSettling).toBe(true);
     });
 
+    it('resets to true when the same ERC20 address is selected on a different chain', () => {
+      mockIsPredictBalanceSelected = false;
+      mockSelectedPaymentToken = { address: '0xUSDC', chainId: '0x1' };
+      mockIsPayQuoteLoading = true;
+      mockIsPayTotalsLoading = true;
+      mockQuotes = [];
+
+      const { result, rerender } = renderHook(() =>
+        usePredictBuyConditions({ ...defaultParams, currentValue: 1 }),
+      );
+
+      act(() => {
+        mockIsPayQuoteLoading = false;
+        mockIsPayTotalsLoading = false;
+        mockQuotes = [{ id: 'q1' }];
+      });
+      rerender({});
+      expect(result.current.isPaySystemSettling).toBe(false);
+
+      act(() => {
+        mockSelectedPaymentToken = { address: '0xUSDC', chainId: '0x2' };
+        mockQuotes = [];
+      });
+      rerender({});
+
+      expect(result.current.isPaySystemSettling).toBe(true);
+      expect(result.current.canPlaceBet).toBe(false);
+    });
+
     it('keeps canPlaceBet false while settling, even if all other conditions are met', () => {
       mockIsPredictBalanceSelected = false;
       mockSelectedPaymentToken = { address: '0xDAI', chainId: '1' };
@@ -886,7 +915,7 @@ describe('usePredictBuyConditions', () => {
       rerender({});
       expect(result.current.isPaySystemSettling).toBe(false);
 
-      // Switch back to Predict balance — resets lastSettledTokenAddress
+      // Switch back to Predict balance — resets lastSettledTokenKey
       act(() => {
         mockIsPredictBalanceSelected = true;
         mockSelectedPaymentToken = null;

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -150,21 +150,29 @@ export const usePredictBuyConditions = ({
     return `${selectedPaymentToken.chainId.toLowerCase()}:${selectedPaymentToken.address.toLowerCase()}`;
   }, [selectedPaymentToken?.address, selectedPaymentToken?.chainId]);
 
-  // Tracks the chain/token pair for which a full quote-loading cycle has
-  // completed. Compared synchronously each render to derive
-  // `isPaySystemSettling` — true from the very first render after the token
-  // identity changes, with no one-frame gap (Bug 1).
-  const [lastSettledTokenKey, setLastSettledTokenKey] = useState<string | null>(
-    null,
-  );
+  const selectedPaymentSettlingKey = useMemo(() => {
+    if (!selectedPaymentTokenKey) {
+      return null;
+    }
+
+    return `${selectedPaymentTokenKey}:${totalPayForPredictBalance}`;
+  }, [selectedPaymentTokenKey, totalPayForPredictBalance]);
+
+  // Tracks the token/amount pair for which a full quote-loading cycle has
+  // completed. Keeping the amount in the key makes same-token amount changes
+  // settle again, while preserving same-token same-amount quotes across a brief
+  // Predict-balance selection.
+  const [lastSettledPaymentKey, setLastSettledPaymentKey] = useState<
+    string | null
+  >(null);
 
   // Synchronous derivation: true from the very first render after the selected
-  // token changes. No effects needed to flip a boolean flag, so there is no
-  // one-frame window where the CTA flashes incorrectly (Bug 1 fixed).
+  // token or amount changes. No effects needed to flip a boolean flag, so there
+  // is no one-frame window where the CTA flashes incorrectly (Bug 1 fixed).
   const isPaySystemSettling =
     !isPredictBalanceSelected &&
-    selectedPaymentTokenKey !== null &&
-    selectedPaymentTokenKey !== lastSettledTokenKey;
+    selectedPaymentSettlingKey !== null &&
+    selectedPaymentSettlingKey !== lastSettledPaymentKey;
 
   const isBalancePulsing = useMemo(
     () => isDepositPending && isPredictBalanceSelected,
@@ -238,23 +246,22 @@ export const usePredictBuyConditions = ({
     const quotesPresent = (quotes?.length ?? 0) > 0;
     if (quotesPresent || !isPayFeesLoading) {
       hasSeenLoadingRef.current = false;
-      setLastSettledTokenKey(selectedPaymentTokenKey);
+      setLastSettledPaymentKey(selectedPaymentSettlingKey);
     }
   }, [
     isPaySystemSettling,
     isPayQuoteLoading,
     isPayFeesLoading,
     quotes,
-    selectedPaymentTokenKey,
+    selectedPaymentSettlingKey,
   ]);
 
-  // Effect 3 — reset when switching back to Predict balance so that returning
-  // to any ERC20 always requires a fresh settling cycle (quotes may need
-  // re-fetching).
+  // Effect 3 — stop any in-flight settling observation when switching back to
+  // Predict balance. Keep the settled payment key so selecting the same token
+  // for the same amount can reuse the existing quote state immediately.
   useEffect(() => {
     if (isPredictBalanceSelected) {
       hasSeenLoadingRef.current = false;
-      setLastSettledTokenKey(null);
     }
   }, [isPredictBalanceSelected]);
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'bignumber.js';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useIsTransactionPayLoading,
   useIsTransactionPayQuoteLoading,
@@ -12,6 +13,8 @@ import { usePredictDeposit } from '../../../hooks/usePredictDeposit';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { usePredictBuyAvailableBalance } from './usePredictBuyAvailableBalance';
+
+const PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS = 1000;
 
 interface UsePredictBuyConditionsParams {
   currentValue: number;
@@ -34,6 +37,7 @@ export const usePredictBuyConditions = ({
   isInputFocused,
   hasBlockingPayAlerts,
 }: UsePredictBuyConditionsParams) => {
+  const navigation = useNavigation();
   const { isBalanceLoading, availableBalance } =
     usePredictBuyAvailableBalance();
   const isPayTotalsLoading = useIsTransactionPayLoading();
@@ -57,6 +61,72 @@ export const usePredictBuyConditions = ({
   // falsely mark a loading cycle as "seen" — which would cause a premature
   // settling exit (Bug 3).
   const hasSeenLoadingRef = useRef(false);
+  const [
+    isPaymentSelectorNavigationLocked,
+    setIsPaymentSelectorNavigationLocked,
+  ] = useState(false);
+  const isPaymentSelectorNavigationLockedRef = useRef(false);
+  const didBlurAfterPaymentSelectorOpenRef = useRef(false);
+  const paymentSelectorUnlockTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+
+  const clearPaymentSelectorUnlockTimer = useCallback(() => {
+    if (paymentSelectorUnlockTimerRef.current) {
+      clearTimeout(paymentSelectorUnlockTimerRef.current);
+      paymentSelectorUnlockTimerRef.current = null;
+    }
+  }, []);
+
+  const updatePaymentSelectorNavigationLock = useCallback(
+    (isLocked: boolean) => {
+      isPaymentSelectorNavigationLockedRef.current = isLocked;
+      setIsPaymentSelectorNavigationLocked(isLocked);
+    },
+    [],
+  );
+
+  const lockPaymentSelectorNavigation = useCallback(() => {
+    clearPaymentSelectorUnlockTimer();
+    didBlurAfterPaymentSelectorOpenRef.current = false;
+    updatePaymentSelectorNavigationLock(true);
+  }, [clearPaymentSelectorUnlockTimer, updatePaymentSelectorNavigationLock]);
+
+  useEffect(() => {
+    const scheduleUnlock = () => {
+      clearPaymentSelectorUnlockTimer();
+      paymentSelectorUnlockTimerRef.current = setTimeout(() => {
+        didBlurAfterPaymentSelectorOpenRef.current = false;
+        updatePaymentSelectorNavigationLock(false);
+        paymentSelectorUnlockTimerRef.current = null;
+      }, PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS);
+    };
+
+    const unsubscribeBlur = navigation.addListener('blur', () => {
+      if (isPaymentSelectorNavigationLockedRef.current) {
+        didBlurAfterPaymentSelectorOpenRef.current = true;
+      }
+    });
+
+    const unsubscribeFocus = navigation.addListener('focus', () => {
+      if (
+        isPaymentSelectorNavigationLockedRef.current &&
+        didBlurAfterPaymentSelectorOpenRef.current
+      ) {
+        scheduleUnlock();
+      }
+    });
+
+    return () => {
+      unsubscribeBlur();
+      unsubscribeFocus();
+      clearPaymentSelectorUnlockTimer();
+    };
+  }, [
+    clearPaymentSelectorUnlockTimer,
+    navigation,
+    updatePaymentSelectorNavigationLock,
+  ]);
 
   const selectedPaymentTokenKey = useMemo(() => {
     if (!selectedPaymentToken?.address || !selectedPaymentToken?.chainId) {
@@ -226,7 +296,8 @@ export const usePredictBuyConditions = ({
       !isRateLimited &&
       !isBalanceLoading &&
       !isPayFeesLoading &&
-      !hasBlockingPayAlerts,
+      !hasBlockingPayAlerts &&
+      !isPaymentSelectorNavigationLocked,
     [
       isPaySystemSettling,
       isConfirming,
@@ -237,6 +308,7 @@ export const usePredictBuyConditions = ({
       isBalanceLoading,
       isPayFeesLoading,
       hasBlockingPayAlerts,
+      isPaymentSelectorNavigationLocked,
     ],
   );
 
@@ -273,5 +345,7 @@ export const usePredictBuyConditions = ({
     isPayFeesLoading,
     isBalancePulsing,
     isPaySystemSettling,
+    isPaymentSelectorNavigationLocked,
+    lockPaymentSelectorNavigation,
   };
 };

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -7,14 +7,16 @@ import {
   useTransactionPayQuotes,
 } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
 import { useTransactionPayAvailableTokens } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayAvailableTokens';
-import { MINIMUM_BET } from '../../../constants/transactions';
+import {
+  MINIMUM_BET,
+  PAYMENT_SELECTOR_NAVIGATION_SAFETY_UNLOCK_MS,
+  PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS,
+} from '../../../constants/transactions';
 import { usePredictBalance } from '../../../hooks/usePredictBalance';
 import { usePredictDeposit } from '../../../hooks/usePredictDeposit';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { usePredictBuyAvailableBalance } from './usePredictBuyAvailableBalance';
-
-const PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS = 1000;
 
 interface UsePredictBuyConditionsParams {
   currentValue: number;
@@ -86,19 +88,31 @@ export const usePredictBuyConditions = ({
     [],
   );
 
+  const unlockPaymentSelectorNavigation = useCallback(() => {
+    clearPaymentSelectorUnlockTimer();
+    didBlurAfterPaymentSelectorOpenRef.current = false;
+    updatePaymentSelectorNavigationLock(false);
+  }, [clearPaymentSelectorUnlockTimer, updatePaymentSelectorNavigationLock]);
+
   const lockPaymentSelectorNavigation = useCallback(() => {
     clearPaymentSelectorUnlockTimer();
     didBlurAfterPaymentSelectorOpenRef.current = false;
     updatePaymentSelectorNavigationLock(true);
-  }, [clearPaymentSelectorUnlockTimer, updatePaymentSelectorNavigationLock]);
+    paymentSelectorUnlockTimerRef.current = setTimeout(
+      unlockPaymentSelectorNavigation,
+      PAYMENT_SELECTOR_NAVIGATION_SAFETY_UNLOCK_MS,
+    );
+  }, [
+    clearPaymentSelectorUnlockTimer,
+    unlockPaymentSelectorNavigation,
+    updatePaymentSelectorNavigationLock,
+  ]);
 
   useEffect(() => {
     const scheduleUnlock = () => {
       clearPaymentSelectorUnlockTimer();
       paymentSelectorUnlockTimerRef.current = setTimeout(() => {
-        didBlurAfterPaymentSelectorOpenRef.current = false;
-        updatePaymentSelectorNavigationLock(false);
-        paymentSelectorUnlockTimerRef.current = null;
+        unlockPaymentSelectorNavigation();
       }, PAYMENT_SELECTOR_NAVIGATION_UNLOCK_DELAY_MS);
     };
 
@@ -125,7 +139,7 @@ export const usePredictBuyConditions = ({
   }, [
     clearPaymentSelectorUnlockTimer,
     navigation,
-    updatePaymentSelectorNavigationLock,
+    unlockPaymentSelectorNavigation,
   ]);
 
   const selectedPaymentTokenKey = useMemo(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -25,7 +25,6 @@ interface UsePredictBuyConditionsParams {
   isUserInputChange: boolean;
   isConfirming: boolean;
   totalPayForPredictBalance: number;
-  isInputFocused: boolean;
   hasBlockingPayAlerts: boolean;
 }
 
@@ -36,7 +35,6 @@ export const usePredictBuyConditions = ({
   isUserInputChange,
   isConfirming,
   totalPayForPredictBalance,
-  isInputFocused,
   hasBlockingPayAlerts,
 }: UsePredictBuyConditionsParams) => {
   const navigation = useNavigation();
@@ -46,11 +44,8 @@ export const usePredictBuyConditions = ({
   const isPayQuoteLoading = useIsTransactionPayQuoteLoading();
   const quotes = useTransactionPayQuotes();
   const { isDepositPending } = usePredictDeposit();
-  const {
-    isPredictBalanceSelected,
-    selectedPaymentToken,
-    resetSelectedPaymentToken,
-  } = usePredictPaymentToken();
+  const { isPredictBalanceSelected, selectedPaymentToken } =
+    usePredictPaymentToken();
   const { data: predictBalance = 0 } = usePredictBalance();
   const { availableTokens } = useTransactionPayAvailableTokens();
 
@@ -337,23 +332,6 @@ export const usePredictBuyConditions = ({
     () => isPreviewCalculating && isUserInputChange,
     [isPreviewCalculating, isUserInputChange],
   );
-
-  useEffect(() => {
-    if (
-      !isPredictBalanceSelected &&
-      !isInputFocused &&
-      totalPayForPredictBalance > 0 &&
-      predictBalance >= totalPayForPredictBalance
-    ) {
-      resetSelectedPaymentToken();
-    }
-  }, [
-    isInputFocused,
-    isPredictBalanceSelected,
-    predictBalance,
-    resetSelectedPaymentToken,
-    totalPayForPredictBalance,
-  ]);
 
   return {
     isBelowMinimum,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -58,21 +58,29 @@ export const usePredictBuyConditions = ({
   // settling exit (Bug 3).
   const hasSeenLoadingRef = useRef(false);
 
-  // Tracks the address of the last ERC20 token for which a full quote-loading
-  // cycle has completed. Compared synchronously each render to derive
+  const selectedPaymentTokenKey = useMemo(() => {
+    if (!selectedPaymentToken?.address || !selectedPaymentToken?.chainId) {
+      return null;
+    }
+
+    return `${selectedPaymentToken.chainId.toLowerCase()}:${selectedPaymentToken.address.toLowerCase()}`;
+  }, [selectedPaymentToken?.address, selectedPaymentToken?.chainId]);
+
+  // Tracks the chain/token pair for which a full quote-loading cycle has
+  // completed. Compared synchronously each render to derive
   // `isPaySystemSettling` — true from the very first render after the token
   // identity changes, with no one-frame gap (Bug 1).
-  const [lastSettledTokenAddress, setLastSettledTokenAddress] = useState<
-    string | null
-  >(null);
+  const [lastSettledTokenKey, setLastSettledTokenKey] = useState<string | null>(
+    null,
+  );
 
   // Synchronous derivation: true from the very first render after the selected
   // token changes. No effects needed to flip a boolean flag, so there is no
   // one-frame window where the CTA flashes incorrectly (Bug 1 fixed).
   const isPaySystemSettling =
     !isPredictBalanceSelected &&
-    selectedPaymentToken !== null &&
-    selectedPaymentToken?.address !== lastSettledTokenAddress;
+    selectedPaymentTokenKey !== null &&
+    selectedPaymentTokenKey !== lastSettledTokenKey;
 
   const isBalancePulsing = useMemo(
     () => isDepositPending && isPredictBalanceSelected,
@@ -146,14 +154,14 @@ export const usePredictBuyConditions = ({
     const quotesPresent = (quotes?.length ?? 0) > 0;
     if (quotesPresent || !isPayFeesLoading) {
       hasSeenLoadingRef.current = false;
-      setLastSettledTokenAddress(selectedPaymentToken?.address ?? null);
+      setLastSettledTokenKey(selectedPaymentTokenKey);
     }
   }, [
     isPaySystemSettling,
     isPayQuoteLoading,
     isPayFeesLoading,
     quotes,
-    selectedPaymentToken,
+    selectedPaymentTokenKey,
   ]);
 
   // Effect 3 — reset when switching back to Predict balance so that returning
@@ -162,7 +170,7 @@ export const usePredictBuyConditions = ({
   useEffect(() => {
     if (isPredictBalanceSelected) {
       hasSeenLoadingRef.current = false;
-      setLastSettledTokenAddress(null);
+      setLastSettledTokenKey(null);
     }
   }, [isPredictBalanceSelected]);
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
@@ -8,6 +8,8 @@ const mockClearOrderError = jest.fn();
 let mockActiveOrder: { error?: string } | null = null;
 let mockIsBalanceLoading = false;
 let mockIsPredictBalanceSelected = true;
+let mockSelectedPaymentToken: { address: string; chainId: string } | null =
+  null;
 
 jest.mock('../../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
@@ -26,6 +28,7 @@ jest.mock('../../../hooks/usePredictBalance', () => ({
 jest.mock('../../../hooks/usePredictPaymentToken', () => ({
   usePredictPaymentToken: () => ({
     isPredictBalanceSelected: mockIsPredictBalanceSelected,
+    selectedPaymentToken: mockSelectedPaymentToken,
   }),
 }));
 
@@ -117,6 +120,7 @@ describe('usePredictBuyError', () => {
     mockActiveOrder = null;
     mockIsBalanceLoading = false;
     mockIsPredictBalanceSelected = true;
+    mockSelectedPaymentToken = null;
   });
 
   describe('errorResult', () => {
@@ -607,6 +611,35 @@ describe('usePredictBuyError', () => {
       act(() => {
         result.current.clearBuyErrorBanner();
       });
+
+      expect(result.current.buyErrorBanner).toBeNull();
+    });
+
+    it('clears a persisted order_failed banner when the selected payment token changes', () => {
+      mockIsPredictBalanceSelected = false;
+      mockSelectedPaymentToken = { address: '0xTokenA', chainId: '0x1' };
+      mockActiveOrder = { error: 'something broke' };
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'parsed message',
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePredictBuyError(defaultParams),
+      );
+
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
+
+      mockActiveOrder = null;
+      rerender({});
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
+
+      mockSelectedPaymentToken = { address: '0xTokenB', chainId: '0x1' };
+      rerender({});
 
       expect(result.current.buyErrorBanner).toBeNull();
     });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
@@ -201,7 +201,7 @@ describe('usePredictBuyError', () => {
       );
     });
 
-    it('returns the generic try-token message for external payment tokens', () => {
+    it('returns the pay token balance alert for external payment tokens', () => {
       mockActiveOrder = { error: 'order failed' };
       mockIsPredictBalanceSelected = false;
 
@@ -213,9 +213,7 @@ describe('usePredictBuyError', () => {
       );
 
       expect(mockGetPlaceOrderErrorOutcome).not.toHaveBeenCalled();
-      expect(result.current.errorMessage).toBe(
-        'Not enough funds. Try a different token.',
-      );
+      expect(result.current.errorMessage).toBe('Pay token balance alert');
       expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
     });
 
@@ -299,9 +297,7 @@ describe('usePredictBuyError', () => {
         }),
       );
 
-      expect(result.current.errorMessage).toBe(
-        'Not enough funds. You can use up to $50.00, or try a different token.',
-      );
+      expect(result.current.errorMessage).toBe('Not enough funds.');
       expect(result.current.errorMessageSource).toBe('insufficient_balance');
     });
 
@@ -375,7 +371,7 @@ describe('usePredictBuyError', () => {
       );
     });
 
-    it('returns generic try-token errorMessage when external token has blockingPayAlertMessage', () => {
+    it('returns pay alert errorMessage when external token has blockingPayAlertMessage', () => {
       mockActiveOrder = { error: 'something broke' };
       mockIsPredictBalanceSelected = false;
       mockGetPlaceOrderErrorOutcome.mockReturnValue({
@@ -390,9 +386,7 @@ describe('usePredictBuyError', () => {
         }),
       );
 
-      expect(result.current.errorMessage).toBe(
-        'Not enough funds. Try a different token.',
-      );
+      expect(result.current.errorMessage).toBe('Pay token balance alert');
       expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
       expect(result.current.buyErrorBanner).toBeNull();
     });
@@ -749,9 +743,7 @@ describe('usePredictBuyError', () => {
         }),
       );
 
-      expect(result.current.errorMessage).toBe(
-        'Not enough funds. Try a different token.',
-      );
+      expect(result.current.errorMessage).toBe('Pay token balance alert');
       expect(result.current.buyErrorBanner).toBeNull();
     });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
@@ -212,6 +212,26 @@ describe('usePredictBuyError', () => {
       expect(result.current.errorMessage).toBe(
         'Not enough funds. Try a different token.',
       );
+      expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
+    });
+
+    it('keeps the pay token balance alert visible while pay fees are loading', () => {
+      mockActiveOrder = { error: 'order failed' };
+      mockIsPredictBalanceSelected = false;
+
+      const { result } = renderHook(() =>
+        usePredictBuyError({
+          ...defaultParams,
+          isPayFeesLoading: true,
+          blockingPayAlertMessage: 'Insufficient payment token balance',
+        }),
+      );
+
+      expect(mockGetPlaceOrderErrorOutcome).not.toHaveBeenCalled();
+      expect(result.current.errorMessage).toBe(
+        'Insufficient payment token balance',
+      );
+      expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
     });
 
     it('returns undefined when activeOrder has no error', () => {
@@ -234,6 +254,7 @@ describe('usePredictBuyError', () => {
       );
 
       expect(result.current.errorMessage).toBe('Preview failed');
+      expect(result.current.errorMessageSource).toBe('preview');
     });
 
     it('returns previewError even when other error conditions exist', () => {
@@ -274,7 +295,10 @@ describe('usePredictBuyError', () => {
         }),
       );
 
-      expect(result.current.errorMessage).toBe('Not enough funds.');
+      expect(result.current.errorMessage).toBe(
+        'Not enough funds. You can use up to $50.00, or try a different token.',
+      );
+      expect(result.current.errorMessageSource).toBe('insufficient_balance');
     });
 
     it('returns generic try-token message when external token balance is insufficient', () => {
@@ -290,6 +314,7 @@ describe('usePredictBuyError', () => {
       expect(result.current.errorMessage).toBe(
         'Not enough funds. Try a different token.',
       );
+      expect(result.current.errorMessageSource).toBe('insufficient_balance');
     });
 
     it('returns undefined when no error conditions exist', () => {
@@ -364,6 +389,7 @@ describe('usePredictBuyError', () => {
       expect(result.current.errorMessage).toBe(
         'Not enough funds. Try a different token.',
       );
+      expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
       expect(result.current.buyErrorBanner).toBeNull();
     });
   });
@@ -536,6 +562,53 @@ describe('usePredictBuyError', () => {
       expect(result.current.buyErrorBanner).toEqual(
         expect.objectContaining({ variant: 'order_failed' }),
       );
+    });
+
+    it('persists order_failed banner when activeOrder error is cleared by controller refresh', () => {
+      mockActiveOrder = { error: 'something broke' };
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'parsed message',
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePredictBuyError(defaultParams),
+      );
+
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
+
+      mockActiveOrder = null;
+      rerender({});
+
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
+    });
+
+    it('clears a persisted order_failed banner when clearBuyErrorBanner is called', () => {
+      mockActiveOrder = { error: 'something broke' };
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'parsed message',
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePredictBuyError(defaultParams),
+      );
+
+      mockActiveOrder = null;
+      rerender({});
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
+
+      act(() => {
+        result.current.clearBuyErrorBanner();
+      });
+
+      expect(result.current.buyErrorBanner).toBeNull();
     });
 
     it('falls back to outcomeTokenPrice for price_changed body when preview is null', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
@@ -15,6 +15,29 @@ export interface PredictBuyErrorBannerData {
   description: string;
 }
 
+export type PredictBuyErrorMessageSource =
+  | 'preview'
+  | 'below_minimum'
+  | 'insufficient_balance'
+  | 'blocking_pay_alert'
+  | 'order_error';
+
+type PredictBuyErrorResult =
+  | {
+      status: 'error';
+      error: string;
+      source: 'blocking_pay_alert' | 'order_error';
+    }
+  | {
+      status: 'order_not_filled';
+      source: 'order_error';
+    };
+
+interface PredictBuyErrorMessageData {
+  message: string;
+  source: PredictBuyErrorMessageSource;
+}
+
 interface UsePredictBuyInfoParams {
   preview?: OrderPreview | null;
   previewError: string | null;
@@ -47,28 +70,54 @@ export const usePredictBuyError = ({
   const { activeOrder, clearOrderError } = usePredictActiveOrder();
   const { isBalanceLoading } = usePredictBuyAvailableBalance();
   const [isOrderNotFilled, setIsOrderNotFilled] = useState(false);
+  const [persistedBuyErrorBanner, setPersistedBuyErrorBanner] =
+    useState<PredictBuyErrorBannerData | null>(null);
   const { isPredictBalanceSelected } = usePredictPaymentToken();
 
-  const errorResult = useMemo(() => {
-    if (isBalanceLoading || isPlacingOrder || isConfirming || !preview) {
-      return undefined;
-    }
-
-    const ready = !isPayFeesLoading && !isPredictBalanceSelected;
-
-    if (ready && !!blockingPayAlertMessage) {
+  const errorResult = useMemo<PredictBuyErrorResult | undefined>(() => {
+    if (
+      !isPlacingOrder &&
+      !isConfirming &&
+      !isPredictBalanceSelected &&
+      !!blockingPayAlertMessage
+    ) {
       return {
         status: 'error',
-        error: strings('predict.order.no_funds_enough_try_token'),
+        error: blockingPayAlertMessage,
+        source: 'blocking_pay_alert',
       };
     }
 
-    return activeOrder?.error
-      ? getPlaceOrderErrorOutcome({
-          error: activeOrder?.error,
-          orderParams: { preview },
-        })
-      : undefined;
+    if (
+      isBalanceLoading ||
+      isPlacingOrder ||
+      isConfirming ||
+      !preview ||
+      isPayFeesLoading
+    ) {
+      return undefined;
+    }
+
+    if (!activeOrder?.error) {
+      return undefined;
+    }
+
+    const orderError = getPlaceOrderErrorOutcome({
+      error: activeOrder?.error,
+      orderParams: { preview },
+    });
+
+    if (
+      orderError.status !== 'error' &&
+      orderError.status !== 'order_not_filled'
+    ) {
+      return undefined;
+    }
+
+    return {
+      ...orderError,
+      source: 'order_error',
+    };
   }, [
     isBalanceLoading,
     isPlacingOrder,
@@ -80,24 +129,43 @@ export const usePredictBuyError = ({
     activeOrder?.error,
   ]);
 
-  const errorMessage = useMemo(() => {
+  const errorMessageData = useMemo<
+    PredictBuyErrorMessageData | undefined
+  >(() => {
     if (previewError) {
-      return previewError;
+      return {
+        message: previewError,
+        source: 'preview',
+      };
     }
 
     if (isBelowMinimum) {
-      return strings('predict.order.prediction_minimum_bet', {
-        amount: formatPrice(MINIMUM_BET, {
-          minimumDecimals: 2,
-          maximumDecimals: 2,
+      return {
+        message: strings('predict.order.prediction_minimum_bet', {
+          amount: formatPrice(MINIMUM_BET, {
+            minimumDecimals: 2,
+            maximumDecimals: 2,
+          }),
         }),
-      });
+        source: 'below_minimum',
+      };
     }
 
     if (isInsufficientBalance) {
-      return isPredictBalanceSelected
-        ? strings('predict.order.no_funds_enough')
-        : strings('predict.order.no_funds_enough_try_token');
+      const formattedMax = formatPrice(maxBetAmount, {
+        minimumDecimals: 2,
+        maximumDecimals: 2,
+      });
+
+      return {
+        message:
+          maxBetAmount >= MINIMUM_BET
+            ? strings('predict.order.prediction_insufficient_funds_try_token', {
+                amount: formattedMax,
+              })
+            : strings('predict.order.no_funds_enough_try_token'),
+        source: 'insufficient_balance',
+      };
     }
 
     if (!errorResult) {
@@ -121,7 +189,11 @@ export const usePredictBuyError = ({
       if (bannerWouldSuppress) {
         return undefined;
       }
-      return errorResult.error;
+
+      return {
+        message: errorResult.error,
+        source: errorResult.source,
+      };
     }
 
     return undefined;
@@ -136,68 +208,86 @@ export const usePredictBuyError = ({
     isSheetMode,
   ]);
 
-  const buyErrorBanner = useMemo<PredictBuyErrorBannerData | null>(() => {
-    // Inline banners are a sheet-mode-only surface. In legacy full-screen
-    // mode the equivalent error is surfaced via `errorMessage` instead.
-    if (!isSheetMode) {
+  const currentBuyErrorBanner =
+    useMemo<PredictBuyErrorBannerData | null>(() => {
+      // Inline banners are a sheet-mode-only surface. In legacy full-screen
+      // mode the equivalent error is surfaced via `errorMessage` instead.
+      if (!isSheetMode) {
+        return null;
+      }
+
+      if (isPlacingOrder || isConfirming) {
+        return null;
+      }
+
+      if (!activeOrder?.error) {
+        return null;
+      }
+
+      if (blockingPayAlertMessage && !isPredictBalanceSelected) {
+        return null;
+      }
+
+      const orderError = getPlaceOrderErrorOutcome({
+        error: activeOrder.error,
+        orderParams: { preview } as PlaceOrderParams,
+      });
+
+      if (!orderError) {
+        return null;
+      }
+
+      if (orderError.status === 'order_not_filled') {
+        const fallbackPrice = preview?.sharePrice ?? outcomeTokenPrice ?? 0;
+        return {
+          variant: 'price_changed',
+          title: strings('predict.order.price_changed_title'),
+          description: strings('predict.order.price_changed_body', {
+            price: formatCents(fallbackPrice),
+          }),
+        };
+      }
+
+      if (orderError.status === 'error') {
+        return {
+          variant: 'order_failed',
+          title: strings('predict.order.order_failed_title'),
+          description: strings('predict.order.order_failed_body'),
+        };
+      }
+
       return null;
+    }, [
+      activeOrder?.error,
+      preview,
+      outcomeTokenPrice,
+      isPlacingOrder,
+      isConfirming,
+      blockingPayAlertMessage,
+      isPredictBalanceSelected,
+      isSheetMode,
+    ]);
+
+  useEffect(() => {
+    if (currentBuyErrorBanner) {
+      setPersistedBuyErrorBanner(currentBuyErrorBanner);
     }
+  }, [currentBuyErrorBanner]);
 
-    if (isPlacingOrder || isConfirming) {
-      return null;
-    }
+  const shouldSuppressBuyErrorBanner =
+    !isSheetMode ||
+    isPlacingOrder ||
+    isConfirming ||
+    Boolean(blockingPayAlertMessage && !isPredictBalanceSelected);
 
-    if (!activeOrder?.error) {
-      return null;
-    }
-
-    if (blockingPayAlertMessage && !isPredictBalanceSelected) {
-      return null;
-    }
-
-    const orderError = getPlaceOrderErrorOutcome({
-      error: activeOrder.error,
-      orderParams: { preview } as PlaceOrderParams,
-    });
-
-    if (!orderError) {
-      return null;
-    }
-
-    if (orderError.status === 'order_not_filled') {
-      const fallbackPrice = preview?.sharePrice ?? outcomeTokenPrice ?? 0;
-      return {
-        variant: 'price_changed',
-        title: strings('predict.order.price_changed_title'),
-        description: strings('predict.order.price_changed_body', {
-          price: formatCents(fallbackPrice),
-        }),
-      };
-    }
-
-    if (orderError.status === 'error') {
-      return {
-        variant: 'order_failed',
-        title: strings('predict.order.order_failed_title'),
-        description: strings('predict.order.order_failed_body'),
-      };
-    }
-
-    return null;
-  }, [
-    activeOrder?.error,
-    preview,
-    outcomeTokenPrice,
-    isPlacingOrder,
-    isConfirming,
-    blockingPayAlertMessage,
-    isPredictBalanceSelected,
-    isSheetMode,
-  ]);
+  const buyErrorBanner =
+    currentBuyErrorBanner ??
+    (shouldSuppressBuyErrorBanner ? null : persistedBuyErrorBanner);
 
   const clearBuyErrorBanner = useCallback(() => {
     clearOrderError();
     setIsOrderNotFilled(false);
+    setPersistedBuyErrorBanner(null);
   }, [clearOrderError]);
 
   const resetOrderNotFilled = clearBuyErrorBanner;
@@ -209,7 +299,8 @@ export const usePredictBuyError = ({
   }, [errorResult]);
 
   return {
-    errorMessage,
+    errorMessage: errorMessageData?.message,
+    errorMessageSource: errorMessageData?.source,
     buyErrorBanner,
     isOrderNotFilled,
     resetOrderNotFilled,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
@@ -169,18 +169,10 @@ export const usePredictBuyError = ({
     }
 
     if (isInsufficientBalance) {
-      const formattedMax = formatPrice(maxBetAmount, {
-        minimumDecimals: 2,
-        maximumDecimals: 2,
-      });
-
       return {
-        message:
-          maxBetAmount >= MINIMUM_BET
-            ? strings('predict.order.prediction_insufficient_funds_try_token', {
-                amount: formattedMax,
-              })
-            : strings('predict.order.no_funds_enough_try_token'),
+        message: isPredictBalanceSelected
+          ? strings('predict.order.no_funds_enough')
+          : strings('predict.order.no_funds_enough_try_token'),
         source: 'insufficient_balance',
       };
     }

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import { MINIMUM_BET } from '../../../constants/transactions';
 import { usePredictActiveOrder } from '../../../hooks/usePredictActiveOrder';
@@ -72,7 +72,24 @@ export const usePredictBuyError = ({
   const [isOrderNotFilled, setIsOrderNotFilled] = useState(false);
   const [persistedBuyErrorBanner, setPersistedBuyErrorBanner] =
     useState<PredictBuyErrorBannerData | null>(null);
-  const { isPredictBalanceSelected } = usePredictPaymentToken();
+  const { isPredictBalanceSelected, selectedPaymentToken } =
+    usePredictPaymentToken();
+  const selectedPaymentTokenKey = useMemo(() => {
+    if (isPredictBalanceSelected) {
+      return 'predict-balance';
+    }
+
+    if (!selectedPaymentToken?.address || !selectedPaymentToken?.chainId) {
+      return 'external-token:unknown';
+    }
+
+    return `${selectedPaymentToken.chainId.toLowerCase()}:${selectedPaymentToken.address.toLowerCase()}`;
+  }, [
+    isPredictBalanceSelected,
+    selectedPaymentToken?.address,
+    selectedPaymentToken?.chainId,
+  ]);
+  const previousSelectedPaymentTokenKeyRef = useRef(selectedPaymentTokenKey);
 
   const errorResult = useMemo<PredictBuyErrorResult | undefined>(() => {
     if (
@@ -273,6 +290,17 @@ export const usePredictBuyError = ({
       setPersistedBuyErrorBanner(currentBuyErrorBanner);
     }
   }, [currentBuyErrorBanner]);
+
+  useEffect(() => {
+    if (
+      previousSelectedPaymentTokenKeyRef.current === selectedPaymentTokenKey
+    ) {
+      return;
+    }
+
+    previousSelectedPaymentTokenKeyRef.current = selectedPaymentTokenKey;
+    setPersistedBuyErrorBanner(null);
+  }, [selectedPaymentTokenKey]);
 
   const shouldSuppressBuyErrorBanner =
     !isSheetMode ||

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
@@ -194,7 +194,7 @@ describe('usePredictBuyInfo', () => {
       expect(result.current.total).toBe(110);
     });
 
-    it('keeps the last accepted deposit fee while confirming', () => {
+    it('returns 0 while confirming when pay totals no longer include fees', () => {
       mockIsPredictBalanceSelected = false;
       mockPayTotals = {
         fees: {
@@ -217,10 +217,10 @@ describe('usePredictBuyInfo', () => {
 
       rerender({ ...defaultParams, isConfirming: true });
 
-      expect(result.current.depositFee).toBe(5);
+      expect(result.current.depositFee).toBe(0);
     });
 
-    it('clears the accepted deposit fee after confirming ends', () => {
+    it('returns 0 after confirming ends when pay totals no longer include fees', () => {
       mockIsPredictBalanceSelected = false;
       mockPayTotals = {
         fees: {
@@ -244,6 +244,34 @@ describe('usePredictBuyInfo', () => {
       rerender({ ...defaultParams, isConfirming: false });
 
       expect(result.current.depositFee).toBe(0);
+    });
+
+    it('does not show stale deposit fee when switching back to Predict balance while confirming', () => {
+      mockIsPredictBalanceSelected = false;
+      mockPayTotals = {
+        fees: {
+          provider: { usd: 1.5 },
+          sourceNetwork: { estimate: { usd: 2.5 } },
+          targetNetwork: { usd: 1.0 },
+        },
+      };
+
+      const { result, rerender } = renderHook(
+        (params: typeof defaultParams) => usePredictBuyInfo(params),
+        {
+          initialProps: { ...defaultParams, isConfirming: true },
+        },
+      );
+
+      expect(result.current.depositFee).toBe(5);
+      expect(result.current.total).toBe(110);
+
+      mockIsPredictBalanceSelected = true;
+
+      rerender({ ...defaultParams, isConfirming: true });
+
+      expect(result.current.depositFee).toBe(0);
+      expect(result.current.total).toBe(105);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../../hooks/usePredictPaymentToken', () => ({
 jest.mock(
   '../../../../../Views/confirmations/hooks/pay/useTransactionPayData',
   () => ({
+    useTransactionPayQuotes: () => [],
     useTransactionPayTotals: () => mockPayTotals,
   }),
 );
@@ -173,7 +174,7 @@ describe('usePredictBuyInfo', () => {
       expect(result.current.depositFee).toBe(2.0);
     });
 
-    it('returns 0 when there is an insufficient pay token balance alert', () => {
+    it('includes depositFee in total when there is an insufficient pay token balance alert', () => {
       mockIsPredictBalanceSelected = false;
       mockPayTotals = {
         fees: {
@@ -188,7 +189,9 @@ describe('usePredictBuyInfo', () => {
 
       const { result } = renderHook(() => usePredictBuyInfo(defaultParams));
 
-      expect(result.current.depositFee).toBe(0);
+      expect(result.current.hasBlockingPayAlerts).toBe(true);
+      expect(result.current.depositFee).toBe(5);
+      expect(result.current.total).toBe(110);
     });
 
     it('keeps the last accepted deposit fee while confirming', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTransactionPayTotals } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
@@ -43,14 +43,12 @@ export const usePredictBuyInfo = ({
     [blockingPayAlerts],
   );
 
-  const [acceptedDepositFee, setAcceptedDepositFee] = useState(0);
-
   const totalPayForPredictBalance = useMemo(
     () => getPredictBuyAllInCost(preview),
     [preview],
   );
 
-  const computedDepositFee = useMemo(() => {
+  const depositFee = useMemo(() => {
     if (isPredictBalanceSelected || !payTotals?.fees) return 0;
     const { provider, sourceNetwork, targetNetwork } = payTotals.fees;
     return new BigNumber(provider?.usd ?? 0)
@@ -58,22 +56,6 @@ export const usePredictBuyInfo = ({
       .plus(targetNetwork?.usd ?? 0)
       .toNumber();
   }, [isPredictBalanceSelected, payTotals?.fees]);
-
-  useEffect(() => {
-    if (computedDepositFee > 0) {
-      setAcceptedDepositFee(computedDepositFee);
-    }
-  }, [computedDepositFee]);
-
-  useEffect(() => {
-    if (!isConfirming) {
-      setAcceptedDepositFee(0);
-    }
-  }, [isConfirming]);
-
-  const fallbackDepositFee = isConfirming ? acceptedDepositFee : 0;
-  const depositFee =
-    computedDepositFee > 0 ? computedDepositFee : fallbackDepositFee;
 
   const rewardsFeeAmount =
     isPlacingOrder || previewError ? undefined : (fees?.totalFee ?? 0);

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
@@ -1,9 +1,6 @@
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
-import {
-  useTransactionPayQuotes,
-  useTransactionPayTotals,
-} from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
+import { useTransactionPayTotals } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { useInsufficientPayTokenBalanceAlert } from '../../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts
@@ -1,6 +1,9 @@
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
-import { useTransactionPayTotals } from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayQuotes,
+  useTransactionPayTotals,
+} from '../../../../../Views/confirmations/hooks/pay/useTransactionPayData';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import { OrderPreview } from '../../../types';
 import { useInsufficientPayTokenBalanceAlert } from '../../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert';
@@ -51,14 +54,13 @@ export const usePredictBuyInfo = ({
   );
 
   const computedDepositFee = useMemo(() => {
-    if (isPredictBalanceSelected || !payTotals?.fees || hasBlockingPayAlerts)
-      return 0;
+    if (isPredictBalanceSelected || !payTotals?.fees) return 0;
     const { provider, sourceNetwork, targetNetwork } = payTotals.fees;
     return new BigNumber(provider?.usd ?? 0)
       .plus(sourceNetwork?.estimate?.usd ?? 0)
       .plus(targetNetwork?.usd ?? 0)
       .toNumber();
-  }, [isPredictBalanceSelected, payTotals?.fees, hasBlockingPayAlerts]);
+  }, [isPredictBalanceSelected, payTotals?.fees]);
 
   useEffect(() => {
     if (computedDepositFee > 0) {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
@@ -297,6 +297,43 @@ describe('usePredictDefaultPaymentToken', () => {
     expect(mockOnPaymentTokenChange).toHaveBeenCalledTimes(1);
   });
 
+  it('does not auto-select again when the same sheet returns to PREVIEW after a manual Predict balance selection', () => {
+    mockPredictBalance = 0.5;
+    mockTokens = [
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
+    ];
+
+    const { rerender } = renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledTimes(1);
+
+    mockActiveOrder = { state: ActiveOrderState.PAY_WITH_ANY_TOKEN };
+    rerender({});
+
+    mockActiveOrder = { state: ActiveOrderState.PREVIEW };
+    rerender({});
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledTimes(1);
+    expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
+  });
+
+  it('still initializes when the active order reaches PREVIEW for the first time', () => {
+    mockPredictBalance = 0.5;
+    mockActiveOrder = { state: ActiveOrderState.DEPOSITING };
+    mockTokens = [
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
+    ];
+
+    const { rerender } = renderHook(() => usePredictDefaultPaymentToken());
+
+    expect(mockOnPaymentTokenChange).not.toHaveBeenCalled();
+
+    mockActiveOrder = { state: ActiveOrderState.PREVIEW };
+    rerender({});
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledTimes(1);
+  });
+
   it('skips non-EVM or non-ERC20 tokens when auto-selecting', () => {
     mockPredictBalance = 0.5;
     mockTokens = [

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.test.ts
@@ -192,14 +192,25 @@ describe('usePredictDefaultPaymentToken', () => {
     expect(mockOnPaymentTokenChange).not.toHaveBeenCalled();
   });
 
-  it('falls back to predict balance when tokens array is empty', () => {
+  it('waits for account tokens before falling back or auto-selecting', () => {
     mockPredictBalance = 0.5;
     mockTokens = [];
 
-    renderHook(() => usePredictDefaultPaymentToken());
+    const { rerender } = renderHook(() => usePredictDefaultPaymentToken());
 
     expect(mockOnPaymentTokenChange).not.toHaveBeenCalled();
-    expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
+    expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
+
+    mockTokens = [
+      createEvmErc20Token({ address: '0x1', symbol: 'USDC', fiatBalance: 100 }),
+    ];
+
+    rerender({});
+
+    expect(mockOnPaymentTokenChange).toHaveBeenCalledWith(
+      expect.objectContaining({ address: '0x1', symbol: 'USDC' }),
+    );
+    expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
   });
 
   it('falls back to predict balance when no tokens have positive fiat balance', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
@@ -38,10 +38,9 @@ export function usePredictDefaultPaymentToken() {
     if (isBalanceLoading) return;
     if (activeOrder?.state !== ActiveOrderState.PREVIEW) return;
 
-    hasInitializedRef.current = true;
-
     const balance = predictBalance ?? 0;
     if (balance >= MINIMUM_BET) {
+      hasInitializedRef.current = true;
       resetSelectedPaymentToken();
       return;
     }
@@ -58,8 +57,14 @@ export function usePredictDefaultPaymentToken() {
     );
 
     if (bestToken) {
+      hasInitializedRef.current = true;
       onPaymentTokenChange(bestToken);
     } else {
+      if (tokens.length === 0) {
+        return;
+      }
+
+      hasInitializedRef.current = true;
       resetSelectedPaymentToken();
     }
   }, [

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictDefaultPaymentToken.ts
@@ -10,11 +10,10 @@ import { ActiveOrderState } from '../../../types';
 import { isTestNet } from '../../../../../../util/networks';
 
 /**
- * Initializes the payment token selection on the buy screen. Waits for
- * the active order to reach PREVIEW state (after initPayWithAnyToken),
- * then either resets to Predict balance or auto-selects the token with
- * the highest fiat balance when Predict balance is below MINIMUM_BET.
- * Resets when the order leaves PREVIEW so it re-runs for the next market.
+ * Initializes the payment token selection once per mounted buy sheet. Waits
+ * for the active order to reach PREVIEW state (after initPayWithAnyToken),
+ * then either resets to Predict balance or auto-selects the token with the
+ * highest fiat balance when Predict balance is below MINIMUM_BET.
  */
 export function usePredictDefaultPaymentToken() {
   const { data: predictBalance, isLoading: isBalanceLoading } =
@@ -24,14 +23,6 @@ export function usePredictDefaultPaymentToken() {
   const { activeOrder } = usePredictActiveOrder();
   const tokens = useAccountTokens();
   const hasInitializedRef = useRef(false);
-  const prevOrderRef = useRef(activeOrder);
-
-  useEffect(() => {
-    if (activeOrder !== prevOrderRef.current) {
-      prevOrderRef.current = activeOrder;
-      hasInitializedRef.current = false;
-    }
-  }, [activeOrder]);
 
   useEffect(() => {
     if (hasInitializedRef.current) return;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes Predict pay-with-any-token quote and CTA timing issues that could appear when users changed payment tokens.

The quote trigger previously deduped updates only by amount, so a new transaction or selected token using the same amount could skip `updatePendingAmount` / `updateTokenAmountCallback` and fail to start the quote request. This PR keys those emissions by transaction id, token address, and chain id so the same amount is still emitted when the active transaction or payment token changes.

The Predict buy CTA could also remain enabled briefly while the payment selector was closing and before the new quote loading state appeared. This PR adds a Predict-only payment-selector navigation lock in `usePredictBuyConditions`, disables the buy CTA/pay row immediately when the selector opens, and releases the lock one second after the screen regains focus.

It also waits for account tokens before defaulting back to Predict balance, avoiding an early fallback while token data is still empty.

Finally, this keeps transaction-pay alert text visible in the Predict bottom-sheet flow, including while quote/pay-fee loading is in progress, and persists order-failed banners after the controller refreshes active order state, preventing alert/banner flicker.

When a pay-totals alert is returned with fee data, the displayed Total now still includes the deposit fee so users can see the actual amount required by the selected payment token.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bugs that could prevent Predict pay-with-any-token quotes and alerts from refreshing correctly after changing payment tokens

## **Related issues**

Fixes: [PRED-882](https://consensyssoftware.atlassian.net/browse/PRED-882?atlOrigin=eyJpIjoiNTlkZTZkMmI1MTJkNDEyZmE0ZTE5NjUxZmVhNDg1ZjQiLCJwIjoiaiJ9)

## **Manual testing steps**

```gherkin
Feature: Predict pay with any token quote refresh

  Scenario: user changes the payment token before placing a bet
    Given the Predict pay-with-any-token feature is enabled
    And the user opens a Predict buy preview with a valid bet amount
    And an external payment token is selected

    When the user opens the payment token selector
    Then the buy CTA is disabled while the selector is open

    When the user selects a different supported payment token
    And the selector closes
    Then the buy CTA remains disabled while the quote refresh starts
    And the quote request is triggered for the selected token and current bet amount
    And the buy CTA only becomes enabled after the quote state has settled

  Scenario: user sees payment and order errors in the Predict bottom sheet
    Given the user opens a Predict buy preview in bottom-sheet mode

    When the selected payment token cannot cover the quote
    Then the transaction-pay alert remains visible

    When order placement fails
    Then the order-failed banner remains visible until the user retries, changes the amount, or closes the sheet
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict buy/payment gating, navigation timing, and error surfacing logic; issues could block order placement or hide critical alerts if the new lock/settling conditions misfire.
> 
> **Overview**
> **Predict pay-with-any-token quote/CTA timing is hardened.** Adds a payment-selector navigation lock (with 1s delayed unlock + 5s safety timeout) and threads it through `PredictBuyWithAnyToken`/`usePredictBuyConditions` to disable the buy CTA and `PredictPayWithRow` immediately while the selector is opening/closing.
> 
> **Quote settling and emissions are made token/tx-aware.** `usePredictBuyConditions` now treats settling as a *token+chain+amount* key (not just token address), and `PredictPayWithAnyTokenInfo` dedupes `updatePendingAmount`/`updateTokenAmount` by `transactionMeta.id + token address + chainId` so selecting a new token/tx with the same amount still re-triggers quotes.
> 
> **Error UX is refined for sheet mode.** `usePredictBuyError` now returns `errorMessageSource`, prioritizes blocking pay-alert text (even while pay fees load), persists `order_failed` banners across controller refreshes, and clears persisted banners on token change; `PredictBuyWithAnyToken` conditionally suppresses only insufficient-balance helper text in Change Payment/Add Funds modes while keeping blocking pay alerts visible alongside banners.
> 
> **Default token and fee display behavior is adjusted.** `usePredictDefaultPaymentToken` waits for account tokens before falling back, and `usePredictBuyInfo` always computes `depositFee` from `payTotals` (including when pay alerts exist) without caching a “last accepted” fee during confirming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea34d01d5b11bc8c907e0fd0c85c1cfb1ed90fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PRED-882]: https://consensyssoftware.atlassian.net/browse/PRED-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ