### PR TITLE
feat(predict): Add World Cup tab data hooks and content

### DIFF
--- a/app/components/UI/Predict/constants/worldCupTabs.test.ts
+++ b/app/components/UI/Predict/constants/worldCupTabs.test.ts
@@ -1,0 +1,54 @@
+import {
+  getPredictWorldCupAvailableTabKeys,
+  PREDICT_WORLD_CUP_TAB_KEYS,
+  resolvePredictWorldCupInitialTab,
+} from './worldCupTabs';
+
+const config = {
+  stages: [
+    { key: 'group-stage', eventIds: ['123'] },
+    { key: 'final', eventIds: ['456'] },
+  ],
+};
+
+describe('worldCupTabs', () => {
+  describe('getPredictWorldCupAvailableTabKeys', () => {
+    it('returns all fixed and configured stage tabs when availability is not supplied', () => {
+      expect(getPredictWorldCupAvailableTabKeys(config)).toEqual([
+        PREDICT_WORLD_CUP_TAB_KEYS.ALL,
+        PREDICT_WORLD_CUP_TAB_KEYS.LIVE,
+        PREDICT_WORLD_CUP_TAB_KEYS.PROPS,
+        'group-stage',
+        'final',
+      ]);
+    });
+
+    it('hides Live, Props, and stage tabs when availability is false', () => {
+      expect(
+        getPredictWorldCupAvailableTabKeys(config, {
+          live: false,
+          props: true,
+          stages: {
+            'group-stage': false,
+            final: true,
+          },
+        }),
+      ).toEqual([PREDICT_WORLD_CUP_TAB_KEYS.ALL, 'props', 'final']);
+    });
+  });
+
+  describe('resolvePredictWorldCupInitialTab', () => {
+    it('falls back to All when requested tab is hidden by availability', () => {
+      expect(
+        resolvePredictWorldCupInitialTab('group-stage', config, {
+          live: true,
+          props: true,
+          stages: {
+            'group-stage': false,
+            final: true,
+          },
+        }),
+      ).toBe(PREDICT_WORLD_CUP_TAB_KEYS.ALL);
+    });
+  });
+});

--- a/app/components/UI/Predict/constants/worldCupTabs.ts
+++ b/app/components/UI/Predict/constants/worldCupTabs.ts
@@ -10,16 +10,32 @@ export const PREDICT_WORLD_CUP_TAB_KEYS = {
 
 export type PredictWorldCupTabKey = string;
 
+export interface PredictWorldCupTabAvailability {
+  live: boolean;
+  props: boolean;
+  stages: Record<string, boolean>;
+}
+
 export const getPredictWorldCupAvailableTabKeys = (
   config?: Pick<PredictWorldCupConfig, 'stages'>,
+  availability?: PredictWorldCupTabAvailability,
 ): string[] => [
-  ...Object.values(PREDICT_WORLD_CUP_TAB_KEYS),
-  ...(config?.stages ?? []).map((stage) => stage.key),
+  PREDICT_WORLD_CUP_TAB_KEYS.ALL,
+  ...(!availability || availability.live
+    ? [PREDICT_WORLD_CUP_TAB_KEYS.LIVE]
+    : []),
+  ...(!availability || availability.props
+    ? [PREDICT_WORLD_CUP_TAB_KEYS.PROPS]
+    : []),
+  ...(config?.stages ?? [])
+    .filter((stage) => !availability || availability.stages[stage.key])
+    .map((stage) => stage.key),
 ];
 
 export const resolvePredictWorldCupInitialTab = (
   requestedTab?: string | null,
   config?: Pick<PredictWorldCupConfig, 'stages'>,
+  availability?: PredictWorldCupTabAvailability,
 ): PredictWorldCupTabKey => {
   const normalizedTab = requestedTab?.toLowerCase();
 
@@ -27,7 +43,10 @@ export const resolvePredictWorldCupInitialTab = (
     return PREDICT_WORLD_CUP_TAB_KEYS.ALL;
   }
 
-  const availableTabKeys = getPredictWorldCupAvailableTabKeys(config);
+  const availableTabKeys = getPredictWorldCupAvailableTabKeys(
+    config,
+    availability,
+  );
 
   return availableTabKeys.includes(normalizedTab)
     ? normalizedTab

--- a/app/components/UI/Predict/hooks/index.ts
+++ b/app/components/UI/Predict/hooks/index.ts
@@ -25,3 +25,15 @@ export {
 } from './usePredictSearch';
 
 export { usePredictCashOut } from './usePredictCashOut';
+
+export {
+  usePredictWorldCupAllMarkets,
+  usePredictWorldCupPropsMarkets,
+  usePredictWorldCupLiveMarkets,
+  usePredictWorldCupStageMarkets,
+  usePredictWorldCupAvailability,
+  usePredictWorldCupAvailableTabs,
+  type UsePredictWorldCupMarketsOptions,
+  type UsePredictWorldCupAvailableTabsOptions,
+  type PredictWorldCupAvailableTab,
+} from './usePredictWorldCup';

--- a/app/components/UI/Predict/hooks/index.ts
+++ b/app/components/UI/Predict/hooks/index.ts
@@ -27,10 +27,7 @@ export {
 export { usePredictCashOut } from './usePredictCashOut';
 
 export {
-  usePredictWorldCupAllMarkets,
-  usePredictWorldCupPropsMarkets,
-  usePredictWorldCupLiveMarkets,
-  usePredictWorldCupStageMarkets,
+  usePredictWorldCupMarkets,
   usePredictWorldCupAvailability,
   usePredictWorldCupAvailableTabs,
   type UsePredictWorldCupMarketsOptions,

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
@@ -1,75 +1,100 @@
-import { renderHook } from '@testing-library/react-native';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
 import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../constants/flags';
-import { usePredictMarketData } from './usePredictMarketData';
+import { Recurrence, type PredictMarket } from '../types';
 import { usePredictWorldCupMarkets } from './usePredictWorldCup';
 
-jest.mock('./usePredictMarketData', () => ({
-  usePredictMarketData: jest.fn(() => ({
-    marketData: [],
-    isFetching: false,
-    isFetchingMore: false,
-    error: null,
-    hasMore: false,
-    refetch: jest.fn(),
-    fetchMore: jest.fn(),
-  })),
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      getMarkets: jest.fn(),
+    },
+  },
 }));
 
-const mockUsePredictMarketData = jest.mocked(usePredictMarketData);
+const mockGetMarkets = jest.mocked(Engine.context.PredictController.getMarkets);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { cacheTime: Infinity, retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+
+const createMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'market-1',
+  title: 'Market 1',
+  description: 'Description',
+  image: 'image.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'hot',
+  tags: [],
+  outcomes: [],
+  liquidity: 0,
+  volume: 0,
+  ...overrides,
+});
 
 describe('usePredictWorldCupMarkets', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePredictMarketData.mockReturnValue({
-      marketData: [],
-      isFetching: false,
-      isFetchingMore: false,
-      error: null,
-      hasMore: false,
-      refetch: jest.fn(),
-      fetchMore: jest.fn(),
-    });
   });
 
-  it('requests All markets with pagination enabled', () => {
-    mockUsePredictMarketData.mockReturnValue({
-      marketData: [],
-      isFetching: false,
-      isFetchingMore: false,
-      error: null,
-      hasMore: true,
-      refetch: jest.fn(),
-      fetchMore: jest.fn(),
-    });
+  it('requests All markets with a cached paginated query', async () => {
+    const { Wrapper } = createWrapper();
+    const allMarket = createMarket({ id: 'all-market' });
+    mockGetMarkets.mockResolvedValue([allMarket]);
 
-    const { result } = renderHook(() =>
-      usePredictWorldCupMarkets({
-        tabKey: 'all',
-        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
-        pageSize: 30,
-      }),
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'all',
+          config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+          pageSize: 30,
+        }),
+      { wrapper: Wrapper },
     );
 
-    expect(mockUsePredictMarketData).toHaveBeenCalledWith({
+    await waitFor(() => expect(result.current.marketData).toEqual([allMarket]));
+
+    expect(mockGetMarkets).toHaveBeenCalledWith({
       category: 'hot',
       customQueryParams:
         'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
-      pageSize: 30,
-      refine: undefined,
-      enabled: true,
+      limit: 30,
+      offset: 0,
     });
-    expect(result.current.hasMore).toBe(true);
+    expect(result.current.hasMore).toBe(false);
   });
 
-  it('requests Props markets with pagination enabled', () => {
-    renderHook(() =>
-      usePredictWorldCupMarkets({
-        tabKey: 'props',
-        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
-      }),
+  it('requests Props markets with a cached paginated query', async () => {
+    const { Wrapper } = createWrapper();
+    const propsMarket = createMarket({ id: 'props-market' });
+    mockGetMarkets.mockResolvedValue([propsMarket]);
+
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'props',
+          config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        }),
+      { wrapper: Wrapper },
     );
 
-    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+    await waitFor(() =>
+      expect(result.current.marketData).toEqual([propsMarket]),
+    );
+
+    expect(mockGetMarkets).toHaveBeenCalledWith(
       expect.objectContaining({
         customQueryParams:
           'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume&ascending=false',
@@ -77,25 +102,25 @@ describe('usePredictWorldCupMarkets', () => {
     );
   });
 
-  it('requests Live markets without pagination', () => {
-    mockUsePredictMarketData.mockReturnValue({
-      marketData: [],
-      isFetching: false,
-      isFetchingMore: true,
-      error: null,
-      hasMore: true,
-      refetch: jest.fn(),
-      fetchMore: jest.fn(),
-    });
+  it('requests Live markets without pagination', async () => {
+    const { Wrapper } = createWrapper();
+    const liveMarket = createMarket({ id: 'live-market' });
+    mockGetMarkets.mockResolvedValue([liveMarket]);
 
-    const { result } = renderHook(() =>
-      usePredictWorldCupMarkets({
-        tabKey: 'live',
-        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
-      }),
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'live',
+          config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        }),
+      { wrapper: Wrapper },
     );
 
-    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+    await waitFor(() =>
+      expect(result.current.marketData).toEqual([liveMarket]),
+    );
+
+    expect(mockGetMarkets).toHaveBeenCalledWith(
       expect.objectContaining({
         customQueryParams:
           'active=true&archived=false&closed=false&series_id=11433&tag_id=100639&live=true&order=startDate',
@@ -105,48 +130,88 @@ describe('usePredictWorldCupMarkets', () => {
     expect(result.current.isFetchingMore).toBe(false);
   });
 
-  it('requests stage markets with all configured event IDs and no pagination', () => {
+  it('requests stage markets with all configured event IDs and no pagination', async () => {
+    const { Wrapper } = createWrapper();
+    const stageMarket = createMarket({ id: 'stage-market' });
     const config = {
       ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
       stages: [{ key: 'group-stage', eventIds: ['123', '456'] }],
     };
+    mockGetMarkets.mockResolvedValue([stageMarket]);
 
-    const { result } = renderHook(() =>
-      usePredictWorldCupMarkets({
-        tabKey: 'group-stage',
-        config,
-      }),
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'group-stage',
+          config,
+        }),
+      { wrapper: Wrapper },
     );
 
-    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+    await waitFor(() =>
+      expect(result.current.marketData).toEqual([stageMarket]),
+    );
+
+    expect(mockGetMarkets).toHaveBeenCalledWith(
       expect.objectContaining({
         customQueryParams:
           'active=true&archived=false&closed=false&id=123&id=456',
-        pageSize: 2,
-        refine: expect.any(Function),
+        limit: 2,
+        offset: 0,
       }),
     );
     expect(result.current.hasMore).toBe(false);
   });
 
   it('skips fetching for a stage without configured event IDs', () => {
+    const { Wrapper } = createWrapper();
     const config = {
       ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
       stages: [{ key: 'empty-stage', eventIds: [] }],
     };
 
-    renderHook(() =>
-      usePredictWorldCupMarkets({
-        tabKey: 'empty-stage',
-        config,
-      }),
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'empty-stage',
+          config,
+        }),
+      { wrapper: Wrapper },
     );
 
-    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customQueryParams: '',
-        enabled: false,
-      }),
+    expect(result.current.marketData).toEqual([]);
+    expect(mockGetMarkets).not.toHaveBeenCalled();
+  });
+
+  it('returns cached data when switching back to a previously loaded tab', async () => {
+    const { Wrapper } = createWrapper();
+    const allMarket = createMarket({ id: 'all-market' });
+    const liveMarket = createMarket({ id: 'live-market' });
+    mockGetMarkets
+      .mockResolvedValueOnce([allMarket])
+      .mockResolvedValueOnce([liveMarket]);
+
+    const { result, rerender } = renderHook(
+      ({ tabKey }: { tabKey: 'all' | 'live' }) =>
+        usePredictWorldCupMarkets({
+          tabKey,
+          config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        }),
+      { initialProps: { tabKey: 'all' }, wrapper: Wrapper },
     );
+
+    await waitFor(() => expect(result.current.marketData).toEqual([allMarket]));
+
+    rerender({ tabKey: 'live' });
+
+    await waitFor(() =>
+      expect(result.current.marketData).toEqual([liveMarket]),
+    );
+
+    mockGetMarkets.mockClear();
+    rerender({ tabKey: 'all' });
+
+    expect(result.current.marketData).toEqual([allMarket]);
+    expect(mockGetMarkets).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
@@ -1,0 +1,152 @@
+import { renderHook } from '@testing-library/react-native';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../constants/flags';
+import { usePredictMarketData } from './usePredictMarketData';
+import { usePredictWorldCupMarkets } from './usePredictWorldCup';
+
+jest.mock('./usePredictMarketData', () => ({
+  usePredictMarketData: jest.fn(() => ({
+    marketData: [],
+    isFetching: false,
+    isFetchingMore: false,
+    error: null,
+    hasMore: false,
+    refetch: jest.fn(),
+    fetchMore: jest.fn(),
+  })),
+}));
+
+const mockUsePredictMarketData = jest.mocked(usePredictMarketData);
+
+describe('usePredictWorldCupMarkets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePredictMarketData.mockReturnValue({
+      marketData: [],
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+  });
+
+  it('requests All markets with pagination enabled', () => {
+    mockUsePredictMarketData.mockReturnValue({
+      marketData: [],
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: true,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      usePredictWorldCupMarkets({
+        tabKey: 'all',
+        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        pageSize: 30,
+      }),
+    );
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith({
+      category: 'hot',
+      customQueryParams:
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
+      pageSize: 30,
+      refine: undefined,
+      enabled: true,
+    });
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('requests Props markets with pagination enabled', () => {
+    renderHook(() =>
+      usePredictWorldCupMarkets({
+        tabKey: 'props',
+        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      }),
+    );
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customQueryParams:
+          'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume&ascending=false',
+      }),
+    );
+  });
+
+  it('requests Live markets without pagination', () => {
+    mockUsePredictMarketData.mockReturnValue({
+      marketData: [],
+      isFetching: false,
+      isFetchingMore: true,
+      error: null,
+      hasMore: true,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      usePredictWorldCupMarkets({
+        tabKey: 'live',
+        config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      }),
+    );
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customQueryParams:
+          'active=true&archived=false&closed=false&series_id=11433&tag_id=100639&live=true&order=startDate',
+      }),
+    );
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.isFetchingMore).toBe(false);
+  });
+
+  it('requests stage markets with all configured event IDs and no pagination', () => {
+    const config = {
+      ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      stages: [{ key: 'group-stage', eventIds: ['123', '456'] }],
+    };
+
+    const { result } = renderHook(() =>
+      usePredictWorldCupMarkets({
+        tabKey: 'group-stage',
+        config,
+      }),
+    );
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customQueryParams:
+          'active=true&archived=false&closed=false&id=123&id=456',
+        pageSize: 2,
+        refine: expect.any(Function),
+      }),
+    );
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('skips fetching for a stage without configured event IDs', () => {
+    const config = {
+      ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      stages: [{ key: 'empty-stage', eventIds: [] }],
+    };
+
+    renderHook(() =>
+      usePredictWorldCupMarkets({
+        tabKey: 'empty-stage',
+        config,
+      }),
+    );
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customQueryParams: '',
+        enabled: false,
+      }),
+    );
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.ts
@@ -1,0 +1,171 @@
+import { useMemo } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { predictQueries } from '../queries';
+import {
+  getPredictWorldCupAvailableTabKeys,
+  PREDICT_WORLD_CUP_TAB_KEYS,
+  type PredictWorldCupTabAvailability,
+  type PredictWorldCupTabKey,
+} from '../constants/worldCupTabs';
+import {
+  buildPredictWorldCupAllQuery,
+  buildPredictWorldCupPropsQuery,
+  resolvePredictWorldCupStageLabel,
+} from '../utils/worldCup';
+import { usePredictMarketData } from './usePredictMarketData';
+import type {
+  PredictWorldCupConfig,
+  PredictWorldCupStageConfig,
+} from '../types/flags';
+
+export interface UsePredictWorldCupMarketsOptions {
+  enabled?: boolean;
+  pageSize?: number;
+}
+
+export interface UsePredictWorldCupAvailableTabsOptions {
+  enabled?: boolean;
+}
+
+export interface PredictWorldCupAvailableTab {
+  key: PredictWorldCupTabKey;
+  label: string;
+  isLive?: boolean;
+}
+
+const DEFAULT_WORLD_CUP_MARKETS_OPTIONS = {
+  enabled: true,
+} as const;
+
+export const usePredictWorldCupAllMarkets = (
+  config: Pick<PredictWorldCupConfig, 'tagSlug'>,
+  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) =>
+  usePredictMarketData({
+    category: 'hot',
+    customQueryParams: buildPredictWorldCupAllQuery(config),
+    pageSize: options.pageSize,
+    enabled: options.enabled,
+  });
+
+export const usePredictWorldCupPropsMarkets = (
+  config: Pick<PredictWorldCupConfig, 'tagSlug' | 'gamesTagId'>,
+  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) =>
+  usePredictMarketData({
+    category: 'hot',
+    customQueryParams: buildPredictWorldCupPropsQuery(config),
+    pageSize: options.pageSize,
+    enabled: options.enabled,
+  });
+
+export const usePredictWorldCupLiveMarkets = (
+  config: Pick<PredictWorldCupConfig, 'seriesId' | 'gamesTagId'>,
+  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) =>
+  useQuery({
+    ...predictQueries.worldCup.options.live(config, {
+      limit: options.pageSize,
+    }),
+    enabled: options.enabled,
+  });
+
+export const usePredictWorldCupStageMarkets = (
+  stage: Pick<PredictWorldCupStageConfig, 'key' | 'eventIds'>,
+  options: Pick<
+    UsePredictWorldCupMarketsOptions,
+    'enabled'
+  > = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) =>
+  useQuery({
+    ...predictQueries.worldCup.options.stage(stage),
+    enabled: options.enabled,
+  });
+
+export const usePredictWorldCupAvailability = (
+  config: Pick<
+    PredictWorldCupConfig,
+    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
+  >,
+  options: UsePredictWorldCupAvailableTabsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) => {
+  const enabled = options.enabled ?? true;
+  const queries = useQueries({
+    queries: [
+      predictQueries.worldCup.options.availability.live(config),
+      predictQueries.worldCup.options.availability.props(config),
+      ...config.stages.map((stage) =>
+        predictQueries.worldCup.options.availability.stage(stage),
+      ),
+    ].map((queryOption) => ({
+      ...queryOption,
+      enabled,
+    })),
+  });
+
+  const availability: PredictWorldCupTabAvailability = {
+    live: queries[0]?.data ?? false,
+    props: queries[1]?.data ?? false,
+    stages: config.stages.reduce<Record<string, boolean>>(
+      (accumulator, stage, index) => ({
+        ...accumulator,
+        [stage.key]: queries[index + 2]?.data ?? false,
+      }),
+      {},
+    ),
+  };
+
+  return {
+    availability,
+    isFetching: queries.some((query) => query.isFetching),
+    isLoading: queries.some((query) => query.isLoading),
+    errors: queries.map((query) => query.error),
+    refetch: () => Promise.all(queries.map((query) => query.refetch())),
+  };
+};
+
+export const usePredictWorldCupAvailableTabs = (
+  config: Pick<
+    PredictWorldCupConfig,
+    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
+  >,
+  options: UsePredictWorldCupAvailableTabsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
+) => {
+  const { availability, ...availabilityQuery } = usePredictWorldCupAvailability(
+    config,
+    options,
+  );
+
+  const tabs = useMemo<PredictWorldCupAvailableTab[]>(() => {
+    const availableKeys = getPredictWorldCupAvailableTabKeys(
+      config,
+      availability,
+    );
+
+    return availableKeys.map((key) => {
+      switch (key) {
+        case PREDICT_WORLD_CUP_TAB_KEYS.ALL:
+          return { key, label: 'All' };
+        case PREDICT_WORLD_CUP_TAB_KEYS.LIVE:
+          return { key, label: 'Live', isLive: true };
+        case PREDICT_WORLD_CUP_TAB_KEYS.PROPS:
+          return { key, label: 'Props' };
+        default: {
+          const stage = config.stages.find(
+            (configuredStage) => configuredStage.key === key,
+          );
+          return {
+            key,
+            label: stage ? resolvePredictWorldCupStageLabel(stage) : key,
+          };
+        }
+      }
+    });
+  }, [availability, config]);
+
+  return {
+    ...availabilityQuery,
+    availability,
+    tabs,
+  };
+};

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { predictQueries } from '../queries';
 import {
   getPredictWorldCupAvailableTabKeys,
@@ -9,16 +9,24 @@ import {
 } from '../constants/worldCupTabs';
 import {
   buildPredictWorldCupAllQuery,
+  buildPredictWorldCupLiveQuery,
   buildPredictWorldCupPropsQuery,
+  buildPredictWorldCupStageEventsQuery,
   resolvePredictWorldCupStageLabel,
 } from '../utils/worldCup';
-import { usePredictMarketData } from './usePredictMarketData';
-import type {
-  PredictWorldCupConfig,
-  PredictWorldCupStageConfig,
-} from '../types/flags';
+import { sortPredictWorldCupMarketsByStartTime } from '../services/worldCup';
+import {
+  usePredictMarketData,
+  type UsePredictMarketDataResult,
+} from './usePredictMarketData';
+import type { PredictWorldCupConfig } from '../types/flags';
 
 export interface UsePredictWorldCupMarketsOptions {
+  tabKey: PredictWorldCupTabKey;
+  config: Pick<
+    PredictWorldCupConfig,
+    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
+  >;
   enabled?: boolean;
   pageSize?: number;
 }
@@ -33,54 +41,110 @@ export interface PredictWorldCupAvailableTab {
   isLive?: boolean;
 }
 
+interface WorldCupMarketDataConfig {
+  queryParams: string;
+  pageSize?: number;
+  paginationEnabled: boolean;
+  refine?: UsePredictWorldCupMarketRefine;
+  enabled: boolean;
+}
+
+type UsePredictWorldCupMarketRefine = NonNullable<
+  Parameters<typeof usePredictMarketData>[0]
+>['refine'];
+
 const DEFAULT_WORLD_CUP_MARKETS_OPTIONS = {
   enabled: true,
 } as const;
 
-export const usePredictWorldCupAllMarkets = (
-  config: Pick<PredictWorldCupConfig, 'tagSlug'>,
-  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
-) =>
-  usePredictMarketData({
+const getWorldCupMarketDataConfig = ({
+  tabKey,
+  config,
+  enabled = true,
+  pageSize,
+}: UsePredictWorldCupMarketsOptions): WorldCupMarketDataConfig => {
+  switch (tabKey) {
+    case PREDICT_WORLD_CUP_TAB_KEYS.ALL:
+      return {
+        queryParams: buildPredictWorldCupAllQuery(config),
+        pageSize,
+        paginationEnabled: true,
+        enabled,
+      };
+    case PREDICT_WORLD_CUP_TAB_KEYS.PROPS:
+      return {
+        queryParams: buildPredictWorldCupPropsQuery(config),
+        pageSize,
+        paginationEnabled: true,
+        enabled,
+      };
+    case PREDICT_WORLD_CUP_TAB_KEYS.LIVE:
+      return {
+        queryParams: buildPredictWorldCupLiveQuery(config),
+        pageSize,
+        paginationEnabled: false,
+        enabled,
+      };
+    default: {
+      const stage = config.stages.find(
+        (configuredStage) => configuredStage.key === tabKey,
+      );
+
+      if (!stage || stage.eventIds.length === 0) {
+        return {
+          queryParams: '',
+          paginationEnabled: false,
+          enabled: false,
+        };
+      }
+
+      return {
+        queryParams: buildPredictWorldCupStageEventsQuery(stage),
+        pageSize: stage.eventIds.length,
+        paginationEnabled: false,
+        refine: sortPredictWorldCupMarketsByStartTime,
+        enabled,
+      };
+    }
+  }
+};
+
+export const usePredictWorldCupMarkets = ({
+  tabKey,
+  config,
+  enabled = DEFAULT_WORLD_CUP_MARKETS_OPTIONS.enabled,
+  pageSize,
+}: UsePredictWorldCupMarketsOptions): UsePredictMarketDataResult => {
+  const marketDataConfig = useMemo(
+    () =>
+      getWorldCupMarketDataConfig({
+        tabKey,
+        config,
+        enabled,
+        pageSize,
+      }),
+    [config, enabled, pageSize, tabKey],
+  );
+
+  const marketData = usePredictMarketData({
     category: 'hot',
-    customQueryParams: buildPredictWorldCupAllQuery(config),
-    pageSize: options.pageSize,
-    enabled: options.enabled,
+    customQueryParams: marketDataConfig.queryParams,
+    pageSize: marketDataConfig.pageSize,
+    refine: marketDataConfig.refine,
+    enabled: marketDataConfig.enabled,
   });
 
-export const usePredictWorldCupPropsMarkets = (
-  config: Pick<PredictWorldCupConfig, 'tagSlug' | 'gamesTagId'>,
-  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
-) =>
-  usePredictMarketData({
-    category: 'hot',
-    customQueryParams: buildPredictWorldCupPropsQuery(config),
-    pageSize: options.pageSize,
-    enabled: options.enabled,
-  });
+  if (marketDataConfig.paginationEnabled) {
+    return marketData;
+  }
 
-export const usePredictWorldCupLiveMarkets = (
-  config: Pick<PredictWorldCupConfig, 'seriesId' | 'gamesTagId'>,
-  options: UsePredictWorldCupMarketsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
-) =>
-  useQuery({
-    ...predictQueries.worldCup.options.live(config, {
-      limit: options.pageSize,
-    }),
-    enabled: options.enabled,
-  });
-
-export const usePredictWorldCupStageMarkets = (
-  stage: Pick<PredictWorldCupStageConfig, 'key' | 'eventIds'>,
-  options: Pick<
-    UsePredictWorldCupMarketsOptions,
-    'enabled'
-  > = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
-) =>
-  useQuery({
-    ...predictQueries.worldCup.options.stage(stage),
-    enabled: options.enabled,
-  });
+  return {
+    ...marketData,
+    hasMore: false,
+    isFetchingMore: false,
+    fetchMore: async () => undefined,
+  };
+};
 
 export const usePredictWorldCupAvailability = (
   config: Pick<

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.ts
@@ -1,5 +1,11 @@
-import { useMemo } from 'react';
-import { useQueries } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo } from 'react';
+import {
+  queryOptions,
+  useInfiniteQuery,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { predictQueries } from '../queries';
 import {
   getPredictWorldCupAvailableTabKeys,
@@ -14,19 +20,17 @@ import {
   buildPredictWorldCupStageEventsQuery,
   resolvePredictWorldCupStageLabel,
 } from '../utils/worldCup';
-import { sortPredictWorldCupMarketsByStartTime } from '../services/worldCup';
 import {
-  usePredictMarketData,
-  type UsePredictMarketDataResult,
-} from './usePredictMarketData';
+  fetchPredictWorldCupMarkets,
+  PREDICT_WORLD_CUP_PAGE_SIZE,
+} from '../services/worldCup';
+import type { PredictMarket } from '../types';
 import type { PredictWorldCupConfig } from '../types/flags';
+import type { UsePredictMarketDataResult } from './usePredictMarketData';
 
 export interface UsePredictWorldCupMarketsOptions {
   tabKey: PredictWorldCupTabKey;
-  config: Pick<
-    PredictWorldCupConfig,
-    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
-  >;
+  config: PredictWorldCupDataConfig;
   enabled?: boolean;
   pageSize?: number;
 }
@@ -41,31 +45,42 @@ export interface PredictWorldCupAvailableTab {
   isLive?: boolean;
 }
 
-interface WorldCupMarketDataConfig {
-  queryParams: string;
-  pageSize?: number;
-  paginationEnabled: boolean;
-  refine?: UsePredictWorldCupMarketRefine;
-  enabled: boolean;
-}
+type PredictWorldCupDataConfig = Pick<
+  PredictWorldCupConfig,
+  'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
+>;
 
-type UsePredictWorldCupMarketRefine = NonNullable<
-  Parameters<typeof usePredictMarketData>[0]
->['refine'];
+interface WorldCupMarketDataConfig {
+  tabKey: PredictWorldCupTabKey;
+  queryParams: string;
+  pageSize: number;
+  paginationEnabled: boolean;
+  enabled: boolean;
+  stage?: PredictWorldCupConfig['stages'][number];
+}
 
 const DEFAULT_WORLD_CUP_MARKETS_OPTIONS = {
   enabled: true,
 } as const;
 
+const PREDICT_WORLD_CUP_MARKETS_STALE_TIME = 10_000;
+
+const getStage = (
+  config: PredictWorldCupDataConfig,
+  tabKey: PredictWorldCupTabKey,
+): PredictWorldCupConfig['stages'][number] | undefined =>
+  config.stages.find((configuredStage) => configuredStage.key === tabKey);
+
 const getWorldCupMarketDataConfig = ({
   tabKey,
   config,
   enabled = true,
-  pageSize,
+  pageSize = PREDICT_WORLD_CUP_PAGE_SIZE,
 }: UsePredictWorldCupMarketsOptions): WorldCupMarketDataConfig => {
   switch (tabKey) {
     case PREDICT_WORLD_CUP_TAB_KEYS.ALL:
       return {
+        tabKey,
         queryParams: buildPredictWorldCupAllQuery(config),
         pageSize,
         paginationEnabled: true,
@@ -73,6 +88,7 @@ const getWorldCupMarketDataConfig = ({
       };
     case PREDICT_WORLD_CUP_TAB_KEYS.PROPS:
       return {
+        tabKey,
         queryParams: buildPredictWorldCupPropsQuery(config),
         pageSize,
         paginationEnabled: true,
@@ -80,34 +96,76 @@ const getWorldCupMarketDataConfig = ({
       };
     case PREDICT_WORLD_CUP_TAB_KEYS.LIVE:
       return {
+        tabKey,
         queryParams: buildPredictWorldCupLiveQuery(config),
         pageSize,
         paginationEnabled: false,
         enabled,
       };
     default: {
-      const stage = config.stages.find(
-        (configuredStage) => configuredStage.key === tabKey,
-      );
+      const stage = getStage(config, tabKey);
 
       if (!stage || stage.eventIds.length === 0) {
         return {
+          tabKey,
           queryParams: '',
+          pageSize,
           paginationEnabled: false,
           enabled: false,
         };
       }
 
       return {
+        tabKey,
         queryParams: buildPredictWorldCupStageEventsQuery(stage),
         pageSize: stage.eventIds.length,
         paginationEnabled: false,
-        refine: sortPredictWorldCupMarketsByStartTime,
         enabled,
+        stage,
       };
     }
   }
 };
+
+const getSingleWorldCupMarketQueryOptions = (
+  marketDataConfig: WorldCupMarketDataConfig,
+  config: PredictWorldCupDataConfig,
+) => {
+  if (marketDataConfig.tabKey === PREDICT_WORLD_CUP_TAB_KEYS.LIVE) {
+    return predictQueries.worldCup.options.live(config, {
+      limit: marketDataConfig.pageSize,
+    });
+  }
+
+  if (marketDataConfig.stage) {
+    return predictQueries.worldCup.options.stage(marketDataConfig.stage);
+  }
+
+  return queryOptions<PredictMarket[], Error>({
+    queryKey: [
+      ...predictQueries.worldCup.keys.all(),
+      'disabled',
+      marketDataConfig.tabKey,
+    ],
+    queryFn: async () => [],
+    staleTime: PREDICT_WORLD_CUP_MARKETS_STALE_TIME,
+  });
+};
+
+const fetchInfiniteWorldCupMarketsPage = async ({
+  queryParams,
+  pageSize,
+  pageParam,
+}: {
+  queryParams: string;
+  pageSize: number;
+  pageParam?: unknown;
+}) =>
+  fetchPredictWorldCupMarkets({
+    queryParams,
+    limit: pageSize,
+    offset: typeof pageParam === 'number' ? pageParam : 0,
+  });
 
 export const usePredictWorldCupMarkets = ({
   tabKey,
@@ -126,31 +184,119 @@ export const usePredictWorldCupMarkets = ({
     [config, enabled, pageSize, tabKey],
   );
 
-  const marketData = usePredictMarketData({
-    category: 'hot',
-    customQueryParams: marketDataConfig.queryParams,
-    pageSize: marketDataConfig.pageSize,
-    refine: marketDataConfig.refine,
-    enabled: marketDataConfig.enabled,
+  const infiniteQuery = useInfiniteQuery<PredictMarket[], Error>({
+    queryKey: predictQueries.worldCup.keys.infiniteMarkets(
+      marketDataConfig.tabKey,
+      marketDataConfig.queryParams,
+      marketDataConfig.pageSize,
+    ),
+    queryFn: ({ pageParam }) =>
+      fetchInfiniteWorldCupMarketsPage({
+        queryParams: marketDataConfig.queryParams,
+        pageSize: marketDataConfig.pageSize,
+        pageParam,
+      }),
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length >= marketDataConfig.pageSize
+        ? allPages.length * marketDataConfig.pageSize
+        : undefined,
+    enabled: marketDataConfig.enabled && marketDataConfig.paginationEnabled,
+    staleTime: PREDICT_WORLD_CUP_MARKETS_STALE_TIME,
   });
 
+  const singleQueryOptions = useMemo(
+    () => getSingleWorldCupMarketQueryOptions(marketDataConfig, config),
+    [config, marketDataConfig],
+  );
+  const singleQuery = useQuery({
+    ...singleQueryOptions,
+    enabled: marketDataConfig.enabled && !marketDataConfig.paginationEnabled,
+  });
+
+  const fetchMore = useCallback(async () => {
+    if (!marketDataConfig.paginationEnabled) {
+      return;
+    }
+
+    await infiniteQuery.fetchNextPage();
+  }, [infiniteQuery, marketDataConfig.paginationEnabled]);
+
+  const refetch = useCallback(async () => {
+    if (marketDataConfig.paginationEnabled) {
+      await infiniteQuery.refetch();
+      return;
+    }
+
+    await singleQuery.refetch();
+  }, [infiniteQuery, marketDataConfig.paginationEnabled, singleQuery]);
+
   if (marketDataConfig.paginationEnabled) {
-    return marketData;
+    return {
+      marketData: infiniteQuery.data?.pages.flat() ?? [],
+      isFetching: infiniteQuery.isLoading,
+      isFetchingMore: infiniteQuery.isFetchingNextPage,
+      error: infiniteQuery.error?.message ?? null,
+      hasMore: infiniteQuery.hasNextPage ?? false,
+      refetch,
+      fetchMore,
+    };
   }
 
   return {
-    ...marketData,
-    hasMore: false,
+    marketData: singleQuery.data ?? [],
+    isFetching: singleQuery.isLoading,
     isFetchingMore: false,
-    fetchMore: async () => undefined,
+    error: singleQuery.error?.message ?? null,
+    hasMore: false,
+    refetch,
+    fetchMore,
   };
 };
 
+const prefetchWorldCupTabMarkets = ({
+  queryClient,
+  tabKey,
+  config,
+}: {
+  queryClient: ReturnType<typeof useQueryClient>;
+  tabKey: PredictWorldCupTabKey;
+  config: PredictWorldCupDataConfig;
+}) => {
+  const marketDataConfig = getWorldCupMarketDataConfig({
+    tabKey,
+    config,
+    enabled: true,
+  });
+
+  if (!marketDataConfig.enabled) {
+    return;
+  }
+
+  if (marketDataConfig.paginationEnabled) {
+    queryClient.prefetchInfiniteQuery({
+      queryKey: predictQueries.worldCup.keys.infiniteMarkets(
+        marketDataConfig.tabKey,
+        marketDataConfig.queryParams,
+        marketDataConfig.pageSize,
+      ),
+      queryFn: ({ pageParam }) =>
+        fetchInfiniteWorldCupMarketsPage({
+          queryParams: marketDataConfig.queryParams,
+          pageSize: marketDataConfig.pageSize,
+          pageParam,
+        }),
+      staleTime: PREDICT_WORLD_CUP_MARKETS_STALE_TIME,
+    });
+    return;
+  }
+
+  queryClient.prefetchQuery(
+    getSingleWorldCupMarketQueryOptions(marketDataConfig, config),
+  );
+};
+
 export const usePredictWorldCupAvailability = (
-  config: Pick<
-    PredictWorldCupConfig,
-    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
-  >,
+  config: PredictWorldCupDataConfig,
   options: UsePredictWorldCupAvailableTabsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
 ) => {
   const enabled = options.enabled ?? true;
@@ -189,12 +335,11 @@ export const usePredictWorldCupAvailability = (
 };
 
 export const usePredictWorldCupAvailableTabs = (
-  config: Pick<
-    PredictWorldCupConfig,
-    'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
-  >,
+  config: PredictWorldCupDataConfig,
   options: UsePredictWorldCupAvailableTabsOptions = DEFAULT_WORLD_CUP_MARKETS_OPTIONS,
 ) => {
+  const queryClient = useQueryClient();
+  const enabled = options.enabled ?? true;
   const { availability, ...availabilityQuery } = usePredictWorldCupAvailability(
     config,
     options,
@@ -226,6 +371,16 @@ export const usePredictWorldCupAvailableTabs = (
       }
     });
   }, [availability, config]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    tabs.forEach((tab) =>
+      prefetchWorldCupTabMarkets({ queryClient, tabKey: tab.key, config }),
+    );
+  }, [config, enabled, queryClient, tabs]);
 
   return {
     ...availabilityQuery,

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.ts
@@ -24,6 +24,7 @@ import {
   fetchPredictWorldCupMarkets,
   PREDICT_WORLD_CUP_PAGE_SIZE,
 } from '../services/worldCup';
+import { strings } from '../../../../../locales/i18n';
 import type { PredictMarket } from '../types';
 import type { PredictWorldCupConfig } from '../types/flags';
 import type { UsePredictMarketDataResult } from './usePredictMarketData';
@@ -345,42 +346,53 @@ export const usePredictWorldCupAvailableTabs = (
     options,
   );
 
-  const tabs = useMemo<PredictWorldCupAvailableTab[]>(() => {
-    const availableKeys = getPredictWorldCupAvailableTabKeys(
-      config,
-      availability,
-    );
+  const availableTabKeys = useMemo(
+    () => getPredictWorldCupAvailableTabKeys(config, availability),
+    [availability, config],
+  );
 
-    return availableKeys.map((key) => {
-      switch (key) {
-        case PREDICT_WORLD_CUP_TAB_KEYS.ALL:
-          return { key, label: 'All' };
-        case PREDICT_WORLD_CUP_TAB_KEYS.LIVE:
-          return { key, label: 'Live', isLive: true };
-        case PREDICT_WORLD_CUP_TAB_KEYS.PROPS:
-          return { key, label: 'Props' };
-        default: {
-          const stage = config.stages.find(
-            (configuredStage) => configuredStage.key === key,
-          );
-          return {
-            key,
-            label: stage ? resolvePredictWorldCupStageLabel(stage) : key,
-          };
+  const tabs = useMemo<PredictWorldCupAvailableTab[]>(
+    () =>
+      availableTabKeys.map((key) => {
+        switch (key) {
+          case PREDICT_WORLD_CUP_TAB_KEYS.ALL:
+            return { key, label: strings('predict.world_cup.tabs.all') };
+          case PREDICT_WORLD_CUP_TAB_KEYS.LIVE:
+            return {
+              key,
+              label: strings('predict.world_cup.tabs.live'),
+              isLive: true,
+            };
+          case PREDICT_WORLD_CUP_TAB_KEYS.PROPS:
+            return { key, label: strings('predict.world_cup.tabs.props') };
+          default: {
+            const stage = config.stages.find(
+              (configuredStage) => configuredStage.key === key,
+            );
+            return {
+              key,
+              label: stage ? resolvePredictWorldCupStageLabel(stage) : key,
+            };
+          }
         }
-      }
-    });
-  }, [availability, config]);
+      }),
+    [availableTabKeys, config.stages],
+  );
+
+  const prefetchTabKeys = availableTabKeys.join(',');
 
   useEffect(() => {
     if (!enabled) {
       return;
     }
 
-    tabs.forEach((tab) =>
-      prefetchWorldCupTabMarkets({ queryClient, tabKey: tab.key, config }),
-    );
-  }, [config, enabled, queryClient, tabs]);
+    prefetchTabKeys
+      .split(',')
+      .filter(Boolean)
+      .forEach((tabKey) =>
+        prefetchWorldCupTabMarkets({ queryClient, tabKey, config }),
+      );
+  }, [config, enabled, prefetchTabKeys, queryClient]);
 
   return {
     ...availabilityQuery,

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -23,8 +23,10 @@ import {
   getIsApprovedForAll,
   getOrderBook,
   getRawBalance,
+  parsePolymarketEvents,
   previewOrder,
 } from './utils';
+import type { PolymarketApiEvent, PolymarketApiTeam } from './types';
 
 const mockSignTypedMessage = jest.fn();
 
@@ -112,6 +114,94 @@ describe('polymarket utils', () => {
     } as ReturnType<
       typeof Engine.context.NetworkController.getNetworkClientById
     >);
+  });
+
+  it('parses World Cup game events with game metadata when team data is available', () => {
+    const teamsByAbbreviation: Record<string, PolymarketApiTeam> = {
+      usa: {
+        id: 'team-usa',
+        name: 'United States',
+        logo: 'usa.png',
+        abbreviation: 'usa',
+        color: 'red',
+        alias: 'USA',
+        league: 'fifwc',
+      },
+      can: {
+        id: 'team-can',
+        name: 'Canada',
+        logo: 'can.png',
+        abbreviation: 'can',
+        color: 'white',
+        alias: 'CAN',
+        league: 'fifwc',
+      },
+    };
+    const event: PolymarketApiEvent = {
+      id: 'event-1',
+      slug: 'fifwc-usa-can-2026-06-12',
+      title: 'United States vs Canada',
+      description: 'World Cup match',
+      icon: 'icon.png',
+      closed: false,
+      series: [
+        {
+          id: '11433',
+          slug: 'world-cup',
+          title: 'World Cup',
+          recurrence: 'none',
+        },
+      ],
+      markets: [
+        {
+          conditionId: 'condition-1',
+          question: 'United States vs Canada',
+          description: 'Market description',
+          icon: 'icon.png',
+          image: 'image.png',
+          groupItemTitle: 'United States',
+          sportsMarketType: 'moneyline',
+          status: 'open',
+          volumeNum: 100,
+          liquidity: 100,
+          negRisk: false,
+          clobTokenIds: '["token-yes","token-no"]',
+          outcomes: '["Yes","No"]',
+          outcomePrices: '["0.5","0.5"]',
+          closed: false,
+          active: true,
+          resolvedBy: '',
+          orderPriceMinTickSize: 0.01,
+          umaResolutionStatus: '',
+        },
+      ],
+      tags: [
+        { id: 'games', label: 'Games', slug: 'games' },
+        { id: 'world-cup', label: 'World Cup', slug: 'fifa-world-cup' },
+      ],
+      liquidity: 100,
+      volume: 100,
+      gameId: 'game-1',
+      startTime: '2026-06-12T20:00:00.000Z',
+      live: false,
+      ended: false,
+    };
+
+    const [market] = parsePolymarketEvents([event], {
+      category: 'hot',
+      teamLookup: (_league, abbreviation) => teamsByAbbreviation[abbreviation],
+    });
+
+    expect(market.game).toEqual(
+      expect.objectContaining({
+        id: 'game-1',
+        league: 'fifwc',
+        startTime: '2026-06-12T20:00:00.000Z',
+        status: 'scheduled',
+        homeTeam: expect.objectContaining({ abbreviation: 'usa' }),
+        awayTeam: expect.objectContaining({ abbreviation: 'can' }),
+      }),
+    );
   });
 
   it('creates API keys against the canonical CLOB host', async () => {

--- a/app/components/UI/Predict/queries/worldCup.test.ts
+++ b/app/components/UI/Predict/queries/worldCup.test.ts
@@ -1,0 +1,202 @@
+import Engine from '../../../../core/Engine';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../constants/flags';
+import { Recurrence, type PredictMarket } from '../types';
+import { predictWorldCupOptions } from './worldCup';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      getMarkets: jest.fn(),
+    },
+  },
+}));
+
+const mockGetMarkets = jest.mocked(Engine.context.PredictController.getMarkets);
+
+const createMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: 'market-1',
+  providerId: 'polymarket',
+  slug: 'market-1',
+  title: 'Market 1',
+  description: 'Description',
+  image: 'image.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'hot',
+  tags: [],
+  outcomes: [],
+  liquidity: 0,
+  volume: 0,
+  ...overrides,
+});
+
+describe('worldCup queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches All markets with the World Cup tag query and pagination', async () => {
+    const markets = [createMarket()];
+    mockGetMarkets.mockResolvedValue(markets);
+
+    const options = predictWorldCupOptions.all(DEFAULT_PREDICT_WORLD_CUP_FLAG, {
+      limit: 10,
+      offset: 20,
+    });
+    const result = await (options.queryFn as () => Promise<PredictMarket[]>)();
+
+    expect(mockGetMarkets).toHaveBeenCalledWith({
+      category: 'hot',
+      customQueryParams:
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+      limit: 10,
+      offset: 20,
+    });
+    expect(result).toEqual(markets);
+  });
+
+  it('fetches Props markets with the games tag excluded and pagination', async () => {
+    mockGetMarkets.mockResolvedValue([createMarket()]);
+
+    const options = predictWorldCupOptions.props(
+      DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      {
+        limit: 25,
+        offset: 50,
+      },
+    );
+    await (options.queryFn as () => Promise<PredictMarket[]>)();
+
+    expect(mockGetMarkets).toHaveBeenCalledWith({
+      category: 'hot',
+      customQueryParams:
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume24hr',
+      limit: 25,
+      offset: 50,
+    });
+  });
+
+  it('fetches Live markets with series, games tag, and live filters', async () => {
+    mockGetMarkets.mockResolvedValue([createMarket()]);
+
+    const options = predictWorldCupOptions.live(
+      DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      {
+        limit: 5,
+      },
+    );
+    await (options.queryFn as () => Promise<PredictMarket[]>)();
+
+    expect(mockGetMarkets).toHaveBeenCalledWith({
+      category: 'hot',
+      customQueryParams:
+        'active=true&archived=false&closed=false&series_id=11433&tag_id=100639&live=true&order=startDate',
+      limit: 5,
+      offset: 0,
+    });
+  });
+
+  it('fetches stage markets with repeated event IDs and sorts by match start time', async () => {
+    const baseGame = {
+      id: 'game-later',
+      startTime: '2026-06-13T20:00:00.000Z',
+      status: 'scheduled' as const,
+      league: 'fifwc' as const,
+      elapsed: null,
+      period: null,
+      score: null,
+      homeTeam: {
+        id: 'team-1',
+        name: 'Team 1',
+        logo: '',
+        abbreviation: 'T1',
+        color: 'black',
+      },
+      awayTeam: {
+        id: 'team-2',
+        name: 'Team 2',
+        logo: '',
+        abbreviation: 'T2',
+        color: 'white',
+      },
+    };
+    const laterMarket = createMarket({
+      id: 'later',
+      title: 'Later',
+      game: baseGame,
+    });
+    const earlierMarket = createMarket({
+      id: 'earlier',
+      title: 'Earlier',
+      game: {
+        ...baseGame,
+        id: 'game-earlier',
+        startTime: '2026-06-12T20:00:00.000Z',
+      },
+    });
+    mockGetMarkets.mockResolvedValue([laterMarket, earlierMarket]);
+
+    const options = predictWorldCupOptions.stage({
+      key: 'group-stage',
+      eventIds: ['123', '456'],
+    });
+    const result = await (options.queryFn as () => Promise<PredictMarket[]>)();
+
+    expect(mockGetMarkets).toHaveBeenCalledWith({
+      category: 'hot',
+      customQueryParams:
+        'active=true&archived=false&closed=false&id=123&id=456',
+      limit: 2,
+      offset: 0,
+    });
+    expect(result.map((market) => market.id)).toEqual(['earlier', 'later']);
+  });
+
+  it('uses lightweight availability requests for Live, Props, and stages', async () => {
+    mockGetMarkets.mockResolvedValue([createMarket()]);
+
+    await (
+      predictWorldCupOptions.availability.live(DEFAULT_PREDICT_WORLD_CUP_FLAG)
+        .queryFn as () => Promise<boolean>
+    )();
+    await (
+      predictWorldCupOptions.availability.props(DEFAULT_PREDICT_WORLD_CUP_FLAG)
+        .queryFn as () => Promise<boolean>
+    )();
+    await (
+      predictWorldCupOptions.availability.stage({
+        key: 'final',
+        eventIds: ['999'],
+      }).queryFn as () => Promise<boolean>
+    )();
+
+    expect(mockGetMarkets).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ limit: 1, offset: 0 }),
+    );
+    expect(mockGetMarkets).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ limit: 1, offset: 0 }),
+    );
+    expect(mockGetMarkets).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        customQueryParams: 'active=true&archived=false&closed=false&id=999',
+        limit: 1,
+        offset: 0,
+      }),
+    );
+  });
+
+  it('hides empty stage tabs without calling the API when no event IDs are configured', async () => {
+    const options = predictWorldCupOptions.availability.stage({
+      key: 'empty-stage',
+      eventIds: [],
+    });
+
+    expect((options.queryFn as () => boolean)()).toBe(false);
+    expect(mockGetMarkets).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Predict/queries/worldCup.test.ts
+++ b/app/components/UI/Predict/queries/worldCup.test.ts
@@ -50,7 +50,7 @@ describe('worldCup queries', () => {
     expect(mockGetMarkets).toHaveBeenCalledWith({
       category: 'hot',
       customQueryParams:
-        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
       limit: 10,
       offset: 20,
     });
@@ -72,7 +72,7 @@ describe('worldCup queries', () => {
     expect(mockGetMarkets).toHaveBeenCalledWith({
       category: 'hot',
       customQueryParams:
-        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume24hr',
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume&ascending=false',
       limit: 25,
       offset: 50,
     });

--- a/app/components/UI/Predict/queries/worldCup.ts
+++ b/app/components/UI/Predict/queries/worldCup.ts
@@ -37,6 +37,15 @@ export const predictWorldCupKeys = {
       limit,
       offset,
     ] as const,
+  infiniteMarkets: (tabKey: string, queryParams: string, limit: number) =>
+    [
+      ...predictWorldCupKeys.all(),
+      'markets',
+      'infinite',
+      tabKey,
+      queryParams,
+      limit,
+    ] as const,
   tab: (queryParams: string) =>
     [...predictWorldCupKeys.all(), 'tab', queryParams] as const,
   availability: (tabKey: string, queryParams: string) =>

--- a/app/components/UI/Predict/queries/worldCup.ts
+++ b/app/components/UI/Predict/queries/worldCup.ts
@@ -1,23 +1,56 @@
+import { queryOptions } from '@tanstack/react-query';
 import {
   buildPredictWorldCupAllQuery,
   buildPredictWorldCupLiveQuery,
   buildPredictWorldCupPropsQuery,
   buildPredictWorldCupStageEventsQuery,
 } from '../utils/worldCup';
+import {
+  fetchPredictWorldCupAvailability,
+  fetchPredictWorldCupMarkets,
+  PREDICT_WORLD_CUP_PAGE_SIZE,
+} from '../services/worldCup';
+import type { PredictMarket } from '../types';
 import type {
   PredictWorldCupConfig,
   PredictWorldCupStageConfig,
 } from '../types/flags';
 
+export interface PredictWorldCupPageOptions {
+  limit?: number;
+  offset?: number;
+}
+
 export const predictWorldCupKeys = {
   all: () => ['predict', 'worldCup'] as const,
+  markets: (
+    tabKey: string,
+    queryParams: string,
+    limit: number,
+    offset: number,
+  ) =>
+    [
+      ...predictWorldCupKeys.all(),
+      'markets',
+      tabKey,
+      queryParams,
+      limit,
+      offset,
+    ] as const,
   tab: (queryParams: string) =>
     [...predictWorldCupKeys.all(), 'tab', queryParams] as const,
+  availability: (tabKey: string, queryParams: string) =>
+    [
+      ...predictWorldCupKeys.all(),
+      'availability',
+      tabKey,
+      queryParams,
+    ] as const,
   stage: (stageKey: string, eventIds: string[]) =>
     [...predictWorldCupKeys.all(), 'stage', stageKey, ...eventIds] as const,
 };
 
-export const predictWorldCupOptions = {
+export const predictWorldCupQueryParams = {
   all: (config: Pick<PredictWorldCupConfig, 'tagSlug'>) =>
     buildPredictWorldCupAllQuery(config),
   props: (config: Pick<PredictWorldCupConfig, 'tagSlug' | 'gamesTagId'>) =>
@@ -26,4 +59,127 @@ export const predictWorldCupOptions = {
     buildPredictWorldCupLiveQuery(config),
   stage: (stage: Pick<PredictWorldCupStageConfig, 'eventIds'>) =>
     buildPredictWorldCupStageEventsQuery(stage),
+};
+
+const getPageOptions = ({
+  limit = PREDICT_WORLD_CUP_PAGE_SIZE,
+  offset = 0,
+}: PredictWorldCupPageOptions = {}) => ({ limit, offset });
+
+const buildMarketsOptions = ({
+  tabKey,
+  queryParams,
+  limit,
+  offset,
+  sortByStartTime = false,
+}: {
+  tabKey: string;
+  queryParams: string;
+  limit: number;
+  offset: number;
+  sortByStartTime?: boolean;
+}) =>
+  queryOptions<PredictMarket[], Error>({
+    queryKey: predictWorldCupKeys.markets(tabKey, queryParams, limit, offset),
+    queryFn: () =>
+      fetchPredictWorldCupMarkets({
+        queryParams,
+        limit,
+        offset,
+        sortByStartTime,
+      }),
+    staleTime: 10_000,
+  });
+
+const buildAvailabilityOptions = ({
+  tabKey,
+  queryParams,
+}: {
+  tabKey: string;
+  queryParams: string;
+}) =>
+  queryOptions<boolean, Error>({
+    queryKey: predictWorldCupKeys.availability(tabKey, queryParams),
+    queryFn: () => fetchPredictWorldCupAvailability(queryParams),
+    staleTime: 10_000,
+  });
+
+export const predictWorldCupOptions = {
+  all: (
+    config: Pick<PredictWorldCupConfig, 'tagSlug'>,
+    pageOptions?: PredictWorldCupPageOptions,
+  ) => {
+    const { limit, offset } = getPageOptions(pageOptions);
+    return buildMarketsOptions({
+      tabKey: 'all',
+      queryParams: predictWorldCupQueryParams.all(config),
+      limit,
+      offset,
+    });
+  },
+  props: (
+    config: Pick<PredictWorldCupConfig, 'tagSlug' | 'gamesTagId'>,
+    pageOptions?: PredictWorldCupPageOptions,
+  ) => {
+    const { limit, offset } = getPageOptions(pageOptions);
+    return buildMarketsOptions({
+      tabKey: 'props',
+      queryParams: predictWorldCupQueryParams.props(config),
+      limit,
+      offset,
+    });
+  },
+  live: (
+    config: Pick<PredictWorldCupConfig, 'seriesId' | 'gamesTagId'>,
+    pageOptions?: PredictWorldCupPageOptions,
+  ) => {
+    const { limit, offset } = getPageOptions(pageOptions);
+    return buildMarketsOptions({
+      tabKey: 'live',
+      queryParams: predictWorldCupQueryParams.live(config),
+      limit,
+      offset,
+    });
+  },
+  stage: (stage: Pick<PredictWorldCupStageConfig, 'key' | 'eventIds'>) => {
+    const queryParams = predictWorldCupQueryParams.stage(stage);
+    const limit = stage.eventIds.length;
+
+    return queryOptions<PredictMarket[], Error>({
+      queryKey: predictWorldCupKeys.stage(stage.key, stage.eventIds),
+      queryFn: () =>
+        limit === 0
+          ? []
+          : fetchPredictWorldCupMarkets({
+              queryParams,
+              limit,
+              sortByStartTime: true,
+            }),
+      staleTime: 10_000,
+    });
+  },
+  availability: {
+    live: (config: Pick<PredictWorldCupConfig, 'seriesId' | 'gamesTagId'>) =>
+      buildAvailabilityOptions({
+        tabKey: 'live',
+        queryParams: predictWorldCupQueryParams.live(config),
+      }),
+    props: (config: Pick<PredictWorldCupConfig, 'tagSlug' | 'gamesTagId'>) =>
+      buildAvailabilityOptions({
+        tabKey: 'props',
+        queryParams: predictWorldCupQueryParams.props(config),
+      }),
+    stage: (stage: Pick<PredictWorldCupStageConfig, 'key' | 'eventIds'>) => {
+      const queryParams = predictWorldCupQueryParams.stage(stage);
+
+      return queryOptions<boolean, Error>({
+        queryKey: predictWorldCupKeys.availability(stage.key, queryParams),
+        queryFn: () =>
+          stage.eventIds.length === 0
+            ? false
+            : fetchPredictWorldCupAvailability(queryParams),
+        staleTime: 10_000,
+      });
+    },
+  },
 };

--- a/app/components/UI/Predict/services/worldCup.ts
+++ b/app/components/UI/Predict/services/worldCup.ts
@@ -1,0 +1,81 @@
+import Engine from '../../../../core/Engine';
+import type { PredictMarket } from '../types';
+
+export const PREDICT_WORLD_CUP_PAGE_SIZE = 20;
+export const PREDICT_WORLD_CUP_AVAILABILITY_LIMIT = 1;
+
+interface FetchPredictWorldCupMarketsParams {
+  queryParams: string;
+  limit?: number;
+  offset?: number;
+  sortByStartTime?: boolean;
+}
+
+const getPredictController = () => {
+  const controller = Engine.context.PredictController;
+
+  if (!controller) {
+    throw new Error('PredictController not available');
+  }
+
+  return controller;
+};
+
+const getMarketStartTimestamp = (market: PredictMarket): number => {
+  const timestamp = Date.parse(market.game?.startTime ?? market.endDate ?? '');
+  return Number.isNaN(timestamp) ? Number.POSITIVE_INFINITY : timestamp;
+};
+
+/**
+ * Returns World Cup markets ordered by match start time when available.
+ * Non-game markets sort after dated game markets and use title as a deterministic tie-breaker.
+ */
+export const sortPredictWorldCupMarketsByStartTime = (
+  markets: PredictMarket[],
+): PredictMarket[] =>
+  [...markets].sort((firstMarket, secondMarket) => {
+    const firstTimestamp = getMarketStartTimestamp(firstMarket);
+    const secondTimestamp = getMarketStartTimestamp(secondMarket);
+
+    if (firstTimestamp !== secondTimestamp) {
+      return firstTimestamp - secondTimestamp;
+    }
+
+    return firstMarket.title.localeCompare(secondMarket.title);
+  });
+
+/**
+ * Fetches World Cup markets through the Predict controller using raw Polymarket query params.
+ */
+export const fetchPredictWorldCupMarkets = async ({
+  queryParams,
+  limit = PREDICT_WORLD_CUP_PAGE_SIZE,
+  offset = 0,
+  sortByStartTime = false,
+}: FetchPredictWorldCupMarketsParams): Promise<PredictMarket[]> => {
+  const controller = getPredictController();
+  const markets = await controller.getMarkets({
+    category: 'hot',
+    customQueryParams: queryParams,
+    limit,
+    offset,
+  });
+
+  return sortByStartTime
+    ? sortPredictWorldCupMarketsByStartTime(markets)
+    : markets;
+};
+
+/**
+ * Performs a lightweight World Cup tab availability check.
+ */
+export const fetchPredictWorldCupAvailability = async (
+  queryParams: string,
+): Promise<boolean> => {
+  const markets = await fetchPredictWorldCupMarkets({
+    queryParams,
+    limit: PREDICT_WORLD_CUP_AVAILABILITY_LIMIT,
+  });
+
+  return markets.length > 0;
+};

--- a/app/components/UI/Predict/utils/worldCup.test.ts
+++ b/app/components/UI/Predict/utils/worldCup.test.ts
@@ -24,7 +24,7 @@ describe('Predict World Cup helpers', () => {
   describe('query helpers', () => {
     it('builds All query with World Cup tag slug', () => {
       expect(buildPredictWorldCupAllQuery(DEFAULT_PREDICT_WORLD_CUP_FLAG)).toBe(
-        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
       );
     });
 
@@ -32,7 +32,7 @@ describe('Predict World Cup helpers', () => {
       expect(
         buildPredictWorldCupPropsQuery(DEFAULT_PREDICT_WORLD_CUP_FLAG),
       ).toBe(
-        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume24hr',
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume&ascending=false',
       );
     });
 
@@ -57,7 +57,7 @@ describe('Predict World Cup helpers', () => {
           DEFAULT_PREDICT_WORLD_CUP_FLAG,
         ),
       ).toBe(
-        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume24hr',
+        'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&exclude_tag_id=100639&order=volume&ascending=false',
       );
     });
   });

--- a/app/components/UI/Predict/utils/worldCup.ts
+++ b/app/components/UI/Predict/utils/worldCup.ts
@@ -33,6 +33,7 @@ export const buildPredictWorldCupAllQuery = ({
   appendBaseWorldCupParams(params);
   params.set('tag_slug', tagSlug);
   params.set('order', 'volume24hr');
+  params.set('ascending', 'false');
   return buildQueryString(params);
 };
 
@@ -44,7 +45,8 @@ export const buildPredictWorldCupPropsQuery = ({
   appendBaseWorldCupParams(params);
   params.set('tag_slug', tagSlug);
   params.set('exclude_tag_id', gamesTagId);
-  params.set('order', 'volume24hr');
+  params.set('order', 'volume');
+  params.set('ascending', 'false');
   return buildQueryString(params);
 };
 

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
@@ -22,6 +22,15 @@ let mockAvailability = {
   props: true,
   stages: {},
 };
+const mockUsePredictWorldCupMarkets: jest.Mock = jest.fn((_args: unknown) => ({
+  marketData: [],
+  isFetching: false,
+  isFetchingMore: false,
+  error: null,
+  hasMore: false,
+  refetch: jest.fn(),
+  fetchMore: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
@@ -52,6 +61,59 @@ jest.mock('../../selectors/featureFlags', () => ({
     'selectPredictWorldCupScreenEnabledFlag',
 }));
 
+jest.mock('@shopify/flash-list', () => {
+  const { View } = jest.requireActual('react-native');
+
+  interface MockItem {
+    id: string;
+  }
+  interface MockFlashListProps {
+    data?: MockItem[];
+    renderItem: (info: { item: MockItem; index: number }) => React.ReactNode;
+    keyExtractor?: (item: MockItem, index: number) => string;
+    ListFooterComponent?: React.ComponentType | React.ReactNode;
+    testID?: string;
+  }
+
+  const FlashList = ({
+    data = [],
+    renderItem,
+    keyExtractor,
+    ListFooterComponent,
+    testID,
+  }: MockFlashListProps) => (
+    <View testID={testID}>
+      {data.map((item, index) => (
+        <View key={keyExtractor ? keyExtractor(item, index) : item.id}>
+          {renderItem({ item, index })}
+        </View>
+      ))}
+      {typeof ListFooterComponent === 'function' ? (
+        <ListFooterComponent />
+      ) : (
+        ListFooterComponent
+      )}
+    </View>
+  );
+
+  return { FlashList };
+});
+
+jest.mock('../../components/PredictMarket', () => {
+  const { Text } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: ({
+      market,
+      testID,
+    }: {
+      market: { title: string };
+      testID: string;
+    }) => <Text testID={testID}>{market.title}</Text>,
+  };
+});
+
 jest.mock('../../hooks', () => ({
   usePredictWorldCupAvailableTabs: () => ({
     tabs: mockAvailableTabs,
@@ -61,6 +123,8 @@ jest.mock('../../hooks', () => ({
     errors: [],
     refetch: jest.fn(),
   }),
+  usePredictWorldCupMarkets: (args: unknown) =>
+    mockUsePredictWorldCupMarkets(args),
 }));
 
 describe('PredictWorldCup', () => {
@@ -84,6 +148,15 @@ describe('PredictWorldCup', () => {
       props: true,
       stages: {},
     };
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: [],
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
   });
 
   it('renders the screen scaffold with All selected by default', () => {
@@ -127,7 +200,7 @@ describe('PredictWorldCup', () => {
     ).toHaveTextContent('props');
   });
 
-  it('updates active tab when a tab is pressed', () => {
+  it('updates active tab and tab content when a tab is pressed', () => {
     render(<PredictWorldCup />);
 
     fireEvent.press(
@@ -137,6 +210,10 @@ describe('PredictWorldCup', () => {
     expect(
       screen.getByTestId(PREDICT_WORLD_CUP_SCREEN_TEST_IDS.INITIAL_TAB),
     ).toHaveTextContent('live');
+    expect(mockUsePredictWorldCupMarkets).toHaveBeenLastCalledWith({
+      tabKey: 'live',
+      config: mockConfig,
+    });
   });
 
   it('uses a configured available stage initial tab', () => {
@@ -159,6 +236,32 @@ describe('PredictWorldCup', () => {
     expect(
       screen.getByTestId(PREDICT_WORLD_CUP_SCREEN_TEST_IDS.INITIAL_TAB),
     ).toHaveTextContent('group-stage');
+  });
+
+  it('renders market content for the active tab', () => {
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: [
+        {
+          id: 'market-1',
+          title: 'World Cup winner',
+        },
+      ],
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+
+    render(<PredictWorldCup />);
+
+    expect(
+      screen.getByTestId(PREDICT_WORLD_CUP_SCREEN_TEST_IDS.MARKET_LIST),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.MARKET_CARD}-1`),
+    ).toHaveTextContent('World Cup winner');
   });
 
   it('does not render tabs hidden by availability', () => {

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
@@ -12,6 +12,16 @@ const mockCanGoBack = jest.fn(() => true);
 let mockRouteParams: { entryPoint?: string; initialTab?: string } | undefined;
 let mockIsScreenEnabled = true;
 let mockConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
+let mockAvailableTabs = [
+  { key: 'all', label: 'All' },
+  { key: 'live', label: 'Live', isLive: true },
+  { key: 'props', label: 'Props' },
+];
+let mockAvailability = {
+  live: true,
+  props: true,
+  stages: {},
+};
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
@@ -42,6 +52,17 @@ jest.mock('../../selectors/featureFlags', () => ({
     'selectPredictWorldCupScreenEnabledFlag',
 }));
 
+jest.mock('../../hooks', () => ({
+  usePredictWorldCupAvailableTabs: () => ({
+    tabs: mockAvailableTabs,
+    availability: mockAvailability,
+    isFetching: false,
+    isLoading: false,
+    errors: [],
+    refetch: jest.fn(),
+  }),
+}));
+
 describe('PredictWorldCup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -52,6 +73,16 @@ describe('PredictWorldCup', () => {
       ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
       enabled: true,
       showWorldCupScreen: true,
+    };
+    mockAvailableTabs = [
+      { key: 'all', label: 'All' },
+      { key: 'live', label: 'Live', isLive: true },
+      { key: 'props', label: 'Props' },
+    ];
+    mockAvailability = {
+      live: true,
+      props: true,
+      stages: {},
     };
   });
 
@@ -66,7 +97,7 @@ describe('PredictWorldCup', () => {
     ).toHaveTextContent('all');
   });
 
-  it('renders fixed tabs and an empty content area', () => {
+  it('renders available tabs and an empty content area', () => {
     render(<PredictWorldCup />);
 
     expect(
@@ -78,6 +109,9 @@ describe('PredictWorldCup', () => {
     expect(
       screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-props`),
     ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-group-a`),
+    ).toBeNull();
     expect(
       screen.getByTestId(PREDICT_WORLD_CUP_SCREEN_TEST_IDS.EMPTY_STATE),
     ).toBeOnTheScreen();
@@ -105,18 +139,47 @@ describe('PredictWorldCup', () => {
     ).toHaveTextContent('live');
   });
 
-  it('uses a configured stage initial tab', () => {
+  it('uses a configured available stage initial tab', () => {
     mockRouteParams = { initialTab: 'group-stage' };
     mockConfig = {
       ...mockConfig,
       stages: [{ key: 'group-stage', eventIds: ['1'] }],
     };
+    mockAvailability = {
+      ...mockAvailability,
+      stages: { 'group-stage': true },
+    };
+    mockAvailableTabs = [
+      ...mockAvailableTabs,
+      { key: 'group-stage', label: 'Group Stage' },
+    ];
 
     render(<PredictWorldCup />);
 
     expect(
       screen.getByTestId(PREDICT_WORLD_CUP_SCREEN_TEST_IDS.INITIAL_TAB),
     ).toHaveTextContent('group-stage');
+  });
+
+  it('does not render tabs hidden by availability', () => {
+    mockAvailableTabs = [{ key: 'all', label: 'All' }];
+    mockAvailability = {
+      live: false,
+      props: false,
+      stages: {},
+    };
+
+    render(<PredictWorldCup />);
+
+    expect(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-all`),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-live`),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-props`),
+    ).toBeNull();
   });
 
   it('falls back to All for an invalid requested initial tab', () => {

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { Pressable, ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -16,12 +17,23 @@ import {
   selectPredictWorldCupConfig,
   selectPredictWorldCupScreenEnabledFlag,
 } from '../../selectors/featureFlags';
-import type { PredictNavigationParamList } from '../../types/navigation';
+import type {
+  PredictEntryPoint,
+  PredictNavigationParamList,
+} from '../../types/navigation';
+import type { PredictMarket as PredictMarketType } from '../../types';
 import {
   resolvePredictWorldCupInitialTab,
   type PredictWorldCupTabKey,
 } from '../../constants/worldCupTabs';
-import { usePredictWorldCupAvailableTabs } from '../../hooks';
+import {
+  usePredictWorldCupAvailableTabs,
+  usePredictWorldCupMarkets,
+} from '../../hooks';
+import PredictMarket from '../../components/PredictMarket';
+import PredictMarketSkeleton from '../../components/PredictMarketSkeleton';
+import PredictOffline from '../../components/PredictOffline';
+import type { PredictWorldCupConfig } from '../../types/flags';
 
 export const PREDICT_WORLD_CUP_SCREEN_TEST_IDS = {
   CONTAINER: 'predict-world-cup-screen',
@@ -29,9 +41,18 @@ export const PREDICT_WORLD_CUP_SCREEN_TEST_IDS = {
   TABS: 'predict-world-cup-tabs',
   TAB: 'predict-world-cup-tab',
   EMPTY_STATE: 'predict-world-cup-empty-state',
+  ERROR_STATE: 'predict-world-cup-error-state',
+  MARKET_LIST: 'predict-world-cup-market-list',
+  MARKET_CARD: 'predict-world-cup-market-card',
+  SKELETON: 'predict-world-cup-skeleton',
 } as const;
 
 type Tw = ReturnType<typeof useTailwind>;
+
+type WorldCupConfigSubset = Pick<
+  PredictWorldCupConfig,
+  'seriesId' | 'tagSlug' | 'gamesTagId' | 'stages'
+>;
 
 const LiveIndicator = ({ tw, size = 8 }: { tw: Tw; size?: number }) => (
   <View
@@ -45,6 +66,136 @@ const LiveIndicator = ({ tw, size = 8 }: { tw: Tw; size?: number }) => (
     ]}
   />
 );
+
+interface WorldCupTabContentProps {
+  activeTab: PredictWorldCupTabKey;
+  config: WorldCupConfigSubset;
+  entryPoint?: PredictEntryPoint;
+}
+
+const WorldCupTabContent = ({
+  activeTab,
+  config,
+  entryPoint,
+}: WorldCupTabContentProps) => {
+  const tw = useTailwind();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const {
+    marketData,
+    isFetching,
+    isFetchingMore,
+    error,
+    hasMore,
+    refetch,
+    fetchMore,
+  } = usePredictWorldCupMarkets({
+    tabKey: activeTab,
+    config,
+  });
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [refetch]);
+
+  const handleEndReached = useCallback(() => {
+    if (hasMore && !isFetchingMore) {
+      fetchMore();
+    }
+  }, [fetchMore, hasMore, isFetchingMore]);
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: PredictMarketType; index: number }) => (
+      <Box twClassName="mb-3">
+        <PredictMarket
+          market={item}
+          entryPoint={entryPoint}
+          testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.MARKET_CARD}-${
+            index + 1
+          }`}
+        />
+      </Box>
+    ),
+    [entryPoint],
+  );
+
+  const keyExtractor = useCallback((item: PredictMarketType) => item.id, []);
+
+  const renderFooter = useCallback(() => {
+    if (!isFetchingMore) {
+      return null;
+    }
+
+    return (
+      <Box twClassName="py-2">
+        <PredictMarketSkeleton
+          testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.SKELETON}-footer-1`}
+        />
+      </Box>
+    );
+  }, [isFetchingMore]);
+
+  if (isFetching && !isRefreshing && !isFetchingMore) {
+    return (
+      <Box twClassName="flex-1 px-4">
+        <PredictMarketSkeleton
+          testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.SKELETON}-1`}
+        />
+        <PredictMarketSkeleton
+          testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.SKELETON}-2`}
+        />
+        <PredictMarketSkeleton
+          testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.SKELETON}-3`}
+        />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box
+        twClassName="flex-1"
+        testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.ERROR_STATE}
+      >
+        <PredictOffline onRetry={handleRefresh} />
+      </Box>
+    );
+  }
+
+  if (marketData.length === 0) {
+    return (
+      <Box
+        twClassName="flex-1 justify-center items-center p-8"
+        testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.EMPTY_STATE}
+      >
+        <Text variant={TextVariant.BodyMd} color={TextColor.PrimaryAlternative}>
+          No World Cup markets available.
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <FlashList
+      testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.MARKET_LIST}
+      data={marketData}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      onEndReached={handleEndReached}
+      onEndReachedThreshold={0.7}
+      ListFooterComponent={renderFooter}
+      refreshControl={
+        <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
+      }
+      contentContainerStyle={tw.style('px-4 pb-4')}
+      showsVerticalScrollIndicator={false}
+    />
+  );
+};
 
 const PredictWorldCup: React.FC = () => {
   const tw = useTailwind();
@@ -69,6 +220,7 @@ const PredictWorldCup: React.FC = () => {
   );
 
   const [activeTab, setActiveTab] = useState<PredictWorldCupTabKey>(initialTab);
+  const entryPoint = route.params?.entryPoint as PredictEntryPoint | undefined;
 
   useEffect(() => {
     setActiveTab(initialTab);
@@ -155,9 +307,10 @@ const PredictWorldCup: React.FC = () => {
           {activeTab}
         </Text>
 
-        <Box
-          twClassName="flex-1"
-          testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.EMPTY_STATE}
+        <WorldCupTabContent
+          activeTab={activeTab}
+          config={config}
+          entryPoint={entryPoint}
         />
       </Box>
     </SafeAreaView>

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
@@ -34,6 +34,7 @@ import PredictMarket from '../../components/PredictMarket';
 import PredictMarketSkeleton from '../../components/PredictMarketSkeleton';
 import PredictOffline from '../../components/PredictOffline';
 import type { PredictWorldCupConfig } from '../../types/flags';
+import { strings } from '../../../../../../locales/i18n';
 
 export const PREDICT_WORLD_CUP_SCREEN_TEST_IDS = {
   CONTAINER: 'predict-world-cup-screen',
@@ -173,7 +174,9 @@ const WorldCupTabContent = ({
         testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.EMPTY_STATE}
       >
         <Text variant={TextVariant.BodyMd} color={TextColor.PrimaryAlternative}>
-          No World Cup markets available.
+          {strings('predict.search_empty_state', {
+            category: strings('predict.world_cup.title'),
+          })}
         </Text>
       </Box>
     );
@@ -257,7 +260,11 @@ const PredictWorldCup: React.FC = () => {
       style={tw.style('flex-1 bg-default')}
       testID={PREDICT_WORLD_CUP_SCREEN_TEST_IDS.CONTAINER}
     >
-      <HeaderStandard title="World Cup" onBack={handleBack} includesTopInset />
+      <HeaderStandard
+        title={strings('predict.world_cup.title')}
+        onBack={handleBack}
+        includesTopInset
+      />
 
       <Box twClassName="flex-1">
         <ScrollView

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
@@ -18,11 +18,10 @@ import {
 } from '../../selectors/featureFlags';
 import type { PredictNavigationParamList } from '../../types/navigation';
 import {
-  PREDICT_WORLD_CUP_TAB_KEYS,
   resolvePredictWorldCupInitialTab,
   type PredictWorldCupTabKey,
 } from '../../constants/worldCupTabs';
-import { resolvePredictWorldCupStageLabel } from '../../utils/worldCup';
+import { usePredictWorldCupAvailableTabs } from '../../hooks';
 
 export const PREDICT_WORLD_CUP_SCREEN_TEST_IDS = {
   CONTAINER: 'predict-world-cup-screen',
@@ -33,18 +32,6 @@ export const PREDICT_WORLD_CUP_SCREEN_TEST_IDS = {
 } as const;
 
 type Tw = ReturnType<typeof useTailwind>;
-
-interface WorldCupTab {
-  key: PredictWorldCupTabKey;
-  label: string;
-  isLive?: boolean;
-}
-
-const DEFAULT_STAGE_TABS: WorldCupTab[] = [
-  { key: 'group-a', label: 'Group A' },
-  { key: 'group-b', label: 'Group B' },
-  { key: 'group-c', label: 'Group C' },
-];
 
 const LiveIndicator = ({ tw, size = 8 }: { tw: Tw; size?: number }) => (
   <View
@@ -67,25 +54,18 @@ const PredictWorldCup: React.FC = () => {
   const config = useSelector(selectPredictWorldCupConfig);
   const isScreenEnabled = useSelector(selectPredictWorldCupScreenEnabledFlag);
 
-  const tabs = useMemo<WorldCupTab[]>(() => {
-    const configuredStageTabs = config.stages.map((stage) => ({
-      key: stage.key,
-      label: resolvePredictWorldCupStageLabel(stage),
-    }));
-
-    return [
-      { key: PREDICT_WORLD_CUP_TAB_KEYS.ALL, label: 'All' },
-      { key: PREDICT_WORLD_CUP_TAB_KEYS.LIVE, label: 'Live', isLive: true },
-      { key: PREDICT_WORLD_CUP_TAB_KEYS.PROPS, label: 'Props' },
-      ...(configuredStageTabs.length
-        ? configuredStageTabs
-        : DEFAULT_STAGE_TABS),
-    ];
-  }, [config.stages]);
+  const { tabs, availability } = usePredictWorldCupAvailableTabs(config, {
+    enabled: isScreenEnabled,
+  });
 
   const initialTab = useMemo(
-    () => resolvePredictWorldCupInitialTab(route.params?.initialTab, config),
-    [config, route.params?.initialTab],
+    () =>
+      resolvePredictWorldCupInitialTab(
+        route.params?.initialTab,
+        config,
+        availability,
+      ),
+    [availability, config, route.params?.initialTab],
   );
 
   const [activeTab, setActiveTab] = useState<PredictWorldCupTabKey>(initialTab);

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
@@ -283,7 +283,7 @@ const PredictWorldCup: React.FC = () => {
                 onPress={() => setActiveTab(tab.key)}
                 style={tw.style(
                   'min-w-[51px] flex-row items-center justify-center gap-2 rounded-xl bg-muted p-2',
-                  isActive && 'bg-white',
+                  isActive && 'bg-icon-default',
                 )}
                 testID={`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-${tab.key}`}
               >


### PR DESCRIPTION
## **Description**

Adds the World Cup Predict data layer and wires it into the dedicated World Cup screen so the tab row and tab content are driven by Polymarket data instead of placeholders.

This includes:
- World Cup-specific query builders/options for All, Live, Props, and configured stage tabs.
- Lightweight availability checks for tabs that should be hidden when empty.
- A unified cached `usePredictWorldCupMarkets` hook using React Query for tab content.
- Prefetching visible World Cup tab content after availability resolves to reduce skeletons during tab switches.
- World Cup screen tab rendering and market list content using existing Predict market cards.
- Unit tests for query shapes, availability behavior, caching, hidden tabs, and World Cup game parsing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: PRED-879

## **Manual testing steps**

```gherkin
Feature: Predict World Cup tab data

  Scenario: user views and switches World Cup tabs
    Given the Predict World Cup feature flag is enabled with World Cup identifiers and stage event IDs
    And the user opens the World Cup Predict screen

    When tab availability finishes loading
    Then tabs with active content are visible
    And tabs without active content are hidden

    When user switches between All, Props, Live, and configured stage tabs
    Then market content loads for the selected tab
    And previously loaded tabs reuse cached data without showing the full loading skeleton again
```

## **Screenshots/Recordings**

N/A — data/query wiring and existing UI composition. Manually validated in simulator during development.

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/aadd8ec0-d5a6-4896-b828-af1e0662d908



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new React Query data-fetching/prefetching paths and changes the World Cup screen to render paginated market lists and conditional tabs based on API-driven availability.
> 
> **Overview**
> **World Cup Predict is now data-driven instead of placeholder-driven.** The PR introduces a World Cup-specific data layer (query keys/options, services, and hooks) to fetch Polymarket markets for `All`, `Live`, `Props`, and configured stage tabs, including pagination where appropriate and deterministic start-time sorting for stage/game markets.
> 
> Tabs are now conditionally shown/hidden based on lightweight availability checks, and `resolvePredictWorldCupInitialTab`/`getPredictWorldCupAvailableTabKeys` take this availability into account. The World Cup screen is rewired to use `usePredictWorldCupAvailableTabs` + `usePredictWorldCupMarkets`, rendering a `FlashList` of `PredictMarket` cards with skeleton/loading, pull-to-refresh, error state, and prefetching of visible tabs to reduce reloads on tab switches.
> 
> Adds/updates unit tests covering query shapes, tab availability + initial-tab fallback, market hook caching/pagination behavior, stage edge cases (no event IDs), and World Cup game parsing in Polymarket utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240a4a1dcf0fe56be96be07c3ce4d51c593dfdc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->