### PR TITLE
fix: handle BTC quote when BTC quote has missing or non-positive network fee data

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -118,6 +118,7 @@ import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button/Button.types.ts';
+import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable/index.ts';
 
 const SCROLL_NEAR_BOTTOM_PX = 160;
 
@@ -271,7 +272,9 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     // Destination address is only needed for EVM <> Non-EVM bridges, or Non-EVM <> Non-EVM bridges (when different)
     (!hasDestinationPicker || (hasDestinationPicker && Boolean(destAddress)));
 
+  const isNetworkFeeUnavailable = useIsNetworkFeeUnavailable(activeQuote);
   const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
+  const hasInsufficientGas = !isNetworkFeeUnavailable && !hasSufficientGas;
   const hasInsufficientBalance = useIsInsufficientBalance({
     amount: sourceAmount,
     token: sourceToken,
@@ -310,18 +313,20 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     (isLoading && !activeQuote) ||
     hasInsufficientBalance ||
     hasInsufficientNativeReserveError ||
+    isNetworkFeeUnavailable ||
     isSubmittingTx ||
     (isHardwareAddress && isSolanaSourced) ||
     !!blockaidError ||
-    !hasSufficientGas ||
+    hasInsufficientGas ||
     !walletAddress;
 
   useBridgeQuoteEvents({
     hasInsufficientBalance,
     hasInsufficientNativeReserveError,
     hasNoQuotesAvailable: isNoQuotesAvailable,
-    hasInsufficientGas: !hasSufficientGas,
+    hasInsufficientGas,
     hasTxAlert: Boolean(blockaidError),
+    isNetworkFeeUnavailable,
     isSubmitDisabled,
     isPriceImpactWarningVisible: shouldShowPriceImpactWarning,
   });

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -21,7 +21,10 @@ import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/te
 import { BigNumber } from 'ethers';
 import Engine from '../../../../../core/Engine';
 import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import {
+  ChainId,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
 import { PriceImpactModalType } from '../PriceImpactModal/constants';
 import { TokenWarningModalMode } from '../TokenWarningModal/constants';
 import { SecurityDataType } from '../../types';
@@ -130,6 +133,18 @@ const mockActiveQuote = {
   quote: {
     ...mockQuoteWithMetadata.quote,
     srcTokenAmount: '1000000000000000000', // calcTokenValue('1.0', 18)
+  },
+};
+
+const mockBtcQuoteWithUnavailableNetworkFee = {
+  ...mockActiveQuote,
+  quote: {
+    ...mockActiveQuote.quote,
+    srcChainId: ChainId.BTC,
+  },
+  totalNetworkFee: {
+    ...mockActiveQuote.totalNetworkFee,
+    amount: '0',
   },
 };
 
@@ -335,6 +350,30 @@ describe('SwapsConfirmButton', () => {
       );
 
       expect(getByText(strings('bridge.insufficient_gas'))).toBeTruthy();
+    });
+
+    it('displays "Insufficient funds" when BTC network fee is unavailable', () => {
+      jest
+        .mocked(useBridgeQuoteData as unknown as jest.Mock)
+        .mockImplementation(() => ({
+          ...mockUseBridgeQuoteData,
+          activeQuote: mockBtcQuoteWithUnavailableNetworkFee,
+        }));
+
+      const { getByText } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: mockState,
+        },
+      );
+
+      expect(getByText(strings('bridge.insufficient_funds'))).toBeTruthy();
+      expect(useHasSufficientGas).toHaveBeenCalledWith({
+        quote: mockBtcQuoteWithUnavailableNetworkFee,
+      });
     });
 
     it('hides label behind loading indicator when submitting', () => {
@@ -773,6 +812,30 @@ describe('SwapsConfirmButton', () => {
       // Label visible because not loading/submitting
       expect(getByText(strings('bridge.insufficient_gas'))).toBeTruthy();
     });
+
+    it('does not show loading when disabled due to unavailable BTC network fee', () => {
+      jest
+        .mocked(useBridgeQuoteData as unknown as jest.Mock)
+        .mockImplementation(() => ({
+          ...mockUseBridgeQuoteData,
+          activeQuote: mockBtcQuoteWithUnavailableNetworkFee,
+        }));
+
+      const { getByText, getByTestId, queryByTestId } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: mockState,
+        },
+      );
+
+      const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      expect(queryByTestId('spinner-container')).toBeNull();
+      expect(getByText(strings('bridge.insufficient_funds'))).toBeTruthy();
+    });
   });
 
   describe('Stale Quote (isQuoteStale)', () => {
@@ -863,6 +926,33 @@ describe('SwapsConfirmButton', () => {
         },
       );
 
+      expect(
+        getByText(strings('quote_expired_modal.get_new_quote')),
+      ).toBeTruthy();
+    });
+
+    it('keeps "Get new quote" enabled when BTC network fee is unavailable', () => {
+      jest
+        .mocked(useBridgeQuoteData as unknown as jest.Mock)
+        .mockImplementation(() => ({
+          ...mockUseBridgeQuoteData,
+          activeQuote: mockBtcQuoteWithUnavailableNetworkFee,
+          needsNewQuote: true,
+          isLoading: false,
+        }));
+
+      const { getByText, getByTestId } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: mockState,
+        },
+      );
+
+      const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
+      expect(button.props.accessibilityState?.disabled).toBe(false);
       expect(
         getByText(strings('quote_expired_modal.get_new_quote')),
       ).toBeTruthy();

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -40,6 +40,7 @@ import type { TokenWarningModalParams } from '../TokenWarningModal';
 import { TokenWarningModalMode } from '../TokenWarningModal/constants';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
+import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable';
 
 interface Props {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -105,7 +106,9 @@ export const SwapsConfirmButton = ({
     transactionActiveAbTests,
   });
 
+  const isNetworkFeeUnavailable = useIsNetworkFeeUnavailable(activeQuote);
   const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
+  const hasInsufficientGas = !isNetworkFeeUnavailable && !hasSufficientGas;
 
   // Check both the display amount and the atomic amount are non-zero.
   // An amount like 0.000000001 BTC (8 decimals) is non-zero as a number but
@@ -166,10 +169,11 @@ export const SwapsConfirmButton = ({
     (isLoading && !activeQuote) ||
     hasInsufficientBalance ||
     hasInsufficientNativeReserveError ||
+    isNetworkFeeUnavailable ||
     isSubmittingTx ||
     (isHardwareAddress && isSolanaSourced) ||
     hasError ||
-    !hasSufficientGas ||
+    hasInsufficientGas ||
     !walletAddress;
 
   const handleContinue = async () => {
@@ -248,9 +252,13 @@ export const SwapsConfirmButton = ({
       return strings('bridge.confirm_swap');
     }
 
-    if (hasInsufficientBalance || hasInsufficientNativeReserveError)
+    if (
+      hasInsufficientBalance ||
+      hasInsufficientNativeReserveError ||
+      isNetworkFeeUnavailable
+    )
       return strings('bridge.insufficient_funds');
-    if (!hasSufficientGas) return strings('bridge.insufficient_gas');
+    if (hasInsufficientGas) return strings('bridge.insufficient_gas');
     if (isSubmittingTx) return strings('bridge.submitting_transaction');
 
     return strings('bridge.confirm_swap');
@@ -260,7 +268,8 @@ export const SwapsConfirmButton = ({
     sourceAmount,
     hasInsufficientBalance,
     hasInsufficientNativeReserveError,
-    hasSufficientGas,
+    isNetworkFeeUnavailable,
+    hasInsufficientGas,
     isSubmittingTx,
     needsNewQuote,
   ]);

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -22,6 +22,7 @@ export const useBridgeQuoteEvents = ({
   hasInsufficientNativeReserveError,
   hasNoQuotesAvailable,
   hasInsufficientGas,
+  isNetworkFeeUnavailable,
   hasTxAlert,
   isSubmitDisabled,
   isPriceImpactWarningVisible,
@@ -30,6 +31,7 @@ export const useBridgeQuoteEvents = ({
   hasInsufficientNativeReserveError: boolean;
   hasNoQuotesAvailable: boolean;
   hasInsufficientGas: boolean;
+  isNetworkFeeUnavailable: boolean;
   hasTxAlert: boolean;
   isSubmitDisabled: boolean;
   isPriceImpactWarningVisible: boolean;
@@ -47,8 +49,11 @@ export const useBridgeQuoteEvents = ({
     const latestWarnings: QuoteWarning[] = [];
 
     hasNoQuotesAvailable && latestWarnings.push('no_quotes');
-    hasInsufficientGas &&
+    if (isNetworkFeeUnavailable) {
+      latestWarnings.push('network_fee_unavailable' as QuoteWarning);
+    } else if (hasInsufficientGas) {
       latestWarnings.push('insufficient_gas_for_selected_quote');
+    }
     hasInsufficientBalance && latestWarnings.push('insufficient_balance');
     hasInsufficientNativeReserveError &&
       // @ts-expect-error - 'insufficient_native_reserve' is a valid QuoteWarning
@@ -60,6 +65,7 @@ export const useBridgeQuoteEvents = ({
   }, [
     hasNoQuotesAvailable,
     hasInsufficientGas,
+    isNetworkFeeUnavailable,
     hasInsufficientBalance,
     hasInsufficientNativeReserveError,
     hasTxAlert,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -42,6 +42,7 @@ describe('useBridgeQuoteEvents', () => {
             hasNoQuotesAvailable: false,
             hasInsufficientBalance: false,
             hasInsufficientGas: false,
+            isNetworkFeeUnavailable: false,
             hasTxAlert: false,
             isSubmitDisabled: false,
             isPriceImpactWarningVisible: false,
@@ -58,6 +59,11 @@ describe('useBridgeQuoteEvents', () => {
   it.each([
     [{ hasNoQuotesAvailable: true }, ['no_quotes']],
     [{ hasInsufficientGas: true }, ['insufficient_gas_for_selected_quote']],
+    [{ isNetworkFeeUnavailable: true }, ['network_fee_unavailable']],
+    [
+      { hasInsufficientGas: true, isNetworkFeeUnavailable: true },
+      ['network_fee_unavailable'],
+    ],
     [{ hasInsufficientBalance: true }, ['insufficient_balance']],
     [{ hasTxAlert: true }, ['tx_alert']],
     [{ isPriceImpactWarningVisible: true }, ['price_impact']],
@@ -84,6 +90,7 @@ describe('useBridgeQuoteEvents', () => {
             hasNoQuotesAvailable: false,
             hasInsufficientBalance: false,
             hasInsufficientGas: false,
+            isNetworkFeeUnavailable: false,
             hasTxAlert: false,
             isSubmitDisabled: false,
             isPriceImpactWarningVisible: false,

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
@@ -1,6 +1,7 @@
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
+  isBitcoinChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useLatestBalance } from '../useLatestBalance';
@@ -50,7 +51,10 @@ export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
   }
 
   // quote.gasFee.effective.amount might be in scientific notation (e.g. 9.200359292e-8), so we need to handle that
-  const gasAmount = quote?.gasFee?.effective?.amount;
+  const gasAmount =
+    sourceChainId && isBitcoinChainId(sourceChainId)
+      ? (quote?.totalNetworkFee?.amount ?? quote?.gasFee?.effective?.amount)
+      : quote?.gasFee?.effective?.amount;
   const effectiveGasFee =
     isNumberValue(gasAmount) && gasAmount != null
       ? new BigNumber(gasAmount).toFixed()

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/useHasSufficientGas.test.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/useHasSufficientGas.test.ts
@@ -2,6 +2,7 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { useHasSufficientGas } from './index';
 import { useLatestBalance } from '../useLatestBalance';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
+import { ChainId } from '@metamask/bridge-controller';
 import { BigNumber } from 'ethers';
 
 // Mock dependencies
@@ -250,6 +251,9 @@ describe('useHasSufficientGas', () => {
             gasFee: {
               effective: { amount: '0.001' }, // 0.001 SOL
             },
+            totalNetworkFee: {
+              amount: '0.02',
+            },
           } as unknown as ReturnType<typeof useBridgeQuoteData>['activeQuote'];
 
         // User has 0.01 SOL
@@ -277,6 +281,9 @@ describe('useHasSufficientGas', () => {
             gasFee: {
               effective: { amount: '0.01' }, // 0.01 SOL
             },
+            totalNetworkFee: {
+              amount: '0.01',
+            },
           } as unknown as ReturnType<typeof useBridgeQuoteData>['activeQuote'];
 
         // User has 0.001 SOL
@@ -291,6 +298,35 @@ describe('useHasSufficientGas', () => {
         );
 
         expect(result.current).toBe(false);
+      });
+    });
+
+    describe('for Bitcoin', () => {
+      it('uses totalNetworkFee to validate BTC gas balance', () => {
+        const mockQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] =
+          {
+            quote: {
+              srcChainId: ChainId.BTC,
+            },
+            gasFee: {
+              effective: { amount: '0' },
+            },
+            totalNetworkFee: {
+              amount: '0.0001',
+            },
+          } as unknown as ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+
+        mockUseLatestBalance.mockReturnValue({
+          displayBalance: '0.001',
+          atomicBalance: BigNumber.from('100000'), // 0.001 BTC in sats
+        });
+
+        const { result } = renderHookWithProvider(
+          () => useHasSufficientGas({ quote: mockQuote }),
+          { state: {} },
+        );
+
+        expect(result.current).toBe(true);
       });
     });
   });

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
@@ -1,0 +1,99 @@
+import { ChainId } from '@metamask/bridge-controller';
+import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
+import { isNetworkFeeUnavailableForQuote } from '.';
+import { useBridgeQuoteData } from '../useBridgeQuoteData';
+
+type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+
+const createQuote = (
+  overrides: Partial<NonNullable<ActiveQuote>> = {},
+): ActiveQuote =>
+  ({
+    ...mockQuoteWithMetadata,
+    ...overrides,
+    quote: {
+      ...mockQuoteWithMetadata.quote,
+      srcChainId: ChainId.BTC,
+      ...overrides.quote,
+    },
+    totalNetworkFee: {
+      ...mockQuoteWithMetadata.totalNetworkFee,
+      amount: '0.0001',
+      ...overrides.totalNetworkFee,
+    },
+  }) as ActiveQuote;
+
+describe('isNetworkFeeUnavailableForQuote', () => {
+  it('returns true for a BTC quote with zero network fee', () => {
+    expect(
+      isNetworkFeeUnavailableForQuote(
+        createQuote({
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '0',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a BTC quote with negative network fee', () => {
+    expect(
+      isNetworkFeeUnavailableForQuote(
+        createQuote({
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '-0.0001',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a BTC quote with missing network fee amount', () => {
+    expect(
+      isNetworkFeeUnavailableForQuote(
+        createQuote({
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: undefined,
+          } as unknown as NonNullable<ActiveQuote>['totalNetworkFee'],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a BTC quote with positive network fee', () => {
+    expect(isNetworkFeeUnavailableForQuote(createQuote())).toBe(false);
+  });
+
+  it('returns false for a non-BTC quote with zero network fee', () => {
+    expect(
+      isNetworkFeeUnavailableForQuote(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: 1,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '0',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the quote has no source chain', () => {
+    expect(
+      isNetworkFeeUnavailableForQuote(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: undefined,
+          } as unknown as NonNullable<ActiveQuote>['quote'],
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@metamask/bridge-controller';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { isNetworkFeeUnavailableForQuote } from '.';
+import { isQuoteNetworkFeeUnavailable } from '.';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 
 type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
@@ -23,10 +23,10 @@ const createQuote = (
     },
   }) as ActiveQuote;
 
-describe('isNetworkFeeUnavailableForQuote', () => {
+describe('isQuoteNetworkFeeUnavailable', () => {
   it('returns true for a BTC quote with zero network fee', () => {
     expect(
-      isNetworkFeeUnavailableForQuote(
+      isQuoteNetworkFeeUnavailable(
         createQuote({
           totalNetworkFee: {
             ...mockQuoteWithMetadata.totalNetworkFee,
@@ -39,7 +39,7 @@ describe('isNetworkFeeUnavailableForQuote', () => {
 
   it('returns true for a BTC quote with negative network fee', () => {
     expect(
-      isNetworkFeeUnavailableForQuote(
+      isQuoteNetworkFeeUnavailable(
         createQuote({
           totalNetworkFee: {
             ...mockQuoteWithMetadata.totalNetworkFee,
@@ -52,7 +52,7 @@ describe('isNetworkFeeUnavailableForQuote', () => {
 
   it('returns true for a BTC quote with missing network fee amount', () => {
     expect(
-      isNetworkFeeUnavailableForQuote(
+      isQuoteNetworkFeeUnavailable(
         createQuote({
           totalNetworkFee: {
             ...mockQuoteWithMetadata.totalNetworkFee,
@@ -64,12 +64,12 @@ describe('isNetworkFeeUnavailableForQuote', () => {
   });
 
   it('returns false for a BTC quote with positive network fee', () => {
-    expect(isNetworkFeeUnavailableForQuote(createQuote())).toBe(false);
+    expect(isQuoteNetworkFeeUnavailable(createQuote())).toBe(false);
   });
 
   it('returns false for a non-BTC quote with zero network fee', () => {
     expect(
-      isNetworkFeeUnavailableForQuote(
+      isQuoteNetworkFeeUnavailable(
         createQuote({
           quote: {
             ...mockQuoteWithMetadata.quote,
@@ -86,7 +86,7 @@ describe('isNetworkFeeUnavailableForQuote', () => {
 
   it('returns false when the quote has no source chain', () => {
     expect(
-      isNetworkFeeUnavailableForQuote(
+      isQuoteNetworkFeeUnavailable(
         createQuote({
           quote: {
             ...mockQuoteWithMetadata.quote,

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import { isBitcoinChainId } from '@metamask/bridge-controller';
+import { useBridgeQuoteData } from '../useBridgeQuoteData';
+
+type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+
+export const isNetworkFeeUnavailableForQuote = (
+  activeQuote: ActiveQuote,
+): boolean => {
+  const sourceChainId = activeQuote?.quote?.srcChainId;
+
+  if (!sourceChainId || !isBitcoinChainId(sourceChainId)) {
+    return false;
+  }
+
+  const networkFeeAmount = activeQuote.totalNetworkFee?.amount;
+  const networkFee =
+    networkFeeAmount == null ? undefined : new BigNumber(networkFeeAmount);
+
+  return (
+    networkFeeAmount == null || !networkFee?.isFinite() || networkFee.lte(0)
+  );
+};
+
+export const useIsNetworkFeeUnavailable = (activeQuote: ActiveQuote): boolean =>
+  useMemo(() => isNetworkFeeUnavailableForQuote(activeQuote), [activeQuote]);

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
@@ -5,7 +5,7 @@ import { useBridgeQuoteData } from '../useBridgeQuoteData';
 
 type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
 
-export const isNetworkFeeUnavailableForQuote = (
+export const isQuoteNetworkFeeUnavailable = (
   activeQuote: ActiveQuote,
 ): boolean => {
   const sourceChainId = activeQuote?.quote?.srcChainId;
@@ -24,4 +24,4 @@ export const isNetworkFeeUnavailableForQuote = (
 };
 
 export const useIsNetworkFeeUnavailable = (activeQuote: ActiveQuote): boolean =>
-  useMemo(() => isNetworkFeeUnavailableForQuote(activeQuote), [activeQuote]);
+  useMemo(() => isQuoteNetworkFeeUnavailable(activeQuote), [activeQuote]);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.test.ts
@@ -25,6 +25,7 @@ import { selectSelectedInternalAccountFormattedAddress } from '../../../../../..
 import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
 import { TextColor } from '@metamask/design-system-react-native';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
+import { ChainId } from '@metamask/bridge-controller';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -179,9 +180,16 @@ const createSourceToken = (overrides: Partial<BridgeToken> = {}): BridgeToken =>
     ...overrides,
   }) as BridgeToken;
 
-const createActiveQuote = () => ({
+const createActiveQuote = (overrides: Record<string, unknown> = {}) => ({
+  ...overrides,
   quote: {
     srcTokenAmount: '10000000000000000',
+    ...((overrides.quote as Record<string, unknown> | undefined) ?? {}),
+  },
+  totalNetworkFee: {
+    amount: '0.0001',
+    ...((overrides.totalNetworkFee as Record<string, unknown> | undefined) ??
+      {}),
   },
 });
 
@@ -354,6 +362,36 @@ describe('useQuickBuyBottomSheet', () => {
       expect(result.current.getButtonLabel()).toBe('bridge.insufficient_gas');
 
       (useHasSufficientGas as jest.Mock).mockReturnValue(true);
+    });
+
+    it('returns the insufficient-funds label when BTC network fee is unavailable', () => {
+      const activeQuote = createActiveQuote({
+        quote: {
+          srcChainId: ChainId.BTC,
+        },
+        totalNetworkFee: {
+          amount: '0',
+        },
+      });
+
+      (useQuickBuyQuotes as jest.Mock).mockReturnValue({
+        activeQuote,
+        destTokenAmount: '1',
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyBottomSheet(createPosition(), jest.fn()),
+      );
+
+      expect(result.current.buttonError).toBe('insufficient_balance');
+      expect(result.current.getButtonLabel()).toBe('bridge.insufficient_funds');
+      expect(useHasSufficientGas).toHaveBeenCalledWith({
+        quote: activeQuote,
+      });
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -447,17 +447,21 @@ export function useQuickBuyBottomSheet(
 
   const isConfirmLoading = isSubmittingTx;
 
-  const buttonError: QuickBuyButtonError | null =
-    hasInsufficientBalance || isNetworkFeeUnavailable
-      ? 'insufficient_balance'
-      : hasInsufficientGas
-        ? 'insufficient_gas'
-        : hasError
-          ? 'no_quotes'
-          : null;
+  let buttonError: QuickBuyButtonError | null = null;
+  if (hasInsufficientBalance || isNetworkFeeUnavailable) {
+    buttonError = 'insufficient_balance';
+  } else if (hasInsufficientGas) {
+    buttonError = 'insufficient_gas';
+  } else if (hasError) {
+    buttonError = 'no_quotes';
+  }
 
-  const confirmButtonState: 'idle' | 'loading' | 'success' =
-    txPhase === 'success' ? 'success' : isConfirmLoading ? 'loading' : 'idle';
+  let confirmButtonState: 'idle' | 'loading' | 'success' = 'idle';
+  if (txPhase === 'success') {
+    confirmButtonState = 'success';
+  } else if (isConfirmLoading) {
+    confirmButtonState = 'loading';
+  }
 
   const getButtonLabel = useCallback(() => {
     if (buttonError) return strings(BUTTON_ERROR_LABELS[buttonError]);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuyBottomSheet/useQuickBuyBottomSheet.ts
@@ -37,6 +37,7 @@ import {
 import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
 import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
 import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
+import { useIsNetworkFeeUnavailable } from '../../../../../UI/Bridge/hooks/useIsNetworkFeeUnavailable';
 import { useInitialSlippage } from '../../../../../UI/Bridge/hooks/useInitialSlippage';
 import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
 import {
@@ -303,7 +304,10 @@ export function useQuickBuyBottomSheet(
     quoteOverride: activeQuote ?? null,
   });
 
+  const isNetworkFeeUnavailable = useIsNetworkFeeUnavailable(activeQuote);
   const hasSufficientGas = useHasSufficientGas({ quote: activeQuote });
+  const hasInsufficientGas =
+    !isNetworkFeeUnavailable && hasSufficientGas === false;
 
   const stxEnabled = useSelector(selectShouldUseSmartTransaction);
   const hasDestinationPicker = isEvmNonEvmBridge || isNonEvmNonEvmBridge;
@@ -430,7 +434,8 @@ export function useQuickBuyBottomSheet(
     isPendingQuoteRefresh ||
     isQuoteLoading ||
     hasInsufficientBalance ||
-    hasSufficientGas === false ||
+    isNetworkFeeUnavailable ||
+    hasInsufficientGas ||
     isSubmittingTx ||
     hasError ||
     isHardwareSolanaBlocked ||
@@ -442,13 +447,14 @@ export function useQuickBuyBottomSheet(
 
   const isConfirmLoading = isSubmittingTx;
 
-  const buttonError: QuickBuyButtonError | null = hasInsufficientBalance
-    ? 'insufficient_balance'
-    : hasSufficientGas === false
-      ? 'insufficient_gas'
-      : hasError
-        ? 'no_quotes'
-        : null;
+  const buttonError: QuickBuyButtonError | null =
+    hasInsufficientBalance || isNetworkFeeUnavailable
+      ? 'insufficient_balance'
+      : hasInsufficientGas
+        ? 'insufficient_gas'
+        : hasError
+          ? 'no_quotes'
+          : null;
 
   const confirmButtonState: 'idle' | 'loading' | 'success' =
     txPhase === 'success' ? 'success' : isConfirmLoading ? 'loading' : 'idle';


### PR DESCRIPTION
## **Description**
This pull request improves how the Bridge UI handles and displays cases where the network fee is unavailable, especially for Bitcoin (BTC) bridges. It introduces a new hook to detect unavailable network fees, updates the logic for disabling/enabling the confirm button, and adjusts messaging and analytics accordingly. The changes also include comprehensive tests for these scenarios.

**Key changes:**

**1. Handling Network Fee Unavailability in the UI**
- Added the `useIsNetworkFeeUnavailable` hook to detect when the network fee (especially for BTC) is unavailable and integrated it into both `BridgeView` and `SwapsConfirmButton` components. This disables the confirm button and updates the label to "Insufficient funds" when the fee is unavailable.

**2. Analytics and Event Tracking**
- Updated the `useBridgeQuoteEvents` hook and its consumers to track when the network fee is unavailable, emitting a new `network_fee_unavailable` warning instead of the generic insufficient gas warning.

**3. Gas Fee Calculation Logic**
- Modified `useHasSufficientGas` to use `totalNetworkFee.amount` for BTC quotes instead of `gasFee.effective.amount`, ensuring correct balance validation for Bitcoin transactions.

**4. Testing and Coverage**
- Added and updated tests for both the UI and hooks to cover scenarios where the BTC network fee is unavailable, ensuring proper button states, messaging, and analytics events. This includes new test cases for `SwapsConfirmButton` and `useBridgeQuoteEvents`, and additional BTC-specific tests for `useHasSufficientGas`.

These updates ensure that users are clearly informed when a bridge transaction cannot proceed due to unavailable network fees, especially for Bitcoin, and that analytics accurately reflect this state.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed BTC quote when BTC quote has missing or non-positive network fee data

## **Related issues**

Fixes: Bridging BTC is failing at the transaction crafting in certain cases

## **Manual testing steps**

BTC quote with unavailable fee

1. Open the Bridge/Swap flow.
2. Select BTC as the source token and ETH as the destination token.
3. Enter an amount that can produce a BTC quote.
4. Simulate or reproduce a quote where the BTC network fee is 0 or unavailable.
5. Confirm the CTA shows Insufficient funds.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bridge confirmation disablement, labeling, and analytics around fee/gas validation, which can block submissions and alter event warnings; impact is mostly limited to BTC and UI state handling but affects core swap/bridge CTA logic.
> 
> **Overview**
> **Improves BTC quote handling when network fee data is missing/invalid.** Adds `useIsNetworkFeeUnavailable` to detect BTC quotes with missing, non-finite, or non-positive `totalNetworkFee.amount`, and uses it to disable submission and show *Insufficient funds* (instead of *Insufficient gas*) in `BridgeView`, `SwapsConfirmButton`, and Quick Buy.
> 
> **Adjusts fee validation + analytics.** `useHasSufficientGas` now prefers `totalNetworkFee.amount` for BTC when checking gas sufficiency, and `useBridgeQuoteEvents` emits a new `network_fee_unavailable` warning (taking precedence over insufficient gas).
> 
> **Expands test coverage.** Adds/updates unit tests to cover BTC network-fee-unavailable cases across confirm button states, “Get new quote” enablement, quote warnings, Quick Buy button errors, and BTC gas validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e4c630fd67b9987a48ac6f3683e291805a503d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->