### PR TITLE
chore: remove allDetectedTokens Earn references

### DIFF
--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
@@ -26,6 +26,8 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+import { toHex } from '@metamask/controller-utils';
+import { CHAIN_ID_TO_AAVE_POOL_CONTRACT } from '@metamask/stake-sdk';
 import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
 import useEarnNetworkPolling from './useEarnNetworkPolling';
 import { RootState } from '../../../../reducers';
@@ -35,6 +37,10 @@ import useCurrencyRatePolling from '../../../hooks/AssetPolling/useCurrencyRateP
 import useTokenRatesPolling from '../../../hooks/AssetPolling/useTokenRatesPolling';
 import useTokenDetectionPolling from '../../../hooks/AssetPolling/useTokenDetectionPolling';
 import Engine from '../../../../core/Engine';
+
+const LENDING_CHAIN_IDS = Object.keys(CHAIN_ID_TO_AAVE_POOL_CONTRACT).map(
+  (chainId) => toHex(chainId),
+);
 
 // Mock console.warn to avoid noise in tests
 const originalConsoleWarn = console.warn;
@@ -121,23 +127,24 @@ describe('useEarnNetworkPolling', () => {
     });
   });
 
-  it('should initialize with empty chain IDs and network client IDs', () => {
+  it('should initialize with lending chain IDs', () => {
     renderHookWithProvider(() => useEarnNetworkPolling(), {
       state: mockState,
     });
 
-    // Initially called with empty arrays
+    const expectedChainIds = expect.arrayContaining(LENDING_CHAIN_IDS);
+
     expect(mockUseTokenBalancesPolling).toHaveBeenCalledWith({
-      chainIds: [],
+      chainIds: expectedChainIds,
     });
     expect(mockUseCurrencyRatePolling).toHaveBeenCalledWith({
-      chainIds: [],
+      chainIds: expectedChainIds,
     });
     expect(mockUseTokenRatesPolling).toHaveBeenCalledWith({
-      chainIds: [],
+      chainIds: expectedChainIds,
     });
     expect(mockUseTokenDetectionPolling).toHaveBeenCalledWith({
-      chainIds: [],
+      chainIds: expectedChainIds,
       address: mockSelectedAccount.address,
     });
   });

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
@@ -55,6 +55,9 @@ describe('useEarnNetworkPolling', () => {
   const mockFindNetworkClientIdByChainId = jest.mocked(
     Engine.context.NetworkController.findNetworkClientIdByChainId,
   );
+  const mockDetectTokens = jest.mocked(
+    Engine.context.TokenDetectionController.detectTokens,
+  );
 
   const mockSelectedAccount =
     MOCK_ACCOUNTS_CONTROLLER_STATE.internalAccounts.accounts[
@@ -95,6 +98,7 @@ describe('useEarnNetworkPolling', () => {
       if (chainId === '0x89') return 'polygon';
       throw new Error(`Network client not found for chain ${chainId}`);
     });
+    mockDetectTokens.mockResolvedValue(undefined);
   });
 
   it('should call all polling hooks when mounted', () => {
@@ -138,6 +142,75 @@ describe('useEarnNetworkPolling', () => {
     });
   });
 
+  it('should call TokenDetectionController.detectTokens when component mounts', () => {
+    renderHookWithProvider(() => useEarnNetworkPolling(), {
+      state: mockState,
+    });
+
+    expect(mockDetectTokens).toHaveBeenCalledWith({
+      chainIds: expect.any(Array),
+      selectedAddress: mockSelectedAccount.address,
+    });
+  });
+
+  it('should not call detectTokens when useTokenDetection is false', () => {
+    const stateWithoutTokenDetection = {
+      ...mockState,
+      engine: {
+        ...mockState.engine,
+        backgroundState: {
+          ...mockState.engine.backgroundState,
+          PreferencesController: {
+            useTokenDetection: false,
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    renderHookWithProvider(() => useEarnNetworkPolling(), {
+      state: stateWithoutTokenDetection,
+    });
+
+    expect(mockDetectTokens).toHaveBeenCalledWith({
+      chainIds: expect.any(Array),
+      selectedAddress: mockSelectedAccount.address,
+    });
+  });
+
+  it('should not call detectTokens when no selected account', () => {
+    const stateWithoutAccount = {
+      ...mockState,
+      engine: {
+        ...mockState.engine,
+        backgroundState: {
+          ...mockState.engine.backgroundState,
+          AccountsController: {
+            ...MOCK_ACCOUNTS_CONTROLLER_STATE,
+            internalAccounts: {
+              ...MOCK_ACCOUNTS_CONTROLLER_STATE.internalAccounts,
+              selectedAccount: '',
+            },
+          },
+          AccountTreeController: {
+            accountTree: {
+              wallets: {},
+            },
+            selectedAccountGroup: '',
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    renderHookWithProvider(() => useEarnNetworkPolling(), {
+      state: stateWithoutAccount,
+    });
+
+    expect(mockDetectTokens).toHaveBeenCalledWith({
+      chainIds: expect.any(Array),
+      selectedAddress: undefined,
+    });
+  });
+
   it('should pass empty chainIds to useTokenDetectionPolling when useTokenDetection is false', () => {
     const stateWithoutTokenDetection = {
       ...mockState,
@@ -160,6 +233,19 @@ describe('useEarnNetworkPolling', () => {
       chainIds: [],
       address: mockSelectedAccount.address,
     });
+  });
+
+  it('should handle detectTokens errors gracefully', async () => {
+    mockDetectTokens.mockRejectedValue(new Error('Failed to detect tokens'));
+
+    expect(() => {
+      renderHookWithProvider(() => useEarnNetworkPolling(), {
+        state: mockState,
+      });
+    }).not.toThrow();
+
+    // Wait for async operations to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   it('should return null', () => {

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.test.ts
@@ -23,9 +23,6 @@ jest.mock('../../../../core/Engine', () => ({
     TokenDetectionController: {
       detectTokens: jest.fn(),
     },
-    TokensController: {
-      addTokens: jest.fn(),
-    },
   },
 }));
 
@@ -58,10 +55,6 @@ describe('useEarnNetworkPolling', () => {
   const mockFindNetworkClientIdByChainId = jest.mocked(
     Engine.context.NetworkController.findNetworkClientIdByChainId,
   );
-  const mockDetectTokens = jest.mocked(
-    Engine.context.TokenDetectionController.detectTokens,
-  );
-  const mockAddTokens = jest.mocked(Engine.context.TokensController.addTokens);
 
   const mockSelectedAccount =
     MOCK_ACCOUNTS_CONTROLLER_STATE.internalAccounts.accounts[
@@ -91,32 +84,6 @@ describe('useEarnNetworkPolling', () => {
         PreferencesController: {
           useTokenDetection: true,
         },
-        TokensController: {
-          allDetectedTokens: {
-            '0x1': {
-              [mockSelectedAccount.address]: {
-                '0x123': {
-                  address: '0x123',
-                  symbol: 'TEST',
-                  decimals: 18,
-                  image: 'test-image.png',
-                  name: 'Test Token',
-                },
-              },
-            },
-            '0x89': {
-              [mockSelectedAccount.address]: {
-                '0x456': {
-                  address: '0x456',
-                  symbol: 'TEST2',
-                  decimals: 6,
-                  image: 'test2-image.png',
-                  name: 'Test Token 2',
-                },
-              },
-            },
-          },
-        },
       },
     },
   } as unknown as RootState;
@@ -128,8 +95,6 @@ describe('useEarnNetworkPolling', () => {
       if (chainId === '0x89') return 'polygon';
       throw new Error(`Network client not found for chain ${chainId}`);
     });
-    mockDetectTokens.mockResolvedValue(undefined);
-    mockAddTokens.mockResolvedValue(undefined);
   });
 
   it('should call all polling hooks when mounted', () => {
@@ -173,123 +138,6 @@ describe('useEarnNetworkPolling', () => {
     });
   });
 
-  it('should call TokenDetectionController.detectTokens when component mounts', () => {
-    renderHookWithProvider(() => useEarnNetworkPolling(), {
-      state: mockState,
-    });
-
-    expect(mockDetectTokens).toHaveBeenCalledWith({
-      chainIds: expect.any(Array),
-      selectedAddress: mockSelectedAccount.address,
-    });
-  });
-
-  it('should not call detectTokens when useTokenDetection is false', () => {
-    const stateWithoutTokenDetection = {
-      ...mockState,
-      engine: {
-        ...mockState.engine,
-        backgroundState: {
-          ...mockState.engine.backgroundState,
-          PreferencesController: {
-            useTokenDetection: false,
-          },
-        },
-      },
-    } as unknown as RootState;
-
-    renderHookWithProvider(() => useEarnNetworkPolling(), {
-      state: stateWithoutTokenDetection,
-    });
-
-    expect(mockDetectTokens).toHaveBeenCalledWith({
-      chainIds: expect.any(Array),
-      selectedAddress: mockSelectedAccount.address,
-    });
-  });
-
-  it('should not call detectTokens when no selected account', () => {
-    const stateWithoutAccount = {
-      ...mockState,
-      engine: {
-        ...mockState.engine,
-        backgroundState: {
-          ...mockState.engine.backgroundState,
-          AccountsController: {
-            ...MOCK_ACCOUNTS_CONTROLLER_STATE,
-            internalAccounts: {
-              ...MOCK_ACCOUNTS_CONTROLLER_STATE.internalAccounts,
-              selectedAccount: '',
-            },
-          },
-          AccountTreeController: {
-            accountTree: {
-              wallets: {},
-            },
-            selectedAccountGroup: '',
-          },
-        },
-      },
-    } as unknown as RootState;
-
-    renderHookWithProvider(() => useEarnNetworkPolling(), {
-      state: stateWithoutAccount,
-    });
-
-    expect(mockDetectTokens).toHaveBeenCalledWith({
-      chainIds: expect.any(Array),
-      selectedAddress: undefined,
-    });
-  });
-
-  it('should call TokensController.addTokens for detected tokens', async () => {
-    renderHookWithProvider(() => useEarnNetworkPolling(), {
-      state: mockState,
-    });
-
-    // Wait for async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    // Verify tokens are added (order may vary based on LENDING_CHAIN_IDS)
-    expect(mockAddTokens).toHaveBeenCalledWith(
-      [
-        {
-          address: '0x123',
-          symbol: 'TEST',
-          decimals: 18,
-          image: 'test-image.png',
-          name: 'Test Token',
-          isERC721: false,
-        },
-      ],
-      'mainnet',
-    );
-  });
-
-  it('should not call addTokens when no detected tokens', async () => {
-    const stateWithoutDetectedTokens = {
-      ...mockState,
-      engine: {
-        ...mockState.engine,
-        backgroundState: {
-          ...mockState.engine.backgroundState,
-          TokensController: {
-            allDetectedTokens: {},
-          },
-        },
-      },
-    } as unknown as RootState;
-
-    renderHookWithProvider(() => useEarnNetworkPolling(), {
-      state: stateWithoutDetectedTokens,
-    });
-
-    // Wait for async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(mockAddTokens).not.toHaveBeenCalled();
-  });
-
   it('should pass empty chainIds to useTokenDetectionPolling when useTokenDetection is false', () => {
     const stateWithoutTokenDetection = {
       ...mockState,
@@ -312,32 +160,6 @@ describe('useEarnNetworkPolling', () => {
       chainIds: [],
       address: mockSelectedAccount.address,
     });
-  });
-
-  it('should handle addTokens errors gracefully', async () => {
-    mockAddTokens.mockRejectedValue(new Error('Failed to add tokens'));
-
-    expect(() => {
-      renderHookWithProvider(() => useEarnNetworkPolling(), {
-        state: mockState,
-      });
-    }).not.toThrow();
-
-    // Wait for async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  it('should handle detectTokens errors gracefully', async () => {
-    mockDetectTokens.mockRejectedValue(new Error('Failed to detect tokens'));
-
-    expect(() => {
-      renderHookWithProvider(() => useEarnNetworkPolling(), {
-        state: mockState,
-      });
-    }).not.toThrow();
-
-    // Wait for async operations to complete
-    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   it('should return null', () => {

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
@@ -52,25 +52,14 @@ export const useEarnNetworkPolling = () => {
     EVM_SCOPE,
   );
   const useTokenDetection = useSelector(selectUseTokenDetection);
-  const [lendingChainIds, setLendingChainIds] = useState<Hex[]>([]);
 
-  useTokenBalancesPolling({ chainIds: lendingChainIds });
-  useCurrencyRatePolling({ chainIds: lendingChainIds });
-  useTokenRatesPolling({ chainIds: lendingChainIds });
+  useTokenBalancesPolling({ chainIds: LENDING_CHAIN_IDS });
+  useCurrencyRatePolling({ chainIds: LENDING_CHAIN_IDS });
+  useTokenRatesPolling({ chainIds: LENDING_CHAIN_IDS });
   useTokenDetectionPolling({
-    chainIds: useTokenDetection ? lendingChainIds : [],
+    chainIds: useTokenDetection ? LENDING_CHAIN_IDS : [],
     address: selectedAccount?.address as Hex,
   });
-
-  useEffect(() => {
-    const validChainIds: Hex[] = [];
-
-    LENDING_CHAIN_IDS.forEach((chainId) => {
-      validChainIds.push(chainId);
-    });
-
-    setLendingChainIds(validChainIds);
-  }, [setLendingChainIds]);
 
   return null;
 };

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
@@ -68,7 +68,7 @@ export const useEarnNetworkPolling = () => {
       chainIds: LENDING_CHAIN_IDS,
       selectedAddress: selectedAccount?.address as Hex,
     }).catch(console.error);
-  }, [selectedAccount?.address, useTokenDetection]);
+  }, [selectedAccount?.address]);
 
   return null;
 };

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
@@ -1,8 +1,9 @@
 import { toHex } from '@metamask/controller-utils';
 import { CHAIN_ID_TO_AAVE_POOL_CONTRACT } from '@metamask/stake-sdk';
 import { Hex } from '@metamask/utils';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectUseTokenDetection } from '../../../../selectors/preferencesController';
 import useCurrencyRatePolling from '../../../hooks/AssetPolling/useCurrencyRatePolling';
@@ -60,6 +61,14 @@ export const useEarnNetworkPolling = () => {
     chainIds: useTokenDetection ? LENDING_CHAIN_IDS : [],
     address: selectedAccount?.address as Hex,
   });
+
+  // Import tokens from all lending chains
+  useEffect(() => {
+    Engine.context.TokenDetectionController.detectTokens({
+      chainIds: LENDING_CHAIN_IDS,
+      selectedAddress: selectedAccount?.address as Hex,
+    }).catch(console.error);
+  }, [selectedAccount?.address, useTokenDetection]);
 
   return null;
 };

--- a/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
+++ b/app/components/UI/Earn/hooks/useEarnNetworkPolling.ts
@@ -1,17 +1,14 @@
-import { Token } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { CHAIN_ID_TO_AAVE_POOL_CONTRACT } from '@metamask/stake-sdk';
 import { Hex } from '@metamask/utils';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import Engine from '../../../../core/Engine';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectUseTokenDetection } from '../../../../selectors/preferencesController';
 import useCurrencyRatePolling from '../../../hooks/AssetPolling/useCurrencyRatePolling';
 import useTokenBalancesPolling from '../../../hooks/AssetPolling/useTokenBalancesPolling';
 import useTokenDetectionPolling from '../../../hooks/AssetPolling/useTokenDetectionPolling';
 import useTokenRatesPolling from '../../../hooks/AssetPolling/useTokenRatesPolling';
-import { RootState } from '../../BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.test';
 import { EVM_SCOPE } from '../constants/networks';
 
 /**
@@ -55,9 +52,6 @@ export const useEarnNetworkPolling = () => {
     EVM_SCOPE,
   );
   const useTokenDetection = useSelector(selectUseTokenDetection);
-  const tokensState = useSelector(
-    (state: RootState) => state.engine?.backgroundState?.TokensController,
-  );
   const [lendingChainIds, setLendingChainIds] = useState<Hex[]>([]);
 
   useTokenBalancesPolling({ chainIds: lendingChainIds });
@@ -77,56 +71,6 @@ export const useEarnNetworkPolling = () => {
 
     setLendingChainIds(validChainIds);
   }, [setLendingChainIds]);
-
-  // Import tokens from all lending chains
-  useEffect(() => {
-    const importLendingTokens = async () => {
-      if (!selectedAccount?.address || !useTokenDetection) return;
-
-      const { TokensController } = Engine.context;
-      const allDetectedTokens = tokensState?.allDetectedTokens || {};
-
-      for (const chainId of LENDING_CHAIN_IDS) {
-        const chainDetectedTokens =
-          allDetectedTokens[chainId]?.[selectedAccount.address];
-        if (
-          chainDetectedTokens &&
-          Object.keys(chainDetectedTokens).length > 0
-        ) {
-          const tokensToImport = Object.values(chainDetectedTokens).map(
-            (token: Token) => ({
-              address: token.address,
-              symbol: token.symbol,
-              decimals: token.decimals,
-              image: token.image,
-              name: token.name,
-              isERC721: false,
-            }),
-          );
-
-          const networkClientId =
-            Engine.context.NetworkController.findNetworkClientIdByChainId(
-              chainId,
-            );
-
-          if (networkClientId && tokensToImport.length > 0) {
-            await TokensController.addTokens(tokensToImport, networkClientId);
-          }
-        }
-      }
-    };
-
-    Engine.context.TokenDetectionController.detectTokens({
-      chainIds: LENDING_CHAIN_IDS,
-      selectedAddress: selectedAccount?.address as Hex,
-    })
-      .then(importLendingTokens)
-      .catch(console.error);
-  }, [
-    tokensState?.allDetectedTokens,
-    selectedAccount?.address,
-    useTokenDetection,
-  ]);
 
   return null;
 };

--- a/app/components/UI/Earn/hooks/useEarnToken.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnToken.test.ts
@@ -163,7 +163,6 @@ const mockState = {
           },
         },
         allIgnoredTokens: {},
-        allDetectedTokens: {},
       } as TokensControllerState,
       TokenBalancesController: {
         tokenBalances: {

--- a/app/components/UI/Earn/hooks/useEarnTokens.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnTokens.test.ts
@@ -174,7 +174,6 @@ const mockState = {
           },
         },
         allIgnoredTokens: {},
-        allDetectedTokens: {},
       } as TokensControllerState,
       TokenBalancesController: {
         tokenBalances: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`allDetectedTokens` has been deprecated and empty for a long time. We are now removing all remaining references to that piece of state since we are in the process of deprecating many assets controllers.

This should not have any effect in the app, as the content of that piece of state is always empty.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3197

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Earn network polling behavior by removing the `TokensController.allDetectedTokens` -> `addTokens` import path and by always triggering `detectTokens` on mount/account change, which could affect token-detection frequency and performance across lending chains.
> 
> **Overview**
> Simplifies `useEarnNetworkPolling` by removing all usage of deprecated `TokensController.allDetectedTokens` and the follow-up `TokensController.addTokens` import flow; the hook now only triggers `TokenDetectionController.detectTokens`.
> 
> Polling hooks are updated to use the static lending `LENDING_CHAIN_IDS` list directly (no local state), and tests are adjusted accordingly, including dropping `addTokens` expectations and removing `allDetectedTokens` from Earn hook test fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4bf79400a4f01c510b0824e626578451029b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->