### PR TITLE
refactor(token-details): remove unused getSwapTokens helper

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@metamask/assets-controllers';
 import {
   computeBuySourceToken,
-  getSwapTokens,
   useHandleOnBuy,
   useHandleOnReceive,
   useHandleOnSend,
@@ -286,19 +285,6 @@ beforeEach(() => {
     networkModal: null,
   });
   mockRampsUnifiedV1Enabled.mockReturnValue(false);
-});
-
-describe('useTokenAtomicActions - getSwapTokens', () => {
-  it('returns sourceToken as the token and destToken as undefined for regular tokens', () => {
-    const result = getSwapTokens(defaultToken);
-
-    expect(result.sourceToken).toMatchObject({
-      address: defaultToken.address,
-      chainId: defaultToken.chainId,
-      symbol: defaultToken.symbol,
-    });
-    expect(result.destToken).toBeUndefined();
-  });
 });
 
 /**

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -23,20 +23,11 @@ import { areAddressesEqual } from '../../../../util/address';
 import { useRampNavigation } from '../../Ramp/hooks/useRampNavigation';
 import { TokenI } from '../../Tokens/types';
 import {
-  isAssetFromTrending,
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
 } from '../../Bridge/hooks/useSwapBridgeNavigation';
-import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../constants/bridge';
-import {
-  getNativeSourceToken,
-  getDefaultDestToken,
-} from '../../Bridge/utils/tokenUtils';
 import { useSendNonEvmAsset } from '../../../hooks/useSendNonEvmAsset';
-import {
-  formatChainIdToCaip,
-  isNativeAddress,
-} from '@metamask/bridge-controller';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { InitSendLocation } from '../../../Views/confirmations/constants/send';
 import { useSendNavigation } from '../../../Views/confirmations/hooks/useSendNavigation';
 import parseRampIntent from '../../Ramp/utils/parseRampIntent';
@@ -187,48 +178,6 @@ const hasPositiveBalance = (balance: string | number | undefined): boolean => {
   }
 
   return false;
-};
-
-/**
- * Determines the source and destination tokens for swap/bridge navigation.
- */
-export const getSwapTokens = (
-  token: TokenI,
-): {
-  sourceToken: BridgeToken | undefined;
-  destToken: BridgeToken | undefined;
-} => {
-  const wantsToBuyToken = isAssetFromTrending(token);
-  const isNative = isNativeAddress(token.address);
-
-  const bridgeToken: BridgeToken = {
-    ...token,
-    address: token.address ?? NATIVE_SWAPS_TOKEN_ADDRESS,
-    chainId: token.chainId as Hex | CaipChainId,
-    decimals: token.decimals,
-    symbol: token.symbol,
-    name: token.name,
-    image: token.image,
-    securityData: adaptTokenSecurityData(token.securityData),
-  };
-
-  if (wantsToBuyToken) {
-    if (isNative) {
-      return {
-        sourceToken: getDefaultDestToken(bridgeToken.chainId),
-        destToken: bridgeToken,
-      };
-    }
-    return {
-      sourceToken: getNativeSourceToken(bridgeToken.chainId),
-      destToken: bridgeToken,
-    };
-  }
-
-  return {
-    sourceToken: bridgeToken,
-    destToken: undefined,
-  };
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

`getSwapTokens` in `app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts` is dead code. A repo-wide search shows zero production callers — the only references are the export itself and a single unit test that exercises it directly.

This PR removes the function, its dedicated `describe('useTokenAtomicActions - getSwapTokens', ...)` test block, and the imports that were only kept around to support it:

- `isAssetFromTrending` (from `../../Bridge/hooks/useSwapBridgeNavigation`)
- `isNativeAddress` (from `@metamask/bridge-controller`)
- `getDefaultDestToken`, `getNativeSourceToken` (from `../../Bridge/utils/tokenUtils`)
- `NATIVE_SWAPS_TOKEN_ADDRESS` (from `../../../../constants/bridge`)

`adaptTokenSecurityData`, `useSwapBridgeNavigation`, `SwapBridgeNavigationLocation`, and `BridgeToken` are kept because they're still consumed by `useHandleOnSwap` / `toCurrentTokenAsBridgeToken`.

No behavior change. Net diff: `2 files changed, 1 insertion(+), 66 deletions(-)`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

No runtime change — pure dead-code removal. Verified via:

```gherkin
Feature: Token Details actions remain unaffected

  Scenario: Existing swap/buy/send/receive handlers still type-check and pass tests
    Given the getSwapTokens helper has been removed
    When yarn lint:tsc runs
    Then there are zero type errors

    When yarn jest app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts --coverage=false runs
    Then all 28 remaining tests pass
```

## **Screenshots/Recordings**

N/A — no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ad7f436-05b6-47f1-97bb-8b819fb48a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ad7f436-05b6-47f1-97bb-8b819fb48a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

