### PR TITLE
fix(card): missing tokens when revoking using external tools

### DIFF
--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -378,4 +378,190 @@ describe('BaanxProvider', () => {
       expect(message).not.toContain('Expiration Time');
     });
   });
+
+  describe('buildSupportedTokens', () => {
+    const LINEA_CHAIN_ID = 'eip155:59144';
+    const USDC_LINEA_ADDRESS = '0x176211869cA2b568f2A7D4EE941E073a821EE1ff';
+    const WETH_LINEA_ADDRESS = '0xweth';
+    const DELEGATION_CONTRACT = '0xdelegation';
+
+    const delegationSettings = {
+      networks: [
+        {
+          network: 'linea',
+          chainId: '0xe708',
+          environment: 'production',
+          delegationContract: DELEGATION_CONTRACT,
+          tokens: {
+            usdc: {
+              symbol: 'USDC',
+              address: USDC_LINEA_ADDRESS,
+              decimals: 6,
+            },
+          },
+        },
+      ],
+    };
+
+    const buildSupportedTokens = (
+      provider: BaanxProvider,
+      fundingAssets: CardFundingAsset[],
+      settings: typeof delegationSettings | null,
+      walletAddress = '',
+    ) =>
+      (
+        provider as unknown as {
+          buildSupportedTokens: (
+            assets: CardFundingAsset[],
+            settings: typeof delegationSettings | null,
+            walletAddress: string,
+          ) => CardFundingAsset[];
+        }
+      ).buildSupportedTokens(fundingAssets, settings, walletAddress);
+
+    it('adds Inactive placeholder from delegationSettings when fundingAssets is empty', () => {
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const result = buildSupportedTokens(
+        provider,
+        [],
+        delegationSettings,
+        '0xwalletA',
+      );
+
+      const usdc = result.find(
+        (a) =>
+          a.address?.toLowerCase() === USDC_LINEA_ADDRESS.toLowerCase() &&
+          a.chainId === LINEA_CHAIN_ID,
+      );
+      expect(usdc).toBeDefined();
+      expect(usdc?.status).toBe(FundingAssetStatus.Inactive);
+      expect(usdc?.walletAddress).toBe('0xwalletA');
+      expect(usdc?.delegationContract).toBe(DELEGATION_CONTRACT);
+    });
+
+    it('preserves Active status and does not add a duplicate for the same wallet', () => {
+      const activeAsset: CardFundingAsset = {
+        symbol: 'USDC',
+        name: 'USD Coin',
+        address: USDC_LINEA_ADDRESS,
+        walletAddress: '0xwalletA',
+        decimals: 6,
+        chainId: LINEA_CHAIN_ID,
+        spendableBalance: '100',
+        spendingCap: '1000',
+        priority: 1,
+        status: FundingAssetStatus.Active,
+      };
+
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const result = buildSupportedTokens(
+        provider,
+        [activeAsset],
+        delegationSettings,
+        '0xwalletA',
+      );
+
+      const usdcEntries = result.filter(
+        (a) =>
+          a.address?.toLowerCase() === USDC_LINEA_ADDRESS.toLowerCase() &&
+          a.chainId === LINEA_CHAIN_ID,
+      );
+      expect(usdcEntries).toHaveLength(1);
+      expect(usdcEntries[0].status).toBe(FundingAssetStatus.Active);
+    });
+
+    it('adds an Inactive placeholder for walletA even when walletB already has an Active entry', () => {
+      const walletBActive: CardFundingAsset = {
+        symbol: 'USDC',
+        name: 'USD Coin',
+        address: USDC_LINEA_ADDRESS,
+        walletAddress: '0xwalletB',
+        decimals: 6,
+        chainId: LINEA_CHAIN_ID,
+        spendableBalance: '100',
+        spendingCap: '1000',
+        priority: 1,
+        status: FundingAssetStatus.Active,
+      };
+
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const result = buildSupportedTokens(
+        provider,
+        [walletBActive],
+        delegationSettings,
+        '0xwalletA',
+      );
+
+      const walletAEntry = result.find(
+        (a) =>
+          a.address?.toLowerCase() === USDC_LINEA_ADDRESS.toLowerCase() &&
+          a.chainId === LINEA_CHAIN_ID &&
+          a.walletAddress === '0xwalletA',
+      );
+      expect(walletAEntry).toBeDefined();
+      expect(walletAEntry?.status).toBe(FundingAssetStatus.Inactive);
+
+      // walletB Active entry must still be present
+      const walletBEntry = result.find((a) => a.walletAddress === '0xwalletB');
+      expect(walletBEntry?.status).toBe(FundingAssetStatus.Active);
+    });
+
+    it('returns fundingAssets unchanged when delegationSettings is null', () => {
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const asset: CardFundingAsset = {
+        symbol: 'WETH',
+        name: 'Wrapped Ether',
+        address: WETH_LINEA_ADDRESS,
+        walletAddress: '0xwalletA',
+        decimals: 18,
+        chainId: LINEA_CHAIN_ID,
+        spendableBalance: '1',
+        spendingCap: '10',
+        priority: 1,
+        status: FundingAssetStatus.Active,
+      };
+
+      const result = buildSupportedTokens(provider, [asset], null, '0xwalletA');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toStrictEqual(asset);
+    });
+
+    it('returns fundingAssets unchanged when delegationSettings has no networks', () => {
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const result = buildSupportedTokens(
+        provider,
+        [],
+        { networks: [] },
+        '0xwalletA',
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('enriches existing assets with delegationContract from matching network', () => {
+      const assetWithoutContract: CardFundingAsset = {
+        symbol: 'USDC',
+        name: 'USD Coin',
+        address: USDC_LINEA_ADDRESS,
+        walletAddress: '0xwalletA',
+        decimals: 6,
+        chainId: LINEA_CHAIN_ID,
+        spendableBalance: '100',
+        spendingCap: '1000',
+        priority: 1,
+        status: FundingAssetStatus.Active,
+      };
+
+      const provider = new BaanxProvider({ service: {} as BaanxService });
+      const result = buildSupportedTokens(
+        provider,
+        [assetWithoutContract],
+        delegationSettings,
+        '0xwalletA',
+      );
+
+      const usdc = result.find((a) => a.walletAddress === '0xwalletA');
+      expect(usdc?.delegationContract).toBe(DELEGATION_CONTRACT);
+    });
+  });
 });

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -368,7 +368,7 @@ export class BaanxProvider implements ICardProvider {
   // -- Card Home Data --
 
   async getCardHomeData(
-    _address: string,
+    address: string,
     tokens: CardAuthTokens,
   ): Promise<CardHomeData> {
     try {
@@ -456,6 +456,7 @@ export class BaanxProvider implements ICardProvider {
       const availableFundingAssets = this.buildSupportedTokens(
         fundingAssets,
         delegationSettings,
+        address,
       );
 
       return {
@@ -1532,16 +1533,36 @@ export class BaanxProvider implements ICardProvider {
 
   /**
    * Merges user's delegated assets with all tokens from delegation settings.
-   * Tokens already in `assets` (matched by token contract address + chainId) are kept.
-   * Additional tokens from settings are added as inactive with zero balance.
+   * Tokens already in `assets` (matched by token contract address + chainId + wallet) are kept.
+   * Additional tokens from settings are added as inactive with zero balance, stamped with
+   * `currentWalletAddress` so each linked wallet gets its own placeholder entry.
    */
   private buildSupportedTokens(
     fundingAssets: CardFundingAsset[],
     delegationSettings: DelegationSettingsResponse | null,
+    currentWalletAddress: string = '',
   ): CardFundingAsset[] {
     const result = [...fundingAssets];
 
     if (!delegationSettings?.networks) return result;
+
+    const currentAddressLower = currentWalletAddress.toLowerCase();
+    // Returns true when a placeholder already exists for the current wallet (or
+    // generically). Entries owned by other wallets do NOT count — this account
+    // can still enable the token independently.
+    // When no current address is known, any existing entry counts (legacy fallback).
+    const hasPlaceholderForCurrentWallet = (
+      tokenAddress: string,
+      chainId: string,
+    ) =>
+      result.some(
+        (a) =>
+          a.address?.toLowerCase() === tokenAddress.toLowerCase() &&
+          a.chainId === chainId &&
+          (!currentAddressLower ||
+            a.walletAddress?.toLowerCase() === currentAddressLower ||
+            !a.walletAddress),
+      );
 
     for (const network of delegationSettings.networks) {
       const networkName = network.network?.toLowerCase() as string;
@@ -1567,12 +1588,9 @@ export class BaanxProvider implements ICardProvider {
       for (const tokenConfig of Object.values(network.tokens ?? {})) {
         if (!tokenConfig.address) continue;
 
-        const alreadyExists = result.some(
-          (a) =>
-            a.address?.toLowerCase() === tokenConfig.address.toLowerCase() &&
-            a.chainId === chainId,
-        );
-        if (alreadyExists) continue;
+        if (hasPlaceholderForCurrentWallet(tokenConfig.address, chainId)) {
+          continue;
+        }
 
         const chainTokens =
           this.cardFeatureFlag?.chains?.[chainId]?.tokens ?? [];
@@ -1587,7 +1605,7 @@ export class BaanxProvider implements ICardProvider {
             isNonProduction && sdkToken?.address
               ? sdkToken.address
               : tokenConfig.address,
-          walletAddress: '',
+          walletAddress: currentWalletAddress,
           decimals: tokenConfig.decimals,
           chainId,
           spendableBalance: '0',

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -393,6 +393,41 @@ describe('selectCardPrimaryToken', () => {
 });
 
 describe('selectCardAvailableTokens', () => {
+  const WALLET_A = '0xwalletA000000000000000000000000000000001';
+  const WALLET_B = '0xwalletB000000000000000000000000000000002';
+
+  const makeAsset = (
+    overrides: Partial<(typeof mockCardHomeData.availableFundingAssets)[0]>,
+  ) => ({ ...mockPrimaryAsset, ...overrides });
+
+  const stateWithAssets = (
+    assets: typeof mockCardHomeData.availableFundingAssets,
+    currentWallet?: string,
+  ) => {
+    if (currentWallet) {
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        jest.fn().mockReturnValue({ address: currentWallet }),
+      );
+    } else {
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        jest.fn().mockReturnValue(undefined),
+      );
+    }
+    return createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        availableFundingAssets: assets,
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+  };
+
+  beforeEach(() => {
+    // Default: no selected account — filter is a no-op.
+    mockSelectSelectedInternalAccountByScope.mockReturnValue(
+      jest.fn().mockReturnValue(undefined),
+    );
+  });
+
   it('returns empty array when cardHomeData is null', () => {
     const state = createMockRootState({ cardHomeData: null });
     expect(selectCardAvailableTokens(state)).toStrictEqual([]);
@@ -411,6 +446,68 @@ describe('selectCardAvailableTokens', () => {
         fundingStatus: FundingStatus.Limited,
       }),
     );
+  });
+
+  it('shows all assets when no account is selected', () => {
+    const assets = [
+      makeAsset({ walletAddress: WALLET_A, status: FundingAssetStatus.Active }),
+      makeAsset({
+        walletAddress: WALLET_B,
+        status: FundingAssetStatus.Inactive,
+      }),
+    ];
+    const state = stateWithAssets(assets);
+    expect(selectCardAvailableTokens(state)).toHaveLength(2);
+  });
+
+  it('always shows Active and Limited tokens regardless of wallet', () => {
+    const assets = [
+      makeAsset({ walletAddress: WALLET_B, status: FundingAssetStatus.Active }),
+      makeAsset({
+        walletAddress: WALLET_B,
+        status: FundingAssetStatus.Limited,
+      }),
+    ];
+    const state = stateWithAssets(assets, WALLET_A);
+    expect(selectCardAvailableTokens(state)).toHaveLength(2);
+  });
+
+  it('shows Inactive token only for the current wallet', () => {
+    const assets = [
+      makeAsset({
+        walletAddress: WALLET_A,
+        status: FundingAssetStatus.Inactive,
+      }),
+      makeAsset({
+        walletAddress: WALLET_B,
+        status: FundingAssetStatus.Inactive,
+      }),
+    ];
+    const state = stateWithAssets(assets, WALLET_A);
+    const tokens = selectCardAvailableTokens(state);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].walletAddress).toBe(WALLET_A);
+  });
+
+  it('shows Inactive token with empty walletAddress for any current wallet', () => {
+    const assets = [
+      makeAsset({ walletAddress: '', status: FundingAssetStatus.Inactive }),
+    ];
+    const state = stateWithAssets(assets, WALLET_A);
+    expect(selectCardAvailableTokens(state)).toHaveLength(1);
+  });
+
+  it('shows Active from walletB and Inactive placeholder for walletA simultaneously', () => {
+    const assets = [
+      makeAsset({ walletAddress: WALLET_B, status: FundingAssetStatus.Active }),
+      makeAsset({
+        walletAddress: WALLET_A,
+        status: FundingAssetStatus.Inactive,
+      }),
+    ];
+    const state = stateWithAssets(assets, WALLET_A);
+    const tokens = selectCardAvailableTokens(state);
+    expect(tokens).toHaveLength(2);
   });
 });
 

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -107,8 +107,25 @@ export const selectCardPrimaryToken = createSelector(
 
 export const selectCardAvailableTokens = createSelector(
   selectCardHomeData,
-  (data): CardFundingToken[] =>
-    (data?.availableFundingAssets ?? []).map(toCardFundingToken),
+  selectSelectedEvmAccount,
+  (data, selectedAccount): CardFundingToken[] => {
+    const currentAddress = selectedAccount?.address?.toLowerCase();
+    return (data?.availableFundingAssets ?? [])
+      .filter((asset) => {
+        if (!currentAddress) return true;
+        // Active/Limited: always show — the user can fund from any linked account.
+        if (
+          asset.status === FundingAssetStatus.Active ||
+          asset.status === FundingAssetStatus.Limited
+        ) {
+          return true;
+        }
+        // Inactive: only show for the current account to avoid duplicate "not enabled" rows.
+        const assetWallet = asset.walletAddress?.toLowerCase();
+        return !assetWallet || assetWallet === currentAddress;
+      })
+      .map(toCardFundingToken);
+  },
 );
 
 export const selectCardFundingTokens = createSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This branch fixes MetaMask Card **available funding assets** so that after a user revokes a token allowance (e.g. via revoke.cash) or when another linked wallet still holds an active delegation, the **currently selected wallet** still gets a correct **Inactive / not enabled** row for supported tokens from Baanx delegation settings—instead of the token disappearing or being incorrectly deduplicated across wallets.

**What changed (high level):**

1. **`BaanxProvider.buildSupportedTokens`** — Replaces wallet-blind deduplication (`address` + `chainId` only) with **`hasPlaceholderForCurrentWallet`**: an existing row only blocks adding an Inactive placeholder for the **same** wallet (or legacy empty `walletAddress`). Another wallet’s Active/Limited row no longer suppresses the current wallet’s placeholder. New Inactive placeholders are stamped with **`walletAddress: currentWalletAddress`** (passed from `getCardHomeData`).
2. **`selectCardAvailableTokens`** — **Active** and **Limited** assets from any linked wallet stay visible; **Inactive** rows are shown only when they belong to the **selected EVM account** (or have no `walletAddress`), avoiding duplicate “not enabled” noise for other accounts.
3. **Tests** — `BaanxProvider.test.ts` covers `buildSupportedTokens` (empty funding list, same-wallet dedup, multi-wallet core case, null / empty `delegationSettings`, contract enrichment). `cardController.test.ts` covers the selector filtering behaviour with mocked selected account.

**Intentionally not included:** A feature-flag fallback that synthesizes tokens without `delegationSettings` (would lack jurisdiction-correct `delegationContract`). When `delegationSettings` is missing or has no `networks`, behaviour stays **return `fundingAssets` as-is** (no synthetic list).

### Why

- **`/v1/wallet/external`** can be empty after revocation while **`/v1/delegation/chain/config`** still lists supported networks/tokens. Placeholders must be built from delegation settings **per selected wallet**, not deduplicated globally across wallets.
- **UI** reads **`availableFundingAssets`** via **`selectCardAvailableTokens`**; filtering Inactive by account keeps the asset list accurate for account switching and multi-wallet Baanx linkage.

### What changed (scoped paths)

| Area | Files / behaviour |
| ---- | ----------------- |
| **Baanx provider** | [`BaanxProvider.ts`](app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts): `getCardHomeData(address, …)` passes `address` into `buildSupportedTokens`; wallet-aware placeholder dedup; Inactive `walletAddress` set to current address. |
| **Selectors** | [`cardController.ts`](app/selectors/cardController.ts): `selectCardAvailableTokens` uses `selectSelectedEvmAccount` and filters Inactive by current address. |
| **Tests** | [`BaanxProvider.test.ts`](app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts), [`cardController.test.ts`](app/selectors/cardController.test.ts). |

### Out of scope (intentional)

- Feature-flag–only token list without `delegationSettings` / `delegationContract`.
- Changes to unauthenticated `getOnChainAssets` (still bypasses `buildSupportedTokens`).

## **Changelog**

CHANGELOG entry: Fixed Card available asset list so supported tokens show per-wallet “not enabled” state after revocation or when another linked wallet still has an active delegation; inactive rows are scoped to the selected account in the token picker.

## **Related issues**

Fixes:

<!-- Add ticket ID(s), e.g. Fixes: MUSD-xxx or #12345 -->

## **Manual testing steps**

```gherkin
Feature: Card available tokens after revocation / multi-wallet

  Background:
    Given I am authenticated with the MetaMask Card (Baanx) backend
    And delegation chain config returns supported networks (e.g. Linea USDC)
    And I may have more than one EVM wallet linked to the same card account

  Scenario: revoke on external tool then open Card
    Given I had delegated USDC on Linea from wallet A
    When I revoke the allowance (e.g. revoke.cash) so wallet external API returns no rows for that delegation
    And I select wallet A in MetaMask
    When I open Card home / spending limit asset list
    Then USDC on Linea still appears as not enabled (Inactive) for wallet A when delegation settings still list the token
    And I can re-enable delegation from that row (contract comes from delegation settings)

  Scenario: another wallet still delegated
    Given wallet B still has an active USDC Linea delegation in Baanx wallet external data
    When I select wallet A (revoked or never delegated)
    Then I still see a not-enabled / Inactive row for USDC Linea for wallet A
    And I still see wallet B’s Active (or Limited) row for awareness

  Scenario: account switch
    Given both wallets have their own Inactive placeholders for the same token
    When I switch the selected EVM account in the app
    Then the available token list shows Inactive rows only for the selected account (plus all Active/Limited from any wallet)
```

## **Screenshots/Recordings**

### **Before**

<!-- Token missing from Card asset list after revoke, or wrong wallet’s row only. -->

### **After**

<!-- Same token visible as not enabled for current wallet; other wallet’s active row still visible if applicable. -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-wallet token placeholder and filtering logic for Card funding assets, which can affect what users see and can re-enable funding; risk is mitigated by added unit coverage but may impact edge cases around wallet selection and legacy empty `walletAddress` rows.
> 
> **Overview**
> Fixes Card `availableFundingAssets` generation and display for multi-wallet scenarios so a supported token can still appear as *Inactive/not enabled* for the **currently selected wallet** even if another linked wallet has an Active/Limited entry or the external-wallet API returns no rows.
> 
> `BaanxProvider.getCardHomeData` now passes the current `address` into `buildSupportedTokens`, which dedupes placeholders by `address + chainId + walletAddress` (with a legacy fallback for empty wallet) and stamps new inactive placeholders with the current wallet’s address while still enriching existing assets with the network `delegationContract`.
> 
> `selectCardAvailableTokens` now filters `Inactive` rows to the selected EVM account (or empty `walletAddress`) while always showing Active/Limited rows from any linked wallet, reducing duplicate “not enabled” entries; new tests cover the wallet-aware placeholder and selector filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730da514d71fe0208f55c6b5e6e734188c4a0ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->