### PR TITLE
ci: skip smart E2E selection for PRs targeting stable branch

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: 'false'
   base-ref:
-    description: 'PR base branch ref passed to the AI analysis script for diff comparison. When release/*, AI selection is skipped and the full E2E suite is selected.'
+    description: 'PR base branch ref passed to the AI analysis script for diff comparison. When release/* or stable, AI selection is skipped and the full E2E suite is selected.'
     required: false
     default: ''
 outputs:
@@ -57,15 +57,15 @@ runs:
           echo "⏭️ SKIP=true due to 'skip-smart-e2e-selection' label on PR"
         fi
 
-    - name: Check release target branch (full E2E, no AI selection)
+    - name: Check release or stable target branch (full E2E, no AI selection)
       id: check-release-target
       shell: bash
       run: |
         echo "SKIP=false" >> "$GITHUB_OUTPUT"
         BASE='${{ inputs.base-ref }}'
-        if [[ -n "$BASE" && "$BASE" == release/* ]]; then
+        if [[ -n "$BASE" && ( "$BASE" == release/* || "$BASE" == "stable" ) ]]; then
           echo "SKIP=true" >> "$GITHUB_OUTPUT"
-          echo "⏭️ Base branch is release/* — skipping AI E2E selection; full E2E suite will run"
+          echo "⏭️ Base branch is release/* or stable — skipping AI E2E selection; full E2E suite will run"
         fi
 
     - name: Checkout for PR analysis
@@ -142,9 +142,9 @@ runs:
           echo "SKIP_REASON=skip-smart-e2e-selection label found" >> "$GITHUB_OUTPUT"
           echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         elif [[ "${{ steps.check-release-target.outputs.SKIP }}" == "true" ]]; then
-          echo "⏭️ Skipping AI analysis - PR targets a release branch (release/*)"
+          echo "⏭️ Skipping AI analysis - PR targets a release or stable branch"
           echo "SKIPPED=true" >> "$GITHUB_OUTPUT"
-          echo "SKIP_REASON=PR targets a release branch (release/*)" >> "$GITHUB_OUTPUT"
+          echo "SKIP_REASON=PR targets a release or stable branch (release/* or stable)" >> "$GITHUB_OUTPUT"
           echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
         else
           echo "✅ Running AI analysis for PR #$PR_NUMBER"

--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -56,7 +56,7 @@ Flakiness detection is applied to modified E2E test files in PRs:
 
 ## Release branches
 
-PRs to release branches (cherry-picked from main) are exempt from the following:
+PRs to release branches (cherry-picks from main to release/\* branches and PRs to stable branch) are exempt from the following:
 
 - Label `pr-not-ready-for-e2e` is not applied
 - Smart AI E2E selection is skipped - all E2E suites are run (if changes are not ignorable-only, e.g. only docs)

--- a/.github/workflows/auto-label-not-ready-for-e2e.yml
+++ b/.github/workflows/auto-label-not-ready-for-e2e.yml
@@ -7,6 +7,7 @@ on:
     types: [opened]
     branches-ignore:
       - 'release/**'
+      - 'stable'
 
 jobs:
   add-label:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Extends the existing release/* skip logic in the Smart E2E Selection action to also skip AI-driven test selection when a PR targets stable. PRs to stable (like hotfixes) should always run the full E2E suite, same as release branches.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that extends existing release-branch exemptions to the `stable` branch; impact is limited to which E2E suites run and whether `pr-not-ready-for-e2e` is auto-applied.
> 
> **Overview**
> Extends the existing release-branch CI behavior to the `stable` branch.
> 
> The `smart-e2e-selection` composite action now skips AI suite selection (falling back to running the full E2E suite) when the PR base ref is `release/*` **or** `stable`, and updates skip messaging accordingly. The auto-label workflow for `pr-not-ready-for-e2e` also ignores PRs targeting `stable`, and the E2E decision tree docs are updated to reflect these exemptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09667264f410e42d15919592b6aaff071780c4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->