### PR TITLE
fix(mm_connect): report deeplink failures to Sentry

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -10,6 +10,7 @@ import Engine from '../../Engine';
 import { analytics } from '../../../util/analytics/analytics';
 import { MetaMetricsEvents } from '../../Analytics';
 import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
+import Logger from '../../../util/Logger';
 
 jest.mock('../adapters/host-application-adapter');
 jest.mock('../store/connection-store');
@@ -23,6 +24,13 @@ jest.mock('../../../util/analytics/analytics', () => ({
     trackEvent: jest.fn(),
   },
 }));
+jest.mock('../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
 jest.mock('../../../store', () => ({
   store: {
     dispatch: jest.fn(),
@@ -33,6 +41,7 @@ jest.mock('../../../store', () => ({
 }));
 
 const mockTrackEvent = analytics.trackEvent as jest.Mock;
+const mockLoggerError = Logger.error as jest.Mock;
 
 // Factory functions for creating mock objects
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -261,6 +270,40 @@ describe('ConnectionRegistry', () => {
       await expect(registry.handleMwpDeeplink(null)).rejects.toThrow(
         'Invalid MWP deeplink: [invalid URL]',
       );
+    });
+
+    it('should report dispatch failures to Sentry via Logger.error', async () => {
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      const dispatchError = new Error('boom');
+      const spyHandleConnectDeeplink = jest
+        .spyOn(registry, 'handleConnectDeeplink')
+        .mockRejectedValue(dispatchError);
+
+      await registry.handleMwpDeeplink(validDeeplink);
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        dispatchError,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: 'sdk-connect-v2',
+            operation: 'handle_mwp_deeplink',
+          }),
+          context: expect.objectContaining({
+            name: 'mwp_deeplink',
+            data: expect.objectContaining({
+              url: expect.stringContaining('[REDACTED]'),
+            }),
+          }),
+        }),
+      );
+
+      spyHandleConnectDeeplink.mockRestore();
     });
   });
 
@@ -889,6 +932,73 @@ describe('ConnectionRegistry', () => {
       expect(mockHostApp.showConnectionError).toHaveBeenCalledTimes(1);
       expect(Connection.create).not.toHaveBeenCalled();
       expect(mockStore.save).not.toHaveBeenCalled();
+    });
+
+    it('should report connect failures to Sentry with dapp/sdk context', async () => {
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      const connectionError = new Error('Connection failed');
+      mockConnection.connect.mockRejectedValue(connectionError);
+
+      await registry.handleConnectDeeplink(validDeeplink);
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        connectionError,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: 'sdk-connect-v2',
+            operation: 'handle_connect_deeplink',
+          }),
+          context: expect.objectContaining({
+            name: 'mwp_deeplink',
+            data: expect.objectContaining({
+              url: expect.stringContaining('[REDACTED]'),
+              dapp_url: 'https://test.dapp',
+              dapp_name: 'Test DApp',
+              sdk_version: '2.0.0',
+              sdk_platform: 'JavaScript',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should report parse failures to Sentry even when no connection request is available', async () => {
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+
+      const invalidDeeplink = 'metamask://connect/mwp?p=not-json';
+
+      await registry.handleConnectDeeplink(invalidDeeplink);
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            feature: 'sdk-connect-v2',
+            operation: 'handle_connect_deeplink',
+          }),
+          context: expect.objectContaining({
+            name: 'mwp_deeplink',
+            data: expect.objectContaining({
+              url: expect.stringContaining('[REDACTED]'),
+              dapp_url: undefined,
+              dapp_name: undefined,
+              sdk_version: undefined,
+              sdk_platform: undefined,
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -291,7 +291,7 @@ describe('ConnectionRegistry', () => {
         dispatchError,
         expect.objectContaining({
           tags: expect.objectContaining({
-            feature: 'sdk-connect-v2',
+            feature: 'mm-connect',
             operation: 'handle_mwp_deeplink',
           }),
           context: expect.objectContaining({
@@ -951,7 +951,7 @@ describe('ConnectionRegistry', () => {
         connectionError,
         expect.objectContaining({
           tags: expect.objectContaining({
-            feature: 'sdk-connect-v2',
+            feature: 'mm-connect',
             operation: 'handle_connect_deeplink',
           }),
           context: expect.objectContaining({
@@ -984,7 +984,7 @@ describe('ConnectionRegistry', () => {
         expect.any(Error),
         expect.objectContaining({
           tags: expect.objectContaining({
-            feature: 'sdk-connect-v2',
+            feature: 'mm-connect',
             operation: 'handle_connect_deeplink',
           }),
           context: expect.objectContaining({

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -18,6 +18,7 @@ import { whenStoreReady } from '../utils/when-store-ready';
 import Engine from '../../Engine';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { INTERNAL_ORIGINS } from '../../../constants/transaction';
+import Logger from '../../../util/Logger';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import type { IMetaMetricsEvent } from '../../Analytics/MetaMetrics.types';
@@ -168,6 +169,19 @@ export class ConnectionRegistry {
         await this.handleConnectDeeplink(url);
       }
     } catch (error) {
+      // Report to Sentry so we have visibility into deeplink dispatch failures.
+      // The local logger.error below is dev-only console output and never
+      // reaches Sentry on its own.
+      Logger.error(error as Error, {
+        tags: {
+          feature: 'sdk-connect-v2',
+          operation: 'handle_mwp_deeplink',
+        },
+        context: {
+          name: 'mwp_deeplink',
+          data: { url: redactUrl(url) },
+        },
+      });
       logger.error('Failed to handle MWP deeplink:', error);
     }
   }
@@ -294,6 +308,25 @@ export class ConnectionRegistry {
 
       logger.debug('Handled connect deeplink.', connInfo?.id);
     } catch (error) {
+      // Report to Sentry so we have visibility into connect-deeplink
+      // failures. The local logger.error below is dev-only console output
+      // and never reaches Sentry on its own.
+      Logger.error(error as Error, {
+        tags: {
+          feature: 'sdk-connect-v2',
+          operation: 'handle_connect_deeplink',
+        },
+        context: {
+          name: 'mwp_deeplink',
+          data: {
+            url: redactUrl(url),
+            dapp_url: connReq?.metadata?.dapp?.url,
+            dapp_name: connReq?.metadata?.dapp?.name,
+            sdk_version: connReq?.metadata?.sdk?.version,
+            sdk_platform: connReq?.metadata?.sdk?.platform,
+          },
+        },
+      });
       logger.error('Failed to handle connect deeplink:', error, redactUrl(url));
       this.hostapp.showConnectionError();
 

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -172,9 +172,18 @@ export class ConnectionRegistry {
       // Report to Sentry so we have visibility into deeplink dispatch failures.
       // The local logger.error below is dev-only console output and never
       // reaches Sentry on its own.
+      //
+      // NOTE: the `feature` tag is intentionally `mm-connect` even though
+      // this file lives under `SDKConnectV2/`. The product name has
+      // converged on "MetaMask Connect" (MMC); the internal directory,
+      // class, and logger names (`SDKConnectV2`, `ConnectionRegistry`,
+      // `[SDKConnectV2]` log prefix) still use the older nomenclature
+      // and need to migrate. Tagging Sentry with the public-facing
+      // feature name now avoids having to rename Sentry dashboards/
+      // alerts later when the code catches up.
       Logger.error(error as Error, {
         tags: {
-          feature: 'sdk-connect-v2',
+          feature: 'mm-connect',
           operation: 'handle_mwp_deeplink',
         },
         context: {
@@ -311,9 +320,14 @@ export class ConnectionRegistry {
       // Report to Sentry so we have visibility into connect-deeplink
       // failures. The local logger.error below is dev-only console output
       // and never reaches Sentry on its own.
+      //
+      // NOTE: `feature: 'mm-connect'` is intentional — see the matching
+      // comment in handleMwpDeeplink above for why the tag uses the
+      // public-facing product name even though this directory is named
+      // `SDKConnectV2/`.
       Logger.error(error as Error, {
         tags: {
-          feature: 'sdk-connect-v2',
+          feature: 'mm-connect',
           operation: 'handle_connect_deeplink',
         },
         context: {


### PR DESCRIPTION
## **Description**

The SDK-V2 `ConnectionRegistry` catches errors in `handleMwpDeeplink` and `handleConnectDeeplink` and routes them through a local `logger` (`app/core/SDKConnectV2/services/logger.ts`) that just prefixes and calls `console.error`. The app's Sentry init (`app/util/sentry/utils.ts`) only wires up `dedupeIntegration` and `extraErrorDataIntegration` — there's no `captureConsoleIntegration` — so those errors (including the well-known `\"Failed to handle connect deeplink\"` string) are silently dropped and never reach Sentry in production.

The only existing signal for these failures is the `failure_reason` property on the `REMOTE_CONNECTION_REQUEST_FAILED` MetaMetrics event, which is useful for aggregate counts but provides no stack trace, no breadcrumbs, and no context.

This PR wires both deeplink-entry catch sites to `Logger.error` from `app/util/Logger`, which already calls `captureException` inside a Sentry scope, respects the metrics opt-in, and supports tags/context. The existing `logger.error` console output is kept so local debugging is unchanged (and `Logger.error` is a no-op in `__DEV__` anyway).

### What's reported

- **Tags** (searchable in Sentry):
  - \`feature: 'mm-connect'\` — intentionally uses the public-facing product name even though the directory/class still use the older \`SDKConnectV2\` nomenclature. There's an inline comment in the code making this explicit; the internal naming needs to migrate but tagging Sentry with the public name now avoids renaming dashboards/alerts later.
  - \`operation: 'handle_mwp_deeplink'\` | \`'handle_connect_deeplink'\`
- **Context** (\`mwp_deeplink\`):
  - \`url\` (redacted via \`redactUrl\` — query/fragment stripped)
  - For \`handle_connect_deeplink\`: \`dapp_url\`, \`dapp_name\`, \`sdk_version\`, \`sdk_platform\` (when the connection request parsed successfully; gracefully \`undefined\` when parse failed)

Scope is intentionally limited to the two deeplink-entry catches — the most user-impactful failures, triggered directly by an incoming deeplink. The other \`console.error\`-only sites in the registry (\`initialize\`, \`evictIfAtCapacity\`, \`reconnectAll\`, \`handleSimpleDeeplink\` 'not found' log) can be addressed in a follow-up if useful.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

Companion PR (provides the QA test surface): [feat(playground): add MWP deeplink failure repro panel](https://github.com/MetaMask/connect-monorepo/pull/300).

## **Manual testing steps**

> Easiest way to exercise every branch reproducibly: use the companion playground PR linked above. It adds a collapsible *QA: MWP deeplink failure repros* card with one tappable deeplink per failure branch. Without that PR you can still test by manually constructing deeplinks (URLs documented in the playground PR description and table).

### Setup

1. Install a debug build of this PR's branch on a real device (Sentry is disabled in E2E / when \`MM_SENTRY_DSN\` is missing — see \`app/util/sentry/utils.ts\` \`setupSentry\`).
2. Accept the metrics opt-in during onboarding (Sentry \`captureException\` only fires when \`METRICS_OPT_IN === AGREED\`).
3. From a desktop browser, deploy or run the [playground branch from connect-monorepo PR #300](https://github.com/MetaMask/connect-monorepo/pull/300) and open it on the device's mobile browser. Expand the *QA: MWP deeplink failure repros* section.

### Feature: SDK-V2 deeplink failure observability

  Scenario: parse failure produces a Sentry event with gracefully missing dapp metadata
  Given the device is set up per the Setup steps above

  When the user taps the *Tap on mobile* button on the *Payload is not valid JSON* row
  Then the MetaMask Mobile app opens and shows a *Connection failed* toast
  And a \`REMOTE_CONNECTION_REQUEST_FAILED\` MetaMetrics event fires with \`failure_reason\` containing \`SyntaxError\` or similar JSON parse text
  And a Sentry event is captured with:
    - tag \`feature: mm-connect\`
    - tag \`operation: handle_connect_deeplink\`
    - context \`mwp_deeplink.url\` ending in \`[REDACTED]\`
    - context \`mwp_deeplink.dapp_url\`, \`dapp_name\`, \`sdk_version\`, \`sdk_platform\` all \`undefined\` (because parsing failed before \`connReq\` was assigned)

  Scenario: handshake failure produces a Sentry event with full dapp/sdk context
  Given the device is set up per the Setup steps above

  When the user taps the *Tap on mobile* button on the *Control: well-formed connect deeplink* row
  Then the deeplink parses successfully (the dapp metadata is well-formed) but the relay handshake will time out / fail because no wallet is on the other end of the fake session id
  And a Sentry event is captured with:
    - tag \`feature: mm-connect\`
    - tag \`operation: handle_connect_deeplink\`
    - context \`mwp_deeplink.dapp_url: \"https://playground.metamask.io\"\`
    - context \`mwp_deeplink.dapp_name: \"MMC Playground (QA Repro)\"\`
    - context \`mwp_deeplink.sdk_version: \"0.0.0-qa-repro\"\`
    - context \`mwp_deeplink.sdk_platform: \"JavaScript\"\`

  Scenario: each remaining failure branch is observable
  Given the device is set up per the Setup steps above

  When the user taps each of the remaining rows (*No payload param*, *Payload parses but is not a ConnectionRequest*, *sessionRequest.id is not a UUID*, *dapp.url claims to be an internal origin*, *c=1 flag but plain payload*, *Payload over 1MB*)
  Then each one produces both a \`REMOTE_CONNECTION_REQUEST_FAILED\` MetaMetrics event and a Sentry event tagged \`feature: mm-connect\`, \`operation: handle_connect_deeplink\`

  Scenario (regression): existing deeplink flow is unchanged
  Given the device has an existing persisted MWP connection from a real dapp

  When the user re-opens the dapp and triggers the *resume connection* flow (simple deeplink with \`?id=…\`)
  Then nothing in the connection flow has changed; no new Sentry events are emitted unless the inner flow actually throws

### Verifying in Sentry

In the project Sentry dashboard:

1. Filter by \`feature:mm-connect\` → only the new events from this PR should appear.
2. Filter by \`operation:handle_connect_deeplink\` vs \`handle_mwp_deeplink\` to separate the connect-flow failures from the wrapper-dispatch failures.
3. On any event, the *Additional Data* panel should show the \`mwp_deeplink\` context block with the redacted URL and dapp/sdk fields.

## **Screenshots/Recordings**

N/A — observability-only change, no user-visible UI difference.

### **Before**

Failures in MWP deeplink dispatch logged only to the device console; no Sentry event.

### **After**

Failures captured in Sentry with searchable tags and dapp/sdk context. Existing console.error preserved for local debugging.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.