### PR TITLE
fix(metamask-pay): cp-7.80.0 use latest on-chain nonce for EIP-7702 authorization list

### DIFF
--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -6,8 +6,9 @@ import {
 import { SignMessenger, getDelegationTransaction } from './delegation';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import { Hex } from '@metamask/utils';
+import { toHex } from '@metamask/controller-utils';
 
-const mockGetNonceLock = jest.fn();
+const mockProviderRequest = jest.fn();
 
 const mockIsAtomicBatchSupported: jest.MockedFn<
   TransactionController['isAtomicBatchSupported']
@@ -18,9 +19,13 @@ jest.spyOn(Math, 'random').mockReturnValue(0);
 jest.mock('../../core/Engine', () => ({
   context: {
     TransactionController: {
-      getNonceLock: () => mockGetNonceLock(),
       isAtomicBatchSupported: (request: IsAtomicBatchSupportedRequest) =>
         mockIsAtomicBatchSupported(request),
+    },
+    NetworkController: {
+      getNetworkClientById: () => ({
+        provider: { request: (args: unknown) => mockProviderRequest(args) },
+      }),
     },
   },
 }));
@@ -32,8 +37,11 @@ const NONCE_MOCK = 123;
 const AUTHORIZATION_SIGNATURE_MOCK =
   '0xf85c827a6994663f3ad617193148711d28f5334ee4ed070166028080a040e292da533253143f134643a03405f1af1de1d305526f44ed27e62061368d4ea051cfb0af34e491aa4d6796dececf95569088322e116c4b2f312bb23f20699269';
 
+const NETWORK_CLIENT_ID_MOCK = 'mainnet';
+
 const TRANSACTION_META_MOCK = {
   chainId: '0x1' as Hex,
+  networkClientId: NETWORK_CLIENT_ID_MOCK,
   nestedTransactions: [
     {
       data: '0x123456781234' as Hex,
@@ -78,10 +86,7 @@ describe('Transaction Delegation Utils', () => {
       },
     ]);
 
-    mockGetNonceLock.mockResolvedValue({
-      nextNonce: NONCE_MOCK,
-      releaseLock: jest.fn(),
-    });
+    mockProviderRequest.mockResolvedValue(toHex(NONCE_MOCK));
   });
 
   describe('getDelegationTransaction', () => {

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -6,9 +6,8 @@ import {
 import { SignMessenger, getDelegationTransaction } from './delegation';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import { Hex } from '@metamask/utils';
-import { toHex } from '@metamask/controller-utils';
 
-const mockProviderRequest = jest.fn();
+const mockGetNonceLock = jest.fn();
 
 const mockIsAtomicBatchSupported: jest.MockedFn<
   TransactionController['isAtomicBatchSupported']
@@ -19,13 +18,9 @@ jest.spyOn(Math, 'random').mockReturnValue(0);
 jest.mock('../../core/Engine', () => ({
   context: {
     TransactionController: {
+      getNonceLock: () => mockGetNonceLock(),
       isAtomicBatchSupported: (request: IsAtomicBatchSupportedRequest) =>
         mockIsAtomicBatchSupported(request),
-    },
-    NetworkController: {
-      getNetworkClientById: () => ({
-        provider: { request: (args: unknown) => mockProviderRequest(args) },
-      }),
     },
   },
 }));
@@ -86,7 +81,10 @@ describe('Transaction Delegation Utils', () => {
       },
     ]);
 
-    mockProviderRequest.mockResolvedValue(toHex(NONCE_MOCK));
+    mockGetNonceLock.mockResolvedValue({
+      nonceDetails: { params: { nextNetworkNonce: NONCE_MOCK } },
+      releaseLock: jest.fn(),
+    });
   });
 
   describe('getDelegationTransaction', () => {

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -134,13 +134,19 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
     throw new Error('Upgrade contract address not found');
   }
 
-  const nonceLock = await TransactionController.getNonceLock(
-    from,
-    networkClientId,
-  );
+  const { NetworkController } = Engine.context;
+  const provider = NetworkController.getNetworkClientById(networkClientId)?.provider;
 
-  const nonce = nonceLock.nextNonce;
-  nonceLock.releaseLock();
+  if (!provider) {
+    throw new Error('Provider not found for network client');
+  }
+
+  const nonceHex = await provider.request({
+    method: 'eth_getTransactionCount',
+    params: [from, 'latest'],
+  });
+
+  const nonce = parseInt(nonceHex as string, 16);
 
   const authorizationSignature = (await messenger.call(
     'KeyringController:signEip7702Authorization',

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -134,19 +134,13 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
     throw new Error('Upgrade contract address not found');
   }
 
-  const { NetworkController } = Engine.context;
-  const provider = NetworkController.getNetworkClientById(networkClientId)?.provider;
+  const nonceLock = await TransactionController.getNonceLock(
+    from,
+    networkClientId,
+  );
 
-  if (!provider) {
-    throw new Error('Provider not found for network client');
-  }
-
-  const nonceHex = await provider.request({
-    method: 'eth_getTransactionCount',
-    params: [from, 'latest'],
-  });
-
-  const nonce = parseInt(nonceHex as string, 16);
+  const nonce = nonceLock.nonceDetails.params.nextNetworkNonce;
+  nonceLock.releaseLock();
 
   const authorizationSignature = (await messenger.call(
     'KeyringController:signEip7702Authorization',


### PR DESCRIPTION
## **Description**

When building the EIP-7702 authorization list for a Pay delegation transaction, the nonce was previously read from `NonceLock.nextNonce` — the value computed by the nonce tracker, which accounts for locally-pending transactions the Relay has no visibility into. This could produce a nonce ahead of the true on-chain state, causing the Relay to reject the authorization as invalid.

The fix reads `NonceLock.nonceDetails.params.nextNetworkNonce` instead — the raw `eth_getTransactionCount` result that the nonce tracker already fetches internally. This gives the committed on-chain nonce the Relay needs to verify the authorization signature, without introducing a separate provider call or adding a new Engine dependency.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: #30798 

## **Manual testing steps**

```gherkin
Feature: EIP-7702 Pay delegation transaction

  Scenario: user submits a Pay transaction requiring EIP-7702 upgrade
    Given the account has not yet been delegated (not upgraded to EIP-7702)
    And the account has locally-pending transactions in the queue

    When user initiates a Pay transaction and confirms
    Then the authorization list is signed with the correct on-chain nonce
    And the transaction submits successfully via Relay
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — no UI change -->

### **After**

<!-- N/A — no UI change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nonce selection for EIP-7702 authorization signing in Pay flows; wrong nonce would break Relay submission but scope is limited to delegation authorization building.
> 
> **Overview**
> **EIP-7702 Pay delegation** now signs the authorization list with the **committed on-chain nonce** (`nonceLock.nonceDetails.params.nextNetworkNonce`) instead of the nonce tracker’s **`nextNonce`**, which can include locally pending txs the Relay cannot see.
> 
> Tests were updated to mock `networkClientId` on transaction meta and to return the new nonce lock shape so `KeyringController:signEip7702Authorization` still receives the expected nonce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0387b8ef2ad1d6830538947fc733a35df60ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->