### PR TITLE
fix(predict): prevent pay token alert flicker

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -257,6 +257,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     isInsufficientBalance,
     isConfirming,
     isPayFeesLoading,
+    isPaySystemSettling,
     blockingPayAlertMessage,
     outcomeTokenPrice: outcomeToken?.price,
     isSheetMode,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts
@@ -150,8 +150,13 @@ export const usePredictBuyConditions = ({
       return null;
     }
 
-    return `${selectedPaymentTokenKey}:${totalPayForPredictBalance}`;
-  }, [selectedPaymentTokenKey, totalPayForPredictBalance]);
+    const amountValue = totalPayForPredictBalance || currentValue;
+    const roundedQuoteAmount = new BigNumber(amountValue)
+      .decimalPlaces(2, BigNumber.ROUND_UP)
+      .toString(10);
+
+    return `${selectedPaymentTokenKey}:${roundedQuoteAmount}`;
+  }, [currentValue, selectedPaymentTokenKey, totalPayForPredictBalance]);
 
   // Tracks the token/amount pair for which a full quote-loading cycle has
   // completed. Keeping the amount in the key makes same-token amount changes

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
@@ -106,6 +106,7 @@ const defaultParams = {
   isBelowMinimum: false,
   isInsufficientBalance: false,
   isPayFeesLoading: false,
+  isPaySystemSettling: false,
   blockingPayAlertMessage: null as string | null,
   // Inline banner UX is sheet-mode-only; default these tests to sheet mode so
   // banner / errorMessage suppression behavior is exercised. The dedicated
@@ -234,6 +235,28 @@ describe('usePredictBuyError', () => {
         'Insufficient payment token balance',
       );
       expect(result.current.errorMessageSource).toBe('blocking_pay_alert');
+    });
+
+    it('suppresses pay token balance alert message while pay system is settling', () => {
+      mockActiveOrder = { error: 'order failed' };
+      mockIsPredictBalanceSelected = false;
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'Order placement failed',
+      });
+
+      const { result } = renderHook(() =>
+        usePredictBuyError({
+          ...defaultParams,
+          isPaySystemSettling: true,
+          blockingPayAlertMessage: 'Insufficient payment token balance',
+        }),
+      );
+
+      expect(result.current.errorMessage).toBeUndefined();
+      expect(result.current.buyErrorBanner).toEqual(
+        expect.objectContaining({ variant: 'order_failed' }),
+      );
     });
 
     it('returns undefined when activeOrder has no error', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
@@ -46,6 +46,7 @@ interface UsePredictBuyInfoParams {
   isBelowMinimum: boolean;
   isInsufficientBalance: boolean;
   isPayFeesLoading: boolean;
+  isPaySystemSettling: boolean;
   blockingPayAlertMessage: string | null;
   outcomeTokenPrice?: number;
   // Inline banner UX (price_changed / order_failed) only exists inside the
@@ -63,6 +64,7 @@ export const usePredictBuyError = ({
   isBelowMinimum,
   isInsufficientBalance,
   isPayFeesLoading,
+  isPaySystemSettling,
   blockingPayAlertMessage,
   outcomeTokenPrice,
   isSheetMode = false,
@@ -96,6 +98,7 @@ export const usePredictBuyError = ({
       !isPlacingOrder &&
       !isConfirming &&
       !isPredictBalanceSelected &&
+      !isPaySystemSettling &&
       !!blockingPayAlertMessage
     ) {
       return {
@@ -141,6 +144,7 @@ export const usePredictBuyError = ({
     isConfirming,
     preview,
     isPayFeesLoading,
+    isPaySystemSettling,
     isPredictBalanceSelected,
     blockingPayAlertMessage,
     activeOrder?.error,
@@ -194,7 +198,11 @@ export const usePredictBuyError = ({
       const bannerWouldSuppress =
         isSheetMode &&
         activeOrder?.error &&
-        !(blockingPayAlertMessage && !isPredictBalanceSelected);
+        !(
+          blockingPayAlertMessage &&
+          !isPredictBalanceSelected &&
+          !isPaySystemSettling
+        );
       if (bannerWouldSuppress) {
         return undefined;
       }
@@ -214,6 +222,7 @@ export const usePredictBuyError = ({
     activeOrder?.error,
     blockingPayAlertMessage,
     isPredictBalanceSelected,
+    isPaySystemSettling,
     isSheetMode,
   ]);
 
@@ -233,7 +242,11 @@ export const usePredictBuyError = ({
         return null;
       }
 
-      if (blockingPayAlertMessage && !isPredictBalanceSelected) {
+      if (
+        blockingPayAlertMessage &&
+        !isPredictBalanceSelected &&
+        !isPaySystemSettling
+      ) {
         return null;
       }
 
@@ -274,6 +287,7 @@ export const usePredictBuyError = ({
       isConfirming,
       blockingPayAlertMessage,
       isPredictBalanceSelected,
+      isPaySystemSettling,
       isSheetMode,
     ]);
 
@@ -298,7 +312,11 @@ export const usePredictBuyError = ({
     !isSheetMode ||
     isPlacingOrder ||
     isConfirming ||
-    Boolean(blockingPayAlertMessage && !isPredictBalanceSelected);
+    Boolean(
+      blockingPayAlertMessage &&
+        !isPredictBalanceSelected &&
+        !isPaySystemSettling,
+    );
 
   const buyErrorBanner =
     currentBuyErrorBanner ??


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes a Predict pay-with-any-token alert flicker where a blocking pay-token alert could briefly take precedence while payment quotes/totals were still settling.

Problem:
- Predict can have a valid external payment token selected while the Transaction Pay quote state is still catching up to the latest amount.
- During that settling window, `blockingPayAlertMessage` could be treated as ready and suppress the active order banner / surface an insufficient-funds style message too early.
- The payment settling key also used the raw total amount, making it more sensitive than the user-facing quote amount needs to be.

Fix:
- Normalize the payment settling key amount by rounding the required quote amount up to two decimals.
- Pass `isPaySystemSettling` into `usePredictBuyError`.
- Prevent blocking pay-token alerts from taking precedence while the pay system is still settling.
- Add focused hook coverage for settling-time pay-alert suppression.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that caused Predict pay-with-any-token alerts to flicker while quotes were loading

## **Related issues**

https://consensyssoftware.atlassian.net/browse/CONF-1345

## **Manual testing steps**

```gherkin
Feature: Predict pay with any token

  Scenario: user changes the Predict order amount while paying with a token
    Given the user is on a Predict market buy flow
    And the user has selected a pay-with-any-token payment token
    When the user changes the order amount
    Then the pay-token alert does not flicker while the new quote is loading
    And the correct blocking alert is shown only after the quote/totals state has settled
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict pay-with-any-token settling and error-surfacing logic, which could change when users see blocking balance alerts vs. order failure banners during quote updates.
> 
> **Overview**
> Prevents *blocking pay-token balance alerts* from flickering/overriding active-order error banners while the Transaction Pay system is still settling after token/amount changes.
> 
> Normalizes the pay-system “settling key” by rounding the tracked quote amount up to 2 decimals, and threads `isPaySystemSettling` into `usePredictBuyError` so pay alerts are suppressed until settling completes. Adds a focused unit test to cover settling-time suppression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d189f4d390404a1ea25f460df6e625b34b622a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->