### PR TITLE
fix(analytics): return false when AnalyticsController state is unreadable

### DIFF
--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -574,7 +574,7 @@ export async function hasMetricsConsent(): Promise<boolean> {
       }
     }
   } catch {
-    // Fall through to legacy storage
+    return false;
   }
 
   // Fallback: legacy METRICS_OPT_IN (migration 108, may be stale)


### PR DESCRIPTION


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `hasMetricsConsent` function previously fell through to the legacy `METRICS_OPT_IN` storage key whenever reading from `AnalyticsController`'s persisted state threw an error. This is incorrect because the `METRICS_OPT_IN` key is **never deleted** (see migration 108) — meaning a stale `AGREED` value could cause Sentry traces to be emitted even when the user had already opted out via the newer analytics controller.

By returning `false` immediately in the `catch` block, we ensure that Sentry stays disabled whenever the analytics controller state cannot be reliably read, defaulting to the privacy-safe behaviour of treating consent as not given.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Sentry traces being sent when AnalyticsController state was unreadable

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Sentry consent fallback behaviour

  Background:
    Given I have MetaMask Mobile installed

  Scenario: AnalyticsController state is unreadable
    Given the AnalyticsController persisted state is corrupted or missing

    When the app starts and evaluates metrics consent
    Then Sentry traces should NOT be sent
    And the app should not fall through to legacy METRICS_OPT_IN storage

  Scenario: AnalyticsController state reports opt-out
    Given the AnalyticsController persisted state is readable
    And optedIn is false

    When the app starts and evaluates metrics consent
    Then Sentry traces should NOT be sent

  Scenario: AnalyticsController state reports opt-in
    Given the AnalyticsController persisted state is readable
    And optedIn is true

    When the app starts and evaluates metrics consent
    Then Sentry traces should be sent normally
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sentry consent gating behavior when persisted analytics state is unreadable, which could affect whether traces are sent/blocked in some edge cases. Scope is small but touches privacy/telemetry control flow.
> 
> **Overview**
> Ensures `hasMetricsConsent()` fails *privacy-safe* by returning `false` if reading/parsing the persisted `AnalyticsController` state throws, instead of falling back to the legacy `METRICS_OPT_IN` key.
> 
> This prevents stale legacy opt-in values from re-enabling Sentry traces when the newer controller state is corrupted or missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905bbd28921d6dc7e464e4ef9a740ed4ed74f34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->