### PR TITLE
test: addresses swap test

### DIFF
--- a/tests/helpers/swap/constants.ts
+++ b/tests/helpers/swap/constants.ts
@@ -1,12 +1,30 @@
+interface QuoteStreamCompleteMock {
+  quoteCount?: number;
+  hasQuotes?: boolean;
+  reason?: string;
+  context?: Record<string, unknown>;
+}
+
+const toSSEEvent = (event: string, data: object) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
 /**
  * Wraps quote fixture objects as an SSE-formatted response string.
  * Required because bridge-controller uses fetchServerEvents (SSE parser)
  * which expects lines prefixed with "data: ". Raw JSON returns zero quotes.
  */
-export function toSSEResponse(quotes: object[]): string {
-  return quotes
-    .map((q) => `event: quote\ndata: ${JSON.stringify(q)}\n\n`)
-    .join('');
+export function toSSEResponse(
+  quotes: object[],
+  complete: QuoteStreamCompleteMock = {},
+): string {
+  const quoteEvents = quotes.map((q) => toSSEEvent('quote', q)).join('');
+  const completeEvent = {
+    quoteCount: quotes.length,
+    hasQuotes: quotes.length > 0,
+    ...complete,
+  };
+
+  return `${quoteEvents}${toSSEEvent('complete', completeEvent)}`;
 }
 
 export const localNodeOptions = {

--- a/tests/smoke/swap/swap-deeplink-smoke.spec.ts
+++ b/tests/smoke/swap/swap-deeplink-smoke.spec.ts
@@ -85,6 +85,7 @@ describe(
             asDetoxElement(QuoteView.amountInput),
             '1.0',
           );
+          await QuoteView.isQuoteDisplayed();
           await Assertions.expectElementToBeVisible(QuoteView.confirmSwap);
 
           // Verify we can navigate back


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Fixes a flaky swap deeplink smoke test where the mocked quote stream could leave the Bridge UI showing “Unable to get a quote right now. Try again.”
- Updated `toSSEResponse` so mocked bridge quote streams include a final `complete` SSE event with `quoteCount` and `hasQuotes`.
- Updated the swap deeplink smoke test to wait for quote details before asserting the confirm swap button.

Context:
`bridge-controller` now tracks quote stream completion from the SSE `complete` event. Our mocked successful quote streams only emitted `quote` events, which made the mocked stream diverge from the real API contract and could produce flaky no-quote UI states in CI.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: 1 in https://consensys.slack.com/archives/C02U025CVU4/p1779181319452809

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that align mocked SSE quote streams with the expected API contract and add a wait to reduce CI flakiness.
> 
> **Overview**
> Fixes swap deeplink smoke-test flakiness by updating `toSSEResponse` to emit a terminal SSE `complete` event (including `quoteCount`/`hasQuotes`, with optional overrides) after all `quote` events, matching the newer bridge quote-stream contract.
> 
> Updates `swap-deeplink-smoke.spec.ts` to explicitly wait for `QuoteView.isQuoteDisplayed()` before asserting `confirmSwap` visibility, reducing timing-related failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d76d28669512edb939f4dacc2625dc367699441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->