### PR TITLE
fix: handle Perps withdraw batch initialization errors cp-7.78.0

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
@@ -198,6 +198,16 @@ describe('usePerpsDepositStatus', () => {
             ],
             hapticsType: NotificationMoment.Error,
           })),
+          withdrawalStartFailed: jest.fn(() => ({
+            variant: ToastVariants.Icon,
+            iconName: IconName.Warning,
+            hasNoTimeout: false,
+            labelOptions: [
+              { label: 'Something went wrong', isBold: true },
+              { label: 'Your withdrawal was not started' },
+            ],
+            hapticsType: NotificationMoment.Error,
+          })),
         },
       },
       // Add minimal stubs for other required properties

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -242,6 +242,25 @@ describe('usePerpsToasts', () => {
           isBold: false,
         });
       });
+
+      it('returns withdrawal start failed configuration with retry action', () => {
+        const onRetry = jest.fn();
+        const { result } = renderHook(() => usePerpsToasts());
+        const config =
+          result.current.PerpsToastOptions.accountManagement.withdrawal.withdrawalStartFailed(
+            onRetry,
+          );
+
+        expect(config.labelOptions).toEqual([
+          { label: 'Something went wrong', isBold: true },
+          { label: '\n', isBold: false },
+          { label: 'Your withdrawal wasn’t started.', isBold: false },
+        ]);
+        expect(config.linkButtonOptions).toMatchObject({
+          label: 'Try again',
+          onPress: onRetry,
+        });
+      });
     });
 
     describe('orderManagement.market', () => {

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -10,6 +10,7 @@ import {
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../constants/navigation/Routes';
+import { mockTheme } from '../../../../util/theme';
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),
@@ -22,9 +23,12 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../../util/haptics');
 
 jest.mock('../../../../util/theme', () => {
-  const { mockTheme } = jest.requireActual('../../../../util/theme');
+  const { mockTheme: actualMockTheme } = jest.requireActual(
+    '../../../../util/theme',
+  );
   return {
-    useAppThemeFromContext: jest.fn(() => mockTheme),
+    mockTheme: actualMockTheme,
+    useAppThemeFromContext: jest.fn(() => actualMockTheme),
   };
 });
 
@@ -259,6 +263,11 @@ describe('usePerpsToasts', () => {
         expect(config.linkButtonOptions).toMatchObject({
           label: 'Try again',
           onPress: onRetry,
+        });
+        expect(config).toMatchObject({
+          iconName: IconName.Error,
+          iconColor: mockTheme.colors.error.default,
+          backgroundColor: mockTheme.colors.accent04.normal,
         });
       });
     });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -11,6 +11,7 @@ import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../constants/navigation/Routes';
 import { mockTheme } from '../../../../util/theme';
+import { darkTheme } from '@metamask/design-tokens';
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),
@@ -267,7 +268,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           iconName: IconName.Error,
           iconColor: mockTheme.colors.error.default,
-          backgroundColor: mockTheme.colors.accent04.normal,
+          backgroundColor: darkTheme.colors.accent04.normal,
         });
       });
     });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -116,6 +116,33 @@ describe('usePerpsToasts', () => {
       });
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
+
+    it('passes retryable withdrawal start failed toast options to toastRef', () => {
+      const onRetry = jest.fn();
+      const { result } = renderHook(() => usePerpsToasts());
+      const config =
+        result.current.PerpsToastOptions.accountManagement.withdrawal.withdrawalStartFailed(
+          onRetry,
+        );
+
+      act(() => {
+        result.current.showToast(config);
+      });
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Error,
+          iconColor: mockTheme.colors.error.default,
+          backgroundColor: darkTheme.colors.accent04.normal,
+          linkButtonOptions: {
+            label: 'Try again',
+            onPress: onRetry,
+          },
+        }),
+      );
+      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Error);
+    });
   });
 
   describe('PerpsToastOptions configurations', () => {

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -11,7 +11,6 @@ import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../constants/navigation/Routes';
 import { mockTheme } from '../../../../util/theme';
-import { darkTheme } from '@metamask/design-tokens';
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),
@@ -134,7 +133,7 @@ describe('usePerpsToasts', () => {
           variant: ToastVariants.Icon,
           iconName: IconName.Error,
           iconColor: mockTheme.colors.error.default,
-          backgroundColor: darkTheme.colors.accent04.normal,
+          backgroundColor: mockTheme.colors.accent04.normal,
           linkButtonOptions: {
             label: 'Try again',
             onPress: onRetry,
@@ -295,7 +294,7 @@ describe('usePerpsToasts', () => {
         expect(config).toMatchObject({
           iconName: IconName.Error,
           iconColor: mockTheme.colors.error.default,
-          backgroundColor: darkTheme.colors.accent04.normal,
+          backgroundColor: mockTheme.colors.accent04.normal,
         });
       });
     });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -31,6 +31,7 @@ import {
   getPerpsDisplaySymbol,
   type Position,
 } from '@metamask/perps-controller';
+import { darkTheme } from '@metamask/design-tokens';
 import { formatPerpsFiat } from '../utils/formatUtils';
 import { handlePerpsError } from '../utils/translatePerpsError';
 import { formatDurationForDisplay } from '../utils/time';
@@ -500,7 +501,7 @@ const usePerpsToasts = (): {
             ...perpsBaseToastOptions.error,
             iconName: IconName.Error,
             iconColor: theme.colors.error.default,
-            backgroundColor: theme.colors.accent04.normal,
+            backgroundColor: darkTheme.colors.accent04.normal,
             labelOptions: getPerpsToastLabels(
               strings('perps.withdrawal.toast_error_title'),
               strings('perps.withdrawal.toast_start_error_description'),
@@ -1012,7 +1013,6 @@ const usePerpsToasts = (): {
       perpsBaseToastOptions.success,
       perpsBaseToastOptions.warning,
       perpsToastButtonOptions,
-      theme.colors.accent04.normal,
       theme.colors.background.muted,
       theme.colors.error.default,
       theme.colors.error.muted,

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -498,6 +498,9 @@ const usePerpsToasts = (): {
           }),
           withdrawalStartFailed: (onRetry: () => void) => ({
             ...perpsBaseToastOptions.error,
+            iconName: IconName.Error,
+            iconColor: theme.colors.error.default,
+            backgroundColor: theme.colors.accent04.normal,
             labelOptions: getPerpsToastLabels(
               strings('perps.withdrawal.toast_error_title'),
               strings('perps.withdrawal.toast_start_error_description'),
@@ -1009,6 +1012,7 @@ const usePerpsToasts = (): {
       perpsBaseToastOptions.success,
       perpsBaseToastOptions.warning,
       perpsToastButtonOptions,
+      theme.colors.accent04.normal,
       theme.colors.background.muted,
       theme.colors.error.default,
       theme.colors.error.muted,

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -31,7 +31,6 @@ import {
   getPerpsDisplaySymbol,
   type Position,
 } from '@metamask/perps-controller';
-import { darkTheme } from '@metamask/design-tokens';
 import { formatPerpsFiat } from '../utils/formatUtils';
 import { handlePerpsError } from '../utils/translatePerpsError';
 import { formatDurationForDisplay } from '../utils/time';
@@ -501,7 +500,7 @@ const usePerpsToasts = (): {
             ...perpsBaseToastOptions.error,
             iconName: IconName.Error,
             iconColor: theme.colors.error.default,
-            backgroundColor: darkTheme.colors.accent04.normal,
+            backgroundColor: theme.colors.accent04.normal,
             labelOptions: getPerpsToastLabels(
               strings('perps.withdrawal.toast_error_title'),
               strings('perps.withdrawal.toast_start_error_description'),
@@ -1013,6 +1012,7 @@ const usePerpsToasts = (): {
       perpsBaseToastOptions.success,
       perpsBaseToastOptions.warning,
       perpsToastButtonOptions,
+      theme.colors.accent04.normal,
       theme.colors.background.muted,
       theme.colors.error.default,
       theme.colors.error.muted,

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -66,6 +66,7 @@ export interface PerpsToastOptionsConfig {
         assetSymbol: string,
       ) => PerpsToastOptions;
       withdrawalFailed: (error?: string) => PerpsToastOptions;
+      withdrawalStartFailed: (onRetry: () => void) => PerpsToastOptions;
     };
   };
   orderManagement: {
@@ -494,6 +495,17 @@ const usePerpsToasts = (): {
                 fallbackMessage: strings('perps.withdrawal.error_generic'),
               }),
             ),
+          }),
+          withdrawalStartFailed: (onRetry: () => void) => ({
+            ...perpsBaseToastOptions.error,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.withdrawal.toast_error_title'),
+              strings('perps.withdrawal.toast_start_error_description'),
+            ),
+            linkButtonOptions: {
+              label: strings('perps.withdrawal.try_again'),
+              onPress: onRetry,
+            },
           }),
         },
       },

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -2,7 +2,7 @@ import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { useNavigation } from '@react-navigation/native';
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
 import { selectDefaultEndpointByChainId } from '../../../../selectors/networkController';
@@ -176,5 +176,46 @@ describe('usePerpsWithdrawConfirmation', () => {
 
     expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(2);
     expect(mockAddTransactionBatch).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes non-Error addTransactionBatch failures before rethrowing', async () => {
+    mockAddTransactionBatch.mockRejectedValueOnce('batch failed');
+
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await expect(
+      act(async () => {
+        await result.current.withdrawWithConfirmation();
+      }),
+    ).rejects.toThrow('batch failed');
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalStartFailedToast);
+  });
+
+  it('swallows retry failures after showing another retryable error toast', async () => {
+    mockAddTransactionBatch
+      .mockRejectedValueOnce(new Error('batch failed'))
+      .mockRejectedValueOnce(new Error('retry failed'));
+
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await expect(
+      act(async () => {
+        await result.current.withdrawWithConfirmation();
+      }),
+    ).rejects.toThrow('batch failed');
+
+    act(() => {
+      retryWithdraw?.();
+    });
+
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(2);
+    expect(mockShowToast).toHaveBeenCalledTimes(2);
+    expect(mockWithdrawalStartFailed).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -55,7 +55,11 @@ const mockNavigateToConfirmation = jest.fn();
 const mockGoBack = jest.fn();
 const mockShowToast = jest.fn();
 const mockWithdrawalStartFailedToast = { labelOptions: [{ label: 'failed' }] };
-const mockWithdrawalStartFailed = jest.fn(() => mockWithdrawalStartFailedToast);
+let retryWithdraw: (() => void) | undefined;
+const mockWithdrawalStartFailed = jest.fn((onRetry: () => void) => {
+  retryWithdraw = onRetry;
+  return mockWithdrawalStartFailedToast;
+});
 
 describe('usePerpsWithdrawConfirmation', () => {
   const mockAddTransactionBatch = jest.mocked(addTransactionBatch);
@@ -72,6 +76,7 @@ describe('usePerpsWithdrawConfirmation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    retryWithdraw = undefined;
 
     mockSelectSelectedInternalAccountAddress.mockReturnValue(MOCK_ACCOUNT);
     mockSelectDefaultEndpointByChainId.mockReturnValue({
@@ -165,10 +170,8 @@ describe('usePerpsWithdrawConfirmation', () => {
     );
     expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalStartFailedToast);
 
-    const retry = mockWithdrawalStartFailed.mock.calls[0][0];
-
     act(() => {
-      retry();
+      retryWithdraw?.();
     });
 
     expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(2);

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -54,8 +54,8 @@ const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
 const mockNavigateToConfirmation = jest.fn();
 const mockGoBack = jest.fn();
 const mockShowToast = jest.fn();
-const mockWithdrawalFailedToast = { labelOptions: [{ label: 'failed' }] };
-const mockWithdrawalFailed = jest.fn(() => mockWithdrawalFailedToast);
+const mockWithdrawalStartFailedToast = { labelOptions: [{ label: 'failed' }] };
+const mockWithdrawalStartFailed = jest.fn(() => mockWithdrawalStartFailedToast);
 
 describe('usePerpsWithdrawConfirmation', () => {
   const mockAddTransactionBatch = jest.mocked(addTransactionBatch);
@@ -90,7 +90,7 @@ describe('usePerpsWithdrawConfirmation', () => {
       PerpsToastOptions: {
         accountManagement: {
           withdrawal: {
-            withdrawalFailed: mockWithdrawalFailed,
+            withdrawalStartFailed: mockWithdrawalStartFailed,
           },
         },
       },
@@ -147,7 +147,7 @@ describe('usePerpsWithdrawConfirmation', () => {
     });
   });
 
-  it('navigates back and shows an error toast when addTransactionBatch fails', async () => {
+  it('navigates back and shows a retryable error toast when addTransactionBatch fails', async () => {
     const error = new Error('batch failed');
     mockAddTransactionBatch.mockRejectedValueOnce(error);
 
@@ -160,7 +160,18 @@ describe('usePerpsWithdrawConfirmation', () => {
     ).rejects.toThrow('batch failed');
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
-    expect(mockWithdrawalFailed).toHaveBeenCalledWith('batch failed');
-    expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalFailedToast);
+    expect(mockWithdrawalStartFailed).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+    expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalStartFailedToast);
+
+    const retry = mockWithdrawalStartFailed.mock.calls[0][0];
+
+    act(() => {
+      retry();
+    });
+
+    expect(mockNavigateToConfirmation).toHaveBeenCalledTimes(2);
+    expect(mockAddTransactionBatch).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -1,4 +1,5 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { useNavigation } from '@react-navigation/native';
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { renderHook, act } from '@testing-library/react-native';
@@ -12,6 +13,11 @@ import { ConfirmationLoader } from '../../../Views/confirmations/components/conf
 import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
 import Routes from '../../../../constants/navigation/Routes';
 import { usePerpsWithdrawConfirmation } from './usePerpsWithdrawConfirmation';
+import usePerpsToasts from './usePerpsToasts';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -40,10 +46,16 @@ jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
   useConfirmNavigation: jest.fn(),
 }));
 
+jest.mock('./usePerpsToasts', () => jest.fn());
+
 const MOCK_ACCOUNT = '0x1234567890123456789012345678901234567890' as Hex;
 const MOCK_TRANSFER_DATA = '0xabcdef' as Hex;
 const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
 const mockNavigateToConfirmation = jest.fn();
+const mockGoBack = jest.fn();
+const mockShowToast = jest.fn();
+const mockWithdrawalFailedToast = { labelOptions: [{ label: 'failed' }] };
+const mockWithdrawalFailed = jest.fn(() => mockWithdrawalFailedToast);
 
 describe('usePerpsWithdrawConfirmation', () => {
   const mockAddTransactionBatch = jest.mocked(addTransactionBatch);
@@ -55,6 +67,8 @@ describe('usePerpsWithdrawConfirmation', () => {
     selectDefaultEndpointByChainId,
   );
   const mockUseConfirmNavigation = jest.mocked(useConfirmNavigation);
+  const mockUseNavigation = jest.mocked(useNavigation);
+  const mockUsePerpsToasts = jest.mocked(usePerpsToasts);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -67,6 +81,19 @@ describe('usePerpsWithdrawConfirmation', () => {
     mockAddTransactionBatch.mockResolvedValue(undefined as never);
     mockUseConfirmNavigation.mockReturnValue({
       navigateToConfirmation: mockNavigateToConfirmation,
+    } as never);
+    mockUseNavigation.mockReturnValue({
+      goBack: mockGoBack,
+    } as never);
+    mockUsePerpsToasts.mockReturnValue({
+      showToast: mockShowToast,
+      PerpsToastOptions: {
+        accountManagement: {
+          withdrawal: {
+            withdrawalFailed: mockWithdrawalFailed,
+          },
+        },
+      },
     } as never);
 
     (useSelector as jest.Mock).mockImplementation(((
@@ -120,7 +147,7 @@ describe('usePerpsWithdrawConfirmation', () => {
     });
   });
 
-  it('propagates error when addTransactionBatch fails', async () => {
+  it('navigates back and shows an error toast when addTransactionBatch fails', async () => {
     const error = new Error('batch failed');
     mockAddTransactionBatch.mockRejectedValueOnce(error);
 
@@ -131,5 +158,9 @@ describe('usePerpsWithdrawConfirmation', () => {
         await result.current.withdrawWithConfirmation();
       }),
     ).rejects.toThrow('batch failed');
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockWithdrawalFailed).toHaveBeenCalledWith('batch failed');
+    expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalFailedToast);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
@@ -39,52 +39,57 @@ export function usePerpsWithdrawConfirmation() {
     amount: '0x0',
   }) as Hex;
 
-  const withdrawWithConfirmation = useCallback(async () => {
-    navigateToConfirmation({
-      loader: ConfirmationLoader.CustomAmount,
-      stack: Routes.PERPS.ROOT,
-    });
-
-    try {
-      await addTransactionBatch({
-        from: selectedAccount as Hex,
-        origin: ORIGIN_METAMASK,
-        networkClientId,
-        disableHook: true,
-        disableSequential: true,
-        transactions: [
-          {
-            params: {
-              to: ARBITRUM_USDC.address,
-              data: transferData,
-            },
-            type: TransactionType.perpsWithdraw,
-          },
-        ],
+  const withdrawWithConfirmation = useCallback(
+    async function runWithdrawWithConfirmation() {
+      navigateToConfirmation({
+        loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PERPS.ROOT,
       });
-    } catch (error) {
-      const errorObj = ensureError(
-        error,
-        'usePerpsWithdrawConfirmation.withdrawWithConfirmation',
-      );
 
-      navigation.goBack();
-      showToast(
-        PerpsToastOptions.accountManagement.withdrawal.withdrawalFailed(
-          errorObj.message,
-        ),
-      );
-      throw errorObj;
-    }
-  }, [
-    navigateToConfirmation,
-    navigation,
-    networkClientId,
-    PerpsToastOptions.accountManagement.withdrawal,
-    selectedAccount,
-    showToast,
-    transferData,
-  ]);
+      try {
+        await addTransactionBatch({
+          from: selectedAccount as Hex,
+          origin: ORIGIN_METAMASK,
+          networkClientId,
+          disableHook: true,
+          disableSequential: true,
+          transactions: [
+            {
+              params: {
+                to: ARBITRUM_USDC.address,
+                data: transferData,
+              },
+              type: TransactionType.perpsWithdraw,
+            },
+          ],
+        });
+      } catch (error) {
+        const errorObj = ensureError(
+          error,
+          'usePerpsWithdrawConfirmation.withdrawWithConfirmation',
+        );
+
+        navigation.goBack();
+        showToast(
+          PerpsToastOptions.accountManagement.withdrawal.withdrawalStartFailed(
+            () => {
+              runWithdrawWithConfirmation().catch(() => undefined);
+            },
+          ),
+        );
+        throw errorObj;
+      }
+    },
+    [
+      navigateToConfirmation,
+      navigation,
+      networkClientId,
+      PerpsToastOptions.accountManagement.withdrawal,
+      selectedAccount,
+      showToast,
+      transferData,
+    ],
+  );
 
   return { withdrawWithConfirmation };
 }

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import { Hex } from '@metamask/utils';
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -12,6 +13,8 @@ import { ConfirmationLoader } from '../../../Views/confirmations/components/conf
 import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
 import { RootState } from '../../../../reducers';
 import Routes from '../../../../constants/navigation/Routes';
+import { ensureError } from '../../../../util/errorUtils';
+import usePerpsToasts from './usePerpsToasts';
 
 /**
  * Hook that triggers the Perps "withdraw to any token" confirmation flow.
@@ -23,6 +26,8 @@ import Routes from '../../../../constants/navigation/Routes';
 export function usePerpsWithdrawConfirmation() {
   const selectedAccount = useSelector(selectSelectedInternalAccountAddress);
   const { navigateToConfirmation } = useConfirmNavigation();
+  const navigation = useNavigation();
+  const { showToast, PerpsToastOptions } = usePerpsToasts();
 
   const { networkClientId } =
     useSelector((state: RootState) =>
@@ -40,23 +45,46 @@ export function usePerpsWithdrawConfirmation() {
       stack: Routes.PERPS.ROOT,
     });
 
-    await addTransactionBatch({
-      from: selectedAccount as Hex,
-      origin: ORIGIN_METAMASK,
-      networkClientId,
-      disableHook: true,
-      disableSequential: true,
-      transactions: [
-        {
-          params: {
-            to: ARBITRUM_USDC.address,
-            data: transferData,
+    try {
+      await addTransactionBatch({
+        from: selectedAccount as Hex,
+        origin: ORIGIN_METAMASK,
+        networkClientId,
+        disableHook: true,
+        disableSequential: true,
+        transactions: [
+          {
+            params: {
+              to: ARBITRUM_USDC.address,
+              data: transferData,
+            },
+            type: TransactionType.perpsWithdraw,
           },
-          type: TransactionType.perpsWithdraw,
-        },
-      ],
-    });
-  }, [navigateToConfirmation, networkClientId, selectedAccount, transferData]);
+        ],
+      });
+    } catch (error) {
+      const errorObj = ensureError(
+        error,
+        'usePerpsWithdrawConfirmation.withdrawWithConfirmation',
+      );
+
+      navigation.goBack();
+      showToast(
+        PerpsToastOptions.accountManagement.withdrawal.withdrawalFailed(
+          errorObj.message,
+        ),
+      );
+      throw errorObj;
+    }
+  }, [
+    navigateToConfirmation,
+    navigation,
+    networkClientId,
+    PerpsToastOptions.accountManagement.withdrawal,
+    selectedAccount,
+    showToast,
+    transferData,
+  ]);
 
   return { withdrawWithConfirmation };
 }

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawStatus.test.ts
@@ -83,6 +83,16 @@ describe('usePerpsWithdrawStatus', () => {
             labelOptions: [{ label: 'Withdrawal failed', isBold: true }],
             hapticsType: NotificationMoment.Error,
           })),
+          withdrawalStartFailed: jest.fn(() => ({
+            variant: ToastVariants.Icon,
+            iconName: IconName.Warning,
+            hasNoTimeout: false,
+            labelOptions: [
+              { label: 'Something went wrong', isBold: true },
+              { label: 'Your withdrawal was not started' },
+            ],
+            hapticsType: NotificationMoment.Error,
+          })),
         },
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.test.tsx
@@ -3,7 +3,7 @@ import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { fireEvent, act, render } from '@testing-library/react-native';
 import React from 'react';
-import { useTheme } from '@react-navigation/native';
+import { useNavigation, useTheme } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
 import { selectDefaultEndpointByChainId } from '../../../../../../selectors/networkController';
@@ -27,6 +27,7 @@ jest.mock('react-redux', () => ({
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
   useTheme: jest.fn(),
 }));
 
@@ -71,6 +72,7 @@ const MOCK_POLYGON_USDCE = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as Hex;
 const MOCK_PROXY_ADDRESS = '0x13032833b30f3388208cda38971fdc839936b042' as Hex;
 const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
 const mockNavigateToConfirmation = jest.fn();
+const mockGoBack = jest.fn();
 const mockSelectMoneyAccountDepositEnabledFlag = jest.mocked(
   selectMoneyAccountDepositEnabledFlag,
 );
@@ -80,6 +82,7 @@ const mockSelectMoneyAccountWithdrawEnabledFlag = jest.mocked(
 
 describe('ConfirmationsDeveloperOptions', () => {
   const mockUseSelector = jest.mocked(useSelector);
+  const mockUseNavigation = jest.mocked(useNavigation);
   const mockUseTheme = jest.mocked(useTheme);
   const mockUseStyles = jest.mocked(useStyles);
   const mockSelectSelectedInternalAccountAddress = jest.mocked(
@@ -97,6 +100,9 @@ describe('ConfirmationsDeveloperOptions', () => {
 
     mockUseTheme.mockReturnValue({
       colors: {},
+    } as never);
+    mockUseNavigation.mockReturnValue({
+      goBack: mockGoBack,
     } as never);
 
     mockUseStyles.mockReturnValue({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1288,7 +1288,9 @@
       "toast_completed_subtitle": "{{amount}} USDC moved to your wallet",
       "toast_completed_any_token_subtitle": "{{amount}} {{token}} moved to your wallet",
       "toast_error_title": "Something went wrong",
-      "toast_error_description": "Failed to proceed with withdrawal"
+      "toast_error_description": "Failed to proceed with withdrawal",
+      "toast_start_error_description": "Your withdrawal wasn’t started.",
+      "try_again": "Try again"
     },
     "quote": {
       "network_fee": "Network fee",


### PR DESCRIPTION
## **Description**

Fixes a Perps Withdraw loading state where users could get stuck on the confirmation skeleton if transaction batch initialization failed before an approval request was created.

The withdraw flow intentionally navigates to Confirmations early and shows a skeleton loader while the transaction batch is created. This PR adds the same failure escape hatch used by similar mobile flows: if `addTransactionBatch` fails, the app navigates back from the confirmation loader and shows the existing withdrawal failed toast.

## **Changelog**

CHANGELOG entry: Fixed a bug that caused Perps Withdraw to stay stuck on a loading screen when withdrawal initialization failed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1392

## **Manual testing steps**

```gherkin
Feature: Perps Withdraw error handling

  Scenario: user sees an error instead of a stuck loading screen
    Given the user is on the Perps home screen
    And Perps withdraw to any token is enabled
    And withdrawal transaction batch initialization fails

    When user taps Withdraw
    Then the confirmation skeleton is dismissed
    And the user is returned to the previous Perps screen
    And a withdrawal failed toast is shown
```

## **Screenshots/Recordings**

### **Before**

Users could remain stuck on the confirmation skeleton loader.

### **After**

The app navigates back and shows the withdrawal failed toast.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps withdraw confirmation flow to handle `addTransactionBatch` failures by navigating back and showing a retry action, which affects user navigation and error handling paths. Risk is moderate due to potential edge cases around retry loops and toast/navigation state.
> 
> **Overview**
> Prevents Perps withdraw from getting stuck on the confirmation skeleton by catching `addTransactionBatch` failures in `usePerpsWithdrawConfirmation`, navigating back, and showing a new **retryable** `withdrawalStartFailed` toast that re-attempts initialization.
> 
> Adds the `withdrawalStartFailed(onRetry)` toast option (styled as an error with a "Try again" link) plus new i18n strings, and updates/extends unit tests and mocks to cover the failure + retry behavior and error normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ae72a160a1fe12af64ab72c3f81ce09322b7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->