### PR TITLE
feat(rewards): resurrect opt-out with soft-delete confirmation flow

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -37,17 +37,27 @@ jest.mock('@metamask/design-system-twrnc-preset', () => {
   };
 });
 
-// Mock RewardSettingsAccountGroupList component
+// Mock RewardSettingsAccountGroupList component — exposes onRequestOptOut via a pressable
 jest.mock('../components/Settings/RewardSettingsAccountGroupList', () => {
-  const { View, Text } = jest.requireActual('react-native');
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: function MockRewardSettingsAccountGroupList() {
+    default: function MockRewardSettingsAccountGroupList({
+      onRequestOptOut,
+    }: {
+      onRequestOptOut?: () => void;
+    }) {
       const ReactActual = jest.requireActual('react');
       return ReactActual.createElement(
         View,
         { testID: 'reward-settings-account-group-list' },
         ReactActual.createElement(Text, null, 'Account Group List'),
+        onRequestOptOut
+          ? ReactActual.createElement(TouchableOpacity, {
+              testID: 'trigger-opt-out',
+              onPress: onRequestOptOut,
+            })
+          : null,
       );
     },
   };
@@ -119,6 +129,48 @@ jest.mock('../components/RewardsInfoBanner', () => {
   };
 });
 
+// Mock OptOutConfirmationSheet — exposes confirm and close buttons for interaction tests
+const mockOptout = jest.fn();
+jest.mock('../hooks/useOptout', () => ({
+  useOptout: () => ({
+    optout: mockOptout,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../components/Settings/OptOutConfirmationSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, TouchableOpacity } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      onConfirm,
+      onClose,
+      errorMessage,
+    }: {
+      onConfirm?: () => void;
+      onClose?: () => void;
+      isLoading?: boolean;
+      errorMessage?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'opt-out-confirmation-sheet' },
+        ReactActual.createElement(TouchableOpacity, {
+          testID: 'opt-out-confirm-button',
+          onPress: onConfirm,
+        }),
+        ReactActual.createElement(TouchableOpacity, {
+          testID: 'opt-out-close-button',
+          onPress: onClose,
+        }),
+        errorMessage
+          ? ReactActual.createElement(View, { testID: 'opt-out-error-banner' })
+          : null,
+      ),
+  };
+});
+
 // Mock LinkedOffDeviceAccountsSheet — renders with a close button for interaction tests
 jest.mock('../components/Settings/LinkedOffDeviceAccountsSheet', () => {
   const ReactActual = jest.requireActual('react');
@@ -176,6 +228,7 @@ describe('RewardsSettingsView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOptout.mockResolvedValue(true);
     store = createMockStore();
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
@@ -407,6 +460,79 @@ describe('RewardsSettingsView', () => {
 
       fireEvent.press(getByTestId('rewards-info-banner'));
       expect(getByTestId('linked-off-device-accounts-sheet')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Opt-out sheet', () => {
+    it('does not render the opt-out sheet on initial mount', () => {
+      const { queryByTestId } = renderWithNavigation(<RewardsSettingsView />);
+      expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+    });
+
+    it('opens the opt-out sheet when onRequestOptOut is triggered', () => {
+      const { getByTestId } = renderWithNavigation(<RewardsSettingsView />);
+      fireEvent.press(getByTestId('trigger-opt-out'));
+      expect(getByTestId('opt-out-confirmation-sheet')).toBeOnTheScreen();
+    });
+
+    it('closes the opt-out sheet when onClose is called', () => {
+      const { getByTestId, queryByTestId } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+      fireEvent.press(getByTestId('trigger-opt-out'));
+      expect(getByTestId('opt-out-confirmation-sheet')).toBeOnTheScreen();
+
+      fireEvent.press(getByTestId('opt-out-close-button'));
+      expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+    });
+
+    it('closes the sheet after a successful opt-out', async () => {
+      mockOptout.mockResolvedValueOnce(true);
+      const { getByTestId, queryByTestId } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+      fireEvent.press(getByTestId('trigger-opt-out'));
+
+      await act(async () => {
+        fireEvent.press(getByTestId('opt-out-confirm-button'));
+      });
+
+      expect(mockOptout).toHaveBeenCalledTimes(1);
+      expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+    });
+
+    it('keeps the sheet open and shows error when opt-out fails', async () => {
+      mockOptout.mockResolvedValueOnce(false);
+      const { getByTestId } = renderWithNavigation(<RewardsSettingsView />);
+      fireEvent.press(getByTestId('trigger-opt-out'));
+
+      await act(async () => {
+        fireEvent.press(getByTestId('opt-out-confirm-button'));
+      });
+
+      expect(mockOptout).toHaveBeenCalledTimes(1);
+      expect(getByTestId('opt-out-confirmation-sheet')).toBeOnTheScreen();
+      expect(getByTestId('opt-out-error-banner')).toBeOnTheScreen();
+    });
+
+    it('clears the error message when the sheet is closed and reopened', async () => {
+      mockOptout.mockResolvedValueOnce(false);
+      const { getByTestId, queryByTestId } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+
+      // Trigger failure to set error
+      fireEvent.press(getByTestId('trigger-opt-out'));
+      await act(async () => {
+        fireEvent.press(getByTestId('opt-out-confirm-button'));
+      });
+      expect(getByTestId('opt-out-error-banner')).toBeOnTheScreen();
+
+      // Close and reopen
+      fireEvent.press(getByTestId('opt-out-close-button'));
+      fireEvent.press(getByTestId('trigger-opt-out'));
+
+      expect(queryByTestId('opt-out-error-banner')).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -11,7 +11,9 @@ import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import RewardSettingsAccountGroupList from '../components/Settings/RewardSettingsAccountGroupList';
 import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import LinkedOffDeviceAccountsSheet from '../components/Settings/LinkedOffDeviceAccountsSheet';
+import OptOutConfirmationSheet from '../components/Settings/OptOutConfirmationSheet';
 import { useLinkedOffDeviceAccounts } from '../hooks/useLinkedOffDeviceAccounts';
+import { useOptout } from '../hooks/useOptout';
 
 export const REWARDS_SETTINGS_SAFE_AREA_TEST_ID = 'rewards-settings-safe-area';
 
@@ -21,9 +23,14 @@ const RewardsSettingsView: React.FC = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const hasTrackedSettingsViewed = useRef(false);
   const [isOffDeviceSheetOpen, setIsOffDeviceSheetOpen] = useState(false);
+  const [isOptOutSheetOpen, setIsOptOutSheetOpen] = useState(false);
+  const [optOutErrorMessage, setOptOutErrorMessage] = useState<
+    string | undefined
+  >();
 
   // Computes off-device accounts; internally fetches subscription accounts from the backend
   const offDeviceAccounts = useLinkedOffDeviceAccounts();
+  const { optout, isLoading: isOptOutLoading } = useOptout();
 
   useTrackRewardsPageView({ page_type: 'settings' });
 
@@ -34,6 +41,26 @@ const RewardsSettingsView: React.FC = () => {
   const handleCloseOffDeviceSheet = useCallback(() => {
     setIsOffDeviceSheetOpen(false);
   }, []);
+
+  const handleRequestOptOut = useCallback(() => {
+    setOptOutErrorMessage(undefined);
+    setIsOptOutSheetOpen(true);
+  }, []);
+
+  const handleOptOutClose = useCallback(() => {
+    setIsOptOutSheetOpen(false);
+    setOptOutErrorMessage(undefined);
+  }, []);
+
+  const handleOptOutConfirm = useCallback(async () => {
+    setOptOutErrorMessage(undefined);
+    const success = await optout();
+    if (success) {
+      setIsOptOutSheetOpen(false);
+    } else {
+      setOptOutErrorMessage(strings('rewards.optout.modal.error_message'));
+    }
+  }, [optout]);
 
   useEffect(() => {
     if (!hasTrackedSettingsViewed.current) {
@@ -73,13 +100,24 @@ const RewardsSettingsView: React.FC = () => {
               />
             </Box>
           )}
-          <RewardSettingsAccountGroupList />
+          <RewardSettingsAccountGroupList
+            onRequestOptOut={handleRequestOptOut}
+          />
         </Box>
 
         {isOffDeviceSheetOpen && (
           <LinkedOffDeviceAccountsSheet
             accounts={offDeviceAccounts}
             onClose={handleCloseOffDeviceSheet}
+          />
+        )}
+
+        {isOptOutSheetOpen && (
+          <OptOutConfirmationSheet
+            isLoading={isOptOutLoading}
+            errorMessage={optOutErrorMessage}
+            onConfirm={handleOptOutConfirm}
+            onClose={handleOptOutClose}
           />
         )}
       </SafeAreaView>

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
@@ -13,6 +13,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.optout.modal.confirm_phrase': 'erase progress',
       'rewards.optout.modal.cancel': 'Cancel',
       'rewards.optout.modal.confirm': 'Confirm',
+      'rewards.optout.modal.error_title': 'Something went wrong',
       'rewards.optout.modal.error_message':
         'Failed to opt out of Rewards. Please try again.',
     };

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OptOutConfirmationSheet from './OptOutConfirmationSheet';
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const map: Record<string, string> = {
+      'rewards.optout.modal.confirmation_title': 'Are you sure?',
+      'rewards.optout.modal.confirmation_description':
+        "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+      'rewards.optout.modal.type_to_confirm': "Type 'erase progress' to continue",
+      'rewards.optout.modal.confirm_phrase': 'erase progress',
+      'rewards.optout.modal.cancel': 'Cancel',
+      'rewards.optout.modal.confirm': 'Confirm',
+      'rewards.optout.modal.error_message': 'Failed to opt out of Rewards. Please try again.',
+    };
+    return map[key] || key;
+  }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text: RNText, View, TouchableOpacity } = jest.requireActual('react-native');
+
+  return {
+    Box: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(View, { testID, ...props }, children),
+    Text: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(RNText, { testID, ...props }, children),
+    Button: ({ children, onPress, testID, isDisabled, isLoading, isDanger, ...props }: { children?: React.ReactNode; onPress?: () => void; testID?: string; isDisabled?: boolean; isLoading?: boolean; isDanger?: boolean; [key: string]: unknown }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { onPress: isDisabled || isLoading ? undefined : onPress, testID, disabled: isDisabled || isLoading, ...props },
+        ReactActual.createElement(RNText, {}, children),
+      ),
+    ButtonIcon: ({ onPress, testID, ...props }: { onPress?: () => void; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(TouchableOpacity, { onPress, testID, ...props }),
+    BottomSheet: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) =>
+      ReactActual.createElement(View, { testID: 'bottom-sheet', onTouchEnd: onClose }, children),
+    TextVariant: { HeadingSm: 'HeadingSm', BodyMd: 'BodyMd', BodySm: 'BodySm' },
+    FontWeight: { Bold: 'Bold' },
+    ButtonVariant: { Primary: 'Primary', Secondary: 'Secondary' },
+    ButtonSize: { Lg: 'Lg' },
+    BoxFlexDirection: { Row: 'row' },
+    BoxAlignItems: { Center: 'center' },
+    BoxJustifyContent: { Center: 'center' },
+    IconName: { Close: 'Close' },
+    IconColor: { IconDefault: 'IconDefault' },
+  };
+});
+
+jest.mock('../../../../../component-library/components/Form/TextField', () => {
+  const ReactActual = jest.requireActual('react');
+  const { TextInput } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ value, onChangeText, testID, placeholder, ...props }: { value?: string; onChangeText?: (text: string) => void; testID?: string; placeholder?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(TextInput, { value, onChangeText, testID, placeholder, ...props }),
+  };
+});
+
+jest.mock('../RewardsErrorBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID, title }: { testID?: string; title?: string }) =>
+      ReactActual.createElement(View, { testID }, ReactActual.createElement(RNText, {}, title)),
+  };
+});
+
+describe('OptOutConfirmationSheet', () => {
+  const defaultProps = {
+    isLoading: false,
+    errorMessage: undefined,
+    onConfirm: jest.fn(),
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title, description, and input label', () => {
+    const { getByTestId, getByText } = render(
+      <OptOutConfirmationSheet {...defaultProps} />,
+    );
+    expect(getByTestId('opt-out-confirmation-title')).toBeTruthy();
+    expect(getByText('Are you sure?')).toBeTruthy();
+    expect(getByTestId('opt-out-confirmation-description')).toBeTruthy();
+    expect(getByTestId('opt-out-confirmation-input-label')).toBeTruthy();
+    expect(getByText("Type 'erase progress' to continue")).toBeTruthy();
+  });
+
+  it('renders the text input', () => {
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} />,
+    );
+    expect(getByTestId('opt-out-confirmation-input')).toBeTruthy();
+  });
+
+  it('does not call onConfirm when phrase does not match', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onConfirm={onConfirm} />,
+    );
+    const input = getByTestId('opt-out-confirmation-input');
+    fireEvent.changeText(input, 'wrong phrase');
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('confirm button calls onConfirm when input matches phrase exactly', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onConfirm={onConfirm} />,
+    );
+    const input = getByTestId('opt-out-confirmation-input');
+    fireEvent.changeText(input, 'erase progress');
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirm button matches phrase case-insensitively', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onConfirm={onConfirm} />,
+    );
+    const input = getByTestId('opt-out-confirmation-input');
+    fireEvent.changeText(input, 'ERASE PROGRESS');
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirm button matches phrase with leading/trailing spaces', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onConfirm={onConfirm} />,
+    );
+    const input = getByTestId('opt-out-confirmation-input');
+    fireEvent.changeText(input, '  erase progress  ');
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onConfirm when input is empty', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onConfirm={onConfirm} />,
+    );
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when cancel is pressed', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('opt-out-confirmation-cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when close icon is pressed', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('opt-out-confirmation-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error banner when errorMessage is provided', () => {
+    const { getByTestId, getByText } = render(
+      <OptOutConfirmationSheet
+        {...defaultProps}
+        errorMessage="Failed to opt out of Rewards. Please try again."
+      />,
+    );
+    expect(getByTestId('opt-out-error-banner')).toBeTruthy();
+  });
+
+  it('does not show error banner when errorMessage is undefined', () => {
+    const { queryByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} errorMessage={undefined} />,
+    );
+    expect(queryByTestId('opt-out-error-banner')).toBeNull();
+  });
+
+  it('does not call onConfirm when isLoading is true even with correct phrase', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(
+      <OptOutConfirmationSheet {...defaultProps} isLoading onConfirm={onConfirm} />,
+    );
+    const input = getByTestId('opt-out-confirmation-input');
+    fireEvent.changeText(input, 'erase progress');
+    fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.test.tsx
@@ -8,11 +8,13 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.optout.modal.confirmation_title': 'Are you sure?',
       'rewards.optout.modal.confirmation_description':
         "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-      'rewards.optout.modal.type_to_confirm': "Type 'erase progress' to continue",
+      'rewards.optout.modal.type_to_confirm':
+        "Type 'erase progress' to continue",
       'rewards.optout.modal.confirm_phrase': 'erase progress',
       'rewards.optout.modal.cancel': 'Cancel',
       'rewards.optout.modal.confirm': 'Confirm',
-      'rewards.optout.modal.error_message': 'Failed to opt out of Rewards. Please try again.',
+      'rewards.optout.modal.error_message':
+        'Failed to opt out of Rewards. Please try again.',
     };
     return map[key] || key;
   }),
@@ -20,23 +22,72 @@ jest.mock('../../../../../../locales/i18n', () => ({
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactActual = jest.requireActual('react');
-  const { Text: RNText, View, TouchableOpacity } = jest.requireActual('react-native');
+  const {
+    Text: RNText,
+    View,
+    TouchableOpacity,
+  } = jest.requireActual('react-native');
 
   return {
-    Box: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(View, { testID, ...props }, children),
-    Text: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(RNText, { testID, ...props }, children),
-    Button: ({ children, onPress, testID, isDisabled, isLoading, isDanger, ...props }: { children?: React.ReactNode; onPress?: () => void; testID?: string; isDisabled?: boolean; isLoading?: boolean; isDanger?: boolean; [key: string]: unknown }) =>
+    Box: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      [key: string]: unknown;
+    }) => ReactActual.createElement(View, { testID, ...props }, children),
+    Text: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      [key: string]: unknown;
+    }) => ReactActual.createElement(RNText, { testID, ...props }, children),
+    Button: ({
+      children,
+      onPress,
+      testID,
+      isDisabled,
+      isLoading,
+      isDanger,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+      isDisabled?: boolean;
+      isLoading?: boolean;
+      isDanger?: boolean;
+      [key: string]: unknown;
+    }) =>
       ReactActual.createElement(
         TouchableOpacity,
-        { onPress: isDisabled || isLoading ? undefined : onPress, testID, disabled: isDisabled || isLoading, ...props },
+        {
+          onPress: isDisabled || isLoading ? undefined : onPress,
+          testID,
+          disabled: isDisabled || isLoading,
+          ...props,
+        },
         ReactActual.createElement(RNText, {}, children),
       ),
-    ButtonIcon: ({ onPress, testID, ...props }: { onPress?: () => void; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(TouchableOpacity, { onPress, testID, ...props }),
-    BottomSheet: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) =>
-      ReactActual.createElement(View, { testID: 'bottom-sheet', onTouchEnd: onClose }, children),
+    ButtonIcon: ({
+      onPress,
+      testID,
+      ...props
+    }: {
+      onPress?: () => void;
+      testID?: string;
+      [key: string]: unknown;
+    }) =>
+      ReactActual.createElement(TouchableOpacity, {
+        onPress,
+        testID,
+        ...props,
+      }),
     TextVariant: { HeadingSm: 'HeadingSm', BodyMd: 'BodyMd', BodySm: 'BodySm' },
     FontWeight: { Bold: 'Bold' },
     ButtonVariant: { Primary: 'Primary', Secondary: 'Secondary' },
@@ -49,13 +100,59 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
+jest.mock('react-native-keyboard-aware-scroll-view', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    KeyboardAwareScrollView: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(View, {}, children),
+  };
+});
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const ReactActual = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({
+        children,
+      }: {
+        children: React.ReactNode;
+        onClose?: () => void;
+        shouldNavigateBack?: boolean;
+      }) =>
+        ReactActual.createElement(View, { testID: 'bottom-sheet' }, children),
+    };
+  },
+);
+
 jest.mock('../../../../../component-library/components/Form/TextField', () => {
   const ReactActual = jest.requireActual('react');
   const { TextInput } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ value, onChangeText, testID, placeholder, ...props }: { value?: string; onChangeText?: (text: string) => void; testID?: string; placeholder?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(TextInput, { value, onChangeText, testID, placeholder, ...props }),
+    default: ({
+      value,
+      onChangeText,
+      testID,
+      placeholder,
+      ...props
+    }: {
+      value?: string;
+      onChangeText?: (text: string) => void;
+      testID?: string;
+      placeholder?: string;
+      [key: string]: unknown;
+    }) =>
+      ReactActual.createElement(TextInput, {
+        value,
+        onChangeText,
+        testID,
+        placeholder,
+        ...props,
+      }),
   };
 });
 
@@ -65,7 +162,11 @@ jest.mock('../RewardsErrorBanner', () => {
   return {
     __esModule: true,
     default: ({ testID, title }: { testID?: string; title?: string }) =>
-      ReactActual.createElement(View, { testID }, ReactActual.createElement(RNText, {}, title)),
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(RNText, {}, title),
+      ),
   };
 });
 
@@ -190,7 +291,11 @@ describe('OptOutConfirmationSheet', () => {
   it('does not call onConfirm when isLoading is true even with correct phrase', () => {
     const onConfirm = jest.fn();
     const { getByTestId } = render(
-      <OptOutConfirmationSheet {...defaultProps} isLoading onConfirm={onConfirm} />,
+      <OptOutConfirmationSheet
+        {...defaultProps}
+        isLoading
+        onConfirm={onConfirm}
+      />,
     );
     const input = getByTestId('opt-out-confirmation-input');
     fireEvent.changeText(input, 'erase progress');

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonIcon,
+  ButtonSize,
+  ButtonVariant,
+  IconColor,
+  IconName,
+  Text,
+  TextVariant,
+  FontWeight,
+  BottomSheet,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import TextField from '../../../../../component-library/components/Form/TextField';
+import RewardsErrorBanner from '../RewardsErrorBanner';
+
+interface OptOutConfirmationSheetProps {
+  isLoading?: boolean;
+  errorMessage?: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export const OPT_OUT_CONFIRMATION_PHRASE = strings(
+  'rewards.optout.modal.confirm_phrase',
+);
+
+const OptOutConfirmationSheet: React.FC<OptOutConfirmationSheetProps> = ({
+  isLoading,
+  errorMessage,
+  onConfirm,
+  onClose,
+}) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const phraseMatches =
+    inputValue.trim().toLowerCase() ===
+    strings('rewards.optout.modal.confirm_phrase').toLowerCase();
+
+  const handleConfirm = useCallback(() => {
+    if (phraseMatches && !isLoading) {
+      onConfirm();
+    }
+  }, [phraseMatches, isLoading, onConfirm]);
+
+  return (
+    <BottomSheet onClose={onClose}>
+      <Box twClassName="px-4 pb-4">
+        {/* Header: centered title + close button */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="mb-4"
+        >
+          <Box twClassName="w-10" />
+          <Box
+            twClassName="flex-1 items-center"
+            justifyContent={BoxJustifyContent.Center}
+          >
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Bold}
+              testID="opt-out-confirmation-title"
+            >
+              {strings('rewards.optout.modal.confirmation_title')}
+            </Text>
+          </Box>
+          <ButtonIcon
+            iconName={IconName.Close}
+            iconProps={{ color: IconColor.IconDefault }}
+            onPress={onClose}
+            testID="opt-out-confirmation-close"
+          />
+        </Box>
+
+        {/* Description */}
+        <Text
+          variant={TextVariant.BodyMd}
+          twClassName="text-alternative text-center mb-6"
+          testID="opt-out-confirmation-description"
+        >
+          {strings('rewards.optout.modal.confirmation_description')}
+        </Text>
+
+        {/* Type to confirm input */}
+        <Box twClassName="mb-6 gap-2">
+          <Text
+            variant={TextVariant.BodySm}
+            twClassName="text-alternative"
+            testID="opt-out-confirmation-input-label"
+          >
+            {strings('rewards.optout.modal.type_to_confirm')}
+          </Text>
+          <TextField
+            testID="opt-out-confirmation-input"
+            value={inputValue}
+            onChangeText={setInputValue}
+            placeholder={strings('rewards.optout.modal.confirm_phrase')}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </Box>
+
+        {/* Error banner */}
+        {errorMessage && (
+          <Box twClassName="mb-4">
+            <RewardsErrorBanner
+              testID="opt-out-error-banner"
+              title={strings('rewards.optout.modal.error_message')}
+              description={errorMessage}
+            />
+          </Box>
+        )}
+
+        {/* Action buttons */}
+        <Box twClassName="gap-2">
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            onPress={handleConfirm}
+            isDisabled={!phraseMatches || isLoading}
+            isLoading={isLoading}
+            isDanger
+            twClassName="w-full"
+            testID="opt-out-confirmation-confirm"
+          >
+            {strings('rewards.optout.modal.confirm')}
+          </Button>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Lg}
+            onPress={onClose}
+            isDisabled={isLoading}
+            twClassName="w-full"
+            testID="opt-out-confirmation-cancel"
+          >
+            {strings('rewards.optout.modal.cancel')}
+          </Button>
+        </Box>
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default OptOutConfirmationSheet;

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
@@ -121,7 +121,7 @@ const OptOutConfirmationSheet: React.FC<OptOutConfirmationSheetProps> = ({
             <Box twClassName="mb-4">
               <RewardsErrorBanner
                 testID="opt-out-error-banner"
-                title={strings('rewards.optout.modal.error_message')}
+                title={strings('rewards.optout.modal.error_title')}
                 description={errorMessage}
               />
             </Box>

--- a/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutConfirmationSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import {
   Box,
   BoxAlignItems,
@@ -13,9 +14,9 @@ import {
   Text,
   TextVariant,
   FontWeight,
-  BottomSheet,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
+import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 
@@ -49,100 +50,110 @@ const OptOutConfirmationSheet: React.FC<OptOutConfirmationSheetProps> = ({
   }, [phraseMatches, isLoading, onConfirm]);
 
   return (
-    <BottomSheet onClose={onClose}>
-      <Box twClassName="px-4 pb-4">
-        {/* Header: centered title + close button */}
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="mb-4"
-        >
-          <Box twClassName="w-10" />
+    <BottomSheet
+      shouldNavigateBack={false}
+      onClose={onClose}
+      keyboardAvoidingViewEnabled={false}
+    >
+      <KeyboardAwareScrollView
+        keyboardShouldPersistTaps="handled"
+        enableOnAndroid
+        extraScrollHeight={20}
+      >
+        <Box twClassName="px-4 pb-4">
+          {/* Header: centered title + close button */}
           <Box
-            twClassName="flex-1 items-center"
-            justifyContent={BoxJustifyContent.Center}
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="mb-4"
           >
-            <Text
-              variant={TextVariant.HeadingSm}
-              fontWeight={FontWeight.Bold}
-              testID="opt-out-confirmation-title"
+            <Box twClassName="w-10" />
+            <Box
+              twClassName="flex-1 items-center"
+              justifyContent={BoxJustifyContent.Center}
             >
-              {strings('rewards.optout.modal.confirmation_title')}
-            </Text>
-          </Box>
-          <ButtonIcon
-            iconName={IconName.Close}
-            iconProps={{ color: IconColor.IconDefault }}
-            onPress={onClose}
-            testID="opt-out-confirmation-close"
-          />
-        </Box>
-
-        {/* Description */}
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="text-alternative text-center mb-6"
-          testID="opt-out-confirmation-description"
-        >
-          {strings('rewards.optout.modal.confirmation_description')}
-        </Text>
-
-        {/* Type to confirm input */}
-        <Box twClassName="mb-6 gap-2">
-          <Text
-            variant={TextVariant.BodySm}
-            twClassName="text-alternative"
-            testID="opt-out-confirmation-input-label"
-          >
-            {strings('rewards.optout.modal.type_to_confirm')}
-          </Text>
-          <TextField
-            testID="opt-out-confirmation-input"
-            value={inputValue}
-            onChangeText={setInputValue}
-            placeholder={strings('rewards.optout.modal.confirm_phrase')}
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-        </Box>
-
-        {/* Error banner */}
-        {errorMessage && (
-          <Box twClassName="mb-4">
-            <RewardsErrorBanner
-              testID="opt-out-error-banner"
-              title={strings('rewards.optout.modal.error_message')}
-              description={errorMessage}
+              <Text
+                variant={TextVariant.HeadingSm}
+                fontWeight={FontWeight.Bold}
+                testID="opt-out-confirmation-title"
+              >
+                {strings('rewards.optout.modal.confirmation_title')}
+              </Text>
+            </Box>
+            <ButtonIcon
+              iconName={IconName.Close}
+              iconProps={{ color: IconColor.IconDefault }}
+              onPress={onClose}
+              testID="opt-out-confirmation-close"
             />
           </Box>
-        )}
 
-        {/* Action buttons */}
-        <Box twClassName="gap-2">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            onPress={handleConfirm}
-            isDisabled={!phraseMatches || isLoading}
-            isLoading={isLoading}
-            isDanger
-            twClassName="w-full"
-            testID="opt-out-confirmation-confirm"
+          {/* Description */}
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-alternative text-center mb-6"
+            testID="opt-out-confirmation-description"
           >
-            {strings('rewards.optout.modal.confirm')}
-          </Button>
-          <Button
-            variant={ButtonVariant.Secondary}
-            size={ButtonSize.Lg}
-            onPress={onClose}
-            isDisabled={isLoading}
-            twClassName="w-full"
-            testID="opt-out-confirmation-cancel"
-          >
-            {strings('rewards.optout.modal.cancel')}
-          </Button>
+            {strings('rewards.optout.modal.confirmation_description')}
+          </Text>
+
+          {/* Type to confirm input */}
+          <Box twClassName="mb-6 gap-2">
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="text-alternative"
+              testID="opt-out-confirmation-input-label"
+            >
+              {strings('rewards.optout.modal.type_to_confirm')}
+            </Text>
+            <TextField
+              testID="opt-out-confirmation-input"
+              value={inputValue}
+              onChangeText={setInputValue}
+              placeholder={strings('rewards.optout.modal.confirm_phrase')}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </Box>
+
+          {/* Error banner */}
+          {errorMessage && (
+            <Box twClassName="mb-4">
+              <RewardsErrorBanner
+                testID="opt-out-error-banner"
+                title={strings('rewards.optout.modal.error_message')}
+                description={errorMessage}
+              />
+            </Box>
+          )}
+
+          {/* Action buttons */}
+          <Box twClassName="gap-2">
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              onPress={handleConfirm}
+              isDisabled={!phraseMatches || isLoading}
+              isLoading={isLoading}
+              isDanger
+              twClassName="w-full"
+              testID="opt-out-confirmation-confirm"
+            >
+              {strings('rewards.optout.modal.confirm')}
+            </Button>
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              onPress={onClose}
+              isDisabled={isLoading}
+              twClassName="w-full"
+              testID="opt-out-confirmation-cancel"
+            >
+              {strings('rewards.optout.modal.cancel')}
+            </Button>
+          </Box>
         </Box>
-      </Box>
+      </KeyboardAwareScrollView>
     </BottomSheet>
   );
 };

--- a/app/components/UI/Rewards/components/Settings/OptOutSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutSection.test.tsx
@@ -1,40 +1,6 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import OptOutSection from './OptOutSection';
-import { useOptout } from '../../hooks/useOptout';
-
-jest.mock('../../hooks/useOptout', () => ({
-  useOptout: jest.fn(),
-}));
-
-let mockConfirmCallback: (() => void) | undefined;
-let mockCloseCallback: (() => void) | undefined;
-let mockSheetIsLoading: boolean | undefined;
-let mockSheetErrorMessage: string | undefined;
-
-jest.mock('./OptOutConfirmationSheet', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, TouchableOpacity, Text: RNText } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ onConfirm, onClose, isLoading, errorMessage }: { onConfirm: () => void; onClose: () => void; isLoading?: boolean; errorMessage?: string }) => {
-      mockConfirmCallback = onConfirm;
-      mockCloseCallback = onClose;
-      mockSheetIsLoading = isLoading;
-      mockSheetErrorMessage = errorMessage;
-      return ReactActual.createElement(
-        View,
-        { testID: 'opt-out-confirmation-sheet' },
-        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-confirm', onPress: onConfirm }),
-        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-close', onPress: onClose }),
-        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-cancel', onPress: onClose }),
-        errorMessage
-          ? ReactActual.createElement(View, { testID: 'opt-out-error-banner' }, ReactActual.createElement(RNText, {}, errorMessage))
-          : null,
-      );
-    },
-  };
-});
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -43,14 +9,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.optout.description':
         "This will remove your accounts from the Rewards program and your progress in any campaigns you've joined. Only do this if you are absolutely sure you want to erase your progress.",
       'rewards.optout.erase_button': 'Erase progress',
-      'rewards.optout.modal.confirmation_title': 'Are you sure?',
-      'rewards.optout.modal.confirmation_description':
-        "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-      'rewards.optout.modal.type_to_confirm': "Type 'erase progress' to continue",
-      'rewards.optout.modal.confirm_phrase': 'erase progress',
-      'rewards.optout.modal.cancel': 'Cancel',
-      'rewards.optout.modal.confirm': 'Confirm',
-      'rewards.optout.modal.error_message': 'Failed to opt out of Rewards. Please try again.',
     };
     return map[key] || key;
   }),
@@ -58,70 +16,74 @@ jest.mock('../../../../../../locales/i18n', () => ({
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactActual = jest.requireActual('react');
-  const { Text: RNText, View, TouchableOpacity } = jest.requireActual('react-native');
+  const {
+    Text: RNText,
+    View,
+    TouchableOpacity,
+  } = jest.requireActual('react-native');
 
   return {
-    Box: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(View, { testID, ...props }, children),
-    Text: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(RNText, { testID, ...props }, children),
-    Button: ({ children, onPress, testID, isDisabled, isLoading, ...props }: { children?: React.ReactNode; onPress?: () => void; testID?: string; isDisabled?: boolean; isLoading?: boolean; [key: string]: unknown }) =>
+    Box: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      [key: string]: unknown;
+    }) => ReactActual.createElement(View, { testID, ...props }, children),
+    Text: ({
+      children,
+      testID,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      testID?: string;
+      [key: string]: unknown;
+    }) => ReactActual.createElement(RNText, { testID, ...props }, children),
+    Button: ({
+      children,
+      onPress,
+      testID,
+      isDisabled,
+      isLoading,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+      isDisabled?: boolean;
+      isLoading?: boolean;
+      [key: string]: unknown;
+    }) =>
       ReactActual.createElement(
         TouchableOpacity,
-        { onPress: isDisabled || isLoading ? undefined : onPress, testID, disabled: isDisabled, ...props },
+        {
+          onPress: isDisabled || isLoading ? undefined : onPress,
+          testID,
+          disabled: isDisabled,
+          ...props,
+        },
         ReactActual.createElement(RNText, {}, children),
       ),
-    ButtonIcon: ({ onPress, testID, ...props }: { onPress?: () => void; testID?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(TouchableOpacity, { onPress, testID, ...props }),
-    BottomSheet: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) =>
-      ReactActual.createElement(View, { testID: 'bottom-sheet' }, children),
-    TextVariant: { HeadingMd: 'HeadingMd', BodyMd: 'BodyMd', BodySm: 'BodySm', HeadingSm: 'HeadingSm' },
+    TextVariant: { HeadingMd: 'HeadingMd', BodyMd: 'BodyMd' },
     FontWeight: { Bold: 'Bold' },
-    ButtonVariant: { Primary: 'Primary', Secondary: 'Secondary' },
+    ButtonVariant: { Secondary: 'Secondary' },
     ButtonSize: { Lg: 'Lg' },
-    IconName: { Close: 'Close', Warning: 'Warning' },
-    IconColor: { IconDefault: 'IconDefault' },
-  };
-});
-
-jest.mock('../../../../../component-library/components/Form/TextField', () => {
-  const ReactActual = jest.requireActual('react');
-  const { TextInput } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ value, onChangeText, testID, placeholder, ...props }: { value?: string; onChangeText?: (text: string) => void; testID?: string; placeholder?: string; [key: string]: unknown }) =>
-      ReactActual.createElement(TextInput, { value, onChangeText, testID, placeholder, ...props }),
-  };
-});
-
-jest.mock('../RewardsErrorBanner', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Text: RNText } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ testID, title }: { testID?: string; title?: string }) =>
-      ReactActual.createElement(View, { testID }, ReactActual.createElement(RNText, {}, title)),
   };
 });
 
 describe('OptOutSection', () => {
-  const mockOptout = jest.fn();
-  const mockUseOptout = useOptout as jest.MockedFunction<typeof useOptout>;
+  const mockOnErasePress = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockConfirmCallback = undefined;
-    mockCloseCallback = undefined;
-    mockSheetIsLoading = undefined;
-    mockSheetErrorMessage = undefined;
-    mockUseOptout.mockReturnValue({
-      optout: mockOptout,
-      isLoading: false,
-    });
   });
 
   it('renders the opt-out section with title, description, and erase button', () => {
-    const { getByTestId, getByText } = render(<OptOutSection />);
+    const { getByTestId, getByText } = render(
+      <OptOutSection onErasePress={mockOnErasePress} />,
+    );
     expect(getByTestId('opt-out-section')).toBeTruthy();
     expect(getByText('Opt out of Rewards')).toBeTruthy();
     expect(getByTestId('opt-out-section-description')).toBeTruthy();
@@ -129,75 +91,11 @@ describe('OptOutSection', () => {
     expect(getByText('Erase progress')).toBeTruthy();
   });
 
-  it('does not show the confirmation sheet initially', () => {
-    const { queryByTestId } = render(<OptOutSection />);
-    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
-  });
-
-  it('opens the confirmation sheet when "Erase progress" is pressed', () => {
-    const { getByTestId } = render(<OptOutSection />);
+  it('calls onErasePress when "Erase progress" is pressed', () => {
+    const { getByTestId } = render(
+      <OptOutSection onErasePress={mockOnErasePress} />,
+    );
     fireEvent.press(getByTestId('opt-out-erase-button'));
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-  });
-
-  it('closes the confirmation sheet when the close button is pressed', () => {
-    const { getByTestId, queryByTestId } = render(<OptOutSection />);
-    fireEvent.press(getByTestId('opt-out-erase-button'));
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-    fireEvent.press(getByTestId('opt-out-confirmation-close'));
-    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
-  });
-
-  it('closes the confirmation sheet when Cancel is pressed', () => {
-    const { getByTestId, queryByTestId } = render(<OptOutSection />);
-    fireEvent.press(getByTestId('opt-out-erase-button'));
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-    fireEvent.press(getByTestId('opt-out-confirmation-cancel'));
-    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
-  });
-
-  it('calls optout and closes sheet on successful confirmation', async () => {
-    mockOptout.mockResolvedValueOnce(true);
-    const { getByTestId, queryByTestId } = render(<OptOutSection />);
-
-    fireEvent.press(getByTestId('opt-out-erase-button'));
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
-    });
-
-    expect(mockOptout).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
-    });
-  });
-
-  it('shows error banner and keeps sheet open on failed confirmation', async () => {
-    mockOptout.mockResolvedValueOnce(false);
-    const { getByTestId } = render(<OptOutSection />);
-
-    fireEvent.press(getByTestId('opt-out-erase-button'));
-
-    await act(async () => {
-      fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
-    });
-
-    expect(mockOptout).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(getByTestId('opt-out-error-banner')).toBeTruthy();
-    });
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-  });
-
-  it('passes isLoading to the confirmation sheet', () => {
-    mockUseOptout.mockReturnValue({
-      optout: mockOptout,
-      isLoading: true,
-    });
-    const { getByTestId } = render(<OptOutSection />);
-    fireEvent.press(getByTestId('opt-out-erase-button'));
-    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
-    expect(mockSheetIsLoading).toBe(true);
+    expect(mockOnErasePress).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Rewards/components/Settings/OptOutSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutSection.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import OptOutSection from './OptOutSection';
+import { useOptout } from '../../hooks/useOptout';
+
+jest.mock('../../hooks/useOptout', () => ({
+  useOptout: jest.fn(),
+}));
+
+let mockConfirmCallback: (() => void) | undefined;
+let mockCloseCallback: (() => void) | undefined;
+let mockSheetIsLoading: boolean | undefined;
+let mockSheetErrorMessage: string | undefined;
+
+jest.mock('./OptOutConfirmationSheet', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, TouchableOpacity, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ onConfirm, onClose, isLoading, errorMessage }: { onConfirm: () => void; onClose: () => void; isLoading?: boolean; errorMessage?: string }) => {
+      mockConfirmCallback = onConfirm;
+      mockCloseCallback = onClose;
+      mockSheetIsLoading = isLoading;
+      mockSheetErrorMessage = errorMessage;
+      return ReactActual.createElement(
+        View,
+        { testID: 'opt-out-confirmation-sheet' },
+        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-confirm', onPress: onConfirm }),
+        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-close', onPress: onClose }),
+        ReactActual.createElement(TouchableOpacity, { testID: 'opt-out-confirmation-cancel', onPress: onClose }),
+        errorMessage
+          ? ReactActual.createElement(View, { testID: 'opt-out-error-banner' }, ReactActual.createElement(RNText, {}, errorMessage))
+          : null,
+      );
+    },
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const map: Record<string, string> = {
+      'rewards.optout.title': 'Opt out of Rewards',
+      'rewards.optout.description':
+        "This will remove your accounts from the Rewards program and your progress in any campaigns you've joined. Only do this if you are absolutely sure you want to erase your progress.",
+      'rewards.optout.erase_button': 'Erase progress',
+      'rewards.optout.modal.confirmation_title': 'Are you sure?',
+      'rewards.optout.modal.confirmation_description':
+        "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+      'rewards.optout.modal.type_to_confirm': "Type 'erase progress' to continue",
+      'rewards.optout.modal.confirm_phrase': 'erase progress',
+      'rewards.optout.modal.cancel': 'Cancel',
+      'rewards.optout.modal.confirm': 'Confirm',
+      'rewards.optout.modal.error_message': 'Failed to opt out of Rewards. Please try again.',
+    };
+    return map[key] || key;
+  }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text: RNText, View, TouchableOpacity } = jest.requireActual('react-native');
+
+  return {
+    Box: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(View, { testID, ...props }, children),
+    Text: ({ children, testID, ...props }: { children?: React.ReactNode; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(RNText, { testID, ...props }, children),
+    Button: ({ children, onPress, testID, isDisabled, isLoading, ...props }: { children?: React.ReactNode; onPress?: () => void; testID?: string; isDisabled?: boolean; isLoading?: boolean; [key: string]: unknown }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { onPress: isDisabled || isLoading ? undefined : onPress, testID, disabled: isDisabled, ...props },
+        ReactActual.createElement(RNText, {}, children),
+      ),
+    ButtonIcon: ({ onPress, testID, ...props }: { onPress?: () => void; testID?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(TouchableOpacity, { onPress, testID, ...props }),
+    BottomSheet: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) =>
+      ReactActual.createElement(View, { testID: 'bottom-sheet' }, children),
+    TextVariant: { HeadingMd: 'HeadingMd', BodyMd: 'BodyMd', BodySm: 'BodySm', HeadingSm: 'HeadingSm' },
+    FontWeight: { Bold: 'Bold' },
+    ButtonVariant: { Primary: 'Primary', Secondary: 'Secondary' },
+    ButtonSize: { Lg: 'Lg' },
+    IconName: { Close: 'Close', Warning: 'Warning' },
+    IconColor: { IconDefault: 'IconDefault' },
+  };
+});
+
+jest.mock('../../../../../component-library/components/Form/TextField', () => {
+  const ReactActual = jest.requireActual('react');
+  const { TextInput } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ value, onChangeText, testID, placeholder, ...props }: { value?: string; onChangeText?: (text: string) => void; testID?: string; placeholder?: string; [key: string]: unknown }) =>
+      ReactActual.createElement(TextInput, { value, onChangeText, testID, placeholder, ...props }),
+  };
+});
+
+jest.mock('../RewardsErrorBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text: RNText } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID, title }: { testID?: string; title?: string }) =>
+      ReactActual.createElement(View, { testID }, ReactActual.createElement(RNText, {}, title)),
+  };
+});
+
+describe('OptOutSection', () => {
+  const mockOptout = jest.fn();
+  const mockUseOptout = useOptout as jest.MockedFunction<typeof useOptout>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfirmCallback = undefined;
+    mockCloseCallback = undefined;
+    mockSheetIsLoading = undefined;
+    mockSheetErrorMessage = undefined;
+    mockUseOptout.mockReturnValue({
+      optout: mockOptout,
+      isLoading: false,
+    });
+  });
+
+  it('renders the opt-out section with title, description, and erase button', () => {
+    const { getByTestId, getByText } = render(<OptOutSection />);
+    expect(getByTestId('opt-out-section')).toBeTruthy();
+    expect(getByText('Opt out of Rewards')).toBeTruthy();
+    expect(getByTestId('opt-out-section-description')).toBeTruthy();
+    expect(getByTestId('opt-out-erase-button')).toBeTruthy();
+    expect(getByText('Erase progress')).toBeTruthy();
+  });
+
+  it('does not show the confirmation sheet initially', () => {
+    const { queryByTestId } = render(<OptOutSection />);
+    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+  });
+
+  it('opens the confirmation sheet when "Erase progress" is pressed', () => {
+    const { getByTestId } = render(<OptOutSection />);
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+  });
+
+  it('closes the confirmation sheet when the close button is pressed', () => {
+    const { getByTestId, queryByTestId } = render(<OptOutSection />);
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+    fireEvent.press(getByTestId('opt-out-confirmation-close'));
+    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+  });
+
+  it('closes the confirmation sheet when Cancel is pressed', () => {
+    const { getByTestId, queryByTestId } = render(<OptOutSection />);
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+    fireEvent.press(getByTestId('opt-out-confirmation-cancel'));
+    expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+  });
+
+  it('calls optout and closes sheet on successful confirmation', async () => {
+    mockOptout.mockResolvedValueOnce(true);
+    const { getByTestId, queryByTestId } = render(<OptOutSection />);
+
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    });
+
+    expect(mockOptout).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(queryByTestId('opt-out-confirmation-sheet')).toBeNull();
+    });
+  });
+
+  it('shows error banner and keeps sheet open on failed confirmation', async () => {
+    mockOptout.mockResolvedValueOnce(false);
+    const { getByTestId } = render(<OptOutSection />);
+
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+
+    await act(async () => {
+      fireEvent.press(getByTestId('opt-out-confirmation-confirm'));
+    });
+
+    expect(mockOptout).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(getByTestId('opt-out-error-banner')).toBeTruthy();
+    });
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+  });
+
+  it('passes isLoading to the confirmation sheet', () => {
+    mockUseOptout.mockReturnValue({
+      optout: mockOptout,
+      isLoading: true,
+    });
+    const { getByTestId } = render(<OptOutSection />);
+    fireEvent.press(getByTestId('opt-out-erase-button'));
+    expect(getByTestId('opt-out-confirmation-sheet')).toBeTruthy();
+    expect(mockSheetIsLoading).toBe(true);
+  });
+});

--- a/app/components/UI/Rewards/components/Settings/OptOutSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutSection.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useCallback, memo } from 'react';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { useOptout } from '../../hooks/useOptout';
+import OptOutConfirmationSheet from './OptOutConfirmationSheet';
+
+const OptOutSection: React.FC = () => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const { optout, isLoading } = useOptout();
+
+  const handleErasePress = useCallback(() => {
+    setErrorMessage(undefined);
+    setIsSheetOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsSheetOpen(false);
+    setErrorMessage(undefined);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    setErrorMessage(undefined);
+    const success = await optout();
+    if (success) {
+      setIsSheetOpen(false);
+    } else {
+      setErrorMessage(strings('rewards.optout.modal.error_message'));
+    }
+  }, [optout]);
+
+  return (
+    <>
+      {/* Divider */}
+      <Box twClassName="mt-4 border-b border-border-muted" />
+
+      <Box testID="opt-out-section" twClassName="gap-4 flex-col p-4">
+        <Box twClassName="gap-2">
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('rewards.optout.title')}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-alternative"
+            testID="opt-out-section-description"
+          >
+            {strings('rewards.optout.description')}
+          </Text>
+        </Box>
+
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={handleErasePress}
+          isDanger
+          twClassName="w-full"
+          testID="opt-out-erase-button"
+        >
+          {strings('rewards.optout.erase_button')}
+        </Button>
+      </Box>
+
+      {isSheetOpen && (
+        <OptOutConfirmationSheet
+          isLoading={isLoading}
+          errorMessage={errorMessage}
+          onConfirm={handleConfirm}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  );
+};
+
+export default memo(OptOutSection);

--- a/app/components/UI/Rewards/components/Settings/OptOutSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/OptOutSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, memo } from 'react';
+import React, { memo } from 'react';
 import {
   Box,
   Text,
@@ -8,75 +8,42 @@ import {
   ButtonSize,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { useOptout } from '../../hooks/useOptout';
-import OptOutConfirmationSheet from './OptOutConfirmationSheet';
 
-const OptOutSection: React.FC = () => {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>();
-  const { optout, isLoading } = useOptout();
+interface OptOutSectionProps {
+  onErasePress: () => void;
+}
 
-  const handleErasePress = useCallback(() => {
-    setErrorMessage(undefined);
-    setIsSheetOpen(true);
-  }, []);
+const OptOutSection: React.FC<OptOutSectionProps> = ({ onErasePress }) => (
+  <>
+    {/* Divider */}
+    <Box twClassName="mt-4 border-b border-border-muted" />
 
-  const handleClose = useCallback(() => {
-    setIsSheetOpen(false);
-    setErrorMessage(undefined);
-  }, []);
-
-  const handleConfirm = useCallback(async () => {
-    setErrorMessage(undefined);
-    const success = await optout();
-    if (success) {
-      setIsSheetOpen(false);
-    } else {
-      setErrorMessage(strings('rewards.optout.modal.error_message'));
-    }
-  }, [optout]);
-
-  return (
-    <>
-      {/* Divider */}
-      <Box twClassName="mt-4 border-b border-border-muted" />
-
-      <Box testID="opt-out-section" twClassName="gap-4 flex-col p-4">
-        <Box twClassName="gap-2">
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('rewards.optout.title')}
-          </Text>
-          <Text
-            variant={TextVariant.BodyMd}
-            twClassName="text-alternative"
-            testID="opt-out-section-description"
-          >
-            {strings('rewards.optout.description')}
-          </Text>
-        </Box>
-
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onPress={handleErasePress}
-          isDanger
-          twClassName="w-full"
-          testID="opt-out-erase-button"
+    <Box testID="opt-out-section" twClassName="gap-4 flex-col p-4">
+      <Box twClassName="gap-2">
+        <Text variant={TextVariant.HeadingMd}>
+          {strings('rewards.optout.title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          twClassName="text-alternative"
+          testID="opt-out-section-description"
         >
-          {strings('rewards.optout.erase_button')}
-        </Button>
+          {strings('rewards.optout.description')}
+        </Text>
       </Box>
 
-      {isSheetOpen && (
-        <OptOutConfirmationSheet
-          isLoading={isLoading}
-          errorMessage={errorMessage}
-          onConfirm={handleConfirm}
-          onClose={handleClose}
-        />
-      )}
-    </>
-  );
-};
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={onErasePress}
+        isDanger
+        twClassName="w-full"
+        testID="opt-out-erase-button"
+      >
+        {strings('rewards.optout.erase_button')}
+      </Button>
+    </Box>
+  </>
+);
 
 export default memo(OptOutSection);

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
@@ -25,6 +25,7 @@ import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import { selectInternalAccountsByGroupId } from '../../../../../selectors/multichainAccounts/accounts';
 import RewardSettingsAccountGroup from './RewardSettingsAccountGroup';
 import ReferredByCodeSection from './ReferredByCodeSection';
+import OptOutSection from './OptOutSection';
 import { RewardSettingsAccountGroupListFlatListItem } from './types';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import RewardsEnvironmentToggle from './RewardsEnvironmentToggle';
@@ -349,6 +350,7 @@ const RewardSettingsAccountGroupList: React.FC = () => {
     () => (
       <Box twClassName="gap-4">
         <ReferredByCodeSection />
+        <OptOutSection />
         <RewardsEnvironmentToggle />
       </Box>
     ),

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
@@ -149,7 +149,13 @@ const AccountProgressSection: React.FC<AccountProgressSectionProps> = memo(
   },
 );
 
-const RewardSettingsAccountGroupList: React.FC = () => {
+interface RewardSettingsAccountGroupListProps {
+  onRequestOptOut?: () => void;
+}
+
+const RewardSettingsAccountGroupList: React.FC<
+  RewardSettingsAccountGroupListProps
+> = ({ onRequestOptOut }) => {
   const tw = useTailwind();
 
   // State to track which wallets are expanded
@@ -350,11 +356,11 @@ const RewardSettingsAccountGroupList: React.FC = () => {
     () => (
       <Box twClassName="gap-4">
         <ReferredByCodeSection />
-        <OptOutSection />
+        {onRequestOptOut && <OptOutSection onErasePress={onRequestOptOut} />}
         <RewardsEnvironmentToggle />
       </Box>
     ),
-    [],
+    [onRequestOptOut],
   );
 
   // Flatten data for FlatList with collapse/expand support

--- a/app/components/UI/Rewards/hooks/useLinkAccountAddress.test.ts
+++ b/app/components/UI/Rewards/hooks/useLinkAccountAddress.test.ts
@@ -97,6 +97,10 @@ describe('useLinkAccountAddress', () => {
       variant: 'icon',
       hapticsType: 'warning',
     }),
+    warning: jest.fn().mockReturnValue({
+      variant: 'icon',
+      hapticsType: 'warning',
+    }),
   };
 
   const mockAccount: InternalAccount = {

--- a/app/components/UI/Rewards/hooks/useLinkAccountGroup.test.ts
+++ b/app/components/UI/Rewards/hooks/useLinkAccountGroup.test.ts
@@ -118,6 +118,10 @@ describe('useLinkAccountGroup', () => {
       variant: 'icon',
       hapticsType: 'warning',
     }),
+    warning: jest.fn().mockReturnValue({
+      variant: 'icon',
+      hapticsType: 'warning',
+    }),
   };
 
   // Mock account data

--- a/app/components/UI/Rewards/hooks/useOptOut.test.ts
+++ b/app/components/UI/Rewards/hooks/useOptOut.test.ts
@@ -5,12 +5,10 @@ import {
   NavigationProp,
   useNavigation,
 } from '@react-navigation/native';
-import { ButtonVariant } from '@metamask/design-system-react-native';
 import { useOptout } from './useOptout';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { resetRewardsState } from '../../../../reducers/rewards';
-import { ModalType } from '../components/RewardsBottomSheetModal';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -19,7 +17,6 @@ import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock'
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { useBulkLinkState } from './useBulkLinkState';
 
-// Mock dependencies
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(),
   useSelector: jest.fn(),
@@ -53,14 +50,6 @@ const mockIdentify = jest.fn();
 
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
 
-// Mock utils
-jest.mock('../utils', () => ({
-  RewardsMetricsButtons: {
-    OPT_OUT_CANCEL: 'opt_out_cancel',
-  },
-}));
-
-// Mock UserProfileProperty
 jest.mock(
   '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types',
   () => ({
@@ -71,9 +60,8 @@ jest.mock(
   }),
 );
 
-// Mock useRewardsToast
 const mockShowToast = jest.fn();
-const mockSuccessToast = jest.fn();
+const mockWarningToast = jest.fn();
 const mockErrorToast = jest.fn();
 
 jest.mock('./useRewardsToast', () => ({
@@ -81,13 +69,12 @@ jest.mock('./useRewardsToast', () => ({
   default: () => ({
     showToast: mockShowToast,
     RewardsToastOptions: {
-      success: mockSuccessToast,
+      warning: mockWarningToast,
       error: mockErrorToast,
     },
   }),
 }));
 
-// Mock useRewardDashboardModals
 const mockResetAllSessionTrackingForRewardsDashboardModals = jest.fn();
 
 jest.mock('./useRewardDashboardModals', () => ({
@@ -105,12 +92,9 @@ jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const mockStrings: Record<string, string> = {
       'rewards.optout.modal.error_message': 'Failed to opt out',
-      'rewards.optout.error_message': 'An error occurred while opting out',
-      'rewards.optout.modal.confirmation_title': 'Are you sure?',
-      'rewards.optout.modal.confirmation_description':
-        'This action cannot be undone',
-      'rewards.optout.modal.processing': 'Processing...',
-      'rewards.optout.modal.confirm': 'Confirm',
+      'rewards.optout.request_received.title': 'Request received',
+      'rewards.optout.request_received.description':
+        'In about 7 days, your progress will be fully erased.',
     };
     return mockStrings[key] || key;
   }),
@@ -144,7 +128,6 @@ describe('useOptout', () => {
     );
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
-      // Fallback for other selectors not under test
       return undefined;
     });
     (
@@ -158,7 +141,6 @@ describe('useOptout', () => {
     });
     mockResetAllSessionTrackingForRewardsDashboardModals.mockClear();
 
-    // Setup metrics mocks
     mockCreateEventBuilder.mockReturnValue({
       addProperties: jest.fn().mockReturnThis(),
       build: jest.fn().mockReturnValue({}),
@@ -173,7 +155,6 @@ describe('useOptout', () => {
       }),
     );
 
-    // Setup useBulkLinkState mock
     mockUseBulkLinkState.mockReturnValue({
       startBulkLink: jest.fn(),
       cancelBulkLink: mockCancelBulkLink,
@@ -198,24 +179,20 @@ describe('useOptout', () => {
 
       expect(result.current.isLoading).toBe(false);
       expect(typeof result.current.optout).toBe('function');
-      expect(typeof result.current.showOptoutBottomSheet).toBe('function');
     });
   });
 
   describe('optout', () => {
     it('should handle successful opt-out', async () => {
-      // Arrange
       mockEngineCall.mockResolvedValueOnce(true);
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(true);
       expect(mockEngineCall).toHaveBeenCalledWith(
         'RewardsController:optOut',
@@ -232,8 +209,7 @@ describe('useOptout', () => {
         mockResetAllSessionTrackingForRewardsDashboardModals,
       ).toHaveBeenCalledTimes(1);
 
-      // Verify metrics tracking
-      expect(mockTrackEvent).toHaveBeenCalledTimes(2); // Started and completed
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
         MetaMetricsEvents.REWARDS_OPT_OUT_STARTED,
       );
@@ -241,38 +217,36 @@ describe('useOptout', () => {
         MetaMetricsEvents.REWARDS_OPT_OUT_COMPLETED,
       );
 
-      // Verify user traits are updated
       expect(mockIdentify).toHaveBeenCalledWith({
         [UserProfileProperty.HAS_REWARDS_OPTED_IN]: UserProfileProperty.OFF,
       });
 
-      // Navigation should not happen in the optout function itself
-      expect(result.current.isLoading).toBe(false);
+      // Should navigate to wallet view and show "Request received" toast
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+      expect(mockWarningToast).toHaveBeenCalledWith(
+        'Request received',
+        'In about 7 days, your progress will be fully erased.',
+      );
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
 
-      // Verify bulk link was cancelled before opt-out
+      expect(result.current.isLoading).toBe(false);
       expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
     });
 
     it('should handle opt-out failure from controller', async () => {
-      // Arrange
       mockEngineCall.mockResolvedValueOnce(false);
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(false);
       expect(mockEngineCall).toHaveBeenCalledWith(
         'RewardsController:optOut',
         mockSubscriptionId,
-      );
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useOptout: Starting opt-out process',
       );
       expect(mockLoggerLog).toHaveBeenCalledWith(
         'useOptout: Opt-out failed - controller returned false',
@@ -280,18 +254,13 @@ describe('useOptout', () => {
       expect(mockErrorToast).toHaveBeenCalledWith('Failed to opt out');
       expect(mockShowToast).toHaveBeenCalled();
 
-      // Verify metrics tracking for failure
-      expect(mockTrackEvent).toHaveBeenCalledTimes(2); // Started and failed
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.REWARDS_OPT_OUT_STARTED,
-      );
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
         MetaMetricsEvents.REWARDS_OPT_OUT_FAILED,
       );
 
-      // Verify user traits are NOT updated on failure
       expect(mockIdentify).not.toHaveBeenCalled();
-
+      expect(mockNavigate).not.toHaveBeenCalled();
       expect(
         mockResetAllSessionTrackingForRewardsDashboardModals,
       ).not.toHaveBeenCalled();
@@ -299,27 +268,17 @@ describe('useOptout', () => {
     });
 
     it('should handle exceptions during opt-out', async () => {
-      // Arrange
       const testError = new Error('Test error message');
       mockEngineCall.mockRejectedValueOnce(testError);
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(false);
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:optOut',
-        mockSubscriptionId,
-      );
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useOptout: Starting opt-out process',
-      );
       expect(mockLoggerLog).toHaveBeenCalledWith(
         'useOptout: Opt-out failed with exception:',
         testError,
@@ -327,55 +286,42 @@ describe('useOptout', () => {
       expect(mockErrorToast).toHaveBeenCalledWith('Failed to opt out');
       expect(mockShowToast).toHaveBeenCalled();
 
-      // Verify metrics tracking for exception
-      expect(mockTrackEvent).toHaveBeenCalledTimes(2); // Started and failed
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.REWARDS_OPT_OUT_STARTED,
-      );
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
         MetaMetricsEvents.REWARDS_OPT_OUT_FAILED,
       );
 
-      // Verify user traits are NOT updated on exception
       expect(mockIdentify).not.toHaveBeenCalled();
-
+      expect(mockNavigate).not.toHaveBeenCalled();
       expect(
         mockResetAllSessionTrackingForRewardsDashboardModals,
       ).not.toHaveBeenCalled();
       expect(result.current.isLoading).toBe(false);
-
-      // Verify bulk link was cancelled before opt-out even on exception
       expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
     });
 
     it('should not proceed if already loading', async () => {
-      // Arrange
       const { result } = renderHook(() => useOptout());
 
-      // Set loading to true by triggering an optout that doesn't resolve immediately
       let resolveSlowPromise: (value: boolean) => void;
       const slowPromise = new Promise<boolean>((resolve) => {
         resolveSlowPromise = resolve;
       });
       mockEngineCall.mockReturnValueOnce(slowPromise);
 
-      // Start first opt-out (this will set isLoading to true)
       let firstOptoutPromise: Promise<boolean>;
       await act(async () => {
         firstOptoutPromise = result.current.optout();
       });
 
-      // Act - Try to call optout while already loading
       let secondOptoutResult = false;
       await act(async () => {
         secondOptoutResult = await result.current.optout();
       });
 
-      // Assert - Second call should return false immediately without calling controller
       expect(secondOptoutResult).toBe(false);
-      expect(mockEngineCall).toHaveBeenCalledTimes(1); // Only called once from the first optout
+      expect(mockEngineCall).toHaveBeenCalledTimes(1);
 
-      // Clean up the first promise
       await act(async () => {
         resolveSlowPromise?.(true);
         if (firstOptoutPromise) {
@@ -385,31 +331,24 @@ describe('useOptout', () => {
     });
 
     it('should not proceed if no subscription ID', async () => {
-      // Arrange
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectRewardsSubscriptionId) {
-          return null; // No subscription ID
-        }
+        if (selector === selectRewardsSubscriptionId) return null;
         return undefined;
       });
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(false);
       expect(mockEngineCall).not.toHaveBeenCalled();
       expect(
         mockResetAllSessionTrackingForRewardsDashboardModals,
       ).not.toHaveBeenCalled();
       expect(result.current.isLoading).toBe(false);
-
-      // Should not cancel bulk link when no subscription ID
       expect(mockCancelBulkLink).not.toHaveBeenCalled();
     });
   });
@@ -424,9 +363,7 @@ describe('useOptout', () => {
         await result.current.optout();
       });
 
-      // Should cancel bulk link before opt-out
       expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
-      expect(mockCancelBulkLink).toHaveBeenCalled();
       expect(mockEngineCall).toHaveBeenCalled();
     });
 
@@ -439,7 +376,6 @@ describe('useOptout', () => {
         await result.current.optout();
       });
 
-      // Should still cancel bulk link even on failure
       expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
     });
 
@@ -453,478 +389,58 @@ describe('useOptout', () => {
         await result.current.optout();
       });
 
-      // Should still cancel bulk link even on exception
-      expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
-    });
-
-    it('should cancel bulk link when opt-out is called from modal', async () => {
-      mockEngineCall.mockResolvedValueOnce(true);
-      const { result } = renderHook(() => useOptout());
-
-      // Act - Show the modal
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get the confirmAction onPress function from the modal params
-      const modalParams = mockNavigate.mock.calls[0][1];
-      const handleOptoutConfirm = modalParams.confirmAction.onPress;
-
-      // Act - Trigger confirm action
-      await act(async () => {
-        await handleOptoutConfirm();
-      });
-
-      // Should cancel bulk link before opt-out
       expect(mockCancelBulkLink).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('showOptoutBottomSheet', () => {
-    it('should navigate to bottom sheet modal with correct params', () => {
-      // Arrange
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
-        {
-          title: 'Are you sure?',
-          description: 'This action cannot be undone',
-          type: ModalType.Danger,
-          onCancel: expect.any(Function),
-          confirmAction: {
-            label: 'Confirm',
-            loadOnPress: true,
-            onPress: expect.any(Function),
-            variant: ButtonVariant.Primary,
-            disabled: false,
-          },
-        },
-      );
-    });
-
-    it('should navigate to provided dismissRoute when cancel is pressed', () => {
-      // Arrange
-      const dismissRoute = 'CustomDismissRoute';
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet(dismissRoute);
-      });
-
-      // Get onCancel function from navigate call
-      const onCancel = mockNavigate.mock.calls[0][1].onCancel;
-
-      // Act - press cancel
-      act(() => {
-        onCancel();
-      });
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(dismissRoute);
-
-      // Verify metrics tracking for cancel
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
-      );
-    });
-
-    it('should navigate to REWARDS_SETTINGS_VIEW when cancel is pressed with no dismissRoute', () => {
-      // Arrange
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get onCancel function from navigate call
-      const onCancel = mockNavigate.mock.calls[0][1].onCancel;
-
-      // Act - press cancel
-      act(() => {
-        onCancel();
-      });
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_SETTINGS_VIEW);
-
-      // Verify metrics tracking for cancel
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
-      );
-    });
-
-    it('should call optout when confirm is pressed', () => {
-      // Mock implementation of useOptout with a spy
-      const optoutSpy = jest.fn();
-
-      // Mock the hook implementation
-      jest
-        .spyOn(jest.requireActual('./useOptout'), 'useOptout')
-        .mockImplementation(() => ({
-          optout: optoutSpy,
-          isLoading: false,
-          showOptoutBottomSheet(dismissRoute?: string) {
-            const dismissModal = () => {
-              mockNavigate(dismissRoute || Routes.REWARDS_SETTINGS_VIEW);
-            };
-
-            mockNavigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
-              title: 'Are you sure?',
-              description: 'This action cannot be undone',
-              type: ModalType.Danger,
-              onCancel: dismissModal,
-              confirmAction: {
-                label: 'Confirm',
-                onPress: this.optout,
-                variant: ButtonVariant.Primary,
-                disabled: false,
-              },
-            });
-          },
-        }));
-
-      // Render the hook
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get onPress function from navigate call
-      const onPress = mockNavigate.mock.calls[0][1].confirmAction.onPress;
-
-      // Act - press confirm
-      act(() => {
-        onPress();
-      });
-
-      // Assert
-      expect(optoutSpy).toHaveBeenCalled();
-    });
-
-    it('should show processing label when loading', () => {
-      // Mock implementation of useOptout with loading state
-      jest
-        .spyOn(jest.requireActual('./useOptout'), 'useOptout')
-        .mockImplementation(() => ({
-          optout: jest.fn(),
-          isLoading: true,
-          showOptoutBottomSheet(dismissRoute?: string) {
-            const dismissModal = () => {
-              mockNavigate(dismissRoute || Routes.REWARDS_SETTINGS_VIEW);
-            };
-
-            mockNavigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
-              title: 'Are you sure?',
-              description: 'This action cannot be undone',
-              type: ModalType.Danger,
-              onCancel: dismissModal,
-              confirmAction: {
-                label: 'Processing...',
-                loadOnPress: true,
-                onPress: this.optout,
-                variant: ButtonVariant.Primary,
-                disabled: true,
-              },
-            });
-          },
-        }));
-
-      // Render the hook
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
-        expect.objectContaining({
-          confirmAction: expect.objectContaining({
-            label: 'Processing...',
-            loadOnPress: true,
-            disabled: true,
-          }),
-        }),
-      );
-    });
-
-    it('should navigate to WALLET_VIEW after successful opt-out from modal', async () => {
-      // Arrange
-      mockEngineCall.mockResolvedValueOnce(true);
-      const { result } = renderHook(() => useOptout());
-
-      // Act - Show the modal
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get the confirmAction onPress function from the modal params
-      const modalParams = mockNavigate.mock.calls[0][1];
-      const handleOptoutConfirm = modalParams.confirmAction.onPress;
-
-      // Act - Trigger confirm action (this should call optout and navigate on success)
-      await act(async () => {
-        await handleOptoutConfirm();
-      });
-
-      // Assert
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:optOut',
-        mockSubscriptionId,
-      );
-      expect(mockDispatch).toHaveBeenCalledWith(mockResetRewardsState());
-      expect(
-        mockResetAllSessionTrackingForRewardsDashboardModals,
-      ).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
-    });
-
-    it('should not navigate after failed opt-out from modal', async () => {
-      // Arrange
-      mockEngineCall.mockResolvedValueOnce(false);
-      const { result } = renderHook(() => useOptout());
-
-      // Reset navigate mock to only track calls after modal is shown
-      jest.clearAllMocks();
-
-      // Act - Show the modal
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get the confirmAction onPress function from the modal params
-      const modalParams = mockNavigate.mock.calls[0][1];
-      const handleOptoutConfirm = modalParams.confirmAction.onPress;
-
-      // Act - Trigger confirm action (this should call optout but not navigate on failure)
-      await act(async () => {
-        await handleOptoutConfirm();
-      });
-
-      // Assert
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:optOut',
-        mockSubscriptionId,
-      );
-      expect(mockErrorToast).toHaveBeenCalledWith('Failed to opt out');
-      expect(mockShowToast).toHaveBeenCalled();
-      // Should not navigate to WALLET_VIEW after failure
-      expect(mockNavigate).toHaveBeenCalledTimes(1); // Only the initial modal navigation
-      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET_VIEW);
-    });
-
-    it('should not navigate after exception during opt-out from modal', async () => {
-      // Arrange
-      const testError = new Error('Controller error');
-      mockEngineCall.mockRejectedValueOnce(testError);
-      const { result } = renderHook(() => useOptout());
-
-      // Reset navigate mock to only track calls after modal is shown
-      jest.clearAllMocks();
-
-      // Act - Show the modal
-      act(() => {
-        result.current.showOptoutBottomSheet();
-      });
-
-      // Get the confirmAction onPress function from the modal params
-      const modalParams = mockNavigate.mock.calls[0][1];
-      const handleOptoutConfirm = modalParams.confirmAction.onPress;
-
-      // Act - Trigger confirm action (this should call optout but not navigate on exception)
-      await act(async () => {
-        await handleOptoutConfirm();
-      });
-
-      // Assert
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:optOut',
-        mockSubscriptionId,
-      );
-      expect(mockErrorToast).toHaveBeenCalledWith('Failed to opt out');
-      expect(mockShowToast).toHaveBeenCalled();
-      // Should not navigate to WALLET_VIEW after exception
-      expect(mockNavigate).toHaveBeenCalledTimes(1); // Only the initial modal navigation
-      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET_VIEW);
-    });
-  });
-
-  describe('edge cases and scenarios', () => {
-    it('should handle empty/undefined subscription ID', async () => {
-      // Arrange
+  describe('edge cases', () => {
+    it('should handle undefined subscription ID', async () => {
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectRewardsSubscriptionId) {
-          return undefined;
-        }
+        if (selector === selectRewardsSubscriptionId) return undefined;
         return undefined;
       });
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(false);
       expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(
-        mockResetAllSessionTrackingForRewardsDashboardModals,
-      ).not.toHaveBeenCalled();
     });
 
     it('should handle empty string subscription ID', async () => {
-      // Arrange
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectRewardsSubscriptionId) {
-          return '';
-        }
+        if (selector === selectRewardsSubscriptionId) return '';
         return undefined;
       });
 
       const { result } = renderHook(() => useOptout());
 
-      // Act
       let optoutResult: boolean | undefined;
       await act(async () => {
         optoutResult = await result.current.optout();
       });
 
-      // Assert
       expect(optoutResult).toBe(false);
       expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(
-        mockResetAllSessionTrackingForRewardsDashboardModals,
-      ).not.toHaveBeenCalled();
     });
 
-    it('should show correct modal params with custom dismiss route', () => {
-      // Arrange
-      const customDismissRoute = 'CustomRoute';
-      const { result } = renderHook(() => useOptout());
-
-      // Act
-      act(() => {
-        result.current.showOptoutBottomSheet(customDismissRoute);
-      });
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
-        expect.objectContaining({
-          title: 'Are you sure?',
-          description: 'This action cannot be undone',
-          type: ModalType.Danger,
-          onCancel: expect.any(Function),
-          confirmAction: expect.objectContaining({
-            label: 'Confirm',
-            loadOnPress: true,
-            onPress: expect.any(Function),
-            variant: ButtonVariant.Primary,
-            disabled: false,
-          }),
-        }),
-      );
-
-      // Test the cancel action with custom dismiss route
-      const onCancel = mockNavigate.mock.calls[0][1].onCancel;
-      act(() => {
-        onCancel();
-      });
-
-      expect(mockNavigate).toHaveBeenCalledWith(customDismissRoute);
-    });
-
-    it('should handle multiple rapid calls to showOptoutBottomSheet', () => {
-      // Arrange
-      const { result } = renderHook(() => useOptout());
-
-      // Act - Call showOptoutBottomSheet multiple times rapidly
-      act(() => {
-        result.current.showOptoutBottomSheet('Route1');
-        result.current.showOptoutBottomSheet('Route2');
-        result.current.showOptoutBottomSheet('Route3');
-      });
-
-      // Assert - Should have been called 3 times
-      expect(mockNavigate).toHaveBeenCalledTimes(3);
-      expect(mockNavigate).toHaveBeenLastCalledWith(
-        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
-        expect.objectContaining({
-          title: expect.any(String),
-          description: expect.any(String),
-        }),
-      );
-    });
-  });
-
-  describe('callback dependencies and memoization', () => {
-    it('should recreate optout callback when dependencies change', () => {
-      // Arrange
+    it('should recreate optout callback when subscription ID changes', () => {
       const { result, rerender } = renderHook(() => useOptout());
       const initialOptout = result.current.optout;
 
-      // Change subscription ID
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectRewardsSubscriptionId) {
+        if (selector === selectRewardsSubscriptionId)
           return 'new-subscription-id';
-        }
         return undefined;
       });
 
-      // Act
       rerender(undefined);
 
-      // Assert
       expect(result.current.optout).not.toBe(initialOptout);
-    });
-
-    it('should recreate showOptoutBottomSheet callback when dependencies change', () => {
-      // Arrange
-      const { result, rerender } = renderHook(() => useOptout());
-      const initialShowOptoutBottomSheet = result.current.showOptoutBottomSheet;
-
-      // Simulate loading state change by mocking a loading scenario
-      let resolveController: (value: boolean) => void;
-      const controllerPromise = new Promise<boolean>((resolve) => {
-        resolveController = resolve;
-      });
-      mockEngineCall.mockReturnValueOnce(controllerPromise);
-
-      // Start optout to change loading state
-      act(() => {
-        result.current.optout();
-      });
-
-      // Act - Rerender to see if callback changed
-      rerender(undefined);
-
-      // Assert - The callback should be different due to isLoading dependency change
-      expect(result.current.showOptoutBottomSheet).not.toBe(
-        initialShowOptoutBottomSheet,
-      );
-
-      // Clean up
-      act(async () => {
-        resolveController?.(true);
-      });
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useOptout.ts
+++ b/app/components/UI/Rewards/hooks/useOptout.ts
@@ -1,26 +1,22 @@
 import { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import { ButtonVariant } from '@metamask/design-system-react-native';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { resetRewardsState } from '../../../../reducers/rewards';
 import { strings } from '../../../../../locales/i18n';
-import { ModalType } from '../components/RewardsBottomSheetModal';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import useRewardsToast from './useRewardsToast';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { useRewardDashboardModals } from './useRewardDashboardModals';
-import { RewardsMetricsButtons } from '../utils';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { useBulkLinkState } from './useBulkLinkState';
 
 interface UseOptoutResult {
   optout: () => Promise<boolean>;
   isLoading: boolean;
-  showOptoutBottomSheet: (dismissRoute?: string) => void;
 }
 
 export const useOptout = (): UseOptoutResult => {
@@ -71,6 +67,16 @@ export const useOptout = (): UseOptoutResult => {
         // Clear rewards Redux state back to initial state
         dispatch(resetRewardsState());
         resetAllSessionTrackingForRewardsDashboardModals();
+
+        // Navigate to home screen then show "Request received" banner
+        navigation.navigate(Routes.WALLET_VIEW);
+        showToast(
+          RewardsToastOptions.warning(
+            strings('rewards.optout.request_received.title'),
+            strings('rewards.optout.request_received.description'),
+          ),
+        );
+
         return true;
       }
       Logger.log('useOptout: Opt-out failed - controller returned false');
@@ -78,7 +84,6 @@ export const useOptout = (): UseOptoutResult => {
         createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED).build(),
       );
 
-      // Show error toast
       showToast(
         RewardsToastOptions.error(
           strings('rewards.optout.modal.error_message'),
@@ -92,7 +97,6 @@ export const useOptout = (): UseOptoutResult => {
         createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED).build(),
       );
 
-      // Show error toast
       showToast(
         RewardsToastOptions.error(
           strings('rewards.optout.modal.error_message'),
@@ -113,57 +117,11 @@ export const useOptout = (): UseOptoutResult => {
     dispatch,
     resetAllSessionTrackingForRewardsDashboardModals,
     cancelBulkLink,
+    navigation,
   ]);
-
-  const showOptoutBottomSheet = useCallback(
-    (dismissRoute?: string) => {
-      const handleOptoutSuccess = () => {
-        navigation.navigate(Routes.WALLET_VIEW);
-      };
-
-      const handleOptoutCancel = () => {
-        // Navigate to dismissRoute if provided, otherwise default to REWARDS_SETTINGS_VIEW
-        navigation.navigate(dismissRoute || Routes.REWARDS_SETTINGS_VIEW);
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED)
-            .addProperties({
-              button_type: RewardsMetricsButtons.OPT_OUT_CANCEL,
-            })
-            .build(),
-        );
-      };
-
-      const handleOptoutConfirm = async () => {
-        const success = await optout();
-        // Only navigate on successful opt-out (when state is reset)
-        if (success) {
-          handleOptoutSuccess();
-        }
-        // If failed, keep modal open to show error toast
-      };
-
-      navigation.navigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
-        title: strings('rewards.optout.modal.confirmation_title'),
-        description: strings('rewards.optout.modal.confirmation_description'),
-        type: ModalType.Danger,
-        onCancel: handleOptoutCancel,
-        confirmAction: {
-          label: isLoading
-            ? strings('rewards.optout.modal.processing')
-            : strings('rewards.optout.modal.confirm'),
-          loadOnPress: true,
-          onPress: handleOptoutConfirm,
-          variant: ButtonVariant.Primary,
-          disabled: isLoading,
-        },
-      });
-    },
-    [navigation, isLoading, optout, trackEvent, createEventBuilder],
-  );
 
   return {
     optout,
     isLoading,
-    showOptoutBottomSheet,
   };
 };

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -422,6 +422,60 @@ describe('useRewardsToast', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('returns warning configuration with title only', () => {
+      const { result } = renderHook(() => useRewardsToast());
+      const config =
+        result.current.RewardsToastOptions.warning('Request received');
+
+      expect(config).toMatchObject({
+        variant: ToastVariants.Icon,
+        iconName: IconName.Warning,
+        iconColor: mockTheme.colors.warning.default,
+        backgroundColor: 'transparent',
+        hapticsType: NotificationMoment.Warning,
+        hasNoTimeout: true,
+      });
+      expect(config.labelOptions).toEqual([
+        { label: 'Request received', isBold: true },
+      ]);
+      expect(config.descriptionOptions).toBeUndefined();
+      expect(config.closeButtonOptions).toMatchObject({
+        variant: ButtonIconVariant.Icon,
+        iconName: IconName.Close,
+      });
+    });
+
+    it('returns warning configuration with title and subtitle', () => {
+      const { result } = renderHook(() => useRewardsToast());
+      const config = result.current.RewardsToastOptions.warning(
+        'Request received',
+        'In about 7 days, your progress will be fully erased.',
+      );
+
+      expect(config).toMatchObject({
+        variant: ToastVariants.Icon,
+        iconName: IconName.Warning,
+        hapticsType: NotificationMoment.Warning,
+        hasNoTimeout: true,
+      });
+      expect(config.labelOptions).toEqual([
+        { label: 'Request received', isBold: true },
+      ]);
+      expect(config.descriptionOptions).toEqual({
+        description: 'In about 7 days, your progress will be fully erased.',
+      });
+    });
+
+    it('calls closeToast when warning close button is pressed', () => {
+      const { result } = renderHook(() => useRewardsToast());
+      const config =
+        result.current.RewardsToastOptions.warning('Request received');
+
+      config.closeButtonOptions?.onPress?.();
+
+      expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    });
+
     it('returns outcomeNonWinner configuration with CTA and close handlers', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onCta = jest.fn();

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -37,6 +37,7 @@ export interface RewardsToastConfig {
   success: (title: string, subtitle?: string) => RewardsToastOptions;
   error: (title: string, subtitle?: string) => RewardsToastOptions;
   loading: (title: string, subtitle?: string) => RewardsToastOptions;
+  warning: (title: string, subtitle?: string) => RewardsToastOptions;
   entriesClosed: (title: string, subtitle?: string) => RewardsToastOptions;
   enableNotificationsNudge: (
     linkButtonOptions: ToastLinkButtonOptions,
@@ -136,6 +137,24 @@ const useRewardsToast = (): {
         ),
         labelOptions: getRewardsToastLabels(title),
         descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        closeButtonOptions: {
+          variant: ButtonIconVariant.Icon,
+          iconName: IconName.Close,
+          onPress: () => {
+            toastRef?.current?.closeToast();
+          },
+        },
+      }),
+      warning: (title: string, subtitle?: string) => ({
+        ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
+        variant: ToastVariants.Icon,
+        iconName: IconName.Warning,
+        iconColor: theme.colors.warning.default,
+        backgroundColor: 'transparent',
+        hapticsType: NotificationMoment.Warning,
+        labelOptions: getRewardsToastLabels(title),
+        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        hasNoTimeout: true,
         closeButtonOptions: {
           variant: ButtonIconVariant.Icon,
           iconName: IconName.Close,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8550,6 +8550,7 @@
         "confirm_phrase": "erase progress",
         "cancel": "Cancel",
         "confirm": "Confirm",
+        "error_title": "Something went wrong",
         "error_message": "Failed to opt out of Rewards. Please try again.",
         "processing": "Processing..."
       },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8541,15 +8541,21 @@
     },
     "optout": {
       "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "description": "This will remove your accounts from the Rewards program and your progress in any campaigns you've joined. Only do this if you are absolutely sure you want to erase your progress.",
+      "erase_button": "Erase progress",
       "modal": {
         "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+        "confirmation_description": "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+        "type_to_confirm": "Type 'erase progress' to continue",
+        "confirm_phrase": "erase progress",
         "cancel": "Cancel",
         "confirm": "Confirm",
         "error_message": "Failed to opt out of Rewards. Please try again.",
         "processing": "Processing..."
+      },
+      "request_received": {
+        "title": "Request received",
+        "description": "In about 7 days, your progress will be fully erased. If you made this request by mistake, please contact support through the app."
       }
     },
     "toast_dismiss": "Dismiss",


### PR DESCRIPTION
## Summary

- Re-introduces the rewards opt-out feature as a **soft delete** reversible within ~7 days, backed by [`va-mmcx-rewards#562`](https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/562)
- Adds `OptOutSection` (title + "Erase progress" button) to the Rewards Settings footer, below `ReferredByCodeSection`
- Adds `OptOutConfirmationSheet` — a `BottomSheet` with a type-to-confirm text input (phrase: "erase progress", case-insensitive + trimmed), Cancel + Confirm (danger) buttons, and an error banner on failure
- On successful opt-out: navigates to wallet home and shows a persistent warning toast ("Request received — in about 7 days, your progress will be fully erased")
- Sheet is rendered at `RewardsSettingsView` level (sibling of the `FlashList`) so the modal overlay covers the full screen, matching the `LinkedOffDeviceAccountsSheet` pattern
- Uses `KeyboardAwareScrollView` inside the sheet so the input and action buttons scroll above the keyboard on Android/iOS
- `useOptout` hook updated: removes old `showOptoutBottomSheet` modal-route flow; on success dispatches `resetRewardsState`, resets session tracking, navigates to `WALLET_VIEW`, and shows a `warning` toast
- `useRewardsToast` gains a `warning` toast variant
- i18n strings updated in `en.json` — no mention of "points" anywhere

## Changelog

CHANGELOG entry: null

## Screenshots

<img width="511" height="1009" alt="Screenshot_2026-05-18_11-24-57" src="https://github.com/user-attachments/assets/38c83ff7-fd48-4ea7-8f72-49557f84e147" />

<img width="500" height="603" alt="Screenshot_2026-05-18_11-24-50" src="https://github.com/user-attachments/assets/1f4974f2-55af-4a6c-98e1-0d0499292d0b" />

<img width="1220" height="2712" alt="image" src="https://github.com/user-attachments/assets/715197f5-f4f5-491b-8571-28f739bbf4b9" />

<img width="1220" height="2712" alt="image" src="https://github.com/user-attachments/assets/e8aac08c-6741-4adf-8fdd-5ae3671850a8" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a destructive opt-out flow that resets Rewards state and changes navigation/toast behavior; bugs here could incorrectly close the sheet or leave users in an inconsistent Rewards state.
> 
> **Overview**
> Re-introduces Rewards opt-out from the Settings screen via a new **type-to-confirm** `OptOutConfirmationSheet`, surfaced from a new footer `OptOutSection` in `RewardSettingsAccountGroupList`.
> 
> Updates `RewardsSettingsView` to manage opt-out sheet open/close/error state and to call `useOptout`, while `useOptout` now performs the opt-out then **resets Rewards state**, navigates to `Routes.WALLET_VIEW`, and shows a persistent `warning` toast.
> 
> Extends `useRewardsToast` with a new `warning` variant and updates i18n strings/tests to cover the new UI and success/error behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ec1ffc275c7fad49e444954dd85ae3f0734b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->