### PR TITLE
feat(assets): add `selectTokenWatchlistEnabled` feature flag selector

### DIFF
--- a/app/components/UI/assets/selectors/featureFlags.test.ts
+++ b/app/components/UI/assets/selectors/featureFlags.test.ts
@@ -1,0 +1,89 @@
+import {
+  ASSET_GLOBAL_WATCHLIST_FLAG_KEY,
+  selectTokenWatchlistEnabled,
+} from './featureFlags';
+// eslint-disable-next-line import-x/no-namespace
+import * as remoteFeatureFlagModule from '../../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('7.73.0'),
+}));
+
+jest.mock(
+  '../../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
+describe('selectTokenWatchlistEnabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mockHasMinimumRequiredVersion?.mockRestore();
+  });
+
+  it('exposes the LaunchDarkly flag key for registry alignment', () => {
+    expect(ASSET_GLOBAL_WATCHLIST_FLAG_KEY).toBe('assets-global-watchlist-v1');
+  });
+
+  it('returns true when enabled is true and minimum version passes', () => {
+    const result = selectTokenWatchlistEnabled.resultFunc({
+      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+        value: { enabled: true, minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toStrictEqual(true);
+  });
+
+  it('returns true for direct version-gated shape (no wrapper)', () => {
+    const result = selectTokenWatchlistEnabled.resultFunc({
+      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+        enabled: true,
+        minimumVersion: '7.73',
+      },
+    });
+    expect(result).toStrictEqual(true);
+  });
+
+  it('returns false when enabled is false', () => {
+    const result = selectTokenWatchlistEnabled.resultFunc({
+      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+        value: { enabled: false, minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toStrictEqual(false);
+  });
+
+  it('returns false when minimum version requirement fails', () => {
+    mockHasMinimumRequiredVersion.mockReturnValue(false);
+    const result = selectTokenWatchlistEnabled.resultFunc({
+      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+        value: { enabled: true, minimumVersion: '99.0.0' },
+      },
+    });
+    expect(result).toStrictEqual(false);
+  });
+
+  it('returns false when flag is missing', () => {
+    expect(selectTokenWatchlistEnabled.resultFunc({})).toStrictEqual(false);
+  });
+
+  it('returns false for malformed payload', () => {
+    const result = selectTokenWatchlistEnabled.resultFunc({
+      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+        value: { variant: 'enabled', minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toStrictEqual(false);
+  });
+});

--- a/app/components/UI/assets/selectors/featureFlags.test.ts
+++ b/app/components/UI/assets/selectors/featureFlags.test.ts
@@ -1,3 +1,4 @@
+import type { Json } from '@metamask/utils';
 import {
   ASSET_GLOBAL_WATCHLIST_FLAG_KEY,
   selectTokenWatchlistEnabled,
@@ -36,7 +37,12 @@ describe('selectTokenWatchlistEnabled', () => {
     expect(ASSET_GLOBAL_WATCHLIST_FLAG_KEY).toBe('assets-global-watchlist-v1');
   });
 
-  const testCases = [
+  const testCases: {
+    name: string;
+    state: Record<string, Json>;
+    hasMinimumVersion: boolean;
+    expected: boolean;
+  }[] = [
     {
       name: 'returns true when enabled is true and minimum version passes',
       state: {

--- a/app/components/UI/assets/selectors/featureFlags.test.ts
+++ b/app/components/UI/assets/selectors/featureFlags.test.ts
@@ -36,54 +36,70 @@ describe('selectTokenWatchlistEnabled', () => {
     expect(ASSET_GLOBAL_WATCHLIST_FLAG_KEY).toBe('assets-global-watchlist-v1');
   });
 
-  it('returns true when enabled is true and minimum version passes', () => {
-    const result = selectTokenWatchlistEnabled.resultFunc({
-      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
-        value: { enabled: true, minimumVersion: '7.73' },
+  const testCases = [
+    {
+      name: 'returns true when enabled is true and minimum version passes',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: true, minimumVersion: '7.73' },
+        },
       },
-    });
-    expect(result).toStrictEqual(true);
-  });
-
-  it('returns true for direct version-gated shape (no wrapper)', () => {
-    const result = selectTokenWatchlistEnabled.resultFunc({
-      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
-        enabled: true,
-        minimumVersion: '7.73',
+      hasMinimumVersion: true,
+      expected: true,
+    },
+    {
+      name: 'returns true for direct version-gated shape (no wrapper)',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '7.73',
+        },
       },
-    });
-    expect(result).toStrictEqual(true);
-  });
-
-  it('returns false when enabled is false', () => {
-    const result = selectTokenWatchlistEnabled.resultFunc({
-      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
-        value: { enabled: false, minimumVersion: '7.73' },
+      hasMinimumVersion: true,
+      expected: true,
+    },
+    {
+      name: 'returns false when enabled is false',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: false, minimumVersion: '7.73' },
+        },
       },
-    });
-    expect(result).toStrictEqual(false);
-  });
-
-  it('returns false when minimum version requirement fails', () => {
-    mockHasMinimumRequiredVersion.mockReturnValue(false);
-    const result = selectTokenWatchlistEnabled.resultFunc({
-      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
-        value: { enabled: true, minimumVersion: '99.0.0' },
+      hasMinimumVersion: true,
+      expected: false,
+    },
+    {
+      name: 'returns false when minimum version requirement fails',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: true, minimumVersion: '99.0.0' },
+        },
       },
-    });
-    expect(result).toStrictEqual(false);
-  });
-
-  it('returns false when flag is missing', () => {
-    expect(selectTokenWatchlistEnabled.resultFunc({})).toStrictEqual(false);
-  });
-
-  it('returns false for malformed payload', () => {
-    const result = selectTokenWatchlistEnabled.resultFunc({
-      [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
-        value: { variant: 'enabled', minimumVersion: '7.73' },
+      hasMinimumVersion: false,
+      expected: false,
+    },
+    {
+      name: 'returns false when flag is missing',
+      state: {},
+      hasMinimumVersion: true,
+      expected: false,
+    },
+    {
+      name: 'returns false for malformed payload',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { variant: 'enabled', minimumVersion: '7.73' },
+        },
       },
-    });
-    expect(result).toStrictEqual(false);
+      hasMinimumVersion: true,
+      expected: false,
+    },
+  ];
+
+  it.each(testCases)('$name', ({ state, hasMinimumVersion, expected }) => {
+    mockHasMinimumRequiredVersion.mockReturnValue(hasMinimumVersion);
+    expect(selectTokenWatchlistEnabled.resultFunc(state)).toStrictEqual(
+      expected,
+    );
   });
 });

--- a/app/components/UI/assets/selectors/featureFlags.ts
+++ b/app/components/UI/assets/selectors/featureFlags.ts
@@ -9,9 +9,7 @@ export const ASSET_GLOBAL_WATCHLIST_FLAG_KEY = 'assets-global-watchlist-v1';
 
 /**
  * Whether the global token watchlist feature is enabled for the current
- * client. Returns `true` only when the remote flag is `enabled` and the
- * running app version satisfies the configured `minimumVersion`.
- * Falls back to `false` for missing or malformed payloads.
+ * client.
  */
 export const selectTokenWatchlistEnabled = createSelector(
   selectRemoteFeatureFlags,

--- a/app/components/UI/assets/selectors/featureFlags.ts
+++ b/app/components/UI/assets/selectors/featureFlags.ts
@@ -5,15 +5,6 @@ import {
   VersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 
-/**
- * LaunchDarkly key for the global token watchlist feature.
- *
- * The flag uses a version-gated JSON variation so we can roll out
- * gradually and enforce a minimum app version:
- * `{ "enabled": true | false, "minimumVersion": "<semver>" }`
- *
- * @see https://consensyssoftware.atlassian.net/browse/ASSETS-3114
- */
 export const ASSET_GLOBAL_WATCHLIST_FLAG_KEY = 'assets-global-watchlist-v1';
 
 /**

--- a/app/components/UI/assets/selectors/featureFlags.ts
+++ b/app/components/UI/assets/selectors/featureFlags.ts
@@ -1,0 +1,33 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
+import {
+  validatedVersionGatedFeatureFlag,
+  VersionGatedFeatureFlag,
+} from '../../../../util/remoteFeatureFlag';
+
+/**
+ * LaunchDarkly key for the global token watchlist feature.
+ *
+ * The flag uses a version-gated JSON variation so we can roll out
+ * gradually and enforce a minimum app version:
+ * `{ "enabled": true | false, "minimumVersion": "<semver>" }`
+ *
+ * @see https://consensyssoftware.atlassian.net/browse/ASSETS-3114
+ */
+export const ASSET_GLOBAL_WATCHLIST_FLAG_KEY = 'assets-global-watchlist-v1';
+
+/**
+ * Whether the global token watchlist feature is enabled for the current
+ * client. Returns `true` only when the remote flag is `enabled` and the
+ * running app version satisfies the configured `minimumVersion`.
+ * Falls back to `false` for missing or malformed payloads.
+ */
+export const selectTokenWatchlistEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags?.[
+      ASSET_GLOBAL_WATCHLIST_FLAG_KEY
+    ] as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -191,6 +191,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  'assets-global-watchlist-v1': {
+    name: 'assets-global-watchlist-v1',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
+
   assetsNftGridEnabled: {
     name: 'assetsNftGridEnabled',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Introduces a version-gated remote feature flag selector for the upcoming global token Watchlist feature, owned by the Assets team. The selector reads the LaunchDarkly flag `assets-global-watchlist-v1` from `RemoteFeatureFlagController` state and returns `true` only when both:

1. The remote payload has `enabled: true`, and
2. The currently running app version satisfies the configured `minimumVersion` (via the existing `validatedVersionGatedFeatureFlag` helper).

It supports both runtime shapes already used elsewhere in the app:

- Direct: `{ enabled: true, minimumVersion: '7.73' }`
- Progressive rollout wrapper: `{ value: { enabled: true, minimumVersion: '7.73' } }`

The file is placed under the new Assets CO path so it lives with the rest of the Watchlist work:

- `app/components/UI/assets/selectors/featureFlags.ts`
- `app/components/UI/assets/selectors/featureFlags.test.ts`

This matches the CODEOWNERS pattern `app/*/*/assets/**` → `@MetaMask/metamask-assets` (see [`.github/CODEOWNERS#L243-L244`](https://github.com/MetaMask/metamask-mobile/blob/main/.github/CODEOWNERS#L243-L244)).

This PR only wires the selector; consumers (Token Details star icon, Homepage section, full-screen Watchlist view, Swap/Bridge pill, Explore trending) will land in follow-up PRs per the tech spec.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [ASSETS-3114](https://consensyssoftware.atlassian.net/browse/ASSETS-3114)

Tech Spec: [WatchList Tech Spec - Technical Breakdown & Tasks → 3.1 Feature Flags](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/401467637802/WatchList+Tech+Spec+-+Technical+Breakdown+Tasks#3.1.-Feature-Flags)

## **Manual testing steps**

```gherkin
Feature: Global token watchlist feature flag

  Scenario: Flag enabled with passing minimum version
    Given the LaunchDarkly flag `assets-global-watchlist-v1` returns `{ enabled: true, minimumVersion: <= current app version >}`
    When `selectTokenWatchlistEnabled` is invoked
    Then it returns `true`

  Scenario: Flag enabled but minimum version above current app version
    Given the LaunchDarkly flag `assets-global-watchlist-v1` returns `{ enabled: true, minimumVersion: '99.0.0' }`
    When `selectTokenWatchlistEnabled` is invoked
    Then it returns `false`

  Scenario: Flag disabled
    Given the LaunchDarkly flag `assets-global-watchlist-v1` returns `{ enabled: false, minimumVersion: <any> }`
    When `selectTokenWatchlistEnabled` is invoked
    Then it returns `false`

  Scenario: Flag missing or malformed
    Given the LaunchDarkly flag `assets-global-watchlist-v1` is absent or returns an unknown variant shape
    When `selectTokenWatchlistEnabled` is invoked
    Then it returns `false`
```

Automated coverage:

```
yarn jest app/components/UI/assets/selectors/featureFlags.test.ts --coverage=false
# 7 passed

yarn lint:tsc
# 0 errors

npx eslint app/components/UI/assets/selectors/featureFlags.ts app/components/UI/assets/selectors/featureFlags.test.ts
# 0 errors
```

## **Screenshots/Recordings**

N/A — no UI change; this PR only adds a selector and unit tests.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — pure selector, no runtime performance impact, no UI surface yet.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7941dcf-9670-4e5d-8ca6-c5ead3ee0d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7941dcf-9670-4e5d-8ca6-c5ead3ee0d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3114]: https://consensyssoftware.atlassian.net/browse/ASSETS-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ