### PR TITLE
ci: fix release-branch-sync (bump pin to @v1, accept ota release branches)

### DIFF
--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync release branches with stable
-        uses: metamask/github-tools/.github/actions/release-branch-sync@v1.2.0
+        uses: metamask/github-tools/.github/actions/release-branch-sync@v1
         with:
           merged-release-branch: ${{ github.event.pull_request.head.ref }}
           github-token: ${{ secrets.STABLE_SYNC_TOKEN }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -23,11 +23,11 @@ jobs:
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Branch '$BRANCH' matches release/X.Y.Z format"
+          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Branch '$BRANCH' matches release/X.Y.Z[-suffix] format"
             echo "is-valid=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Branch '$BRANCH' does not match release/X.Y.Z format. Skipping."
+            echo "Branch '$BRANCH' does not match release/X.Y.Z[-suffix] format. Skipping."
             echo "is-valid=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -23,11 +23,11 @@ jobs:
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
-            echo "Branch '$BRANCH' matches release/X.Y.Z[-suffix] format"
+          if [[ "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Branch '$BRANCH' starts with release/X.Y.Z"
             echo "is-valid=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Branch '$BRANCH' does not match release/X.Y.Z[-suffix] format. Skipping."
+            echo "Branch '$BRANCH' does not start with release/X.Y.Z. Skipping."
             echo "is-valid=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Description

The `Release Branch Sync` workflow is supposed to open a `stable -> release/X.Y.Z` sync PR every time a release PR is merged into `stable`. Two issues were preventing it from working. This PR fixes both.

### Issue 1: action ref was frozen at `@v1.2.0`
Fix: switch the action ref from the frozen `@v1.2.0` to the moving `@v1` major alias, matching what `metamask-extension` uses.

### Issue 2: gate regex silently skipped ota release branches like `release/7.76.3-ota`

The `validate-branch` job's regex required a strict `release/X.Y.Z` format, so OTA release branches were silently skipped. 
Fix: fix the regex to accept branch starts with `release/X.Y.Z`  so OTA release branches also trigger `stable -> release/X.Y.Z` syncs. 

CHANGELOG entry: null

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/contributor-docs/blob/main/docs/code-standards.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (n/a — workflow-only change)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is which release branches trigger the sync and which action version runs.
> 
> **Overview**
> The `Release Branch Sync` workflow now treats any branch starting with `release/X.Y.Z` as valid (instead of requiring an exact `release/X.Y.Z` match), so suffixed branches like OTA releases will also trigger the sync.
> 
> It also updates the `release-branch-sync` action reference from the pinned `@v1.2.0` to the moving major tag `@v1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5967093e94291c97990b42b94d6c64e5bb3ea1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->