### PR TITLE
fix: cp-7.78.0 ensure perf e2e run on release branch

### DIFF
--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -38,21 +38,10 @@ jobs:
       - name: Check release trigger conditions
         id: check
         run: |
-          # Always run for manual dispatch
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          # Always run for manual dispatch or release branch pushes
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || ("${{ github.event_name }}" == "push" && "${{ github.ref_name }}" =~ ^release/) ]]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
-            echo "Performance tests triggered by manual dispatch"
-          # For push events, only run if the triggering commit is a metamaskbot version bump
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            COMMIT_MESSAGE=$(git log -1 --format="%s" "${{ github.sha }}")
-            COMMIT_AUTHOR=$(git log -1 --format="%ae" "${{ github.sha }}")
-            if [[ "$COMMIT_MESSAGE" =~ "Bump version number" && "$COMMIT_AUTHOR" =~ ^metamaskbot@ ]]; then
-              echo "should-run=true" >> "$GITHUB_OUTPUT"
-              echo "Push triggered by metamaskbot version bump: $COMMIT_MESSAGE"
-            else
-              echo "should-run=false" >> "$GITHUB_OUTPUT"
-              echo "Push is not a metamaskbot version bump — skipping. Author: $COMMIT_AUTHOR | Message: $COMMIT_MESSAGE"
-            fi
+            echo "Performance tests triggered by ${{ github.event_name }}"
           # For scheduled runs, check for recent metamaskbot version bumps
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             git fetch --all
@@ -67,11 +56,13 @@ jobs:
               # Check if the commit message contains "Bump version number" (ignore [skip ci])
               COMMIT_MESSAGE=$(git log -1 --format="%s" "$COMMIT_HASH")
               if [[ "$COMMIT_MESSAGE" =~ "Bump version number" ]]; then
-                # Only run if the commit is from the last 30 minutes (to avoid re-running the same commit)
+                # Check if we've already processed this commit by looking for a workflow run with this commit
+                # We'll use a simple approach: check if the commit is from the last 30 minutes
                 COMMIT_TIME=$(git log -1 --format="%ct" "$COMMIT_HASH")
                 CURRENT_TIME=$(date +%s)
                 TIME_DIFF=$((CURRENT_TIME - COMMIT_TIME))
                 
+                # Only run if the commit is from the last 30 minutes (to avoid re-running the same commit)
                 if [[ $TIME_DIFF -lt 1800 ]]; then
                   echo "should-run=true" >> "$GITHUB_OUTPUT"
                   echo "Recent metamaskbot version bump found (within last 30 min): $RECENT_VERSION_BUMP"


### PR DESCRIPTION



<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions gating logic for when the performance E2E workflow runs, without touching app/runtime code.
> 
> **Overview**
> Ensures the `run-performance-e2e-release.yml` workflow runs for **all** pushes to `release/*` branches (in addition to `workflow_dispatch`), instead of only running on push when the commit was a `metamaskbot` version bump.
> 
> Keeps the scheduled trigger behavior (checking for recent `metamaskbot` version bumps) but updates comments/logging to reflect the new push trigger conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdedbe29de0eb1227ddf8db629b8f13cfb2e38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->