### PR TITLE
test(snaps): Disable device synchronization in all tests

### DIFF
--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -518,6 +518,7 @@ export async function withFixtures(
     useCommandQueueServer = false,
     analyticsExpectations,
     shouldPrefetchSwapTokens = true,
+    disableSynchronization = false,
   } = options;
 
   // Clean up any stale port forwarding from previous failed tests
@@ -647,6 +648,12 @@ export async function withFixtures(
         languageAndLocale,
         permissions,
       });
+    }
+
+    if (disableSynchronization) {
+      await device.disableSynchronization();
+    } else {
+      await device.enableSynchronization();
     }
 
     // Dismiss dev screens if running locally (not in CI)

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -463,4 +463,5 @@ export interface WithFixturesOptions {
   useCommandQueueServer?: boolean;
   analyticsExpectations?: AnalyticsExpectations;
   shouldPrefetchSwapTokens?: boolean;
+  disableSynchronization?: boolean;
 }

--- a/tests/page-objects/Browser/BrowserView.ts
+++ b/tests/page-objects/Browser/BrowserView.ts
@@ -325,7 +325,6 @@ class Browser {
     url: string,
     options: { skipUrlEditorDismissal?: boolean } = {},
   ): Promise<void> {
-    // await device.disableSynchronization(); // because animations makes typing into the browser slow
     await Gestures.typeText(this.urlInputBoxID, url, {
       hideKeyboard: true,
       elemDescription: 'URL input box',
@@ -350,7 +349,6 @@ class Browser {
         });
       }
     }
-    // await device.enableSynchronization(); // re-enabling synchronization
   }
 
   /**

--- a/tests/page-objects/Browser/BrowserView.ts
+++ b/tests/page-objects/Browser/BrowserView.ts
@@ -325,7 +325,7 @@ class Browser {
     url: string,
     options: { skipUrlEditorDismissal?: boolean } = {},
   ): Promise<void> {
-    await device.disableSynchronization(); // because animations makes typing into the browser slow
+    // await device.disableSynchronization(); // because animations makes typing into the browser slow
     await Gestures.typeText(this.urlInputBoxID, url, {
       hideKeyboard: true,
       elemDescription: 'URL input box',
@@ -350,7 +350,7 @@ class Browser {
         });
       }
     }
-    await device.enableSynchronization(); // re-enabling synchronization
+    // await device.enableSynchronization(); // re-enabling synchronization
   }
 
   /**

--- a/tests/smoke/snaps/test-snap-background-events.spec.ts
+++ b/tests/smoke/snaps/test-snap-background-events.spec.ts
@@ -18,6 +18,7 @@ describe(SmokeSnaps('Background Events Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -34,6 +35,7 @@ describe(SmokeSnaps('Background Events Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         const futureDate = new Date(Date.now() + 5_000).toISOString();
@@ -57,6 +59,7 @@ describe(SmokeSnaps('Background Events Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('backgroundEventDurationInput', 'PT5S');
@@ -78,6 +81,7 @@ describe(SmokeSnaps('Background Events Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         // Intentionally scheduling an event for 1 hour into the future, so it
@@ -114,6 +118,7 @@ describe(SmokeSnaps('Background Events Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         const pastDate = new Date(Date.now() - 5_000).toISOString();

--- a/tests/smoke/snaps/test-snap-bip-32.spec.ts
+++ b/tests/smoke/snaps/test-snap-bip-32.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -31,6 +32,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('getPublicKeyBip32Button');
@@ -47,6 +49,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('messageSecp256k1Input', 'foo bar');
@@ -66,6 +69,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('messageEd25519Input', 'foo bar');
@@ -85,6 +89,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('messageEd25519Bip32Input', 'foo bar');
@@ -104,6 +109,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'SRP 1');
@@ -124,6 +130,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'SRP 2');
@@ -144,6 +151,7 @@ describe(SmokeSnaps('BIP-32 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip32EntropyDropDown', 'Invalid');

--- a/tests/smoke/snaps/test-snap-bip-44.spec.ts
+++ b/tests/smoke/snaps/test-snap-bip-44.spec.ts
@@ -15,6 +15,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -31,6 +32,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('getPublicKeyBip44Button');
@@ -47,6 +49,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('messageBip44Input', '1234');
@@ -65,6 +68,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'SRP 1');
@@ -84,6 +88,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'SRP 2');
@@ -103,6 +108,7 @@ describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('bip44EntropyDropDown', 'Invalid');

--- a/tests/smoke/snaps/test-snap-client-status.spec.ts
+++ b/tests/smoke/snaps/test-snap-client-status.spec.ts
@@ -16,6 +16,7 @@ describe(SmokeSnaps('Client Status Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -32,6 +33,7 @@ describe(SmokeSnaps('Client Status Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('sendClientStatusButton');

--- a/tests/smoke/snaps/test-snap-cronjob.spec.ts
+++ b/tests/smoke/snaps/test-snap-cronjob.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('Cronjob Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/snaps/test-snap-dialog.spec.ts
+++ b/tests/smoke/snaps/test-snap-dialog.spec.ts
@@ -17,6 +17,7 @@ describe(SmokeSnaps('Dialog Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -34,6 +35,7 @@ describe(SmokeSnaps('Dialog Snap Tests'), () => {
         {
           fixture: new FixtureBuilder().build(),
           skipReactNativeReload: true,
+          disableSynchronization: true,
         },
         async () => {
           await TestSnaps.tapButton('sendAlertButton');
@@ -54,6 +56,7 @@ describe(SmokeSnaps('Dialog Snap Tests'), () => {
         {
           fixture: new FixtureBuilder().build(),
           skipReactNativeReload: true,
+          disableSynchronization: true,
         },
         async () => {
           await TestSnaps.tapButton('sendConfirmationButton');
@@ -70,6 +73,7 @@ describe(SmokeSnaps('Dialog Snap Tests'), () => {
         {
           fixture: new FixtureBuilder().build(),
           skipReactNativeReload: true,
+          disableSynchronization: true,
         },
         async () => {
           await TestSnaps.tapButton('sendConfirmationButton');
@@ -88,6 +92,7 @@ describe(SmokeSnaps('Dialog Snap Tests'), () => {
         {
           fixture: new FixtureBuilder().build(),
           skipReactNativeReload: true,
+          disableSynchronization: true,
         },
         async () => {
           await TestSnaps.tapButton('sendCustomButton');

--- a/tests/smoke/snaps/test-snap-ethereum-provider.spec.ts
+++ b/tests/smoke/snaps/test-snap-ethereum-provider.spec.ts
@@ -21,6 +21,7 @@ describe(SmokeSnaps('Ethereum Provider Snap Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(
             mockServer,

--- a/tests/smoke/snaps/test-snap-get-entropy.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-entropy.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('Get Entropy Snap Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -31,6 +32,7 @@ describe(SmokeSnaps('Get Entropy Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('entropyMessageInput', '1234');
@@ -63,6 +65,7 @@ describe(SmokeSnaps('Get Entropy Snap Tests'), () => {
         {
           fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
           skipReactNativeReload: true,
+          disableSynchronization: true,
         },
         async () => {
           await TestSnaps.selectInDropdown('getEntropyDropDown', entropySource);
@@ -86,6 +89,7 @@ describe(SmokeSnaps('Get Entropy Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.selectInDropdown('getEntropyDropDown', 'Invalid');

--- a/tests/smoke/snaps/test-snap-get-file.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-file.spec.ts
@@ -14,6 +14,7 @@ describe(SmokeSnaps('Get File Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -30,6 +31,7 @@ describe(SmokeSnaps('Get File Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('sendGetFileTextButton');

--- a/tests/smoke/snaps/test-snap-get-preferences.spec.ts
+++ b/tests/smoke/snaps/test-snap-get-preferences.spec.ts
@@ -19,6 +19,7 @@ describe(SmokeSnaps('Get Preferences Snap Tests'), () => {
           .build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/snaps/test-snap-image.spec.ts
+++ b/tests/smoke/snaps/test-snap-image.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('Image Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -31,6 +32,7 @@ describe(SmokeSnaps('Image Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('showSVGImage');
@@ -48,6 +50,7 @@ describe(SmokeSnaps('Image Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('showPNGImage');

--- a/tests/smoke/snaps/test-snap-installed.spec.ts
+++ b/tests/smoke/snaps/test-snap-installed.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('Installed Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -35,6 +36,7 @@ describe(SmokeSnaps('Installed Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('sendErrorButton');

--- a/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
+++ b/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
@@ -17,6 +17,7 @@ describe(SmokeSnaps('Interactive UI Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -33,6 +34,7 @@ describe(SmokeSnaps('Interactive UI Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('createDialogButton');
@@ -78,6 +80,7 @@ describe(SmokeSnaps('Interactive UI Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('createDialogDisabledButton');

--- a/tests/smoke/snaps/test-snap-jsx.spec.ts
+++ b/tests/smoke/snaps/test-snap-jsx.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('JSX Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -31,6 +32,7 @@ describe(SmokeSnaps('JSX Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.tapButton('displayJsxButton');

--- a/tests/smoke/snaps/test-snap-lifecycle.spec.ts
+++ b/tests/smoke/snaps/test-snap-lifecycle.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('Lifecycle hooks Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -38,6 +39,7 @@ describe(SmokeSnaps('Lifecycle hooks Snap Tests'), () => {
           .build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         try {

--- a/tests/smoke/snaps/test-snap-manage-state.spec.ts
+++ b/tests/smoke/snaps/test-snap-manage-state.spec.ts
@@ -14,6 +14,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -32,6 +33,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.fillMessage('dataStateInput', '"bar"');
@@ -53,6 +55,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.tapButton('clearStateButton');
@@ -68,6 +71,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.fillMessage('dataUnencryptedStateInput', '"bar"');
@@ -92,6 +96,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.tapButton('clearStateUnencryptedButton');
@@ -112,6 +117,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.fillMessage('dataManageStateInput', '23');
@@ -132,6 +138,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.tapButton('clearManageStateButton');
@@ -153,6 +160,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.fillMessage(
@@ -173,6 +181,7 @@ describe(SmokeSnaps('Manage State Snap Tests'), () => {
           {
             fixture: new FixtureBuilder().build(),
             skipReactNativeReload: true,
+            disableSynchronization: true,
           },
           async () => {
             await TestSnaps.tapButton('clearUnencryptedManageStateButton');

--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -20,6 +20,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -36,6 +37,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await BrowserView.tapCloseBrowserButton();
@@ -68,6 +70,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await BrowserView.tapCloseBrowserButton();
@@ -101,6 +104,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await BrowserView.tapCloseBrowserButton();

--- a/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
+++ b/tests/smoke/snaps/test-snap-multichain-provider.spec.ts
@@ -21,6 +21,7 @@ describe(SmokeSnaps('Multichain Provider Snap Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(
             mockServer,

--- a/tests/smoke/snaps/test-snap-name-lookup.spec.ts
+++ b/tests/smoke/snaps/test-snap-name-lookup.spec.ts
@@ -24,6 +24,7 @@ describe(SmokeSnaps('Name Lookup Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/snaps/test-snap-network-access.spec.ts
+++ b/tests/smoke/snaps/test-snap-network-access.spec.ts
@@ -17,6 +17,7 @@ describe(SmokeSnaps('Network Access Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
         localNodeOptions: [
           {
             type: LocalNodeType.anvil,
@@ -42,12 +43,6 @@ describe(SmokeSnaps('Network Access Snap Tests'), () => {
         );
 
         // Use WebSockets
-        // Disable synchronization on iOS before starting WebSocket to prevent
-        // Detox from hanging due to the open connection keeping the app "busy"
-        if (device.getPlatform() === 'ios') {
-          await device.disableSynchronization();
-        }
-
         const webSocketUrl = `ws://localhost:${getAnvilPortForTest()}`;
         await TestSnaps.fillMessage('webSocketUrlInput', webSocketUrl);
         await TestSnaps.tapButton('startWebSocket');

--- a/tests/smoke/snaps/test-snap-preinstalled.spec.ts
+++ b/tests/smoke/snaps/test-snap-preinstalled.spec.ts
@@ -22,6 +22,7 @@ describe(SmokeSnaps('Preinstalled Snap Tests'), () => {
         fixture: new FixtureBuilder().withMetaMetricsOptIn().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
         analyticsExpectations: testSnapPreinstalledAnalyticsExpectations,
       },
       async () => {

--- a/tests/smoke/snaps/test-snap-rpc.spec.ts
+++ b/tests/smoke/snaps/test-snap-rpc.spec.ts
@@ -14,6 +14,7 @@ describe(SmokeSnaps('Snap RPC Tests'), () => {
         fixture: new FixtureBuilder().withMultiSRPKeyringController().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/snaps/test-snap-uilinks.spec.ts
+++ b/tests/smoke/snaps/test-snap-uilinks.spec.ts
@@ -15,6 +15,7 @@ describe(SmokeSnaps('UI Links Snap Test'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();

--- a/tests/smoke/snaps/test-snap-wasm.spec.ts
+++ b/tests/smoke/snaps/test-snap-wasm.spec.ts
@@ -14,6 +14,7 @@ describe(SmokeSnaps('WASM Snap Tests'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await loginToApp();
@@ -30,6 +31,7 @@ describe(SmokeSnaps('WASM Snap Tests'), () => {
       {
         fixture: new FixtureBuilder().build(),
         skipReactNativeReload: true,
+        disableSynchronization: true,
       },
       async () => {
         await TestSnaps.fillMessage('wasmInput', '23');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Add an optional property `disableSynchronization` to `withFixtures` and use it for all Snaps tests. This saves a large chunk of time when running these E2Es (**over 40s for some tests**).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust Detox synchronization behavior across many E2E specs; main risk is increased flakiness or hidden timing issues in the Snaps smoke suite.
> 
> **Overview**
> Adds a new `withFixtures` option, `disableSynchronization`, and applies it to the Snaps smoke tests to run them with Detox synchronization turned off.
> 
> `withFixtures` now explicitly enables or disables synchronization after (re)launch, and ad-hoc sync toggling in `BrowserView.navigateToURL` (and the iOS WebSocket workaround in `test-snap-network-access.spec.ts`) is removed in favor of the centralized flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f29881cbba2dcf5b0755f9cf95eff3bad05699f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->