### PR TITLE
chore: ohlcv reduce initial delay cp-7.78.0

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.test.ts
@@ -269,13 +269,15 @@ describe('useOHLCVRealtime', () => {
         jest.advanceTimersByTime(500);
       });
 
-      // Advance past staleness threshold (10s) + one check interval (5s)
+      // Advance past staleness threshold (5s) + one check interval (5s)
       await act(async () => {
-        jest.advanceTimersByTime(10_000 + 5_000);
+        jest.advanceTimersByTime(5_000 + 5_000);
       });
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      const fetchUrl = mockFetch.mock.calls[0][0] as string;
+      // Called twice: once immediately after subscribe, once from staleness check
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Check the last fetch call (from staleness check)
+      const fetchUrl = mockFetch.mock.calls[1][0] as string;
       expect(fetchUrl).toContain('price.api.cx.metamask.io/v3/ohlcv/');
       expect(fetchUrl).toContain('/latest');
       expect(fetchUrl).toContain('timePeriod=1d');
@@ -332,7 +334,8 @@ describe('useOHLCVRealtime', () => {
         jest.advanceTimersByTime(3_000);
       });
 
-      expect(mockFetch).not.toHaveBeenCalled();
+      // Only called once immediately after subscribe, not again since WS is active
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result.current.latestBar).not.toBeNull();
     });
 
@@ -367,9 +370,8 @@ describe('useOHLCVRealtime', () => {
         });
       });
 
-      // pollLatest() is called immediately when chain goes down
-      // No need to advance time for staleness check
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Called twice: once immediately after subscribe, once when chain goes down
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it('does not poll when chainStatusChanged is for a different chain', async () => {
@@ -391,12 +393,13 @@ describe('useOHLCVRealtime', () => {
         });
       });
 
-      // Advance but not past staleness threshold from subscribe time (10s)
+      // Advance but not past staleness threshold from subscribe time (5s)
       await act(async () => {
-        jest.advanceTimersByTime(5_000);
+        jest.advanceTimersByTime(3_000);
       });
 
-      expect(mockFetch).not.toHaveBeenCalled();
+      // Only called once immediately after subscribe, not again for different chain
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('handles REST API failure gracefully', async () => {
@@ -413,10 +416,11 @@ describe('useOHLCVRealtime', () => {
 
       // Force staleness
       await act(async () => {
-        jest.advanceTimersByTime(10_000 + 5_000);
+        jest.advanceTimersByTime(5_000 + 5_000);
       });
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Called twice: once immediately after subscribe, once from staleness check
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(result.current.latestBar).toBeNull();
     });
 

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
@@ -132,11 +132,6 @@ export function useOHLCVRealtime({
       const controller = new AbortController();
       pollingAbortRef.current = controller;
 
-      // eslint-disable-next-line no-console
-      console.log(
-        `[OHLCV Realtime] 📡 Fetching via REST API for ${assetId} ${interval}`,
-      );
-
       try {
         const bar = await fetchLatestBar(
           assetId,
@@ -148,22 +143,9 @@ export function useOHLCVRealtime({
         if (bar) {
           lastMessageTimeRef.current = Date.now();
           setLatestBar(bar);
-          // eslint-disable-next-line no-console
-          console.log(
-            `[OHLCV Realtime] ✅ REST bar received for ${assetId} ${interval}`,
-            {
-              timestamp: bar.timestamp,
-              close: bar.close,
-              source: 'REST',
-            },
-          );
         }
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `[OHLCV Realtime] ❌ REST fetch failed for ${assetId} ${interval}`,
-          err,
-        );
+      } catch {
+        // no-op
       }
     };
 
@@ -172,19 +154,6 @@ export function useOHLCVRealtime({
       bar: WSOHLCVBar;
     }) => {
       if (payload.channel === channelRef.current) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[OHLCV Realtime] 🔌 WebSocket bar received for ${assetId} ${interval}`,
-          {
-            channel: payload.channel,
-            bar: {
-              timestamp: payload.bar.timestamp,
-              close: payload.bar.close,
-            },
-            source: 'WEBSOCKET',
-          },
-        );
-        
         lastMessageTimeRef.current = Date.now();
         chainDownRef.current = false;
         setLatestBar(payload.bar);
@@ -263,7 +232,7 @@ export function useOHLCVRealtime({
 
         subscribedRef.current = true;
         lastMessageTimeRef.current = Date.now();
-        
+
         // Immediate poll for instant data, then staleness check handles rest
         pollLatest();
       } catch {

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
@@ -26,7 +26,7 @@ const DEBOUNCE_MS = 500;
 const STALENESS_CHECK_INTERVAL_MS = 5_000;
 
 /** If no WS message arrives within this window, consider the stream stale */
-const STALENESS_THRESHOLD_MS = 10_000;
+const STALENESS_THRESHOLD_MS = 5_000;
 
 const OHLCV_BASE_URL = 'https://price.api.cx.metamask.io/v3/ohlcv';
 
@@ -132,6 +132,11 @@ export function useOHLCVRealtime({
       const controller = new AbortController();
       pollingAbortRef.current = controller;
 
+      // eslint-disable-next-line no-console
+      console.log(
+        `[OHLCV Realtime] 📡 Fetching via REST API for ${assetId} ${interval}`,
+      );
+
       try {
         const bar = await fetchLatestBar(
           assetId,
@@ -143,9 +148,22 @@ export function useOHLCVRealtime({
         if (bar) {
           lastMessageTimeRef.current = Date.now();
           setLatestBar(bar);
+          // eslint-disable-next-line no-console
+          console.log(
+            `[OHLCV Realtime] ✅ REST bar received for ${assetId} ${interval}`,
+            {
+              timestamp: bar.timestamp,
+              close: bar.close,
+              source: 'REST',
+            },
+          );
         }
-      } catch {
-        // no-op
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[OHLCV Realtime] ❌ REST fetch failed for ${assetId} ${interval}`,
+          err,
+        );
       }
     };
 
@@ -154,6 +172,19 @@ export function useOHLCVRealtime({
       bar: WSOHLCVBar;
     }) => {
       if (payload.channel === channelRef.current) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[OHLCV Realtime] 🔌 WebSocket bar received for ${assetId} ${interval}`,
+          {
+            channel: payload.channel,
+            bar: {
+              timestamp: payload.bar.timestamp,
+              close: payload.bar.close,
+            },
+            source: 'WEBSOCKET',
+          },
+        );
+        
         lastMessageTimeRef.current = Date.now();
         chainDownRef.current = false;
         setLatestBar(payload.bar);
@@ -232,6 +263,9 @@ export function useOHLCVRealtime({
 
         subscribedRef.current = true;
         lastMessageTimeRef.current = Date.now();
+        
+        // Immediate poll for instant data, then staleness check handles rest
+        pollLatest();
       } catch {
         // Subscribe failure is handled via subscriptionError event → immediate REST poll.
       }

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
@@ -60,6 +60,16 @@ async function fetchLatestBar(
 
   if (!bar) return null;
 
+  // Validate that we have valid numeric data
+  if (
+    typeof bar.timestamp !== 'number' ||
+    typeof bar.close !== 'number' ||
+    Number.isNaN(bar.timestamp) ||
+    Number.isNaN(bar.close)
+  ) {
+    return null;
+  }
+
   return {
     timestamp: bar.timestamp / 1000,
     open: bar.open,

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVRealtime.ts
@@ -86,7 +86,7 @@ function extractChainId(assetId: string): string {
  *
  * Includes a staleness-based HTTP polling fallback:
  * - Tracks `lastMessageTime` on every WS bar received.
- * - Every 5 seconds checks if no WS message arrived within the last 10 seconds.
+ * - Every 5 seconds checks if no WS message arrived within the last 5 seconds.
  * - On subscribe error or chain-down, immediately polls `/latest` (no wait).
  * - When stale, continues polling `/latest` every 5s (matching WS heartbeat).
  */
@@ -205,7 +205,7 @@ export function useOHLCVRealtime({
     stalenessTimerRef.current = setInterval(() => {
       const elapsed = Date.now() - lastMessageTimeRef.current;
       const isStale =
-        lastMessageTimeRef.current > 0 && elapsed > STALENESS_THRESHOLD_MS;
+        lastMessageTimeRef.current > 0 && elapsed >= STALENESS_THRESHOLD_MS;
 
       if (isStale || chainDownRef.current) {
         pollLatest();


### PR DESCRIPTION


## **Description**

## Problem
Chart data took ~9-10 seconds to display after navigating to token details. Performance logs showed it takes approximately 9.4 seconds from WebSocket subscription until the first bar update arrives from the server.

## Solution
Implemented immediate REST API polling to provide data while waiting for the first WebSocket update:

1. **Reduced staleness threshold** from 10s to 5s
2. **Added immediate data fetch** via REST API right after WebSocket subscription

## Timeline Observed
```
T=0ms     - Subscribe to WebSocket
T=~300ms  - First REST data arrives (immediate!)
T=5s      - Second REST poll (WebSocket not ready yet)
T=9.4s    - First WebSocket update arrives, REST polling stops
T=14.4s+  - WebSocket continues with regular updates (~5s intervals)
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: OHLCV chart data now loads in ~300ms via REST API while establishing WebSocket connection, reducing initial load time from 9.4s to 300ms.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chart data fetching timing by triggering immediate REST polls and a shorter staleness threshold, which could increase network traffic or cause unexpected polling behavior if timing assumptions are wrong.
> 
> **Overview**
> Reduces perceived OHLCV chart load time by **polling the `/latest` REST endpoint immediately after a successful WebSocket subscribe**, instead of waiting for the first WS bar.
> 
> Shortens the WS staleness threshold from `10s` to `5s`, tweaks stale detection to use `>=`, and adds basic numeric validation in `fetchLatestBar` to drop malformed REST responses. Tests are updated to reflect the new timing and the additional initial REST fetch (many cases now expect **two** `fetch` calls: immediate + staleness/chain-down).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d5c11686b45c04a81c22a98d7a6c94d890278a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->