### PR TITLE
chore: bump `@metamask/tron-wallet-snap` to `1.25.4-preview-7aab63e`

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^65.1.0",
     "@metamask/transaction-pay-controller": "^22.1.0",
-    "@metamask/tron-wallet-snap": "^1.25.3",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e",
     "@metamask/utils": "^11.11.0",
     "@myx-trade/sdk": "^0.1.265",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10353,10 +10353,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.25.3":
-  version: 1.25.3
-  resolution: "@metamask/tron-wallet-snap@npm:1.25.3"
-  checksum: 10/689d97290b8b1a317f5e8e71884080240cef460d171721ebe28ab8f9eb00b9693910fd583177826618d5e1bb73661f5f5a547c997880c97bc0870cd72066e290
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e":
+  version: 1.25.4-preview-7aab63e
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.25.4-preview-7aab63e"
+  checksum: 10/fe046f85e57af9ee5bf0099cd693ff32afb60096b2b0ea19feec5f7462abf90814761e693d04ba4bfe3d5ccc9b29d9aa4726046848f8384d28bfcc6529391c2b
   languageName: node
   linkType: hard
 
@@ -35325,7 +35325,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^65.1.0"
     "@metamask/transaction-pay-controller": "npm:^22.1.0"
-    "@metamask/tron-wallet-snap": "npm:^1.25.3"
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e"
     "@metamask/utils": "npm:^11.11.0"
     "@myx-trade/sdk": "npm:^0.1.265"
     "@ngraveio/bc-ur": "npm:^1.1.6"


### PR DESCRIPTION
## Description

Bumps `@metamask/tron-wallet-snap` to the published preview build from MetaMask/snap-tron-wallet#301.

Preview package: `@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e`
Preview comment: https://github.com/MetaMask/snap-tron-wallet/pull/301#issuecomment-4442507877

## Changelog

CHANGELOG entry: null

## Related issues

n/a

## Manual testing steps

n/a

## Screenshots/Recordings

### Before

n/a

### After

n/a