### PR TITLE
fix(rewards): patch invalidateSubscriptionCache

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -300,9 +300,13 @@ export type RewardsControllerGetSeasonStatusAction = {
 };
 
 /**
- * Invalidate a specific subscription and its linked accounts
- * This is a surgical approach that only affects the specified subscription,
- * preserving other subscriptions' state.
+ * Invalidate local state for a subscription and its linked rewards accounts.
+ *
+ * Removes the subscription metadata entry, resets any linked rewards account
+ * state to opted-out, resets the active rewards account when it belongs to
+ * the subscription, and removes the stored session token. This intentionally
+ * does not clear rewards API caches such as vipDashboard; pair it with
+ * invalidateSubscriptionCache when cached data must be removed.
  *
  * @param subscriptionId - The subscription ID to invalidate
  */
@@ -733,8 +737,14 @@ export type RewardsControllerInvalidateReferralDetailsCacheAction = {
 /**
  * Invalidate cached data for a subscription
  *
- * @param subscriptionId - The subscription ID to invalidate cache for
- * @param seasonId - The season ID (defaults to current season)
+ * Clears cached rewards API data only. This does not alter linked account
+ * auth state, subscription metadata, or stored session tokens; pair it with
+ * invalidateSubscriptionAndAccounts when auth/account state must be reset.
+ *
+ * @param options - Cache invalidation scope
+ * @param options.subscriptionId - The subscription ID to invalidate cache for
+ * @param options.seasonId - Optional season ID to limit invalidation to season-scoped cache entries
+ * @param options.campaignId - Optional campaign ID to limit invalidation to campaign-scoped cache entries
  */
 export type RewardsControllerInvalidateSubscriptionCacheAction = {
   type: `RewardsController:invalidateSubscriptionCache`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -21,11 +21,16 @@ import {
   type CampaignState,
   type CampaignParticipantStatusState,
   type CampaignLeaderboardPositionState,
+  type OndoGmPortfolioState,
+  type OndoGmActivityState,
+  type PerpsTradingCampaignLeaderboardPositionState,
   type SubscriptionBenefitsState,
   type SubscriptionBenefitDto,
+  type OffDeviceSubscriptionAccountsState,
   type VipDashboardDto,
   type VipDashboardState,
   type VipFeesResponseDto,
+  type VipPerpsFeesState,
   type SubscriptionDto,
 } from './types';
 import type { CaipAccountId, Json } from '@metamask/utils';
@@ -5558,9 +5563,9 @@ describe('RewardsController', () => {
       );
 
       // Verify cache invalidation still happens
-      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
-        testSubscriptionId,
-      );
+      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith({
+        subscriptionId: testSubscriptionId,
+      });
       expect(invalidateSubscriptionAndAccountsSpy).toHaveBeenCalledWith(
         testSubscriptionId,
       );
@@ -5666,9 +5671,9 @@ describe('RewardsController', () => {
       ).rejects.toThrow();
 
       // Verify cache invalidation
-      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
-        testSubscriptionId,
-      );
+      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith({
+        subscriptionId: testSubscriptionId,
+      });
       expect(invalidateSubscriptionAndAccountsSpy).toHaveBeenCalledWith(
         testSubscriptionId,
       );
@@ -5748,9 +5753,9 @@ describe('RewardsController', () => {
       );
 
       // Verify cache invalidation still happens
-      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
-        mockSubscriptionId,
-      );
+      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith({
+        subscriptionId: mockSubscriptionId,
+      });
       expect(invalidateSubscriptionAndAccountsSpy).toHaveBeenCalledWith(
         mockSubscriptionId,
       );
@@ -5829,9 +5834,9 @@ describe('RewardsController', () => {
       );
 
       // Verify cache invalidation still happens
-      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
-        mockSubscriptionId,
-      );
+      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith({
+        subscriptionId: mockSubscriptionId,
+      });
       expect(invalidateSubscriptionAndAccountsSpy).toHaveBeenCalledWith(
         mockSubscriptionId,
       );
@@ -8815,8 +8820,46 @@ describe('RewardsController', () => {
       );
     });
 
-    it('successfully apply bonus code and invalidate cache', async () => {
+    it('successfully applies bonus code and invalidates points events cache', async () => {
       // Arrange
+      const compositeKey = `current:${mockSubscriptionId}`;
+      const typedPointsEventsKey = `${compositeKey}:BONUS_CODE`;
+      const initialState = getRewardsControllerDefaultState();
+
+      initialState.pointsEvents[compositeKey] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      };
+      initialState.pointsEvents[typedPointsEventsKey] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      };
+      initialState.subscriptionBenefits[mockSubscriptionId] = {
+        benefits: [],
+        limit: 10,
+        lastFetched: Date.now(),
+      } as SubscriptionBenefitsState;
+      initialState.vipDashboard[mockSubscriptionId] = {
+        lastFetched: Date.now(),
+      } as VipDashboardState;
+      initialState.vipPerpsFees[mockSubscriptionId] = {
+        hyperliquidBuilderFeeBips: '4',
+        lastFetched: Date.now(),
+      } as VipPerpsFeesState;
+      initialState.offDeviceSubscriptionAccounts[mockSubscriptionId] = {
+        accounts: ['eip155:1:0x123'],
+        lastFetched: Date.now(),
+      } as OffDeviceSubscriptionAccountsState;
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: initialState,
+      });
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockMessenger.call.mockImplementation((action, ..._args): any => {
         if (action === 'RewardsDataService:applyBonusCode') {
@@ -8825,13 +8868,8 @@ describe('RewardsController', () => {
         return Promise.resolve();
       });
 
-      const invalidateSpy = jest.spyOn(
-        controller,
-        'invalidateSubscriptionCache',
-      );
-
       // Act
-      await controller.applyBonusCode(mockBonusCode, mockSubscriptionId);
+      await testController.applyBonusCode(mockBonusCode, mockSubscriptionId);
 
       // Assert
       expect(mockMessenger.call).toHaveBeenCalledWith(
@@ -8839,9 +8877,22 @@ describe('RewardsController', () => {
         { bonusCode: mockBonusCode },
         mockSubscriptionId,
       );
-      expect(invalidateSpy).toHaveBeenCalledWith(mockSubscriptionId);
-
-      invalidateSpy.mockRestore();
+      expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
+      expect(
+        testController.state.pointsEvents[typedPointsEventsKey],
+      ).toBeUndefined();
+      expect(
+        testController.state.subscriptionBenefits[mockSubscriptionId],
+      ).toBeDefined();
+      expect(
+        testController.state.vipDashboard[mockSubscriptionId],
+      ).toBeDefined();
+      expect(
+        testController.state.vipPerpsFees[mockSubscriptionId],
+      ).toBeDefined();
+      expect(
+        testController.state.offDeviceSubscriptionAccounts[mockSubscriptionId],
+      ).toBeDefined();
     });
 
     it('throws error when service fails', async () => {
@@ -9515,7 +9566,7 @@ describe('RewardsController', () => {
   });
 
   describe('invalidateSubscriptionAndAccounts', () => {
-    it('also drops the cached VIP dashboard entry for the invalidated subscription', async () => {
+    it('clears subscription metadata without clearing cached VIP dashboard data', async () => {
       const subscriptionId = 'sub-vip';
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -9573,7 +9624,10 @@ describe('RewardsController', () => {
 
       await testController.invalidateSubscriptionAndAccounts(subscriptionId);
 
-      expect(testController.state.vipDashboard[subscriptionId]).toBeUndefined();
+      expect(
+        testController.state.subscriptions[subscriptionId],
+      ).toBeUndefined();
+      expect(testController.state.vipDashboard[subscriptionId]).toBeDefined();
     });
 
     it('correctly invalidate a specific subscription and its linked accounts', async () => {
@@ -9617,12 +9671,12 @@ describe('RewardsController', () => {
       await testController.invalidateSubscriptionAndAccounts(subscriptionId);
 
       // Assert
-      // Subscription should be removed
+      // Subscription metadata should be removed by this helper.
       expect(
         testController.state.subscriptions[subscriptionId],
       ).toBeUndefined();
 
-      // Account linked to this subscription should be reset
+      // Account linked to this subscription should be reset.
       expect(testController.state.accounts[CAIP_ACCOUNT_1]).toEqual({
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -9632,7 +9686,7 @@ describe('RewardsController', () => {
         lastFreshOptInStatusCheck: null,
       });
 
-      // activeAccount should be reset since it's linked to this subscription
+      // activeAccount should be reset since it's linked to this subscription.
       expect(testController.state.activeAccount).toEqual({
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -9688,7 +9742,7 @@ describe('RewardsController', () => {
       // Verify activeAccount remains null
       expect(testController.state.activeAccount).toBeNull();
 
-      // Verify subscription is removed
+      // Verify subscription metadata is removed
       expect(
         testController.state.subscriptions[subscriptionId],
       ).toBeUndefined();
@@ -9754,7 +9808,7 @@ describe('RewardsController', () => {
       await testController.invalidateSubscriptionAndAccounts(subscriptionId);
 
       // Assert
-      // activeAccount is reset to default values while preserving account field
+      // activeAccount is reset to default values while preserving account field.
       expect(testController.state.activeAccount).toEqual({
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -9830,7 +9884,6 @@ describe('RewardsController', () => {
       await testController.invalidateSubscriptionAndAccounts(subscriptionId1);
 
       // Assert
-      // Only subscription1 should be removed
       expect(
         testController.state.subscriptions[subscriptionId1],
       ).toBeUndefined();
@@ -9854,7 +9907,7 @@ describe('RewardsController', () => {
         true,
       );
 
-      // activeAccount should be reset since it's linked to subscription1
+      // activeAccount should be reset since it's linked to subscription1.
       expect(testController.state.activeAccount?.subscriptionId).toBeNull();
 
       // Verify that removeSubscriptionToken was called only for subscription1
@@ -9923,12 +9976,11 @@ describe('RewardsController', () => {
       await testController.invalidateSubscriptionAndAccounts(subscriptionId);
 
       // Assert
-      // Subscription should be removed
       expect(
         testController.state.subscriptions[subscriptionId],
       ).toBeUndefined();
 
-      // Both accounts linked to this subscription should be reset
+      // Both accounts linked to this subscription should be reset.
       expect(testController.state.accounts[CAIP_ACCOUNT_1]).toEqual({
         account: CAIP_ACCOUNT_1,
         hasOptedIn: false,
@@ -9954,7 +10006,7 @@ describe('RewardsController', () => {
         false,
       );
 
-      // activeAccount should be reset since it's linked to this subscription
+      // activeAccount should be reset since it's linked to this subscription.
       expect(testController.state.activeAccount?.subscriptionId).toBeNull();
 
       // Verify that removeSubscriptionToken was called
@@ -10056,14 +10108,13 @@ describe('RewardsController', () => {
       // Assert - other state properties should remain unchanged
       expect(testController.state.seasons).toEqual(originalSeasons);
 
-      // And verify the expected changes occurred
+      // And verify the expected changes occurred.
       expect(
         testController.state.subscriptions[subscriptionId],
       ).toBeUndefined();
       expect(
         testController.state.accounts[CAIP_ACCOUNT_1].subscriptionId,
       ).toBeNull();
-      // activeAccount is reset to default values while preserving account field
       expect(testController.state.activeAccount?.subscriptionId).toBeNull();
 
       // Verify that removeSubscriptionToken was called
@@ -13433,8 +13484,11 @@ describe('RewardsController', () => {
       // Verify cache invalidation was logged
       expect(mockLogger.log).toHaveBeenCalledWith(
         'RewardsController: Invalidated cache for subscription',
-        subscriptionId,
-        'all seasons',
+        {
+          subscriptionId,
+          seasonId: 'all seasons',
+          campaignId: 'all campaigns',
+        },
       );
     });
 
@@ -13599,8 +13653,11 @@ describe('RewardsController', () => {
       // Verify cache invalidation was logged
       expect(mockLogger.log).toHaveBeenCalledWith(
         'RewardsController: Invalidated cache for subscription',
-        subscriptionId,
-        'all seasons',
+        {
+          subscriptionId,
+          seasonId: 'all seasons',
+          campaignId: 'all campaigns',
+        },
       );
     });
 
@@ -13878,8 +13935,11 @@ describe('RewardsController', () => {
       // Verify cache invalidation was logged
       expect(mockLogger.log).toHaveBeenCalledWith(
         'RewardsController: Invalidated cache for subscription',
-        subscriptionId,
-        'all seasons',
+        {
+          subscriptionId,
+          seasonId: 'all seasons',
+          campaignId: 'all campaigns',
+        },
       );
     });
 
@@ -15922,8 +15982,9 @@ describe('RewardsController', () => {
       );
     });
 
-    it('invalidates subscription cache after successful claim', async () => {
+    it('invalidates points events cache after successful claim', async () => {
       const currentSeasonCompositeKey = `current:${mockSubscriptionId}`;
+      const typedPointsEventsKey = `${currentSeasonCompositeKey}:PERPS`;
       const initialState = {
         activeAccount: null,
         accounts: {},
@@ -15975,7 +16036,20 @@ describe('RewardsController', () => {
             lastFetched: Date.now(),
           },
         },
-        pointsEvents: {},
+        pointsEvents: {
+          [currentSeasonCompositeKey]: {
+            results: [],
+            has_more: false,
+            cursor: null,
+            lastFetched: Date.now(),
+          },
+          [typedPointsEventsKey]: {
+            results: [],
+            has_more: false,
+            cursor: null,
+            lastFetched: Date.now(),
+          },
+        },
       };
 
       controller = new RewardsController({
@@ -15988,16 +16062,24 @@ describe('RewardsController', () => {
       // Act
       await controller.claimReward(mockRewardId, mockSubscriptionId);
 
-      // Assert - Cache should be invalidated for current season
+      // Assert - points events cache should be invalidated for current season
+      expect(
+        controller.state.pointsEvents[currentSeasonCompositeKey],
+      ).toBeUndefined();
+      expect(
+        controller.state.pointsEvents[typedPointsEventsKey],
+      ).toBeUndefined();
+
+      // Assert - other subscription caches should remain intact
       expect(
         controller.state.seasonStatuses[currentSeasonCompositeKey],
-      ).toBeUndefined();
+      ).toBeDefined();
       expect(
         controller.state.activeBoosts[currentSeasonCompositeKey],
-      ).toBeUndefined();
+      ).toBeDefined();
       expect(
         controller.state.unlockedRewards[currentSeasonCompositeKey],
-      ).toBeUndefined();
+      ).toBeDefined();
     });
 
     it('throws error when rewards are not enabled', async () => {
@@ -16125,7 +16207,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('invalidates cache for current season by default', async () => {
+    it('does not invalidate season status after successful claim', async () => {
       // Arrange
       const currentSeasonCompositeKey = `current:${mockSubscriptionId}`;
       const initialState = {
@@ -16163,7 +16245,14 @@ describe('RewardsController', () => {
         },
         activeBoosts: {},
         unlockedRewards: {},
-        pointsEvents: {},
+        pointsEvents: {
+          [currentSeasonCompositeKey]: {
+            results: [],
+            has_more: false,
+            cursor: null,
+            lastFetched: Date.now(),
+          },
+        },
       };
 
       controller = new RewardsController({
@@ -16176,13 +16265,16 @@ describe('RewardsController', () => {
       // Act
       await controller.claimReward(mockRewardId, mockSubscriptionId);
 
-      // Assert - Current season cache should be invalidated
+      // Assert - only points events cache should be invalidated
       expect(
         controller.state.seasonStatuses[currentSeasonCompositeKey],
+      ).toBeDefined();
+      expect(
+        controller.state.pointsEvents[currentSeasonCompositeKey],
       ).toBeUndefined();
     });
 
-    it('logs cache invalidation', async () => {
+    it('logs points events cache invalidation', async () => {
       // Arrange
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -16196,9 +16288,8 @@ describe('RewardsController', () => {
 
       // Assert
       expect(mockLogger.log).toHaveBeenCalledWith(
-        'RewardsController: Invalidated cache for subscription',
-        mockSubscriptionId,
-        'all seasons',
+        'RewardsController: Invalidated points events cache for subscription',
+        { subscriptionId: mockSubscriptionId },
       );
     });
   });
@@ -16970,6 +17061,7 @@ describe('RewardsController', () => {
       // Create initial state with some data
       const initialState = getRewardsControllerDefaultState();
       const compositeKey = `${seasonId}:${subscriptionId}`; // Correct format: seasonId:subscriptionId
+      const typedPointsEventsKey = `${compositeKey}:SWAP`;
 
       // Add test data to state
       initialState.seasonStatuses[compositeKey] = {} as SeasonStatusState;
@@ -16994,6 +17086,28 @@ describe('RewardsController', () => {
         cursor: null,
         lastFetched: Date.now(),
       };
+      initialState.pointsEvents[typedPointsEventsKey] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      };
+      initialState.subscriptionBenefits[subscriptionId] = {
+        benefits: [],
+        limit: 10,
+        lastFetched: Date.now(),
+      } as SubscriptionBenefitsState;
+      initialState.vipDashboard[subscriptionId] = {
+        lastFetched: Date.now(),
+      } as VipDashboardState;
+      initialState.vipPerpsFees[subscriptionId] = {
+        hyperliquidBuilderFeeBips: '4',
+        lastFetched: Date.now(),
+      } as VipPerpsFeesState;
+      initialState.offDeviceSubscriptionAccounts[subscriptionId] = {
+        accounts: ['eip155:1:0x123'],
+        lastFetched: Date.now(),
+      } as OffDeviceSubscriptionAccountsState;
 
       // Create a controller with our test state
       const testController = new RewardsController({
@@ -17002,7 +17116,7 @@ describe('RewardsController', () => {
       });
 
       // Act - directly call the method
-      testController.invalidateSubscriptionCache(subscriptionId, seasonId);
+      testController.invalidateSubscriptionCache({ subscriptionId, seasonId });
 
       // Assert - verify the cache was invalidated for the specific season
       expect(testController.state.seasonStatuses[compositeKey]).toBeUndefined();
@@ -17014,6 +17128,17 @@ describe('RewardsController', () => {
         testController.state.subscriptionReferralDetails[compositeKey],
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
+      expect(
+        testController.state.pointsEvents[typedPointsEventsKey],
+      ).toBeUndefined();
+      expect(
+        testController.state.subscriptionBenefits[subscriptionId],
+      ).toBeDefined();
+      expect(testController.state.vipDashboard[subscriptionId]).toBeDefined();
+      expect(testController.state.vipPerpsFees[subscriptionId]).toBeDefined();
+      expect(
+        testController.state.offDeviceSubscriptionAccounts[subscriptionId],
+      ).toBeDefined();
     });
 
     it('invalidates all seasons when seasonId is not provided', async () => {
@@ -17026,6 +17151,7 @@ describe('RewardsController', () => {
       const initialState = getRewardsControllerDefaultState();
       const compositeKey1 = `${seasonId1}:${subscriptionId}`; // Correct format: seasonId:subscriptionId
       const compositeKey2 = `${seasonId2}:${subscriptionId}`; // Correct format: seasonId:subscriptionId
+      const typedPointsEventsKey = `${compositeKey1}:PERPS`;
 
       // Add test data to state for multiple seasons
       initialState.seasonStatuses[compositeKey1] = {} as SeasonStatusState;
@@ -17072,6 +17198,12 @@ describe('RewardsController', () => {
         cursor: null,
         lastFetched: Date.now(),
       };
+      initialState.pointsEvents[typedPointsEventsKey] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      };
 
       // Create a controller with our test state
       const testController = new RewardsController({
@@ -17080,7 +17212,7 @@ describe('RewardsController', () => {
       });
 
       // Act - call without seasonId to invalidate all seasons
-      testController.invalidateSubscriptionCache(subscriptionId);
+      testController.invalidateSubscriptionCache({ subscriptionId });
 
       // Assert - verify all seasons for this subscription were invalidated
       expect(
@@ -17105,6 +17237,50 @@ describe('RewardsController', () => {
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey1]).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey2]).toBeUndefined();
+      expect(
+        testController.state.pointsEvents[typedPointsEventsKey],
+      ).toBeUndefined();
+    });
+
+    it('invalidates subscription-keyed caches', async () => {
+      // Arrange
+      const subscriptionId = 'test-subscription-id';
+      const initialState = getRewardsControllerDefaultState();
+
+      initialState.subscriptionBenefits[subscriptionId] = {
+        benefits: [],
+        limit: 10,
+        lastFetched: Date.now(),
+      } as SubscriptionBenefitsState;
+      initialState.vipDashboard[subscriptionId] = {
+        lastFetched: Date.now(),
+      } as VipDashboardState;
+      initialState.vipPerpsFees[subscriptionId] = {
+        hyperliquidBuilderFeeBips: '4',
+        lastFetched: Date.now(),
+      } as VipPerpsFeesState;
+      initialState.offDeviceSubscriptionAccounts[subscriptionId] = {
+        accounts: ['eip155:1:0x123'],
+        lastFetched: Date.now(),
+      } as OffDeviceSubscriptionAccountsState;
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: initialState,
+      });
+
+      // Act
+      testController.invalidateSubscriptionCache({ subscriptionId });
+
+      // Assert
+      expect(
+        testController.state.subscriptionBenefits[subscriptionId],
+      ).toBeUndefined();
+      expect(testController.state.vipDashboard[subscriptionId]).toBeUndefined();
+      expect(testController.state.vipPerpsFees[subscriptionId]).toBeUndefined();
+      expect(
+        testController.state.offDeviceSubscriptionAccounts[subscriptionId],
+      ).toBeUndefined();
     });
 
     it('handles empty state gracefully when invalidating specific season', async () => {
@@ -17123,10 +17299,10 @@ describe('RewardsController', () => {
 
       // Act - should not throw error even when cache is empty
       expect(() =>
-        emptyStateInvalidateController.invalidateSubscriptionCache(
+        emptyStateInvalidateController.invalidateSubscriptionCache({
           subscriptionId,
           seasonId,
-        ),
+        }),
       ).not.toThrow();
 
       // Assert - state should remain empty
@@ -17164,9 +17340,9 @@ describe('RewardsController', () => {
 
       // Act - should not throw error even when cache is empty
       expect(() =>
-        emptyStateInvalidateAllSeasonsController.invalidateSubscriptionCache(
+        emptyStateInvalidateAllSeasonsController.invalidateSubscriptionCache({
           subscriptionId,
-        ),
+        }),
       ).not.toThrow();
 
       // Assert - state should remain empty
@@ -17198,9 +17374,9 @@ describe('RewardsController', () => {
       ).toHaveLength(0);
     });
 
-    it('only invalidate data for the specified subscription when invalidating all seasons', async () => {
+    it('only invalidates data for the specified subscription when invalidating all seasons', async () => {
       // Arrange
-      const subscriptionId1 = 'test-subscription-1';
+      const subscriptionId1 = 'test-subscription';
       const subscriptionId2 = 'test-subscription-2';
       const seasonId = 'test-season-id';
 
@@ -17261,7 +17437,9 @@ describe('RewardsController', () => {
       });
 
       // Act - invalidate cache only for subscription1
-      testController.invalidateSubscriptionCache(subscriptionId1);
+      testController.invalidateSubscriptionCache({
+        subscriptionId: subscriptionId1,
+      });
 
       // Assert - subscription1 data should be invalidated
       expect(
@@ -17336,7 +17514,7 @@ describe('RewardsController', () => {
       });
 
       // Act - invalidate all seasons for the subscription
-      testController.invalidateSubscriptionCache(subscriptionId);
+      testController.invalidateSubscriptionCache({ subscriptionId });
 
       // Assert - all cache entries for this subscription should be invalidated
       expect(
@@ -17386,7 +17564,10 @@ describe('RewardsController', () => {
 
       // Act - should handle partial cache gracefully
       expect(() =>
-        testController.invalidateSubscriptionCache(subscriptionId, seasonId),
+        testController.invalidateSubscriptionCache({
+          subscriptionId,
+          seasonId,
+        }),
       ).not.toThrow();
 
       // Assert - existing cache entries should be invalidated
@@ -17443,7 +17624,10 @@ describe('RewardsController', () => {
 
       // Act - should handle special characters gracefully
       expect(() =>
-        testController.invalidateSubscriptionCache(subscriptionId, seasonId),
+        testController.invalidateSubscriptionCache({
+          subscriptionId,
+          seasonId,
+        }),
       ).not.toThrow();
 
       // Assert - cache should be invalidated correctly
@@ -17458,7 +17642,7 @@ describe('RewardsController', () => {
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
     });
 
-    it('invalidates campaign and ondo leaderboard data when seasonId is provided', async () => {
+    it('does not invalidate campaign data when only seasonId is provided', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const seasonId = 'test-season-id';
@@ -17514,7 +17698,7 @@ describe('RewardsController', () => {
       });
 
       // Act
-      testController.invalidateSubscriptionCache(subscriptionId, seasonId);
+      testController.invalidateSubscriptionCache({ subscriptionId, seasonId });
 
       // Assert - season data cleared
       expect(
@@ -17524,15 +17708,195 @@ describe('RewardsController', () => {
       expect(testController.state.campaigns.CAMPAIGNS_CACHE_KEY).toBeDefined();
       expect(
         testController.state.campaignParticipantStatus[campaignCompositeKey],
-      ).toBeUndefined();
+      ).toBeDefined();
       expect(
         testController.state.ondoCampaignLeaderboardPositions[
           campaignCompositeKey
         ],
-      ).toBeUndefined();
+      ).toBeDefined();
     });
 
-    it('invalidates campaign and ondo leaderboard data when no seasonId is provided', async () => {
+    it('invalidates only matching campaign data when campaignId is provided', async () => {
+      // Arrange
+      const subscriptionId = 'test-subscription-id';
+      const otherSubscriptionId = 'other-subscription-id';
+      const seasonId = 'test-season-id';
+      const campaignId1 = 'campaign-1';
+      const campaignId2 = 'campaign-2';
+
+      const initialState = getRewardsControllerDefaultState();
+      const seasonCompositeKey = `${seasonId}:${subscriptionId}`;
+      const campaignKey1 = `${subscriptionId}:${campaignId1}`;
+      const campaignKey2 = `${subscriptionId}:${campaignId2}`;
+      const otherCampaignKey = `${otherSubscriptionId}:${campaignId1}`;
+
+      initialState.seasonStatuses[seasonCompositeKey] = {} as SeasonStatusState;
+      initialState.campaignParticipantStatus[campaignKey1] = {
+        optedIn: true,
+        participantCount: 5,
+        lastFetched: Date.now(),
+      } as CampaignParticipantStatusState;
+      initialState.campaignParticipantStatus[campaignKey2] = {
+        optedIn: false,
+        participantCount: 3,
+        lastFetched: Date.now(),
+      } as CampaignParticipantStatusState;
+      initialState.campaignParticipantStatus[otherCampaignKey] = {
+        optedIn: true,
+        participantCount: 7,
+        lastFetched: Date.now(),
+      } as CampaignParticipantStatusState;
+      initialState.ondoCampaignLeaderboardPositions[campaignKey1] = {
+        projectedTier: 'STARTER',
+        rank: 10,
+        totalInTier: 200,
+        rateOfReturn: 0,
+        currentUsdValue: 0,
+        totalUsdDeposited: 0,
+        netDeposit: 0,
+        qualifiedDays: 10,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as CampaignLeaderboardPositionState;
+      initialState.ondoCampaignLeaderboardPositions[campaignKey2] = {
+        projectedTier: 'UPPER',
+        rank: 1,
+        totalInTier: 50,
+        rateOfReturn: 0,
+        currentUsdValue: 0,
+        totalUsdDeposited: 0,
+        netDeposit: 0,
+        qualifiedDays: 10,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as CampaignLeaderboardPositionState;
+      initialState.ondoCampaignLeaderboardPositions[otherCampaignKey] = {
+        projectedTier: 'MID',
+        rank: 2,
+        totalInTier: 75,
+        rateOfReturn: 0,
+        currentUsdValue: 0,
+        totalUsdDeposited: 0,
+        netDeposit: 0,
+        qualifiedDays: 10,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as CampaignLeaderboardPositionState;
+      initialState.ondoCampaignPortfolio[campaignKey1] = {
+        positions: [],
+        summary: {},
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as unknown as OndoGmPortfolioState;
+      initialState.ondoCampaignActivity[campaignKey1] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      } as OndoGmActivityState;
+      initialState.perpsTradingCampaignLeaderboardPositions[campaignKey1] = {
+        rank: 4,
+        pnl: 0,
+        notionalVolume: 0,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as PerpsTradingCampaignLeaderboardPositionState;
+      initialState.perpsTradingCampaignLeaderboardPositions[campaignKey2] = {
+        rank: 6,
+        pnl: 0,
+        notionalVolume: 0,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as PerpsTradingCampaignLeaderboardPositionState;
+      initialState.subscriptionBenefits[subscriptionId] = {
+        benefits: [],
+        limit: 10,
+        lastFetched: Date.now(),
+      } as SubscriptionBenefitsState;
+      initialState.vipDashboard[subscriptionId] = {
+        lastFetched: Date.now(),
+      } as VipDashboardState;
+      initialState.vipPerpsFees[subscriptionId] = {
+        hyperliquidBuilderFeeBips: '4',
+        lastFetched: Date.now(),
+      } as VipPerpsFeesState;
+      initialState.offDeviceSubscriptionAccounts[subscriptionId] = {
+        accounts: ['eip155:1:0x123'],
+        lastFetched: Date.now(),
+      } as OffDeviceSubscriptionAccountsState;
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: initialState,
+      });
+
+      // Act
+      testController.invalidateSubscriptionCache({
+        subscriptionId,
+        campaignId: campaignId1,
+      });
+
+      // Assert - campaign-specific data cleared
+      expect(
+        testController.state.campaignParticipantStatus[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.ondoCampaignLeaderboardPositions[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.ondoCampaignPortfolio[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.ondoCampaignActivity[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.perpsTradingCampaignLeaderboardPositions[
+          campaignKey1
+        ],
+      ).toBeUndefined();
+
+      // Assert - other campaign and season data untouched
+      expect(
+        testController.state.seasonStatuses[seasonCompositeKey],
+      ).toBeDefined();
+      expect(
+        testController.state.campaignParticipantStatus[campaignKey2],
+      ).toBeDefined();
+      expect(
+        testController.state.campaignParticipantStatus[otherCampaignKey],
+      ).toBeDefined();
+      expect(
+        testController.state.ondoCampaignLeaderboardPositions[campaignKey2],
+      ).toBeDefined();
+      expect(
+        testController.state.ondoCampaignLeaderboardPositions[otherCampaignKey],
+      ).toBeDefined();
+      expect(
+        testController.state.perpsTradingCampaignLeaderboardPositions[
+          campaignKey2
+        ],
+      ).toBeDefined();
+      expect(
+        testController.state.subscriptionBenefits[subscriptionId],
+      ).toBeDefined();
+      expect(testController.state.vipDashboard[subscriptionId]).toBeDefined();
+      expect(testController.state.vipPerpsFees[subscriptionId]).toBeDefined();
+      expect(
+        testController.state.offDeviceSubscriptionAccounts[subscriptionId],
+      ).toBeDefined();
+    });
+
+    it('invalidates all campaign-scoped data when only subscriptionId is provided', async () => {
       // Arrange
       const subscriptionId = 'test-subscription-id';
       const otherSubscriptionId = 'other-subscription-id';
@@ -17620,6 +17984,37 @@ describe('RewardsController', () => {
         computedAt: '',
         lastFetched: Date.now(),
       } as CampaignLeaderboardPositionState;
+      initialState.ondoCampaignPortfolio[campaignKey1] = {
+        positions: [],
+        summary: {},
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as unknown as OndoGmPortfolioState;
+      initialState.ondoCampaignActivity[campaignKey1] = {
+        results: [],
+        has_more: false,
+        cursor: null,
+        lastFetched: Date.now(),
+      } as OndoGmActivityState;
+      initialState.perpsTradingCampaignLeaderboardPositions[campaignKey1] = {
+        rank: 4,
+        pnl: 0,
+        notionalVolume: 0,
+        qualified: true,
+        neighbors: [],
+        computedAt: '',
+        lastFetched: Date.now(),
+      } as PerpsTradingCampaignLeaderboardPositionState;
+      initialState.perpsTradingCampaignLeaderboardPositions[otherCampaignKey] =
+        {
+          rank: 1,
+          pnl: 0,
+          notionalVolume: 0,
+          qualified: true,
+          neighbors: [],
+          computedAt: '',
+          lastFetched: Date.now(),
+        } as PerpsTradingCampaignLeaderboardPositionState;
 
       const testController = new RewardsController({
         messenger: mockMessenger,
@@ -17627,7 +18022,7 @@ describe('RewardsController', () => {
       });
 
       // Act
-      testController.invalidateSubscriptionCache(subscriptionId);
+      testController.invalidateSubscriptionCache({ subscriptionId });
 
       // Assert - campaigns are NOT cleared (global data, not subscription-specific)
       expect(testController.state.campaigns.CAMPAIGNS_CACHE_KEY).toBeDefined();
@@ -17640,6 +18035,17 @@ describe('RewardsController', () => {
       expect(
         testController.state.ondoCampaignLeaderboardPositions[campaignKey1],
       ).toBeUndefined();
+      expect(
+        testController.state.ondoCampaignPortfolio[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.ondoCampaignActivity[campaignKey1],
+      ).toBeUndefined();
+      expect(
+        testController.state.perpsTradingCampaignLeaderboardPositions[
+          campaignKey1
+        ],
+      ).toBeUndefined();
 
       // Assert - other subscription data untouched
       expect(
@@ -17647,6 +18053,11 @@ describe('RewardsController', () => {
       ).toBeDefined();
       expect(
         testController.state.ondoCampaignLeaderboardPositions[otherCampaignKey],
+      ).toBeDefined();
+      expect(
+        testController.state.perpsTradingCampaignLeaderboardPositions[
+          otherCampaignKey
+        ],
       ).toBeDefined();
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -351,6 +351,38 @@ interface CacheOptions<T> {
   swrCallback?: (old: T, fresh: T) => void; // Callback triggered after SWR refresh, to invalidate cache
 }
 
+interface InvalidateSubscriptionCacheOptions {
+  subscriptionId: string;
+  seasonId?: string;
+  campaignId?: string;
+}
+
+type MutableCacheRecord = Record<string, unknown>;
+
+function deleteMatchingCacheEntries(
+  cache: MutableCacheRecord | undefined,
+  matches: (key: string) => boolean,
+): void {
+  if (!cache) return;
+
+  Object.keys(cache).forEach((key) => {
+    if (matches(key)) {
+      delete cache[key];
+    }
+  });
+}
+
+function deleteMatchingMapEntries<T>(
+  cache: Map<string, T>,
+  matches: (key: string) => boolean,
+): void {
+  Array.from(cache.keys()).forEach((key) => {
+    if (matches(key)) {
+      cache.delete(key);
+    }
+  });
+}
+
 /**
  * Get a value, from cache if exist
  */
@@ -805,6 +837,64 @@ export class RewardsController extends BaseController<
   }
 
   /**
+   * Create campaign subscription composite key for state storage
+   */
+  #createSubscriptionCampaignCompositeKey(
+    subscriptionId: string,
+    campaignId: string,
+  ): string {
+    return `${subscriptionId}:${campaignId}`;
+  }
+
+  #matchesSeasonSubscriptionCacheKey(
+    key: string,
+    subscriptionId: string,
+    seasonId?: string,
+  ): boolean {
+    if (seasonId !== undefined) {
+      const expectedKey = this.#createSeasonSubscriptionCompositeKey(
+        seasonId,
+        subscriptionId,
+      );
+      return key === expectedKey || key.startsWith(`${expectedKey}:`);
+    }
+
+    const [, keySubscriptionId] = key.split(':');
+    return keySubscriptionId === subscriptionId;
+  }
+
+  #matchesSubscriptionCampaignCacheKey(
+    key: string,
+    subscriptionId: string,
+    campaignId?: string,
+  ): boolean {
+    if (campaignId !== undefined) {
+      const expectedKey = this.#createSubscriptionCampaignCompositeKey(
+        subscriptionId,
+        campaignId,
+      );
+      return key === expectedKey || key.startsWith(`${expectedKey}:`);
+    }
+
+    const [keySubscriptionId] = key.split(':');
+    return keySubscriptionId === subscriptionId;
+  }
+
+  #invalidatePointsEventsCache(subscriptionId: string): void {
+    const pointsEventsCacheMatches = (key: string) =>
+      this.#matchesSeasonSubscriptionCacheKey(key, subscriptionId);
+
+    this.update((state) => {
+      deleteMatchingCacheEntries(state.pointsEvents, pointsEventsCacheMatches);
+    });
+
+    Logger.log(
+      'RewardsController: Invalidated points events cache for subscription',
+      { subscriptionId },
+    );
+  }
+
+  /**
    * Get stored season status for a given composite key
    */
   #getSeasonStatus(
@@ -1001,7 +1091,7 @@ export class RewardsController extends BaseController<
         captureException(reauthError as Error, {
           tags: { feature: 'rewards', context: 'withAuthRetry.reauth_failed' },
         });
-        this.invalidateSubscriptionCache(subscriptionId);
+        this.invalidateSubscriptionCache({ subscriptionId });
         await this.invalidateSubscriptionAndAccounts(subscriptionId);
         throw reauthError;
       }
@@ -1783,7 +1873,10 @@ export class RewardsController extends BaseController<
         },
       );
 
-      this.invalidateSubscriptionCache(params.subscriptionId, params.seasonId);
+      this.invalidateSubscriptionCache({
+        subscriptionId: params.subscriptionId,
+        seasonId: params.seasonId,
+      });
 
       this.messenger.publish('RewardsController:balanceUpdated', {
         seasonId: params.seasonId,
@@ -2304,18 +2397,20 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Invalidate a specific subscription and its linked accounts
-   * This is a surgical approach that only affects the specified subscription,
-   * preserving other subscriptions' state.
+   * Invalidate local state for a subscription and its linked rewards accounts.
+   *
+   * Removes the subscription metadata entry, resets any linked rewards account
+   * state to opted-out, resets the active rewards account when it belongs to
+   * the subscription, and removes the stored session token. This intentionally
+   * does not clear rewards API caches such as vipDashboard; pair it with
+   * invalidateSubscriptionCache when cached data must be removed.
    * @param subscriptionId - The subscription ID to invalidate
    */
   async invalidateSubscriptionAndAccounts(
     subscriptionId: string,
   ): Promise<void> {
     this.update((state) => {
-      // Remove the failing subscription
       delete state.subscriptions[subscriptionId];
-      delete state.vipDashboard[subscriptionId];
 
       // Clear accounts linked to this subscription only
       Object.entries(state.accounts).forEach(([caipAccount, accountState]) => {
@@ -2710,23 +2805,9 @@ export class RewardsController extends BaseController<
           delete state.accounts[state.activeAccount.account];
           state.activeAccount = null;
         }
-        // Clear all cached data keyed by this subscription ID
-        Object.keys(state.campaignParticipantStatus).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.campaignParticipantStatus[key];
-          }
-        });
-        Object.keys(state.ondoCampaignLeaderboardPositions).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.ondoCampaignLeaderboardPositions[key];
-          }
-        });
-        Object.keys(state.ondoCampaignPortfolio).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.ondoCampaignPortfolio[key];
-          }
-        });
       });
+
+      this.invalidateSubscriptionCache({ subscriptionId });
 
       Logger.log('RewardsController: Logout completed successfully');
     } catch (error) {
@@ -3133,7 +3214,9 @@ export class RewardsController extends BaseController<
       // Only invalidate related data if requested
       if (invalidateRelatedData) {
         // Invalidate cache for the linked account
-        this.invalidateSubscriptionCache(updatedSubscription.id);
+        this.invalidateSubscriptionCache({
+          subscriptionId: updatedSubscription.id,
+        });
 
         // Emit event to trigger UI refresh
         this.messenger.publish('RewardsController:accountLinked', {
@@ -3217,7 +3300,9 @@ export class RewardsController extends BaseController<
     // Invalidate cache and emit event if at least one account was successfully linked
     if (lastSuccessfullyLinked?.subscriptionId) {
       // Invalidate cache for the linked account
-      this.invalidateSubscriptionCache(lastSuccessfullyLinked.subscriptionId);
+      this.invalidateSubscriptionCache({
+        subscriptionId: lastSuccessfullyLinked.subscriptionId,
+      });
 
       // Emit event to trigger UI refresh
       this.messenger.publish('RewardsController:accountLinked', {
@@ -3254,8 +3339,8 @@ export class RewardsController extends BaseController<
       );
 
       if (result.success) {
-        // Invalidate caches and subscription-specific state
-        this.invalidateSubscriptionCache(subscriptionId);
+        // Opt-out removes the local subscription auth state and its API caches.
+        this.invalidateSubscriptionCache({ subscriptionId });
         await this.invalidateSubscriptionAndAccounts(subscriptionId);
 
         Logger.log(
@@ -3535,7 +3620,10 @@ export class RewardsController extends BaseController<
     if (!this.isRewardsFeatureEnabled()) {
       return { optedIn: false, participantCount: 0 };
     }
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const wasAlreadyOptedIn =
       this.state.campaignParticipantStatus[key]?.optedIn === true;
     const result = await this.#withAuthRetry(async () => {
@@ -3546,17 +3634,7 @@ export class RewardsController extends BaseController<
         campaignId,
       )) as CampaignParticipantStatusDto;
     }, subscriptionId);
-    // Invalidate the participant status cache and leaderboard / portfolio cache
-    this.update((state) => {
-      delete state.campaignParticipantStatus[key];
-      delete state.ondoCampaignLeaderboardPositions[key];
-      delete (
-        state.ondoCampaignPortfolio as Record<
-          string,
-          OndoGmPortfolioState | undefined
-        >
-      )[key];
-    });
+    this.invalidateSubscriptionCache({ subscriptionId, campaignId });
     // Only emit if the user wasn't already opted in, to avoid redundant refetches
     if (!wasAlreadyOptedIn) {
       this.messenger.publish('RewardsController:campaignOptedIn', {
@@ -3591,7 +3669,10 @@ export class RewardsController extends BaseController<
     if (!this.isRewardsFeatureEnabled()) {
       return { optedIn: false, participantCount: 0 };
     }
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const result = await wrapWithCache<CampaignParticipantStatusDto>({
       key,
       ttl: CAMPAIGN_PARTICIPANT_STATUS_CACHE_THRESHOLD_MS,
@@ -3742,7 +3823,10 @@ export class RewardsController extends BaseController<
     if (!this.isRewardsFeatureEnabled()) {
       return null;
     }
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     try {
       return await wrapWithCache<PerpsTradingCampaignParticipantOutcomeDto | null>(
         {
@@ -3799,7 +3883,10 @@ export class RewardsController extends BaseController<
       return null;
     }
 
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const result = await wrapWithCache<CampaignLeaderboardPositionDto | null>({
       key,
       ttl: ONDO_CAMPAIGN_LEADERBOARD_POSITION_CACHE_THRESHOLD_MS,
@@ -3875,7 +3962,10 @@ export class RewardsController extends BaseController<
     if (!this.isRewardsFeatureEnabled()) {
       return null;
     }
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     try {
       return await wrapWithCache<OndoGmCampaignParticipantOutcomeDto | null>({
         key,
@@ -3929,7 +4019,10 @@ export class RewardsController extends BaseController<
       return null;
     }
 
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const result = await wrapWithCache<OndoGmPortfolioDto | null>({
       key,
       ttl: ONDO_CAMPAIGN_PORTFOLIO_POSITION_CACHE_THRESHOLD_MS,
@@ -4025,7 +4118,10 @@ export class RewardsController extends BaseController<
       );
     }
 
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const result = await wrapWithCache<PaginatedOndoGmActivityDto>({
       key,
       ttl: ONDO_CAMPAIGN_ACTIVITY_CACHE_THRESHOLD_MS,
@@ -4076,7 +4172,10 @@ export class RewardsController extends BaseController<
     campaignId: string,
     subscriptionId: string,
   ): Promise<PaginatedOndoGmActivityDto> {
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
 
     const hasChanged = await this.hasActivityChanged(
       campaignId,
@@ -4142,7 +4241,10 @@ export class RewardsController extends BaseController<
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) return false;
 
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const cached = this.state.ondoCampaignActivity[key];
 
     const cachedLatestTimestamp = cached?.results?.[0]?.timestamp;
@@ -4184,8 +4286,7 @@ export class RewardsController extends BaseController<
         subscriptionId,
       );
 
-      // Invalidate cache for the active subscription
-      this.invalidateSubscriptionCache(subscriptionId);
+      this.#invalidatePointsEventsCache(subscriptionId);
 
       // Emit event to trigger UI refresh
       this.messenger.publish('RewardsController:rewardClaimed', {
@@ -4475,8 +4576,7 @@ export class RewardsController extends BaseController<
         subscriptionId,
       );
 
-      // Invalidate caches so hooks refetch fresh data on next render
-      this.invalidateSubscriptionCache(subscriptionId);
+      this.#invalidatePointsEventsCache(subscriptionId);
 
       Logger.log(
         'RewardsController: Successfully applied bonus code',
@@ -4531,106 +4631,86 @@ export class RewardsController extends BaseController<
 
   /**
    * Invalidate cached data for a subscription
-   * @param subscriptionId - The subscription ID to invalidate cache for
-   * @param seasonId - The season ID (defaults to current season)
+   *
+   * Clears cached rewards API data only. This does not alter linked account
+   * auth state, subscription metadata, or stored session tokens; pair it with
+   * invalidateSubscriptionAndAccounts when auth/account state must be reset.
+   *
+   * @param options - Cache invalidation scope
+   * @param options.subscriptionId - The subscription ID to invalidate cache for
+   * @param options.seasonId - Optional season ID to limit invalidation to season-scoped cache entries
+   * @param options.campaignId - Optional campaign ID to limit invalidation to campaign-scoped cache entries
    */
-  invalidateSubscriptionCache(subscriptionId: string, seasonId?: string): void {
-    if (seasonId) {
-      // Invalidate specific season
-      const compositeKey = this.#createSeasonSubscriptionCompositeKey(
-        seasonId,
+  invalidateSubscriptionCache({
+    subscriptionId,
+    seasonId,
+    campaignId,
+  }: InvalidateSubscriptionCacheOptions): void {
+    const shouldInvalidateAllCompositeCaches =
+      seasonId === undefined && campaignId === undefined;
+    const shouldInvalidateSeasonCaches =
+      shouldInvalidateAllCompositeCaches || seasonId !== undefined;
+    const shouldInvalidateCampaignCaches =
+      shouldInvalidateAllCompositeCaches || campaignId !== undefined;
+
+    const seasonCacheMatches = (key: string) =>
+      this.#matchesSeasonSubscriptionCacheKey(key, subscriptionId, seasonId);
+    const campaignCacheMatches = (key: string) =>
+      this.#matchesSubscriptionCampaignCacheKey(
+        key,
         subscriptionId,
+        campaignId,
       );
-      this.update((state) => {
-        delete state.vipDashboard[subscriptionId];
-        delete state.seasonStatuses[compositeKey];
-        delete state.unlockedRewards[compositeKey];
-        delete state.activeBoosts[compositeKey];
-        delete state.pointsEvents[compositeKey];
-        delete state.subscriptionReferralDetails[compositeKey];
-        Object.keys(state.campaignParticipantStatus).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.campaignParticipantStatus[key];
-          }
-        });
-        Object.keys(state.ondoCampaignLeaderboardPositions).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.ondoCampaignLeaderboardPositions[key];
-          }
-        });
-        const portfolioByKeySeason = state.ondoCampaignPortfolio as Record<
-          string,
-          OndoGmPortfolioState | undefined
-        >;
-        Object.keys(portfolioByKeySeason).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete portfolioByKeySeason[key];
-          }
-        });
-      });
-    } else {
-      // Invalidate all seasons for this subscription
-      this.update((state) => {
-        delete state.vipDashboard[subscriptionId];
-        Object.keys(state.seasonStatuses).forEach((key) => {
-          if (key.includes(subscriptionId)) {
-            delete state.seasonStatuses[key];
-          }
-        });
-        Object.keys(state.unlockedRewards).forEach((key) => {
-          if (key.includes(subscriptionId)) {
-            delete state.unlockedRewards[key];
-          }
-        });
-        Object.keys(state.activeBoosts).forEach((key) => {
-          if (key.includes(subscriptionId)) {
-            delete state.activeBoosts[key];
-          }
-        });
-        Object.keys(state.pointsEvents).forEach((key) => {
-          if (key.includes(subscriptionId)) {
-            delete state.pointsEvents[key];
-          }
-        });
-        Object.keys(state.subscriptionReferralDetails).forEach((key) => {
-          if (key.includes(subscriptionId)) {
-            delete state.subscriptionReferralDetails[key];
-          }
-        });
-        // Invalidate off-device subscription accounts cache
-        delete (
-          state.offDeviceSubscriptionAccounts as Record<
-            string,
-            OffDeviceSubscriptionAccountsState
-          >
-        )[subscriptionId];
-        Object.keys(state.campaignParticipantStatus).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.campaignParticipantStatus[key];
-          }
-        });
-        Object.keys(state.ondoCampaignLeaderboardPositions).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete state.ondoCampaignLeaderboardPositions[key];
-          }
-        });
-        const portfolioByKeyAllSeasons = state.ondoCampaignPortfolio as Record<
-          string,
-          OndoGmPortfolioState | undefined
-        >;
-        Object.keys(portfolioByKeyAllSeasons).forEach((key) => {
-          if (key.startsWith(`${subscriptionId}:`)) {
-            delete portfolioByKeyAllSeasons[key];
-          }
-        });
-      });
+
+    this.update((state) => {
+      if (shouldInvalidateAllCompositeCaches) {
+        delete state.subscriptionBenefits?.[subscriptionId];
+        delete state.vipDashboard?.[subscriptionId];
+        delete state.vipPerpsFees?.[subscriptionId];
+        delete state.offDeviceSubscriptionAccounts?.[subscriptionId];
+      }
+
+      if (shouldInvalidateSeasonCaches) {
+        [
+          state.seasonStatuses,
+          state.unlockedRewards,
+          state.activeBoosts,
+          state.pointsEvents,
+          state.subscriptionReferralDetails,
+        ].forEach((cache) =>
+          deleteMatchingCacheEntries(cache, seasonCacheMatches),
+        );
+      }
+
+      if (shouldInvalidateCampaignCaches) {
+        [
+          state.campaignParticipantStatus,
+          state.ondoCampaignLeaderboardPositions,
+          state.ondoCampaignPortfolio,
+          state.ondoCampaignActivity,
+          state.perpsTradingCampaignLeaderboardPositions,
+        ].forEach((cache) =>
+          deleteMatchingCacheEntries(cache, campaignCacheMatches),
+        );
+      }
+    });
+
+    if (shouldInvalidateCampaignCaches) {
+      deleteMatchingMapEntries(
+        this.#participantOutcomeCache,
+        campaignCacheMatches,
+      );
+      deleteMatchingMapEntries(
+        this.#perpsTradingParticipantOutcomeCache,
+        campaignCacheMatches,
+      );
     }
 
-    Logger.log(
-      'RewardsController: Invalidated cache for subscription',
+    Logger.log('RewardsController: Invalidated cache for subscription', {
       subscriptionId,
-      seasonId || 'all seasons',
-    );
+      seasonId: seasonId ?? 'all seasons',
+      campaignId: campaignId ?? 'all campaigns',
+    });
   }
 
   /**
@@ -4706,7 +4786,10 @@ export class RewardsController extends BaseController<
       return null;
     }
 
-    const key = `${subscriptionId}:${campaignId}`;
+    const key = this.#createSubscriptionCampaignCompositeKey(
+      subscriptionId,
+      campaignId,
+    );
     const result =
       await wrapWithCache<PerpsTradingCampaignLeaderboardPositionDto | null>({
         key,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
- Refactors `invalidateSubscriptionCache` to take an options object: { subscriptionId, seasonId?, campaignId? }.
- Adds centralized cache-key helpers for season/subscription and subscription/campaign composite keys, replacing hardcoded ${subscriptionId}:${campaignId} usage.
- Makes cache invalidation more scoped:
 -- subscriptionId + seasonId: season-scoped caches only.
 -- subscriptionId + campaignId: campaign-scoped caches only.
 -- subscriptionId only: all subscription-related rewards API caches.
- Keeps invalidateSubscriptionAndAccounts focused on subscription/account auth state: removes subscription metadata, resets linked account state and active account, removes token, but does not clear vipDashboard.
- Narrows claim reward and bonus code handling to invalidate points-events cache only, instead of clearing broad subscription caches.
- Updates logout, auth retry, account linking, opt-out, balance update, and campaign opt-in call sites to use the new invalidation API.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation semantics in `RewardsController`, including new season/campaign scoping and narrower invalidations after reward claims/bonus codes, which could leave stale UI data or trigger extra refetches if callers rely on prior broad clears.
> 
> **Overview**
> Refactors `RewardsController.invalidateSubscriptionCache` to accept an options object (`{ subscriptionId, seasonId?, campaignId? }`) and centralizes composite-key generation/matching so invalidation can be targeted to *season-scoped* vs *campaign-scoped* caches, plus subscription-keyed caches (e.g. benefits/VIP/off-device accounts) only when doing a full subscription clear.
> 
> Separates responsibilities between auth/account reset and cache clearing: `invalidateSubscriptionAndAccounts` now removes subscription metadata, resets linked account state, and removes the session token **without** clearing rewards API caches like `vipDashboard`, while `logout`, `optOut`, account linking flows, auth-retry, and balance update paths are updated to use the new invalidation API.
> 
> Narrows post-mutation invalidation: `claimReward` and `applyBonusCode` now invalidate only `pointsEvents` for the subscription (with updated logging), and the test suite is updated/expanded to reflect the new scoping rules and typed cache-key deletion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d25a2778cb8088c71f05a6171d56e48648db42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->