### PR TITLE
test: removes non used dead code

### DIFF
--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -517,7 +517,6 @@ export async function withFixtures(
     skipReactNativeReload = false,
     useCommandQueueServer = false,
     analyticsExpectations,
-    shouldPrefetchSwapTokens = true,
     disableSynchronization = false,
   } = options;
 
@@ -704,11 +703,6 @@ export async function withFixtures(
         cleanupErrors.push(analyticsError as Error);
         logger.error('Analytics expectations failed');
       }
-    }
-
-    if (mockServerInstance && shouldPrefetchSwapTokens) {
-      logger.debug('Mocking swap popular tokens fetch');
-      await mockSwapPopularTokens(mockServerInstance.server);
     }
 
     // Enter drain mode AFTER endTestfn / analyticsExpectations so analytics events are still captured,

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -62,7 +62,6 @@ import {
   setupAccountActivityMocks,
   resetAccountActivityMockState,
 } from '../../websocket/account-activity-mocks';
-import { mockSwapPopularTokens } from '../../helpers/swap/swap-mocks';
 
 const logger = createLogger({
   name: 'FixtureHelper',

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -462,6 +462,5 @@ export interface WithFixturesOptions {
   skipReactNativeReload?: boolean;
   useCommandQueueServer?: boolean;
   analyticsExpectations?: AnalyticsExpectations;
-  shouldPrefetchSwapTokens?: boolean;
   disableSynchronization?: boolean;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
https://github.com/MetaMask/metamask-mobile/pull/29587 added code that is test specific oriented and isn't being used. This PR removes this code in order to cleanup FixtureHelper.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: 

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only cleanup: removes an unused option and associated mock wiring, which could only affect E2E tests that implicitly relied on the default swap popular-tokens mock.
> 
> **Overview**
> Removes the unused `shouldPrefetchSwapTokens` option from `WithFixturesOptions` and eliminates the corresponding `FixtureHelper.withFixtures` cleanup-time hook that auto-mocked the swap popular-tokens endpoint.
> 
> E2E tests must now explicitly set up swap token mocks (e.g., via swap-specific test mocks) rather than relying on `withFixtures` to preconfigure them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9918112e7bc862de231bb6e8addbfd7da4180aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->