### PR TITLE
chore(release): release-changelog/7.76.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.76.3]
+
+### Added
+
+- Added Predict transaction publishing hooks to support the Polymarket Deposit Wallet flow. (#29914)
+- Added support for depositing to a Polymarket Deposit Wallet in Predict, while preserving legacy Safe behavior for users with existing Polymarket activity. (#29917)
+- Added Polymarket Deposit Wallet order placement support in Predict. (#29933)
+- Added support for claiming Predict positions through the Polymarket Deposit Wallet. (#29936)
+
+### Fixed
+
+- Disabled Predict withdrawals for Polymarket Deposit Wallet users with a temporary "withdrawals unavailable" bottom sheet, while legacy Safe users keep the existing flow. (#29941)
+
 ## [7.76.0]
 
 ### Added
@@ -11422,7 +11435,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.76.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.76.3...HEAD
+[7.76.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.76.0...v7.76.3
 [7.76.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.75.1...v7.76.0
 [7.75.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.75.0...v7.75.1
 [7.75.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.74.3...v7.75.0


### PR DESCRIPTION
## **Description**

Adds a `7.76.3` section to `CHANGELOG.md` covering the 5 cherry-picked PRs on `release/7.76.3-ota` 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Cherry-picked PRs included in `release/7.76.3-ota`:
- #29914 — feat(predict): add confirmation hook plumbing
- #29917 — feat(predict): add deposit wallet deposit foundation
- #29933 — feat(predict): add Deposit Wallet order flow
- #29936 — feat(predict): add deposit wallet claim flow
- #29941 — fix(predict): disable Deposit Wallet withdrawals



## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates `CHANGELOG.md` release notes and compare links with no runtime or logic impact.
> 
> **Overview**
> Adds a new `7.76.3` section to `CHANGELOG.md` documenting the Predict Polymarket Deposit Wallet work (deposit/order/claim flows, publishing hooks) and the temporary withdrawal disablement for deposit-wallet users.
> 
> Updates the footer compare links so `[Unreleased]` now compares from `v7.76.3`, and adds the `[7.76.3]` compare link (`v7.76.0...v7.76.3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271161b8acd5babfafffbc9dcd2c560c08d5e0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->