### PR TITLE
ci: fix e2e report dependency handling

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -313,9 +313,9 @@ runs:
         path: |
           node_modules
           .yarn/install-state.gz
-        key: ${{ inputs.cache-prefix }}-yarn-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        key: ${{ inputs.cache-prefix }}-yarn-v2-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}-yarn-${{ inputs.platform }}-${{ runner.os }}-
+          ${{ inputs.cache-prefix }}-yarn-v2-${{ inputs.platform }}-${{ runner.os }}-
       continue-on-error: true
 
     - name: Install JavaScript dependencies with retry

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.0"
+    "@actions/github": "^6.0.0",
+    "xml2js": "^0.5.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.0",

--- a/.github/scripts/yarn.lock
+++ b/.github/scripts/yarn.lock
@@ -137,6 +137,7 @@ __metadata:
     "@types/node": "npm:^20.16.2"
     ts-node: "npm:^10.5.0"
     typescript: "npm:~5.4.5"
+    xml2js: "npm:^0.5.0"
   languageName: unknown
   linkType: soft
 
@@ -1247,6 +1248,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 10/0909cedcd9f011ceeac80c0240a92d64ef712cf6c04e0f6ee236a8d812f86a59f61bee6bb5da28d75306db050b99e0593051ea77351795822253b984af6cf044
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.1.1, semver@npm:^7.3.5, semver@npm:^7.5.3":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
@@ -1615,6 +1623,23 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^4.0.1"
   checksum: 10/648efddba54d478d0e4330ab6f239976df3b9752b123db5dc9405d9b5af768fa9d70ce60c52fdbe61d1200d24350bc4fbcbaf09288496c2be050de126bd95b7e
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "xml2js@npm:0.5.0"
+  dependencies:
+    sax: "npm:>=0.6.0"
+    xmlbuilder: "npm:~11.0.0"
+  checksum: 10/27c4d759214e99be5ec87ee5cb1290add427fa43df509d3b92d10152b3806fd2f7c9609697a18b158ccf2caa01e96af067cdba93196f69ca10c90e4f79a08896
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 10/c8c3d208783718db5b285101a736cd8e6b69a5c265199a0739abaa93d1a1b7de5489fd16df4e776e18b2c98cb91f421a7349e99fd8c1ebeb44ecfed72a25091a
   languageName: node
   linkType: hard
 

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -353,29 +353,25 @@ jobs:
           path: all-test-artifacts/
           retention-days: 7
 
+      - name: Install CI script dependencies
+        continue-on-error: true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd .github/scripts && yarn --immutable
+
       - name: Create mobile JSON test report
         id: create-json-report
         continue-on-error: true
         run: |
-          # Create a temporary directory for xml2js to avoid conflicts
-          mkdir -p temp-deps && cd temp-deps
-          npm init -y
-          npm install xml2js@0.5.0 --no-audit --no-fund
-
-          # Copy node_modules to workspace
-          cp -r node_modules ${{ github.workspace }}/
-
-          # Run the mobile test report generator
-          cd ${{ github.workspace }}
           TEST_RESULTS_PATH=all-test-artifacts \
           TEST_RUNS_PATH=test/test-results/test-runs-android.json \
           RUN_ID=${{ github.run_id }} \
           PR_NUMBER=${{ github.event.pull_request.number || '0' }} \
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
           node .github/scripts/e2e-create-json-test-report.mjs
-
-          # Clean up temporary node_modules
-          rm -rf node_modules
 
       - name: Upload JSON test report (Namespace)
         if: ${{ steps.create-json-report.outcome == 'success' && inputs.runner_provider == 'namespace' }}

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -368,29 +368,25 @@ jobs:
           path: all-test-artifacts/
           retention-days: 7
 
+      - name: Install CI script dependencies
+        continue-on-error: true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd .github/scripts && yarn --immutable
+
       - name: Create mobile JSON test report
         id: create-json-report
         continue-on-error: true
         run: |
-          # Create a temporary directory for xml2js to avoid conflicts
-          mkdir -p temp-deps && cd temp-deps
-          npm init -y
-          npm install xml2js@0.5.0 --no-audit --no-fund
-
-          # Copy node_modules to workspace
-          cp -r node_modules ${{ github.workspace }}/
-
-          # Run the mobile test report generator
-          cd ${{ github.workspace }}
           TEST_RESULTS_PATH=all-test-artifacts \
           TEST_RUNS_PATH=test/test-results/test-runs-ios.json \
           RUN_ID=${{ github.run_id }} \
           PR_NUMBER=${{ github.event.pull_request.number || '0' }} \
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
           node .github/scripts/e2e-create-json-test-report.mjs
-
-          # Clean up temporary node_modules
-          rm -rf node_modules
 
       - name: Upload JSON test report (Namespace)
         if: ${{ steps.create-json-report.outcome == 'success' && inputs.runner_provider == 'namespace' }}

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -327,21 +327,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "📊 Merging Detox JUnit XML reports..."
-
-          # Install xml2js for XML parsing (lightweight, no full yarn install needed)
-          mkdir -p temp-deps && cd temp-deps
-          npm init -y > /dev/null 2>&1
-          npm install xml2js@0.6.2 --no-audit --no-fund --silent
-
-          # Copy node_modules to workspace for script usage
-          cp -r node_modules ${{ github.workspace }}/
-          cd ${{ github.workspace }}
-
-          # Run merge script
           node .github/scripts/e2e-merge-detox-junit-reports.mjs
-
-          # Clean up temporary node_modules
-          rm -rf node_modules temp-deps
 
       # Merge previous test results with current results to preserve pass/fail history across re-runs.
       # Without this, tests that passed in attempt N but were skipped in attempt N+1 would have no
@@ -352,38 +338,14 @@ jobs:
         continue-on-error: true
         run: |
           echo "📊 Merging previous test results to preserve history..."
-
-          # Install xml2js for XML parsing (lightweight, no full yarn install needed)
-          mkdir -p temp-deps && cd temp-deps
-          npm init -y > /dev/null 2>&1
-          npm install xml2js@0.6.2 --no-audit --no-fund --silent
-
-          # Copy node_modules to workspace for script usage
-          cp -r node_modules ${{ github.workspace }}/
-          cd ${{ github.workspace }}
-
-          # Run merge script to combine previous results with current
           node .github/scripts/e2e-merge-test-results.mjs ./previous-test-results ./tests/reports
-
-          # Clean up temporary node_modules
-          rm -rf node_modules temp-deps
 
       - name: Rebuild merged JUnit after previous-results merge (on re-run)
         if: ${{ !cancelled() && steps.merge-previous-results.outcome == 'success' }}
         continue-on-error: true
         run: |
           echo "📊 Rebuilding merged junit.xml after previous-results merge..."
-
-          mkdir -p temp-deps && cd temp-deps
-          npm init -y > /dev/null 2>&1
-          npm install xml2js@0.6.2 --no-audit --no-fund --silent
-
-          cp -r node_modules ${{ github.workspace }}/
-          cd ${{ github.workspace }}
-
           node .github/scripts/e2e-merge-detox-junit-reports.mjs
-
-          rm -rf node_modules temp-deps
 
       - name: Upload JUnit XML results (Namespace)
         if: ${{ always() && inputs.runner_provider == 'namespace' }}


### PR DESCRIPTION
## Description

Fixes an E2E CI dependency-cache failure where the test shard script could fail before running any Detox tests with:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'xml2js'
```

Root cause: some E2E report steps installed `xml2js` into a temporary npm project, copied that temporary `node_modules` into the repository workspace, then removed `node_modules` from the workspace. Because the E2E setup action caches `node_modules` and `.yarn/install-state.gz`, a job could later restore a dependency cache whose Yarn install state looked valid while the workspace dependency tree was missing or incomplete.

This PR keeps the existing Yarn install-state cache speedup, but prevents old poisoned cache entries from being reused and removes the report-step behavior that could corrupt the workspace dependency tree.

### Why each change was made

- `.github/actions/setup-e2e-env/action.yml`
  - Keeps caching both `node_modules` and `.yarn/install-state.gz` so E2E jobs keep the intended CI speedup.
  - Bumps the cache namespace from `yarn-...` to `yarn-v2-...` so new jobs do not restore old cache entries that may have been saved after `node_modules` was deleted or partially overwritten.
  - The `v2` cache key is a one-time cache bust, not a functional dependency change. It avoids relying on manual cache deletion, which is easy to miss across platform/runner/cache-prefix variants.

- `.github/workflows/run-e2e-workflow.yml`
  - Removes ad hoc `npm install xml2js`, temporary `node_modules` copying, and `rm -rf node_modules` from the reusable E2E report merge steps.
  - These jobs already run the normal project dependency setup, and `xml2js` is already declared in the root `package.json`, so the merge scripts can use the repo-installed dependency tree directly.
  - This prevents report generation from mutating the dependency tree that later cache post-steps may save.

- `.github/workflows/run-e2e-smoke-tests-android.yml` and `.github/workflows/run-e2e-smoke-tests-ios.yml`
  - Removes the same temporary npm install/copy/delete pattern from smoke rollup report jobs.
  - Adds a small `cd .github/scripts && yarn --immutable` install step for the rollup-only jobs, because those jobs only set up Node and do not run the full app dependency install.
  - Marks the install step `continue-on-error: true` to preserve the existing best-effort behavior of JSON report creation.

- `.github/scripts/package.json` and `.github/scripts/yarn.lock`
  - Adds `xml2js` to the CI scripts package so lightweight smoke rollup jobs can run `e2e-create-json-test-report.mjs` without installing packages into or deleting from the repository root.

## Changelog

CHANGELOG entry: null

## Validation

- `cd .github/scripts && yarn --immutable`
- `git diff --check`
- YAML parse check for the touched workflow/action files
- JSON parse check for `.github/scripts/package.json`

## Notes for reviewers

This PR intentionally keeps `.yarn/install-state.gz` in the E2E cache for CI performance. The cache key bump is included only to avoid restoring already-existing cache entries from the old namespace that may have been saved after root `node_modules` was deleted by report steps.