### PR TITLE
fix: Polish Settings list for consistency

### DIFF
--- a/app/components/UI/SettingsDrawer/index.js
+++ b/app/components/UI/SettingsDrawer/index.js
@@ -11,18 +11,21 @@ import Icon, {
 import {
   Box,
   BoxFlexDirection,
+  FontWeight,
   ListItem,
-} from '@metamask/design-system-react-native';
-import Text, {
-  TextVariant,
+  Text,
   TextColor,
-} from '../../../component-library/components/Texts/Text';
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
-const createStyles = (colors, titleColor) =>
+const createStyles = (colors) =>
   StyleSheet.create({
     root: {
       backgroundColor: colors.background.default,
-      padding: 16,
+      paddingTop: 12,
+      paddingBottom: 12,
+      paddingLeft: 16,
+      paddingRight: 16,
     },
     action: {
       paddingLeft: 16,
@@ -92,19 +95,27 @@ const SettingsDrawer = ({
   warning,
   renderArrowRight = true,
   testID,
-  titleColor = TextColor.Default,
+  titleColor = TextColor.TextDefault,
 }) => {
   const { colors } = useTheme();
-  const styles = createStyles(colors, titleColor);
+  const styles = createStyles(colors);
   return (
     <TouchableOpacity onPress={onPress} testID={testID}>
       <ListItem style={styles.root} gap={16}>
         <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1">
-          <Text variant={TextVariant.BodyLGMedium} color={titleColor}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={titleColor}
+          >
             {title}
           </Text>
           {description && (
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+            >
               {description}
             </Text>
           )}
@@ -116,8 +127,8 @@ const SettingsDrawer = ({
                 name={IconName.Danger}
               />
               <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Error}
+                variant={TextVariant.BodyMd}
+                color={TextColor.ErrorDefault}
                 style={styles.warningText}
               >
                 {warning}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR refines the typography for list items in Settings so the UI is consistent.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/pull/30171
https://github.com/MetaMask/metamask-mobile/pull/30229

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**



| Before | After |
|:------:|:-----:|
| <img width="1206" height="2622" alt="simulator_screenshot_19521A79-09ED-4725-95C3-D88FDB1C26B8" src="https://github.com/user-attachments/assets/96b05cb0-de01-472a-af84-476184919da6" />  | <img width="1206" height="2622" alt="simulator_screenshot_6474652D-D51D-4C40-A76C-7DCBC59AF805" src="https://github.com/user-attachments/assets/df46721e-4013-4068-89a4-6ee3869dae8f" />  |




## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
