### PR TITLE
refactor(predict): use native stack navigators for Predict routes

### DIFF
--- a/app/components/UI/Predict/routes/index.test.tsx
+++ b/app/components/UI/Predict/routes/index.test.tsx
@@ -93,7 +93,15 @@ jest.mock('../../../Views/confirmations/components/confirm', () => ({
 jest.mock(
   '../../../../constants/navigation/clearStackNavigatorOptions',
   () => ({
-    clearStackNavigatorOptions: {},
+    clearNativeStackNavigatorOptions: {},
+    transparentModalScreenOptions: {},
+  }),
+);
+
+jest.mock(
+  '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations',
+  () => ({
+    useEmptyNavHeaderForConfirmations: () => ({ headerShown: false }),
   }),
 );
 

--- a/app/components/UI/Predict/routes/index.tsx
+++ b/app/components/UI/Predict/routes/index.tsx
@@ -1,217 +1,118 @@
-import {
-  createStackNavigator,
-  type StackNavigationOptions,
-} from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import {
+  clearNativeStackNavigatorOptions,
+  transparentModalScreenOptions,
+} from '../../../../constants/navigation/clearStackNavigatorOptions';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
-import PredictMarketDetails from '../views/PredictMarketDetails';
-import PredictUnavailableModal from '../views/PredictUnavailableModal';
+import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 import PredictActivityDetail from '../components/PredictActivityDetail/PredictActivityDetail';
+import PredictGTMModal from '../components/PredictGTMModal';
+import { PredictPreviewSheetProvider } from '../contexts';
+import { selectPredictWithAnyTokenEnabledFlag } from '../selectors/featureFlags';
 import { PredictNavigationParamList } from '../types/navigation';
 import PredictAddFundsModal from '../views/PredictAddFundsModal/PredictAddFundsModal';
-import PredictFeed from '../views/PredictFeed';
-import PredictGTMModal from '../components/PredictGTMModal';
-import { Dimensions } from 'react-native';
-import { useSelector } from 'react-redux';
-import { PredictPreviewSheetProvider } from '../contexts';
 import PredictBuyPreview from '../views/PredictBuyPreview/PredictBuyPreview';
 import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken';
+import PredictFeed from '../views/PredictFeed';
+import PredictMarketDetails from '../views/PredictMarketDetails';
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
-import { selectPredictWithAnyTokenEnabledFlag } from '../selectors/featureFlags';
-import { clearStackNavigatorOptions } from '../../../../constants/navigation/clearStackNavigatorOptions';
+import PredictUnavailableModal from '../views/PredictUnavailableModal';
 
-interface PredictConfirmationRouteParams {
-  animationEnabled?: boolean;
-}
+const Stack = createNativeStackNavigator<PredictNavigationParamList>();
+const ModalStack = createNativeStackNavigator<PredictNavigationParamList>();
 
-const getConfirmationTransitionSpec = (
-  disableOpenAnimation: boolean,
-): StackNavigationOptions['transitionSpec'] =>
-  disableOpenAnimation
-    ? {
-        open: { animation: 'timing' as const, config: { duration: 0 } },
-        close: { animation: 'timing' as const, config: { duration: 300 } },
-      }
-    : undefined;
+const PredictModalStack = () => {
+  const emptyNavHeaderOptions = useEmptyNavHeaderForConfirmations();
 
-const getPredictConfirmationScreenOptions = ({
-  route,
-}: {
-  route: {
-    params?: PredictConfirmationRouteParams;
-  };
-}): StackNavigationOptions => {
-  const disableOpenAnimation = route.params?.animationEnabled === false;
-
-  return {
-    headerLeft: () => null,
-    headerShown: true,
-    title: '',
-    transitionSpec: getConfirmationTransitionSpec(disableOpenAnimation),
-  };
+  return (
+    <ModalStack.Navigator
+      screenOptions={{
+        ...clearNativeStackNavigatorOptions,
+        ...transparentModalScreenOptions,
+      }}
+    >
+      <ModalStack.Screen
+        name={Routes.PREDICT.MODALS.UNAVAILABLE}
+        component={PredictUnavailableModal}
+      />
+      <ModalStack.Screen
+        name={Routes.PREDICT.MODALS.GTM_MODAL}
+        component={PredictGTMModal}
+      />
+      <ModalStack.Screen
+        name={Routes.PREDICT.MODALS.ADD_FUNDS_SHEET}
+        component={PredictAddFundsModal}
+      />
+      <ModalStack.Screen
+        name={Routes.PREDICT.ACTIVITY_DETAIL}
+        component={PredictActivityDetail}
+      />
+      <ModalStack.Screen
+        name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}
+        component={Confirm}
+        options={emptyNavHeaderOptions}
+      />
+      <ModalStack.Screen
+        name={Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER}
+        component={Confirm}
+        options={{ headerShown: false }}
+      />
+    </ModalStack.Navigator>
+  );
 };
-
-const slideFromRightInterpolator: StackNavigationOptions['cardStyleInterpolator'] =
-  ({ current }) => ({
-    cardStyle: {
-      transform: [
-        {
-          translateX: current.progress.interpolate({
-            inputRange: [0, 1],
-            outputRange: [Dimensions.get('window').width, 0],
-          }),
-        },
-      ],
-    },
-  });
-
-const Stack = createStackNavigator<PredictNavigationParamList>();
-const ModalStack = createStackNavigator<PredictNavigationParamList>();
-
-const PredictModalStack = () => (
-  <ModalStack.Navigator
-    screenOptions={{
-      ...clearStackNavigatorOptions,
-      presentation: 'transparentModal',
-    }}
-  >
-    <ModalStack.Screen
-      name={Routes.PREDICT.MODALS.UNAVAILABLE}
-      component={PredictUnavailableModal}
-      options={{
-        cardStyleInterpolator: ({ current }) => ({
-          cardStyle: {
-            opacity: current.progress,
-          },
-        }),
-      }}
-    />
-    <ModalStack.Screen
-      name={Routes.PREDICT.MODALS.GTM_MODAL}
-      component={PredictGTMModal}
-      options={{
-        cardStyleInterpolator: ({ current }) => ({
-          cardStyle: {
-            opacity: current.progress,
-          },
-        }),
-      }}
-    />
-    <ModalStack.Screen
-      name={Routes.PREDICT.MODALS.ADD_FUNDS_SHEET}
-      component={PredictAddFundsModal}
-      options={{
-        cardStyleInterpolator: ({ current }) => ({
-          cardStyle: {
-            opacity: current.progress,
-          },
-        }),
-      }}
-    />
-    <ModalStack.Screen
-      name={Routes.PREDICT.ACTIVITY_DETAIL}
-      component={PredictActivityDetail}
-      options={{
-        headerShown: false,
-      }}
-    />
-    <ModalStack.Screen
-      name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}
-      component={Confirm}
-      options={getPredictConfirmationScreenOptions}
-    />
-    <ModalStack.Screen
-      name={Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER}
-      component={Confirm}
-      options={({
-        route,
-      }: {
-        route: { params?: PredictConfirmationRouteParams };
-      }) => {
-        const disableOpenAnimation = route.params?.animationEnabled === false;
-
-        return {
-          headerShown: false,
-          transitionSpec: getConfirmationTransitionSpec(disableOpenAnimation),
-        };
-      }}
-    />
-  </ModalStack.Navigator>
-);
 
 const PredictScreenStack = () => {
   const payWithAnyTokenEnabled = useSelector(
     selectPredictWithAnyTokenEnabledFlag,
   );
+  const emptyNavHeaderOptions = useEmptyNavHeaderForConfirmations();
   const BuyPreviewComponent = payWithAnyTokenEnabled
     ? PredictBuyWithAnyToken
     : PredictBuyPreview;
 
   return (
     <PredictPreviewSheetProvider>
-      <Stack.Navigator initialRouteName={Routes.PREDICT.MARKET_LIST}>
+      <Stack.Navigator
+        initialRouteName={Routes.PREDICT.MARKET_LIST}
+        screenOptions={{ headerShown: false }}
+      >
         <Stack.Screen
           name={Routes.PREDICT.MARKET_LIST}
           component={PredictFeed}
           options={{
             title: strings('predict.markets.title'),
-            headerShown: false,
-            animationEnabled: false,
+            animation: 'none',
           }}
         />
 
         <Stack.Screen
           name={Routes.PREDICT.MODALS.BUY_PREVIEW}
           component={BuyPreviewComponent}
-          options={{
-            headerShown: false,
-            cardStyleInterpolator: slideFromRightInterpolator,
-          }}
         />
 
         <Stack.Screen
           name={Routes.PREDICT.MODALS.SELL_PREVIEW}
           component={PredictSellPreview}
-          options={{
-            headerShown: false,
-            cardStyleInterpolator: slideFromRightInterpolator,
-          }}
         />
 
         <Stack.Screen
           name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}
           component={Confirm}
-          options={getPredictConfirmationScreenOptions}
+          options={emptyNavHeaderOptions}
         />
 
         <Stack.Screen
           name={Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER}
           component={Confirm}
-          options={({
-            route,
-          }: {
-            route: { params?: PredictConfirmationRouteParams };
-          }) => {
-            const disableOpenAnimation =
-              route.params?.animationEnabled === false;
-
-            return {
-              headerShown: false,
-              transitionSpec:
-                getConfirmationTransitionSpec(disableOpenAnimation),
-            };
-          }}
         />
 
         <Stack.Screen
           name={Routes.PREDICT.MARKET_DETAILS}
           component={PredictMarketDetails}
-          options={{
-            headerShown: false,
-            cardStyleInterpolator: slideFromRightInterpolator,
-          }}
         />
       </Stack.Navigator>
     </PredictPreviewSheetProvider>

--- a/app/components/UI/Predict/routes/index.tsx
+++ b/app/components/UI/Predict/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import {
@@ -8,20 +7,21 @@ import {
   transparentModalScreenOptions,
 } from '../../../../constants/navigation/clearStackNavigatorOptions';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
+import PredictMarketDetails from '../views/PredictMarketDetails';
+import PredictUnavailableModal from '../views/PredictUnavailableModal';
 import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 import PredictActivityDetail from '../components/PredictActivityDetail/PredictActivityDetail';
-import PredictGTMModal from '../components/PredictGTMModal';
-import { PredictPreviewSheetProvider } from '../contexts';
-import { selectPredictWithAnyTokenEnabledFlag } from '../selectors/featureFlags';
 import { PredictNavigationParamList } from '../types/navigation';
 import PredictAddFundsModal from '../views/PredictAddFundsModal/PredictAddFundsModal';
+import PredictFeed from '../views/PredictFeed';
+import PredictWorldCup from '../views/PredictWorldCup';
+import PredictGTMModal from '../components/PredictGTMModal';
+import { useSelector } from 'react-redux';
+import { PredictPreviewSheetProvider } from '../contexts';
 import PredictBuyPreview from '../views/PredictBuyPreview/PredictBuyPreview';
 import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken';
-import PredictFeed from '../views/PredictFeed';
-import PredictMarketDetails from '../views/PredictMarketDetails';
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
-import PredictUnavailableModal from '../views/PredictUnavailableModal';
-import PredictWorldCup from '../views/PredictWorldCup';
+import { selectPredictWithAnyTokenEnabledFlag } from '../selectors/featureFlags';
 
 const Stack = createNativeStackNavigator<PredictNavigationParamList>();
 const ModalStack = createNativeStackNavigator<PredictNavigationParamList>();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
POC: https://docs.google.com/document/d/1_oDELkGRLUgaAeMs2NSzG9w1UyjsD5VSKQlW7yW5oZU/edit?tab=t.0#heading=h.gba8s4wq9tzu
Android build: https://github.com/MetaMask/metamask-mobile/actions/runs/25829982981

Switches Predict’s main and modal navigators from @react-navigation/stack to @react-navigation/native-stack, aligns modal/confirmation options with other feature stacks (e.g. Money), and removes JS-stack-only transition customization that no longer applies.

**What changed**
PredictScreenStack: createNativeStackNavigator with screenOptions={{ headerShown: false }}; market list uses animation: 'none' instead of animationEnabled: false.

PredictModalStack: Uses clearNativeStackNavigatorOptions + transparentModalScreenOptions instead of clearStackNavigatorOptions + per-screen opacity interpolators.

Confirmations: REDESIGNED_CONFIRMATIONS uses useEmptyNavHeaderForConfirmations() (same pattern as Money); NO_HEADER uses headerShown: false.

Removed: getConfirmationTransitionSpec, PredictConfirmationRouteParams, getPredictConfirmationScreenOptions, slideFromRightInterpolator, and all cardStyleInterpolator blocks on modal screens.

**Behavior notes**
Push screens (buy/sell preview, market details): rely on native stack default push animation (slide from right on Android; system behavior on iOS) instead of the previous manual translateX interpolator.
Transparent modals (unavailable, GTM, add funds): no longer fade the route card via interpolator; modal/sheet UIs own their presentation; outer stack uses transparent modal + animation: 'none' from the shared preset.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="382" height="768" alt="predict before part 1" src="https://github.com/user-attachments/assets/c494c723-9913-4cbb-a9ff-c91b66d7e172" />
<img width="382" height="768" alt="predict before part 2" src="https://github.com/user-attachments/assets/0897d06f-b842-4f24-abfb-0ac6167b3020" />
<img width="382" height="786" alt="predict before part 3" src="https://github.com/user-attachments/assets/0b9fdefc-d434-47cf-9e41-551fe5f49e68" />

### **After**
<img width="382" height="786" alt="Predict after part 1" src="https://github.com/user-attachments/assets/204b4512-294e-4dbe-8ac6-bad7b96160b2" />
<img width="382" height="786" alt="predict after part 2" src="https://github.com/user-attachments/assets/5fd683bb-e7d8-4bae-b677-1cd698f39368" />
<img width="382" height="786" alt="predict after part 3" src="https://github.com/user-attachments/assets/b8fc7459-6be5-4e4a-8b44-93443b0f25ef" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Predict navigation stacks and screen option presets, which can subtly alter transition behavior and header presentation across multiple screens/modals. Risk is moderate because it’s UI/navigation-only and doesn’t touch business logic, but regressions would impact user flow.
> 
> **Overview**
> Migrates Predict’s main and modal navigators from `@react-navigation/stack` to `@react-navigation/native-stack`, standardizing screen options via `clearNativeStackNavigatorOptions` and `transparentModalScreenOptions`.
> 
> Removes JS-stack-only transition customizations (custom interpolators and confirmation transitionSpec) and updates confirmation routes to use `useEmptyNavHeaderForConfirmations` (or `headerShown: false`) while relying on native-stack defaults for push/modal animations. Test mocks were updated to reflect the new navigation option exports and confirmations header hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b0c8220c5e33ba29046dbc3b5ef40364fad117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->