### PR TITLE
fix(rewards): musd calculator

### DIFF
--- a/app/components/UI/Rewards/Views/MusdCalculatorView.test.tsx
+++ b/app/components/UI/Rewards/Views/MusdCalculatorView.test.tsx
@@ -66,13 +66,6 @@ describe('MusdCalculatorView', () => {
     expect(getByTestId('musd-calculator-tab')).toBeOnTheScreen();
   });
 
-  it('wraps the calculator in a keyboard avoiding view', () => {
-    const { getByTestId } = render(<MusdCalculatorView />);
-    expect(
-      getByTestId('musd-calculator-keyboard-avoiding-view'),
-    ).toBeOnTheScreen();
-  });
-
   it('tracks REWARDS_PAGE_VIEWED on mount with page_type musd_calculator', () => {
     render(<MusdCalculatorView />);
 

--- a/app/components/UI/Rewards/Views/MusdCalculatorView.tsx
+++ b/app/components/UI/Rewards/Views/MusdCalculatorView.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { HeaderStandard } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
-import { KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
@@ -19,21 +18,14 @@ const MusdCalculatorView: React.FC = () => {
     <ErrorBoundary navigation={navigation} view="MusdCalculatorView">
       <SafeAreaView
         edges={{ top: 'additive' }}
-        style={tw.style('flex-1 bg-default')}
+        style={tw.style('flex-1 bg-default pb-4')}
       >
         <HeaderStandard
           title={strings('rewards.musd.page_title')}
           onBack={() => navigation.goBack()}
           backButtonProps={{ testID: 'header-back-button' }}
         />
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
-          style={tw.style('flex-1')}
-          testID="musd-calculator-keyboard-avoiding-view"
-        >
-          <MusdCalculatorTab />
-        </KeyboardAvoidingView>
+        <MusdCalculatorTab />
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.test.tsx
@@ -9,13 +9,27 @@ import { amountToPercent } from '../../../utils/musdCalculatorSlider';
 const mockPanGestureHandlers: {
   onBegin?: (event: { x: number }) => void;
   onUpdate?: (event: { x: number }) => void;
+  onEnd?: (event: { x: number }) => void;
   onFinalize?: (event: { x: number }) => void;
+} = {};
+const mockTapGestureHandlers: {
+  onEnd?: (event: { x: number }) => void;
 } = {};
 
 jest.mock('react-native-gesture-handler', () => ({
   GestureHandlerRootView: jest.requireActual('react-native').View,
   GestureDetector: ({ children }: { children: React.ReactNode }) => children,
   Gesture: {
+    Simultaneous: jest.fn((...gestures: unknown[]) => gestures),
+    Tap: jest.fn(() => ({
+      onEnd: jest.fn(function (
+        this: unknown,
+        handler: (event: { x: number }) => void,
+      ) {
+        mockTapGestureHandlers.onEnd = handler;
+        return this;
+      }),
+    })),
     Pan: jest.fn(() => ({
       minDistance: jest.fn().mockReturnThis(),
       onBegin: jest.fn(function (
@@ -30,6 +44,13 @@ jest.mock('react-native-gesture-handler', () => ({
         handler: (event: { x: number }) => void,
       ) {
         mockPanGestureHandlers.onUpdate = handler;
+        return this;
+      }),
+      onEnd: jest.fn(function (
+        this: unknown,
+        handler: (event: { x: number }) => void,
+      ) {
+        mockPanGestureHandlers.onEnd = handler;
         return this;
       }),
       onFinalize: jest.fn(function (
@@ -60,12 +81,18 @@ jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => key),
 }));
 
-jest.mock('../../../../SimulationDetails/FiatDisplay/useFiatFormatter', () =>
-  jest.fn(
-    () => (value: { toNumber: () => number }) =>
-      `$${value.toNumber().toLocaleString('en-US')}`,
-  ),
-);
+jest.mock('react-native-keyboard-aware-scroll-view', () => {
+  const ReactActual = jest.requireActual('react');
+  const { ScrollView } = jest.requireActual('react-native');
+  return {
+    KeyboardAwareScrollView: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+    }) => ReactActual.createElement(ScrollView, props, children),
+  };
+});
 
 jest.mock('../../../../../../core/DeeplinkManager', () => ({
   handleDeeplink: jest.fn(),
@@ -90,7 +117,9 @@ describe('MusdCalculatorTab', () => {
     jest.clearAllMocks();
     mockPanGestureHandlers.onBegin = undefined;
     mockPanGestureHandlers.onUpdate = undefined;
+    mockPanGestureHandlers.onEnd = undefined;
     mockPanGestureHandlers.onFinalize = undefined;
+    mockTapGestureHandlers.onEnd = undefined;
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
         trackEvent: mockTrackEvent,
@@ -112,6 +141,20 @@ describe('MusdCalculatorTab', () => {
     expect(getByText('rewards.musd.buy_button')).toBeOnTheScreen();
     expect(getByText('rewards.musd.swap_button')).toBeOnTheScreen();
     expect(getByTestId('musd-slider-track')).toBeOnTheScreen();
+  });
+
+  it('uses a keyboard-aware scroll container for the amount input', () => {
+    const { getByTestId } = render(<MusdCalculatorTab />);
+    const scrollView = getByTestId(
+      'musd-calculator-keyboard-aware-scroll-view',
+    );
+
+    expect(scrollView).toHaveProp('keyboardShouldPersistTaps', 'handled');
+    expect(scrollView).toHaveProp('keyboardDismissMode', 'none');
+    expect(scrollView).toHaveProp('enableOnAndroid', true);
+    expect(scrollView).toHaveProp('enableAutomaticScroll', true);
+    expect(scrollView).toHaveProp('enableResetScrollToCoords', false);
+    expect(scrollView).toHaveProp('extraScrollHeight', 20);
   });
 
   it('calls handleDeeplink and tracks buy_musd event when Buy button is pressed', () => {
@@ -159,14 +202,14 @@ describe('MusdCalculatorTab', () => {
     });
 
     const locationX = (amountToPercent(5000) / 100) * 300;
-    fireEvent(track, 'pressIn', {
-      nativeEvent: { locationX },
+    await act(async () => {
+      mockTapGestureHandlers.onEnd?.({ x: locationX });
     });
 
     await waitFor(() => {
       expect(getByTestId('musd-slider-amount-display')).toHaveProp(
         'value',
-        '$5,000',
+        '5000',
       );
       expect(
         getByText(/rewards\.musd\.earnings_per_day_suffix/),
@@ -183,44 +226,35 @@ describe('MusdCalculatorTab', () => {
     const { getByTestId, getByText } = render(<MusdCalculatorTab />);
     const amountInput = getByTestId('musd-slider-amount-display');
 
-    fireEvent(amountInput, 'focus');
     fireEvent.changeText(amountInput, '5000');
 
     await waitFor(() => {
       expect(amountInput).toHaveProp('value', '5000');
       expect(getByText(/\$150/)).toBeOnTheScreen();
     });
-
-    fireEvent(amountInput, 'endEditing');
-
-    await waitFor(() => {
-      expect(amountInput).toHaveProp('value', '$5,000');
-    });
   });
 
-  it('accepts amounts over the slider maximum', async () => {
+  it('caps typed amounts at the slider maximum', async () => {
     const { getByTestId, getByText } = render(<MusdCalculatorTab />);
     const amountInput = getByTestId('musd-slider-amount-display');
 
-    fireEvent(amountInput, 'focus');
     fireEvent.changeText(amountInput, '12000');
 
     await waitFor(() => {
-      expect(amountInput).toHaveProp('value', '12000');
-      expect(getByText(/\$360/)).toBeOnTheScreen();
+      expect(amountInput).toHaveProp('value', '10000');
+      expect(getByText(/\$300/)).toBeOnTheScreen();
     });
   });
 
-  it('normalizes decorated decimal input while editing', async () => {
+  it('normalizes decorated decimal input to two decimal places while editing', async () => {
     const { getByTestId, getByText } = render(<MusdCalculatorTab />);
     const amountInput = getByTestId('musd-slider-amount-display');
 
-    fireEvent(amountInput, 'focus');
     fireEvent.changeText(amountInput, '$1,234.56.78');
 
     await waitFor(() => {
-      expect(amountInput).toHaveProp('value', '1234.5678');
-      expect(getByText(/\$37\.037/)).toBeOnTheScreen();
+      expect(amountInput).toHaveProp('value', '1234.56');
+      expect(getByText(/\$37\.04/)).toBeOnTheScreen();
     });
   });
 
@@ -228,7 +262,6 @@ describe('MusdCalculatorTab', () => {
     const { getByTestId, getAllByText } = render(<MusdCalculatorTab />);
     const amountInput = getByTestId('musd-slider-amount-display');
 
-    fireEvent(amountInput, 'focus');
     fireEvent.changeText(amountInput, '.');
 
     await waitFor(() => {
@@ -240,13 +273,13 @@ describe('MusdCalculatorTab', () => {
   it('ignores slider presses before the track is measured', () => {
     const { getByTestId } = render(<MusdCalculatorTab />);
 
-    fireEvent(getByTestId('musd-slider-track'), 'pressIn', {
-      nativeEvent: { locationX: 200 },
+    act(() => {
+      mockTapGestureHandlers.onEnd?.({ x: 200 });
     });
 
     expect(getByTestId('musd-slider-amount-display')).toHaveProp(
       'value',
-      '$1,000',
+      '1000',
     );
   });
 
@@ -261,15 +294,77 @@ describe('MusdCalculatorTab', () => {
     act(() => {
       mockPanGestureHandlers.onBegin?.({ x: 150 });
       mockPanGestureHandlers.onUpdate?.({ x: 300 });
+      mockPanGestureHandlers.onEnd?.({ x: 300 });
       mockPanGestureHandlers.onFinalize?.({ x: 300 });
     });
 
     await waitFor(() => {
       expect(getByTestId('musd-slider-amount-display')).toHaveProp(
         'value',
-        '$10,000',
+        '10000',
       );
     });
+  });
+
+  it('does not reset the slider when a press finalizes without a pan', async () => {
+    const { getByTestId } = render(<MusdCalculatorTab />);
+    const track = getByTestId('musd-slider-track');
+
+    fireEvent(track, 'layout', {
+      nativeEvent: { layout: { width: 300, height: 32, x: 0, y: 0 } },
+    });
+
+    const locationX = (amountToPercent(5000) / 100) * 300;
+    await act(async () => {
+      mockTapGestureHandlers.onEnd?.({ x: locationX });
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('musd-slider-amount-display')).toHaveProp(
+        'value',
+        '5000',
+      );
+    });
+
+    act(() => {
+      mockPanGestureHandlers.onFinalize?.({ x: 0 });
+    });
+
+    expect(getByTestId('musd-slider-amount-display')).toHaveProp(
+      'value',
+      '5000',
+    );
+  });
+
+  it('does not reset when tapping the same slider position twice', async () => {
+    const { getByTestId } = render(<MusdCalculatorTab />);
+    const track = getByTestId('musd-slider-track');
+
+    fireEvent(track, 'layout', {
+      nativeEvent: { layout: { width: 300, height: 32, x: 0, y: 0 } },
+    });
+
+    const locationX = (amountToPercent(5000) / 100) * 300;
+
+    await act(async () => {
+      mockTapGestureHandlers.onEnd?.({ x: locationX });
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('musd-slider-amount-display')).toHaveProp(
+        'value',
+        '5000',
+      );
+    });
+
+    await act(async () => {
+      mockTapGestureHandlers.onEnd?.({ x: locationX });
+    });
+
+    expect(getByTestId('musd-slider-amount-display')).toHaveProp(
+      'value',
+      '5000',
+    );
   });
 
   it('ignores pan gesture handlers before the track is measured', () => {
@@ -282,7 +377,7 @@ describe('MusdCalculatorTab', () => {
 
     expect(getByTestId('musd-slider-amount-display')).toHaveProp(
       'value',
-      '$1,000',
+      '1000',
     );
   });
 });

--- a/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
+++ b/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
@@ -5,7 +5,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Keyboard, Pressable, ScrollView, TextInput } from 'react-native';
+import { LayoutChangeEvent, TextInput } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
@@ -29,7 +30,6 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { BigNumber } from 'bignumber.js';
 import { EthScope } from '@metamask/keyring-api';
 import { CaipAssetType } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
@@ -49,12 +49,13 @@ import {
   MUSD_TOKEN_ADDRESS,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../../Earn/constants/musd';
-import useFiatFormatter from '../../../../SimulationDetails/FiatDisplay/useFiatFormatter';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { RewardsMetricsButtons } from '../../../utils';
+import { formatUsd } from '../../../utils/formatUtils';
 import {
   amountToPercent,
   clampAmount,
+  MAX_AMOUNT,
   MUSD_CALCULATOR_APY,
   percentToAmount,
   SNAP_POINTS,
@@ -83,6 +84,9 @@ const THUMB_DRAG_SCALE = THUMB_SIZE_DRAG / THUMB_SIZE_REST;
 const SLIDER_ROW_HEIGHT = 32;
 /** ms between JS amount updates while dragging — keeps labels in sync without a re-render every frame */
 const SLIDER_AMOUNT_THROTTLE_MS = 48;
+const INITIAL_AMOUNT = SNAP_POINTS[1];
+const KEYBOARD_EXTRA_SCROLL_HEIGHT = 20;
+const MAX_DECIMAL_PLACES = 2;
 
 const normalizeAmountInput = (value: string) => {
   const numeric = value.replace(/[^0-9.]/g, '');
@@ -92,62 +96,38 @@ const normalizeAmountInput = (value: string) => {
     return whole;
   }
 
-  return `${whole}.${decimalParts.join('')}`;
+  return `${whole}.${decimalParts.join('').slice(0, MAX_DECIMAL_PLACES)}`;
 };
 
-const MusdCalculatorTab: React.FC = () => {
-  const tw = useTailwind();
-  const { trackEvent, createEventBuilder } = useAnalytics();
-  const [amount, setAmount] = useState(1000);
-  const amountRef = useRef(1000);
+const getAmountInputState = (value: string) => {
+  const inputValue = normalizeAmountInput(value);
+  const numericAmount = Number(inputValue);
 
+  if (Number.isFinite(numericAmount) && numericAmount > MAX_AMOUNT) {
+    return {
+      amount: MAX_AMOUNT,
+      inputValue: String(MAX_AMOUNT),
+    };
+  }
+
+  return {
+    amount: Number.isFinite(numericAmount) ? numericAmount : 0,
+    inputValue,
+  };
+};
+
+const useMusdSlider = (
+  amount: number,
+  onAmountChange: (nextAmount: number) => void,
+) => {
   const thumbScale = useSharedValue(1);
   const trackWidthShared = useSharedValue(0);
-  /** 0–100 linear track % while dragging (follows finger); at rest matches {@link amountToPercent}(amount). */
-  const thumbLinearPctShared = useSharedValue(amountToPercent(1000));
+  const thumbLinearPctShared = useSharedValue(amountToPercent(INITIAL_AMOUNT));
   const lastThrottledAmountSyncRef = useRef(0);
 
-  const ethSourceToken = useMemo(
-    () => getNativeSourceToken(EthScope.Mainnet),
-    [],
-  );
-
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
-  const formatCurrency = useCallback(
-    (value: number) => formatFiat(new BigNumber(value)),
-    [formatFiat],
-  );
-  const [amountInputValue, setAmountInputValue] = useState(() =>
-    formatCurrency(1000),
-  );
-  const [isAmountInputFocused, setIsAmountInputFocused] = useState(false);
-
   useEffect(() => {
-    amountRef.current = amount;
-    if (!isAmountInputFocused) {
-      setAmountInputValue(formatCurrency(amount));
-    }
     thumbLinearPctShared.value = amountToPercent(amount);
-  }, [amount, formatCurrency, isAmountInputFocused, thumbLinearPctShared]);
-
-  const scaleMinLabel = useMemo(
-    () => formatCurrency(SNAP_POINTS[0]),
-    [formatCurrency],
-  );
-  const scaleMidLabel = useMemo(
-    () => formatCurrency(SNAP_POINTS[1]),
-    [formatCurrency],
-  );
-  const scaleMaxLabel = useMemo(
-    () => formatCurrency(SNAP_POINTS[2]),
-    [formatCurrency],
-  );
-
-  const yearlyEarnings = useMemo(() => amount * MUSD_CALCULATOR_APY, [amount]);
-  const dailyEarnings = useMemo(
-    () => (amount * MUSD_CALCULATOR_APY) / 365,
-    [amount],
-  );
+  }, [amount, thumbLinearPctShared]);
 
   const syncAmountFromLinearPct = useCallback(
     (linearPct: number, force: boolean) => {
@@ -159,9 +139,9 @@ const MusdCalculatorTab: React.FC = () => {
         return;
       }
       lastThrottledAmountSyncRef.current = now;
-      setAmount(clampAmount(percentToAmount(linearPct)));
+      onAmountChange(clampAmount(percentToAmount(linearPct)));
     },
-    [],
+    [onAmountChange],
   );
 
   const commitSliderAtX = useCallback(
@@ -174,27 +154,19 @@ const MusdCalculatorTab: React.FC = () => {
       const linearPct = (clampedX / w) * 100;
       thumbLinearPctShared.value = linearPct;
       const next = clampAmount(percentToAmount(linearPct));
-      setAmount(next);
+      onAmountChange(next);
       thumbLinearPctShared.value = amountToPercent(next);
       lastThrottledAmountSyncRef.current = 0;
     },
-    [thumbLinearPctShared, trackWidthShared],
+    [onAmountChange, thumbLinearPctShared, trackWidthShared],
   );
 
   const panGesture = useMemo(
     () =>
       Gesture.Pan()
         .minDistance(2)
-        .onBegin((e) => {
+        .onBegin(() => {
           thumbScale.value = withTiming(THUMB_DRAG_SCALE, { duration: 150 });
-          const w = trackWidthShared.value;
-          if (w <= 0) {
-            return;
-          }
-          const clampedX = Math.max(0, Math.min(w, e.x));
-          const linearPct = (clampedX / w) * 100;
-          thumbLinearPctShared.value = linearPct;
-          runOnJS(syncAmountFromLinearPct)(linearPct, true);
         })
         .onUpdate((e) => {
           const w = trackWidthShared.value;
@@ -206,9 +178,11 @@ const MusdCalculatorTab: React.FC = () => {
           thumbLinearPctShared.value = linearPct;
           runOnJS(syncAmountFromLinearPct)(linearPct, false);
         })
-        .onFinalize((e) => {
-          thumbScale.value = withTiming(1, { duration: 150 });
+        .onEnd((e) => {
           runOnJS(commitSliderAtX)(e.x);
+        })
+        .onFinalize(() => {
+          thumbScale.value = withTiming(1, { duration: 150 });
         }),
     [
       thumbScale,
@@ -217,6 +191,19 @@ const MusdCalculatorTab: React.FC = () => {
       syncAmountFromLinearPct,
       commitSliderAtX,
     ],
+  );
+
+  const tapGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd((e) => {
+        runOnJS(commitSliderAtX)(e.x);
+      }),
+    [commitSliderAtX],
+  );
+
+  const sliderGesture = useMemo(
+    () => Gesture.Simultaneous(tapGesture, panGesture),
+    [tapGesture, panGesture],
   );
 
   const animatedFillStyle = useAnimatedStyle(() => {
@@ -234,6 +221,47 @@ const MusdCalculatorTab: React.FC = () => {
       left: filled - THUMB_SIZE_REST / 2,
     };
   });
+
+  const handleSliderLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      trackWidthShared.value = event.nativeEvent.layout.width;
+    },
+    [trackWidthShared],
+  );
+
+  return {
+    animatedFillStyle,
+    animatedThumbStyle,
+    handleSliderLayout,
+    sliderGesture,
+  };
+};
+
+const MusdCalculatorTab: React.FC = () => {
+  const tw = useTailwind();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const [amount, setAmount] = useState<number>(INITIAL_AMOUNT);
+
+  const ethSourceToken = useMemo(
+    () => getNativeSourceToken(EthScope.Mainnet),
+    [],
+  );
+
+  const [amountInputValue, setAmountInputValue] = useState(() =>
+    String(INITIAL_AMOUNT),
+  );
+  const handleAmountChange = useCallback((nextAmount: number) => {
+    setAmount(nextAmount);
+    setAmountInputValue(String(nextAmount));
+  }, []);
+  const slider = useMusdSlider(amount, handleAmountChange);
+
+  const scaleMinLabel = formatUsd(SNAP_POINTS[0]);
+  const scaleMidLabel = formatUsd(SNAP_POINTS[1]);
+  const scaleMaxLabel = formatUsd(SNAP_POINTS[2]);
+
+  const yearlyEarnings = amount * MUSD_CALCULATOR_APY;
+  const dailyEarnings = yearlyEarnings / 365;
 
   const handleBuyMusd = useCallback(() => {
     trackEvent(
@@ -260,30 +288,23 @@ const MusdCalculatorTab: React.FC = () => {
     goToSwaps();
   }, [goToSwaps, trackEvent, createEventBuilder]);
 
-  const handleAmountInputFocus = useCallback(() => {
-    setIsAmountInputFocused(true);
-    setAmountInputValue(String(amount));
-  }, [amount]);
-
   const handleAmountInputChange = useCallback((value: string) => {
-    const normalizedValue = normalizeAmountInput(value);
-    setAmountInputValue(normalizedValue);
-
-    const nextAmount = Number(normalizedValue);
-    amountRef.current = Number.isFinite(nextAmount) ? nextAmount : 0;
-    setAmount(amountRef.current);
+    const nextInputState = getAmountInputState(value);
+    setAmountInputValue(nextInputState.inputValue);
+    setAmount(nextInputState.amount);
   }, []);
 
-  const handleAmountInputEndEditing = useCallback(() => {
-    setIsAmountInputFocused(false);
-    setAmountInputValue(formatCurrency(amountRef.current));
-  }, [formatCurrency]);
-
   return (
-    <ScrollView
+    <KeyboardAwareScrollView
       style={tw.style('flex-1')}
-      contentContainerStyle={tw.style('flex-grow px-4 pb-8 pt-2')}
+      contentContainerStyle={tw.style('flex-grow px-4 pb-4 pt-2')}
       keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="none"
+      enableOnAndroid
+      enableAutomaticScroll
+      enableResetScrollToCoords={false}
+      extraScrollHeight={KEYBOARD_EXTRA_SCROLL_HEIGHT}
+      testID="musd-calculator-keyboard-aware-scroll-view"
     >
       <Box twClassName="flex-1 flex-col">
         <Box
@@ -335,7 +356,7 @@ const MusdCalculatorTab: React.FC = () => {
                 twClassName="text-[64px] leading-[72px] font-semibold"
               >
                 {strings('rewards.musd.yearly_positive_prefix')}
-                {formatCurrency(yearlyEarnings)}
+                {formatUsd(yearlyEarnings)}
               </Text>
               <Text
                 variant={TextVariant.HeadingMd}
@@ -356,7 +377,7 @@ const MusdCalculatorTab: React.FC = () => {
                 color={TextColor.TextAlternative}
                 fontWeight={FontWeight.Medium}
               >
-                {formatCurrency(dailyEarnings)}
+                {formatUsd(dailyEarnings)}
                 {strings('rewards.musd.earnings_per_day_suffix')}
               </Text>
             </Box>
@@ -374,11 +395,7 @@ const MusdCalculatorTab: React.FC = () => {
               <TextInput
                 keyboardType="numeric"
                 returnKeyType="done"
-                onFocus={handleAmountInputFocus}
                 onChangeText={handleAmountInputChange}
-                onEndEditing={handleAmountInputEndEditing}
-                onSubmitEditing={Keyboard.dismiss}
-                blurOnSubmit
                 selectTextOnFocus
                 value={amountInputValue}
                 accessibilityLabel={strings('rewards.musd.slider_amount_label')}
@@ -389,17 +406,12 @@ const MusdCalculatorTab: React.FC = () => {
               />
             </Box>
 
-            <GestureDetector gesture={panGesture}>
-              <Pressable
+            <GestureDetector gesture={slider.sliderGesture}>
+              <Animated.View
                 testID="musd-slider-track"
                 accessibilityRole="adjustable"
-                accessibilityValue={{ text: formatCurrency(amount) }}
-                onLayout={(event) => {
-                  trackWidthShared.value = event.nativeEvent.layout.width;
-                }}
-                onPressIn={(event) => {
-                  commitSliderAtX(event.nativeEvent.locationX);
-                }}
+                accessibilityValue={{ text: formatUsd(amount) }}
+                onLayout={slider.handleSliderLayout}
                 style={tw.style('h-8 w-full justify-center')}
               >
                 <Box
@@ -416,7 +428,7 @@ const MusdCalculatorTab: React.FC = () => {
                       height: TRACK_HEIGHT,
                       top: (SLIDER_ROW_HEIGHT - TRACK_HEIGHT) / 2,
                     },
-                    animatedFillStyle,
+                    slider.animatedFillStyle,
                   ]}
                 />
                 <Animated.View
@@ -429,10 +441,10 @@ const MusdCalculatorTab: React.FC = () => {
                       height: THUMB_SIZE_REST,
                       top: (SLIDER_ROW_HEIGHT - THUMB_SIZE_REST) / 2,
                     },
-                    animatedThumbStyle,
+                    slider.animatedThumbStyle,
                   ]}
                 />
-              </Pressable>
+              </Animated.View>
             </GestureDetector>
 
             <Box
@@ -488,7 +500,7 @@ const MusdCalculatorTab: React.FC = () => {
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Stretch}
-          twClassName="gap-4"
+          twClassName="gap-4 py-4 mb-2"
         >
           <Button
             variant={ButtonVariant.Primary}
@@ -510,7 +522,7 @@ const MusdCalculatorTab: React.FC = () => {
           </Button>
         </Box>
       </Box>
-    </ScrollView>
+    </KeyboardAwareScrollView>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
https://consensyssoftware.atlassian.net/browse/RWDS-1294
https://consensyssoftware.atlassian.net/browse/RWDS-1295
https://consensyssoftware.atlassian.net/browse/RWDS-1297

- Updated the mUSD calculator screen container to align better with other Rewards views and avoid unnecessary nested keyboard handling.
- Moved keyboard handling into MusdCalculatorTab with KeyboardAwareScrollView so the amount input stays visible while editing.
- Simplified calculator state: raw string for the text input, numeric amount for slider and earnings calculations.
- Normalized amount input to strip decorations, limit to two decimal places, and cap values at 10,000.
- Reused the shared formatUsd utility instead of local fiat formatter/BigNumber wiring.
- Refactored slider gesture handling to separate tap and pan behavior, fixing resets when tapping or long-pressing the slider.
- Removed unnecessary input focus/end-edit/submit handlers.
- Removed unnecessary useMemo usage for simple labels and earnings calculations.
- Added regression tests for keyboard-aware behavior, input normalization, amount capping, and slider reset cases.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/0a80bef1-8dfa-41db-a41e-8a1432a005b8



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors slider gesture handling and amount parsing/formatting, which can affect user-entered values and earnings calculations across iOS/Android keyboard behavior.
> 
> **Overview**
> Improves the mUSD calculator UX by **moving keyboard avoidance into the tab** via `KeyboardAwareScrollView` and simplifying the view container (removing the outer `KeyboardAvoidingView` and adjusting padding).
> 
> Refactors `MusdCalculatorTab` to keep **raw numeric input state**, cap input at `MAX_AMOUNT`, and limit decimals to 2, while switching all USD display to the shared `formatUsd` helper.
> 
> Reworks slider interactions to use **simultaneous tap + pan gestures** (instead of `Pressable` press handling) to prevent unintended slider resets, and adds/updates tests to cover keyboard-aware props, input normalization/capping, and gesture regression cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d920981b39d914e81d6b013eadf4c277ffc4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->