### PR TITLE
chore(theme): gate pure-black dark mode behind pureBlackDarkMode flag

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -222,6 +222,5 @@ export MM_HARDWARE_WALLET_ONBOARDING_REDESIGN=
 
 ## Pure-black design-tokens preview
 # Set to "true" to render dark mode against the DS pure-black preview tokens
-# (mirrors the cursor/background-default-pure-black-2ad1 DS branch). Audit
-# tool for the pure-black migration — does not ship the preview package.
+# Audit tool for the pure-black migration — does not ship the preview package
 export MM_PURE_BLACK_PREVIEW="false"

--- a/.js.env.example
+++ b/.js.env.example
@@ -219,3 +219,9 @@ export MM_BRAZE_API_KEY_ANDROID=
 
 ## Hardware Wallet Redesign
 export MM_HARDWARE_WALLET_ONBOARDING_REDESIGN=
+
+## Pure-black design-tokens preview
+# Set to "true" to render dark mode against the DS pure-black preview tokens
+# (mirrors the cursor/background-default-pure-black-2ad1 DS branch). Audit
+# tool for the pure-black migration — does not ship the preview package.
+export MM_PURE_BLACK_PREVIEW="false"

--- a/app/util/theme/preBootPureBlack.ts
+++ b/app/util/theme/preBootPureBlack.ts
@@ -13,9 +13,9 @@
  * twrnc preset. If the DS team ever freezes the exported token objects,
  * this approach breaks and we fall back to forking the preset.
  *
- * Flag source: hardcoded constant below, gated on `__DEV__`. Flip
- * `PURE_BLACK_ENABLED` to `true` in your working copy, restart Metro, audit
- * your flows, flip back. Will never apply in release builds.
+ * Flag source: `MM_PURE_BLACK_PREVIEW` in `.js.env`. Inlined at bundle time
+ * by `babel-plugin-transform-inline-environment-variables`. Default is off;
+ * set to `"true"` in `.js.env` (or in a CI build profile's env) and rebuild.
  *
  * Values mirror the DS preview branch `cursor/background-default-pure-black-2ad1`
  * commit c84e301a "feat: Refine pure black colors (#1137)". Re-diff and update
@@ -23,11 +23,13 @@
  */
 /* eslint-disable @metamask/design-tokens/color-no-hex */
 import { brandColor, darkTheme } from '@metamask/design-tokens';
+import Logger from '../Logger';
 
-// Flip locally to audit your flows; never commit as `true`.
-const PURE_BLACK_ENABLED = false;
+const PURE_BLACK_ENABLED = process.env.MM_PURE_BLACK_PREVIEW === 'true';
 
-if (__DEV__ && PURE_BLACK_ENABLED) {
+Logger.log('[pure-black] enabled:', PURE_BLACK_ENABLED);
+
+if (PURE_BLACK_ENABLED) {
   Object.assign(brandColor, {
     grey600: '#2b2b30',
     grey700: '#222226',
@@ -62,6 +64,5 @@ if (__DEV__ && PURE_BLACK_ENABLED) {
     muted: '#e2e2ff26',
   });
 
-  // eslint-disable-next-line no-console
-  console.log('[pure-black] preview tokens applied');
+  Logger.log('[pure-black] preview tokens applied');
 }

--- a/app/util/theme/preBootPureBlack.ts
+++ b/app/util/theme/preBootPureBlack.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure-black preview override.
+ *
+ * Mutates `brandColor` and `darkTheme.colors` from `@metamask/design-tokens`
+ * at module-load time, BEFORE `@metamask/design-system-twrnc-preset` imports
+ * them. The twrnc preset bakes token values into its Tailwind config at
+ * import time (see `themeColors` in the preset's `colors.ts`), so the only
+ * way to make `bg-default` / `border-muted` / etc. resolve to pure-black
+ * values is to mutate the upstream token objects first.
+ *
+ * Contract: this file MUST be the first import in `index.js`, before any
+ * other module that transitively imports `@metamask/design-tokens` or the
+ * twrnc preset. If the DS team ever freezes the exported token objects,
+ * this approach breaks and we fall back to forking the preset.
+ *
+ * Flag source: hardcoded constant below, gated on `__DEV__`. Flip
+ * `PURE_BLACK_ENABLED` to `true` in your working copy, restart Metro, audit
+ * your flows, flip back. Will never apply in release builds.
+ *
+ * Values mirror the DS preview branch `cursor/background-default-pure-black-2ad1`
+ * commit c84e301a "feat: Refine pure black colors (#1137)". Re-diff and update
+ * when the preview branch advances.
+ */
+/* eslint-disable @metamask/design-tokens/color-no-hex */
+import { brandColor, darkTheme } from '@metamask/design-tokens';
+
+// Flip locally to audit your flows; never commit as `true`.
+const PURE_BLACK_ENABLED = false;
+
+if (__DEV__ && PURE_BLACK_ENABLED) {
+  Object.assign(brandColor, {
+    grey600: '#2b2b30',
+    grey700: '#222226',
+    grey800: '#18181b',
+    grey900: '#0d0d0f',
+    grey1000: '#000000',
+  });
+
+  Object.assign(darkTheme.colors.background, {
+    default: brandColor.grey1000,
+    alternative: brandColor.grey900,
+    section: brandColor.grey800,
+    subsection: brandColor.grey700,
+    muted: '#e2e2ff1b',
+    defaultHover: '#18181b',
+    defaultPressed: '#222226',
+    mutedHover: '#e2e2ff26',
+    mutedPressed: '#e2e2ff30',
+    hover: '#e2e2ff1b',
+    pressed: '#e2e2ff30',
+  });
+
+  Object.assign(darkTheme.colors.text, {
+    muted: brandColor.grey500,
+  });
+
+  Object.assign(darkTheme.colors.icon, {
+    muted: brandColor.grey500,
+  });
+
+  Object.assign(darkTheme.colors.border, {
+    muted: '#e2e2ff26',
+  });
+
+  // eslint-disable-next-line no-console
+  console.log('[pure-black] preview tokens applied');
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+// Pure-black preview token override. MUST be first — mutates upstream
+// design-tokens before the twrnc preset imports them. See file for details.
+import './app/util/theme/preBootPureBlack';
+
 // Shim is used to ensure API compatibility for React Native and provides polyfills for globals
 import './shim.js';
 


### PR DESCRIPTION
## **Description**

The design system is shifting dark mode from dark grey to pure black. Some components hardcode colors or render poorly against pure black (disappearing backgrounds, broken contrast), so every flow needs an audit. The original plan was a long-lived branch `chore/test-design-tokens-preview-dbe1fac` merged as one mega-PR but decided on this approach

This PR introduces a feature flag `pureBlackDarkMode` that gates a pure-black override in the dark theme. Default behavior is unchanged; flipping the flag re-renders the tree against pure black so teams can audit their own surfaces and ship fixes independently.

**Options considered**

- **A. Long-lived feature branch (original plan).** No flag plumbing, but produces one huge PR with constant rebase pain and blocks teams from shipping incrementally.
- **B. npm alias to ship both token packages in parallel.** Lets old and new tokens coexist at runtime, but adds bundle bloat and is unnecessary since the new tokens are just a new version of the same package.
- **C. Single package bump + feature flag (chosen).** One package, no bloat; reuses existing `RemoteFeatureFlagController` + local override; theme provider is already runtime-reactive so flips re-render instantly. Small "legacy color override" map is the only ongoing cost, and it's deleted in one final cleanup.

**Why C**

Other teams can audit and fix their flows on their own cadence in normal small PRs against `main`, no shared branch to coordinate around. Per design system feedback, this also matches the right phasing: keep token experimentation in-app while colors are still being finalized, and only carry decisions back into MMDS preview builds once they're locked. Pushing changes through MMDS releases and package management while designs are still in flux is painful; iterating in-app first. Same approach DS team used for Headers, keeps the feedback loop tight.

**Rollout phases**

1. **Beta:** override tokens in mobile/extension under the flag to finalize colors and propagate work to teams.
2. **Decision:** once locked, mirror token changes into MMDS preview build PRs for double-check.
3. **Merge:** once preview builds are approved, merge into MMDS and remove the flag + override map.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-743

## **Manual testing steps**

```gherkin
Feature: pure-black dark mode feature flag

  Scenario: flag off (default)
    Given the app is running in dark mode
    And pureBlackDarkMode is not overridden
    Then dark mode renders with the existing dark-grey backgrounds

  Scenario: flag on
    Given the app is running in dark mode
    When user calls useFeatureFlagOverride().setOverride('pureBlackDarkMode', true)
    Then background.default and background.alternative render as #000000
    And the change applies across the tree without a reload
```

## **Screenshots/Recordings**

### Current branch

https://github.com/user-attachments/assets/29f508b8-590c-4149-b2cf-74619ccce78a

### Compared to patched package with pure black (the real deal)

https://github.com/user-attachments/assets/cb9798aa-ccab-4568-a059-2772527ff46a


### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces global, import-order-sensitive mutation of `@metamask/design-tokens` at app startup; while gated off by default, enabling it changes core theme colors app-wide and could cause unexpected styling regressions.
> 
> **Overview**
> Adds an *opt-in* pure-black dark-mode preview gated by `MM_PURE_BLACK_PREVIEW` (default `false`), documented in `.js.env.example`.
> 
> Introduces `preBootPureBlack.ts`, which conditionally mutates `@metamask/design-tokens` (`brandColor` and `darkTheme.colors`) at module-load time, and wires it into `index.js` as the first import so Tailwind/twrnc preset token values resolve to the overridden pure-black palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bdef392bd45048fd92b04994da4a4f7e2b0e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->