### PR TITLE
refactor: migrate `WalletDetails` to design-system-react-native

### DIFF
--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/components/AddAccountItem.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/components/AddAccountItem.tsx
@@ -8,14 +8,14 @@ import {
   JustifyContent,
 } from '../../../../../UI/Box/box.types';
 import { Box } from '../../../../../UI/Box/Box';
-import Text, {
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconSize,
-  IconName,
+import {
+  Icon,
   IconColor,
-} from '../../../../../../component-library/components/Icons/Icon';
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import AnimatedSpinner, {
   SpinnerSize,
 } from '../../../../../UI/AnimatedSpinner';
@@ -71,11 +71,11 @@ export const AddAccountItem: React.FC<AddAccountItemProps> = ({
             <Icon
               name={IconName.Add}
               size={IconSize.Md}
-              color={IconColor.Primary}
+              color={IconColor.PrimaryDefault}
             />
           )}
         </Box>
-        <Text variant={TextVariant.BodyMD} style={styles.addAccountButtonText}>
+        <Text variant={TextVariant.BodyMd} style={styles.addAccountButtonText}>
           {isLoading
             ? strings('multichain_accounts.wallet_details.creating_account')
             : strings('multichain_accounts.wallet_details.create_account')}
@@ -84,5 +84,3 @@ export const AddAccountItem: React.FC<AddAccountItemProps> = ({
     </TouchableOpacity>
   );
 };
-
-export default AddAccountItem;

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.test.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.test.tsx
@@ -23,7 +23,6 @@ import {
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
-import { AvatarAccountType } from '../../../../../component-library/components/Avatars/Avatar';
 
 jest.mock('../utils/getInternalAccountsFromWallet');
 jest.mock('../hooks/useWalletBalances');
@@ -184,7 +183,7 @@ const mockWallet = createMockWallet('1', 'Test Wallet', [
 
 const mockInitialState: Partial<RootState> = {
   settings: {
-    avatarAccountType: AvatarAccountType.Maskicon,
+    avatarAccountType: 'Maskicon',
   },
   engine: {
     backgroundState: {

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
@@ -4,15 +4,18 @@ import { TouchableOpacity, View } from 'react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import HeaderBase from '../../../../../component-library/components/HeaderBase';
-import ButtonLink from '../../../../../component-library/components/Buttons/Button/variants/ButtonLink';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconSize,
+import {
+  FontWeight,
+  HeaderBase,
+  ButtonIconSize,
+  Icon,
+  IconColor,
   IconName,
-} from '../../../../../component-library/components/Icons/Icon';
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { WalletDetailsIds } from '../WalletDetails.testIds';
 import {
   AlignItems,
@@ -36,7 +39,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
 import AccountCell from '../../../../../component-library/components-temp/MultichainAccounts/AccountCell/AccountCell';
 import { selectAccountGroupsByWallet } from '../../../../../selectors/multichainAccounts/accountTreeController';
-import AddAccountItem from './components/AddAccountItem';
+import { AddAccountItem } from './components/AddAccountItem';
 import Logger from '../../../../../util/Logger';
 import Engine from '../../../../../core/Engine';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
@@ -51,8 +54,7 @@ export const BaseWalletDetails = ({
   children,
 }: BaseWalletDetailsProps) => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(styleSheet, {});
-  const { colors } = theme;
+  const { styles } = useStyles(styleSheet, {});
   const [isLoading, setIsLoading] = useState(false);
   const accountGroupsFlashListRef =
     useRef<FlashListRef<AccountGroupListItem> | null>(null);
@@ -169,14 +171,13 @@ export const BaseWalletDetails = ({
     <SafeAreaView style={styles.safeArea}>
       <HeaderBase
         style={styles.header}
-        startAccessory={
-          <ButtonLink
-            testID={WalletDetailsIds.BACK_BUTTON}
-            labelTextVariant={TextVariant.BodyMDMedium}
-            label={<Icon name={IconName.ArrowLeft} size={IconSize.Md} />}
-            onPress={() => navigation.goBack()}
-          />
-        }
+        startButtonIconProps={{
+          testID: WalletDetailsIds.BACK_BUTTON,
+          iconName: IconName.ArrowLeft,
+          size: ButtonIconSize.Md,
+          onPress: () => navigation.goBack(),
+          accessibilityLabel: strings('navigation.back'),
+        }}
       >
         {wallet.metadata.name}
       </HeaderBase>
@@ -185,7 +186,7 @@ export const BaseWalletDetails = ({
         testID={WalletDetailsIds.WALLET_DETAILS_CONTAINER}
       >
         <View style={styles.walletName}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('multichain_accounts.wallet_details.wallet_name')}
           </Text>
           <Box
@@ -194,13 +195,17 @@ export const BaseWalletDetails = ({
             alignItems={AlignItems.center}
             gap={8}
           >
-            <Text style={styles.text} variant={TextVariant.BodyMDMedium}>
+            <Text
+              style={styles.text}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >
               {wallet.metadata.name}
             </Text>
           </Box>
         </View>
         <View testID={WalletDetailsIds.WALLET_BALANCE} style={styles.balance}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('multichain_accounts.wallet_details.balance')}
           </Text>
           <Box
@@ -211,7 +216,11 @@ export const BaseWalletDetails = ({
             {formattedWalletTotalBalance === undefined ? (
               <AnimatedSpinner size={SpinnerSize.SM} />
             ) : (
-              <Text style={styles.text} variant={TextVariant.BodyMDMedium}>
+              <Text
+                style={styles.text}
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+              >
                 {formattedWalletTotalBalance}
               </Text>
             )}
@@ -223,7 +232,7 @@ export const BaseWalletDetails = ({
             onPress={handleRevealSRP}
             style={styles.srpSection}
           >
-            <Text variant={TextVariant.BodyMDMedium}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('accounts.secret_recovery_phrase')}
             </Text>
             <Box
@@ -239,8 +248,9 @@ export const BaseWalletDetails = ({
                 {isSRPBackedUp === false && (
                   <TouchableOpacity onPress={handleBackupPressed}>
                     <Text
-                      variant={TextVariant.BodyMDMedium}
-                      style={{ color: colors.error.default }}
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                      color={TextColor.ErrorDefault}
                     >
                       {strings('multichain_accounts.wallet_details.back_up')}
                     </Text>
@@ -249,7 +259,7 @@ export const BaseWalletDetails = ({
                 <Icon
                   name={IconName.ArrowRight}
                   size={IconSize.Md}
-                  color={colors.text.alternative}
+                  color={IconColor.IconAlternative}
                 />
               </Box>
             </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Migrates `WalletDetails`, `BaseWalletDetails` and `AddAccountItem` imports from deprecated component-library components to `@metamask/design-system-react-native` named imports.
- Replaces the deprecated `ButtonLink` back button with HeaderBase `startButtonIconProps`.
- Updates the `BaseWalletDetails` test to avoid importing the deprecated `AvatarAccountType` enum.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/MUL-1690

## **Manual testing steps**

```gherkin
Feature: Multichain Account Details (shell and modal, part 2)

  Scenario: Wallet details screen, header, and back navigation
    Given the user opened Multichain Wallet Details from the accounts flow
    When the header shows the wallet name, all the wallet properties, and accounts
    Then the back control returns to the previous screen without layout regressions
```

## **Screenshots/Recordings**

<img width="300" alt="Simulator Screenshot - iPhone 16 - 2026-05-14 at 00 07 11" src="https://github.com/user-attachments/assets/93c9da5c-f8bf-4459-92de-0e6534cc7f84" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUL-1689]: https://consensyssoftware.atlassian.net/browse/MUL-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that primarily swaps component imports/props and updates tests; main risk is minor visual/accessibility regressions from design-system prop/variant changes.
> 
> **Overview**
> Migrates `BaseWalletDetails` and `AddAccountItem` from deprecated component-library `Text`/`Icon`/`HeaderBase`/`ButtonLink` usage to `@metamask/design-system-react-native`, including updated typography variants, colors, and icon color tokens.
> 
> Replaces the custom back `ButtonLink` with `HeaderBase` `startButtonIconProps` (adds `accessibilityLabel`) and converts `AddAccountItem` to a named export, updating imports accordingly.
> 
> Updates `BaseWalletDetails` tests to avoid importing deprecated `AvatarAccountType` by using the `'Maskicon'` literal in initial state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97a1b227e6c4673b16934ef421cc79b852a64bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->