### PR TITLE
test: skip flaky mUSD Conversion Happy Path E2E spec cp-7.70.0

### DIFF
--- a/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
+++ b/tests/smoke/wallet/musd-conversion-happy-path.spec.ts
@@ -52,7 +52,7 @@ function withMusdFixturesOptions(
   };
 }
 
-describe(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
+describe.skip(SmokeWalletPlatform('mUSD Conversion Happy Path'), () => {
   beforeAll(async () => {
     jest.setTimeout(150000);
     // Do not launch app here: launch happens inside withFixtures (restartDevice: true)


### PR DESCRIPTION
This commit skips the mUSD Conversion Happy Path E2E test due to intermittent failures observed in the wallet-platform-android-smoke-2 shard. The entire test suite is temporarily disabled to unblock CI while the underlying issues are investigated. Re-enablement is tracked under [MMQA-1813](https://consensyssoftware.atlassian.net/browse/MMQA-1813).

## **Description**

The `mUSD Conversion Happy Path` E2E spec (`tests/smoke/wallet/musd-conversion-happy-path.spec.ts`) has been failing intermittently in the `wallet-platform-android-smoke-2` shard and is blocking CI. The top-level `describe` block is switched to `describe.skip` so the suite no longer runs while we investigate the underlying flakiness. Re-enablement is tracked under [MMQA-1813](https://consensyssoftware.atlassian.net/browse/MMQA-1813).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1813](https://consensyssoftware.atlassian.net/browse/MMQA-1813)

## **Manual testing steps**

```gherkin
Feature: Skip flaky mUSD Conversion Happy Path E2E spec

  Scenario: CI no longer runs the flaky mUSD suite
    Given the wallet-platform-android-smoke-2 shard is being executed
    When the test runner discovers tests/smoke/wallet/musd-conversion-happy-path.spec.ts
    Then the entire "mUSD Conversion Happy Path" describe block is skipped
    And the shard completes without failures from this suite
```

## **Screenshots/Recordings**

### **Before**

N/A — test-only change.

### **After**

N/A — test-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1813]: https://consensyssoftware.atlassian.net/browse/MMQA-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1813]: https://consensyssoftware.atlassian.net/browse/MMQA-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1813]: https://consensyssoftware.atlassian.net/browse/MMQA-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only disables an E2E smoke test suite by switching the top-level `describe` to `describe.skip`, with no production code impact.
> 
> **Overview**
> Disables the entire `mUSD Conversion Happy Path` wallet smoke E2E spec by changing its top-level `describe` to `describe.skip`, preventing the flaky suite from running in CI while issues are investigated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c937c19b2d007a4f2b5cb15b9c7a9e425aeb69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->