### PR TITLE
fix(skills): pin *.sh to LF so scripts run in WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Windows files should use crlf line endings
 # https://help.github.com/articles/dealing-with-line-endings/
 *.bat text eol=crlf
+
+# Shell scripts must keep LF so they run in WSL on Windows.
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- Pin `*.sh` to `eol=lf` in `.gitattributes`.
- Without it, Windows clones with `core.autocrlf=true` rewrite `scripts/skills-sync.sh` to CRLF, and `bash` fails in WSL with `set: invalid option` and `$'\r': command not found`. Git Bash tolerated it; WSL did not.
- Companion fix to the extension PR ([MetaMask/metamask-extension#42488](https://github.com/MetaMask/metamask-extension/pull/42488)) and the upstream `.gitattributes` in Consensys/skills.

## Test plan
- [ ] `git check-attr -a scripts/skills-sync.sh` reports `eol: lf`
- [ ] Fresh clone on Windows/WSL keeps LF; `yarn skills` runs without `\r` errors
- [ ] macOS/Linux: no diff after pull

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to git line-ending attributes; it only affects how `*.sh` files are checked out on Windows/WSL and should not impact runtime logic.
> 
> **Overview**
> Ensures `*.sh` files are always checked out with **LF** by adding `*.sh text eol=lf` to `.gitattributes`, preventing Windows `autocrlf` clones from rewriting scripts to CRLF and breaking execution in WSL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788deae01ed89992aaf88536c651bcf02b97314a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->