### PR TITLE
chore(rewards): fix VIP perps fee edge cases

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -3793,7 +3793,11 @@ describe('RewardsController', () => {
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is 0 (closes 100%-discount loophole)', async () => {
+      it('returns 10000 (100% discount) when the VIP builder fee is 0 — a valid zero-fee tier', async () => {
+        // builderFeeBips=0 means zero VIP builder fee, which in the conversion
+        // formula 10000 * (1 - builderFee/baseFee) maps to a full 100%
+        // discount. Tier 0 / no-VIP is already signalled upstream by
+        // fees=null, so 0 must not be rejected as invalid here.
         buildController('0');
 
         const result = await controller.getPerpsDiscountForAccount(
@@ -3801,8 +3805,8 @@ describe('RewardsController', () => {
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(0);
-        expect(Logger.log).toHaveBeenCalledWith(
+        expect(result).toBe(10000);
+        expect(Logger.log).not.toHaveBeenCalledWith(
           'RewardsController: VIP fees returned an invalid builderFeeBips:',
           '0',
         );
@@ -3972,6 +3976,123 @@ describe('RewardsController', () => {
         );
 
         expect(result).toBe(0);
+        expect(mockMessenger.call).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('VIP subscription fallback for non-enrolled accounts', () => {
+      const SUB_VIP = 'sub-vip-fallback';
+      const SUB_NON_VIP = 'sub-non-vip';
+      const BASE_FEE_BIPS_LOCAL = 10;
+
+      const nonVipSubscription: SubscriptionDto = {
+        id: SUB_NON_VIP,
+        referralCode: 'REF-NV',
+        accounts: [],
+        features: { vip: { enabled: false } },
+      };
+      const vipSubscriptionLocal: SubscriptionDto = {
+        id: SUB_VIP,
+        referralCode: 'REF-VIP',
+        accounts: [],
+        features: { vip: { enabled: true } },
+      };
+      const vipFeesResponse: VipFeesResponseDto = {
+        vipTier: 1,
+        fees: {
+          hyperliquid: { builderCode: '0xbuilder', builderFeeBips: '5' },
+          swaps: { feeBips: '50' },
+        },
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      };
+
+      it('uses the first VIP subscription id when the caller account has no subscription', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {},
+            subscriptions: {
+              [SUB_NON_VIP]: nonVipSubscription,
+              [SUB_VIP]: vipSubscriptionLocal,
+            },
+          },
+          isDisabled: () => false,
+        });
+        mockMessenger.call.mockImplementation((method, ..._args): any => {
+          if (method === 'RewardsDataService:getVipFees') {
+            return Promise.resolve(vipFeesResponse);
+          }
+          return Promise.resolve(null);
+        });
+
+        const result = await controller.getPerpsDiscountForAccount(
+          CAIP_ACCOUNT_2,
+          BASE_FEE_BIPS_LOCAL,
+        );
+
+        // builderFeeBips=5 vs base=10 → 50% discount.
+        expect(result).toBe(5000);
+        expect(mockMessenger.call).toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          SUB_VIP,
+        );
+      });
+
+      it('uses the caller account subscription when it is already enrolled, even with a VIP subscription in state', async () => {
+        const enrolledAccount = 'eip155:0:0xenrolled' as CaipAccountId;
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [enrolledAccount]: {
+                account: enrolledAccount,
+                hasOptedIn: true,
+                subscriptionId: SUB_NON_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: {
+              [SUB_NON_VIP]: nonVipSubscription,
+              [SUB_VIP]: vipSubscriptionLocal,
+            },
+          },
+          isDisabled: () => false,
+        });
+        mockMessenger.call.mockResolvedValue(null);
+
+        const result = await controller.getPerpsDiscountForAccount(
+          enrolledAccount,
+          BASE_FEE_BIPS_LOCAL,
+        );
+
+        // Non-VIP subscription short-circuits to 0 without calling /vip/fees.
+        expect(result).toBe(0);
+        expect(mockMessenger.call).not.toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          expect.anything(),
+        );
+      });
+
+      it('returns null when no VIP subscription exists and the caller is not enrolled', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {},
+            subscriptions: { [SUB_NON_VIP]: nonVipSubscription },
+          },
+          isDisabled: () => false,
+        });
+
+        const result = await controller.getPerpsDiscountForAccount(
+          CAIP_ACCOUNT_2,
+          BASE_FEE_BIPS_LOCAL,
+        );
+
+        expect(result).toBeNull();
         expect(mockMessenger.call).not.toHaveBeenCalled();
       });
     });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1644,6 +1644,11 @@ export class RewardsController extends BaseController<
    * when the account isn't on a VIP-enabled subscription or the fetch fails
    * — callers should treat null as "no discount" (0). Returns 0 when the
    * backend returns no builder fee (fees=null) or an invalid builderFeeBips.
+   *
+   * The discount is tied to the subscription, not the wallet, so if the
+   * caller account isn't enrolled we fall back to the first VIP subscription
+   * in state — that way a VIP user still gets their discount when trading
+   * from a non-enrolled wallet.
    */
   async #getVipPerpsDiscountBips(
     account: CaipAccountId,
@@ -1652,7 +1657,13 @@ export class RewardsController extends BaseController<
     if (!Number.isFinite(baseFeeBips) || baseFeeBips <= 0) return null;
 
     const accountState = this.#getAccountState(account);
-    const subscriptionId = accountState?.subscriptionId;
+    let subscriptionId = accountState?.subscriptionId ?? null;
+    if (!subscriptionId) {
+      const vipEntry = Object.entries(this.state.subscriptions ?? {}).find(
+        ([, sub]) => sub?.features?.vip?.enabled,
+      );
+      subscriptionId = vipEntry?.[0] ?? null;
+    }
     if (!subscriptionId) return null;
 
     const subscription = this.state.subscriptions[subscriptionId];
@@ -1696,7 +1707,11 @@ export class RewardsController extends BaseController<
     }
 
     const builderFeeBips = parseFloat(builderFeeBipsRaw);
-    if (!Number.isFinite(builderFeeBips) || builderFeeBips <= 0) {
+    // builderFeeBips = 0 is valid: it means zero VIP builder fee, i.e. a 100%
+    // discount. builderFeeBips = baseFeeBips means no discount. Only reject
+    // non-finite or negative values here; tier 0 / no-VIP is already
+    // represented upstream by fees=null.
+    if (!Number.isFinite(builderFeeBips) || builderFeeBips < 0) {
       Logger.log(
         'RewardsController: VIP fees returned an invalid builderFeeBips:',
         builderFeeBipsRaw,


### PR DESCRIPTION
## Summary

- **`RewardsController#getVipPerpsDiscountBips`**: if the caller account has no `subscriptionId` in state (i.e. not enrolled), fall back to the first VIP-enabled subscription in the subscriptions map and use its id to look up `/vip/fees`. The perps discount is tied to the subscription, not the wallet — a VIP user trading from a non-enrolled wallet should still receive their discount.
- **`RewardsController#getVipPerpsDiscountBips`** (review follow-up from #30024): accept `builderFeeBips === 0` as a valid zero-fee VIP tier (→ 100% discount) and only reject negative or non-finite values. Tier 0 / no-VIP is already signalled upstream by `fees=null`, so the numeric guard only needs to reject genuinely invalid values. Also clarifies the comment about builderFeeBips semantics (0 = zero VIP builder fee, `baseFeeBips` = no discount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)