### PR TITLE
fix(build): set IS_DEVICE_BUILD=true for BrowserStack iOS builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -946,6 +946,7 @@ fi
 # have set from the generic main-e2e config (which uses IS_SIM_BUILD=true for emulators).
 if [ "${IS_BROWSERSTACK_BUILD:-false}" = "true" ]; then
 	export IS_SIM_BUILD="false"
+	export IS_DEVICE_BUILD="true"
 fi
 
 if [ "$METAMASK_ENVIRONMENT" == "production" ]; then


### PR DESCRIPTION
## Summary

- When `IS_BROWSERSTACK_BUILD=true`, `build.sh` sets `IS_SIM_BUILD="false"` but left `IS_DEVICE_BUILD` unset.
- The `generateIosBinary` device-build block only runs when `IS_DEVICE_BUILD=true` **or** `IS_SIM_BUILD` is empty:
  ```bash
  if [ "$IS_DEVICE_BUILD" = "true" ] || [ -z "$IS_SIM_BUILD" ]; then
  ```
- With `IS_SIM_BUILD="false"` (non-empty) and `IS_DEVICE_BUILD` unset, the condition was always `false`, so `xcodebuild -exportArchive` never ran, no IPA was produced, and `rename-artifacts.js` left `ios_ipa_path` empty.
- The `upload-artifact` step in `build.yml` then failed with **"Input required and not supplied: path"**.
- Fix: add `export IS_DEVICE_BUILD="true"` alongside the existing `IS_SIM_BUILD="false"` in the BrowserStack block.

## Test plan

- [ ] Trigger a BrowserStack iOS build (`IS_BROWSERSTACK_BUILD=true`) and confirm the IPA is produced at `ios/build/output/MetaMask.ipa`
- [ ] Confirm `upload-artifact` step succeeds with a valid `ios_ipa_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script change that only affects BrowserStack CI by toggling environment flags; main risk is unintended side effects if other steps rely on `IS_DEVICE_BUILD` being unset.
> 
> **Overview**
> BrowserStack iOS builds now explicitly export `IS_DEVICE_BUILD=true` when `IS_BROWSERSTACK_BUILD=true`, alongside forcing `IS_SIM_BUILD=false`.
> 
> This ensures the device-build path in `generateIosBinary` (and downstream artifact renaming/output like `ios_ipa_path`) runs for BrowserStack jobs, preventing missing IPA artifacts in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa4fd61a8785d45ba6865ba7b8dac5fc54b476b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->