### PR TITLE
chore(predict): add world cup tab to main predict feed

### DIFF
--- a/app/components/UI/Predict/constants/feedTabs.ts
+++ b/app/components/UI/Predict/constants/feedTabs.ts
@@ -1,4 +1,5 @@
 import type { PredictCategory } from '../types';
+import { PREDICT_WORLD_CUP_FEED_PARAM } from './worldCupTabs';
 
 export type PredictTabKey = PredictCategory;
 
@@ -21,9 +22,15 @@ export const PREDICT_HOT_TAB: PredictTabConfig = {
   labelKey: 'predict.category.hot',
 };
 
+export const PREDICT_WORLD_CUP_TAB: PredictTabConfig = {
+  key: PREDICT_WORLD_CUP_FEED_PARAM,
+  labelKey: 'predict.world_cup.title',
+};
+
 export const PREDICT_ALL_TABS: readonly PredictTabConfig[] = [
   ...PREDICT_BASE_TABS,
   PREDICT_HOT_TAB,
+  PREDICT_WORLD_CUP_TAB,
 ];
 
 const PREDICT_TAB_KEYS = PREDICT_ALL_TABS.map((tab) => tab.key);

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -184,20 +184,26 @@ describe('usePredictTabs', () => {
     });
   });
 
-  describe('hotTabQueryParams', () => {
-    it('returns undefined when hot tab is disabled', () => {
+  describe('tab custom query params', () => {
+    it('does not add custom query params to base tabs', () => {
       const { result } = renderHook(() => usePredictTabs());
 
-      expect(result.current.hotTabQueryParams).toBeUndefined();
+      expect(
+        result.current.tabs.every((tab) => tab.customQueryParams === undefined),
+      ).toBe(true);
     });
 
-    it('returns query params when hot tab is enabled', () => {
+    it('adds query params to the hot tab when enabled', () => {
       mockHotTabFlag.enabled = true;
       mockHotTabFlag.queryParams = 'test=value';
 
       const { result } = renderHook(() => usePredictTabs());
 
-      expect(result.current.hotTabQueryParams).toBe('test=value');
+      expect(result.current.tabs[0]).toEqual({
+        key: 'hot',
+        label: 'predict.category.hot',
+        customQueryParams: 'test=value',
+      });
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -1,4 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../constants/flags';
+import { buildPredictWorldCupAllQuery } from '../utils/worldCup';
 import { usePredictTabs } from './usePredictTabs';
 
 const mockRouteParams: { tab?: string } = {};
@@ -13,9 +15,29 @@ const mockHotTabFlag: { enabled: boolean; queryParams: string | undefined } = {
   enabled: false,
   queryParams: undefined,
 };
+let mockIsWorldCupMainFeedTabEnabled = false;
+let mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
 
 jest.mock('react-redux', () => ({
-  useSelector: () => mockHotTabFlag,
+  useSelector: (selector: string) => {
+    switch (selector) {
+      case 'selectPredictHotTabFlag':
+        return mockHotTabFlag;
+      case 'selectPredictWorldCupMainFeedTabEnabledFlag':
+        return mockIsWorldCupMainFeedTabEnabled;
+      case 'selectPredictWorldCupConfig':
+        return mockWorldCupConfig;
+      default:
+        return undefined;
+    }
+  },
+}));
+
+jest.mock('../selectors/featureFlags', () => ({
+  selectPredictHotTabFlag: 'selectPredictHotTabFlag',
+  selectPredictWorldCupConfig: 'selectPredictWorldCupConfig',
+  selectPredictWorldCupMainFeedTabEnabledFlag:
+    'selectPredictWorldCupMainFeedTabEnabledFlag',
 }));
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -28,6 +50,8 @@ describe('usePredictTabs', () => {
     mockRouteParams.tab = undefined;
     mockHotTabFlag.enabled = false;
     mockHotTabFlag.queryParams = undefined;
+    mockIsWorldCupMainFeedTabEnabled = false;
+    mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
   });
 
   describe('tabs array', () => {
@@ -47,6 +71,42 @@ describe('usePredictTabs', () => {
       expect(result.current.tabs[0].key).toBe('hot');
       expect(result.current.tabs[1].key).toBe('trending');
     });
+
+    it('does not include World Cup tab when main feed tab flag is disabled', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs.map((tab) => tab.key)).not.toContain(
+        'world-cup',
+      );
+    });
+
+    it('includes World Cup tab at beginning when enabled', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs).toHaveLength(7);
+      expect(result.current.tabs[0]).toEqual({
+        key: 'world-cup',
+        label: 'predict.world_cup.title',
+        customQueryParams: buildPredictWorldCupAllQuery(mockWorldCupConfig),
+      });
+      expect(result.current.tabs[1].key).toBe('trending');
+    });
+
+    it('places World Cup before Hot when both tabs are enabled', () => {
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'test=value';
+      mockIsWorldCupMainFeedTabEnabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs.map((tab) => tab.key).slice(0, 3)).toEqual([
+        'world-cup',
+        'hot',
+        'trending',
+      ]);
+    });
   });
 
   describe('activeIndex', () => {
@@ -54,6 +114,15 @@ describe('usePredictTabs', () => {
       const { result } = renderHook(() => usePredictTabs());
 
       expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('defaults to 0 (World Cup) when World Cup tab is enabled and no tab is requested', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.tabs[0].key).toBe('world-cup');
     });
 
     it('sets active index to requested tab position', () => {
@@ -70,6 +139,25 @@ describe('usePredictTabs', () => {
       const { result } = renderHook(() => usePredictTabs());
 
       expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('defaults to trending when World Cup tab is requested but disabled', () => {
+      mockRouteParams.tab = 'world-cup';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.initialTabKey).toBe('trending');
+    });
+
+    it('sets active index to requested World Cup tab when enabled', () => {
+      mockRouteParams.tab = 'world-cup';
+      mockIsWorldCupMainFeedTabEnabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.initialTabKey).toBe('world-cup');
     });
 
     it('updates when setActiveIndex is called', () => {
@@ -203,6 +291,24 @@ describe('usePredictTabs', () => {
         key: 'hot',
         label: 'predict.category.hot',
         customQueryParams: 'test=value',
+      });
+    });
+
+    it('adds exact World Cup query params to the World Cup tab when enabled', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+      mockWorldCupConfig = {
+        ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        enabled: true,
+        showMainFeedTab: true,
+        tagSlug: 'custom-world-cup',
+      };
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs[0]).toEqual({
+        key: 'world-cup',
+        label: 'predict.world_cup.title',
+        customQueryParams: buildPredictWorldCupAllQuery(mockWorldCupConfig),
       });
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -14,6 +14,7 @@ import type { PredictNavigationParamList } from '../types/navigation';
 export interface FeedTab {
   key: PredictTabKey;
   label: string;
+  customQueryParams?: string;
 }
 
 export interface UsePredictTabsResult {
@@ -21,7 +22,6 @@ export interface UsePredictTabsResult {
   activeIndex: number;
   setActiveIndex: (index: number) => void;
   initialTabKey: PredictTabKey;
-  hotTabQueryParams?: string;
 }
 
 export const usePredictTabs = (): UsePredictTabsResult => {
@@ -39,11 +39,12 @@ export const usePredictTabs = (): UsePredictTabsResult => {
       baseTabs.unshift({
         key: PREDICT_HOT_TAB.key,
         label: strings(PREDICT_HOT_TAB.labelKey),
+        customQueryParams: hotTabFlag.queryParams,
       });
     }
 
     return baseTabs;
-  }, [hotTabFlag.enabled]);
+  }, [hotTabFlag.enabled, hotTabFlag.queryParams]);
 
   const requestedTabKey = isPredictTabKey(route.params?.tab)
     ? route.params?.tab
@@ -109,6 +110,5 @@ export const usePredictTabs = (): UsePredictTabsResult => {
     activeIndex,
     setActiveIndex,
     initialTabKey: initialTabKeyRef.current,
-    hotTabQueryParams: hotTabFlag.queryParams,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -2,14 +2,20 @@ import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useRoute, RouteProp } from '@react-navigation/native';
 import { strings } from '../../../../../locales/i18n';
-import { selectPredictHotTabFlag } from '../selectors/featureFlags';
+import {
+  selectPredictHotTabFlag,
+  selectPredictWorldCupConfig,
+  selectPredictWorldCupMainFeedTabEnabledFlag,
+} from '../selectors/featureFlags';
 import {
   PREDICT_BASE_TABS,
   PREDICT_HOT_TAB,
+  PREDICT_WORLD_CUP_TAB,
   isPredictTabKey,
   type PredictTabKey,
 } from '../constants/feedTabs';
 import type { PredictNavigationParamList } from '../types/navigation';
+import { buildPredictWorldCupAllQuery } from '../utils/worldCup';
 
 export interface FeedTab {
   key: PredictTabKey;
@@ -28,6 +34,10 @@ export const usePredictTabs = (): UsePredictTabsResult => {
   const route =
     useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
   const hotTabFlag = useSelector(selectPredictHotTabFlag);
+  const isWorldCupMainFeedTabEnabled = useSelector(
+    selectPredictWorldCupMainFeedTabEnabledFlag,
+  );
+  const worldCupConfig = useSelector(selectPredictWorldCupConfig);
 
   const tabs: FeedTab[] = useMemo(() => {
     const baseTabs: FeedTab[] = PREDICT_BASE_TABS.map((tab) => ({
@@ -43,11 +53,27 @@ export const usePredictTabs = (): UsePredictTabsResult => {
       });
     }
 
-    return baseTabs;
-  }, [hotTabFlag.enabled, hotTabFlag.queryParams]);
+    if (isWorldCupMainFeedTabEnabled) {
+      baseTabs.unshift({
+        key: PREDICT_WORLD_CUP_TAB.key,
+        label: strings(PREDICT_WORLD_CUP_TAB.labelKey),
+        customQueryParams: buildPredictWorldCupAllQuery(worldCupConfig),
+      });
+    }
 
-  const requestedTabKey = isPredictTabKey(route.params?.tab)
+    return baseTabs;
+  }, [
+    hotTabFlag.enabled,
+    hotTabFlag.queryParams,
+    isWorldCupMainFeedTabEnabled,
+    worldCupConfig,
+  ]);
+
+  const requestedValidTabKey = isPredictTabKey(route.params?.tab)
     ? route.params?.tab
+    : undefined;
+  const requestedTabKey = tabs.some((tab) => tab.key === requestedValidTabKey)
+    ? requestedValidTabKey
     : undefined;
 
   const initialTabKeyRef = useRef<PredictTabKey>(

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -16,6 +16,7 @@ import {
   clearClobMarketInfoSessionState,
   createApiKey,
   deriveApiKey,
+  fetchEventsFromPolymarketApi,
   getAllowance,
   getClobMarketInfo,
   getClobMarketInfoSafe,
@@ -202,6 +203,63 @@ describe('polymarket utils', () => {
         awayTeam: expect.objectContaining({ abbreviation: 'can' }),
       }),
     );
+  });
+
+  describe('fetchEventsFromPolymarketApi', () => {
+    const mockEventsPaginationResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ data: [] }),
+    };
+
+    beforeEach(() => {
+      mockEventsPaginationResponse.json.mockClear();
+      mockFetch.mockResolvedValue(mockEventsPaginationResponse);
+    });
+
+    it('uses exact World Cup custom query params without normal feed filters', async () => {
+      await fetchEventsFromPolymarketApi({
+        category: 'world-cup',
+        limit: 20,
+        offset: 40,
+        customQueryParams:
+          'active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gamma-api.polymarket.com/events/pagination?limit=20&offset=40&active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+      );
+      const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).not.toContain('liquidity_min');
+      expect(requestedUrl).not.toContain('volume_min');
+    });
+
+    it('falls back to default World Cup query params without normal feed filters', async () => {
+      await fetchEventsFromPolymarketApi({
+        category: 'world-cup',
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gamma-api.polymarket.com/events/pagination?limit=10&offset=0&active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+      );
+      const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).not.toContain('liquidity_min');
+      expect(requestedUrl).not.toContain('volume_min');
+    });
+
+    it('keeps Hot category default query on normal feed filters without custom params', async () => {
+      await fetchEventsFromPolymarketApi({
+        category: 'hot',
+        limit: 20,
+        offset: 0,
+      });
+
+      const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).toContain('liquidity_min=10000');
+      expect(requestedUrl).toContain('volume_min=10000');
+      expect(requestedUrl).toContain('&order=volume24hr');
+    });
   });
 
   it('creates API keys against the canonical CLOB host', async () => {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -241,9 +241,10 @@ describe('polymarket utils', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://gamma-api.polymarket.com/events/pagination?limit=10&offset=0&active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr',
+        'https://gamma-api.polymarket.com/events/pagination?limit=10&offset=0&active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
       );
       const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).toContain('ascending=false');
       expect(requestedUrl).not.toContain('liquidity_min');
       expect(requestedUrl).not.toContain('volume_min');
     });

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1234,7 +1234,7 @@ export const fetchEventsFromPolymarketApi = async (
   if (isExactQueryTabWithCustomQuery) {
     queryParamsEvents = `${limitParam}&${offsetParam}&${customQueryParams}`;
   } else if (category === 'world-cup') {
-    queryParamsEvents = `${limitParam}&${offsetParam}&active=true&archived=false&closed=false&tag_slug=${PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG}&order=volume24hr`;
+    queryParamsEvents = `${limitParam}&${offsetParam}&active=true&archived=false&closed=false&tag_slug=${PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG}&order=volume24hr&ascending=false`;
   } else {
     const active = `active=true`;
     const archived = `archived=false`;

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -75,6 +75,7 @@ import {
   OrderBook,
 } from './types';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../../constants/errors';
+import { PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG } from '../../constants/flags';
 import { PredictFeeCollection } from '../../types/flags';
 import { roundToFiveDecimals } from '../../utils/orders';
 import { getMinAmountReceivedWithSlippage } from './protocol/slippage';
@@ -1194,6 +1195,11 @@ export interface FetchEventsResult {
   isSearch: boolean;
 }
 
+const EXACT_QUERY_PARAM_CATEGORIES: readonly PredictCategory[] = [
+  'hot',
+  'world-cup',
+];
+
 export const fetchEventsFromPolymarketApi = async (
   params?: GetParsedMarketsOptions,
 ): Promise<FetchEventsResult> => {
@@ -1222,10 +1228,13 @@ export const fetchEventsFromPolymarketApi = async (
 
   let queryParamsEvents: string;
 
-  const isHotTabWithCustomQuery = category === 'hot' && customQueryParams;
+  const isExactQueryTabWithCustomQuery =
+    EXACT_QUERY_PARAM_CATEGORIES.includes(category) && customQueryParams;
 
-  if (isHotTabWithCustomQuery) {
+  if (isExactQueryTabWithCustomQuery) {
     queryParamsEvents = `${limitParam}&${offsetParam}&${customQueryParams}`;
+  } else if (category === 'world-cup') {
+    queryParamsEvents = `${limitParam}&${offsetParam}&active=true&archived=false&closed=false&tag_slug=${PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG}&order=volume24hr`;
   } else {
     const active = `active=true`;
     const archived = `archived=false`;
@@ -1235,7 +1244,10 @@ export const fetchEventsFromPolymarketApi = async (
     const volume = `volume_min=${10000.0}`;
     const liquidity = `liquidity_min=${10000.0}`;
 
-    const categoryTagMap: Record<PredictCategory, string> = {
+    const categoryTagMap: Record<
+      Exclude<PredictCategory, 'world-cup'>,
+      string
+    > = {
       trending: '&order=volume24hr',
       'ending-soon': '&order=endDate',
       new: '&order=startDate&exclude_tag_id=102169',

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -140,7 +140,8 @@ export type PredictCategory =
   | 'sports'
   | 'crypto'
   | 'politics'
-  | 'hot';
+  | 'hot'
+  | 'world-cup';
 
 // Sports league types
 export type PredictSportsLeague =

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -10,6 +10,8 @@ import {
   getPredictFeedSelector,
   getPredictFeedMockSelector,
 } from '../../Predict.testIds';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../../constants/flags';
+import { buildPredictWorldCupAllQuery } from '../../utils/worldCup';
 
 jest.mock('react-native-reanimated', () => {
   const Reanimated = jest.requireActual('react-native-reanimated/mock');
@@ -77,6 +79,14 @@ import { usePredictMarketData } from '../../hooks/usePredictMarketData';
 const mockUsePredictMarketData = usePredictMarketData as jest.Mock;
 
 const mockUseSelector = jest.fn();
+const mockHotTabFlag: { enabled: boolean; queryParams?: string } = {
+  enabled: false,
+  queryParams: undefined,
+};
+let mockIsWorldCupMainFeedTabEnabled = false;
+let mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
+let mockIsFeaturedCarouselEnabled = false;
+let mockIsUpDownEnabled = false;
 
 jest.mock('react-redux', () => {
   const actualReactRedux = jest.requireActual('react-redux');
@@ -87,7 +97,13 @@ jest.mock('react-redux', () => {
 });
 
 jest.mock('../../selectors/featureFlags', () => ({
-  selectPredictHotTabFlag: jest.fn(),
+  selectPredictFeaturedCarouselEnabledFlag:
+    'selectPredictFeaturedCarouselEnabledFlag',
+  selectPredictHotTabFlag: 'selectPredictHotTabFlag',
+  selectPredictUpDownEnabledFlag: 'selectPredictUpDownEnabledFlag',
+  selectPredictWorldCupConfig: 'selectPredictWorldCupConfig',
+  selectPredictWorldCupMainFeedTabEnabledFlag:
+    'selectPredictWorldCupMainFeedTabEnabledFlag',
 }));
 
 jest.mock('../../../../hooks/useDebouncedValue', () => ({
@@ -275,9 +291,27 @@ describe('PredictFeed', () => {
     });
     mockUseFocusEffect.mockImplementation(() => undefined);
     mockGetInstance.mockReturnValue(mockSessionManager);
-    mockUseSelector.mockReturnValue({
-      enabled: false,
-      queryParams: undefined,
+    mockHotTabFlag.enabled = false;
+    mockHotTabFlag.queryParams = undefined;
+    mockIsWorldCupMainFeedTabEnabled = false;
+    mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
+    mockIsFeaturedCarouselEnabled = false;
+    mockIsUpDownEnabled = false;
+    mockUseSelector.mockImplementation((selector: string) => {
+      switch (selector) {
+        case 'selectPredictFeaturedCarouselEnabledFlag':
+          return mockIsFeaturedCarouselEnabled;
+        case 'selectPredictHotTabFlag':
+          return mockHotTabFlag;
+        case 'selectPredictUpDownEnabledFlag':
+          return mockIsUpDownEnabled;
+        case 'selectPredictWorldCupConfig':
+          return mockWorldCupConfig;
+        case 'selectPredictWorldCupMainFeedTabEnabledFlag':
+          return mockIsWorldCupMainFeedTabEnabled;
+        default:
+          return undefined;
+      }
     });
     mockUseFeedScrollManager.mockReturnValue({
       headerTranslateY: { value: 0 },
@@ -815,10 +849,8 @@ describe('PredictFeed', () => {
 
   describe('hot tab feature flag', () => {
     it('renders Hot tab first when flag is enabled', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149&order=volume24hr',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149&order=volume24hr';
 
       const { getByTestId } = render(<PredictFeed />);
 
@@ -831,10 +863,8 @@ describe('PredictFeed', () => {
     });
 
     it('passes Hot tab custom query params to market data fetching', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149&order=volume24hr',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149&order=volume24hr';
 
       render(<PredictFeed />);
 
@@ -851,10 +881,8 @@ describe('PredictFeed', () => {
     });
 
     it('does not render Hot tab when flag is disabled', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: false,
-        queryParams: undefined,
-      });
+      mockHotTabFlag.enabled = false;
+      mockHotTabFlag.queryParams = undefined;
 
       const { queryByTestId, getByTestId } = render(<PredictFeed />);
 
@@ -867,10 +895,8 @@ describe('PredictFeed', () => {
     });
 
     it('renders seven category tabs when hot tab is enabled', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149';
 
       const { getByTestId } = render(<PredictFeed />);
 
@@ -898,10 +924,8 @@ describe('PredictFeed', () => {
     });
 
     it('renders seven pager pages when hot tab is enabled', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149&tag_id=100995&order=volume24hr',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149&tag_id=100995&order=volume24hr';
 
       const { getByTestId } = render(<PredictFeed />);
 
@@ -929,10 +953,8 @@ describe('PredictFeed', () => {
     });
 
     it('tracks tab change for hot tab when swiped to', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149';
 
       const mockOnTabSwitch = jest.fn();
       mockUseFeedScrollManager.mockReturnValue({
@@ -957,10 +979,8 @@ describe('PredictFeed', () => {
     });
 
     it('starts session with hot as initial tab when requested via deeplink', () => {
-      mockUseSelector.mockReturnValue({
-        enabled: true,
-        queryParams: 'tag_id=149',
-      });
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149';
       mockUseRoute.mockReturnValue({
         params: {
           entryPoint: 'homepage_new_prediction',
@@ -973,6 +993,101 @@ describe('PredictFeed', () => {
       expect(mockSessionManager.startSession).toHaveBeenCalledWith(
         'homepage_new_prediction',
         'hot',
+      );
+    });
+  });
+
+  describe('World Cup tab feature flag', () => {
+    it('does not render World Cup tab when flag is disabled', () => {
+      const { queryByTestId } = render(<PredictFeed />);
+
+      expect(
+        queryByTestId(getPredictFeedMockSelector.tabKey('world-cup')),
+      ).toBeNull();
+    });
+
+    it('renders World Cup tab and page first when flag is enabled', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+      mockWorldCupConfig = {
+        ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        enabled: true,
+        showMainFeedTab: true,
+      };
+
+      const { getByTestId } = render(<PredictFeed />);
+
+      expect(
+        getByTestId(getPredictFeedMockSelector.tabKey('world-cup')),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(getPredictFeedMockSelector.pagerPage(0)),
+      ).toBeOnTheScreen();
+      expect(mockSessionManager.startSession).toHaveBeenCalledWith(
+        'homepage_new_prediction',
+        'world-cup',
+      );
+    });
+
+    it('places World Cup before Hot when both flags are enabled', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+      mockWorldCupConfig = {
+        ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        enabled: true,
+        showMainFeedTab: true,
+      };
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149';
+
+      const mockOnTabSwitch = jest.fn();
+      mockUseFeedScrollManager.mockReturnValue({
+        headerTranslateY: { value: 0 },
+        headerHidden: false,
+        headerHeight: 100,
+        tabBarHeight: 48,
+        layoutReady: true,
+        onTabSwitch: mockOnTabSwitch,
+        scrollHandler: jest.fn(),
+        onHeaderLayout: jest.fn(),
+        onTabBarLayout: jest.fn(),
+      });
+
+      const { getByTestId } = render(<PredictFeed />);
+
+      fireEvent(
+        getByTestId(getPredictFeedMockSelector.pagerPage(0)),
+        'onTouchEnd',
+      );
+      fireEvent(
+        getByTestId(getPredictFeedMockSelector.pagerPage(1)),
+        'onTouchEnd',
+      );
+
+      expect(mockSessionManager.trackTabChange).toHaveBeenCalledWith(
+        'world-cup',
+      );
+      expect(mockSessionManager.trackTabChange).toHaveBeenCalledWith('hot');
+    });
+
+    it('passes World Cup custom query params to market data fetching', () => {
+      mockIsWorldCupMainFeedTabEnabled = true;
+      mockWorldCupConfig = {
+        ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        enabled: true,
+        showMainFeedTab: true,
+        tagSlug: 'custom-world-cup',
+      };
+
+      render(<PredictFeed />);
+
+      const worldCupTabCall = mockUsePredictMarketData.mock.calls.find(
+        (call: [{ category?: string }]) => call[0].category === 'world-cup',
+      );
+
+      expect(worldCupTabCall?.[0]).toEqual(
+        expect.objectContaining({
+          category: 'world-cup',
+          customQueryParams: buildPredictWorldCupAllQuery(mockWorldCupConfig),
+        }),
       );
     });
   });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -830,6 +830,26 @@ describe('PredictFeed', () => {
       ).toBeOnTheScreen();
     });
 
+    it('passes Hot tab custom query params to market data fetching', () => {
+      mockUseSelector.mockReturnValue({
+        enabled: true,
+        queryParams: 'tag_id=149&order=volume24hr',
+      });
+
+      render(<PredictFeed />);
+
+      const hotTabCall = mockUsePredictMarketData.mock.calls.find(
+        (call: [{ category?: string }]) => call[0].category === 'hot',
+      );
+
+      expect(hotTabCall?.[0]).toEqual(
+        expect.objectContaining({
+          category: 'hot',
+          customQueryParams: 'tag_id=149&order=volume24hr',
+        }),
+      );
+    });
+
     it('does not render Hot tab when flag is disabled', () => {
       mockUseSelector.mockReturnValue({
         enabled: false,

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -438,7 +438,6 @@ interface PredictFeedTabsProps {
   headerHeight: number;
   tabBarHeight: number;
   headerHidden: boolean;
-  hotTabQueryParams?: string;
   initialPage: number;
 }
 
@@ -450,7 +449,6 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
   headerHeight,
   tabBarHeight,
   headerHidden,
-  hotTabQueryParams,
   initialPage,
 }) => {
   const tw = useTailwind();
@@ -489,9 +487,7 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
             headerHeight={headerHeight}
             tabBarHeight={tabBarHeight}
             headerHidden={headerHidden}
-            customQueryParams={
-              tab.key === 'hot' ? hotTabQueryParams : undefined
-            }
+            customQueryParams={tab.customQueryParams}
           />
         </View>
       ))}
@@ -632,13 +628,7 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
   walletHeaderTranslateY,
   walletHeaderHeight,
 }) => {
-  const {
-    tabs,
-    activeIndex,
-    setActiveIndex,
-    initialTabKey,
-    hotTabQueryParams,
-  } = usePredictTabs();
+  const { tabs, activeIndex, setActiveIndex, initialTabKey } = usePredictTabs();
 
   const tw = useTailwind();
   const { colors } = useTheme();
@@ -794,7 +784,6 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
               headerHeight={headerHeight}
               tabBarHeight={tabBarHeight + 6}
               headerHidden={headerHidden}
-              hotTabQueryParams={hotTabQueryParams}
               initialPage={activeIndex}
             />
           )}


### PR DESCRIPTION
## **Description**

This PR adds the World Cup tab to the main Predict feed behind the existing `predictWorldCup.enabled && showMainFeedTab` configuration.

It does this by:

- adding `world-cup` as a Predict tab/category key and rendering it before Hot and Trending when enabled
- moving tab-specific query params onto each `FeedTab`, so Hot and World Cup can coexist without special casing Hot in `PredictFeed`
- using `buildPredictWorldCupAllQuery` for the main feed World Cup tab so it mirrors the dedicated World Cup screen All tab market universe
- extending Polymarket event query handling so exact custom params are respected for Hot and World Cup categories
- preserving existing tab behavior by falling back to the first visible tab when a requested tab is hidden

Automated coverage was added or updated for tab injection/order, disabled behavior, custom query params, and World Cup event query generation.

Verified with:

- `yarn jest app/components/UI/Predict/hooks/usePredictTabs.test.ts`
- `yarn jest app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx`
- `yarn jest app/components/UI/Predict/providers/polymarket/utils.test.ts`

## **Changelog**

CHANGELOG entry: Added a World Cup tab to the Predict feed when enabled.

## **Related issues**

Fixes: [PRED-874](https://consensyssoftware.atlassian.net/browse/PRED-874)

## **Manual testing steps**

```gherkin
Feature: Predict World Cup main feed tab

  Scenario: World Cup tab appears first when enabled
    Given Predict is available
    And the predictWorldCup flag is enabled with showMainFeedTab true
    When user opens the main Predict feed
    Then the World Cup tab appears before Trending
    And World Cup markets load from the World Cup All tab query

  Scenario: World Cup and Hot tabs coexist when both flags are enabled
    Given predictWorldCup is enabled with showMainFeedTab true
    And predictHotTab is enabled
    When user opens the main Predict feed
    Then World Cup appears first
    And Hot appears after World Cup
    And selecting Hot loads Hot tab markets

  Scenario: World Cup tab remains hidden when disabled
    Given predictWorldCup is disabled or showMainFeedTab is false
    When user opens the main Predict feed
    Then the World Cup tab is not shown
    And Trending is the first standard tab

  Scenario: World Cup tab can be opened from the main feed tab deeplink
    Given predictWorldCup is enabled with showMainFeedTab true
    When user opens https://link.metamask.io/predict?tab=world-cup
    Then the main Predict feed opens with the World Cup tab selected
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/f499a887-a570-40c0-b7e8-f434f878beac

### **Before**

N/A

### **After**

To be added after manual testing.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-874]: https://consensyssoftware.atlassian.net/browse/PRED-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab composition and Polymarket event query generation for new `world-cup` category, which can affect which markets are fetched and shown when feature flags/deeplinks are used.
> 
> **Overview**
> Adds a new `world-cup` category/tab to the main Predict feed (gated by `selectPredictWorldCupMainFeedTabEnabledFlag`), rendered ahead of Hot/Trending and selectable via deeplink when available.
> 
> Refactors tab handling so each `FeedTab` carries optional `customQueryParams`, letting Hot and World Cup supply their own Polymarket query strings without `PredictFeed` special-casing.
> 
> Updates `fetchEventsFromPolymarketApi` to treat Hot and World Cup as *exact-query* categories (skip default liquidity/volume filters when `customQueryParams` are provided) and adds a World Cup default query fallback using `PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG`. Tests are expanded across `usePredictTabs`, `PredictFeed`, and Polymarket utils to cover ordering, deeplink fallback when tabs are hidden, and query param behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94108b76a902e3f34f3140c3940db7c581442db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->