### PR TITLE
chore(rewards): add total outflow when user has cashed out value

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.test.tsx
@@ -505,7 +505,7 @@ describe('OndoCampaignStatsView', () => {
     ).toBeDefined();
   });
 
-  it('shows outflow and a separate days-held row when the portfolio has cashed out', () => {
+  it('shows outflow, total inflow, and days held when the portfolio has cashed out', () => {
     mockUseGetCampaignParticipantStatus.mockReturnValue({
       status: { optedIn: true, participantCount: 1 },
       isLoading: false,
@@ -536,6 +536,10 @@ describe('OndoCampaignStatsView', () => {
     expect(
       getByText('rewards.ondo_campaign_stats.label_outflow'),
     ).toBeDefined();
+    expect(
+      getByText('rewards.ondo_campaign_stats.label_total_inflow'),
+    ).toBeDefined();
+    expect(getByText('$11,000.00')).toBeDefined();
     const daysHeldLabels = getAllByText(
       'rewards.ondo_campaign_stats.label_days_held',
     );
@@ -598,6 +602,29 @@ describe('OndoCampaignStatsView', () => {
     });
     const { getByText } = render(<OndoCampaignStatsView />);
     expect(getByText('+15.00%')).toBeDefined();
+  });
+
+  it('hides total inflow when there is no cashed out value', () => {
+    mockUseGetOndoPortfolioPosition.mockReturnValue({
+      ...portfolioDefaults,
+      portfolio: {
+        positions: [],
+        summary: {
+          totalCurrentValue: '15000',
+          totalBookValue: '13000',
+          totalUsdDeposited: '13000',
+          netDeposit: '12500',
+          totalCashedOut: '0',
+          portfolioPnl: '2000',
+          portfolioPnlPercent: '0.15',
+        },
+        computedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    const { queryByText } = render(<OndoCampaignStatsView />);
+    expect(
+      queryByText('rewards.ondo_campaign_stats.label_total_inflow'),
+    ).toBeNull();
   });
 
   it('shows negative return with error color class when portfolio return is negative', () => {

--- a/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignStatsView.tsx
@@ -128,6 +128,10 @@ const OndoCampaignStatsView: React.FC = () => {
     ? formatUsd(portfolioData.summary.netDeposit)
     : '-';
 
+  const totalInflowValue = portfolioData?.summary
+    ? formatUsd(portfolioData.summary.totalUsdDeposited)
+    : '-';
+
   const hasCashedOut = portfolioData?.summary
     ? parseFloat(portfolioData.summary.totalCashedOut) > 0
     : false;
@@ -268,9 +272,16 @@ const OndoCampaignStatsView: React.FC = () => {
               </Box>
             )}
 
-            {/* Days held (when outflow row present) */}
+            {/* Total inflow | Days held (when outflow row present) */}
             {!isCampaignComplete && hasCashedOut && (
               <Box flexDirection={BoxFlexDirection.Row}>
+                <StatCell
+                  label={strings(
+                    'rewards.ondo_campaign_stats.label_total_inflow',
+                  )}
+                  value={totalInflowValue}
+                  isLoading={portfolioLoading}
+                />
                 <StatCell
                   label={strings('rewards.ondo_campaign_stats.label_days_held')}
                   value={daysHeldValue}
@@ -278,7 +289,6 @@ const OndoCampaignStatsView: React.FC = () => {
                   valueColor={TextColor.TextDefault}
                   suffix={isQualified ? <CheckIcon /> : undefined}
                 />
-                <Box twClassName="flex-1" />
               </Box>
             )}
 

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Ihr Rang",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Nettozufluss",
+      "label_total_inflow": "Gesamtzufluss",
       "label_outflow": "Kapitalabfluss",
       "label_days_held": "Tage gehalten",
       "qualified_title": "Sie sind qualifiziert",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Η κατάταξή σας",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Καθαρές εισροές",
+      "label_total_inflow": "Συνολικές εισροές",
       "label_outflow": "Εκροές",
       "label_days_held": "Ημέρες διακράτησης",
       "qualified_title": "Πληροίτε τις προϋποθέσεις",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Your rank",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Net inflow",
+      "label_total_inflow": "Total inflow",
       "label_outflow": "Outflow",
       "label_days_held": "Days held",
       "qualified_title": "You're qualified",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Tu rango",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Flujo neto de entrada",
+      "label_total_inflow": "Entrada total",
       "label_outflow": "Flujo de salida",
       "label_days_held": "Días de retención",
       "qualified_title": "Estás calificado",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Votre classement",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Flux net entrant",
+      "label_total_inflow": "Entrées totales",
       "label_outflow": "Flux sortant",
       "label_days_held": "Jours de détention",
       "qualified_title": "Vous êtes qualifié",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "आपकी रैंक",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "नेट इनफ्लो",
+      "label_total_inflow": "कुल इनफ्लो",
       "label_outflow": "आउटफ्लो",
       "label_days_held": "दिनों तक होल्ड किया",
       "qualified_title": "आप क्वालिफ़ाई कर चुके हैं",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Peringkat Anda",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Arus masuk bersih",
+      "label_total_inflow": "Total arus masuk",
       "label_outflow": "Arus keluar",
       "label_days_held": "Hari kepemilikan",
       "qualified_title": "Anda memenuhi syarat",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "ランク",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "純流入額",
+      "label_total_inflow": "総流入額",
       "label_outflow": "流出額",
       "label_days_held": "保有日数",
       "qualified_title": "対象となります",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "내 등급",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "순유입",
+      "label_total_inflow": "총 유입",
       "label_outflow": "순유출",
       "label_days_held": "보유 일수",
       "qualified_title": "자격 충족",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Sua classificação",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Fluxo de entrada líquido",
+      "label_total_inflow": "Fluxo de entrada total",
       "label_outflow": "Fluxo de saída",
       "label_days_held": "Dias mantidos",
       "qualified_title": "Você se qualifica",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Ваш ранг",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Чистый приток",
+      "label_total_inflow": "Общий приток",
       "label_outflow": "Отток",
       "label_days_held": "Дней удержания",
       "qualified_title": "Вы соответствуете требованиям",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Rank mo",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Net inflow",
+      "label_total_inflow": "Total inflow",
       "label_outflow": "Outflow",
       "label_days_held": "Mga araw na na-hold",
       "qualified_title": "Kwalipikado ka",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Sıralamanız",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Net para girişi",
+      "label_total_inflow": "Toplam para girişi",
       "label_outflow": "Para Çıkışı",
       "label_days_held": "Tutulan gün sayısı",
       "qualified_title": "Uygunsunuz",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "Thứ hạng của bạn",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "Dòng tiền vào ròng",
+      "label_total_inflow": "Tổng dòng tiền vào",
       "label_outflow": "Dòng tiền ra",
       "label_days_held": "Số ngày nắm giữ",
       "qualified_title": "Bạn đủ điều kiện",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -8695,6 +8695,7 @@
       "label_your_rank": "您的排名",
       "label_portfolio": "Portfolio",
       "label_net_inflow": "净流入",
+      "label_total_inflow": "总流入",
       "label_outflow": "流出",
       "label_days_held": "持有天数",
       "qualified_title": "您已具备资格",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-05-13 at 16 24 11" src="https://github.com/user-attachments/assets/cfe429da-f3b7-43ad-96cc-59b32616936c" />
Display total inflow value when user has cashed out from Ondo
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change gated on `totalCashedOut > 0`, plus i18n string additions and test updates; no auth, network, or data-write paths are modified.
> 
> **Overview**
> Adds a new **"Total inflow"** stat to `OndoCampaignStatsView`, displayed alongside *Days held* when a user has a non-zero `totalCashedOut` (i.e., the outflow row is shown). Uses `summary.totalUsdDeposited` for the value and keeps it hidden when no cash-out has occurred.
> 
> Updates the Ondo campaign stats tests to assert the new row/value and adds `label_total_inflow` translations across supported locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d4104ebebe1fad57744326f1ffe05b8707d6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->