### PR TITLE
fix(INFRA-3631): remove explicit permissions from shadow CI workflow

### DIFF
--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -17,11 +17,6 @@ concurrency:
   group: ns-shadow-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  actions: read
-  id-token: write
-
 jobs:
   shadow-ci:
     name: '[shadow] CI'


### PR DESCRIPTION
## **Description**

Fixes `startup_failure` on all shadow CI runs since PR #30158 merged.

**Root cause**: The shadow workflow (`ci-namespace-shadow.yml`) declared an explicit `permissions:` block with only `contents: read`, `actions: read`, `id-token: write`. When using `workflow_call`, the caller's permissions become the **ceiling** for the called workflow. `ci.yml` jobs require `statuses: write`, `issues: write`, and `pull-requests: write` — all missing from the caller's ceiling, causing GitHub to reject the workflow at startup before any job runs.

**Fix**: Remove the explicit `permissions:` block so the shadow workflow inherits the repo's default token permissions — matching `ci.yml`'s own behavior when triggered directly (it also has no top-level `permissions:` block).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3631

## **Manual testing steps**

```gherkin
Scenario: Shadow CI starts successfully
  Given ci-namespace-shadow.yml has no explicit permissions block
  When a push to main or PR triggers the shadow workflow
  Then the shadow-ci job should start ci.yml via workflow_call
  And ci.yml jobs should have sufficient permissions to run
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only adjusts GitHub Actions token permission inheritance to prevent `workflow_call` startup failures.
> 
> **Overview**
> Removes the top-level `permissions` block from `ci-namespace-shadow.yml` so the shadow workflow no longer caps the token permissions available to the called `ci.yml` workflow.
> 
> This allows `ci.yml` jobs that require write scopes (e.g., commit statuses and PR/issue updates) to start successfully when invoked via `workflow_call`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f531bd1613666461ddb8faddbd3a8bbee67a9b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->