### PR TITLE
fix: Polish Settings Backup and Sync section for consistency

### DIFF
--- a/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.styles.ts
+++ b/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.styles.ts
@@ -2,24 +2,23 @@ import { colors } from '@metamask/design-tokens';
 import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   setting: {
-    marginTop: 8,
-    paddingTop: 16,
-    borderTopColor: colors.dark.border.muted,
-    borderTopWidth: 1,
+    marginTop: 24,
   },
   heading: {
     flexDirection: 'column',
     paddingBottom: 8,
   },
   featureView: {
-    marginVertical: 8,
+    marginVertical: 12,
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'center',
   },
   featureNameAndIcon: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
-    gap: 8,
+    alignItems: 'center',
+    gap: 12,
   },
 });
 

--- a/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.tsx
+++ b/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { View, Switch, InteractionManager } from 'react-native';
 
 import {
+  FontWeight,
   Text,
   TextColor,
   TextVariant,
@@ -94,7 +95,13 @@ const FeatureToggle = ({
     <View style={styles.featureView}>
       <View style={styles.featureNameAndIcon}>
         <Icon name={section.iconName} />
-        <Text>{section.titleI18NKey}</Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
+          {section.titleI18NKey}
+        </Text>
       </View>
       <Switch
         testID={section.testID}
@@ -129,7 +136,11 @@ const BackupAndSyncFeaturesToggles = () => {
         <Text variant={TextVariant.HeadingSm}>
           {strings('backupAndSync.manageWhatYouSync.title')}
         </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+        >
           {strings('backupAndSync.manageWhatYouSync.description')}
         </Text>
       </View>

--- a/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.styles.ts
+++ b/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.styles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 const styles = StyleSheet.create({
   setting: {
-    marginVertical: 16,
+    marginTop: 0,
   },
   heading: {
     flexDirection: 'row',

--- a/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.tsx
+++ b/app/components/UI/Identity/BackupAndSyncToggle/BackupAndSyncToggle.tsx
@@ -4,6 +4,7 @@ import { View, Switch, Linking, InteractionManager } from 'react-native';
 // import { useNavigation } from '@react-navigation/native';
 
 import {
+  FontWeight,
   Text,
   TextVariant,
   TextColor,
@@ -166,9 +167,18 @@ const BackupAndSyncToggle = ({
           testID={BACKUP_AND_SYNC_TOGGLE_TEST_IDS.TOGGLE}
         />
       </View>
-      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
         {strings('backupAndSync.enable.description')}
-        <Text color={TextColor.InfoDefault} onPress={handleLink}>
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.InfoDefault}
+          onPress={handleLink}
+        >
           {strings('backupAndSync.privacyLink')}
         </Text>
       </Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR polishes the typography, button styles and spacing for the Backup and Sync section in Settings so the styling is aligned with the rest of the product. This is part of a wider initiative to refine our sections pattern in the product.

See other Settings PRs for context.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: update settings ui for backup and sync

## **Related issues**

Fixes: 
https://github.com/MetaMask/metamask-mobile/pull/30229
https://github.com/MetaMask/metamask-mobile/pull/30171

## **Manual testing steps**

```gherkin
Feature: Backup and sync settings — layout & typography (DQA)

  Scenario: User verifies Backup and sync screen matches DQA
    Given the user is on Settings
    When they open "Backup and sync" and review the main toggle, privacy link, and "Manage what you sync" (Accounts / Contacts)
    Then layout and typography look correct (spacing, no stray top border on the sync block, centered rows, medium-weight labels/copy), the privacy link opens, and toggling the main switch does not clip or break the layout
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

| Before | After |
|:------:|:-----:|
| <img width="1206" height="2622" alt="simulator_screenshot_3F0FCC98-92C4-4ED0-92E3-AA52DA82784E" src="https://github.com/user-attachments/assets/97eb1962-3028-404d-9cd7-67fbcff30adf" />  | <img width="1206" height="2622" alt="simulator_screenshot_2F142922-0E02-460E-9778-6E4632FF53AC" src="https://github.com/user-attachments/assets/48963ec9-468f-4c7f-8254-6f0070296d21" />  |




## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust layout and `Text` styling in Settings, with no changes to backup/sync behavior, state, or analytics logic.
> 
> **Overview**
> Polishes the Settings **Backup & Sync** section to better match design-system patterns by adjusting spacing/alignment and standardizing typography.
> 
> Updates `BackupAndSyncToggle` and `BackupAndSyncFeaturesToggles` to use explicit `Text` variants with `FontWeight.Medium`, tweaks margins/vertical rhythm, and aligns feature rows/icons with consistent centering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bbc6d6229b3190ef56df46e2c657348a53fac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->