### PR TITLE
feat: attach wallet-setup attribution to social login analytics

### DIFF
--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -78,6 +78,7 @@ import { MIGRATION_ERROR_HAPPENED } from '../../../constants/storage';
 import { AccountType } from '../../../constants/onboarding';
 import { FeatureFlagNames } from '../../../constants/featureFlags';
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import { ATTRIBUTION_DEFAULT_TTL_MS } from '../../../core/redux/slices/attribution';
 import { endTrace, TraceName } from '../../../util/trace';
 
 // Mock netinfo - using existing mock
@@ -1120,6 +1121,277 @@ describe('Onboarding', () => {
           onboardingTraceCtx: expect.any(Object),
         }),
       );
+    });
+
+    it('attaches persisted attribution to Social Login Completed for Google create wallet when marketing consent is granted', async () => {
+      (mockAnalytics.isEnabled as jest.Mock).mockReturnValue(true);
+      const capturedAt = Date.now() - 60_000;
+      const stateWithAttribution = {
+        ...mockInitialState,
+        security: {
+          allowLoginWithRememberMe: false,
+          dataCollectionForMarketing: true,
+          isNFTAutoDetectionModalViewed: false,
+          osAuthEnabled: true,
+        },
+        attribution: {
+          attribution: {
+            utm_source: 'google-ads',
+            utm_campaign: 'spring',
+            attribution_id: 'slc-google-1',
+            capturedAt,
+          },
+        },
+      };
+
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockResolvedValue({
+        type: 'success',
+        existingUser: false,
+        accountName: 'test@example.com',
+      });
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        { state: stateWithAttribution },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      const googleOAuthFunction = navCall[1].params.onPressContinueWithGoogle;
+
+      await act(async () => {
+        await googleOAuthFunction(true);
+        await flushPromises();
+        await flushPromises();
+      });
+
+      expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Social Login Completed',
+          properties: expect.objectContaining({
+            account_type: AccountType.MetamaskGoogle,
+            utm_source: 'google-ads',
+            utm_campaign: 'spring',
+            attribution_id: 'slc-google-1',
+          }),
+        }),
+      );
+    });
+
+    it('attaches persisted attribution to Social Login Completed for Apple create wallet when marketing consent is granted', async () => {
+      (mockAnalytics.isEnabled as jest.Mock).mockReturnValue(true);
+      const capturedAt = Date.now() - 60_000;
+      const stateWithAttribution = {
+        ...mockInitialState,
+        security: {
+          allowLoginWithRememberMe: false,
+          dataCollectionForMarketing: true,
+          isNFTAutoDetectionModalViewed: false,
+          osAuthEnabled: true,
+        },
+        attribution: {
+          attribution: {
+            utm_source: 'newsletter',
+            utm_medium: 'email',
+            attribution_id: 'slc-apple-1',
+            capturedAt,
+          },
+        },
+      };
+
+      mockCreateLoginHandler.mockReturnValue('mockAppleHandler');
+      mockOAuthService.handleOAuthLogin.mockResolvedValue({
+        type: 'success',
+        existingUser: false,
+        accountName: 'test@icloud.com',
+      });
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        { state: stateWithAttribution },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      const appleOAuthFunction = navCall[1].params.onPressContinueWithApple;
+
+      await act(async () => {
+        await appleOAuthFunction(true);
+        await flushPromises();
+        await flushPromises();
+      });
+
+      expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Social Login Completed',
+          properties: expect.objectContaining({
+            account_type: AccountType.MetamaskApple,
+            utm_source: 'newsletter',
+            utm_medium: 'email',
+            attribution_id: 'slc-apple-1',
+          }),
+        }),
+      );
+    });
+
+    it('does not attach UTM to Social Login Completed when marketing consent is false', async () => {
+      (mockAnalytics.isEnabled as jest.Mock).mockReturnValue(true);
+      const capturedAt = Date.now() - 60_000;
+      const stateNoMarketingConsent = {
+        ...mockInitialState,
+        security: {
+          allowLoginWithRememberMe: false,
+          dataCollectionForMarketing: false,
+          isNFTAutoDetectionModalViewed: false,
+          osAuthEnabled: true,
+        },
+        attribution: {
+          attribution: {
+            utm_source: 'should-not-appear',
+            capturedAt,
+          },
+        },
+      };
+
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockResolvedValue({
+        type: 'success',
+        existingUser: false,
+        accountName: 'test@example.com',
+      });
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        { state: stateNoMarketingConsent },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      await act(async () => {
+        await navCall[1].params.onPressContinueWithGoogle(true);
+        await flushPromises();
+        await flushPromises();
+      });
+
+      const socialLoginCall = (
+        mockAnalytics.trackEvent as jest.Mock
+      ).mock.calls.find(
+        (args) =>
+          args[0] &&
+          typeof args[0] === 'object' &&
+          'name' in args[0] &&
+          (args[0] as { name: string }).name === 'Social Login Completed',
+      );
+
+      expect(socialLoginCall).toBeDefined();
+      const socialEventPayload = socialLoginCall?.[0] as {
+        properties: Record<string, unknown>;
+      };
+      expect(socialEventPayload.properties).not.toHaveProperty('utm_source');
+    });
+
+    it('does not attach UTM to Social Login Completed when persisted attribution is expired', async () => {
+      (mockAnalytics.isEnabled as jest.Mock).mockReturnValue(true);
+      const stateExpiredAttribution = {
+        ...mockInitialState,
+        security: {
+          allowLoginWithRememberMe: false,
+          dataCollectionForMarketing: true,
+          isNFTAutoDetectionModalViewed: false,
+          osAuthEnabled: true,
+        },
+        attribution: {
+          attribution: {
+            utm_source: 'expired-src',
+            capturedAt: Date.now() - ATTRIBUTION_DEFAULT_TTL_MS - 1,
+          },
+        },
+      };
+
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockResolvedValue({
+        type: 'success',
+        existingUser: false,
+        accountName: 'test@example.com',
+      });
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        { state: stateExpiredAttribution },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      await act(async () => {
+        await navCall[1].params.onPressContinueWithGoogle(true);
+        await flushPromises();
+        await flushPromises();
+      });
+
+      const socialLoginCall = (
+        mockAnalytics.trackEvent as jest.Mock
+      ).mock.calls.find(
+        (args) =>
+          args[0] &&
+          typeof args[0] === 'object' &&
+          'name' in args[0] &&
+          (args[0] as { name: string }).name === 'Social Login Completed',
+      );
+
+      expect(socialLoginCall).toBeDefined();
+      const socialEventPayload = socialLoginCall?.[0] as {
+        properties: Record<string, unknown>;
+      };
+      expect(socialEventPayload.properties).not.toHaveProperty('utm_source');
     });
 
     it('calls Apple OAuth login for import wallet flow', async () => {

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -87,6 +87,7 @@ import OAuthLoginService from '../../../core/OAuthService/OAuthService';
 import { OAuthError, OAuthErrorType } from '../../../core/OAuthService/error';
 import { createLoginHandler } from '../../../core/OAuthService/OAuthLoginHandlers';
 import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
+import { selectWalletSetupCompletedAttributionAnalyticsProps } from '../../../selectors/attribution';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { setupSentry } from '../../../util/sentry/utils';
 import ErrorBoundary from '../ErrorBoundary';
@@ -163,6 +164,9 @@ const Onboarding = () => {
   );
   const isGoogleLoginIosUnsupportedBlockingEnabled = useSelector(
     selectGoogleLoginIosUnsupportedBlockingEnabled,
+  );
+  const walletSetupAttributionAnalyticsProps = useSelector(
+    selectWalletSetupCompletedAttributionAnalyticsProps,
   );
 
   const setLoading = useCallback(
@@ -460,6 +464,7 @@ const Onboarding = () => {
 
       track(MetaMetricsEvents.SOCIAL_LOGIN_COMPLETED, {
         account_type: accountType,
+        ...walletSetupAttributionAnalyticsProps,
       });
       if (createWallet) {
         if (result.existingUser) {
@@ -529,7 +534,13 @@ const Onboarding = () => {
         });
       }
     },
-    [navigation, track, dispatch, onboardingVersion],
+    [
+      navigation,
+      track,
+      dispatch,
+      onboardingVersion,
+      walletSetupAttributionAnalyticsProps,
+    ],
   );
 
   const handleOAuthLoginError = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
* PR adds the marketing attribution fields used on Wallet Setup Completed (utm_*, attribution_id, etc.) to Social Login Completed, so mid-funnel analysis can segment by campaign without funnel-only joins
* Jira: https://consensyssoftware.atlassian.net/browse/TO-723
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Social Login Completed attribution 

  Scenario: Google sign-in emits UTM when consent and persisted attribution exist
    Given marketing consent is enabled and attribution was persisted from a deeplink
    When the user completes Google social login successfully
    Then SOCIAL_LOGIN_COMPLETED includes utm_* and attribution_id consistent with Wallet Setup Completed

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="757" height="142" alt="Screenshot 2026-05-19 at 11 31 57 AM" src="https://github.com/user-attachments/assets/9bb7f602-3eff-4198-858f-70880d053ebf" />
<img width="1180" height="103" alt="Screenshot 2026-05-19 at 11 34 10 AM" src="https://github.com/user-attachments/assets/56978317-d45c-4501-ae0c-37e59db29849" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only augments `SOCIAL_LOGIN_COMPLETED` analytics payloads with existing attribution fields gated by marketing consent/TTL, plus adds test coverage for the new behavior.
> 
> **Overview**
> **Adds marketing attribution fields to social-login analytics.** The `SOCIAL_LOGIN_COMPLETED` event now includes the same persisted campaign properties used for `WALLET_SETUP_COMPLETED` (e.g., `utm_*`, `attribution_id`) by spreading `selectWalletSetupCompletedAttributionAnalyticsProps` into the tracked properties.
> 
> **Expands onboarding tests** to assert attribution is included for Google/Apple when marketing consent is enabled, and omitted when consent is disabled or the persisted attribution has expired (using `ATTRIBUTION_DEFAULT_TTL_MS`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b8fceb39a65ea65fc839165d91f42aba9ff7bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->