### PR TITLE
chore: Disable iOS external group distribution by default

### DIFF
--- a/.github/workflows/auto-rc-ota-build-core.yml
+++ b/.github/workflows/auto-rc-ota-build-core.yml
@@ -142,5 +142,4 @@ jobs:
       build_commit_sha: ${{ needs.trigger-build.outputs.built_commit_sha }}
       build_version: ${{ needs.trigger-build.outputs.semantic_version }}
       build_number: ${{ needs.trigger-build.outputs.ios_version_code }}
-      distribute_external: false
     secrets: inherit

--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'MetaMask BETA & Release Candidates'
       distribute_external:
-        description: 'Whether to distribute to external testers. Defaults to false; nightly-build.yml relies on the script default (true) so it always distributes externally.'
+        description: 'Whether to distribute to external testers. Defaults to false'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'MetaMask BETA & Release Candidates'
       distribute_external:
-        description: 'Whether to distribute to external testers. Defaults to false'
+        description: 'Whether to distribute to external testers. (default: false)'
         required: false
         type: boolean
         default: false
@@ -55,7 +55,7 @@ on:
           - 'MM Card Team'
           - 'Ramp Provider Testing'
       distribute_external:
-        description: 'Whether to distribute to external testers'
+        description: 'Whether to distribute to external testers (default: false)'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,7 +31,6 @@ jobs:
       source_branch: main
       environment: exp
       testflight_group: 'MetaMask BETA & Release Candidates'
-      distribute_external: true
     secrets: inherit
 
   # ── iOS rc: build + TestFlight upload (after exp for sequential versions) ─
@@ -43,7 +42,6 @@ jobs:
       source_branch: main
       environment: rc
       testflight_group: 'MetaMask BETA & Release Candidates'
-      distribute_external: false
     secrets: inherit
 
   # ── Android exp: ephemeral branch + build ──────────────────────────────

--- a/.github/workflows/runway-production-builds.yml
+++ b/.github/workflows/runway-production-builds.yml
@@ -65,5 +65,4 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
-      distribute_external: false
     secrets: inherit

--- a/.github/workflows/runway-rc-builds.yml
+++ b/.github/workflows/runway-rc-builds.yml
@@ -65,7 +65,6 @@ jobs:
       build_commit_sha: ${{ needs.build.outputs.built_commit_sha }}
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
-      distribute_external: false
     secrets: inherit
 
   slack-notification:

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -40,10 +40,10 @@ on:
         required: true
         type: string
       distribute_external:
-        description: 'Whether to distribute to external testers. Set false for nightly/internal builds to avoid expiring previous TestFlight builds.'
+        description: 'Whether to distribute to external testers. Defaults to false'
         required: false
         type: boolean
-        default: true
+        default: false
       runner_provider:
         description: Runner provider forwarded from the caller
         required: false

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -40,7 +40,7 @@ on:
         required: true
         type: string
       distribute_external:
-        description: 'Whether to distribute to external testers. Defaults to false'
+        description: 'Whether to distribute to external testers. (default: false)'
         required: false
         type: boolean
         default: false

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -20,7 +20,7 @@ platform :ios do
     # Convert groups parameter to array (Fastlane CLI passes strings, not arrays)
     groups_param = options[:groups] || ['MetaMask BETA & Release Candidates']
     groups = groups_param.is_a?(Array) ? groups_param : [groups_param]
-    distribute_external = options[:distribute_external].nil? ? true : options[:distribute_external].to_s.downcase == 'true'
+    distribute_external = options[:distribute_external].nil? ? false : options[:distribute_external].to_s.downcase == 'true'
     notify_external_testers = distribute_external
     
     if ipa_path.nil? || ipa_path.empty?

--- a/scripts/upload-to-testflight.sh
+++ b/scripts/upload-to-testflight.sh
@@ -10,7 +10,7 @@
 #   branch              - Git branch name (required)
 #   ipa_path            - Optional: Direct path to IPA file (if not provided, uses find-ipa-file.sh)
 #   testflight_group    - Optional: TestFlight external testing group name (default: MetaMask BETA & Release Candidates)
-#   distribute_external - Optional: Whether to distribute to external testers (default: true)
+#   distribute_external - Optional: Whether to distribute to external testers (default: false)
 #
 # Environment variables:
 #   IPA_PATH - IPA path (set by find-ipa-file.sh if not provided as argument)
@@ -27,7 +27,7 @@ PIPELINE_NAME="$1"
 BRANCH="$2"
 LOCAL_IPA_PATH="$3"
 TESTFLIGHT_GROUP="${4:-MetaMask BETA & Release Candidates}"
-DISTRIBUTE_EXTERNAL="${5:-true}"
+DISTRIBUTE_EXTERNAL="${5:-false}"
 
 # Get IPA path: use argument if provided, otherwise use find-ipa-file.sh
 if [ -n "$LOCAL_IPA_PATH" ]; then


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

These changes disables iOS external group distribution by default within our workflows. We're going to try relying on internal group distribution instead since it removes the Apple review bottleneck from External builds. Uploaded builds to internal groups will be immediately available.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-607

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `distribute_external` behavior for iOS TestFlight uploads across GitHub workflows and Fastlane, which could unintentionally stop external tester distribution if callers relied on the prior default.
> 
> **Overview**
> iOS TestFlight uploads now **default to internal-only distribution** by setting `distribute_external` to `false` by default in `upload-to-testflight.yml`, `scripts/upload-to-testflight.sh`, and the Fastlane `upload_to_testflight_only` lane.
> 
> Workflow callers (e.g. `nightly-build.yml`, `runway-*-builds.yml`, `auto-rc-ota-build-core.yml`) remove explicit `distribute_external` overrides and update input descriptions to reflect the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b15fb74f80623f4694036100779222ef5e24c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->