### PR TITLE
ci: restrict production OTA pushes to release branch PRs

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -95,13 +95,13 @@ jobs:
   verify-release-branch:
     name: Verify release branch (production only)
     runs-on: ubuntu-latest
-    env:
-      PR_NUMBER: ${{ env.TARGET_PR_NUMBER }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_REPOSITORY: ${{ github.repository }}
-      TARGET_CHANNEL: ${{ env.TARGET_CHANNEL }}
     steps:
       - name: Enforce release branch for production channel
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -92,6 +92,71 @@ jobs:
         run: |
           .github/scripts/validate-pr-commit.sh
 
+  verify-release-branch:
+    name: Verify release branch (production only)
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ env.TARGET_PR_NUMBER }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      TARGET_CHANNEL: ${{ env.TARGET_CHANNEL }}
+    steps:
+      - name: Enforce release branch for production channel
+        run: |
+          set -euo pipefail
+
+          if [ "${TARGET_CHANNEL}" != "production" ]; then
+            echo "ℹ️  Channel is '${TARGET_CHANNEL}' — release branch check skipped."
+            {
+              echo "### ℹ️ Release branch check skipped"
+              echo ""
+              echo "Channel \`${TARGET_CHANNEL}\` does not require a release branch."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "🔒 Production channel selected — verifying PR head branch..."
+
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+
+          pr_details=$(curl -sS \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}")
+
+          if ! echo "$pr_details" | jq -e '.id' > /dev/null 2>&1; then
+            echo "::error title=PR not found::Could not resolve PR #${PR_NUMBER}"
+            exit 1
+          fi
+
+          head_ref=$(echo "$pr_details" | jq -r '.head.ref')
+
+          if [[ "$head_ref" != release/* ]]; then
+            {
+              echo "### ❌ Production OTA push rejected"
+              echo ""
+              echo "Production channel pushes are only allowed from a release branch PR."
+              echo ""
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| PR | #${PR_NUMBER} |"
+              echo "| Head branch | \`${head_ref}\` |"
+              echo "| Required pattern | \`release/*\` |"
+              echo ""
+              echo "Re-run this workflow against a PR whose head branch is a release branch (for example \`release/7.78.0\`)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Invalid branch for production OTA::PR #${PR_NUMBER} head branch is '${head_ref}' but must match 'release/*'"
+            exit 1
+          fi
+
+          {
+            echo "### ✅ Release branch verified"
+            echo ""
+            echo "PR #${PR_NUMBER} head branch \`${head_ref}\` is a release branch."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ PR #${PR_NUMBER} head branch '${head_ref}' is a release branch"
+
   ota-summary:
     name: OTA Update Summary
     needs: validate-pr
@@ -115,6 +180,7 @@ jobs:
     name: Setup Dependencies (PR)
     needs:
       - validate-pr
+      - verify-release-branch
     uses: ./.github/workflows/setup-node-modules.yml
     with:
       ref: ${{ needs.validate-pr.outputs.commit_sha }}
@@ -127,6 +193,7 @@ jobs:
     name: Setup Dependencies (Base)
     needs:
       - validate-pr
+      - verify-release-branch
     uses: ./.github/workflows/setup-node-modules.yml
     with:
       ref: ${{ inputs.base_branch }}
@@ -137,7 +204,7 @@ jobs:
 
   prepare:
     name: Load OTA build config
-    needs: [validate-pr]
+    needs: [validate-pr, verify-release-branch]
     runs-on: ubuntu-latest
     outputs:
       github_environment: ${{ steps.config.outputs.github_environment }}
@@ -340,6 +407,7 @@ jobs:
       - fingerprint-comparison
       - approval
       - validate-pr
+      - verify-release-branch
       - setup-dependencies
       - prepare
     if: >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Adds a hard guardrail to the OTA push workflow so that **production** channel updates can only be dispatched from a PR whose head branch matches `release/*`. Previously, anyone with workflow dispatch permissions could push an OTA update to the production channel from any PR — the only safeguards downstream were the release-team approval step and the fingerprint comparison, neither of which protects against pushing the wrong branch's code to production users.

This change introduces a new dedicated job, `verify-release-branch`, that runs early in `push-eas-update.yml`:
- **For `exp` / `rc` channels** — the job logs an info message and exits 0 (no behavior change for non-production flows).
- **For `production` channel** — the job fetches the target PR via the GitHub API, reads `head.ref`, and fails the run with a clear annotation and step-summary block if the head branch does not match `release/*`.

The gate is added to the `needs:` of the expensive downstream jobs (`setup-dependencies`, `setup-dependencies-base`, `prepare`, `push-update`) so a doomed production run fails fast — saving ~5–10 minutes of CI per misfire — and surfaces as its own red box in the Actions UI labelled "Verify release branch (production only)", rather than being buried inside the existing `validate-pr` step.

Because the check lives inside `push-eas-update.yml` itself, it is automatically inherited by every caller that invokes the workflow via `workflow_call`:
- `runway-ota-production.yml` (hardcoded `channel: production`) — gate enforced
- `runway-ota-rc.yml` (hardcoded `channel: rc`) — gate skipped
- `auto-rc-ota-build-core.yml` (dynamic `channel`) — gate enforced only when the dynamic channel resolves to `production`
No changes are required in any caller workflow.

workflow tests:
from non release branch to production (fail): https://github.com/MetaMask/metamask-mobile/actions/runs/25946843695

from release branch to production (pass):
https://github.com/MetaMask/metamask-mobile/actions/runs/25946935860

from non release branch to non production (pass):
https://github.com/MetaMask/metamask-mobile/actions/runs/25946974294


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Production OTA channel restricted to release branch PRs
  
Scenario: Production OTA push from a non-release branch PR is rejected
    Given a PR exists whose head branch is "fix/some-non-release-change"
    When a maintainer dispatches "Push OTA Update" with channel="production" and that PR number
    Then the workflow run shows a failed job named "Verify release branch (production only)"
    And the run summary contains "Production OTA push rejected" with the PR number and offending head branch
    And no downstream jobs (setup-dependencies, fingerprint-comparison, push-update) execute
  
Scenario: Production OTA push from a release branch PR is allowed
    Given a PR exists whose head branch is "release/7.78.0"
    When a maintainer dispatches "Push OTA Update" with channel="production" and that PR number
    Then the "Verify release branch (production only)" job succeeds
    And the run summary contains "Release branch verified"
    And the workflow proceeds through fingerprint comparison, approval, and the push-update job
  
Scenario: Non-production OTA push is unaffected
    Given any PR exists
    When a maintainer dispatches "Push OTA Update" with channel="exp" or channel="rc"
    Then the "Verify release branch (production only)" job succeeds with "Release branch check skipped"
    And the workflow proceeds normally
  
Scenario: Runway production OTA flow still works
    Given the user dispatches "Runway OTA Production" with source_branch="release/7.78.0"
    And an open PR exists whose head branch is "release/7.78.0"
    When Runway resolves the PR via runway-ota-resolve-context
    And calls push-eas-update.yml with channel="production"
    Then the new gate verifies the PR head branch matches "release/*"
    And the OTA update proceeds end-to-end

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production OTA release workflow gating; a misconfiguration or GitHub API/JQ failure could incorrectly block legitimate production updates.
> 
> **Overview**
> Adds a new `verify-release-branch` job to `push-eas-update.yml` that **blocks production OTA updates unless the target PR’s head branch matches `release/*`**, using the GitHub API to read `head.ref` and emitting clear run summaries/errors.
> 
> Wires this guard into the `needs:` chain for the expensive downstream jobs (`setup-dependencies`, `setup-dependencies-base`, `prepare`, `push-update`) so invalid production runs fail fast, while non-production channels (`exp`/`rc`) explicitly skip the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f89dc9eaa446aadf9ad44e7c7261c8cfec299ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->