### PR TITLE
fix: Fix version bump verification

### DIFF
--- a/scripts/set-build-version.sh
+++ b/scripts/set-build-version.sh
@@ -78,13 +78,6 @@ perform_updates () {
 CURRENT_ANDROID_VERSION_NUMBER=$(awk '/^[[:space:]]+versionCode /{print $2; exit}' $ANDROID_BUILD_GRADLE_FILE)
 CURRENT_IOS_VERSION_NUMBER=$(awk -F'[[:space:]=;]+' '/CURRENT_PROJECT_VERSION/{print $3; exit}' $IOS_PROJECT_FILE)
 
-if [[ "$CURRENT_ANDROID_VERSION_NUMBER" != "$CURRENT_IOS_VERSION_NUMBER" ]]; then
-  echo "Android versionCode ($CURRENT_ANDROID_VERSION_NUMBER) and iOS CURRENT_PROJECT_VERSION ($CURRENT_IOS_VERSION_NUMBER) are out of sync."
-  log_and_exit "Realign Android and iOS build numbers before proceeding."
-fi
-
-CURRENT_VERSION_NUMBER="$CURRENT_ANDROID_VERSION_NUMBER"
-
 if [[ -z $VERSION_NUMBER ]]; then
   log_and_exit "VERSION_NUMBER not specified, aborting!"
 fi
@@ -95,12 +88,17 @@ if ! [[ $VERSION_NUMBER =~ $NAT ]] || [[ $VERSION_NUMBER =~ $SEMVER_REGEX ]]; th
 fi
 
 echo "VERSION_NUMBER is $VERSION_NUMBER."
-echo "CURRENT_VERSION_NUMBER is $CURRENT_VERSION_NUMBER."
+echo "CURRENT_ANDROID_VERSION_NUMBER is $CURRENT_ANDROID_VERSION_NUMBER."
+echo "CURRENT_IOS_VERSION_NUMBER is $CURRENT_IOS_VERSION_NUMBER."
 
-# ensure VERSION_NUMBER goes up
-if [[ "$VERSION_NUMBER" -le "$CURRENT_VERSION_NUMBER" ]]; then
-  echo "version $VERSION_NUMBER is less than or equal to current: $CURRENT_VERSION_NUMBER"
-  exit 1
+# ensure Android version number goes up
+if [[ "$VERSION_NUMBER" -le "$CURRENT_ANDROID_VERSION_NUMBER" ]]; then
+  log_and_exit "Android version $VERSION_NUMBER is less than or equal to current: $CURRENT_ANDROID_VERSION_NUMBER"
+fi
+
+# ensure iOS version number goes up
+if [[ "$VERSION_NUMBER" -le "$CURRENT_IOS_VERSION_NUMBER" ]]; then
+  log_and_exit "iOS version $VERSION_NUMBER is less than or equal to current: $CURRENT_IOS_VERSION_NUMBER"
 fi
 
 echo "VERSION_NUMBER is valid."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This relaxes the version bump script to verify both iOS and Android bumps upwards

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to build version validation; main impact is potentially blocking releases if either platform’s build number doesn’t strictly increase.
> 
> **Overview**
> Updates `scripts/set-build-version.sh` to **stop requiring Android and iOS build numbers to be in sync**, and instead validates the provided `VERSION_NUMBER` is **greater than each platform’s current value**.
> 
> Improves logging by printing `CURRENT_ANDROID_VERSION_NUMBER` and `CURRENT_IOS_VERSION_NUMBER`, and routes version-regression failures through `log_and_exit` for consistent error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f04caa53475049909ad19415874c2d30fa7f4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->