### PR TITLE
feat: Increase MM Connect loading toast duration

### DIFF
--- a/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
@@ -81,7 +81,7 @@ describe('HostApplicationAdapter', () => {
       expect(showSimpleNotification).toHaveBeenCalledTimes(1);
       expect(showSimpleNotification).toHaveBeenCalledWith({
         id: 'session-123',
-        autodismiss: 8000,
+        autodismiss: 10000,
         title: 'sdk_connect_v2.show_loading.title',
         description: 'sdk_connect_v2.show_loading.description',
         status: 'pending',

--- a/app/core/SDKConnectV2/adapters/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.ts
@@ -19,7 +19,7 @@ export class HostApplicationAdapter implements IHostApplicationAdapter {
     store.dispatch(
       showSimpleNotification({
         id: conninfo.id,
-        autodismiss: 8000,
+        autodismiss: 10000,
         title: strings('sdk_connect_v2.show_loading.title'),
         description: strings('sdk_connect_v2.show_loading.description', {
           dappName: conninfo.metadata.dapp.name,

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -497,7 +497,9 @@ describe('ConnectionRegistry', () => {
 
         // Sanity: the rest of the happy path still ran.
         expect(mockStore.save).toHaveBeenCalledTimes(1);
-        expect(mockHostApp.syncConnectionList).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.syncConnectionList).toHaveBeenCalledWith([
+          mockConnection,
+        ]);
       });
 
       it('does NOT dismiss the loading toast for QR flows even when connect() fails', async () => {

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -502,7 +502,7 @@ describe('ConnectionRegistry', () => {
         ]);
       });
 
-      it('does NOT dismiss the loading toast for QR flows even when connect() fails', async () => {
+      it('dismisses the loading toast for QR flows when connect() fails so it does not overlap the error toast', async () => {
         registry = new ConnectionRegistry(
           RELAY_URL,
           mockKeyManager,
@@ -527,7 +527,7 @@ describe('ConnectionRegistry', () => {
 
         expect(mockHostApp.showConnectionLoading).toHaveBeenCalledTimes(1);
         expect(mockHostApp.showConnectionError).toHaveBeenCalledTimes(1);
-        expect(mockHostApp.hideConnectionLoading).not.toHaveBeenCalled();
+        expect(mockHostApp.hideConnectionLoading).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -85,6 +85,11 @@ describe('ConnectionRegistry', () => {
         channel: 'handshake:aabbccdd-1122-3344-5566-778899aabbcc',
         mode: 'trusted',
         expiresAt: Date.now() + 600_000,
+        // Direct deeplink flows always include an initialMessage; QR flows do not.
+        initialMessage: {
+          type: 'message',
+          payload: { method: 'wallet_createSession' },
+        },
       },
       metadata: {
         dapp: {
@@ -442,10 +447,86 @@ describe('ConnectionRegistry', () => {
           transport_type: TransportType.MWP,
           sdk_version: '2.0.0',
           sdk_platform: 'JavaScript',
-          dapp_name: 'Test DApp',
-          dapp_url: 'https://test.dapp',
         }),
       );
+    });
+
+    describe('hideConnectionLoading dismissal', () => {
+      const buildDeeplink = (request: ConnectionRequest): string =>
+        `metamask://connect/mwp?p=${encodeURIComponent(JSON.stringify(request))}`;
+
+      it('dismisses the loading toast on success for direct deeplink flows (initialMessage present)', async () => {
+        registry = new ConnectionRegistry(
+          RELAY_URL,
+          mockKeyManager,
+          mockHostApp,
+          mockStore,
+        );
+
+        // mockConnectionRequest already has initialMessage set in beforeEach.
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        expect(mockHostApp.showConnectionLoading).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.hideConnectionLoading).toHaveBeenCalledTimes(1);
+      });
+
+      it('does NOT dismiss the loading toast on success for QR flows (no initialMessage)', async () => {
+        registry = new ConnectionRegistry(
+          RELAY_URL,
+          mockKeyManager,
+          mockHostApp,
+          mockStore,
+        );
+
+        const qrRequest: ConnectionRequest = {
+          ...mockConnectionRequest,
+          sessionRequest: {
+            ...mockConnectionRequest.sessionRequest,
+            initialMessage: undefined,
+          },
+        };
+        const qrDeeplink = buildDeeplink(qrRequest);
+
+        await registry.handleConnectDeeplink(qrDeeplink);
+
+        // QR flow still shows the loading toast — it just isn't manually
+        // hidden, since the dapp sends wallet_createSession asynchronously
+        // and the toast must stay visible until the autodismiss fires.
+        expect(mockHostApp.showConnectionLoading).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.hideConnectionLoading).not.toHaveBeenCalled();
+
+        // Sanity: the rest of the happy path still ran.
+        expect(mockStore.save).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.syncConnectionList).toHaveBeenCalledTimes(1);
+      });
+
+      it('does NOT dismiss the loading toast for QR flows even when connect() fails', async () => {
+        registry = new ConnectionRegistry(
+          RELAY_URL,
+          mockKeyManager,
+          mockHostApp,
+          mockStore,
+        );
+
+        mockConnection.connect.mockRejectedValue(
+          new Error('handshake timeout'),
+        );
+
+        const qrRequest: ConnectionRequest = {
+          ...mockConnectionRequest,
+          sessionRequest: {
+            ...mockConnectionRequest.sessionRequest,
+            initialMessage: undefined,
+          },
+        };
+        const qrDeeplink = buildDeeplink(qrRequest);
+
+        await registry.handleConnectDeeplink(qrDeeplink);
+
+        expect(mockHostApp.showConnectionLoading).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.showConnectionError).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.hideConnectionLoading).not.toHaveBeenCalled();
+      });
     });
 
     it('should handle invalid URL gracefully', async () => {
@@ -585,10 +666,6 @@ describe('ConnectionRegistry', () => {
         expect.objectContaining({
           remote_session_id: mockConnectionRequest.sessionRequest.id,
           transport_type: TransportType.MWP,
-          sdk_version: '2.0.0',
-          sdk_platform: 'JavaScript',
-          dapp_name: 'Test DApp',
-          dapp_url: 'https://test.dapp',
           failure_reason: 'Connection failed',
         }),
       );

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -280,6 +280,7 @@ export class ConnectionRegistry {
       await this.evictIfAtCapacity();
 
       connInfo = this.toConnectionInfo(connReq);
+
       this.hostapp.showConnectionLoading(connInfo);
       conn = await Connection.create(
         connInfo,
@@ -314,7 +315,15 @@ export class ConnectionRegistry {
 
       if (conn) await this.disconnect(conn.id);
     } finally {
-      if (connInfo) this.hostapp.hideConnectionLoading(connInfo);
+      // For direct deeplink flows from native browser / react native, the connection request will have an initial message in the session request.
+      // This means an approval will be shown to the user soon after the MWP handshake is complete, so we can safely dismiss the loading toast.
+      // For QR flow, the connection request will not have an initial message in the session request because the dapp is expected to send it separately after the MWP handshake is complete.
+      // Because there may be a longer delay until the wallet receives the initial message from the dapp directly, we should not dismiss the loading toast immediately after the MWP handshake is complete.
+
+      const isQrFlow = connReq?.sessionRequest.initialMessage === undefined;
+      if (connInfo && !isQrFlow) {
+        this.hostapp.hideConnectionLoading(connInfo);
+      }
     }
   }
 

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -247,6 +247,7 @@ export class ConnectionRegistry {
     let conn: Connection | undefined;
     let connInfo: ConnectionInfo | undefined;
     let connReq: ConnectionRequest | undefined;
+    let didConnectionFail = false;
 
     try {
       connReq = this.parseConnectionRequest(url);
@@ -297,6 +298,7 @@ export class ConnectionRegistry {
     } catch (error) {
       logger.error('Failed to handle connect deeplink:', error, redactUrl(url));
       this.hostapp.showConnectionError();
+      didConnectionFail = true;
 
       // Track the failure before cleanup so the event fires even if
       // disconnect() throws.
@@ -315,13 +317,22 @@ export class ConnectionRegistry {
 
       if (conn) await this.disconnect(conn.id);
     } finally {
-      // For direct deeplink flows from native browser / react native, the connection request will have an initial message in the session request.
-      // This means an approval will be shown to the user soon after the MWP handshake is complete, so we can safely dismiss the loading toast.
-      // For QR flow, the connection request will not have an initial message in the session request because the dapp is expected to send it separately after the MWP handshake is complete.
-      // Because there may be a longer delay until the wallet receives the initial message from the dapp directly, we should not dismiss the loading toast immediately after the MWP handshake is complete.
-
+      // Loading-toast dismissal rules:
+      // - On failure, always dismiss the loading toast. Otherwise the user
+      //   would briefly see both a "loading" toast and the error toast at
+      //   the same time, and the loading toast would linger after the error
+      //   toast auto-dismisses.
+      // - On success for direct deeplink flows (initialMessage present), the
+      //   connection request includes the initial RPC, so an approval will
+      //   surface immediately after the MWP handshake — it's safe to dismiss
+      //   the loading toast right away.
+      // - On success for QR flows (no initialMessage), the dapp sends
+      //   wallet_createSession separately after the handshake. There may be
+      //   a noticeable delay before the approval appears, so we keep the
+      //   loading toast visible and let it autodismiss naturally.
       const isQrFlow = connReq?.sessionRequest.initialMessage === undefined;
-      if (connInfo && !isQrFlow) {
+      const shouldHideLoadingToast = didConnectionFail || !isQrFlow;
+      if (connInfo && shouldHideLoadingToast) {
         this.hostapp.hideConnectionLoading(connInfo);
       }
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Increases the loading toast duration for the MM Connect initial handshake flow. In particular, the loading toast is no longer explicitly dismissed when the handshake flow is missing an initialMessage, indicating it is a QR based flow and that the dapp will send an initial request separately. In regular deeplink (non-QR based) flows, the initialMessage is populated with the initial wallet_createSession request, and so there is very little delay between when the MWP handshake is completed and an approval is shown to the user. In the new QR based flow, the initialMessage is not populated (to reduce QR code density, making it easier to scan) and the wallet_createSession request comes from the desktop dapp after the MWP handshake is complete which leads to the potential for longer delay between when the user scans the QR code, opens the wallet, and finally sees the approval prompt for permissions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Make the MetaMask Connect loading toast display more accurately

**Not sure if this really warrants a changelog though** 

## **Related issues**

See: https://github.com/MetaMask/connect-monorepo/pull/295

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible connection-handshake UX and alters when loading notifications are dismissed based on `initialMessage`, which could leave toasts lingering if flow detection is wrong. Logic is localized to SDKConnectV2 connect-deeplink handling with added tests covering the new cases.
> 
> **Overview**
> Increases the SDKConnectV2 connect "loading" toast autodismiss from `8000` to `10000` ms.
> 
> Updates `ConnectionRegistry.handleConnectDeeplink` to **conditionally hide** the loading toast: always hide on failure, hide on success only when `sessionRequest.initialMessage` is present (direct deeplink), and *do not* manually hide on successful QR flows (no `initialMessage`) so the toast persists until autodismiss. Adds/updates tests to cover the QR vs direct-deeplink dismissal behavior and ensure failures still dismiss the loading toast to avoid overlapping with error toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f543730dba996d917079c008de98f2aae536ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->