### PR TITLE
test(snaps): Revert broken E2E change

### DIFF
--- a/tests/smoke/snaps/test-snap-get-entropy.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-entropy.spec.ts
@@ -8,28 +8,7 @@ import Assertions from '../../framework/Assertions';
 
 jest.setTimeout(150_000);
 
-/**
- * The account-activity mock WebSocket (started with default fixtures) keeps the
- * iOS UI busy in Detox's view; disable sync for the test body so gestures and
- * webview scripts are not blocked waiting for idle. Same idea as
- * test-snap-network-access.spec.ts (WebSocket section).
- */
-async function withIosDetoxSyncDisabledForAccountActivityWs<T>(
-  fn: () => Promise<T>,
-): Promise<T> {
-  if (device.getPlatform() === 'ios') {
-    await device.disableSynchronization();
-  }
-  try {
-    return await fn();
-  } finally {
-    if (device.getPlatform() === 'ios') {
-      await device.enableSynchronization();
-    }
-  }
-}
-
-describe.skip(SmokeSnaps('Get Entropy Snap Tests'), () => {
+describe(SmokeSnaps('Get Entropy Snap Tests'), () => {
   it('connects to the Get Entropy Snap', async () => {
     await withFixtures(
       {
@@ -38,13 +17,11 @@ describe.skip(SmokeSnaps('Get Entropy Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
-        await withIosDetoxSyncDisabledForAccountActivityWs(async () => {
-          await loginToApp();
-          await navigateToBrowserView();
-          await TestSnaps.navigateToTestSnap();
+        await loginToApp();
+        await navigateToBrowserView();
+        await TestSnaps.navigateToTestSnap();
 
-          await TestSnaps.installSnap('connectGetEntropyButton');
-        });
+        await TestSnaps.installSnap('connectGetEntropyButton');
       },
     );
   });
@@ -56,18 +33,16 @@ describe.skip(SmokeSnaps('Get Entropy Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
-        await withIosDetoxSyncDisabledForAccountActivityWs(async () => {
-          await TestSnaps.fillMessage('entropyMessageInput', '1234');
-          await TestSnaps.tapButton('signEntropyMessageButton');
-          await Assertions.expectTextDisplayed('Signature request', {
-            description: 'Snap signature request should be visible',
-          });
-          await TestSnaps.approveSignRequest();
-          await TestSnaps.checkResultSpan(
-            'entropySignResultSpan',
-            '"0x9341785782b512c86235612365f1076b16731ed9473beb4d0804c30b7fcc3a055aa7103b02dc64014d923220712dfbef023ddcf6327b313ea2dfd4d83dc5a53e1c5e7f4e10bce49830eded302294054df8a7a46e5b6cb3e50eec564ecba17941"',
-          );
+        await TestSnaps.fillMessage('entropyMessageInput', '1234');
+        await TestSnaps.tapButton('signEntropyMessageButton');
+        await Assertions.expectTextDisplayed('Signature request', {
+          description: 'Snap signature request should be visible',
         });
+        await TestSnaps.approveSignRequest();
+        await TestSnaps.checkResultSpan(
+          'entropySignResultSpan',
+          '"0x9341785782b512c86235612365f1076b16731ed9473beb4d0804c30b7fcc3a055aa7103b02dc64014d923220712dfbef023ddcf6327b313ea2dfd4d83dc5a53e1c5e7f4e10bce49830eded302294054df8a7a46e5b6cb3e50eec564ecba17941"',
+        );
       },
     );
   });
@@ -90,22 +65,17 @@ describe.skip(SmokeSnaps('Get Entropy Snap Tests'), () => {
           skipReactNativeReload: true,
         },
         async () => {
-          await withIosDetoxSyncDisabledForAccountActivityWs(async () => {
-            await TestSnaps.selectInDropdown(
-              'getEntropyDropDown',
-              entropySource,
-            );
-            await TestSnaps.fillMessage('entropyMessageInput', '5678');
-            await TestSnaps.tapButton('signEntropyMessageButton');
-            await Assertions.expectTextDisplayed('Signature request', {
-              description: 'Snap signature request should be visible',
-            });
-            await TestSnaps.approveSignRequest();
-            await TestSnaps.checkResultSpan(
-              'entropySignResultSpan',
-              `"${result}"`,
-            );
+          await TestSnaps.selectInDropdown('getEntropyDropDown', entropySource);
+          await TestSnaps.fillMessage('entropyMessageInput', '5678');
+          await TestSnaps.tapButton('signEntropyMessageButton');
+          await Assertions.expectTextDisplayed('Signature request', {
+            description: 'Snap signature request should be visible',
           });
+          await TestSnaps.approveSignRequest();
+          await TestSnaps.checkResultSpan(
+            'entropySignResultSpan',
+            `"${result}"`,
+          );
         },
       );
     },
@@ -118,17 +88,15 @@ describe.skip(SmokeSnaps('Get Entropy Snap Tests'), () => {
         skipReactNativeReload: true,
       },
       async () => {
-        await withIosDetoxSyncDisabledForAccountActivityWs(async () => {
-          await TestSnaps.selectInDropdown('getEntropyDropDown', 'Invalid');
-          await TestSnaps.fillMessage('entropyMessageInput', 'foo bar');
-          await TestSnaps.tapButton('signEntropyMessageButton');
-          await TestSnaps.approveSignRequest();
-          await Assertions.expectTextDisplayed(
-            'Entropy source with ID "invalid" not found.',
-            { timeout: 30000 },
-          );
-          await TestSnaps.dismissAlert();
-        });
+        await TestSnaps.selectInDropdown('getEntropyDropDown', 'Invalid');
+        await TestSnaps.fillMessage('entropyMessageInput', 'foo bar');
+        await TestSnaps.tapButton('signEntropyMessageButton');
+        await TestSnaps.approveSignRequest();
+        await Assertions.expectTextDisplayed(
+          'Entropy source with ID "invalid" not found.',
+          { timeout: 30000 },
+        );
+        await TestSnaps.dismissAlert();
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

https://github.com/MetaMask/metamask-mobile/commit/ccd38a01a79b2dbac71ed8bcd376fb06171c6dcf disabled device synchronization for this entire test on iOS. This seems to break after navigating to the test dapp. Reverting the change made the test pass locally.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that revert an iOS-specific Detox synchronization workaround and re-enable a previously skipped smoke spec.
> 
> **Overview**
> Re-enables the `Get Entropy Snap Tests` smoke spec by removing `describe.skip`.
> 
> Reverts the iOS-only Detox synchronization disabling wrapper around the test steps, running the flows (`loginToApp`/navigation/signing/invalid source) normally again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d825279fb1bdba0fb8ae6ef70c723d55e712e89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->