### PR TITLE
feat(watchlist): add local-storage backed watchlist storage utils [ASSETS-3115]

### DIFF
--- a/app/components/UI/assets/watchlist/storage.test.ts
+++ b/app/components/UI/assets/watchlist/storage.test.ts
@@ -1,0 +1,195 @@
+import StorageWrapper from '../../../../store/storage-wrapper';
+import {
+  EMPTY_BLOB,
+  WATCHLIST_STORAGE_PATH,
+  readFromTokenWatchList,
+  writeToTokenWatchList,
+  type WatchlistBlob,
+} from './storage';
+
+jest.mock('../../../../store/storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+  },
+}));
+
+const mockedStorageWrapper = StorageWrapper as jest.Mocked<
+  typeof StorageWrapper
+>;
+
+describe('watchlist storage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('WATCHLIST_STORAGE_PATH', () => {
+    it('matches the agreed storage path from the tech spec', () => {
+      expect(WATCHLIST_STORAGE_PATH).toBe('watchlistV1.tokens');
+    });
+  });
+
+  describe('EMPTY_BLOB', () => {
+    it('exposes a valid empty blob with version 1 and no assets', () => {
+      expect(EMPTY_BLOB).toStrictEqual({ assets: [], version: 1 });
+    });
+  });
+
+  describe('readFromTokenWatchList', () => {
+    it('reads from the configured storage path', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(null);
+
+      await readFromTokenWatchList();
+
+      expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(
+        WATCHLIST_STORAGE_PATH,
+      );
+    });
+
+    it('returns EMPTY_BLOB when storage is empty (null)', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(null);
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual(EMPTY_BLOB);
+    });
+
+    it('returns EMPTY_BLOB when storage value is an empty string', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue('');
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual(EMPTY_BLOB);
+    });
+
+    it('parses a fully populated valid blob from storage', async () => {
+      const stored: WatchlistBlob = {
+        assets: ['eip155:1/erc20:0xabc', 'eip155:1/erc20:0xdef'],
+        version: 1,
+      };
+      mockedStorageWrapper.getItem.mockResolvedValue(JSON.stringify(stored));
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual(stored);
+    });
+
+    it('applies schema defaults for missing fields', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(JSON.stringify({}));
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual(EMPTY_BLOB);
+    });
+
+    it('applies the default version when only assets is provided', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(
+        JSON.stringify({ assets: ['eip155:1/erc20:0xabc'] }),
+      );
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual({
+        assets: ['eip155:1/erc20:0xabc'],
+        version: 1,
+      });
+    });
+
+    it('throws when the stored blob has the wrong asset type', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(
+        JSON.stringify({ assets: [123], version: 1 }),
+      );
+
+      await expect(readFromTokenWatchList()).rejects.toThrow();
+    });
+
+    it('throws when the stored blob has a non-literal version', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue(
+        JSON.stringify({ assets: [], version: 2 }),
+      );
+
+      await expect(readFromTokenWatchList()).rejects.toThrow();
+    });
+
+    it('throws when the stored value is not valid JSON', async () => {
+      mockedStorageWrapper.getItem.mockResolvedValue('{not-json');
+
+      await expect(readFromTokenWatchList()).rejects.toThrow();
+    });
+  });
+
+  describe('writeToTokenWatchList', () => {
+    it('writes a validated blob to the configured storage path', async () => {
+      const blob: WatchlistBlob = {
+        assets: ['eip155:1/erc20:0xabc'],
+        version: 1,
+      };
+
+      await writeToTokenWatchList(blob);
+
+      expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+        WATCHLIST_STORAGE_PATH,
+        JSON.stringify(blob),
+      );
+    });
+
+    it('writes EMPTY_BLOB correctly', async () => {
+      await writeToTokenWatchList(EMPTY_BLOB);
+
+      expect(mockedStorageWrapper.setItem).toHaveBeenCalledWith(
+        WATCHLIST_STORAGE_PATH,
+        JSON.stringify(EMPTY_BLOB),
+      );
+    });
+
+    it('rejects and does not write when the blob has the wrong asset type', async () => {
+      const invalid = {
+        assets: [123],
+        version: 1,
+      } as unknown as WatchlistBlob;
+
+      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
+      expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
+    });
+
+    it('rejects and does not write when the blob has a non-literal version', async () => {
+      const invalid = {
+        assets: [],
+        version: 2,
+      } as unknown as WatchlistBlob;
+
+      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
+      expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
+    });
+
+    it('rejects and does not write when assets is not an array', async () => {
+      const invalid = {
+        assets: 'not-an-array',
+        version: 1,
+      } as unknown as WatchlistBlob;
+
+      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
+      expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('read/write round trip', () => {
+    it('produces a value that can be read back as-is', async () => {
+      const blob: WatchlistBlob = {
+        assets: ['eip155:1/erc20:0xabc', 'eip155:137/erc20:0xdef'],
+        version: 1,
+      };
+
+      mockedStorageWrapper.setItem.mockImplementation(async () => undefined);
+      await writeToTokenWatchList(blob);
+
+      const written = mockedStorageWrapper.setItem.mock.calls[0][1] as string;
+      mockedStorageWrapper.getItem.mockResolvedValue(written);
+
+      const result = await readFromTokenWatchList();
+
+      expect(result).toStrictEqual(blob);
+    });
+  });
+});

--- a/app/components/UI/assets/watchlist/storage.test.ts
+++ b/app/components/UI/assets/watchlist/storage.test.ts
@@ -138,33 +138,23 @@ describe('watchlist storage', () => {
       );
     });
 
-    it('rejects and does not write when the blob has the wrong asset type', async () => {
-      const invalid = {
-        assets: [123],
-        version: 1,
-      } as unknown as WatchlistBlob;
-
-      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
-      expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
-    });
-
-    it('rejects and does not write when the blob has a non-literal version', async () => {
-      const invalid = {
-        assets: [],
-        version: 2,
-      } as unknown as WatchlistBlob;
-
-      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
-      expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
-    });
-
-    it('rejects and does not write when assets is not an array', async () => {
-      const invalid = {
-        assets: 'not-an-array',
-        version: 1,
-      } as unknown as WatchlistBlob;
-
-      await expect(writeToTokenWatchList(invalid)).rejects.toThrow();
+    it.each([
+      {
+        case: 'the blob has the wrong asset type',
+        invalid: { assets: [123], version: 1 },
+      },
+      {
+        case: 'the blob has a non-literal version',
+        invalid: { assets: [], version: 2 },
+      },
+      {
+        case: 'assets is not an array',
+        invalid: { assets: 'not-an-array', version: 1 },
+      },
+    ])('rejects and does not write when $case', async ({ invalid }) => {
+      await expect(
+        writeToTokenWatchList(invalid as unknown as WatchlistBlob),
+      ).rejects.toThrow();
       expect(mockedStorageWrapper.setItem).not.toHaveBeenCalled();
     });
   });

--- a/app/components/UI/assets/watchlist/storage.test.ts
+++ b/app/components/UI/assets/watchlist/storage.test.ts
@@ -96,24 +96,21 @@ describe('watchlist storage', () => {
       });
     });
 
-    it('throws when the stored blob has the wrong asset type', async () => {
-      mockedStorageWrapper.getItem.mockResolvedValue(
-        JSON.stringify({ assets: [123], version: 1 }),
-      );
-
-      await expect(readFromTokenWatchList()).rejects.toThrow();
-    });
-
-    it('throws when the stored blob has a non-literal version', async () => {
-      mockedStorageWrapper.getItem.mockResolvedValue(
-        JSON.stringify({ assets: [], version: 2 }),
-      );
-
-      await expect(readFromTokenWatchList()).rejects.toThrow();
-    });
-
-    it('throws when the stored value is not valid JSON', async () => {
-      mockedStorageWrapper.getItem.mockResolvedValue('{not-json');
+    it.each([
+      {
+        case: 'the stored blob has the wrong asset type',
+        stored: JSON.stringify({ assets: [123], version: 1 }),
+      },
+      {
+        case: 'the stored blob has a non-literal version',
+        stored: JSON.stringify({ assets: [], version: 2 }),
+      },
+      {
+        case: 'the stored value is not valid JSON',
+        stored: '{not-json',
+      },
+    ])('throws when $case', async ({ stored }) => {
+      mockedStorageWrapper.getItem.mockResolvedValue(stored);
 
       await expect(readFromTokenWatchList()).rejects.toThrow();
     });

--- a/app/components/UI/assets/watchlist/storage.test.ts
+++ b/app/components/UI/assets/watchlist/storage.test.ts
@@ -75,25 +75,23 @@ describe('watchlist storage', () => {
       expect(result).toStrictEqual(stored);
     });
 
-    it('applies schema defaults for missing fields', async () => {
-      mockedStorageWrapper.getItem.mockResolvedValue(JSON.stringify({}));
+    it.each([
+      {
+        case: 'schema defaults for missing fields',
+        stored: {},
+        expected: EMPTY_BLOB,
+      },
+      {
+        case: 'the default version when only assets is provided',
+        stored: { assets: ['eip155:1/erc20:0xabc'] },
+        expected: { assets: ['eip155:1/erc20:0xabc'], version: 1 },
+      },
+    ])('applies $case', async ({ stored, expected }) => {
+      mockedStorageWrapper.getItem.mockResolvedValue(JSON.stringify(stored));
 
       const result = await readFromTokenWatchList();
 
-      expect(result).toStrictEqual(EMPTY_BLOB);
-    });
-
-    it('applies the default version when only assets is provided', async () => {
-      mockedStorageWrapper.getItem.mockResolvedValue(
-        JSON.stringify({ assets: ['eip155:1/erc20:0xabc'] }),
-      );
-
-      const result = await readFromTokenWatchList();
-
-      expect(result).toStrictEqual({
-        assets: ['eip155:1/erc20:0xabc'],
-        version: 1,
-      });
+      expect(result).toStrictEqual(expected);
     });
 
     it.each([

--- a/app/components/UI/assets/watchlist/storage.ts
+++ b/app/components/UI/assets/watchlist/storage.ts
@@ -1,0 +1,62 @@
+import {
+  array,
+  create,
+  defaulted,
+  type Infer,
+  literal,
+  object,
+  string,
+} from '@metamask/superstruct';
+
+import StorageWrapper from '../../../../store/storage-wrapper';
+
+export const WATCHLIST_STORAGE_PATH = 'watchlistV1.tokens';
+
+const WatchlistBlobSchema = object({
+  assets: defaulted(array(string()), () => []),
+  version: defaulted(literal(1), () => 1 as const),
+});
+
+export type WatchlistBlob = Infer<typeof WatchlistBlobSchema>;
+
+export const EMPTY_BLOB: WatchlistBlob = { assets: [], version: 1 };
+
+/**
+ * Read the watchlist blob from local device storage.
+ *
+ * The raw value is parsed through {@link WatchlistBlobSchema} before it is
+ * returned, so callers can rely on the shape (and the schema-applied
+ * defaults) of the result.
+ *
+ * NOTE: This is a temporary local-storage backed implementation. Once the
+ * Account Universal Storage (AUS) SDK is ready, swap the body of this
+ * function to delegate to the SDK while preserving the same signature and
+ * validation contract.
+ */
+export async function readFromTokenWatchList(): Promise<WatchlistBlob> {
+  const raw = await StorageWrapper.getItem(WATCHLIST_STORAGE_PATH);
+  if (!raw) return EMPTY_BLOB;
+  return create(JSON.parse(raw), WatchlistBlobSchema);
+}
+
+/**
+ * Write the watchlist blob to local device storage.
+ *
+ * The input blob is validated against {@link WatchlistBlobSchema} before it
+ * is serialized and persisted, guaranteeing that only well-formed data ever
+ * reaches storage.
+ *
+ * NOTE: This is a temporary local-storage backed implementation. Once the
+ * Account Universal Storage (AUS) SDK is ready, swap the body of this
+ * function to delegate to the SDK while preserving the same signature and
+ * validation contract.
+ */
+export async function writeToTokenWatchList(
+  blob: WatchlistBlob,
+): Promise<void> {
+  const validated = create(blob, WatchlistBlobSchema);
+  await StorageWrapper.setItem(
+    WATCHLIST_STORAGE_PATH,
+    JSON.stringify(validated),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Adds the initial **Storage Integration** layer for the WatchList feature, as scoped by [ASSETS-3115](https://consensyssoftware.atlassian.net/browse/ASSETS-3115) and the [WatchList Tech Spec](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/401467637802/WatchList+Tech+Spec+-+Technical+Breakdown+Tasks#block-ca5ff63649b3).

The [AUS SDK changes](https://github.com/MetaMask/core/pull/8836) are not yet available, so this PR introduces a temporary local-device implementation backed by the existing MMKV-based `StorageWrapper`. The async API and schema-validation contract are designed to remain stable, so the body of the two exported functions can later be swapped to delegate to the AUS SDK without changes for callers.

New module: `app/components/UI/assets/watchlist/storage.ts`

- `WatchlistBlobSchema` — `@metamask/superstruct` schema describing the persisted blob:
  - `assets`: defaulted `array(string())`
  - `version`: defaulted `literal(1)`
- `WatchlistBlob` — type inferred from the schema.
- `WATCHLIST_STORAGE_PATH = 'watchlistV1.tokens'` and `EMPTY_BLOB = { assets: [], version: 1 }` constants (matching the tech-spec snippet).
- `readFromTokenWatchList(): Promise<WatchlistBlob>` — reads from `StorageWrapper`, returns `EMPTY_BLOB` when no value is stored, otherwise `JSON.parse`s and validates through `WatchlistBlobSchema` (applying schema defaults) before returning. Per ticket AC: _"must parse through the defined schema before client can use it"_.
- `writeToTokenWatchList(blob): Promise<void>` — validates the input through `WatchlistBlobSchema` first, then `JSON.stringify`s and writes via `StorageWrapper`. Per ticket AC: _"must validate input before stringify and store"_.

Note on file path: the ticket asks for `app/components/UI/assets/watchlist/storage.ts` (lowercase `assets/`). There is also an existing `app/components/UI/Assets/` (capital `A`). On case-insensitive filesystems (macOS APFS default, Windows NTFS default) these two folders will collide. Flagging for awareness — happy to rename to `Assets/watchlist/` (or another path) if preferred.

## **Changelog**

CHANGELOG entry: null 

## **Related issues**

Fixes: [ASSETS-3115](https://consensyssoftware.atlassian.net/browse/ASSETS-3115)
Parent story: [ASSETS-2912 — \[Mobile\]\[WatchList\] Allow users to add, remove, and view their watchlisted tokens](https://consensyssoftware.atlassian.net/browse/ASSETS-2912)
Tech Spec: [WatchList Tech Spec — Technical Breakdown Tasks](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/401467637802/WatchList+Tech+Spec+-+Technical+Breakdown+Tasks#block-ca5ff63649b3)
Related SDK PR (future swap-in): https://github.com/MetaMask/core/pull/8836

## **Manual testing steps**

This PR introduces internal utility functions with no UI surface yet, so there is nothing to test manually in-app. Verified via unit tests:

```gherkin
Feature: WatchList local-device storage utilities

  Scenario: read with empty storage
    Given the WATCHLIST_STORAGE_PATH key is unset
    When the caller invokes readFromTokenWatchList()
    Then the result is EMPTY_BLOB ({ assets: [], version: 1 })

  Scenario: read with valid stored blob
    Given a valid JSON-serialized WatchlistBlob is stored at WATCHLIST_STORAGE_PATH
    When the caller invokes readFromTokenWatchList()
    Then the parsed blob is returned with schema defaults applied where fields are missing

  Scenario: read with invalid stored data
    Given the stored value has the wrong shape (e.g. non-string asset entries, or version !== 1)
    When the caller invokes readFromTokenWatchList()
    Then the promise rejects (no silently-malformed data reaches callers)

  Scenario: write with a valid blob
    Given a valid WatchlistBlob
    When the caller invokes writeToTokenWatchList(blob)
    Then StorageWrapper.setItem is called with WATCHLIST_STORAGE_PATH and the JSON-stringified blob

  Scenario: write with an invalid blob
    Given a malformed blob (wrong asset type, wrong version, or wrong shape)
    When the caller invokes writeToTokenWatchList(blob)
    Then the promise rejects and StorageWrapper.setItem is NOT called
```

## **Screenshots/Recordings**

### **Before**

N/A — new utility module, no UI.

### **After**

N/A — new utility module, no UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (`storage.test.ts`, 17 cases, all passing)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

Not applicable — internal storage helper, no perf-critical UI path or new in-app surface.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ed5d6b3-936f-4ff8-aa9f-c7ab0f588eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ed5d6b3-936f-4ff8-aa9f-c7ab0f588eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3115]: https://consensyssoftware.atlassian.net/browse/ASSETS-3115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASSETS-3115]: https://consensyssoftware.atlassian.net/browse/ASSETS-3115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ