### PR TITLE
ci: align post-build fingerprint source with E2E merge ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,14 @@ jobs:
     outputs:
       fingerprint: ${{ steps.publish.outputs.fingerprint }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-node@v4
+      # Use the default ref (refs/pull/N/merge on pull_request, github.sha otherwise) so the
+      # fingerprint is computed against the SAME working tree that `build-android-e2e.yml`,
+      # `build-ios-e2e.yml`, and `run-e2e-workflow.yml` check out and build/test against.
+      # Posting on `pull_request.head.sha` while fingerprinting the PR head tree would let
+      # two PRs with identical heads but different merges collide on the cache key — and the
+      # native build then runs against a different (merge) tree than the one we fingerprinted.
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -115,8 +119,11 @@ jobs:
         uses: ./.github/actions/post-build-source-hash
         with:
           github-token: ${{ github.token }}
-          # .head.sha = PR head (pull_request events); github.sha fallback = pushed/scheduled commit
-          # (push to main, merge_group, schedule) where no PR payload exists.
+          # Commit statuses must be posted on a real commit SHA (not the merge ref).
+          # `find-reusable-build` looks up the status via `run.head_sha` from
+          # `listWorkflowRuns`, which GitHub reports as the PR head SHA for pull_request
+          # events and as the pushed/scheduled commit SHA otherwise — so this is the same
+          # SHA the lookup queries against.
           target-sha: ${{ github.event.pull_request.head.sha || github.sha }}
 
   dedupe:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Update `post-build-source-hash` in `ci.yml` to use default checkout ref (`refs/pull/<n>/merge` on PRs), matching the same source tree used by E2E build/test workflows.

Keep `target-sha` as `${{ github.event.pull_request.head.sha || github.sha }}` so commit status posting and `find-reusable-build` lookup by `run.head_sha` still work correctly.
  
**Why**
Previously, fingerprint generation used PR head checkout while E2E builds/tests ran on merge checkout.  
That could allow fingerprint/cache reuse across PRs that had the same head tree but different merge trees.  
Now fingerprinting and E2E execution are aligned to the same checked-out code.

Before: fingerprint(PR head tree) → posted on PR head SHA. Build/tests ran against merge tree. → cache key keyed on a tree that wasn't built.

Now: fingerprint(merge tree) → posted on PR head SHA. Build/tests still run against merge tree. → cache key correctly represents the artifact contents.



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI caching/status behavior for E2E artifact reuse by altering what git ref is fingerprinted, which could affect cache hits/misses and workflow execution if assumptions are wrong.
> 
> **Overview**
> Aligns the `post-build-source-hash` job in `ci.yml` to compute the source fingerprint from the default GitHub checkout ref (PR `refs/pull/<n>/merge`), matching the tree used by the E2E build/test reusable workflows and avoiding cache-key collisions between different PR merge results.
> 
> Keeps commit status posting (`target-sha`) pinned to the real commit SHA (`pull_request.head.sha` or `github.sha`) while updating the job to use `actions/checkout@v6` and `actions/setup-node@v6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883a17a66da64a09cfb8eb2a08934a000c86e056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->