### PR TITLE
feat: pass getUseAssetsControllerForRates to bridge controller

### DIFF
--- a/app/core/Engine/controllers/bridge-controller/bridge-controller-init.test.ts
+++ b/app/core/Engine/controllers/bridge-controller/bridge-controller-init.test.ts
@@ -23,6 +23,10 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { buildAndTrackEvent } from '../../utils/analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import type { AnalyticsTrackingEvent } from '@metamask/analytics-controller';
+import {
+  ASSETS_UNIFY_STATE_FLAG,
+  ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+} from '../../../../selectors/featureFlagController/assetsUnifyState';
 
 jest.mock('@metamask/bridge-controller');
 jest.mock('../../utils/analytics');
@@ -258,6 +262,87 @@ describe('BridgeController Init', () => {
         'bridge_completed',
         { property: 'value' },
       );
+    });
+
+    describe('getUseAssetsControllerForRates', () => {
+      function buildInitRequestWithCallMock(callImpl: () => unknown) {
+        return buildInitRequestMock({
+          initMessenger: {
+            call: jest.fn().mockImplementation(callImpl),
+          } as unknown as BridgeControllerInitMessenger,
+        });
+      }
+
+      it('returns true when the assets unify state feature flag is enabled', () => {
+        // Arrange
+        const requestMock = buildInitRequestWithCallMock(() => ({
+          remoteFeatureFlags: {
+            [ASSETS_UNIFY_STATE_FLAG]: {
+              enabled: true,
+              featureVersion: ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+            },
+          },
+        }));
+
+        // Act
+        bridgeControllerInit(requestMock);
+
+        // Assert
+        const { getUseAssetsControllerForRates } =
+          bridgeControllerClassMock.mock.calls[0][0];
+        expect(getUseAssetsControllerForRates).toBeDefined();
+        expect(getUseAssetsControllerForRates?.()).toBe(true);
+      });
+
+      it('returns false when the assets unify state feature flag is disabled', () => {
+        // Arrange
+        const requestMock = buildInitRequestWithCallMock(() => ({
+          remoteFeatureFlags: {
+            [ASSETS_UNIFY_STATE_FLAG]: { enabled: false, featureVersion: null },
+          },
+        }));
+
+        // Act
+        bridgeControllerInit(requestMock);
+
+        // Assert
+        const constructorOptions = bridgeControllerClassMock.mock.calls[0][0];
+        expect(constructorOptions.getUseAssetsControllerForRates?.()).toBe(
+          false,
+        );
+      });
+
+      it('returns false when the feature flag is absent', () => {
+        // Arrange
+        const requestMock = buildInitRequestWithCallMock(() => ({
+          remoteFeatureFlags: {},
+        }));
+
+        // Act
+        bridgeControllerInit(requestMock);
+
+        // Assert
+        const constructorOptions = bridgeControllerClassMock.mock.calls[0][0];
+        expect(constructorOptions.getUseAssetsControllerForRates?.()).toBe(
+          false,
+        );
+      });
+
+      it('returns false when initMessenger.call throws', () => {
+        // Arrange
+        const requestMock = buildInitRequestWithCallMock(() => {
+          throw new Error('Controller not ready');
+        });
+
+        // Act
+        bridgeControllerInit(requestMock);
+
+        // Assert
+        const constructorOptions = bridgeControllerClassMock.mock.calls[0][0];
+        expect(constructorOptions.getUseAssetsControllerForRates?.()).toBe(
+          false,
+        );
+      });
     });
 
     it('handles trackMetaMetricsFn with no properties', () => {

--- a/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
+++ b/app/core/Engine/controllers/bridge-controller/bridge-controller-init.ts
@@ -22,6 +22,11 @@ import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import { trace } from '../../../../util/trace';
 import Logger from '../../../../util/Logger';
 import packageJSON from '../../../../../package.json';
+import {
+  ASSETS_UNIFY_STATE_FLAG,
+  ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+  isAssetsUnifyStateFeatureEnabled,
+} from '../../../../selectors/featureFlagController/assetsUnifyState';
 
 const { version: clientVersion } = packageJSON;
 
@@ -75,6 +80,25 @@ export const bridgeControllerInit: MessengerClientInitFunction<
         );
       },
       traceFn: trace as TraceCallback,
+
+      getUseAssetsControllerForRates: () => {
+        try {
+          const remoteFeatureFlagState = initMessenger.call(
+            'RemoteFeatureFlagController:getState',
+          );
+          const featureFlag =
+            remoteFeatureFlagState?.remoteFeatureFlags?.[
+              ASSETS_UNIFY_STATE_FLAG
+            ];
+
+          return isAssetsUnifyStateFeatureEnabled(
+            featureFlag,
+            ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+          );
+        } catch {
+          return false;
+        }
+      },
     });
 
     return { controller: bridgeController };

--- a/app/core/Engine/messengers/bridge-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-controller-messenger/index.ts
@@ -1,5 +1,6 @@
 import { BridgeControllerMessenger } from '@metamask/bridge-controller';
 import { AnalyticsControllerActions } from '@metamask/analytics-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { RootExtendedMessenger, RootMessenger } from '../../types';
 import {
   Messenger,
@@ -44,7 +45,9 @@ export function getBridgeControllerMessenger(
   return messenger;
 }
 
-type BridgeControllerInitMessengerActions = AnalyticsControllerActions;
+type BridgeControllerInitMessengerActions =
+  | AnalyticsControllerActions
+  | RemoteFeatureFlagControllerGetStateAction;
 
 /**
  * Get the BridgeControllerInitMessenger for the BridgeController.
@@ -76,7 +79,10 @@ export function getBridgeControllerInitMessenger(
   });
 
   rootMessenger.delegate({
-    actions: ['AnalyticsController:trackEvent'],
+    actions: [
+      'AnalyticsController:trackEvent',
+      'RemoteFeatureFlagController:getState',
+    ],
     events: [],
     messenger,
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Pass the hook to BridgeController so it acts based on the feature flag.

No behaviour changes with the flag off.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3198

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `BridgeController` initialization behavior by consulting remote feature flags and wiring new messenger permissions; could affect bridge rate sourcing when the flag is enabled or if flag state retrieval fails.
> 
> **Overview**
> Adds a `getUseAssetsControllerForRates` hook to `BridgeController` initialization that checks the `assetsUnifyState` remote feature flag (v1) via `RemoteFeatureFlagController:getState`, defaulting to `false` on missing/invalid state or errors.
> 
> Updates the bridge init messenger types/delegation to allow calling `RemoteFeatureFlagController:getState`, and extends unit tests to cover enabled/disabled/absent/exception cases for the new hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c05d6ec3aab5d78269698f8d0145e599962124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->