### PR TITLE
chore(rewards): cache client requirement for 30 min

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -332,6 +332,7 @@ import { setPendingDeeplink } from '../../../reducers/rewards';
 import { useSeasonStatus } from './hooks/useSeasonStatus';
 import { useGeoRewardsMetadata } from './hooks/useGeoRewardsMetadata';
 import { useRewardsNotificationsNudge } from './hooks/useRewardsNotificationsNudge';
+import useRewardsVersionGuard from './hooks/useRewardsVersionGuard';
 
 const mockSelectRewardsSubscriptionId =
   selectRewardsSubscriptionId as jest.MockedFunction<
@@ -357,6 +358,8 @@ const mockUseRewardsNotificationsNudge =
   useRewardsNotificationsNudge as jest.MockedFunction<
     typeof useRewardsNotificationsNudge
   >;
+const mockUseRewardsVersionGuard =
+  useRewardsVersionGuard as jest.MockedFunction<typeof useRewardsVersionGuard>;
 
 describe('RewardsNavigator', () => {
   let store: ReturnType<typeof configureStore>;
@@ -373,6 +376,9 @@ describe('RewardsNavigator', () => {
     });
     mockUseGeoRewardsMetadata.mockReturnValue({
       fetchGeoRewardsMetadata: jest.fn(),
+    });
+    mockUseRewardsVersionGuard.mockReturnValue({
+      fetchVersionRequirements: jest.fn(),
     });
     mockSelectIsRewardsVersionBlocked.mockReturnValue(false);
 
@@ -424,6 +430,35 @@ describe('RewardsNavigator', () => {
 
   const renderWithNavigation = (component: React.ReactElement) =>
     render(buildNavWrapper(component));
+
+  describe('Version guard refresh key', () => {
+    it('passes the active Rewards route to the version guard', () => {
+      mockUseNavigationState.mockImplementation(
+        (selector: (state: unknown) => unknown) =>
+          selector({
+            index: 0,
+            routes: [
+              {
+                name: Routes.REWARDS_VIEW,
+                state: {
+                  index: 1,
+                  routes: [
+                    { name: Routes.REWARDS_DASHBOARD },
+                    { name: Routes.REWARDS_CAMPAIGNS_VIEW },
+                  ],
+                },
+              },
+            ],
+          }),
+      );
+
+      renderWithNavigation(<RewardsNavigator />);
+
+      expect(mockUseRewardsVersionGuard).toHaveBeenCalledWith({
+        refreshKey: Routes.REWARDS_CAMPAIGNS_VIEW,
+      });
+    });
+  });
 
   describe('Initial route determination', () => {
     beforeEach(() => {

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -40,6 +40,7 @@ import { useRewardsNotificationsNudge } from './hooks/useRewardsNotificationsNud
 import useRewardsToast from './hooks/useRewardsToast';
 import { strings } from '../../../../locales/i18n';
 import PerpsTradingCampaignWinningView from './Views/PerpsTradingCampaignWinningView';
+import { getActiveRouteNameFromNavigationState } from './utils';
 
 let sessionNotificationsNudgeShown = false;
 const Stack = createStackNavigator();
@@ -62,7 +63,11 @@ const RewardsNavigator: React.FC = () => {
   // available regardless of mount status.
   const skipNextEffectRef = useRef(false);
 
-  useRewardsVersionGuard();
+  const activeRewardsRoute = useNavigationState(
+    getActiveRouteNameFromNavigationState,
+  );
+
+  useRewardsVersionGuard({ refreshKey: activeRewardsRoute });
 
   // Set candidate subscription ID in Redux state when component mounts and account changes
   useCandidateSubscriptionId();
@@ -93,14 +98,6 @@ const RewardsNavigator: React.FC = () => {
         ),
       );
     },
-  });
-
-  const activeRewardsRoute = useNavigationState((state) => {
-    const currentTabRoute = state.routes[state.index];
-    const stackState = currentTabRoute?.state;
-    const stackIndex =
-      typeof stackState?.index === 'number' ? stackState.index : 0;
-    return stackState?.routes[stackIndex]?.name;
   });
 
   useEffect(() => {

--- a/app/components/UI/Rewards/hooks/useRewardsVersionGuard.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsVersionGuard.ts
@@ -8,6 +8,10 @@ import {
   setVersionGuardError,
 } from '../../../../reducers/rewards';
 
+interface UseRewardsVersionGuardOptions {
+  refreshKey?: unknown;
+}
+
 interface UseRewardsVersionGuardReturn {
   fetchVersionRequirements: () => Promise<void>;
 }
@@ -17,7 +21,9 @@ interface UseRewardsVersionGuardReturn {
  * and stores the result + loading/error state in Redux. The actual blocked
  * check is done via the selectIsRewardsVersionBlocked selector.
  */
-const useRewardsVersionGuard = (): UseRewardsVersionGuardReturn => {
+const useRewardsVersionGuard = ({
+  refreshKey,
+}: UseRewardsVersionGuardOptions = {}): UseRewardsVersionGuardReturn => {
   const dispatch = useDispatch();
   const isLoadingRef = useRef(false);
 
@@ -48,8 +54,10 @@ const useRewardsVersionGuard = (): UseRewardsVersionGuardReturn => {
 
   useFocusEffect(
     useCallback(() => {
+      // Refresh when callers pass a new route/page key while this screen is focused.
+      void refreshKey;
       fetchVersionRequirements();
-    }, [fetchVersionRequirements]),
+    }, [fetchVersionRequirements, refreshKey]),
   );
 
   return { fetchVersionRequirements };

--- a/app/components/UI/Rewards/utils.test.ts
+++ b/app/components/UI/Rewards/utils.test.ts
@@ -3,6 +3,7 @@ import {
   SOLANA_SIGNUP_NOT_SUPPORTED,
   convertInternalAccountToCaipAccountId,
   deriveAccountMetricProps,
+  getActiveRouteNameFromNavigationState,
 } from './utils';
 import { parseCaipChainId, toCaipAccountId } from '@metamask/utils';
 import Logger from '../../../util/Logger';
@@ -201,6 +202,47 @@ describe('Rewards Utils', () => {
           mockAccount.address,
         );
       });
+    });
+  });
+
+  describe('getActiveRouteNameFromNavigationState', () => {
+    it('returns the active route name from a nested navigation state', () => {
+      const routeName = getActiveRouteNameFromNavigationState({
+        index: 1,
+        routes: [
+          { name: 'Wallet' },
+          {
+            name: 'RewardsTab',
+            state: {
+              index: 1,
+              routes: [
+                { name: 'RewardsDashboard' },
+                { name: 'RewardsCampaignsView' },
+              ],
+            },
+          },
+        ],
+      });
+
+      expect(routeName).toBe('RewardsCampaignsView');
+    });
+
+    it('falls back to the route name when there is no nested state', () => {
+      const routeName = getActiveRouteNameFromNavigationState({
+        index: 0,
+        routes: [{ name: 'RewardsDashboard' }],
+      });
+
+      expect(routeName).toBe('RewardsDashboard');
+    });
+
+    it('returns undefined when the navigation state has no active route', () => {
+      const routeName = getActiveRouteNameFromNavigationState({
+        index: 2,
+        routes: [{ name: 'RewardsDashboard' }],
+      });
+
+      expect(routeName).toBeUndefined();
     });
   });
 

--- a/app/components/UI/Rewards/utils.ts
+++ b/app/components/UI/Rewards/utils.ts
@@ -137,6 +137,29 @@ export const deriveAccountMetricProps = (account?: InternalAccount) => {
   };
 };
 
+interface NavigationRouteLike {
+  name?: string;
+  state?: NavigationStateLike;
+}
+
+export interface NavigationStateLike {
+  index?: number;
+  routes?: readonly NavigationRouteLike[];
+}
+
+export const getActiveRouteNameFromNavigationState = (
+  state?: NavigationStateLike,
+): string | undefined => {
+  const routeIndex = typeof state?.index === 'number' ? state.index : 0;
+  const route = state?.routes?.[routeIndex];
+
+  if (!route) {
+    return undefined;
+  }
+
+  return getActiveRouteNameFromNavigationState(route.state) ?? route.name;
+};
+
 // Referral URL builder
 export const REFERRAL_LINK_PATH = 'link.metamask.io/rewards?referral=';
 export const REFERRAL_BASE_URL = `https://${REFERRAL_LINK_PATH}`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -711,7 +711,7 @@ export type RewardsControllerApplyBonusCodeAction = {
 
 /**
  * Fetch the minimum client version requirements from the public API.
- * Cached in memory for the controller's lifetime (one fetch per app session).
+ * Cached for 30 minutes using controller state, matching other endpoint caches.
  * This is a public (unauthenticated) endpoint that does not require
  * the rewards feature to be enabled.
  */

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -185,9 +185,7 @@ class TestableRewardsController extends RewardsController {
     return this.state.seasonStatuses[`${subscriptionId}:${seasonId}`] || null;
   }
 
-  public testUpdate(
-    callback: (state: RewardsControllerState) => void | RewardsControllerState,
-  ) {
+  public testUpdate(callback: Parameters<typeof this.update>[0]) {
     this.update(callback);
   }
 }
@@ -16374,6 +16372,7 @@ describe('RewardsController', () => {
       activeBoosts: {},
       campaignParticipantStatus: {},
       campaigns: {},
+      clientVersionRequirements: null,
       offDeviceSubscriptionAccounts: {},
       ondoCampaignActivity: {},
       ondoCampaignDeposits: {},
@@ -16405,6 +16404,7 @@ describe('RewardsController', () => {
       activeBoosts: {},
       campaignParticipantStatus: {},
       campaigns: {},
+      clientVersionRequirements: null,
       offDeviceSubscriptionAccounts: {},
       ondoCampaignActivity: {},
       ondoCampaignDeposits: {},
@@ -16441,6 +16441,7 @@ describe('RewardsController', () => {
       activeBoosts: {},
       campaignParticipantStatus: {},
       campaigns: {},
+      clientVersionRequirements: null,
       offDeviceSubscriptionAccounts: {},
       ondoCampaignActivity: {},
       ondoCampaignDeposits: {},
@@ -20348,6 +20349,10 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).toHaveBeenCalledWith(
         'RewardsDataService:getClientVersionRequirements',
       );
+      expect(controller.state.clientVersionRequirements).toEqual({
+        ...mockRequirements,
+        lastFetched: 123,
+      });
     });
 
     it('returns cached result on subsequent calls', async () => {
@@ -20366,6 +20371,59 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalledWith(
         'RewardsDataService:getClientVersionRequirements',
       );
+    });
+
+    it('returns fresh cached version requirements from controller state', async () => {
+      const cachedRequirements = {
+        minimumMobileVersion: '7.72.0',
+        lastFetched: 123,
+      };
+      const cachedController = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          clientVersionRequirements: cachedRequirements,
+        },
+      });
+
+      const result = await cachedController.getClientVersionRequirements();
+
+      expect(result).toEqual({
+        minimumMobileVersion: cachedRequirements.minimumMobileVersion,
+      });
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:getClientVersionRequirements',
+      );
+    });
+
+    it('refetches cached version requirements after 30 minutes', async () => {
+      const staleFetchedAt = 0;
+      const refetchedAt = 1000 * 60 * 31;
+      jest.spyOn(Date, 'now').mockReturnValue(refetchedAt);
+
+      const cachedController = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          clientVersionRequirements: {
+            minimumMobileVersion: '7.71.0',
+            lastFetched: staleFetchedAt,
+          },
+        },
+      });
+      const mockRequirements = {
+        minimumMobileVersion: '7.72.0',
+      };
+      mockMessenger.call.mockResolvedValue(mockRequirements);
+
+      const result = await cachedController.getClientVersionRequirements();
+
+      expect(result).toEqual(mockRequirements);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getClientVersionRequirements',
+      );
+      expect(cachedController.state.clientVersionRequirements).toEqual({
+        ...mockRequirements,
+        lastFetched: refetchedAt,
+      });
     });
 
     it('does not require rewards feature to be enabled', async () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -45,6 +45,7 @@ import {
   type LineaTokenRewardDto,
   type OffDeviceSubscriptionAccountsState,
   type ClientVersionRequirementDto,
+  type ClientVersionRequirementState,
   type CampaignState,
   type CampaignDtoState,
   type SubscriptionBenefitsState,
@@ -172,6 +173,9 @@ const PERPS_TRADING_CAMPAIGN_VOLUME_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 min
 // Perps Trading participant outcome cache threshold
 const PERPS_TRADING_PARTICIPANT_OUTCOME_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
 
+// Client version requirements cache threshold
+const CLIENT_VERSION_REQUIREMENTS_CACHE_THRESHOLD_MS = 1000 * 60 * 30; // 30 minutes
+
 // Opt-in status stale threshold for not opted-in accounts to force a fresh check
 const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
 
@@ -297,6 +301,12 @@ const metadata: StateMetadata<RewardsControllerState> = {
     usedInUi: true,
   },
   perpsTradingCampaignVolume: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: true,
+  },
+  clientVersionRequirements: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: false,
@@ -501,7 +511,6 @@ export class RewardsController extends BaseController<
     string,
     { payload: OndoGmCampaignParticipantOutcomeDto; lastFetched: number }
   > = new Map();
-  #clientVersionRequirements: ClientVersionRequirementDto | null = null;
   #isDisabled: () => boolean;
   #isBitcoinOptinEnabled: () => boolean;
   #isTronOptinEnabled: () => boolean;
@@ -4493,20 +4502,35 @@ export class RewardsController extends BaseController<
 
   /**
    * Fetch the minimum client version requirements from the public API.
-   * Cached in memory for the controller's lifetime (one fetch per app session).
+   * Cached for 30 minutes using controller state, matching other endpoint caches.
    * This is a public (unauthenticated) endpoint that does not require
    * the rewards feature to be enabled.
    */
   async getClientVersionRequirements(): Promise<ClientVersionRequirementDto> {
-    if (this.#clientVersionRequirements) {
-      return this.#clientVersionRequirements;
+    const cached = this.state.clientVersionRequirements;
+    if (
+      cached &&
+      Date.now() - cached.lastFetched <
+        CLIENT_VERSION_REQUIREMENTS_CACHE_THRESHOLD_MS
+    ) {
+      const { lastFetched, ...payload } = cached;
+      return payload;
     }
 
+    Logger.log(
+      'RewardsController: Fetching fresh client version requirements via API call',
+    );
     const result = (await this.messenger.call(
       'RewardsDataService:getClientVersionRequirements',
     )) as ClientVersionRequirementDto;
 
-    this.#clientVersionRequirements = result;
+    this.update((state) => {
+      state.clientVersionRequirements = {
+        ...result,
+        lastFetched: Date.now(),
+      } as ClientVersionRequirementState;
+    });
+
     return result;
   }
 

--- a/app/core/Engine/controllers/rewards-controller/defaultState.ts
+++ b/app/core/Engine/controllers/rewards-controller/defaultState.ts
@@ -27,6 +27,7 @@ export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
   perpsTradingCampaignLeaderboard: {},
   perpsTradingCampaignLeaderboardPositions: {},
   perpsTradingCampaignVolume: {},
+  clientVersionRequirements: null,
   pointsEstimateHistory: [],
   rewardsEnvUrl: null,
 });

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -2128,6 +2128,8 @@ export type RewardsControllerState = {
   perpsTradingCampaignVolume: {
     [campaignId: string]: PerpsTradingCampaignVolumeState;
   };
+  /** Cached client version requirements for the public version guard endpoint. */
+  clientVersionRequirements: ClientVersionRequirementState | null;
   /**
    * History of points estimates for Customer Support diagnostics.
    * Stores the last N successful estimates to verify user-reported discrepancies.
@@ -2276,6 +2278,13 @@ export interface ClientVersionRequirementDto {
   minimumMobileVersion?: string;
   minimumExtensionVersion?: string;
 }
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ClientVersionRequirementState = {
+  minimumMobileVersion?: string;
+  minimumExtensionVersion?: string;
+  lastFetched: number;
+};
 
 /**
  * The action which can be used to retrieve the state of the RewardsController.

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -2304,6 +2304,29 @@ describe('rewardsReducer', () => {
       );
     });
 
+    it('should default version guard state when rehydrating older persisted rewards state', () => {
+      const persistedRewardsState = {
+        ...initialState,
+      } as Partial<RewardsState>;
+      delete persistedRewardsState.versionGuardMinimumMobileVersion;
+      delete persistedRewardsState.versionGuardLoading;
+      delete persistedRewardsState.versionGuardError;
+      const rehydrateAction = {
+        type: 'persist/REHYDRATE',
+        payload: {
+          rewards: persistedRewardsState,
+        },
+      };
+
+      const state = rewardsReducer(initialState, rehydrateAction);
+
+      expect(state.versionGuardMinimumMobileVersion).toBe(
+        initialState.versionGuardMinimumMobileVersion,
+      );
+      expect(state.versionGuardLoading).toBe(initialState.versionGuardLoading);
+      expect(state.versionGuardError).toBe(initialState.versionGuardError);
+    });
+
     it('should restore seasonWaysToEarn from persisted state', () => {
       const persistedRewardsState: RewardsState = {
         ...initialState,

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -324,7 +324,7 @@ export const initialState: RewardsState = {
 
 interface RehydrateAction extends Action<'persist/REHYDRATE'> {
   payload?: {
-    rewards?: RewardsState;
+    rewards?: Partial<RewardsState>;
   };
 }
 

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3585,14 +3585,29 @@ describe('Rewards selectors', () => {
       expect(selectVersionGuardMinimumMobileVersion(state)).toBeNull();
     });
 
+    it('selectVersionGuardMinimumMobileVersion falls back to null when missing from older state', () => {
+      const state = createMockRootState({});
+      expect(selectVersionGuardMinimumMobileVersion(state)).toBeNull();
+    });
+
     it('selectVersionGuardLoading returns loading state', () => {
       const state = createMockRootState({ versionGuardLoading: true });
       expect(selectVersionGuardLoading(state)).toBe(true);
     });
 
+    it('selectVersionGuardLoading falls back to false when missing from older state', () => {
+      const state = createMockRootState({});
+      expect(selectVersionGuardLoading(state)).toBe(false);
+    });
+
     it('selectVersionGuardError returns error state', () => {
       const state = createMockRootState({ versionGuardError: true });
       expect(selectVersionGuardError(state)).toBe(true);
+    });
+
+    it('selectVersionGuardError falls back to false when missing from older state', () => {
+      const state = createMockRootState({});
+      expect(selectVersionGuardError(state)).toBe(false);
     });
 
     describe('selectIsRewardsVersionBlocked', () => {

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -235,13 +235,14 @@ export const selectCampaignParticipantCount =
 
 // Version guard selectors
 export const selectVersionGuardMinimumMobileVersion = (state: RootState) =>
-  state.rewards.versionGuardMinimumMobileVersion;
+  state.rewards.versionGuardMinimumMobileVersion ??
+  initialState.versionGuardMinimumMobileVersion;
 
 export const selectVersionGuardLoading = (state: RootState) =>
-  state.rewards.versionGuardLoading;
+  state.rewards.versionGuardLoading ?? initialState.versionGuardLoading;
 
 export const selectVersionGuardError = (state: RootState) =>
-  state.rewards.versionGuardError;
+  state.rewards.versionGuardError ?? initialState.versionGuardError;
 
 /**
  * Returns true when the current app version is below the minimum required
@@ -249,7 +250,7 @@ export const selectVersionGuardError = (state: RootState) =>
  * Returns false when requirements have not been fetched yet.
  */
 export const selectIsRewardsVersionBlocked = (state: RootState): boolean => {
-  const minVersion = state.rewards.versionGuardMinimumMobileVersion;
+  const minVersion = selectVersionGuardMinimumMobileVersion(state);
   if (!minVersion) return false;
   return !hasMinimumRequiredVersion(minVersion);
 };

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -808,6 +808,7 @@
     "perpsTradingCampaignLeaderboard": {},
     "perpsTradingCampaignLeaderboardPositions": {},
     "perpsTradingCampaignVolume": {},
+    "clientVersionRequirements": null,
     "campaignParticipantStatus": {},
     "unlockedRewards": {},
     "seasonStatuses": {},


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how client version requirements are cached and persisted in `RewardsController`, which could affect update-blocking behavior if the cache becomes stale or is incorrectly rehydrated. Also adjusts navigation-driven refresh logic, so regressions could appear as missing/extra guard refreshes when switching Rewards screens.
> 
> **Overview**
> Rewards client version requirements are now cached for **30 minutes** in `RewardsController` state (persisted + rehydrated) instead of an in-memory per-session cache, including a `lastFetched` timestamp and tests for fresh vs. stale behavior.
> 
> The Rewards UI version guard is updated to **refresh based on the currently active Rewards route**, using a new `getActiveRouteNameFromNavigationState` utility and passing a `refreshKey` into `useRewardsVersionGuard`; tests were added for both the route extraction utility and the navigator’s guard call.
> 
> Redux version-guard selectors and rehydration logic were hardened to **gracefully handle older persisted state** by falling back to `initialState` defaults when fields are missing, with added unit tests and updated background state fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67813a166918a69a583926249d336b3b7f29b4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->