### PR TITLE
fix(rewards): Update mUSD calculator input max to 10M

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.test.tsx
@@ -234,11 +234,72 @@ describe('MusdCalculatorTab', () => {
     });
   });
 
-  it('caps typed amounts at the slider maximum', async () => {
+  it('allows typed amounts above the slider maximum', async () => {
     const { getByTestId, getByText } = render(<MusdCalculatorTab />);
     const amountInput = getByTestId('musd-slider-amount-display');
 
     fireEvent.changeText(amountInput, '12000');
+
+    await waitFor(() => {
+      expect(amountInput).toHaveProp('value', '12000');
+      expect(getByText(/\$360/)).toBeOnTheScreen();
+    });
+  });
+
+  it('compacts yearly earnings when the input amount is at the compact threshold', async () => {
+    const { getByTestId, getByText } = render(<MusdCalculatorTab />);
+    const amountInput = getByTestId('musd-slider-amount-display');
+
+    fireEvent.changeText(amountInput, '2552222');
+
+    await waitFor(() => {
+      expect(amountInput).toHaveProp('value', '2552222');
+      expect(getByText(/\$77K/)).toBeOnTheScreen();
+    });
+  });
+
+  it('caps typed amounts at the input maximum', async () => {
+    const { getByTestId, getByText } = render(<MusdCalculatorTab />);
+    const amountInput = getByTestId('musd-slider-amount-display');
+
+    fireEvent.changeText(amountInput, '12000000');
+
+    await waitFor(() => {
+      expect(amountInput).toHaveProp('value', '10000000');
+      expect(getByText(/\$300K/)).toBeOnTheScreen();
+    });
+  });
+
+  it('formats compact yearly earnings without decimals', async () => {
+    const { getByTestId, getByText } = render(<MusdCalculatorTab />);
+    const amountInput = getByTestId('musd-slider-amount-display');
+
+    fireEvent.changeText(amountInput, '4115200');
+
+    await waitFor(() => {
+      expect(amountInput).toHaveProp('value', '4115200');
+      expect(getByText(/\$123K/)).toBeOnTheScreen();
+    });
+  });
+
+  it('returns typed amounts above the slider maximum to the slider scale after touching the slider', async () => {
+    const { getByTestId, getByText } = render(<MusdCalculatorTab />);
+    const amountInput = getByTestId('musd-slider-amount-display');
+    const track = getByTestId('musd-slider-track');
+
+    fireEvent(track, 'layout', {
+      nativeEvent: { layout: { width: 300, height: 32, x: 0, y: 0 } },
+    });
+    fireEvent.changeText(amountInput, '12000');
+
+    await waitFor(() => {
+      expect(amountInput).toHaveProp('value', '12000');
+      expect(getByText(/\$360/)).toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      mockTapGestureHandlers.onEnd?.({ x: 300 });
+    });
 
     await waitFor(() => {
       expect(amountInput).toHaveProp('value', '10000');

--- a/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
+++ b/app/components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx
@@ -51,11 +51,11 @@ import {
 } from '../../../../Earn/constants/musd';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { RewardsMetricsButtons } from '../../../utils';
-import { formatUsd } from '../../../utils/formatUtils';
+import { formatCompactUsd, formatUsd } from '../../../utils/formatUtils';
 import {
   amountToPercent,
   clampAmount,
-  MAX_AMOUNT,
+  MAX_AMOUNT as MAX_SLIDER_AMOUNT,
   MUSD_CALCULATOR_APY,
   percentToAmount,
   SNAP_POINTS,
@@ -87,6 +87,8 @@ const SLIDER_AMOUNT_THROTTLE_MS = 48;
 const INITIAL_AMOUNT = SNAP_POINTS[1];
 const KEYBOARD_EXTRA_SCROLL_HEIGHT = 20;
 const MAX_DECIMAL_PLACES = 2;
+const MAX_INPUT_AMOUNT = 10_000_000;
+const COMPACT_USD_THRESHOLD = 100_000;
 
 const normalizeAmountInput = (value: string) => {
   const numeric = value.replace(/[^0-9.]/g, '');
@@ -103,10 +105,10 @@ const getAmountInputState = (value: string) => {
   const inputValue = normalizeAmountInput(value);
   const numericAmount = Number(inputValue);
 
-  if (Number.isFinite(numericAmount) && numericAmount > MAX_AMOUNT) {
+  if (Number.isFinite(numericAmount) && numericAmount > MAX_INPUT_AMOUNT) {
     return {
-      amount: MAX_AMOUNT,
-      inputValue: String(MAX_AMOUNT),
+      amount: MAX_INPUT_AMOUNT,
+      inputValue: String(MAX_INPUT_AMOUNT),
     };
   }
 
@@ -126,7 +128,9 @@ const useMusdSlider = (
   const lastThrottledAmountSyncRef = useRef(0);
 
   useEffect(() => {
-    thumbLinearPctShared.value = amountToPercent(amount);
+    thumbLinearPctShared.value = amountToPercent(
+      Math.min(amount, MAX_SLIDER_AMOUNT),
+    );
   }, [amount, thumbLinearPctShared]);
 
   const syncAmountFromLinearPct = useCallback(
@@ -262,6 +266,10 @@ const MusdCalculatorTab: React.FC = () => {
 
   const yearlyEarnings = amount * MUSD_CALCULATOR_APY;
   const dailyEarnings = yearlyEarnings / 365;
+  const yearlyEarningsLabel =
+    amount >= COMPACT_USD_THRESHOLD
+      ? formatCompactUsd(yearlyEarnings, { maximumFractionDigits: 0 })
+      : formatUsd(yearlyEarnings);
 
   const handleBuyMusd = useCallback(() => {
     trackEvent(
@@ -356,7 +364,7 @@ const MusdCalculatorTab: React.FC = () => {
                 twClassName="text-[64px] leading-[72px] font-semibold"
               >
                 {strings('rewards.musd.yearly_positive_prefix')}
-                {formatUsd(yearlyEarnings)}
+                {yearlyEarningsLabel}
               </Text>
               <Text
                 variant={TextVariant.HeadingMd}

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -1652,5 +1652,11 @@ describe('formatUtils', () => {
     it('formats negative thousands', () => {
       expect(formatCompactUsd(-75_000)).toBe('-$75K');
     });
+
+    it('formats compact values without decimals when requested', () => {
+      expect(formatCompactUsd(123_456, { maximumFractionDigits: 0 })).toBe(
+        '$123K',
+      );
+    });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -343,19 +343,23 @@ export const formatUsd = (value: string | number): string =>
  * @example formatCompactUsd(25000)   // '$25K'
  * @example formatCompactUsd(500)     // '$500'
  */
-export const formatCompactUsd = (value: number): string => {
+export const formatCompactUsd = (
+  value: number,
+  options?: { maximumFractionDigits?: number },
+): string => {
   const abs = Math.abs(value);
   const sign = value < 0 ? '-' : '';
+  const maximumFractionDigits = options?.maximumFractionDigits ?? 1;
+  const formatCompactValue = (compact: number) =>
+    `${Number(compact.toFixed(maximumFractionDigits))}`;
 
   if (abs >= 1_000_000) {
     const compact = abs / 1_000_000;
-    const formatted = compact % 1 === 0 ? `${compact}` : compact.toFixed(1);
-    return `${sign}$${formatted}M`;
+    return `${sign}$${formatCompactValue(compact)}M`;
   }
   if (abs >= 1_000) {
     const compact = abs / 1_000;
-    const formatted = compact % 1 === 0 ? `${compact}` : compact.toFixed(1);
-    return `${sign}$${formatted}K`;
+    return `${sign}$${formatCompactValue(compact)}K`;
   }
   return `${sign}$${abs}`;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
- Split mUSD calculator input max from slider max:
-- text input now accepts up to 10,000,000
-- slider scale remains capped at 10,000
- Added compact yearly earnings formatting when the input amount is >= 100,000.
- When typed input is above the slider max, the slider stays visually pinned to the right. Touching or dragging the slider brings the amount back onto the slider scale.

https://github.com/user-attachments/assets/b6136ea3-f03a-4c07-b3d2-c34e636c8bb1



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized UI/input/formatting changes to the Rewards mUSD calculator with updated tests; no auth, network, or persistence logic touched.
> 
> **Overview**
> The mUSD Rewards calculator now accepts typed amounts up to `10,000,000` while keeping the slider scale capped at `10,000`, with the slider thumb visually pinned at max when the typed value exceeds the slider range and returning to slider scale on the next slider interaction.
> 
> Yearly earnings display switches to *compact USD* formatting (e.g., `$123K`) when the input amount is `>= 100,000`, enabled by extending `formatCompactUsd` to support an optional `maximumFractionDigits` setting.
> 
> Tests are updated/added to cover the new input cap behavior, slider resync behavior, and compact earnings formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7f98a064ec071703844167b12192ebada4363f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->