### PR TITLE
refactor(rewards): decouple referral details from season

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
@@ -64,7 +64,6 @@ import {
   getPerpsHeroCardViewSelector,
 } from '../../Perps.testIds';
 import { useReferralDetails } from '../../../Rewards/hooks/useReferralDetails';
-import { useSeasonStatus } from '../../../Rewards/hooks/useSeasonStatus';
 import { ensureError } from '../../../../../util/errorUtils';
 
 // To add a new card, add the image to the array.
@@ -96,9 +95,6 @@ const PerpsHeroCardView: React.FC = () => {
   const isReferralEnabled = useSelector(
     selectPerpsRewardsReferralCodeEnabledFlag,
   );
-
-  // Fetch season status to populate seasonId (required by useReferralDetails)
-  useSeasonStatus({ onlyForExplicitFetch: false });
 
   // Fetch referral details to ensure code is available for display
   useReferralDetails();

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -250,11 +250,6 @@ jest.mock('./hooks/useRewardCampaigns', () => ({
   useRewardCampaigns: jest.fn(),
 }));
 
-// Mock useSeasonStatus hook
-jest.mock('./hooks/useSeasonStatus', () => ({
-  useSeasonStatus: jest.fn(),
-}));
-
 // Mock useGeoRewardsMetadata hook
 jest.mock('./hooks/useGeoRewardsMetadata', () => ({
   useGeoRewardsMetadata: jest.fn(),
@@ -329,7 +324,6 @@ import {
   selectPendingDeeplink,
 } from '../../../reducers/rewards/selectors';
 import { setPendingDeeplink } from '../../../reducers/rewards';
-import { useSeasonStatus } from './hooks/useSeasonStatus';
 import { useGeoRewardsMetadata } from './hooks/useGeoRewardsMetadata';
 import { useRewardsNotificationsNudge } from './hooks/useRewardsNotificationsNudge';
 import useRewardsVersionGuard from './hooks/useRewardsVersionGuard';
@@ -348,9 +342,6 @@ const mockSelectPendingDeeplink = selectPendingDeeplink as jest.MockedFunction<
   typeof selectPendingDeeplink
 >;
 
-const mockUseSeasonStatus = useSeasonStatus as jest.MockedFunction<
-  typeof useSeasonStatus
->;
 const mockUseGeoRewardsMetadata = useGeoRewardsMetadata as jest.MockedFunction<
   typeof useGeoRewardsMetadata
 >;
@@ -371,9 +362,6 @@ describe('RewardsNavigator', () => {
     // Set default mock return values
     mockSelectRewardsSubscriptionId.mockReturnValue(null);
     mockSelectPendingDeeplink.mockReturnValue(null);
-    mockUseSeasonStatus.mockReturnValue({
-      fetchSeasonStatus: jest.fn(),
-    });
     mockUseGeoRewardsMetadata.mockReturnValue({
       fetchGeoRewardsMetadata: jest.fn(),
     });
@@ -679,16 +667,6 @@ describe('RewardsNavigator', () => {
       expect(true).toBe(true);
     });
 
-    it('calls useSeasonStatus hook with correct parameters', () => {
-      // Act
-      renderWithNavigation(<RewardsNavigator />);
-
-      // Assert
-      expect(mockUseSeasonStatus).toHaveBeenCalledWith({
-        onlyForExplicitFetch: false,
-      });
-    });
-
     it('uses selectors for subscription state management', () => {
       // Arrange
       mockSelectRewardsSubscriptionId.mockClear();
@@ -714,23 +692,6 @@ describe('RewardsNavigator', () => {
 
       // Assert
       expect(mockUseGeoRewardsMetadata).toHaveBeenCalledWith({});
-    });
-
-    it('integrates useSeasonStatus hook properly', () => {
-      // Arrange
-      const mockFetchSeasonStatus = jest.fn();
-      mockUseSeasonStatus.mockReturnValue({
-        fetchSeasonStatus: mockFetchSeasonStatus,
-      });
-
-      // Act
-      renderWithNavigation(<RewardsNavigator />);
-
-      // Assert
-      expect(mockUseSeasonStatus).toHaveBeenCalledTimes(1);
-      expect(mockUseSeasonStatus).toHaveBeenCalledWith({
-        onlyForExplicitFetch: false,
-      });
     });
   });
 
@@ -920,7 +881,6 @@ describe('RewardsNavigator', () => {
       mockSelectRewardsSubscriptionId.mockReturnValue('test-subscription-id');
       mockSelectPendingDeeplink.mockReturnValue(null);
       mockSelectIsRewardsVersionBlocked.mockReturnValue(false);
-      mockUseSeasonStatus.mockReturnValue({ fetchSeasonStatus: jest.fn() });
       mockUseGeoRewardsMetadata.mockReturnValue({
         fetchGeoRewardsMetadata: jest.fn(),
       });

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -33,7 +33,6 @@ import { useNavigation, useNavigationState } from '@react-navigation/native';
 import { useTheme } from '../../../util/theme';
 import useRewardsVersionGuard from './hooks/useRewardsVersionGuard';
 import RewardsUpdateRequired from './components/RewardsUpdateRequired/RewardsUpdateRequired';
-import { useSeasonStatus } from './hooks/useSeasonStatus';
 import { useGeoRewardsMetadata } from './hooks/useGeoRewardsMetadata';
 import { useReferralDetails } from './hooks/useReferralDetails';
 import { useRewardsNotificationsNudge } from './hooks/useRewardsNotificationsNudge';
@@ -71,9 +70,6 @@ const RewardsNavigator: React.FC = () => {
 
   // Set candidate subscription ID in Redux state when component mounts and account changes
   useCandidateSubscriptionId();
-
-  // This is used to fetch season status data when the component mounts
-  useSeasonStatus({ onlyForExplicitFetch: false });
 
   // Fetch geo rewards metadata so optinAllowedForGeo is available across all rewards screens
   useGeoRewardsMetadata({});

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.test.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.test.tsx
@@ -23,6 +23,13 @@ jest.mock('../../../../../reducers/rewards/selectors', () => ({
   selectSeasonStatusLoading: jest.fn(),
 }));
 
+// Mock useSeasonStatus — the component now drives its own fetch on focus
+jest.mock('../../hooks/useSeasonStatus', () => ({
+  useSeasonStatus: jest.fn(() => ({
+    fetchSeasonStatus: jest.fn(),
+  })),
+}));
+
 // Mock i18n
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, unknown>) => {
@@ -41,14 +48,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
     }
     return result;
   }),
-}));
-
-// Mock useSeasonStatus hook
-const mockFetchSeasonStatus = jest.fn();
-jest.mock('../../hooks/useSeasonStatus', () => ({
-  useSeasonStatus: jest.fn(() => ({
-    fetchSeasonStatus: mockFetchSeasonStatus,
-  })),
 }));
 
 // Mock Tailwind
@@ -184,7 +183,6 @@ jest.mock('../RewardsErrorBanner', () => {
 describe('PreviousSeasonSummary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetchSeasonStatus.mockClear();
 
     // Default mock implementation
     mockUseSelector.mockImplementation((selector) => {
@@ -289,22 +287,6 @@ describe('PreviousSeasonSummary', () => {
       const { queryByTestId } = render(<PreviousSeasonSummary />);
 
       expect(queryByTestId('rewards-error-banner')).toBeNull();
-    });
-
-    it('calls fetchSeasonStatus when retry button is pressed', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSeasonName) return 'Season 1';
-        if (selector === selectSeasonStatusError) return true;
-        if (selector === selectSeasonStatusLoading) return false;
-        return undefined;
-      });
-
-      const { getByTestId } = render(<PreviousSeasonSummary />);
-
-      const retryButton = getByTestId('error-retry-button');
-      fireEvent.press(retryButton);
-
-      expect(mockFetchSeasonStatus).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.tsx
+++ b/app/components/UI/Rewards/components/PreviousSeason/PreviousSeasonSummary.tsx
@@ -22,7 +22,7 @@ import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 
 const PreviousSeasonSummary = () => {
   const { fetchSeasonStatus } = useSeasonStatus({
-    onlyForExplicitFetch: true,
+    onlyForExplicitFetch: false,
   });
   const seasonName = useSelector(selectSeasonName);
   const seasonError = useSelector(selectSeasonStatusError);

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
@@ -92,10 +92,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
       'rewards.referral.actions.share_referral_subject': 'Join me on MetaMask!',
-      'rewards.season_status_error.error_fetching_title':
-        "Season balance couldn't be loaded",
-      'rewards.season_status_error.error_fetching_description':
-        'Check your connection and try again.',
       'rewards.referral_details_error.error_fetching_title':
         "Referral details couldn't be loaded",
       'rewards.referral_details_error.error_fetching_description':
@@ -158,30 +154,21 @@ describe('ReferralDetails', () => {
           return 'REFER123';
         case 'selectReferralCount':
           return 5;
-        case 'selectBalanceRefereePortion':
-          return 1500;
         case 'selectSeasonStatusLoading':
           return false;
         case 'selectReferralDetailsLoading':
           return false;
         case 'selectReferralDetailsError':
           return false;
-        case 'selectSeasonStatusError':
-          return false;
-        case 'selectSeasonStartDate':
-          return '2024-01-01';
         case 'selectSeasonWaysToEarn':
           return mockSeasonWaysToEarn;
         default:
           // Default fallback values
           if (selector.name === 'selectReferralCode') return 'REFER123';
           if (selector.name === 'selectReferralCount') return 5;
-          if (selector.name === 'selectBalanceRefereePortion') return 1500;
           if (selector.name === 'selectSeasonStatusLoading') return false;
           if (selector.name === 'selectReferralDetailsLoading') return false;
           if (selector.name === 'selectReferralDetailsError') return false;
-          if (selector.name === 'selectSeasonStatusError') return false;
-          if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
           if (selector.name === 'selectSeasonWaysToEarn')
             return mockSeasonWaysToEarn;
           return null;
@@ -258,7 +245,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralDetailsLoading') return loading;
         if (selector.name === 'selectReferralDetailsError') return error;
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusError') return false;
         if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         return null;
@@ -287,7 +273,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralDetailsLoading') return loading;
         if (selector.name === 'selectReferralDetailsError') return error;
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusError') return false;
         if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         return null;
@@ -312,7 +297,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return referralCode;
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -331,7 +315,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return null;
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -348,7 +331,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return referralCode;
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -367,7 +349,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return '';
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -386,7 +367,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return referralCode;
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -405,7 +385,6 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralCode') return null;
         // Default values for other selectors
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -424,7 +403,6 @@ describe('ReferralDetails', () => {
         // Default values for other selectors
         if (selector.name === 'selectReferralCode') return 'REFER123';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
       });
@@ -443,7 +421,6 @@ describe('ReferralDetails', () => {
         // Default values for other selectors
         if (selector.name === 'selectReferralCode') return 'REFER123';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
@@ -463,7 +440,6 @@ describe('ReferralDetails', () => {
         // Default values for other selectors
         if (selector.name === 'selectReferralCode') return 'REFER123';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         return null;
       });
 
@@ -482,7 +458,6 @@ describe('ReferralDetails', () => {
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
         if (selector.name === 'selectReferralCode') return null;
         if (selector.name === 'selectReferralCount') return undefined;
-        if (selector.name === 'selectBalanceRefereePortion') return null;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -497,7 +472,6 @@ describe('ReferralDetails', () => {
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
         if (selector.name === 'selectReferralCode') return 'REFER123';
         if (selector.name === 'selectReferralCount') return 0;
-        if (selector.name === 'selectBalanceRefereePortion') return 0;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         return null;
@@ -520,65 +494,13 @@ describe('ReferralDetails', () => {
   });
 
   describe('error handling', () => {
-    it('should show season status error banner when season status error occurs and no season start date', () => {
-      // Arrange
-      mockUseSelector.mockImplementation((selector: SelectorFunction) => {
-        if (selector.name === 'selectSeasonStatusError') return true;
-        if (selector.name === 'selectSeasonStartDate') return null;
-        if (selector.name === 'selectReferralCode') return 'REFER123';
-        if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
-        if (selector.name === 'selectSeasonStatusLoading') return false;
-        if (selector.name === 'selectReferralDetailsLoading') return false;
-        if (selector.name === 'selectReferralDetailsError') return false;
-        return null;
-      });
-
-      // Act
-      const { getByTestId, queryByTestId } = renderComponent();
-
-      // Assert
-      expect(getByTestId('rewards-error-banner')).toBeTruthy();
-      expect(getByTestId('error-title')).toBeTruthy();
-      expect(getByTestId('error-description')).toBeTruthy();
-      // Other components should not be rendered
-      expect(queryByTestId('referral-info-section')).toBeNull();
-      expect(queryByTestId('referral-actions-section')).toBeNull();
-    });
-
-    it('should not show season status error when season start date exists', () => {
-      // Arrange
-      mockUseSelector.mockImplementation((selector: SelectorFunction) => {
-        if (selector.name === 'selectSeasonStatusError') return true;
-        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
-        if (selector.name === 'selectReferralCode') return 'REFER123';
-        if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
-        if (selector.name === 'selectSeasonStatusLoading') return false;
-        if (selector.name === 'selectReferralDetailsLoading') return false;
-        if (selector.name === 'selectReferralDetailsError') return false;
-        return null;
-      });
-
-      // Act
-      const { queryByTestId, getByTestId } = renderComponent();
-
-      // Assert
-      expect(queryByTestId('rewards-error-banner')).toBeNull();
-      // Normal components should render
-      expect(getByTestId('referral-info-section')).toBeTruthy();
-    });
-
     it('should show referral details error banner when referral details error occurs and not loading with no referral code', () => {
       // Arrange
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
         if (selector.name === 'selectReferralDetailsError') return true;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         if (selector.name === 'selectReferralCode') return null;
-        if (selector.name === 'selectSeasonStatusError') return false;
-        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
@@ -603,10 +525,7 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralDetailsError') return true;
         if (selector.name === 'selectReferralDetailsLoading') return true;
         if (selector.name === 'selectReferralCode') return null;
-        if (selector.name === 'selectSeasonStatusError') return false;
-        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
@@ -626,10 +545,7 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralDetailsError') return true;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         if (selector.name === 'selectReferralCode') return 'REFER123';
-        if (selector.name === 'selectSeasonStatusError') return false;
-        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
@@ -654,10 +570,7 @@ describe('ReferralDetails', () => {
         if (selector.name === 'selectReferralDetailsError') return true;
         if (selector.name === 'selectReferralDetailsLoading') return false;
         if (selector.name === 'selectReferralCode') return null;
-        if (selector.name === 'selectSeasonStatusError') return false;
-        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
         if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
@@ -689,14 +602,11 @@ describe('ReferralDetails', () => {
     it('should maintain accessibility when error banners are shown', () => {
       // Arrange
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
-        if (selector.name === 'selectSeasonStatusError') return true;
-        if (selector.name === 'selectSeasonStartDate') return null;
-        if (selector.name === 'selectReferralCode') return 'REFER123';
-        if (selector.name === 'selectReferralCount') return 5;
-        if (selector.name === 'selectBalanceRefereePortion') return 1500;
-        if (selector.name === 'selectSeasonStatusLoading') return false;
+        if (selector.name === 'selectReferralDetailsError') return true;
         if (selector.name === 'selectReferralDetailsLoading') return false;
-        if (selector.name === 'selectReferralDetailsError') return false;
+        if (selector.name === 'selectReferralCode') return null;
+        if (selector.name === 'selectReferralCount') return 5;
+        if (selector.name === 'selectSeasonStatusLoading') return false;
         return null;
       });
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
@@ -9,8 +9,6 @@ import {
   selectReferralCode,
   selectReferralDetailsError,
   selectReferralDetailsLoading,
-  selectSeasonStatusError,
-  selectSeasonStartDate,
 } from '../../../../../reducers/rewards/selectors';
 import { useReferralDetails } from '../../hooks/useReferralDetails';
 import RewardsErrorBanner from '../RewardsErrorBanner';
@@ -26,8 +24,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   showInfoSection = true,
 }) => {
   const referralCode = useSelector(selectReferralCode);
-  const seasonStatusError = useSelector(selectSeasonStatusError);
-  const seasonStartDate = useSelector(selectSeasonStartDate);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
   const referralDetailsError = useSelector(selectReferralDetailsError);
 
@@ -60,17 +56,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
       );
     }
   };
-
-  if (seasonStatusError && !seasonStartDate) {
-    return (
-      <RewardsErrorBanner
-        title={strings('rewards.season_status_error.error_fetching_title')}
-        description={strings(
-          'rewards.season_status_error.error_fetching_description',
-        )}
-      />
-    );
-  }
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-6">

--- a/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
@@ -72,9 +72,7 @@ describe('useReferralDetails', () => {
   });
 
   it('returns a fetch function', () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
 
     const { result } = renderHook(() => useReferralDetails());
 
@@ -86,26 +84,7 @@ describe('useReferralDetails', () => {
 
   it('skips fetch when subscriptionId is missing', () => {
     mockUseSelector.mockClear();
-    mockUseSelector
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce('test-season-id');
-
-    renderHook(() => useReferralDetails());
-
-    // Execute the focus effect callback to trigger the fetch logic
-    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
-    focusCallback();
-
-    expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsError(false));
-    expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
-    expect(mockEngineCall).not.toHaveBeenCalled();
-  });
-
-  it('skips fetch when seasonId is missing', () => {
-    mockUseSelector.mockClear();
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce(null);
+    mockUseSelector.mockReturnValueOnce(null);
 
     renderHook(() => useReferralDetails());
 
@@ -119,9 +98,7 @@ describe('useReferralDetails', () => {
   });
 
   it('fetches referral details successfully', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     mockEngineCall.mockResolvedValue(mockReferralDetails);
 
     renderHook(() => useReferralDetails());
@@ -135,7 +112,6 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getReferralDetails',
       'test-subscription-id',
-      'test-season-id',
     );
     expect(mockDispatch).toHaveBeenCalledWith(
       setReferralDetails({
@@ -148,9 +124,7 @@ describe('useReferralDetails', () => {
   });
 
   it('handles fetch error and dispatch error state', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     const mockError = new Error('Network error');
     mockEngineCall.mockRejectedValue(mockError);
 
@@ -165,16 +139,13 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getReferralDetails',
       'test-subscription-id',
-      'test-season-id',
     );
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsError(true));
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
   });
 
   it('registers focus effect callback', () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
 
     renderHook(() => useReferralDetails());
 
@@ -182,9 +153,7 @@ describe('useReferralDetails', () => {
   });
 
   it('does not fetch on mount when fetchOnMount is false', () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
 
     renderHook(() => useReferralDetails({ fetchOnMount: false }));
 
@@ -195,9 +164,7 @@ describe('useReferralDetails', () => {
   });
 
   it('still returns fetchReferralDetails when fetchOnMount is false', () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
 
     const { result } = renderHook(() =>
       useReferralDetails({ fetchOnMount: false }),
@@ -207,9 +174,7 @@ describe('useReferralDetails', () => {
   });
 
   it('prevents duplicate fetch calls when already loading', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     // First call will start loading and never resolve
     mockEngineCall.mockImplementation(
       () =>
@@ -230,9 +195,7 @@ describe('useReferralDetails', () => {
   });
 
   it('sets loading to true at start and false after completion', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     mockEngineCall.mockResolvedValue(mockReferralDetails);
 
     renderHook(() => useReferralDetails());
@@ -247,9 +210,7 @@ describe('useReferralDetails', () => {
   });
 
   it('sets loading to false even when error occurs', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     const mockError = new Error('Network error');
     mockEngineCall.mockRejectedValue(mockError);
 
@@ -264,9 +225,7 @@ describe('useReferralDetails', () => {
   });
 
   it('should handle null response from controller', async () => {
-    mockUseSelector
-      .mockReturnValueOnce('test-subscription-id')
-      .mockReturnValueOnce('test-season-id');
+    mockUseSelector.mockReturnValueOnce('test-subscription-id');
     mockEngineCall.mockResolvedValue(null);
 
     renderHook(() => useReferralDetails());

--- a/app/components/UI/Rewards/hooks/useReferralDetails.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.ts
@@ -1,14 +1,13 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectSeasonId } from '../../../../reducers/rewards/selectors';
 import {
   setReferralDetails,
   setReferralDetailsError,
   setReferralDetailsLoading,
 } from '../../../../reducers/rewards';
 import Engine from '../../../../core/Engine';
-import type { SubscriptionSeasonReferralDetailState } from '../../../../core/Engine/controllers/rewards-controller/types';
+import type { SubscriptionReferralDetailState } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useFocusEffect } from '@react-navigation/native';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 
@@ -21,11 +20,10 @@ export const useReferralDetails = ({
 } => {
   const dispatch = useDispatch();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const seasonId = useSelector(selectSeasonId);
   const isLoadingRef = useRef(false);
 
   const fetchReferralDetails = useCallback(async (): Promise<void> => {
-    if (!subscriptionId || !seasonId) {
+    if (!subscriptionId) {
       dispatch(setReferralDetailsError(false));
       dispatch(setReferralDetailsLoading(false));
       return;
@@ -39,11 +37,10 @@ export const useReferralDetails = ({
       dispatch(setReferralDetailsLoading(true));
       dispatch(setReferralDetailsError(false));
 
-      const referralDetails: SubscriptionSeasonReferralDetailState | null =
+      const referralDetails: SubscriptionReferralDetailState | null =
         await Engine.controllerMessenger.call(
           'RewardsController:getReferralDetails',
           subscriptionId,
-          seasonId,
         );
 
       dispatch(
@@ -51,7 +48,6 @@ export const useReferralDetails = ({
           referralCode: referralDetails?.referralCode,
           refereeCount: referralDetails?.totalReferees,
           referredByCode: referralDetails?.referredByCode,
-          referralPoints: referralDetails?.referralPoints,
         }),
       );
     } catch (error) {
@@ -60,7 +56,7 @@ export const useReferralDetails = ({
       isLoadingRef.current = false;
       dispatch(setReferralDetailsLoading(false));
     }
-  }, [dispatch, subscriptionId, seasonId]);
+  }, [dispatch, subscriptionId]);
 
   useFocusEffect(
     useCallback(() => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -272,11 +272,11 @@ export type RewardsControllerIsRewardsFeatureEnabledAction = {
 };
 
 /**
- * Check if there is an active season
- *
- * @returns Promise<boolean> - True if there is an active season, false otherwise
- * An active season exists when getSeasonMetadata('current') returns a value
- * and the current date is between the season's startDate and endDate
+ * Check if there is an active season.
+ * Temporarily hardcoded to false while no season is configured. Callers
+ * gate season-scoped flows (points estimates, rewards rows, dashboard
+ * fetches) off this; the perps VIP fee discount is independent and
+ * unaffected.
  */
 export type RewardsControllerHasActiveSeasonAction = {
   type: `RewardsController:hasActiveSeason`;
@@ -327,8 +327,7 @@ export type RewardsControllerInvalidateSubscriptionAndAccountsAction = {
  * Get referral details with caching
  *
  * @param subscriptionId - The subscription ID for authentication
- * @param seasonId - The season ID to get referral details for
- * @returns Promise<SubscriptionSeasonReferralDetailsDto> - The referral details data
+ * @returns Promise<SubscriptionReferralDetailState | null> - The referral details data
  */
 export type RewardsControllerGetReferralDetailsAction = {
   type: `RewardsController:getReferralDetails`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -694,6 +694,12 @@ describe('RewardsController', () => {
   });
 
   describe('estimatePoints', () => {
+    // hasActiveSeason is hardcoded to false; force-enable it for these tests so the
+    // estimate path is exercised. Individual tests can override.
+    beforeEach(() => {
+      jest.spyOn(controller, 'hasActiveSeason').mockResolvedValue(true);
+    });
+
     it('returns default response when disabled via isDisabled callback', async () => {
       const isDisabled = () => true;
       const disabledController = new RewardsController({
@@ -903,24 +909,13 @@ describe('RewardsController', () => {
     });
 
     it('returns default response when there is no active season', async () => {
+      jest.spyOn(controller, 'hasActiveSeason').mockResolvedValue(false);
+
       const mockRequest = {
         activityType: 'SWAP' as const,
         account: CAIP_ACCOUNT_1,
         activityContext: {},
       };
-
-      // Mock getSeasonMetadata to return null (no active season)
-      // This simulates getSeasonMetadata('current') returning null
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: null,
-            next: null,
-            previous: null,
-          });
-        }
-        return Promise.resolve(null);
-      });
 
       const result = await controller.estimatePoints(mockRequest);
 
@@ -1919,250 +1914,11 @@ describe('RewardsController', () => {
   });
 
   describe('hasActiveSeason', () => {
-    it('returns false when rewards feature is disabled', async () => {
-      const isDisabled = () => true;
-      const disabledController = new RewardsController({
-        messenger: mockMessenger,
-        state: getRewardsControllerDefaultState(),
-        isDisabled,
-      });
-
-      const result = await disabledController.hasActiveSeason();
+    it('always returns false (temporarily hardcoded while no season is configured)', async () => {
+      const result = await controller.hasActiveSeason();
 
       expect(result).toBe(false);
       expect(mockMessenger.call).not.toHaveBeenCalled();
-    });
-
-    it('returns false when getSeasonMetadata returns null', async () => {
-      // Mock getSeasonMetadata to return null by having getDiscoverSeasons return null for current
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: null,
-            next: null,
-            previous: null,
-          });
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when getSeasonMetadata throws an error', async () => {
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.reject(new Error('API error'));
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(false);
-      expect(mockLogger.log).toHaveBeenCalledWith(
-        'RewardsController: Failed to check active season:',
-        'API error',
-      );
-    });
-
-    it('returns true when getSeasonMetadata returns an active season (current date between start and end)', async () => {
-      // Use a realistic timestamp (2023-11-15)
-      const now = 1700000000000;
-      const mockSeasonId = 'season123';
-      const mockSeasonMetadata = {
-        id: mockSeasonId,
-        name: 'Test Season',
-        startDate: new Date(now - 86400000), // 1 day ago
-        endDate: new Date(now + 86400000), // 1 day from now
-        tiers: createTestTiers(),
-        activityTypes: [],
-        waysToEarn: [],
-      };
-
-      // Use fake timers to control Date constructor
-      jest.useFakeTimers();
-      jest.setSystemTime(now);
-
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: {
-              id: mockSeasonId,
-              startDate: new Date(now - 86400000),
-              endDate: new Date(now + 86400000),
-            },
-            next: null,
-            previous: null,
-          });
-        }
-        if (method === 'RewardsDataService:getSeasonMetadata') {
-          return Promise.resolve(mockSeasonMetadata);
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(true);
-
-      jest.useRealTimers();
-    });
-
-    it('returns false when season has not started yet (startDate in future)', async () => {
-      const now = Date.now();
-      const mockSeasonId = 'season123';
-      const mockSeasonMetadata = {
-        id: mockSeasonId,
-        name: 'Future Season',
-        startDate: new Date(now + 86400000), // 1 day from now
-        endDate: new Date(now + 172800000), // 2 days from now
-        tiers: createTestTiers(),
-      };
-
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: {
-              id: mockSeasonId,
-              startDate: new Date(now + 86400000),
-              endDate: new Date(now + 172800000),
-            },
-            next: null,
-            previous: null,
-          });
-        }
-        if (method === 'RewardsDataService:getSeasonMetadata') {
-          return Promise.resolve(mockSeasonMetadata);
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when season has ended (endDate in past)', async () => {
-      const now = Date.now();
-      const mockSeasonId = 'season123';
-      const mockSeasonMetadata = {
-        id: mockSeasonId,
-        name: 'Past Season',
-        startDate: new Date(now - 172800000), // 2 days ago
-        endDate: new Date(now - 86400000), // 1 day ago
-        tiers: createTestTiers(),
-      };
-
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: {
-              id: mockSeasonId,
-              startDate: new Date(now - 172800000),
-              endDate: new Date(now - 86400000),
-            },
-            next: null,
-            previous: null,
-          });
-        }
-        if (method === 'RewardsDataService:getSeasonMetadata') {
-          return Promise.resolve(mockSeasonMetadata);
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(false);
-    });
-
-    it('returns true when season starts exactly today (startDate equals current date)', async () => {
-      // Use a realistic timestamp (2023-11-15)
-      const now = 1700000000000;
-      const mockSeasonId = 'season123';
-      const mockSeasonMetadata = {
-        id: mockSeasonId,
-        name: 'Season Starting Today',
-        startDate: new Date(now), // Today
-        endDate: new Date(now + 86400000), // 1 day from now
-        tiers: createTestTiers(),
-        activityTypes: [],
-        waysToEarn: [],
-      };
-
-      // Use fake timers to control Date constructor
-      jest.useFakeTimers();
-      jest.setSystemTime(now);
-
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: {
-              id: mockSeasonId,
-              startDate: new Date(now),
-              endDate: new Date(now + 86400000),
-            },
-            next: null,
-            previous: null,
-          });
-        }
-        if (method === 'RewardsDataService:getSeasonMetadata') {
-          return Promise.resolve(mockSeasonMetadata);
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(true);
-
-      jest.useRealTimers();
-    });
-
-    it('returns true when season ends exactly today (endDate equals current date)', async () => {
-      // Use a realistic timestamp (2023-11-15)
-      const now = 1700000000000;
-      const mockSeasonId = 'season123';
-      const mockSeasonMetadata = {
-        id: mockSeasonId,
-        name: 'Season Ending Today',
-        startDate: new Date(now - 86400000), // 1 day ago
-        endDate: new Date(now), // Today
-        tiers: createTestTiers(),
-        activityTypes: [],
-        waysToEarn: [],
-      };
-
-      // Use fake timers to control Date constructor
-      jest.useFakeTimers();
-      jest.setSystemTime(now);
-
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (method === 'RewardsDataService:getDiscoverSeasons') {
-          return Promise.resolve({
-            current: {
-              id: mockSeasonId,
-              startDate: new Date(now - 86400000),
-              endDate: new Date(now),
-            },
-            next: null,
-            previous: null,
-          });
-        }
-        if (method === 'RewardsDataService:getSeasonMetadata') {
-          return Promise.resolve(mockSeasonMetadata);
-        }
-        return Promise.resolve(null);
-      });
-
-      const result = await controller.hasActiveSeason();
-
-      expect(result).toBe(true);
-
-      jest.useRealTimers();
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -14,7 +14,7 @@ import {
   type SeasonStatusState,
   type SeasonTierDto,
   type SeasonDtoState,
-  type SubscriptionSeasonReferralDetailState,
+  type SubscriptionReferralDetailState,
   type SeasonStateDto,
   SeasonRewardType,
   type LineaTokenRewardDto,
@@ -6690,7 +6690,6 @@ describe('RewardsController', () => {
 
   describe('getReferralDetails', () => {
     const mockSubscriptionId = 'sub123';
-    const mockSeasonId = 'season456';
 
     it('returns null when feature flag is disabled', async () => {
       const disabledController = new RewardsController({
@@ -6709,21 +6708,17 @@ describe('RewardsController', () => {
         isDisabled: () => true,
       });
 
-      const result = await disabledController.getReferralDetails(
-        mockSubscriptionId,
-        mockSeasonId,
-      );
+      const result =
+        await disabledController.getReferralDetails(mockSubscriptionId);
       expect(result).toBeNull();
     });
 
     it('returns cached referral details when cache is fresh', async () => {
       const recentTime = Date.now() - 10000; // 10 seconds ago (within 1 minute threshold)
-      const compositeKey = `${mockSeasonId}:${mockSubscriptionId}`;
-      const mockReferralDetailsState: SubscriptionSeasonReferralDetailState = {
+      const mockReferralDetailsState: SubscriptionReferralDetailState = {
         referralCode: 'REF456',
         totalReferees: 10,
         referredByCode: 'REFERRER200',
-        referralPoints: 500,
         lastFetched: recentTime,
       };
 
@@ -6742,7 +6737,7 @@ describe('RewardsController', () => {
           },
           seasons: {},
           subscriptionReferralDetails: {
-            [compositeKey]: mockReferralDetailsState,
+            [mockSubscriptionId]: mockReferralDetailsState,
           },
           seasonStatuses: {},
           activeBoosts: {},
@@ -6752,10 +6747,7 @@ describe('RewardsController', () => {
         isDisabled: () => false,
       });
 
-      const result = await controller.getReferralDetails(
-        mockSubscriptionId,
-        mockSeasonId,
-      );
+      const result = await controller.getReferralDetails(mockSubscriptionId);
 
       expect(result).toEqual(mockReferralDetailsState);
       expect(result?.referralCode).toBe('REF456');
@@ -6765,7 +6757,6 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).not.toHaveBeenCalledWith(
         'RewardsDataService:getReferralDetails',
         expect.anything(),
-        expect.anything(),
       );
     });
 
@@ -6774,7 +6765,6 @@ describe('RewardsController', () => {
         referralCode: 'NEWFRESH123',
         totalReferees: 25,
         referredByCode: 'REFERRER500',
-        referralPoints: 1000,
       };
 
       controller = new RewardsController({
@@ -6802,14 +6792,10 @@ describe('RewardsController', () => {
 
       mockMessenger.call.mockResolvedValue(mockApiResponse);
 
-      const result = await controller.getReferralDetails(
-        mockSubscriptionId,
-        mockSeasonId,
-      );
+      const result = await controller.getReferralDetails(mockSubscriptionId);
 
       expect(mockMessenger.call).toHaveBeenCalledWith(
         'RewardsDataService:getReferralDetails',
-        mockSeasonId,
         mockSubscriptionId,
       );
 
@@ -6822,12 +6808,10 @@ describe('RewardsController', () => {
     });
 
     it('updates state when fetching fresh referral details', async () => {
-      const compositeKey = `${mockSeasonId}:${mockSubscriptionId}`;
       const mockApiResponse = {
         referralCode: 'UPDATED789',
         totalReferees: 15,
         referredByCode: 'REFERRER300',
-        referralPoints: 750,
       };
 
       controller = new RewardsController({
@@ -6855,10 +6839,7 @@ describe('RewardsController', () => {
 
       mockMessenger.call.mockResolvedValue(mockApiResponse);
 
-      const result = await controller.getReferralDetails(
-        mockSubscriptionId,
-        mockSeasonId,
-      );
+      const result = await controller.getReferralDetails(mockSubscriptionId);
 
       // Check that the result is the converted state object
       expect(result).toBeDefined();
@@ -6868,7 +6849,7 @@ describe('RewardsController', () => {
       expect(result?.lastFetched).toBeGreaterThan(Date.now() - 1000);
 
       const updatedReferralDetails =
-        controller.state.subscriptionReferralDetails[compositeKey];
+        controller.state.subscriptionReferralDetails[mockSubscriptionId];
       expect(updatedReferralDetails).toBeDefined();
       expect(updatedReferralDetails).toEqual(result); // Should be the same object
       expect(updatedReferralDetails.referralCode).toBe(
@@ -6913,7 +6894,7 @@ describe('RewardsController', () => {
       mockMessenger.call.mockRejectedValue(apiError);
 
       await expect(
-        controller.getReferralDetails(mockSubscriptionId, mockSeasonId),
+        controller.getReferralDetails(mockSubscriptionId),
       ).rejects.toThrow('API connection failed');
     });
 
@@ -6945,7 +6926,7 @@ describe('RewardsController', () => {
       mockMessenger.call.mockRejectedValue(numberError);
 
       await expect(
-        controller.getReferralDetails(mockSubscriptionId, mockSeasonId),
+        controller.getReferralDetails(mockSubscriptionId),
       ).rejects.toEqual(404);
     });
   });
@@ -10184,11 +10165,10 @@ describe('RewardsController', () => {
             },
           },
           subscriptionReferralDetails: {
-            [`season1:${subscriptionId}`]: {
+            [subscriptionId]: {
               referralCode: 'REF123',
               totalReferees: 5,
               referredByCode: 'REFERRER100',
-              referralPoints: 250,
               lastFetched: Date.now(),
             },
           },
@@ -17200,11 +17180,10 @@ describe('RewardsController', () => {
         boosts: [],
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey] = {
+      initialState.subscriptionReferralDetails[subscriptionId] = {
         referralCode: 'REF123',
         totalReferees: 5,
         referredByCode: 'REFERRER123',
-        referralPoints: 100,
         lastFetched: Date.now(),
       };
       initialState.pointsEvents[compositeKey] = {
@@ -17251,9 +17230,10 @@ describe('RewardsController', () => {
         testController.state.unlockedRewards[compositeKey],
       ).toBeUndefined();
       expect(testController.state.activeBoosts[compositeKey]).toBeUndefined();
+      // Referral details are not season-scoped, so they survive a season-scoped invalidation
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey],
-      ).toBeUndefined();
+        testController.state.subscriptionReferralDetails[subscriptionId],
+      ).toBeDefined();
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
       expect(
         testController.state.pointsEvents[typedPointsEventsKey],
@@ -17299,18 +17279,10 @@ describe('RewardsController', () => {
         boosts: [],
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey1] = {
+      initialState.subscriptionReferralDetails[subscriptionId] = {
         referralCode: 'REF1',
         totalReferees: 3,
         referredByCode: 'REFERRER1',
-        referralPoints: 50,
-        lastFetched: Date.now(),
-      };
-      initialState.subscriptionReferralDetails[compositeKey2] = {
-        referralCode: 'REF2',
-        totalReferees: 4,
-        referredByCode: 'REFERRER2',
-        referralPoints: 75,
         lastFetched: Date.now(),
       };
       initialState.pointsEvents[compositeKey1] = {
@@ -17357,10 +17329,7 @@ describe('RewardsController', () => {
       expect(testController.state.activeBoosts[compositeKey1]).toBeUndefined();
       expect(testController.state.activeBoosts[compositeKey2]).toBeUndefined();
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey1],
-      ).toBeUndefined();
-      expect(
-        testController.state.subscriptionReferralDetails[compositeKey2],
+        testController.state.subscriptionReferralDetails[subscriptionId],
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey1]).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey2]).toBeUndefined();
@@ -17531,18 +17500,16 @@ describe('RewardsController', () => {
         boosts: [],
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey1] = {
+      initialState.subscriptionReferralDetails[subscriptionId1] = {
         referralCode: 'REF1',
         totalReferees: 2,
         referredByCode: 'REFERRER1',
-        referralPoints: 30,
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey2] = {
+      initialState.subscriptionReferralDetails[subscriptionId2] = {
         referralCode: 'REF2',
         totalReferees: 3,
         referredByCode: 'REFERRER2',
-        referralPoints: 45,
         lastFetched: Date.now(),
       };
       initialState.pointsEvents[compositeKey1] = {
@@ -17577,7 +17544,7 @@ describe('RewardsController', () => {
       ).toBeUndefined();
       expect(testController.state.activeBoosts[compositeKey1]).toBeUndefined();
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey1],
+        testController.state.subscriptionReferralDetails[subscriptionId1],
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey1]).toBeUndefined();
 
@@ -17586,7 +17553,7 @@ describe('RewardsController', () => {
       expect(testController.state.unlockedRewards[compositeKey2]).toBeDefined();
       expect(testController.state.activeBoosts[compositeKey2]).toBeDefined();
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey2],
+        testController.state.subscriptionReferralDetails[subscriptionId2],
       ).toBeDefined();
       expect(testController.state.pointsEvents[compositeKey2]).toBeDefined();
     });
@@ -17620,11 +17587,10 @@ describe('RewardsController', () => {
         boosts: [],
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey1] = {
+      initialState.subscriptionReferralDetails[subscriptionId] = {
         referralCode: 'REF1',
         totalReferees: 2,
         referredByCode: 'REFERRER1',
-        referralPoints: 30,
         lastFetched: Date.now(),
       };
       initialState.pointsEvents[compositeKey2] = {
@@ -17661,7 +17627,7 @@ describe('RewardsController', () => {
       ).toBeUndefined();
       expect(testController.state.activeBoosts[compositeKey3]).toBeUndefined();
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey1],
+        testController.state.subscriptionReferralDetails[subscriptionId],
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey2]).toBeUndefined();
     });
@@ -17705,7 +17671,7 @@ describe('RewardsController', () => {
       // activeBoosts, subscriptionReferralDetails, and pointsEvents should remain empty (no error)
       expect(testController.state.activeBoosts[compositeKey]).toBeUndefined();
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey],
+        testController.state.subscriptionReferralDetails[subscriptionId],
       ).toBeUndefined();
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
     });
@@ -17729,11 +17695,10 @@ describe('RewardsController', () => {
         boosts: [],
         lastFetched: Date.now(),
       };
-      initialState.subscriptionReferralDetails[compositeKey] = {
+      initialState.subscriptionReferralDetails[subscriptionId] = {
         referralCode: 'REF_123',
         totalReferees: 1,
         referredByCode: 'REFERRER_123',
-        referralPoints: 10,
         lastFetched: Date.now(),
       };
       initialState.pointsEvents[compositeKey] = {
@@ -17763,9 +17728,10 @@ describe('RewardsController', () => {
         testController.state.unlockedRewards[compositeKey],
       ).toBeUndefined();
       expect(testController.state.activeBoosts[compositeKey]).toBeUndefined();
+      // Referral details are not season-scoped, so they survive a season-scoped invalidation
       expect(
-        testController.state.subscriptionReferralDetails[compositeKey],
-      ).toBeUndefined();
+        testController.state.subscriptionReferralDetails[subscriptionId],
+      ).toBeDefined();
       expect(testController.state.pointsEvents[compositeKey]).toBeUndefined();
     });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -2242,33 +2242,14 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Check if there is an active season
-   * @returns Promise<boolean> - True if there is an active season, false otherwise
-   * An active season exists when getSeasonMetadata('current') returns a value
-   * and the current date is between the season's startDate and endDate
+   * Check if there is an active season.
+   * Temporarily hardcoded to false while no season is configured. Callers
+   * gate season-scoped flows (points estimates, rewards rows, dashboard
+   * fetches) off this; the perps VIP fee discount is independent and
+   * unaffected.
    */
   async hasActiveSeason(): Promise<boolean> {
-    const rewardsEnabled = this.isRewardsFeatureEnabled();
-    if (!rewardsEnabled) {
-      return false;
-    }
-
-    try {
-      const seasonDto = await this.getSeasonMetadata('current');
-      if (!seasonDto) {
-        return false;
-      }
-      return (
-        new Date(seasonDto.endDate) >= new Date() &&
-        new Date(seasonDto.startDate) <= new Date()
-      );
-    } catch (error) {
-      Logger.log(
-        'RewardsController: Failed to check active season:',
-        error instanceof Error ? error.message : String(error),
-      );
-      return false;
-    }
+    return false;
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -10,7 +10,7 @@ import {
   type SeasonStatusState,
   type SeasonTierState,
   type SeasonTierDto,
-  type SubscriptionSeasonReferralDetailState,
+  type SubscriptionReferralDetailState,
   type GeoRewardsMetadata,
   type SubscriptionDto,
   type PaginatedPointsEventsDto,
@@ -2493,23 +2493,17 @@ export class RewardsController extends BaseController<
   /**
    * Get referral details with caching
    * @param subscriptionId - The subscription ID for authentication
-   * @param seasonId - The season ID to get referral details for
-   * @returns Promise<SubscriptionSeasonReferralDetailsDto> - The referral details data
+   * @returns Promise<SubscriptionReferralDetailState | null> - The referral details data
    */
   async getReferralDetails(
     subscriptionId: string,
-    seasonId: string,
-  ): Promise<SubscriptionSeasonReferralDetailState | null> {
+  ): Promise<SubscriptionReferralDetailState | null> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
       return null;
     }
-    const compositeKey = this.#createSeasonSubscriptionCompositeKey(
-      seasonId,
-      subscriptionId,
-    );
-    const result = await wrapWithCache<SubscriptionSeasonReferralDetailState>({
-      key: compositeKey,
+    const result = await wrapWithCache<SubscriptionReferralDetailState>({
+      key: subscriptionId,
       ttl: REFERRAL_DETAILS_CACHE_THRESHOLD_MS,
       readCache: (key) => {
         const cached = this.state.subscriptionReferralDetails[key] || undefined;
@@ -2520,17 +2514,15 @@ export class RewardsController extends BaseController<
         this.#withAuthRetry(async () => {
           Logger.log(
             'RewardsController: Fetching fresh referral details data via API call for',
-            { subscriptionId, seasonId },
+            { subscriptionId },
           );
           const referralDetails = await this.messenger.call(
             'RewardsDataService:getReferralDetails',
-            seasonId,
             subscriptionId,
           );
           return {
             referralCode: referralDetails.referralCode,
             totalReferees: referralDetails.totalReferees,
-            referralPoints: referralDetails.referralPoints,
             referredByCode: referralDetails.referredByCode,
             lastFetched: Date.now(),
           };
@@ -4674,11 +4666,7 @@ export class RewardsController extends BaseController<
    */
   invalidateReferralDetailsCache(subscriptionId: string): void {
     this.update((state) => {
-      Object.keys(state.subscriptionReferralDetails).forEach((key) => {
-        if (key.includes(subscriptionId)) {
-          delete state.subscriptionReferralDetails[key];
-        }
-      });
+      delete state.subscriptionReferralDetails[subscriptionId];
     });
 
     Logger.log(
@@ -4726,6 +4714,7 @@ export class RewardsController extends BaseController<
         delete state.vipDashboard?.[subscriptionId];
         delete state.vipPerpsFees?.[subscriptionId];
         delete state.offDeviceSubscriptionAccounts?.[subscriptionId];
+        delete state.subscriptionReferralDetails?.[subscriptionId];
       }
 
       if (shouldInvalidateSeasonCaches) {
@@ -4734,7 +4723,6 @@ export class RewardsController extends BaseController<
           state.unlockedRewards,
           state.activeBoosts,
           state.pointsEvents,
-          state.subscriptionReferralDetails,
         ].forEach((cache) =>
           deleteMatchingCacheEntries(cache, seasonCacheMatches),
         );

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -11,7 +11,7 @@ import type {
   EstimatePointsDto,
   EstimatedPointsDto,
   SeasonStateDto,
-  SubscriptionSeasonReferralDetailsDto,
+  SubscriptionReferralDetailsDto,
   PointsBoostEnvelopeDto,
   ClaimRewardDto,
   GetPointsEventsLastUpdatedDto,
@@ -1105,9 +1105,9 @@ describe('RewardsDataService', () => {
       } as unknown as Response;
       mockFetch.mockResolvedValue(mockResponse);
 
-      await expect(
-        service.getReferralDetails('season-1', 'sub-1'),
-      ).rejects.toThrow('Get referral details failed: 401');
+      await expect(service.getReferralDetails('sub-1')).rejects.toThrow(
+        'Get referral details failed: 401',
+      );
     });
 
     it('throws AuthorizationFailedError for 403 on different endpoints', async () => {
@@ -1793,13 +1793,11 @@ describe('RewardsDataService', () => {
 
   describe('getReferralDetails', () => {
     const mockSubscriptionId = 'test-subscription-123';
-    const mockSeasonId = 'test-season-456';
 
-    const mockReferralDetailsResponse: SubscriptionSeasonReferralDetailsDto = {
+    const mockReferralDetailsResponse: SubscriptionReferralDetailsDto = {
       referralCode: 'TEST123',
       totalReferees: 5,
       referredByCode: 'REFERRER100',
-      referralPoints: 500,
     };
 
     beforeEach(() => {
@@ -1811,15 +1809,12 @@ describe('RewardsDataService', () => {
       mockFetch.mockResolvedValue(mockResponse);
     });
 
-    it('gets referral details for a season', async () => {
-      const result = await service.getReferralDetails(
-        mockSeasonId,
-        mockSubscriptionId,
-      );
+    it('gets referral details for the current subscription', async () => {
+      const result = await service.getReferralDetails(mockSubscriptionId);
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `https://uat.rewards.test/seasons/${mockSeasonId}/referral-details`,
+        `https://uat.rewards.test/subscriptions/referral-details`,
         expect.objectContaining({
           method: 'GET',
           credentials: 'omit',
@@ -1833,7 +1828,7 @@ describe('RewardsDataService', () => {
     });
 
     it('includes subscription ID in token retrieval', async () => {
-      await service.getReferralDetails(mockSeasonId, mockSubscriptionId);
+      await service.getReferralDetails(mockSubscriptionId);
 
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1855,7 +1850,7 @@ describe('RewardsDataService', () => {
       mockFetch.mockResolvedValue(mockResponse);
 
       await expect(
-        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
+        service.getReferralDetails(mockSubscriptionId),
       ).rejects.toThrow('Get referral details failed: 404');
     });
 
@@ -1864,7 +1859,7 @@ describe('RewardsDataService', () => {
       mockFetch.mockRejectedValue(fetchError);
 
       await expect(
-        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
+        service.getReferralDetails(mockSubscriptionId),
       ).rejects.toThrow('Network error');
     });
 
@@ -1875,10 +1870,7 @@ describe('RewardsDataService', () => {
         token: undefined,
       });
 
-      const result = await service.getReferralDetails(
-        mockSeasonId,
-        mockSubscriptionId,
-      );
+      const result = await service.getReferralDetails(mockSubscriptionId);
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1895,10 +1887,7 @@ describe('RewardsDataService', () => {
       // Mock token retrieval throwing an error
       mockGetSubscriptionToken.mockRejectedValue(new Error('Token error'));
 
-      const result = await service.getReferralDetails(
-        mockSeasonId,
-        mockSubscriptionId,
-      );
+      const result = await service.getReferralDetails(mockSubscriptionId);
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1921,7 +1910,7 @@ describe('RewardsDataService', () => {
       );
 
       await expect(
-        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
+        service.getReferralDetails(mockSubscriptionId),
       ).rejects.toThrow('AbortError');
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -4,7 +4,7 @@ import type {
   LoginResponseDto,
   EstimatePointsDto,
   EstimatedPointsDto,
-  SubscriptionSeasonReferralDetailsDto,
+  SubscriptionReferralDetailsDto,
   PaginatedPointsEventsDto,
   GetPointsEventsDto,
   MobileLoginDto,
@@ -960,17 +960,15 @@ export class RewardsDataService {
   }
 
   /**
-   * Get referral details for a specific subscription and season.
-   * @param seasonId - The season ID to get referral details for.
+   * Get referral details for the current subscription.
    * @param subscriptionId - The subscription ID for authentication.
    * @returns The referral details DTO.
    */
   async getReferralDetails(
-    seasonId: string,
     subscriptionId: string,
-  ): Promise<SubscriptionSeasonReferralDetailsDto> {
+  ): Promise<SubscriptionReferralDetailsDto> {
     const response = await this.makeRequest(
-      `/seasons/${seasonId}/referral-details`,
+      `/subscriptions/referral-details`,
       {
         method: 'GET',
       },
@@ -981,7 +979,7 @@ export class RewardsDataService {
       throw new Error(`Get referral details failed: ${response.status}`);
     }
     const data = await response.json();
-    return data as SubscriptionSeasonReferralDetailsDto;
+    return data as SubscriptionReferralDetailsDto;
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1541,11 +1541,10 @@ export interface SeasonStatusDto {
   currentTierId: string;
 }
 
-export interface SubscriptionSeasonReferralDetailsDto {
+export interface SubscriptionReferralDetailsDto {
   referralCode: string;
   totalReferees: number;
   referredByCode: string;
-  referralPoints: number;
 }
 
 export interface PointsBoostEnvelopeDto {
@@ -1617,11 +1616,10 @@ export interface ClaimRewardDto {
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type SubscriptionSeasonReferralDetailState = {
+export type SubscriptionReferralDetailState = {
   referralCode: string;
   totalReferees: number;
   referredByCode: string;
-  referralPoints: number;
   lastFetched?: number;
 };
 
@@ -2077,7 +2075,7 @@ export type RewardsControllerState = {
   subscriptions: { [subscriptionId: string]: SubscriptionDto };
   seasons: { [seasonId: string]: SeasonDtoState };
   subscriptionReferralDetails: {
-    [compositeId: string]: SubscriptionSeasonReferralDetailState;
+    [subscriptionId: string]: SubscriptionReferralDetailState;
   };
   subscriptionBenefits: {
     [subscriptionId: string]: SubscriptionBenefitsState;

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -227,7 +227,6 @@ describe('rewardsReducer', () => {
           },
         ],
         balanceTotal: 1000,
-        balanceRefereePortion: 200,
         currentTier: {
           id: 'tier-gold',
           name: 'Gold',
@@ -1387,7 +1386,6 @@ describe('rewardsReducer', () => {
           },
           nextTierPointsNeeded: 1000,
           balanceTotal: 1500,
-          balanceRefereePortion: 300,
           balanceUpdatedAt: new Date('2024-06-01'),
           onboardingActiveStep: OnboardingStep.STEP_2,
           onboardingReferralCode: 'ONBOARDING_REF',
@@ -1453,9 +1451,6 @@ describe('rewardsReducer', () => {
           initialState.nextTierPointsNeeded,
         );
         expect(state.balanceTotal).toBe(initialState.balanceTotal);
-        expect(state.balanceRefereePortion).toBe(
-          initialState.balanceRefereePortion,
-        );
         expect(state.balanceUpdatedAt).toBe(initialState.balanceUpdatedAt);
         expect(state.activeBoosts).toBe(initialState.activeBoosts);
         expect(state.pointsEvents).toBe(initialState.pointsEvents);
@@ -2008,7 +2003,6 @@ describe('rewardsReducer', () => {
         },
         nextTierPointsNeeded: 1000,
         balanceTotal: 5000,
-        balanceRefereePortion: 1000,
         balanceUpdatedAt: new Date('2024-01-01'),
         seasonName: 'Test Season',
         seasonStartDate: new Date('2024-01-01'),
@@ -2139,7 +2133,6 @@ describe('rewardsReducer', () => {
         nextTier: null,
         nextTierPointsNeeded: null,
         balanceTotal: 2000,
-        balanceRefereePortion: 400,
         balanceUpdatedAt: new Date('2024-05-01'),
         seasonName: 'Persisted Season',
         seasonStartDate: new Date('2024-01-01'),
@@ -2271,7 +2264,6 @@ describe('rewardsReducer', () => {
           persistedRewardsState.hideCurrentAccountNotOptedInBanner,
         // These fields are restored from persisted state
         nextTierPointsNeeded: persistedRewardsState.nextTierPointsNeeded,
-        balanceRefereePortion: persistedRewardsState.balanceRefereePortion,
       };
       expect(state).toEqual(expectedState);
     });
@@ -2501,9 +2493,6 @@ describe('rewardsReducer', () => {
       expect(state.nextTierPointsNeeded).toBe(
         initialState.nextTierPointsNeeded,
       );
-      expect(state.balanceRefereePortion).toBe(
-        initialState.balanceRefereePortion,
-      );
     });
 
     it('should preserve current non-persistent state while restoring persisted UI state', () => {
@@ -2511,7 +2500,6 @@ describe('rewardsReducer', () => {
       const currentState = {
         ...initialState,
         nextTierPointsNeeded: 500, // This should be preserved
-        balanceRefereePortion: 100, // This should be preserved
         activeTab: 'activity' as const, // This should be reset to initial
         seasonStatusLoading: true, // This should be reset to initial
         onboardingActiveStep: OnboardingStep.STEP_3, // This should be reset to initial
@@ -2540,7 +2528,6 @@ describe('rewardsReducer', () => {
 
       // Assert - Non-persistent state should be preserved from current state
       expect(state.nextTierPointsNeeded).toBe(null); // Restored from persisted state (initialState)
-      expect(state.balanceRefereePortion).toBe(0); // Restored from persisted state (initialState)
 
       // Persisted UI state should be restored
       expect(state.seasonId).toBe('persisted-season');

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -90,7 +90,6 @@ export interface RewardsState {
 
   // Season Balance state
   balanceTotal: number | null;
-  balanceRefereePortion: number | null;
   balanceUpdatedAt: Date | null;
 
   // Onboarding state
@@ -231,7 +230,6 @@ export const initialState: RewardsState = {
   nextTierPointsNeeded: null,
 
   balanceTotal: 0,
-  balanceRefereePortion: 0,
   balanceUpdatedAt: null,
 
   onboardingActiveStep: OnboardingStep.INTRO,
@@ -382,7 +380,6 @@ const rewardsSlice = createSlice({
         referralCode?: string;
         refereeCount?: number;
         referredByCode?: string;
-        referralPoints?: number;
       }>,
     ) => {
       if (action.payload.referralCode !== undefined) {
@@ -393,9 +390,6 @@ const rewardsSlice = createSlice({
       }
       if (action.payload.referredByCode !== undefined) {
         state.referredByCode = action.payload.referredByCode;
-      }
-      if (action.payload.referralPoints !== undefined) {
-        state.balanceRefereePortion = action.payload.referralPoints;
       }
       state.referralDetailsLoading = false;
     },
@@ -947,8 +941,6 @@ const rewardsSlice = createSlice({
               nextTier: action.payload.rewards.nextTier,
               nextTierPointsNeeded: action.payload.rewards.nextTierPointsNeeded,
               balanceTotal: action.payload.rewards.balanceTotal,
-              balanceRefereePortion:
-                action.payload.rewards.balanceRefereePortion,
               balanceUpdatedAt: action.payload.rewards.balanceUpdatedAt,
               activeBoosts: action.payload.rewards.activeBoosts,
               pointsEvents: action.payload.rewards.pointsEvents,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -9,7 +9,6 @@ import {
   selectCurrentTier,
   selectNextTier,
   selectNextTierPointsNeeded,
-  selectBalanceRefereePortion,
   selectBalanceUpdatedAt,
   selectSeasonStatusLoading,
   selectSeasonStatusError,
@@ -325,38 +324,6 @@ describe('Rewards selectors', () => {
 
       const { result } = renderHook(() =>
         useSelector(selectNextTierPointsNeeded),
-      );
-      expect(result.current).toBe(0);
-    });
-  });
-
-  describe('selectBalanceRefereePortion', () => {
-    it('returns null when referee portion is null', () => {
-      const mockState = { rewards: { balanceRefereePortion: null } };
-      mockedUseSelector.mockImplementation((selector) => selector(mockState));
-
-      const { result } = renderHook(() =>
-        useSelector(selectBalanceRefereePortion),
-      );
-      expect(result.current).toBeNull();
-    });
-
-    it('returns referee portion when set', () => {
-      const mockState = { rewards: { balanceRefereePortion: 750.5 } };
-      mockedUseSelector.mockImplementation((selector) => selector(mockState));
-
-      const { result } = renderHook(() =>
-        useSelector(selectBalanceRefereePortion),
-      );
-      expect(result.current).toBe(750.5);
-    });
-
-    it('returns zero referee portion when set to zero', () => {
-      const mockState = { rewards: { balanceRefereePortion: 0 } };
-      mockedUseSelector.mockImplementation((selector) => selector(mockState));
-
-      const { result } = renderHook(() =>
-        useSelector(selectBalanceRefereePortion),
       );
       expect(result.current).toBe(0);
     });
@@ -1727,13 +1694,11 @@ describe('Rewards selectors', () => {
       it('handles zero values correctly', () => {
         const state = createMockRootState({
           balanceTotal: 0,
-          balanceRefereePortion: 0,
           refereeCount: 0,
           nextTierPointsNeeded: 0,
         });
 
         expect(selectBalanceTotal(state)).toBe(0);
-        expect(selectBalanceRefereePortion(state)).toBe(0);
         expect(selectReferralCount(state)).toBe(0);
         expect(selectNextTierPointsNeeded(state)).toBe(0);
       });
@@ -1741,13 +1706,11 @@ describe('Rewards selectors', () => {
       it('handles negative values correctly', () => {
         const state = createMockRootState({
           balanceTotal: -100,
-          balanceRefereePortion: -50,
           refereeCount: -1,
           nextTierPointsNeeded: -10,
         });
 
         expect(selectBalanceTotal(state)).toBe(-100);
-        expect(selectBalanceRefereePortion(state)).toBe(-50);
         expect(selectReferralCount(state)).toBe(-1);
         expect(selectNextTierPointsNeeded(state)).toBe(-10);
       });
@@ -1755,13 +1718,11 @@ describe('Rewards selectors', () => {
       it('handles very large numbers correctly', () => {
         const state = createMockRootState({
           balanceTotal: Number.MAX_SAFE_INTEGER,
-          balanceRefereePortion: 999999999,
           refereeCount: 1000000,
           nextTierPointsNeeded: Number.MAX_SAFE_INTEGER,
         });
 
         expect(selectBalanceTotal(state)).toBe(Number.MAX_SAFE_INTEGER);
-        expect(selectBalanceRefereePortion(state)).toBe(999999999);
         expect(selectReferralCount(state)).toBe(1000000);
         expect(selectNextTierPointsNeeded(state)).toBe(Number.MAX_SAFE_INTEGER);
       });
@@ -1769,11 +1730,9 @@ describe('Rewards selectors', () => {
       it('handles floating point numbers correctly', () => {
         const state = createMockRootState({
           balanceTotal: 123.456789,
-          balanceRefereePortion: 67.89,
         });
 
         expect(selectBalanceTotal(state)).toBe(123.456789);
-        expect(selectBalanceRefereePortion(state)).toBe(67.89);
       });
     });
 
@@ -1972,7 +1931,6 @@ describe('Rewards selectors', () => {
         },
         nextTierPointsNeeded: 1000,
         balanceTotal: 2750.5,
-        balanceRefereePortion: 1250.25,
         balanceUpdatedAt: new Date('2024-03-15T14:30:00Z'),
         onboardingActiveStep: OnboardingStep.STEP_3,
         candidateSubscriptionId: 'sub-candidate-12345',
@@ -2017,7 +1975,6 @@ describe('Rewards selectors', () => {
         expect(selectNextTier(comprehensiveState)?.name).toBe('Gold');
         expect(selectNextTierPointsNeeded(comprehensiveState)).toBe(1000);
         expect(selectBalanceTotal(comprehensiveState)).toBe(2750.5);
-        expect(selectBalanceRefereePortion(comprehensiveState)).toBe(1250.25);
         expect(selectBalanceUpdatedAt(comprehensiveState)).toEqual(
           new Date('2024-03-15T14:30:00Z'),
         );

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -27,9 +27,6 @@ export const selectNextTier = (state: RootState) => state.rewards.nextTier;
 export const selectNextTierPointsNeeded = (state: RootState) =>
   state.rewards.nextTierPointsNeeded;
 
-export const selectBalanceRefereePortion = (state: RootState) =>
-  state.rewards.balanceRefereePortion;
-
 export const selectBalanceUpdatedAt = (state: RootState) =>
   state.rewards.balanceUpdatedAt;
 

--- a/tests/component-view/presets/perpsStatePreset.ts
+++ b/tests/component-view/presets/perpsStatePreset.ts
@@ -101,7 +101,7 @@ export const initialStatePerps = () =>
           },
           // usePerpsPaymentTokens -> useTokensWithBalance reads TokenBalancesController
           TokenBalancesController: { tokenBalances: {} },
-          // HeroCardView -> useReferralDetails/useSeasonStatus -> selectRewardsSubscriptionId reads RewardsController
+          // HeroCardView -> useReferralDetails reads RewardsController
           RewardsController: {
             activeAccount: null,
           } as Record<string, unknown>,

--- a/tests/framework/fixtures/json/default-fixture.json
+++ b/tests/framework/fixtures/json/default-fixture.json
@@ -730,7 +730,6 @@
       "activeBoostsError": false,
       "activeBoostsLoading": false,
       "activeTab": "overview",
-      "balanceRefereePortion": 0,
       "balanceTotal": 0,
       "balanceUpdatedAt": null,
       "benefits": [],


### PR DESCRIPTION
## Summary

**What:** Decouples rewards referral-details from the season concept and short-circuits `hasActiveSeason()` to `false` while no season is configured. Stops the noisy `Failed to check active season` dashboard log.

**Why:** No active season exists; the app was making a doomed `/discover/seasons` round-trip on every dashboard mount, and the referral-details API was pointlessly keyed by `seasonId`.

### Functional impact (for QA)

| Area | Before | After |
|---|---|---|
| Rewards dashboard mount | Triggered `hasActiveSeason` → `/discover/seasons` fetch; logged failure when none | No fetch, no log |
| Referral code on dashboard | Fetched per-season via `/seasons/:id/referral-details` | Fetched via `/subscriptions/referral-details` (subscription-scoped) |
| Previous Season Summary page | Data populated by ambient `RewardsNavigator` fetch | Page now drives its own season-status fetch on focus |
| "Earn points" estimates (Swap / Bridge / Perps / Predict) | Showed estimated points when a season was active | Always `0` points / `0` bonus (until `hasActiveSeason` is un-stubbed) |
| Perps rewards opt-in row | Visible when an active season existed | Hidden (gated by `hasActiveSeason`) |
| Bridge & Predict reward gating | Active when season existed | Skipped |
| **Perps VIP fee discount** | Computed via `/vip/fees` | **Unchanged ✅** — independent code path, no season dependency |

### Technical changes

| Concern | Change |
|---|---|
| `RewardsController.hasActiveSeason` | Hardcoded `return false` (temporary; reversible single-line change) |
| Referral-details endpoint | `GET /seasons/:id/referral-details` → `GET /subscriptions/referral-details` |
| `useReferralDetails` hook | No longer reads `selectSeasonId`; takes only `subscriptionId` |
| Controller cache key | `subscriptionReferralDetails` keyed by `subscriptionId` (was `seasonId:subscriptionId` composite) |
| Cache invalidation | Referral details now cleared on subscription-scope invalidation only, not season-scope |
| Removed hooks/selectors | `useSeasonStatus` removed from `RewardsNavigator` and `PerpsHeroCardView`; `selectSeasonStatusError` + `selectSeasonStartDate` removed from `ReferralDetails` |
| Removed dead state | `referralPoints` field (DTO + state) and the `balanceRefereePortion` Redux field + `selectBalanceRefereePortion` selector — never read by any UI |
| Renamed types | `SubscriptionSeasonReferralDetail{s,}{Dto,State}` → `SubscriptionReferralDetail{s,}{Dto,State}` |
| `PreviousSeasonSummary` | `useSeasonStatus({ onlyForExplicitFetch: true })` → `false` (now drives its own fetch) |

### What Perps reviewers should verify

- ✅ VIP fee discount still applies on perps trade confirmation screens (uses `getPerpsDiscountForAccount` → `/vip/fees`, no season dependency).
- ⚠️ The "earn rewards" row on the Perps page is **intentionally hidden** while no season exists. Confirm this is the desired interim state.
- ⚠️ Points estimates on perps trade confirmation will show **0** while no season exists. Same.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rewards data-fetching behavior and caching by removing season-scoped referral details and hardcoding `hasActiveSeason()` to `false`, which will suppress season-gated UI/points estimates until re-enabled. Risk is moderate due to broad reach across Rewards/Perps screens and controller/service API contract changes.
> 
> **Overview**
> **Referral details are no longer season-scoped.** `RewardsDataService.getReferralDetails` and `RewardsController.getReferralDetails` drop the `seasonId` parameter, switch to `GET /subscriptions/referral-details`, and store cache entries keyed only by `subscriptionId` (with updated invalidation behavior).
> 
> **Season gating is effectively turned off for now.** `RewardsController.hasActiveSeason()` is hardcoded to return `false`, and callsites/tests are updated accordingly (e.g., `RewardsNavigator`/`PerpsHeroCardView` stop prefetching season status; `ReferralDetails` removes the season-status error gate; `PreviousSeasonSummary` now uses `useSeasonStatus({ onlyForExplicitFetch: false })`).
> 
> **Redux/types cleanup.** Removes unused `referralPoints`/`balanceRefereePortion` state and selector, and renames referral detail DTO/state types to `SubscriptionReferralDetailsDto`/`SubscriptionReferralDetailState`, with fixtures/tests updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fa9b0ffe37eaeec1eab2f71586a496fb526078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->