### PR TITLE
feat(rewards): always fetch /vip/fees for perps discount regardless of local VIP flag

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -173,17 +173,25 @@ export type RewardsControllerGetOptInStatusAction = {
 /**
  * Get perps fee discount for an account.
  *
- * When the account's active subscription has VIP enabled, this calls the
- * authenticated `/vip/fees` endpoint and converts the absolute VIP builder
- * fee into a discount fraction relative to `baseFeeBips`. Non-VIP accounts
- * receive no discount.
+ * Calls the authenticated `/vip/fees` endpoint (bypassing the local
+ * `subscription.features.vip.enabled` flag — the backend is the source of
+ * truth) and converts the absolute VIP builder fee into a discount fraction
+ * relative to `baseFeeBips`. Responses are cached per-subscription for
+ * `VIP_PERPS_FEES_CACHE_THRESHOLD_MS`. When the backend returns a valid fee
+ * response the controller also flips the subscription's
+ * `features.vip.enabled` flag to `true` so the rest of the app reflects the
+ * user's VIP status.
  *
  * @param account - The account address in CAIP-10 format
  * @param baseFeeBips - The perps MetaMask builder base fee in basis points
  * that the caller would apply absent any discount. Used to convert the VIP
  * absolute fee into a discount fraction (caller owns the source of truth
  * for the base fee; the controller is a pure transformer).
- * @returns Promise resolving to the discount in basis points (0-10000), or null when we can't determine the discount.
+ * @returns Promise<number | null> — Discount in basis points (0-10000), or
+ * null when the discount is currently unknowable (rewards disabled, no
+ * subscription, unhydrated cache, fetch error). Callers should treat null
+ * as "no discount available yet" and retry next call. A literal 0 means
+ * "no discount applies" (tier-0 / non-VIP response, out-of-range bips).
  */
 export type RewardsControllerGetPerpsDiscountForAccountAction = {
   type: `RewardsController:getPerpsDiscountForAccount`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -3966,7 +3966,7 @@ describe('RewardsController', () => {
           },
           isDisabled: () => false,
         });
-        mockMessenger.call.mockImplementation((method): any => {
+        mockMessenger.call.mockImplementation((method, ..._args): any => {
           if (method === 'RewardsDataService:getVipFees') {
             return Promise.resolve({
               vipTier: 0,
@@ -4016,7 +4016,7 @@ describe('RewardsController', () => {
           },
           isDisabled: () => false,
         });
-        mockMessenger.call.mockImplementation((method): any => {
+        mockMessenger.call.mockImplementation((method, ..._args): any => {
           if (method === 'RewardsDataService:getVipFees') {
             return Promise.resolve(buildVipFeesResponse('5'));
           }
@@ -4044,7 +4044,7 @@ describe('RewardsController', () => {
         const deferred = new Promise<VipFeesResponseDto>((res) => {
           resolveVipFees = res;
         });
-        mockMessenger.call.mockImplementation((method): any => {
+        mockMessenger.call.mockImplementation((method, ..._args): any => {
           if (method === 'RewardsDataService:getVipFees') {
             return deferred;
           }
@@ -4086,7 +4086,8 @@ describe('RewardsController', () => {
         // Only one network call despite two concurrent requests
         expect(
           mockMessenger.call.mock.calls.filter(
-            ([m]: [string]) => m === 'RewardsDataService:getVipFees',
+            ([m, ..._rest]: [string, ...unknown[]]) =>
+              m === 'RewardsDataService:getVipFees',
           ),
         ).toHaveLength(1);
       });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -3776,22 +3776,22 @@ describe('RewardsController', () => {
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is negative', async () => {
-        buildController('-5'); // caught by the <= 0 guard before range check
+      it('returns null and logs when the VIP builder fee is negative', async () => {
+        buildController('-5'); // caught by the < 0 guard
 
         const result = await controller.getPerpsDiscountForAccount(
           VIP_COERCED_ACCOUNT,
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(0);
+        expect(result).toBeNull();
         expect(Logger.log).toHaveBeenCalledWith(
           'RewardsController: VIP fees returned an invalid builderFeeBips:',
           '-5',
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is 0 (closes 100%-discount loophole)', async () => {
+      it('returns 10000 when the VIP builder fee is 0 (full discount, boundary)', async () => {
         buildController('0');
 
         const result = await controller.getPerpsDiscountForAccount(
@@ -3799,14 +3799,17 @@ describe('RewardsController', () => {
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(0);
-        expect(Logger.log).toHaveBeenCalledWith(
+        expect(result).toBe(10000);
+        expect(Logger.log).not.toHaveBeenCalledWith(
           'RewardsController: VIP fees returned an invalid builderFeeBips:',
-          '0',
+          expect.anything(),
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is an empty string', async () => {
+      it('returns 0 when the VIP builder fee is an empty string (treated as missing fee)', async () => {
+        // Empty string is caught by the tier-0 guard (!builderFeeBips is true
+        // for '') before the parseFloat validation is reached. This is the same
+        // behaviour as the extension.
         buildController('');
 
         const result = await controller.getPerpsDiscountForAccount(
@@ -3815,13 +3818,13 @@ describe('RewardsController', () => {
         );
 
         expect(result).toBe(0);
-        expect(Logger.log).toHaveBeenCalledWith(
+        expect(Logger.log).not.toHaveBeenCalledWith(
           'RewardsController: VIP fees returned an invalid builderFeeBips:',
-          '',
+          expect.anything(),
         );
       });
 
-      it('returns 0 and logs when the VIP builder fee is non-numeric', async () => {
+      it('returns null and logs when the VIP builder fee is non-numeric', async () => {
         buildController('abc');
 
         const result = await controller.getPerpsDiscountForAccount(
@@ -3829,7 +3832,7 @@ describe('RewardsController', () => {
           BASE_FEE_BIPS,
         );
 
-        expect(result).toBe(0);
+        expect(result).toBeNull();
         expect(Logger.log).toHaveBeenCalledWith(
           'RewardsController: VIP fees returned an invalid builderFeeBips:',
           'abc',
@@ -3940,7 +3943,7 @@ describe('RewardsController', () => {
         expect(mockMessenger.call).not.toHaveBeenCalled();
       });
 
-      it('returns 0 when the subscription is not VIP-enabled', async () => {
+      it('calls /vip/fees even when subscription is not locally flagged VIP, returns 0 for tier-0 response', async () => {
         controller = new RewardsController({
           messenger: mockMessenger,
           state: {
@@ -3963,6 +3966,16 @@ describe('RewardsController', () => {
           },
           isDisabled: () => false,
         });
+        mockMessenger.call.mockImplementation((method): any => {
+          if (method === 'RewardsDataService:getVipFees') {
+            return Promise.resolve({
+              vipTier: 0,
+              fees: null,
+              updatedAt: null,
+            } as VipFeesResponseDto);
+          }
+          return Promise.resolve(undefined);
+        });
 
         const result = await controller.getPerpsDiscountForAccount(
           VIP_COERCED_ACCOUNT,
@@ -3970,7 +3983,112 @@ describe('RewardsController', () => {
         );
 
         expect(result).toBe(0);
-        expect(mockMessenger.call).not.toHaveBeenCalled();
+        expect(mockMessenger.call).toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          SUB_VIP,
+        );
+        // Tier-0: subscription must NOT be promoted to VIP
+        expect(
+          controller.state.subscriptions[SUB_VIP]?.features?.vip?.enabled,
+        ).toBe(false);
+      });
+
+      it('calls /vip/fees even when subscription is not locally flagged VIP, promotes VIP status on valid fee response', async () => {
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: {
+              [SUB_VIP]: {
+                ...vipSubscription,
+                features: { vip: { enabled: false } },
+              },
+            },
+          },
+          isDisabled: () => false,
+        });
+        mockMessenger.call.mockImplementation((method): any => {
+          if (method === 'RewardsDataService:getVipFees') {
+            return Promise.resolve(buildVipFeesResponse('5'));
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const result = await controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        expect(result).toBe(5000);
+        expect(mockMessenger.call).toHaveBeenCalledWith(
+          'RewardsDataService:getVipFees',
+          SUB_VIP,
+        );
+        // Backend confirmed VIP → subscription flag promoted to true
+        expect(
+          controller.state.subscriptions[SUB_VIP]?.features?.vip?.enabled,
+        ).toBe(true);
+      });
+
+      it('deduplicates concurrent /vip/fees fetches for the same subscriptionId', async () => {
+        let resolveVipFees!: (v: VipFeesResponseDto) => void;
+        const deferred = new Promise<VipFeesResponseDto>((res) => {
+          resolveVipFees = res;
+        });
+        mockMessenger.call.mockImplementation((method): any => {
+          if (method === 'RewardsDataService:getVipFees') {
+            return deferred;
+          }
+          return Promise.resolve(undefined);
+        });
+        controller = new RewardsController({
+          messenger: mockMessenger,
+          state: {
+            ...getRewardsControllerDefaultState(),
+            accounts: {
+              [VIP_COERCED_ACCOUNT]: {
+                account: VIP_COERCED_ACCOUNT,
+                hasOptedIn: true,
+                subscriptionId: SUB_VIP,
+                perpsFeeDiscount: null,
+                lastPerpsDiscountRateFetched: null,
+              } as RewardsAccountState,
+            },
+            subscriptions: { [SUB_VIP]: vipSubscription },
+          },
+          isDisabled: () => false,
+        });
+
+        // Fire two concurrent calls before the first resolves
+        const p1 = controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+        const p2 = controller.getPerpsDiscountForAccount(
+          VIP_COERCED_ACCOUNT,
+          BASE_FEE_BIPS,
+        );
+
+        resolveVipFees(buildVipFeesResponse('5'));
+        const [r1, r2] = await Promise.all([p1, p2]);
+
+        expect(r1).toBe(5000);
+        expect(r2).toBe(5000);
+        // Only one network call despite two concurrent requests
+        expect(
+          mockMessenger.call.mock.calls.filter(
+            ([m]: [string]) => m === 'RewardsDataService:getVipFees',
+          ),
+        ).toHaveLength(1);
       });
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -515,6 +515,11 @@ export class RewardsController extends BaseController<
   #isBitcoinOptinEnabled: () => boolean;
   #isTronOptinEnabled: () => boolean;
   #reauthPromises: Map<string, Promise<void>> = new Map();
+
+  // Deduplicates concurrent /vip/fees fetches for the same subscriptionId.
+  // Cleared when the promise settles (success or failure).
+  #vipFeesFetchInFlight: Map<string, Promise<VipFeesResponseDto | 0>> =
+    new Map();
   #perpsTradingParticipantOutcomeCache: Map<
     string,
     {
@@ -1622,17 +1627,25 @@ export class RewardsController extends BaseController<
   /**
    * Get perps fee discount for an account.
    *
-   * When the account's active subscription has VIP enabled, this calls the
-   * authenticated `/vip/fees` endpoint and converts the absolute VIP builder
-   * fee into a discount fraction relative to `baseFeeBips`. Non-VIP accounts
-   * receive no discount.
+   * Calls the authenticated `/vip/fees` endpoint (bypassing the local
+   * `subscription.features.vip.enabled` flag — the backend is the source of
+   * truth) and converts the absolute VIP builder fee into a discount fraction
+   * relative to `baseFeeBips`. Responses are cached per-subscription for
+   * `VIP_PERPS_FEES_CACHE_THRESHOLD_MS`. When the backend returns a valid fee
+   * response the controller also flips the subscription's
+   * `features.vip.enabled` flag to `true` so the rest of the app reflects the
+   * user's VIP status.
    *
    * @param account - The account address in CAIP-10 format
    * @param baseFeeBips - The perps MetaMask builder base fee in basis points
    * that the caller would apply absent any discount. Used to convert the VIP
    * absolute fee into a discount fraction (caller owns the source of truth
    * for the base fee; the controller is a pure transformer).
-   * @returns Promise resolving to the discount in basis points (0-10000), or null when we can't determine the discount.
+   * @returns Promise<number | null> — Discount in basis points (0-10000), or
+   * null when the discount is currently unknowable (rewards disabled, no
+   * subscription, unhydrated cache, fetch error). Callers should treat null
+   * as "no discount available yet" and retry next call. A literal 0 means
+   * "no discount applies" (tier-0 / non-VIP response, out-of-range bips).
    */
   async getPerpsDiscountForAccount(
     account: CaipAccountId,
@@ -1649,10 +1662,11 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Resolve a VIP-driven perps discount for the given account. Returns null
-   * when the account isn't on a VIP-enabled subscription or the fetch fails
-   * — callers should treat null as "no discount" (0). Returns 0 when the
-   * backend returns no builder fee (fees=null) or an invalid builderFeeBips.
+   * Resolve a VIP-driven perps discount for the given account. Always calls
+   * /vip/fees (cached) regardless of local VIP status — the backend is the
+   * source of truth. Returns null when the discount is currently unknowable
+   * (invalid input, no subscription, fetch error). Returns 0 when no discount
+   * applies (tier-0 response, out-of-range bips).
    */
   async #getVipPerpsDiscountBips(
     account: CaipAccountId,
@@ -1666,7 +1680,6 @@ export class RewardsController extends BaseController<
 
     const subscription = this.state.subscriptions[subscriptionId];
     if (!subscription) return null;
-    if (!subscription?.features?.vip?.enabled) return 0;
 
     let builderFeeBipsRaw: string;
     const cached = this.state.vipPerpsFees[subscriptionId];
@@ -1676,25 +1689,57 @@ export class RewardsController extends BaseController<
     ) {
       builderFeeBipsRaw = cached.hyperliquidBuilderFeeBips;
     } else {
-      try {
-        const vipFeeResponse: VipFeesResponseDto = await this.#withAuthRetry(
+      // Deduplicate concurrent fetches: if there's already an in-flight
+      // request for this subscriptionId, await it instead of firing another.
+      let inFlight = this.#vipFeesFetchInFlight.get(subscriptionId);
+      if (!inFlight) {
+        inFlight = this.#withAuthRetry(
           () =>
             this.messenger.call(
               'RewardsDataService:getVipFees',
               subscriptionId,
             ),
           subscriptionId,
-        );
-        const rawBuilderFee = vipFeeResponse?.fees?.hyperliquid?.builderFeeBips;
-        if (rawBuilderFee == null) return 0;
-        builderFeeBipsRaw = rawBuilderFee;
-        const next: VipPerpsFeesState = {
-          hyperliquidBuilderFeeBips: builderFeeBipsRaw,
-          lastFetched: Date.now(),
-        };
-        this.update((state) => {
-          state.vipPerpsFees[subscriptionId] = next;
+        ).then((vipFeeResponse): VipFeesResponseDto | 0 => {
+          // Tier-0 response: backend says no VIP fees — return sentinel 0
+          // without caching so the next call re-checks.
+          if (
+            !vipFeeResponse?.fees ||
+            vipFeeResponse.vipTier <= 0 ||
+            !vipFeeResponse.fees.hyperliquid?.builderFeeBips
+          ) {
+            return 0;
+          }
+          const rawBips = vipFeeResponse.fees.hyperliquid.builderFeeBips;
+          const next: VipPerpsFeesState = {
+            hyperliquidBuilderFeeBips: rawBips,
+            lastFetched: Date.now(),
+          };
+          this.update((state) => {
+            state.vipPerpsFees[subscriptionId] = next;
+            // Promote the subscription's VIP flag so the rest of the app
+            // reflects the user's VIP status without waiting for a full refresh.
+            const subState = state.subscriptions[subscriptionId];
+            if (subState) {
+              subState.features = {
+                ...subState.features,
+                vip: { enabled: true },
+              };
+            }
+          });
+          return vipFeeResponse;
         });
+        this.#vipFeesFetchInFlight.set(subscriptionId, inFlight);
+        const cleanup = () =>
+          this.#vipFeesFetchInFlight.delete(subscriptionId);
+        inFlight.then(cleanup, cleanup);
+      }
+
+      try {
+        const result = await inFlight;
+        if (result === 0) return 0;
+        const feeResponse = result as VipFeesResponseDto;
+        builderFeeBipsRaw = feeResponse.fees!.hyperliquid.builderFeeBips;
       } catch (error) {
         Logger.log(
           'RewardsController: VIP fees fetch failed; returning no discount:',
@@ -1705,18 +1750,17 @@ export class RewardsController extends BaseController<
     }
 
     const builderFeeBips = parseFloat(builderFeeBipsRaw);
-    if (!Number.isFinite(builderFeeBips) || builderFeeBips <= 0) {
+    if (!Number.isFinite(builderFeeBips) || builderFeeBips < 0) {
       Logger.log(
         'RewardsController: VIP fees returned an invalid builderFeeBips:',
         builderFeeBipsRaw,
       );
-      return 0;
+      return null;
     }
 
-    // Valid range is [0, 10000]: 0 means VIP fee equals base (no discount),
-    // 10000 means VIP fee is 0 (100% discount). Anything outside that range
-    // would require a negative builder fee or one larger than the base —
-    // both indicate backend misconfig, so log and return 0.
+    // Valid range is [0, 10000]: 0 means free (100% discount), 10000 is
+    // unreachable (VIP fee would have to be negative). Anything outside
+    // [0, 10000] indicates backend misconfig — log and return 0.
     const rawDiscountBips = Math.round(
       10000 * (1 - builderFeeBips / baseFeeBips),
     );

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1730,8 +1730,7 @@ export class RewardsController extends BaseController<
           return vipFeeResponse;
         });
         this.#vipFeesFetchInFlight.set(subscriptionId, inFlight);
-        const cleanup = () =>
-          this.#vipFeesFetchInFlight.delete(subscriptionId);
+        const cleanup = () => this.#vipFeesFetchInFlight.delete(subscriptionId);
         inFlight.then(cleanup, cleanup);
       }
 
@@ -1739,7 +1738,8 @@ export class RewardsController extends BaseController<
         const result = await inFlight;
         if (result === 0) return 0;
         const feeResponse = result as VipFeesResponseDto;
-        builderFeeBipsRaw = feeResponse.fees!.hyperliquid.builderFeeBips;
+        if (!feeResponse.fees) return null;
+        builderFeeBipsRaw = feeResponse.fees.hyperliquid.builderFeeBips;
       } catch (error) {
         Logger.log(
           'RewardsController: VIP fees fetch failed; returning no discount:',


### PR DESCRIPTION
## Description

Mirrors the extension change in [metamask-extension#42606](https://github.com/MetaMask/metamask-extension/pull/42606) for mobile.

The `RewardsController.getPerpsDiscountForAccount` previously short-circuited with `return 0` when `subscription.features.vip.enabled` was `false` in local state. This meant a user who was actually VIP would get no discount until a full subscription refresh happened to flip that flag.

### What changed

- **Remove the VIP gate**: `#getVipPerpsDiscountBips` no longer short-circuits on `!subscription.features.vip.enabled`. It always calls `/vip/fees` (the backend is the source of truth).
- **In-flight deduplication**: added `#vipFeesFetchInFlight: Map<string, Promise>` — concurrent calls for the same subscription share one network round-trip instead of firing duplicate requests.
- **VIP promotion on valid response**: when the backend returns a valid builder fee, the controller now flips `subscription.features.vip.enabled = true` in state so the rest of the app reflects VIP status without waiting for a full refresh.
- **Align invalid-fee semantics with extension**:
  - Negative / NaN `builderFeeBips` → `null` (unknowable, caller retries)
  - `builderFeeBips = 0` → valid 100% discount (10000 bips) — previously rejected as invalid

Cache behaviour and TTL (5 min, per-subscription) are unchanged.

## Manual testing steps

1. With a subscription where `features.vip.enabled = false` locally but the user is actually VIP on the backend: open the perps order entry screen and confirm the discounted fee is applied.
2. Confirm `/vip/fees` is called once, not twice, when two concurrent fee lookups fire for the same subscription (check network panel or logging).
3. After a valid VIP fee response, confirm `features.vip.enabled` flips to `true` in state.
4. With a non-VIP subscription (tier-0 response from backend): confirm fee stays at base rate and no error is thrown.

## Changelog

CHANGELOG entry: null

## Related

- Extension mirror: MetaMask/metamask-extension#42606

Co-authored-by: VGR-GIT <vangulckrik@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perps fee discount resolution to always hit the authenticated `/vip/fees` path (with new in-flight deduplication and state promotion), which can affect pricing/discount behavior and introduce subtle caching/state-update edge cases.
> 
> **Overview**
> Updates `RewardsController.getPerpsDiscountForAccount` to **always fetch** authenticated VIP perps fees (cached) regardless of the local `subscription.features.vip.enabled` flag, treating the backend as the source of truth.
> 
> Adds **in-flight request deduplication** per `subscriptionId` for `/vip/fees` and, on a valid VIP fee response, **promotes** `subscription.features.vip.enabled` to `true` in controller state so the rest of the app reflects VIP status immediately.
> 
> Adjusts discount semantics to match the extension: `builderFeeBips=0` now yields a full `10000` bips discount, while negative/NaN fees return `null` (retryable) instead of `0`; tests and action-type docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f123e4b4d4aeabf5cc8d35cb79c429447e2126af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->