### PR TITLE
feat: use refresh tokens hook

### DIFF
--- a/app/components/UI/Tokens/hooks/useRefreshTokens.test.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.test.ts
@@ -1,0 +1,263 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { BtcScope, EthScope, SolScope } from '@metamask/keyring-api';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import type { Hex } from '@metamask/utils';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import Logger from '../../../../util/Logger';
+import { selectIsAssetsUnifyStateEnabled } from '../../../../selectors/featureFlagController/assetsUnifyState';
+import { useRefreshTokens } from './useRefreshTokens';
+
+const mockGetAssets = jest.fn().mockResolvedValue({});
+const mockUpdateBalance = jest.fn().mockResolvedValue(undefined);
+const mockPerformEvmTokenRefresh = jest.fn().mockResolvedValue(undefined);
+const mockAccountByScope = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector: (state: Record<string, never>) => unknown) =>
+    selector({}),
+  ),
+}));
+
+jest.mock(
+  '../../../../selectors/featureFlagController/assetsUnifyState',
+  () => ({
+    selectIsAssetsUnifyStateEnabled: jest.fn(),
+  }),
+);
+
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => mockAccountByScope),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    AssetsController: {
+      getAssets: (...args: unknown[]) => mockGetAssets(...args),
+    },
+    MultichainBalancesController: {
+      updateBalance: (...args: unknown[]) => mockUpdateBalance(...args),
+    },
+  },
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+jest.mock('../util/tokenRefreshUtils', () => ({
+  performEvmTokenRefresh: (...args: unknown[]) =>
+    mockPerformEvmTokenRefresh(...args),
+}));
+
+const evmNetworkConfigurationsByChainId = {
+  '0x1': { chainId: '0x1' as Hex, nativeCurrency: 'ETH' },
+  '0x89': { chainId: '0x89' as Hex, nativeCurrency: 'POL' },
+} as const;
+
+const makeAccount = (id: string): InternalAccount =>
+  ({ id, address: '0xabc', type: 'eip155:eoa' }) as InternalAccount;
+
+describe('useRefreshTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+    mockAccountByScope.mockImplementation((scope: unknown) => {
+      if (scope === EthScope.Mainnet) {
+        return makeAccount('evm-account');
+      }
+      if (scope === SolScope.Mainnet) {
+        return makeAccount('sol-account');
+      }
+      if (scope === BtcScope.Mainnet) {
+        return makeAccount('btc-account');
+      }
+      return undefined;
+    });
+  });
+
+  it('calls AssetsController.getAssets with chain ids and fungible asset types when unified assets are enabled', async () => {
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    const expectedChainIds = Object.values(
+      evmNetworkConfigurationsByChainId,
+    ).map((config) => toEvmCaipChainId(config.chainId));
+
+    expect(mockGetAssets).toHaveBeenCalledTimes(1);
+    expect(mockGetAssets).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'evm-account' }),
+        expect.objectContaining({ id: 'sol-account' }),
+        expect.objectContaining({ id: 'btc-account' }),
+      ]),
+      {
+        forceUpdate: true,
+        chainIds: expectedChainIds,
+        assetTypes: ['fungible'],
+      },
+    );
+    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
+    expect(mockUpdateBalance).not.toHaveBeenCalled();
+  });
+
+  it('skips AssetsController.getAssets when unified assets state is disabled', async () => {
+    (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAssets).not.toHaveBeenCalled();
+    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledWith(
+      evmNetworkConfigurationsByChainId,
+    );
+  });
+
+  it('skips AssetsController.getAssets when no scoped accounts exist', async () => {
+    mockAccountByScope.mockReturnValue(undefined);
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAssets).not.toHaveBeenCalled();
+    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call MultichainBalancesController.updateBalance when the group has no Solana or Bitcoin scoped account', async () => {
+    mockAccountByScope.mockImplementation((scope: unknown) => {
+      if (scope === EthScope.Mainnet) {
+        return makeAccount('evm-only');
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAssets).toHaveBeenCalledTimes(1);
+    expect(mockGetAssets).toHaveBeenCalledWith(
+      [expect.objectContaining({ id: 'evm-only' })],
+      expect.objectContaining({
+        forceUpdate: true,
+        assetTypes: ['fungible'],
+      }),
+    );
+    expect(mockUpdateBalance).not.toHaveBeenCalled();
+    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
+  });
+
+  it('calls MultichainBalancesController.updateBalance for each present non-EVM scoped account when unified assets state is disabled', async () => {
+    (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+    mockAccountByScope.mockImplementation((scope: unknown) => {
+      if (scope === EthScope.Mainnet) {
+        return makeAccount('evm-1');
+      }
+      if (scope === SolScope.Mainnet) {
+        return makeAccount('sol-1');
+      }
+      if (scope === BtcScope.Mainnet) {
+        return undefined;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetAssets).not.toHaveBeenCalled();
+    expect(mockUpdateBalance).toHaveBeenCalledTimes(1);
+    expect(mockUpdateBalance).toHaveBeenCalledWith('sol-1');
+    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and continues when AssetsController.getAssets rejects', async () => {
+    mockGetAssets.mockRejectedValueOnce(new Error('network'));
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'useRefreshTokens: AssetsController.getAssets failed',
+    );
+    expect(mockPerformEvmTokenRefresh).not.toHaveBeenCalled();
+    expect(mockUpdateBalance).not.toHaveBeenCalled();
+  });
+
+  it('logs per-account errors when MultichainBalancesController.updateBalance rejects', async () => {
+    (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+    mockUpdateBalance.mockRejectedValueOnce(new Error('sol-down'));
+    mockAccountByScope.mockImplementation((scope: unknown) => {
+      if (scope === EthScope.Mainnet) {
+        return makeAccount('evm-1');
+      }
+      if (scope === SolScope.Mainnet) {
+        return makeAccount('sol-1');
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() =>
+      useRefreshTokens({
+        evmNetworkConfigurationsByChainId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'useRefreshTokens: failed to refresh balance for non-EVM account sol-1',
+    );
+    expect(mockPerformEvmTokenRefresh).toHaveBeenCalledTimes(1);
+    expect(mockGetAssets).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Tokens/hooks/useRefreshTokens.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.ts
@@ -12,7 +12,7 @@ import { selectSelectedInternalAccountByScope } from '../../../../selectors/mult
 import { performEvmTokenRefresh } from '../util/tokenRefreshUtils';
 
 /** Homepage token list: native + ERC-20 / SPL fungibles (not NFT collections). */
-const REFRESH_ASSET_TYPES: AssetType[] = ['token', 'price', 'metadata'];
+const REFRESH_ASSET_TYPES: AssetType[] = ['fungible'];
 
 interface UseRefreshTokensOptions {
   /** EVM network configurations restricted to the chains that should be polled. */
@@ -23,16 +23,13 @@ interface UseRefreshTokensOptions {
 }
 
 /**
- * Refreshes tokens for the currently selected account group across all
- * supported scopes (EVM, Solana, Bitcoin):
+ * Refreshes tokens for the currently selected account group across all supported scopes (EVM, Solana, Bitcoin).
  *
- * 1. When the unified assets state flag is enabled, force-refreshes the
- * AssetsController for every scoped account in the group.
- * 2. Triggers `MultichainBalancesController.updateBalance` for every non-EVM
- * scoped account (Solana, Bitcoin, …) — not just Solana.
- * 3. Runs the EVM token detection / balance / rate refresh.
+ * When the unified assets state flag is enabled and the group has at least one scoped account, force-refreshes
+ * `AssetsController` only, then returns (no legacy multichain or EVM controller refresh).
  *
- * Steps 2 and 3 run in parallel since they target different controllers.
+ * Otherwise triggers `MultichainBalancesController.updateBalance` for every non-EVM scoped account (Solana,
+ * Bitcoin, …) and runs the EVM token detection / balance / rate refresh in parallel.
  */
 export const useRefreshTokens = ({
   evmNetworkConfigurationsByChainId,
@@ -57,8 +54,7 @@ export const useRefreshTokens = ({
       bitcoinAccount,
     ].filter((account): account is InternalAccount => Boolean(account));
 
-    // Non-EVM accounts whose balances are refreshed via the multichain
-    // balances controller. EVM balances are refreshed separately below.
+    // Legacy path only: unified refresh returns above.
     const nonEvmAccounts: InternalAccount[] = [
       solanaAccount,
       bitcoinAccount,
@@ -81,6 +77,8 @@ export const useRefreshTokens = ({
           'useRefreshTokens: AssetsController.getAssets failed',
         );
       }
+
+      return;
     }
 
     await Promise.all([

--- a/app/components/UI/Tokens/hooks/useRefreshTokens.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.ts
@@ -1,0 +1,95 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { BtcScope, EthScope, SolScope } from '@metamask/keyring-api';
+import { Hex } from '@metamask/utils';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { selectIsAssetsUnifyStateEnabled } from '../../../../selectors/featureFlagController/assetsUnifyState';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import { performEvmTokenRefresh } from '../util/tokenRefreshUtils';
+
+interface UseRefreshTokensOptions {
+  /** EVM network configurations restricted to the chains that should be polled. */
+  evmNetworkConfigurationsByChainId: Record<
+    string,
+    { chainId: Hex; nativeCurrency: string }
+  >;
+}
+
+/**
+ * Refreshes tokens for the currently selected account group across all
+ * supported scopes (EVM, Solana, Bitcoin):
+ *
+ * 1. When the unified assets state flag is enabled, force-refreshes the
+ * AssetsController for every scoped account in the group.
+ * 2. Triggers `MultichainBalancesController.updateBalance` for every non-EVM
+ * scoped account (Solana, Bitcoin, …) — not just Solana.
+ * 3. Runs the EVM token detection / balance / rate refresh.
+ *
+ * Steps 2 and 3 run in parallel since they target different controllers.
+ */
+export const useRefreshTokens = ({
+  evmNetworkConfigurationsByChainId,
+}: UseRefreshTokensOptions) => {
+  const isAssetsUnifyStateEnabled = useSelector(
+    selectIsAssetsUnifyStateEnabled,
+  );
+  const accountByScope = useSelector(selectSelectedInternalAccountByScope);
+
+  // Resolve every scoped account that exists in the selected group.
+  // Missing scopes (e.g. group with no Bitcoin account) resolve to undefined.
+  const evmAccount = accountByScope(EthScope.Mainnet);
+  const solanaAccount = accountByScope(SolScope.Mainnet);
+  const bitcoinAccount = accountByScope(BtcScope.Mainnet);
+
+  const refresh = useCallback(async () => {
+    const { AssetsController, MultichainBalancesController } = Engine.context;
+
+    const scopedAccounts: InternalAccount[] = [
+      evmAccount,
+      solanaAccount,
+      bitcoinAccount,
+    ].filter((account): account is InternalAccount => Boolean(account));
+
+    // Non-EVM accounts whose balances are refreshed via the multichain
+    // balances controller. EVM balances are refreshed separately below.
+    const nonEvmAccounts: InternalAccount[] = [
+      solanaAccount,
+      bitcoinAccount,
+    ].filter((account): account is InternalAccount => Boolean(account));
+
+    if (isAssetsUnifyStateEnabled && scopedAccounts.length > 0) {
+      try {
+        await AssetsController.getAssets(scopedAccounts, { forceUpdate: true });
+      } catch (error) {
+        Logger.error(
+          error as Error,
+          'useRefreshTokens: AssetsController.getAssets failed',
+        );
+      }
+    }
+
+    await Promise.all([
+      ...nonEvmAccounts.map(async (account) => {
+        try {
+          await MultichainBalancesController.updateBalance(account.id);
+        } catch (error) {
+          Logger.error(
+            error as Error,
+            `useRefreshTokens: failed to refresh balance for non-EVM account ${account.id}`,
+          );
+        }
+      }),
+      performEvmTokenRefresh(evmNetworkConfigurationsByChainId),
+    ]);
+  }, [
+    isAssetsUnifyStateEnabled,
+    evmAccount,
+    solanaAccount,
+    bitcoinAccount,
+    evmNetworkConfigurationsByChainId,
+  ]);
+
+  return { refresh };
+};

--- a/app/components/UI/Tokens/hooks/useRefreshTokens.ts
+++ b/app/components/UI/Tokens/hooks/useRefreshTokens.ts
@@ -1,13 +1,18 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { BtcScope, EthScope, SolScope } from '@metamask/keyring-api';
-import { Hex } from '@metamask/utils';
+import type { AssetType } from '@metamask/assets-controller';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { selectIsAssetsUnifyStateEnabled } from '../../../../selectors/featureFlagController/assetsUnifyState';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { performEvmTokenRefresh } from '../util/tokenRefreshUtils';
+
+/** Homepage token list: native + ERC-20 / SPL fungibles (not NFT collections). */
+const REFRESH_ASSET_TYPES: AssetType[] = ['token', 'price', 'metadata'];
 
 interface UseRefreshTokensOptions {
   /** EVM network configurations restricted to the chains that should be polled. */
@@ -60,8 +65,16 @@ export const useRefreshTokens = ({
     ].filter((account): account is InternalAccount => Boolean(account));
 
     if (isAssetsUnifyStateEnabled && scopedAccounts.length > 0) {
+      const chainIds: CaipChainId[] = Object.values(
+        evmNetworkConfigurationsByChainId,
+      ).map(({ chainId }) => toEvmCaipChainId(chainId));
+
       try {
-        await AssetsController.getAssets(scopedAccounts, { forceUpdate: true });
+        await AssetsController.getAssets(scopedAccounts, {
+          forceUpdate: true,
+          chainIds,
+          assetTypes: REFRESH_ASSET_TYPES,
+        });
       } catch (error) {
         Logger.error(
           error as Error,

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -87,9 +87,9 @@ jest.mock('../../../../UI/Earn/hooks/useMusdConversionEligibility', () => ({
   useMusdConversionEligibility: () => mockUseMusdConversionEligibility(),
 }));
 
-const mockRefreshTokens = jest.fn().mockResolvedValue(undefined);
-jest.mock('../../../../UI/Tokens/util/refreshTokens', () => ({
-  refreshTokens: (...args: unknown[]) => mockRefreshTokens(...args),
+const mockRefresh = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../UI/Tokens/hooks/useRefreshTokens', () => ({
+  useRefreshTokens: () => ({ refresh: mockRefresh }),
 }));
 
 const mockFetchTrendingTokens = jest.fn().mockResolvedValue(undefined);
@@ -416,7 +416,7 @@ const mockTrendingTokenData = [
 describe('TokensSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRefreshTokens.mockResolvedValue(undefined);
+    mockRefresh.mockResolvedValue(undefined);
     mockUseTrendingRequest.mockReturnValue({
       results: [],
       isLoading: false,
@@ -658,12 +658,12 @@ describe('TokensSection', () => {
     expect(screen.getByText('MetaMask USD')).toBeOnTheScreen();
   });
 
-  it('renders ErrorState when refreshTokens throws for non-zero balance account', async () => {
+  it('renders ErrorState when refresh hook throws for non-zero balance account', async () => {
     mockUseIsZeroBalanceAccount.mockReturnValue(false);
     mockSortedTokenKeys.mockReturnValue([
       { chainId: '0x1', address: '0xtoken1', isStaked: false },
     ]);
-    mockRefreshTokens.mockRejectedValue(new Error('Network error'));
+    mockRefresh.mockRejectedValue(new Error('Network error'));
 
     const ref = React.createRef<{ refresh: () => Promise<void> }>();
     renderWithProvider(
@@ -685,7 +685,7 @@ describe('TokensSection', () => {
     mockSortedTokenKeys.mockReturnValue([
       { chainId: '0x1', address: '0xtoken1', isStaked: false },
     ]);
-    mockRefreshTokens.mockRejectedValueOnce(new Error('Network error'));
+    mockRefresh.mockRejectedValueOnce(new Error('Network error'));
 
     const ref = React.createRef<{ refresh: () => Promise<void> }>();
     renderWithProvider(
@@ -756,7 +756,7 @@ describe('TokensSection', () => {
       fireEvent.press(screen.getByTestId('error-state-retry-button'));
     });
 
-    expect(mockRefreshTokens).toHaveBeenCalledTimes(1);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('does not show RemoveTokenBottomSheet by default', () => {
@@ -850,7 +850,7 @@ describe('TokensSection', () => {
     });
   });
 
-  it('calls refreshTokens for non-zero balance pull-to-refresh', async () => {
+  it('invokes the refresh hook for non-zero balance pull-to-refresh', async () => {
     mockUseIsZeroBalanceAccount.mockReturnValue(false);
     mockSortedTokenKeys.mockReturnValue([
       { chainId: '0x1', address: '0xtoken1', isStaked: false },
@@ -865,12 +865,7 @@ describe('TokensSection', () => {
       await ref.current?.refresh();
     });
 
-    expect(mockRefreshTokens).toHaveBeenCalledTimes(1);
-    expect(mockRefreshTokens).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isSolanaSelected: false,
-      }),
-    );
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
   describe('mode="positions-only"', () => {

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -28,13 +28,11 @@ import { SectionRefreshHandle, HomeSectionMode } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 import { PopularTokensList } from './components';
 import { selectSelectedInternalAccountId } from '../../../../../selectors/accountsController';
-import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
-import { SolScope } from '@metamask/keyring-api';
 import { toHex } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
-import { refreshTokens } from '../../../../UI/Tokens/util/refreshTokens';
 import TokenListSkeleton from '../../../../UI/Tokens/TokenList/TokenListSkeleton/TokenListSkeleton';
 import { useRemoveToken } from '../../../../UI/Tokens/hooks/useRemoveToken';
+import { useRefreshTokens } from '../../../../UI/Tokens/hooks/useRefreshTokens';
 import useHomeViewedEvent, {
   HomeSectionNames,
   type HomeSectionName,
@@ -129,10 +127,10 @@ const TokensSectionMain = forwardRef<SectionRefreshHandle, TokensSectionProps>(
       );
     }, [evmNetworkConfigurationsByChainId, popularChainIds]);
     const selectedAccountId = useSelector(selectSelectedInternalAccountId);
-    const selectedSolanaAccount =
-      useSelector(selectSelectedInternalAccountByScope)(SolScope.Mainnet) ||
-      null;
-    const isSolanaSelected = selectedSolanaAccount !== null;
+
+    const { refresh: refreshTokensForGroup } = useRefreshTokens({
+      evmNetworkConfigurationsByChainId: evmNetworkConfigurationsForRefresh,
+    });
 
     const prevAccountIdRef = useRef(selectedAccountId);
     // Reset section error when account changes (not on initial mount) so the new account gets a fresh state
@@ -183,22 +181,12 @@ const TokensSectionMain = forwardRef<SectionRefreshHandle, TokensSectionProps>(
         await popularTokensListRef.current?.refresh();
       } else {
         try {
-          await refreshTokens({
-            isSolanaSelected,
-            evmNetworkConfigurationsByChainId:
-              evmNetworkConfigurationsForRefresh,
-            selectedAccountId,
-          });
+          await refreshTokensForGroup();
         } catch {
           setHasTokensError(true);
         }
       }
-    }, [
-      isZeroBalanceAccount,
-      isSolanaSelected,
-      evmNetworkConfigurationsForRefresh,
-      selectedAccountId,
-    ]);
+    }, [isZeroBalanceAccount, refreshTokensForGroup]);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -81,7 +81,10 @@ export const getAccountTrackerControllerAccountsByChainId =
             assetId as CaipAssetType,
           );
 
-          // No need to check if the chain is EVM, we already filtered out non-EVM accounts
+          if (parsedChain.namespace !== KnownCaipNamespace.Eip155) {
+            continue;
+          }
+
           const hexChainId = decimalToPrefixedHex(parsedChain.reference);
           const amount = balanceData?.amount ?? '0';
 
@@ -158,7 +161,10 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
 
         const assetType = parseCaipAssetType(assetId);
 
-        // No need to check if the chain is EVM, we already filtered out non-EVM accounts
+        if (assetType.chain.namespace !== KnownCaipNamespace.Eip155) {
+          continue;
+        }
+
         const hexChainId = decimalToPrefixedHex(
           assetType.chain.reference,
         ) as Hex;
@@ -282,6 +288,14 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         }
 
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
+
+        // TokenBalancesController is EVM-only; skip non-eip155 assets (e.g.
+        // Solana) that can appear under the same account in unified state.
+        // Otherwise `decimalToPrefixedHex` on a non-decimal reference yields
+        // invalid keys such as `0xNaN`.
+        if (assetType.chain.namespace !== KnownCaipNamespace.Eip155) {
+          continue;
+        }
 
         const hexChainId = decimalToPrefixedHex(
           assetType.chain.reference,

--- a/app/selectors/assets/balances.ts
+++ b/app/selectors/assets/balances.ts
@@ -35,22 +35,23 @@ import {
   selectSelectedAccountGroupId,
 } from '../multichainAccounts/accountTreeController';
 import {
+  selectMultichainBalances,
+  selectMultichainAssetsRates,
+  selectMultichainAssetsAllIgnoredAssets,
+  selectMultichainAssets,
+  selectMultichainAssetsMetadata,
+} from '../multichain/multichain';
+import { selectTokenMarketData } from '../tokenRatesController';
+import { selectAllTokenBalances } from '../tokenBalancesController';
+import { selectAllTokens } from '../tokensController';
+import {
+  selectCurrentCurrency,
+  selectCurrencyRates,
+} from '../currencyRateController';
+import {
   selectInternalAccountsById,
   selectSelectedInternalAccountId,
 } from '../accountsController';
-import {
-  getCurrencyRateControllerCurrencyRates,
-  getCurrencyRateControllerCurrentCurrency,
-  getMultichainAssetsRatesControllerConversionRates,
-  getMultiChainAssetsControllerAccountsAssets,
-  getMultiChainAssetsControllerAllIgnoredAssets,
-  getMultiChainAssetsControllerAssetsMetadata,
-  getMultiChainBalancesControllerBalances,
-  getTokenBalancesControllerTokenBalances,
-  getTokenRatesControllerMarketData,
-  getTokensControllerAllIgnoredTokens,
-  getTokensControllerAllTokens,
-} from './assets-migration';
 import type { NetworkConfig } from '@metamask/network-enablement-controller';
 
 // Narrow controller-state shapes using existing selectors
@@ -89,40 +90,29 @@ const selectAccountsStateForBalances = createSelector(
     }) as AccountsControllerState,
 );
 
-// The per-controller wrappers below pack their input into the `*ControllerState`
-// shape expected by `calculateBalanceForAllWallets` /
-// `calculateBalanceChangeFor*` from `@metamask/assets-controllers`.
-//
-// Each input selector comes from `./assets-migration`, which transparently
-// switches its source depending on the `assetsUnifyState` feature flag:
-//   - Flag off: returns the legacy controller's state (unchanged behaviour).
-//   - Flag on: returns the equivalent shape derived from `AssetsController`
-//     state, so the balance calculations operate on the unified state without
-//     any other code in this file needing to change.
-
 const selectTokenBalancesStateForBalances = createSelector(
-  [getTokenBalancesControllerTokenBalances],
+  [selectAllTokenBalances],
   (tokenBalances): TokenBalancesControllerState =>
     ({ tokenBalances }) as TokenBalancesControllerState,
 );
 
 const selectTokenRatesStateForBalances = createSelector(
-  [getTokenRatesControllerMarketData],
+  [selectTokenMarketData],
   (marketData): TokenRatesControllerState =>
     ({ marketData }) as TokenRatesControllerState,
 );
 
 const selectMultichainBalancesStateForBalances = createSelector(
-  [getMultiChainBalancesControllerBalances],
+  [selectMultichainBalances],
   (balances): MultichainBalancesControllerState =>
     ({ balances }) as MultichainBalancesControllerState,
 );
 
 const selectMultichainAssetsControllerStateForBalances = createSelector(
   [
-    getMultiChainAssetsControllerAccountsAssets,
-    getMultiChainAssetsControllerAssetsMetadata,
-    getMultiChainAssetsControllerAllIgnoredAssets,
+    selectMultichainAssets,
+    selectMultichainAssetsMetadata,
+    selectMultichainAssetsAllIgnoredAssets,
   ],
   (
     accountsAssets,
@@ -136,26 +126,23 @@ const selectMultichainAssetsControllerStateForBalances = createSelector(
 );
 
 const selectMultichainAssetsRatesStateForBalances = createSelector(
-  [getMultichainAssetsRatesControllerConversionRates],
+  [selectMultichainAssetsRates],
   (conversionRates): MultichainAssetsRatesControllerState =>
     ({ conversionRates }) as MultichainAssetsRatesControllerState,
 );
 
 const selectTokensStateForBalances = createSelector(
-  [getTokensControllerAllTokens, getTokensControllerAllIgnoredTokens],
-  (allTokens, allIgnoredTokens): TokensControllerState =>
+  [selectAllTokens],
+  (allTokens): TokensControllerState =>
     ({
       allTokens: allTokens ?? {},
-      allIgnoredTokens: allIgnoredTokens ?? {},
+      allIgnoredTokens: {},
       allDetectedTokens: {},
     }) as TokensControllerState,
 );
 
 const selectCurrencyRateStateForBalances = createSelector(
-  [
-    getCurrencyRateControllerCurrentCurrency,
-    getCurrencyRateControllerCurrencyRates,
-  ],
+  [selectCurrentCurrency, selectCurrencyRates],
   (currentCurrency, currencyRates): CurrencyRateState =>
     ({
       currentCurrency: currentCurrency ?? 'usd',

--- a/app/selectors/assets/balances.ts
+++ b/app/selectors/assets/balances.ts
@@ -35,23 +35,22 @@ import {
   selectSelectedAccountGroupId,
 } from '../multichainAccounts/accountTreeController';
 import {
-  selectMultichainBalances,
-  selectMultichainAssetsRates,
-  selectMultichainAssetsAllIgnoredAssets,
-  selectMultichainAssets,
-  selectMultichainAssetsMetadata,
-} from '../multichain/multichain';
-import { selectTokenMarketData } from '../tokenRatesController';
-import { selectAllTokenBalances } from '../tokenBalancesController';
-import { selectAllTokens } from '../tokensController';
-import {
-  selectCurrentCurrency,
-  selectCurrencyRates,
-} from '../currencyRateController';
-import {
   selectInternalAccountsById,
   selectSelectedInternalAccountId,
 } from '../accountsController';
+import {
+  getCurrencyRateControllerCurrencyRates,
+  getCurrencyRateControllerCurrentCurrency,
+  getMultichainAssetsRatesControllerConversionRates,
+  getMultiChainAssetsControllerAccountsAssets,
+  getMultiChainAssetsControllerAllIgnoredAssets,
+  getMultiChainAssetsControllerAssetsMetadata,
+  getMultiChainBalancesControllerBalances,
+  getTokenBalancesControllerTokenBalances,
+  getTokenRatesControllerMarketData,
+  getTokensControllerAllIgnoredTokens,
+  getTokensControllerAllTokens,
+} from './assets-migration';
 import type { NetworkConfig } from '@metamask/network-enablement-controller';
 
 // Narrow controller-state shapes using existing selectors
@@ -90,29 +89,40 @@ const selectAccountsStateForBalances = createSelector(
     }) as AccountsControllerState,
 );
 
+// The per-controller wrappers below pack their input into the `*ControllerState`
+// shape expected by `calculateBalanceForAllWallets` /
+// `calculateBalanceChangeFor*` from `@metamask/assets-controllers`.
+//
+// Each input selector comes from `./assets-migration`, which transparently
+// switches its source depending on the `assetsUnifyState` feature flag:
+//   - Flag off: returns the legacy controller's state (unchanged behaviour).
+//   - Flag on: returns the equivalent shape derived from `AssetsController`
+//     state, so the balance calculations operate on the unified state without
+//     any other code in this file needing to change.
+
 const selectTokenBalancesStateForBalances = createSelector(
-  [selectAllTokenBalances],
+  [getTokenBalancesControllerTokenBalances],
   (tokenBalances): TokenBalancesControllerState =>
     ({ tokenBalances }) as TokenBalancesControllerState,
 );
 
 const selectTokenRatesStateForBalances = createSelector(
-  [selectTokenMarketData],
+  [getTokenRatesControllerMarketData],
   (marketData): TokenRatesControllerState =>
     ({ marketData }) as TokenRatesControllerState,
 );
 
 const selectMultichainBalancesStateForBalances = createSelector(
-  [selectMultichainBalances],
+  [getMultiChainBalancesControllerBalances],
   (balances): MultichainBalancesControllerState =>
     ({ balances }) as MultichainBalancesControllerState,
 );
 
 const selectMultichainAssetsControllerStateForBalances = createSelector(
   [
-    selectMultichainAssets,
-    selectMultichainAssetsMetadata,
-    selectMultichainAssetsAllIgnoredAssets,
+    getMultiChainAssetsControllerAccountsAssets,
+    getMultiChainAssetsControllerAssetsMetadata,
+    getMultiChainAssetsControllerAllIgnoredAssets,
   ],
   (
     accountsAssets,
@@ -126,23 +136,26 @@ const selectMultichainAssetsControllerStateForBalances = createSelector(
 );
 
 const selectMultichainAssetsRatesStateForBalances = createSelector(
-  [selectMultichainAssetsRates],
+  [getMultichainAssetsRatesControllerConversionRates],
   (conversionRates): MultichainAssetsRatesControllerState =>
     ({ conversionRates }) as MultichainAssetsRatesControllerState,
 );
 
 const selectTokensStateForBalances = createSelector(
-  [selectAllTokens],
-  (allTokens): TokensControllerState =>
+  [getTokensControllerAllTokens, getTokensControllerAllIgnoredTokens],
+  (allTokens, allIgnoredTokens): TokensControllerState =>
     ({
       allTokens: allTokens ?? {},
-      allIgnoredTokens: {},
+      allIgnoredTokens: allIgnoredTokens ?? {},
       allDetectedTokens: {},
     }) as TokensControllerState,
 );
 
 const selectCurrencyRateStateForBalances = createSelector(
-  [selectCurrentCurrency, selectCurrencyRates],
+  [
+    getCurrencyRateControllerCurrentCurrency,
+    getCurrencyRateControllerCurrencyRates,
+  ],
   (currentCurrency, currencyRates): CurrencyRateState =>
     ({
       currentCurrency: currentCurrency ?? 'usd',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: use refresh tokens hook for the new assets controller

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the homepage pull-to-refresh behavior to route through unified-assets `AssetsController.getAssets` when enabled and alters how balances refresh across EVM/Solana/Bitcoin scopes, which could impact token list freshness and error handling. Selector hardening reduces risk of bad keys but touches asset migration shaping used by controllers.
> 
> **Overview**
> Adds a new `useRefreshTokens` hook that refreshes token data for the selected *account group* across EVM/Solana/Bitcoin: when unified assets is enabled it force-refreshes `AssetsController.getAssets` for all scoped accounts (fungibles only) and returns early; otherwise it refreshes non-EVM balances via `MultichainBalancesController.updateBalance` while running the existing EVM refresh in parallel, with per-path error logging.
> 
> Updates `TokensSection` (and tests) to use this hook instead of the legacy `refreshTokens` util for pull-to-refresh/error retry. Hardens `assets-migration` selectors to skip non-`eip155` asset IDs in unified state, preventing invalid chainId keys (e.g. `0xNaN`) when non-EVM assets appear under the same account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d7b76a684a4f9488f65374003c0b8ba601aa4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->