### PR TITLE
chore: add source property to all Market Insights analytics events

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -32,6 +32,7 @@ let mockRouteParams: {
   token?: Record<string, unknown>;
   isPerps?: boolean;
   hasPerpsPosition?: boolean;
+  source?: 'token_details' | 'perps' | 'unknown';
 } = {
   assetSymbol: 'ETH',
   assetIdentifier: 'eip155:1/erc20:0x123',
@@ -541,7 +542,7 @@ describe('MarketInsightsView', () => {
         properties: expect.objectContaining({
           asset_symbol: 'eth',
           interaction_type: 'source_click',
-          source: 'https://www.coindesk.com/article',
+          source_url: 'https://www.coindesk.com/article',
         }),
       }),
     );

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -160,6 +160,8 @@ interface MarketInsightsRouteParams {
   isPerps?: boolean;
   /** When true, the user has an existing perps position for this asset */
   hasPerpsPosition?: boolean;
+  /** Surface from which Market Insights was accessed */
+  source?: 'token_details' | 'perps' | 'unknown';
 }
 
 /**
@@ -187,6 +189,7 @@ const MarketInsightsView: React.FC = () => {
     token: stickyFooterToken,
     isPerps = false,
     hasPerpsPosition = false,
+    source: routeSource = 'unknown',
   } = route.params;
 
   const isMarketInsightsEnabled = isPerps
@@ -278,6 +281,7 @@ const MarketInsightsView: React.FC = () => {
       .addProperties({
         ...assetIdProperty,
         ...assetSymbolProperty,
+        source: routeSource,
       })
       .build();
     trackEvent(event);
@@ -288,6 +292,7 @@ const MarketInsightsView: React.FC = () => {
     createEventBuilder,
     assetIdProperty,
     assetSymbolProperty,
+    routeSource,
   ]);
 
   const handleTweetPress = useCallback((url: string) => {
@@ -321,6 +326,7 @@ const MarketInsightsView: React.FC = () => {
             ...assetIdProperty,
             ...assetSymbolProperty,
             interaction_type: direction,
+            source: routeSource,
           })
           .build();
         trackEvent(event);
@@ -340,6 +346,7 @@ const MarketInsightsView: React.FC = () => {
       assetIdProperty,
       assetSymbolProperty,
       assetSymbol,
+      routeSource,
     ],
   );
 
@@ -351,10 +358,17 @@ const MarketInsightsView: React.FC = () => {
         ...assetIdProperty,
         ...assetSymbolProperty,
         interaction_type: 'swap',
+        source: routeSource,
       })
       .build();
     trackEvent(event);
-  }, [trackEvent, createEventBuilder, assetIdProperty, assetSymbolProperty]);
+  }, [
+    trackEvent,
+    createEventBuilder,
+    assetIdProperty,
+    assetSymbolProperty,
+    routeSource,
+  ]);
 
   const handleStickyBuyPress = useCallback(() => {
     const event = createEventBuilder(
@@ -364,10 +378,17 @@ const MarketInsightsView: React.FC = () => {
         ...assetIdProperty,
         ...assetSymbolProperty,
         interaction_type: 'buy',
+        source: routeSource,
       })
       .build();
     trackEvent(event);
-  }, [trackEvent, createEventBuilder, assetIdProperty, assetSymbolProperty]);
+  }, [
+    trackEvent,
+    createEventBuilder,
+    assetIdProperty,
+    assetSymbolProperty,
+    routeSource,
+  ]);
 
   const handleTrendPress = useCallback((trend: MarketInsightsTrend) => {
     const hasArticles = trend.articles.length > 0;
@@ -410,7 +431,7 @@ const MarketInsightsView: React.FC = () => {
     (
       interactionType: 'thumbs_up' | 'thumbs_down' | 'source_click',
       options?: {
-        source?: string;
+        source_url?: string;
         feedbackReason?: MarketInsightsFeedbackReason;
         feedbackText?: string;
       },
@@ -419,7 +440,8 @@ const MarketInsightsView: React.FC = () => {
         ...assetIdProperty,
         ...assetSymbolProperty,
         interaction_type: interactionType,
-        ...(options?.source ? { source: options.source } : {}),
+        source: routeSource,
+        ...(options?.source_url ? { source_url: options.source_url } : {}),
         ...(options?.feedbackReason
           ? { feedback_reason: options.feedbackReason }
           : {}),
@@ -434,7 +456,13 @@ const MarketInsightsView: React.FC = () => {
         .build();
       trackEvent(event);
     },
-    [trackEvent, createEventBuilder, assetIdProperty, assetSymbolProperty],
+    [
+      trackEvent,
+      createEventBuilder,
+      assetIdProperty,
+      assetSymbolProperty,
+      routeSource,
+    ],
   );
 
   const showFeedbackSubmittedToast = useCallback(() => {
@@ -512,7 +540,7 @@ const MarketInsightsView: React.FC = () => {
       if (!isSafeUrl(url)) {
         return;
       }
-      trackMarketInsightsInteraction('source_click', { source: url });
+      trackMarketInsightsInteraction('source_click', { source_url: url });
       setSelectedTrend(null);
       navigation.navigate(Routes.BROWSER.HOME, {
         screen: Routes.BROWSER.VIEW,
@@ -541,6 +569,7 @@ const MarketInsightsView: React.FC = () => {
       .addProperties({
         ...assetIdProperty,
         ...assetSymbolProperty,
+        source: routeSource,
       })
       .build();
     trackEvent(event);
@@ -553,6 +582,7 @@ const MarketInsightsView: React.FC = () => {
     assetIdentifier,
     trackEvent,
     createEventBuilder,
+    routeSource,
   ]);
 
   if (showLoadingSkeleton && !report && !error) {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.test.tsx
@@ -129,6 +129,7 @@ describe('MarketInsightsEntryCard', () => {
         timeAgo="3m ago"
         onPress={mockPress}
         caip19Id={'eip155:1/erc20:0xtest' as CaipAssetType}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -152,6 +153,7 @@ describe('MarketInsightsEntryCard', () => {
         }
         timeAgo="3m ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -177,6 +179,7 @@ describe('MarketInsightsEntryCard', () => {
         timeAgo="1m ago"
         onPress={jest.fn()}
         caip19Id={'eip155:1/erc20:0xtest' as CaipAssetType}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -192,6 +195,7 @@ describe('MarketInsightsEntryCard', () => {
         properties: {
           caip19: 'eip155:1/erc20:0xtest',
           asset_symbol: 'eth',
+          source: 'token_details',
           digest_id: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
         },
       }),
@@ -212,6 +216,7 @@ describe('MarketInsightsEntryCard', () => {
         }
         timeAgo="1m ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -230,6 +235,7 @@ describe('MarketInsightsEntryCard', () => {
         report={mockReport as never}
         timeAgo="5h ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -245,6 +251,7 @@ describe('MarketInsightsEntryCard', () => {
         report={mockReport as never}
         timeAgo="3m ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -299,6 +306,7 @@ describe('MarketInsightsEntryCard', () => {
         report={mockReport as never}
         timeAgo="3m ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -326,6 +334,7 @@ describe('MarketInsightsEntryCard', () => {
         timeAgo="3m ago"
         onPress={jest.fn()}
         onDisclaimerPress={onDisclaimerPress}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );
@@ -343,6 +352,7 @@ describe('MarketInsightsEntryCard', () => {
         report={mockReport as never}
         timeAgo="3m ago"
         onPress={jest.fn()}
+        source="token_details"
         testID="market-insights-entry-card"
       />,
     );

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -132,6 +132,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
   onPress,
   onDisclaimerPress,
   caip19Id,
+  source,
   testID,
 }) => {
   const tw = useTailwind();
@@ -178,11 +179,12 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
       .addProperties({
         caip19: caip19Id,
         asset_symbol: report.asset,
+        source,
         ...(digestId !== undefined ? { digest_id: digestId } : {}),
       })
       .build();
     trackEvent(event);
-  }, [trackEvent, createEventBuilder, caip19Id, report]);
+  }, [trackEvent, createEventBuilder, caip19Id, report, source]);
 
   const { ref: cardRef, onLayout: onVisibilityLayout } = useViewportTracking(
     handleVisible,

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.types.ts
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.types.ts
@@ -15,6 +15,8 @@ export interface MarketInsightsEntryCardProps {
    * by the parent component (AssetOverviewContent in the token details flow).
    */
   caip19Id?: CaipAssetType;
+  /** Surface from which the Market Insights feature was accessed */
+  source: 'token_details' | 'perps' | 'unknown';
   /** Optional test ID */
   testID?: string;
 }

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -3635,6 +3635,7 @@ describe('PerpsMarketDetailsView', () => {
         MetaMetricsEvents.MARKET_INSIGHTS_OPENED,
         expect.objectContaining({
           perps_market: 'BTC',
+          source: 'perps',
           asset_symbol: 'BTC',
           digest_id: 'b9265d68-d776-55ad-9cc6-gdbbbf07fg033',
         }),

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1078,6 +1078,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     if (!market?.symbol) return;
     track(MetaMetricsEvents.MARKET_INSIGHTS_OPENED, {
       perps_market: market.symbol,
+      source: 'perps',
       ...(perpsInsightsReport && {
         asset_symbol: perpsInsightsReport.asset,
         digest_id: perpsInsightsReport.digestId,
@@ -1092,6 +1093,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       assetIdentifier: market.symbol,
       isPerps: true,
       hasPerpsPosition: !!existingPosition,
+      source: 'perps',
     });
   }, [
     market?.symbol,
@@ -1416,6 +1418,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
                 timeAgo={perpsInsightsTimeAgo}
                 onPress={handleMarketInsightsPress}
                 onDisclaimerPress={() => setIsInsightsDisclaimerVisible(true)}
+                source="perps"
                 testID={MarketInsightsSelectorsIDs.ENTRY_CARD}
               />
             ) : (

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.test.tsx
@@ -428,6 +428,7 @@ describe('AssetOverviewContent', () => {
       );
       expect(mockAddProperties).toHaveBeenCalledWith({
         caip19: 'eip155:1/erc20:0x123',
+        source: 'token_details',
         asset_symbol: 'eth',
         digest_id: 'a8154c57-c665-449c-8bb5-fcaae96ef922',
       });

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -500,6 +500,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
       const event = createEventBuilder(MetaMetricsEvents.MARKET_INSIGHTS_OPENED)
         .addProperties({
           caip19: marketInsightsCaip19Id,
+          source: 'token_details',
           ...(marketInsightsReport && {
             asset_symbol: marketInsightsReport.asset,
             digest_id: marketInsightsReport.digestId,
@@ -519,6 +520,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
       tokenImageUrl: token.image || token.logo,
       pricePercentChange: percentChange,
       token,
+      source: 'token_details',
     });
   }, [
     navigation,
@@ -742,6 +744,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
                   onPress={handleMarketInsightsPress}
                   onDisclaimerPress={onMarketInsightsDisclaimerPress}
                   caip19Id={marketInsightsCaip19Id ?? undefined}
+                  source="token_details"
                   testID="market-insights-entry-card"
                 />
               ) : (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adds a required source property to all five Market Insights Segment events, and renames the source URL field on Market Insights Interaction to source_url to avoid collision.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics payload shape and navigation params for Market Insights, with updated tests; main risk is downstream dashboards/consumers expecting the old `source` URL field name.
> 
> **Overview**
> Adds a `source` dimension (`token_details` | `perps` | `unknown`) to Market Insights navigation params and threads it through **all Market Insights analytics events** (`OPENED`, `VIEWED`, `CLOSED`, `INTERACTION`, `CARD_SCROLLED_TO_VIEW`).
> 
> Renames the Market Insights interaction click property from `source` to `source_url` to avoid colliding with the new surface `source`, and updates callers/tests in Token Details, Perps, and Market Insights views accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4be181a0e0d6a46a2acee2c4fc89be285543548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->