### PR TITLE
ci(build): convert build.yml to workflow_call-only and add Build Android wrapper

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       environment:
-        description: 'Build environment / track (exp, beta, rc)'
+        description: 'Build environment / track. Must be one of: exp, beta, rc (enforced by validate-inputs).'
         required: true
         type: string
       upload_to_sentry:
@@ -73,7 +73,24 @@ permissions:
   id-token: write
 
 jobs:
+  # workflow_call inputs cannot use `type: choice` in GitHub Actions, so we enforce
+  # the allowed `environment` values at runtime to prevent other workflows from
+  # invoking this wrapper with arbitrary build tracks.
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate environment input
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          case "$ENVIRONMENT" in
+            exp|beta|rc) echo "✅ environment=$ENVIRONMENT is allowed" ;;
+            *) echo "::error::Invalid environment '$ENVIRONMENT'. Must be one of: exp, beta, rc"; exit 1 ;;
+          esac
+
   prepare-build-branch:
+    needs: [validate-inputs]
     uses: ./.github/workflows/create-build-branch.yml
     with:
       source_branch: ${{ inputs.source_branch }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,111 @@
+name: Build Android
+
+# Creates a temp branch, bumps version (build.yml), builds the Android APK/AAB.
+# Mirrors build-and-upload-to-testflight.yml but Android-only and without the upload step.
+# APK/AAB artifacts stay attached to the build.yml run via its existing Upload Android * steps.
+#
+on:
+  workflow_call:
+    inputs:
+      source_branch:
+        description: 'Branch, tag, or SHA to build'
+        required: true
+        type: string
+      environment:
+        description: 'Build environment / track (exp, beta, rc)'
+        required: true
+        type: string
+      upload_to_sentry:
+        description: 'If true, enable Sentry CLI upload of JS source maps and native debug symbols during the build'
+        required: false
+        type: boolean
+        default: false
+      runner_provider:
+        description: Runner provider forwarded from the caller
+        required: false
+        type: string
+        default: current
+    outputs:
+      build_branch:
+        description: 'Ephemeral build branch created from source_branch'
+        value: ${{ jobs.prepare-build-branch.outputs.build_branch }}
+      built_commit_sha:
+        description: 'Resolved commit SHA at the version-bump commit after build succeeded'
+        value: ${{ jobs.build.outputs.built_commit_sha }}
+      semantic_version:
+        description: 'package.json version at the built commit'
+        value: ${{ jobs.build.outputs.semantic_version }}
+      android_version_code:
+        description: 'android/app/build.gradle versionCode at the built commit'
+        value: ${{ jobs.build.outputs.android_version_code }}
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Branch, tag, or SHA to build'
+        required: true
+        type: string
+        default: 'main'
+      environment:
+        description: 'Build environment / track'
+        required: true
+        type: choice
+        options:
+          - exp
+          - beta
+          - rc
+        default: rc
+      upload_to_sentry:
+        description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
+        required: false
+        type: boolean
+        default: false
+      runner_provider:
+        description: Runner provider for this manual trial run
+        required: false
+        type: choice
+        options:
+          - current
+          - namespace
+        default: current
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  prepare-build-branch:
+    uses: ./.github/workflows/create-build-branch.yml
+    with:
+      source_branch: ${{ inputs.source_branch }}
+    secrets: inherit
+
+  build:
+    name: Build Android (${{ inputs.environment }})
+    needs: [prepare-build-branch]
+    uses: ./.github/workflows/build.yml
+    with:
+      build_name: main-${{ inputs.environment }}
+      platform: android
+      skip_version_bump: false
+      source_branch: ${{ needs.prepare-build-branch.outputs.build_branch }}
+      upload_to_sentry: ${{ inputs.upload_to_sentry }}
+      runner_provider: ${{ inputs.runner_provider }}
+    secrets: inherit
+
+  cleanup-build-branch:
+    name: Cleanup build branch
+    needs: [prepare-build-branch, build]
+    if: always()
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PR_TOKEN || github.token }}
+      - name: Delete temporary build branch
+        env:
+          BRANCH: ${{ needs.prepare-build-branch.outputs.build_branch }}
+        run: |
+          if [ -n "$BRANCH" ]; then
+            git push origin --delete "$BRANCH" || true
+            echo "🧹 Deleted build branch: $BRANCH"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,13 @@ name: Build Mobile App
 
 on:
   workflow_call:
-    # workflow_call inputs cannot use `type: choice`, so the closed sets below
-    # (build_name keys from builds.yml, platform, runner_provider) are enforced
-    # at runtime by the validate-inputs job before any expensive work runs.
     inputs:
       build_name:
-        description: 'Must be a key declared under `builds:` in builds.yml (enforced by validate-inputs).'
         required: true
         type: string
       platform:
-        description: 'Target platform. Must be one of: android, ios, both (enforced by validate-inputs).'
         required: true
-        type: string
+        type: string # android, ios, or both
       skip_version_bump:
         required: false
         type: boolean
@@ -26,12 +21,12 @@ on:
         type: string
         default: ''
       upload_to_sentry:
-        description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
+        description: 'If true, enable Sentry CLI upload of JS source maps and native debug symbols during the build'
         required: false
         type: boolean
         default: false
       runner_provider:
-        description: 'Runner provider forwarded from the caller. Must be one of: current, namespace (enforced by validate-inputs).'
+        description: Runner provider forwarded from the caller
         required: false
         type: string
         default: current
@@ -60,51 +55,54 @@ on:
       ios_version_code:
         description: 'ios/MetaMask.xcodeproj/project.pbxproj CURRENT_PROJECT_VERSION at the built commit'
         value: ${{ jobs.emit-build-metadata.outputs.ios_version_code }}
+  workflow_dispatch:
+    inputs:
+      build_name:
+        required: true
+        type: choice
+        options:
+          - main-prod
+          - main-beta
+          - main-rc
+          - main-test
+          - main-e2e
+          - main-exp
+          - main-dev
+          - main-dev-expo
+          - flask-prod
+          - flask-test
+          - flask-e2e
+          - flask-dev
+      platform:
+        required: true
+        type: choice
+        options: [android, ios, both]
+      skip_version_bump:
+        required: false
+        type: boolean
+        default: false
+      upload_to_sentry:
+        description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
+        required: false
+        type: boolean
+        default: false
+      runner_provider:
+        description: Runner provider for this manual trial run
+        required: true
+        type: choice
+        options:
+          - current
+          - namespace
+        default: current
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  # Enforce the closed sets that workflow_dispatch used to express via `type: choice`.
-  # workflow_call inputs only support string/boolean/number, so we validate at runtime
-  # and fail fast (before checkout / yarn install / version bump / runner allocation).
-  validate-inputs:
-    name: Validate inputs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          sparse-checkout: |
-            builds.yml
-          sparse-checkout-cone-mode: false
-      - name: Validate inputs against allowed options
-        env:
-          BUILD_NAME: ${{ inputs.build_name }}
-          PLATFORM: ${{ inputs.platform }}
-          RUNNER_PROVIDER: ${{ inputs.runner_provider }}
-        run: |
-          case "$PLATFORM" in
-            android|ios|both) ;;
-            *) echo "::error::Invalid platform '$PLATFORM'. Must be one of: android, ios, both"; exit 1 ;;
-          esac
-          case "$RUNNER_PROVIDER" in
-            current|namespace) ;;
-            *) echo "::error::Invalid runner_provider '$RUNNER_PROVIDER'. Must be one of: current, namespace"; exit 1 ;;
-          esac
-          ALLOWED_BUILDS=$(yq -r '.builds | keys | .[]' builds.yml)
-          if ! echo "$ALLOWED_BUILDS" | grep -Fxq "$BUILD_NAME"; then
-            echo "::error::Invalid build_name '$BUILD_NAME'. Not declared under 'builds:' in builds.yml. Allowed:"
-            echo "$ALLOWED_BUILDS" | sed 's/^/  - /'
-            exit 1
-          fi
-          echo "✅ build_name=$BUILD_NAME, platform=$PLATFORM, runner_provider=$RUNNER_PROVIDER"
-
   # Bump version in repo (package.json, ios/android) before building.
   # Skipped when skip_version_bump=true (e.g. nightly builds where the bump is owned upstream).
   update-build-version:
-    needs: [validate-inputs]
     if: ${{ !inputs.skip_version_bump }}
     uses: ./.github/workflows/update-latest-build-version.yml
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,18 @@ name: Build Mobile App
 
 on:
   workflow_call:
+    # workflow_call inputs cannot use `type: choice`, so the closed sets below
+    # (build_name keys from builds.yml, platform, runner_provider) are enforced
+    # at runtime by the validate-inputs job before any expensive work runs.
     inputs:
       build_name:
+        description: 'Must be a key declared under `builds:` in builds.yml (enforced by validate-inputs).'
         required: true
         type: string
       platform:
+        description: 'Target platform. Must be one of: android, ios, both (enforced by validate-inputs).'
         required: true
-        type: string # android, ios, or both
+        type: string
       skip_version_bump:
         required: false
         type: boolean
@@ -21,12 +26,12 @@ on:
         type: string
         default: ''
       upload_to_sentry:
-        description: 'If true, enable Sentry CLI upload of JS source maps and native debug symbols during the build'
+        description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
         required: false
         type: boolean
         default: false
       runner_provider:
-        description: Runner provider forwarded from the caller
+        description: 'Runner provider forwarded from the caller. Must be one of: current, namespace (enforced by validate-inputs).'
         required: false
         type: string
         default: current
@@ -61,9 +66,45 @@ permissions:
   id-token: write
 
 jobs:
+  # Enforce the closed sets that workflow_dispatch used to express via `type: choice`.
+  # workflow_call inputs only support string/boolean/number, so we validate at runtime
+  # and fail fast (before checkout / yarn install / version bump / runner allocation).
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            builds.yml
+          sparse-checkout-cone-mode: false
+      - name: Validate inputs against allowed options
+        env:
+          BUILD_NAME: ${{ inputs.build_name }}
+          PLATFORM: ${{ inputs.platform }}
+          RUNNER_PROVIDER: ${{ inputs.runner_provider }}
+        run: |
+          case "$PLATFORM" in
+            android|ios|both) ;;
+            *) echo "::error::Invalid platform '$PLATFORM'. Must be one of: android, ios, both"; exit 1 ;;
+          esac
+          case "$RUNNER_PROVIDER" in
+            current|namespace) ;;
+            *) echo "::error::Invalid runner_provider '$RUNNER_PROVIDER'. Must be one of: current, namespace"; exit 1 ;;
+          esac
+          ALLOWED_BUILDS=$(yq -r '.builds | keys | .[]' builds.yml)
+          if ! echo "$ALLOWED_BUILDS" | grep -Fxq "$BUILD_NAME"; then
+            echo "::error::Invalid build_name '$BUILD_NAME'. Not declared under 'builds:' in builds.yml. Allowed:"
+            echo "$ALLOWED_BUILDS" | sed 's/^/  - /'
+            exit 1
+          fi
+          echo "✅ build_name=$BUILD_NAME, platform=$PLATFORM, runner_provider=$RUNNER_PROVIDER"
+
   # Bump version in repo (package.json, ios/android) before building.
   # Skipped when skip_version_bump=true (e.g. nightly builds where the bump is owned upstream).
   update-build-version:
+    needs: [validate-inputs]
     if: ${{ !inputs.skip_version_bump }}
     uses: ./.github/workflows/update-latest-build-version.yml
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,45 +55,6 @@ on:
       ios_version_code:
         description: 'ios/MetaMask.xcodeproj/project.pbxproj CURRENT_PROJECT_VERSION at the built commit'
         value: ${{ jobs.emit-build-metadata.outputs.ios_version_code }}
-  workflow_dispatch:
-    inputs:
-      build_name:
-        required: true
-        type: choice
-        options:
-          - main-prod
-          - main-beta
-          - main-rc
-          - main-test
-          - main-e2e
-          - main-exp
-          - main-dev
-          - main-dev-expo
-          - flask-prod
-          - flask-test
-          - flask-e2e
-          - flask-dev
-      platform:
-        required: true
-        type: choice
-        options: [android, ios, both]
-      skip_version_bump:
-        required: false
-        type: boolean
-        default: false
-      upload_to_sentry:
-        description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
-        required: false
-        type: boolean
-        default: false
-      runner_provider:
-        description: Runner provider for this manual trial run
-        required: true
-        type: choice
-        options:
-          - current
-          - namespace
-        default: current
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary


- Adds a new `build-android.yml` (`Build Android`) workflow that mirrors the structure of `build-and-upload-to-testflight.yml` but for Android APK/AAB: creates an ephemeral build branch, bumps the version via `build.yml`, builds the Android artifacts, and cleans up the branch. No upload step.
- Adds runtime `validate-inputs` guards to both workflows to enforce the same closed sets that `workflow_dispatch` previously expressed via `type: choice` (since `workflow_call` inputs do not support `type: choice`).

## Changes

### `build-android.yml` (new)

- `workflow_call` + `workflow_dispatch` triggers
- Inputs: `source_branch` (required, "Branch, tag, or SHA to build"), `environment` (`exp`/`beta`/`rc`), `upload_to_sentry`, `runner_provider`
- Outputs: `build_branch`, `built_commit_sha`, `semantic_version`, `android_version_code`
- Jobs: `validate-inputs` → `prepare-build-branch` (create-build-branch.yml) → `build` (build.yml, platform: android) → `cleanup-build-branch`
- APK/AAB artifacts are uploaded by the existing `Upload Android *` steps inside `build.yml`; no new artifact handling needed in the wrapper

## Callers unaffected

All existing callers of `build.yml` (`nightly-build.yml`, `runway-rc-builds.yml`, `runway-production-builds.yml`, `expo-dev-build.yml`, `auto-rc-ota-build-core.yml`, `build-android-upload-to-browserstack.yml`, `build-ios-upload-to-browserstack.yml`, `build-and-upload-to-testflight.yml`) continue to work unchanged — they all use `workflow_call`.

## Manual testing

- [ ] Trigger `Build Android` workflow manually from GitHub Actions UI with a valid branch and `environment: rc`
- [ ] Verify `validate-inputs` fails fast with a clear error if an invalid `environment` or `build_name` is passed programmatically



Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI workflow entrypoints and adds new runtime validation, which could break manual builds or callers if inputs/keys don’t match `builds.yml` or if `yq` isn’t available on runners.
> 
> **Overview**
> Adds a new `Build Android` workflow (`build-android.yml`) that can be manually triggered or called by other workflows to create an ephemeral build branch, run the existing reusable `build.yml` for Android (`main-exp/beta/rc`), and then delete the temporary branch.
> 
> Updates `build.yml` to be `workflow_call`-only by removing its `workflow_dispatch` trigger and adding a fast-fail `validate-inputs` job that enforces allowed `platform`/`runner_provider` values and requires `build_name` to exist in `builds.yml` before running version bump/build steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b9790853ea72be1367b7ac6215cad0c8fabb39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->