### PR TITLE
feat(card): handle unauthenticated case on money account linkage

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
@@ -24,6 +24,20 @@ jest.mock('../../../../../core/Engine', () => ({
   },
 }));
 
+const mockNavigationServiceNavigate = jest.fn();
+const mockNavigationServiceGoBack = jest.fn();
+jest.mock('../../../../../core/NavigationService', () => ({
+  __esModule: true,
+  default: {
+    get navigation() {
+      return {
+        navigate: mockNavigationServiceNavigate,
+        goBack: mockNavigationServiceGoBack,
+      };
+    },
+  },
+}));
+
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockReset = jest.fn();
@@ -440,6 +454,35 @@ describe('CardAuthentication Component', () => {
           routes: [{ name: Routes.CARD.HOME }],
         });
       });
+    });
+
+    it('pops Card.ROOT off the root navigator on successful login when postAuthRedirect is set (no inner Card-stack reset, no cross-stack navigate)', async () => {
+      mockRouteParams = {
+        postAuthRedirect: {
+          screen: Routes.MONEY.ROOT,
+          params: { screen: Routes.MONEY.HOME },
+        },
+      };
+      mockSubmitMutateAsync.mockResolvedValue({ done: true });
+      render();
+      const emailInput = screen.getByTestId('email-field');
+      const passwordInput = screen.getByTestId('password-field');
+      const loginButton = screen.getByTestId(
+        CardAuthenticationSelectors.VERIFY_ACCOUNT_BUTTON,
+      );
+
+      fireEvent.changeText(emailInput, 'test@example.com');
+      fireEvent.changeText(passwordInput, 'password123');
+      fireEvent.press(loginButton);
+
+      await waitFor(() => {
+        expect(mockNavigationServiceGoBack).toHaveBeenCalledTimes(1);
+      });
+      // The origin (e.g. the Money tab) lives below Card.ROOT in the outer
+      // navigator — popping reveals it without touching its own state or
+      // doing a cross-stack navigate.
+      expect(mockNavigationServiceNavigate).not.toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalled();
     });
 
     it('does not navigate when login error exists', () => {

--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -30,6 +30,7 @@ import { selectCardUserLocation } from '../../../../../selectors/cardController'
 import { CardMessageBoxType, type CardLocation } from '../../types';
 import { CardActions, CardScreens } from '../../util/metrics';
 import OnboardingStep from '../../components/Onboarding/OnboardingStep';
+import NavigationService from '../../../../../core/NavigationService';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { countryCodeToFlag } from '../../util/countryCodeToFlag';
 
@@ -41,7 +42,12 @@ const autoComplete = Platform.select<TextInputProps['autoComplete']>({
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CardAuthenticationParams = {
-  CardAuthentication: { showAuthPrompt?: boolean } | undefined;
+  CardAuthentication:
+    | {
+        showAuthPrompt?: boolean;
+        postAuthRedirect?: { screen: string; params?: object };
+      }
+    | undefined;
 };
 
 const CardAuthentication = () => {
@@ -51,6 +57,7 @@ const CardAuthentication = () => {
   const route =
     useRoute<RouteProp<CardAuthenticationParams, 'CardAuthentication'>>();
   const showAuthPrompt = route.params?.showAuthPrompt ?? false;
+  const postAuthRedirect = route.params?.postAuthRedirect;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -207,6 +214,11 @@ const CardAuthentication = () => {
           return;
         }
 
+        if (postAuthRedirect) {
+          NavigationService.navigation?.goBack();
+          return;
+        }
+
         // Successful login — navigate to home
         navigation.reset({
           index: 0,
@@ -228,6 +240,7 @@ const CardAuthentication = () => {
       dispatch,
       trackEvent,
       createEventBuilder,
+      postAuthRedirect,
     ],
   );
 

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -7,9 +7,15 @@ import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountCon
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import {
   selectCardDelegationSettings,
+  selectCardHomeDataStatus,
   selectIsCardAuthenticated,
+  selectIsCardholder,
   selectIsMoneyAccountDelegatedForCard,
 } from '../../../../selectors/cardController';
+import {
+  selectPendingMoneyAccountCardLink,
+  setPendingMoneyAccountCardLink,
+} from '../../../../core/redux/slices/card';
 import { selectMoneyEnableMoneyAccountFlag } from '../../Money/selectors/featureFlags';
 import { resolveMoneyAccountCardToken } from '../../../../core/Engine/controllers/card-controller/utils/moneyAccountCardToken';
 import Routes from '../../../../constants/navigation/Routes';
@@ -17,8 +23,10 @@ import { BAANX_MAX_LIMIT } from '../constants';
 import { FundingStatus } from '../types';
 import { useMoneyAccountCardLinkage } from './useMoneyAccountCardLinkage';
 
+const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+  useDispatch: () => mockDispatch,
 }));
 
 const mockNavigate = jest.fn();
@@ -118,22 +126,30 @@ const MOCK_TOKEN = {
   delegationContract: '0xdelegation',
 };
 
+type CardHomeDataStatusMock = 'idle' | 'loading' | 'success' | 'error';
+
 const buildSelectors = (
   overrides: {
     primaryMoneyAccount?: { address: string } | undefined;
     vaultConfig?: unknown;
     isMoneyAccountEnabled?: boolean;
     isCardAuthenticated?: boolean;
+    isCardholder?: boolean;
     delegationSettings?: unknown;
     isAlreadyDelegated?: boolean;
+    pendingMoneyAccountCardLink?: boolean;
+    cardHomeDataStatus?: CardHomeDataStatusMock;
   } = {},
 ) => ({
   primaryMoneyAccount: { address: MONEY_ACCOUNT_ADDRESS },
   vaultConfig: { id: 'vault-1' },
   isMoneyAccountEnabled: true,
   isCardAuthenticated: true,
+  isCardholder: false,
   delegationSettings: { ok: true },
   isAlreadyDelegated: false,
+  pendingMoneyAccountCardLink: false,
+  cardHomeDataStatus: 'success' as CardHomeDataStatusMock,
   ...overrides,
 });
 
@@ -146,10 +162,14 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
       return state.isMoneyAccountEnabled;
     if (selector === selectIsCardAuthenticated)
       return state.isCardAuthenticated;
+    if (selector === selectIsCardholder) return state.isCardholder;
     if (selector === selectCardDelegationSettings)
       return state.delegationSettings;
+    if (selector === selectCardHomeDataStatus) return state.cardHomeDataStatus;
     if (selector === selectIsMoneyAccountDelegatedForCard)
       return state.isAlreadyDelegated;
+    if (selector === selectPendingMoneyAccountCardLink)
+      return state.pendingMoneyAccountCardLink;
     return undefined;
   });
 };
@@ -297,6 +317,319 @@ describe('useMoneyAccountCardLinkage', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockLinkMoneyAccountCard).not.toHaveBeenCalled();
       expect(mockShowToast).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('startLinkFlow (entrypoint branching)', () => {
+    const ORIGIN = {
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
+    } as const;
+
+    it('opens the Link Card sheet when the user is authenticated and can link', () => {
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
+        screen: Routes.MONEY.MODALS.LINK_CARD_SHEET,
+      });
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when the user is authenticated and the Money Account is already delegated', () => {
+      applySelectorMocks(buildSelectors({ isAlreadyDelegated: true }));
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('shows the error toast and does not navigate when Money Account requirements are missing', () => {
+      applySelectorMocks(buildSelectors({ vaultConfig: undefined }));
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the error toast when Monad USDC cannot be resolved AND the user is authenticated', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValueOnce(null);
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a not-authenticated cardholder to CardAuthentication with postAuthRedirect and sets the pending flag', () => {
+      applySelectorMocks(
+        buildSelectors({ isCardAuthenticated: false, isCardholder: true }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(true),
+      );
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+        screen: Routes.CARD.HOME,
+        params: {
+          screen: Routes.CARD.AUTHENTICATION,
+          params: { postAuthRedirect: ORIGIN, showAuthPrompt: true },
+        },
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('routes a not-authenticated non-cardholder to Card Onboarding with moneyAccountLinkIntent and sets the pending flag', () => {
+      applySelectorMocks(
+        buildSelectors({ isCardAuthenticated: false, isCardholder: false }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(true),
+      );
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+        screen: Routes.CARD.HOME,
+        params: {
+          screen: Routes.CARD.ONBOARDING.ROOT,
+          params: { moneyAccountLinkIntent: true },
+        },
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('still routes a not-authenticated cardholder to CardAuthentication when the funding token is null (token resolves after login)', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValueOnce(null);
+      applySelectorMocks(
+        buildSelectors({ isCardAuthenticated: false, isCardholder: true }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(true),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+        screen: Routes.CARD.HOME,
+        params: {
+          screen: Routes.CARD.AUTHENTICATION,
+          params: { postAuthRedirect: ORIGIN, showAuthPrompt: true },
+        },
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('still routes a not-authenticated non-cardholder to onboarding when the funding token is null (token resolves after login)', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValueOnce(null);
+      applySelectorMocks(
+        buildSelectors({ isCardAuthenticated: false, isCardholder: false }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(true),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+        screen: Routes.CARD.HOME,
+        params: {
+          screen: Routes.CARD.ONBOARDING.ROOT,
+          params: { moneyAccountLinkIntent: true },
+        },
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resume effect (pendingMoneyAccountCardLink)', () => {
+    it('opens the Link Card sheet and clears the flag when authenticated and canLink', () => {
+      applySelectorMocks(buildSelectors({ pendingMoneyAccountCardLink: true }));
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
+        screen: Routes.MONEY.MODALS.LINK_CARD_SHEET,
+      });
+    });
+
+    it('clears the flag silently when authenticated but already delegated', () => {
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          isAlreadyDelegated: true,
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('clears the flag silently when authenticated but requirements are missing', () => {
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          vaultConfig: undefined,
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('does nothing while the user is not yet authenticated', () => {
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          isCardAuthenticated: false,
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('keeps the flag set when the funding token is null but card home data is still loading', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'loading',
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('keeps the flag set when the funding token is null and card home data is still idle', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'idle',
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('clears the flag silently once card home data has loaded but the funding token is still unresolved', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'success',
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('clears the flag silently when card home data fetch errors and the funding token cannot be resolved', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'error',
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('opens the sheet on rerender once the funding token resolves after card home data succeeds', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'loading',
+        }),
+      );
+      const { rerender } = renderLinkageHook();
+
+      // First render: data still loading, flag must stay set.
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+
+      mockResolveMoneyAccountCardToken.mockReturnValue(MOCK_TOKEN);
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: true,
+          cardHomeDataStatus: 'success',
+        }),
+      );
+      rerender();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(false),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
+        screen: Routes.MONEY.MODALS.LINK_CARD_SHEET,
+      });
     });
   });
 

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -1,6 +1,12 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
   IconColor as ReactNativeDsIconColor,
@@ -22,9 +28,15 @@ import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountCon
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import {
   selectCardDelegationSettings,
+  selectCardHomeDataStatus,
   selectIsCardAuthenticated,
+  selectIsCardholder,
   selectIsMoneyAccountDelegatedForCard,
 } from '../../../../selectors/cardController';
+import {
+  selectPendingMoneyAccountCardLink,
+  setPendingMoneyAccountCardLink,
+} from '../../../../core/redux/slices/card';
 import { selectMoneyEnableMoneyAccountFlag } from '../../Money/selectors/featureFlags';
 import {
   hasMoneyAccountCardRequirements,
@@ -42,6 +54,11 @@ export type LinkageStatus =
   | 'error'
   | 'cancelled';
 
+export interface LinkFlowOrigin {
+  screen: string;
+  params?: object;
+}
+
 export interface UseMoneyAccountCardLinkageReturn {
   hasMoneyAccountRequirements: boolean;
   isCardAuthenticated: boolean;
@@ -53,6 +70,7 @@ export interface UseMoneyAccountCardLinkageReturn {
   isLinking: boolean;
   error: Error | null;
 
+  startLinkFlow: (origin: LinkFlowOrigin) => void;
   openLinkCardSheet: () => void;
   confirmLinkInBackground: () => Promise<boolean>;
   reset: () => void;
@@ -71,6 +89,7 @@ export const useMoneyAccountCardLinkage =
     const { toastRef } = useContext(ToastContext);
     const theme = useTheme();
     const navigation = useNavigation();
+    const dispatch = useDispatch();
 
     const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
     const vaultConfig = useSelector(selectMoneyAccountVaultConfig);
@@ -78,9 +97,14 @@ export const useMoneyAccountCardLinkage =
       selectMoneyEnableMoneyAccountFlag,
     );
     const isCardAuthenticated = useSelector(selectIsCardAuthenticated);
+    const isCardholder = useSelector(selectIsCardholder);
     const delegationSettings = useSelector(selectCardDelegationSettings);
+    const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
     const isAlreadyDelegated = useSelector(
       selectIsMoneyAccountDelegatedForCard,
+    );
+    const pendingMoneyAccountCardLink = useSelector(
+      selectPendingMoneyAccountCardLink,
     );
 
     const [status, setStatus] = useState<LinkageStatus>('idle');
@@ -174,6 +198,100 @@ export const useMoneyAccountCardLinkage =
       });
     }, [canLink, primaryMoneyAccount?.address, navigation, showErrorToast]);
 
+    const startLinkFlow = useCallback(
+      (origin: LinkFlowOrigin): void => {
+        if (!hasRequirements || !primaryMoneyAccount?.address) {
+          showErrorToast();
+          return;
+        }
+
+        if (isCardAuthenticated) {
+          if (isAlreadyDelegated) {
+            return;
+          }
+
+          if (!moneyAccountCardToken) {
+            showErrorToast();
+            return;
+          }
+
+          openLinkCardSheet();
+          return;
+        }
+
+        dispatch(setPendingMoneyAccountCardLink(true));
+
+        if (isCardholder) {
+          navigation.navigate(Routes.CARD.ROOT, {
+            screen: Routes.CARD.HOME,
+            params: {
+              screen: Routes.CARD.AUTHENTICATION,
+              params: { postAuthRedirect: origin, showAuthPrompt: true },
+            },
+          });
+          return;
+        }
+
+        navigation.navigate(Routes.CARD.ROOT, {
+          screen: Routes.CARD.HOME,
+          params: {
+            screen: Routes.CARD.ONBOARDING.ROOT,
+            params: { moneyAccountLinkIntent: true },
+          },
+        });
+      },
+      [
+        hasRequirements,
+        moneyAccountCardToken,
+        primaryMoneyAccount?.address,
+        isCardAuthenticated,
+        isAlreadyDelegated,
+        isCardholder,
+        openLinkCardSheet,
+        showErrorToast,
+        navigation,
+        dispatch,
+      ],
+    );
+
+    useEffect(() => {
+      if (!pendingMoneyAccountCardLink) return;
+      if (!isCardAuthenticated) return;
+
+      if (!hasRequirements || !primaryMoneyAccount?.address) {
+        dispatch(setPendingMoneyAccountCardLink(false));
+        return;
+      }
+
+      if (isAlreadyDelegated) {
+        dispatch(setPendingMoneyAccountCardLink(false));
+        return;
+      }
+
+      if (!moneyAccountCardToken) {
+        if (
+          cardHomeDataStatus === 'success' ||
+          cardHomeDataStatus === 'error'
+        ) {
+          dispatch(setPendingMoneyAccountCardLink(false));
+        }
+        return;
+      }
+
+      dispatch(setPendingMoneyAccountCardLink(false));
+      openLinkCardSheet();
+    }, [
+      pendingMoneyAccountCardLink,
+      isCardAuthenticated,
+      hasRequirements,
+      moneyAccountCardToken,
+      primaryMoneyAccount?.address,
+      isAlreadyDelegated,
+      cardHomeDataStatus,
+      openLinkCardSheet,
+      dispatch,
+    ]);
+
     const confirmLinkInBackground = useCallback(async (): Promise<boolean> => {
       if (!canLink || !primaryMoneyAccount?.address) {
         showErrorToast();
@@ -241,6 +359,7 @@ export const useMoneyAccountCardLinkage =
       isLinking: status === 'pending',
       error,
 
+      startLinkFlow,
       openLinkCardSheet,
       confirmLinkInBackground,
       reset,

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -114,6 +114,7 @@ const mockSelectIsCardholder = jest.mocked(selectIsCardholder);
 const mockGetDetectedGeolocation = jest.mocked(getDetectedGeolocation);
 const mockUseMoneyAccountCardLinkage = jest.mocked(useMoneyAccountCardLinkage);
 const mockOpenLinkCardSheet = jest.fn();
+const mockStartLinkFlow = jest.fn();
 
 const mockUseMoneyAccountTransactions = jest.mocked(
   useMoneyAccountTransactions,
@@ -185,6 +186,7 @@ describe('MoneyHomeView', () => {
     mockGetDetectedGeolocation.mockReturnValue('US');
 
     mockOpenLinkCardSheet.mockReset();
+    mockStartLinkFlow.mockReset();
     mockUseMoneyAccountCardLinkage.mockReturnValue({
       hasMoneyAccountRequirements: false,
       isCardAuthenticated: false,
@@ -194,6 +196,7 @@ describe('MoneyHomeView', () => {
       status: 'idle',
       isLinking: false,
       error: null,
+      startLinkFlow: mockStartLinkFlow,
       openLinkCardSheet: mockOpenLinkCardSheet,
       reset: jest.fn(),
     } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
@@ -676,23 +679,33 @@ describe('MoneyHomeView', () => {
       expect(getByTestId(MoneyFooterTestIds.CONTAINER)).toBeOnTheScreen();
     });
 
-    it('navigates to Card home when onboarding CTA is tapped by cardholder without Money account readiness', () => {
+    it('delegates to startLinkFlow with the Money home origin when onboarding CTA is tapped', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
       fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+      expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
+      expect(mockStartLinkFlow).toHaveBeenCalledWith({
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
         screen: Routes.CARD.HOME,
       });
       expect(mockOpenLinkCardSheet).not.toHaveBeenCalled();
     });
 
-    it('navigates to Card home when the MetaMaskCard link button is tapped by cardholder without Money account readiness', () => {
+    it('delegates to startLinkFlow with the Money home origin when MetaMaskCard link button is tapped', () => {
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
       fireEvent.press(getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON));
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+      expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
+      expect(mockStartLinkFlow).toHaveBeenCalledWith({
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
         screen: Routes.CARD.HOME,
       });
       expect(mockOpenLinkCardSheet).not.toHaveBeenCalled();
@@ -709,59 +722,46 @@ describe('MoneyHomeView', () => {
           status: 'idle',
           isLinking: false,
           error: null,
+          startLinkFlow: mockStartLinkFlow,
           openLinkCardSheet: mockOpenLinkCardSheet,
           reset: jest.fn(),
         } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
       });
 
-      it('calls openLinkCardSheet and does NOT navigate when onboarding CTA is tapped', async () => {
+      it('still calls startLinkFlow (not openLinkCardSheet directly) when onboarding CTA is tapped', async () => {
         const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
         await act(async () => {
           fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
         });
 
-        expect(mockOpenLinkCardSheet).toHaveBeenCalledTimes(1);
+        expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
+        expect(mockStartLinkFlow).toHaveBeenCalledWith({
+          screen: Routes.MONEY.ROOT,
+          params: { screen: Routes.MONEY.HOME },
+        });
+        expect(mockOpenLinkCardSheet).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
           screen: Routes.CARD.HOME,
         });
       });
 
-      it('calls openLinkCardSheet and does NOT navigate when MetaMaskCard link button is tapped', async () => {
+      it('still calls startLinkFlow (not openLinkCardSheet directly) when MetaMaskCard link button is tapped', async () => {
         const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
         await act(async () => {
           fireEvent.press(getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON));
         });
 
-        expect(mockOpenLinkCardSheet).toHaveBeenCalledTimes(1);
+        expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
+        expect(mockStartLinkFlow).toHaveBeenCalledWith({
+          screen: Routes.MONEY.ROOT,
+          params: { screen: Routes.MONEY.HOME },
+        });
+        expect(mockOpenLinkCardSheet).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
           screen: Routes.CARD.HOME,
         });
-      });
-    });
-
-    it('navigates to Card home (does NOT call openLinkCardSheet) when prerequisites are met but Monad USDC token is missing (canLink=false)', () => {
-      mockUseMoneyAccountCardLinkage.mockReturnValue({
-        hasMoneyAccountRequirements: true,
-        isCardAuthenticated: true,
-        primaryMoneyAccount: { address: '0xabc' },
-        moneyAccountCardToken: null,
-        canLink: false,
-        status: 'idle',
-        isLinking: false,
-        error: null,
-        openLinkCardSheet: mockOpenLinkCardSheet,
-        reset: jest.fn(),
-      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
-
-      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
-
-      fireEvent.press(getByTestId(MoneyOnboardingCardTestIds.CTA_BUTTON));
-
-      expect(mockOpenLinkCardSheet).not.toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
-        screen: Routes.CARD.HOME,
       });
     });
   });

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -71,7 +71,7 @@ const MoneyHomeView = () => {
   const { allTransactions, moneyAddress } = useMoneyAccountTransactions();
 
   const isCardholder = useSelector(selectIsCardholder);
-  const { canLink, openLinkCardSheet } = useMoneyAccountCardLinkage();
+  const { startLinkFlow } = useMoneyAccountCardLinkage();
   const geolocation = useSelector(getDetectedGeolocation);
   const isUS = geolocation?.toUpperCase().split('-')[0] === 'US';
 
@@ -135,14 +135,11 @@ const MoneyHomeView = () => {
   }, [navigation]);
 
   const handleLinkCardPress = useCallback(() => {
-    if (isCardholder && canLink) {
-      openLinkCardSheet();
-      return;
-    }
-    navigation.navigate(Routes.CARD.ROOT, {
-      screen: Routes.CARD.HOME,
+    startLinkFlow({
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
     });
-  }, [isCardholder, canLink, openLinkCardSheet, navigation]);
+  }, [startLinkFlow]);
 
   const handleApyInfoPress = useCallback(() => {
     navigation.navigate(Routes.MONEY.MODALS.ROOT, {

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -12,6 +12,8 @@ import cardReducer, {
   selectOnboardingId,
   selectContactVerificationId,
   selectConsentSetId,
+  setPendingMoneyAccountCardLink,
+  selectPendingMoneyAccountCardLink,
 } from '.';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -23,6 +25,7 @@ const CARD_STATE_MOCK: CardSliceState = {
     contactVerificationId: null,
     consentSetId: null,
   },
+  pendingMoneyAccountCardLink: false,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,6 +37,7 @@ const EMPTY_CARD_STATE_MOCK: CardSliceState = {
     contactVerificationId: null,
     consentSetId: null,
   },
+  pendingMoneyAccountCardLink: false,
 };
 
 describe('Card Selectors', () => {
@@ -50,6 +54,22 @@ describe('Card Selectors', () => {
       };
       const mockRootState = { card: stateWithFlag } as unknown as RootState;
       expect(selectHasViewedCardButton(mockRootState)).toBe(true);
+    });
+  });
+
+  describe('selectPendingMoneyAccountCardLink', () => {
+    it('returns false by default from initial state', () => {
+      const mockRootState = { card: initialState } as unknown as RootState;
+      expect(selectPendingMoneyAccountCardLink(mockRootState)).toBe(false);
+    });
+
+    it('returns true when pendingMoneyAccountCardLink is true', () => {
+      const stateWithFlag: CardSliceState = {
+        ...initialState,
+        pendingMoneyAccountCardLink: true,
+      };
+      const mockRootState = { card: stateWithFlag } as unknown as RootState;
+      expect(selectPendingMoneyAccountCardLink(mockRootState)).toBe(true);
     });
   });
 
@@ -135,11 +155,34 @@ describe('Card Reducer', () => {
           contactVerificationId: null,
           consentSetId: null,
         },
+        pendingMoneyAccountCardLink: true,
       };
 
       const state = cardReducer(currentState, resetCardState());
 
       expect(state).toEqual(initialState);
+    });
+
+    describe('setPendingMoneyAccountCardLink', () => {
+      it('sets pendingMoneyAccountCardLink to true', () => {
+        const state = cardReducer(
+          initialState,
+          setPendingMoneyAccountCardLink(true),
+        );
+        expect(state.pendingMoneyAccountCardLink).toBe(true);
+      });
+
+      it('sets pendingMoneyAccountCardLink back to false', () => {
+        const current: CardSliceState = {
+          ...initialState,
+          pendingMoneyAccountCardLink: true,
+        };
+        const state = cardReducer(
+          current,
+          setPendingMoneyAccountCardLink(false),
+        );
+        expect(state.pendingMoneyAccountCardLink).toBe(false);
+      });
     });
 
     describe('setHasViewedCardButton', () => {

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -12,6 +12,7 @@ export interface CardSliceState {
   hasViewedCardButton: boolean;
   onboarding: OnboardingState;
   isDaimoDemo: boolean;
+  pendingMoneyAccountCardLink: boolean;
 }
 
 export const initialState: CardSliceState = {
@@ -22,6 +23,7 @@ export const initialState: CardSliceState = {
     consentSetId: null,
   },
   isDaimoDemo: false,
+  pendingMoneyAccountCardLink: false,
 };
 
 const name = 'card';
@@ -52,6 +54,9 @@ const slice = createSlice({
         contactVerificationId: null,
         consentSetId: null,
       };
+    },
+    setPendingMoneyAccountCardLink: (state, action: PayloadAction<boolean>) => {
+      state.pendingMoneyAccountCardLink = action.payload;
     },
   },
 });
@@ -88,6 +93,11 @@ export const selectConsentSetId = createSelector(
   (card) => card.onboarding.consentSetId,
 );
 
+export const selectPendingMoneyAccountCardLink = createSelector(
+  selectCardState,
+  (card) => card.pendingMoneyAccountCardLink,
+);
+
 // Actions
 export const {
   resetCardState,
@@ -97,4 +107,5 @@ export const {
   setConsentSetId,
   resetOnboardingState,
   setIsDaimoDemo,
+  setPendingMoneyAccountCardLink,
 } = actions;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This branch improves the **Money Account → Card linkage** entry flow when the user is **not** authenticated with the Card backend.

**Previous behaviour:** Link-card CTAs from Money Account effectively sent unauthenticated users to Card home without completing auth or resuming linkage.

**New behaviour:**

1. **Authenticated** — Unchanged: if requirements are met and the account is not already delegated, open the linkage bottom sheet (still requires `moneyAccountCardToken` when authenticated).
2. **Not authenticated, cardholder** — Set a Redux `pendingMoneyAccountCardLink` flag, navigate into Card (`CARD.ROOT` → `CARD.HOME` → `CARD.AUTHENTICATION`) with `showAuthPrompt: true` and a `postAuthRedirect` payload (origin for future multi-entrypoint use). After successful login, **`NavigationService.navigation.goBack()`** pops the pushed `Card.ROOT` so the user returns to the tab they came from (e.g. Money) **without** leaving `CardAuthentication` on the stack or cross-navigating with a flicker. A `useEffect` in [`useMoneyAccountCardLinkage`](app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx) resumes: waits for `cardHomeDataStatus` to reach `success` or `error` before clearing the pending flag when `moneyAccountCardToken` is still missing (avoids clearing too early while card home data loads post-login); if delegated already, clears pending; if token is present, opens the linkage sheet and clears pending.
3. **Not authenticated, not a cardholder** — Navigates to Card onboarding root with `moneyAccountLinkIntent: true` (Spending-limit lock for Money as spending source remains for a follow-up branch).

**What changed (high level):**

1. **Redux** — [`app/core/redux/slices/card/index.ts`](app/core/redux/slices/card/index.ts): `pendingMoneyAccountCardLink`, `setPendingMoneyAccountCardLink`, `selectPendingMoneyAccountCardLink`.
2. **Hook** — [`useMoneyAccountCardLinkage.tsx`](app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx): `startLinkFlow(origin)`, nested navigation for auth vs onboarding, resume effect with `selectCardHomeDataStatus` gating.
3. **Money UI** — [`MoneyHomeView.tsx`](app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx): link CTA calls `startLinkFlow` with root-level origin `{ screen: Routes.MONEY.ROOT, params: { screen: Routes.MONEY.HOME } }`.
4. **Card auth** — [`CardAuthentication.tsx`](app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx): optional route params `postAuthRedirect` / `showAuthPrompt`; on successful login when `postAuthRedirect` is set, `goBack()` on the root `NavigationService` instead of resetting to Card home or navigating to Money by name.

### Why

- Cardholders who start linkage from Money need **auth first**, then **the same bottom sheet** once delegation data is ready, without losing context or leaving a stale auth screen on the stack when returning to tabs.
- **`moneyAccountCardToken`** is unavailable until post-auth card data loads; gating on **`cardHomeDataStatus`** avoids dropping the pending flag during that window.

### What changed (scoped paths)

| Area | Files / behaviour |
| ---- | ----------------- |
| **Redux (card slice)** | [`app/core/redux/slices/card/index.ts`](app/core/redux/slices/card/index.ts), [`app/core/redux/slices/card/index.test.ts`](app/core/redux/slices/card/index.test.ts) |
| **Linkage hook** | [`app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx`](app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx), [`.test.tsx`](app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx) |
| **Card login** | [`app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx`](app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx), [`.test.tsx`](app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx) |
| **Money home** | [`app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx`](app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx), [`.test.tsx`](app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx) |

### Out of scope (intentional)

- Onboarding branch: locking Money Account as spending source on Spending Limit (`moneyAccountLinkIntent` wiring beyond navigation is deferred).

## **Changelog**

CHANGELOG entry: Improved Money Account link-to-Card flow for unauthenticated cardholders (auth screen, return to origin tab without stale stack, resume linkage sheet after card data loads); added pending linkage Redux flag and onboarding navigation intent for non-cardholders.

## **Related issues**

Fixes:

<!-- Add ticket ID(s), e.g. Fixes: MUSD-xxx or #12345 -->

## **Manual testing steps**

```gherkin
Feature: Money Account link card when not authenticated (cardholder)

  Background:
    Given Money Account is enabled and requirements for card linkage are met
    And the user is a Card cardholder but not authenticated with the Card backend

  Scenario: link card from Money home
    When the user taps the link card CTA from Money Account home
    Then they are taken to Card authentication with the auth prompt as configured
    When the user completes login successfully
    Then they return to Money Account (tab under the pushed Card stack is revealed)
    And Card authentication is not left on the stack when re-opening the Card tab
    When card home / delegation data has finished loading
    Then the linkage bottom sheet opens if the Money account is not already delegated and a card token is available

  Scenario: already delegated after login
    When the user completes login and data shows the Money account is already delegated
    Then the pending linkage flow clears without showing the sheet

  Scenario: authenticated user
    Given the user is already authenticated with Card
    When they tap link card from Money home and are not already delegated
    Then the linkage bottom sheet opens as before (no redirect to auth)
```

## **Screenshots/Recordings**

### **Before**

<!-- Unauthenticated: redirect to Card home only; no resume sheet; possible stack flicker. -->

### **After**

<!-- Auth → back to Money tab → linkage sheet after data load; clean Card tab stack. -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies cross-stack navigation and linkage orchestration using a new Redux pending flag; main risk is regressions in navigation stack behavior or incorrectly resuming/clearing the pending linkage state after login.
> 
> **Overview**
> Improves the Money Account → Card linkage entry flow for unauthenticated users by introducing a `pendingMoneyAccountCardLink` Redux flag and a new `startLinkFlow(origin)` API in `useMoneyAccountCardLinkage` that routes users to Card auth/onboarding and resumes opening the Link Card sheet after authentication.
> 
> Updates `CardAuthentication` to accept an optional `postAuthRedirect` param and, on successful login, pop `Card.ROOT` via `NavigationService.navigation.goBack()` instead of resetting the inner Card stack, preserving the originating tab’s navigation state.
> 
> Refactors `MoneyHomeView` link-card CTAs to call `startLinkFlow` (passing the Money home origin) and expands unit tests to cover the new branching and resume behavior, including token-resolution and data-loading edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34bad9c37d49287c3f0674a82bf512ab6dfab5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->