### PR TITLE
chore: remove multichain historicalPrices references

### DIFF
--- a/app/components/hooks/useTokenHistoricalPrices.ts
+++ b/app/components/hooks/useTokenHistoricalPrices.ts
@@ -1,12 +1,8 @@
-import { CaipAssetId, CaipAssetType, Hex } from '@metamask/utils';
+import { CaipAssetId, Hex } from '@metamask/utils';
 import { getDecimalChainId } from '../../util/networks';
 import { useState, useEffect } from 'react';
 import { TraceName, endTrace, trace } from '../../util/trace';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-import { selectMultichainHistoricalPrices } from '../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF
 import { useSelector } from 'react-redux';
-import Engine from '../../core/Engine';
 import { TokenI } from '../UI/Tokens/types';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { selectLastSelectedSolanaAccount } from '../../selectors/accountsController';
@@ -16,29 +12,6 @@ export type TimePeriod = '1d' | '1w' | '7d' | '1m' | '3m' | '1y' | '3y' | 'all';
 export type TokenPrice = [string, number];
 
 const placeholderPrices = Array(289).fill(['0', 0] as TokenPrice);
-
-export const standardizeTimeInterval = (timePeriod: TimePeriod) => {
-  switch (timePeriod) {
-    case '1d':
-      return 'P1D';
-    case '1w':
-      return 'P7D';
-    case '7d':
-      return 'P7D';
-    case '1m':
-      return 'P1M';
-    case '3m':
-      return 'P3M';
-    case '1y':
-      return 'P1Y';
-    case '3y':
-      return 'P3Y';
-    case 'all':
-      return 'P1000Y';
-    default:
-      return 'P1D';
-  }
-};
 
 const useTokenHistoricalPrices = ({
   asset,
@@ -61,11 +34,6 @@ const useTokenHistoricalPrices = ({
   isLoading: boolean;
   error: Error | undefined;
 } => {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  const multichainHistoricalPrices = useSelector(
-    selectMultichainHistoricalPrices,
-  );
-  ///: END:ONLY_INCLUDE_IF
   const resultChainId = formatChainIdToCaip(asset.chainId as Hex);
   const isNonEvmAsset = resultChainId === asset.chainId;
   const [prices, setPrices] = useState<TokenPrice[]>(placeholderPrices);
@@ -81,75 +49,51 @@ const useTokenHistoricalPrices = ({
   useEffect(() => {
     const fetchPrices = async () => {
       setIsLoading(true);
+
       try {
+        const baseUri = 'https://price.api.cx.metamask.io/v3';
+
+        let caipChainId: string;
+        let assetIdentifier: string;
+
         if (isNonEvmAsset) {
           const caip19Address = asset.address as CaipAssetId;
           const isCaipAssetType = caip19Address.startsWith(`${asset.chainId}`);
 
-          // TODO; this is a temporary fix to ensure the address is a CaipAssetType asset;
-          const normalizedCaipAssetTypeAddress = isCaipAssetType
-            ? caip19Address
-            : (`${asset.chainId}/token:${asset.address}` as CaipAssetType);
-          const standardizedTimeInterval = standardizeTimeInterval(timePeriod);
-
-          trace({
-            name: TraceName.FetchHistoricalPrices,
-            data: {
-              normalizedCaipAssetTypeAddress,
-            },
-          });
-
-          await Engine.context.MultichainAssetsRatesController.fetchHistoricalPricesForAsset(
-            normalizedCaipAssetTypeAddress,
-            lastSelectedNonEvmAccount,
-          );
-
-          endTrace({ name: TraceName.FetchHistoricalPrices });
-
-          const result =
-            multichainHistoricalPrices[normalizedCaipAssetTypeAddress][
-              vsCurrency
-            ].intervals[standardizedTimeInterval];
-
-          // Transform to ensure first value is string and second is number with max precision
-          const transformedResult = result.map(
-            ([timestamp, price]) =>
-              [timestamp.toString(), Number(price)] as TokenPrice,
-          );
-
-          setPrices(transformedResult);
+          caipChainId = asset.chainId as string;
+          assetIdentifier = isCaipAssetType
+            ? caip19Address.split('/')[1]
+            : `token:${asset.address}`;
         } else {
-          const baseUri = 'https://price.api.cx.metamask.io/v3';
-          const decimalChainId = getDecimalChainId(chainId);
-          const caipChainId = `eip155:${decimalChainId}`;
-          // CAIP-19 format: eip155:{chainId}/erc20:{address}
-          const assetIdentifier = `erc20:${address}`;
-          const uri = new URL(
-            `${baseUri}/historical-prices/${caipChainId}/${assetIdentifier}`,
-          );
-          uri.searchParams.set(
-            'timePeriod',
-            timePeriod === '1w' ? '7d' : timePeriod,
-          );
-          uri.searchParams.set('vsCurrency', vsCurrency);
-          if (from && to) {
-            uri.searchParams.set('from', from.toString());
-            uri.searchParams.set('to', to.toString());
-          }
-
-          trace({
-            name: TraceName.FetchHistoricalPrices,
-            data: { uri: uri.toString() },
-          });
-          const response = await fetch(uri.toString());
-          endTrace({ name: TraceName.FetchHistoricalPrices });
-          if (response.status === 204) {
-            setPrices([]);
-            return;
-          }
-          const data: { prices: TokenPrice[] } = await response.json();
-          setPrices(data.prices as TokenPrice[]);
+          caipChainId = `eip155:${getDecimalChainId(chainId)}`;
+          assetIdentifier = `erc20:${address}`;
         }
+
+        const uri = new URL(
+          `${baseUri}/historical-prices/${caipChainId}/${assetIdentifier}`,
+        );
+        uri.searchParams.set(
+          'timePeriod',
+          timePeriod === '1w' ? '7d' : timePeriod,
+        );
+        uri.searchParams.set('vsCurrency', vsCurrency);
+        if (from && to) {
+          uri.searchParams.set('from', from.toString());
+          uri.searchParams.set('to', to.toString());
+        }
+
+        trace({
+          name: TraceName.FetchHistoricalPrices,
+          data: { uri: uri.toString() },
+        });
+        const response = await fetch(uri.toString());
+        endTrace({ name: TraceName.FetchHistoricalPrices });
+        if (response.status === 204) {
+          setPrices([]);
+          return;
+        }
+        const data: { prices: TokenPrice[] } = await response.json();
+        setPrices(data.prices as TokenPrice[]);
       } catch (e: unknown) {
         setError(e as Error);
       } finally {
@@ -166,11 +110,8 @@ const useTokenHistoricalPrices = ({
     vsCurrency,
     isNonEvmAsset,
     asset.address,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     asset.chainId,
     lastSelectedNonEvmAccount,
-    multichainHistoricalPrices,
-    ///: END:ONLY_INCLUDE_IF
   ]);
 
   return { data: prices, isLoading, error };

--- a/app/components/hooks/useTokenHistoricalPrices.ts
+++ b/app/components/hooks/useTokenHistoricalPrices.ts
@@ -1,11 +1,9 @@
-import { CaipAssetId, Hex } from '@metamask/utils';
+import { Hex } from '@metamask/utils';
 import { getDecimalChainId } from '../../util/networks';
 import { useState, useEffect } from 'react';
 import { TraceName, endTrace, trace } from '../../util/trace';
-import { useSelector } from 'react-redux';
 import { TokenI } from '../UI/Tokens/types';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
-import { selectLastSelectedSolanaAccount } from '../../selectors/accountsController';
 
 export type TimePeriod = '1d' | '1w' | '7d' | '1m' | '3m' | '1y' | '3y' | 'all';
 
@@ -40,9 +38,6 @@ const useTokenHistoricalPrices = ({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error>();
 
-  // TODO; the asset.address received here is not a CaipAssetType asset when its coming from bridge flow; this is happening because of useTopTokens hook retuning the address for non evm as not a CaipAssetType asset;
-  // TODO; we need to fix this;
-
   useEffect(() => {
     const fetchPrices = async () => {
       setIsLoading(true);
@@ -54,13 +49,8 @@ const useTokenHistoricalPrices = ({
         let assetIdentifier: string;
 
         if (isNonEvmAsset) {
-          const caip19Address = asset.address as CaipAssetId;
-          const isCaipAssetType = caip19Address.startsWith(`${asset.chainId}`);
-
           caipChainId = asset.chainId as string;
-          assetIdentifier = isCaipAssetType
-            ? caip19Address.split('/')[1]
-            : `token:${asset.address}`;
+          assetIdentifier = asset.address.split('/')[1];
         } else {
           caipChainId = `eip155:${getDecimalChainId(chainId)}`;
           assetIdentifier = `erc20:${address}`;

--- a/app/components/hooks/useTokenHistoricalPrices.ts
+++ b/app/components/hooks/useTokenHistoricalPrices.ts
@@ -39,9 +39,6 @@ const useTokenHistoricalPrices = ({
   const [prices, setPrices] = useState<TokenPrice[]>(placeholderPrices);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error>();
-  const lastSelectedNonEvmAccount = useSelector(
-    selectLastSelectedSolanaAccount,
-  );
 
   // TODO; the asset.address received here is not a CaipAssetType asset when its coming from bridge flow; this is happening because of useTopTokens hook retuning the address for non evm as not a CaipAssetType asset;
   // TODO; we need to fix this;
@@ -111,7 +108,6 @@ const useTokenHistoricalPrices = ({
     isNonEvmAsset,
     asset.address,
     asset.chainId,
-    lastSelectedNonEvmAccount,
   ]);
 
   return { data: prices, isLoading, error };

--- a/app/selectors/multichain/multichain.test.ts
+++ b/app/selectors/multichain/multichain.test.ts
@@ -8,7 +8,6 @@ import {
   selectMultichainTransactions,
   selectSelectedAccountMultichainNetworkAggregatedBalance,
   selectNonEvmTransactions,
-  selectMultichainHistoricalPrices,
   makeSelectNonEvmAssetById,
   selectMultichainTokenListForAccountsAnyChain,
 } from './multichain';
@@ -1221,38 +1220,6 @@ describe('MultichainNonEvm Selectors', () => {
           next: null,
           lastUpdated: 0,
         });
-      });
-    });
-  });
-
-  describe('selectMultichainHistoricalPrices', () => {
-    const testAsset = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
-
-    it('returns empty object if no historical prices are available', () => {
-      const state = getEvmState(undefined);
-      state.engine.backgroundState.MultichainAssetsRatesController.historicalPrices =
-        {};
-
-      expect(selectMultichainHistoricalPrices(state)).toStrictEqual({});
-    });
-
-    it('Returns historical prices for a given asset', () => {
-      const testCurrency = 'usd';
-      const state = getEvmState(undefined);
-      const mockHistoricalPricesForAsset = {
-        [testCurrency]: {
-          intervals: {},
-          updateTime: 1737542312,
-          expirationTime: 1737542312,
-        },
-      };
-      state.engine.backgroundState.MultichainAssetsRatesController.historicalPrices =
-        {
-          [testAsset]: mockHistoricalPricesForAsset,
-        };
-
-      expect(selectMultichainHistoricalPrices(state)).toStrictEqual({
-        [testAsset]: mockHistoricalPricesForAsset,
       });
     });
   });

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -172,16 +172,6 @@ export const selectMultichainAssetsRates = createDeepEqualSelector(
   { devModeChecks: { identityFunctionCheck: 'never' } },
 );
 
-/**
- * @deprecated
- * This selector accesses deprecated AssetsController state directly.
- * It is only used in the useTokenHistoricalPrices hook.
- */
-export function selectMultichainHistoricalPrices(state: RootState) {
-  return state.engine.backgroundState.MultichainAssetsRatesController
-    .historicalPrices;
-}
-
 export const selectMultichainTokenListForAccountId = createDeepEqualSelector(
   getMultiChainBalancesControllerBalances,
   getMultiChainAssetsControllerAccountsAssets,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Remove references to multichain `historicalPrices`. Data is fetched from price api.

This should not change anything in the app. Behaviour remains the same.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3232

## **Manual testing steps**

```gherkin
Feature: Historical price chart on token detail screen

  Scenario: EVM native asset price chart loads
    Given I have an EVM account with ETH on Ethereum Mainnet
    When I tap on ETH in my token list to open the token detail screen
    Then I see a price chart with historical price data
    And I can switch between time periods (1D, 1W, 1M, 3M, 1Y) and the chart updates

  Scenario: EVM ERC20 asset price chart loads
    Given I have an EVM account with an ERC20 token (e.g. USDC or LINK) on Ethereum Mainnet
    When I tap on the ERC20 token to open the token detail screen
    Then I see a price chart with historical price data
    And I can switch between time periods (1D, 1W, 1M, 3M, 1Y) and the chart updates

  Scenario: Non-EVM native asset price chart loads
    Given I have a Solana account with SOL
    When I tap on SOL in my token list to open the token detail screen
    Then I see a price chart with historical price data
    And I can switch between time periods (1D, 1W, 1M, 3M, 1Y) and the chart updates

  Scenario: Non-EVM (Solana) SPL token price chart loads
    Given I have a Solana account with an SPL token (e.g. USDC on Solana)
    When I tap on the SPL token to open the token detail screen
    Then I see a price chart with historical price data
    And I can switch between time periods (1D, 1W, 1M, 3M, 1Y) and the chart updates
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because non-EVM historical price fetching behavior changes from controller-backed Redux state to direct price API calls and now assumes a specific `asset.address` CAIP formatting (split on `/`).
> 
> **Overview**
> **Removes Redux/controller-backed multichain historical price plumbing.** `useTokenHistoricalPrices` no longer reads `MultichainAssetsRatesController.historicalPrices`, no longer depends on the selected non-EVM account, and deletes the `standardizeTimeInterval` mapping.
> 
> **Unifies historical price fetching via the price API for both EVM and non-EVM assets.** The hook now always builds a `price.api.cx.metamask.io/v3/historical-prices` URL, using CAIP chain IDs for non-EVM assets and deriving the non-EVM asset identifier from `asset.address`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a2980dc0b7bacfc661579b08c2596dc395f10a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->