### PR TITLE
chore: remove Palm network from network picker

### DIFF
--- a/app/components/hooks/useAddNetwork.test.ts
+++ b/app/components/hooks/useAddNetwork.test.ts
@@ -18,7 +18,7 @@ describe('useAddNetwork', () => {
         nickname: 'Ethereum',
         rpcUrl: 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
         ticker: 'ETH',
-        warning: true,
+        warning: false,
         rpcPrefs: {
           blockExplorerUrl: 'https://etherscan.io',
           imageUrl: 'https://etherscan.io/images/svg/brands/eth.svg',

--- a/app/components/hooks/useAddNetwork.test.ts
+++ b/app/components/hooks/useAddNetwork.test.ts
@@ -18,6 +18,7 @@ describe('useAddNetwork', () => {
         nickname: 'Ethereum',
         rpcUrl: 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
         ticker: 'ETH',
+        warning: true,
         rpcPrefs: {
           blockExplorerUrl: 'https://etherscan.io',
           imageUrl: 'https://etherscan.io/images/svg/brands/eth.svg',

--- a/app/util/networks/customNetworks.test.ts
+++ b/app/util/networks/customNetworks.test.ts
@@ -15,7 +15,6 @@ describe('popularNetwork', () => {
       'BNB Chain': toHex('56'),
       Base: toHex('8453'),
       OP: toHex('10'),
-      Palm: toHex('11297108109'),
       Polygon: toHex('137'),
       'zkSync Era': toHex('324'),
       Sei: toHex('1329'),

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -117,17 +117,6 @@ export const PopularList = [
     },
   },
   {
-    chainId: toHex('11297108109'),
-    nickname: 'Palm',
-    rpcUrl: `https://palm-mainnet.infura.io/v3/${infuraProjectId}`,
-    ticker: 'PALM',
-    rpcPrefs: {
-      blockExplorerUrl: 'https://palm.chainlens.com',
-      imageUrl: 'PALM',
-      imageSource: require('../../images/palm.png'),
-    },
-  },
-  {
     chainId: toHex('137'),
     nickname: 'Polygon',
     rpcUrl: `https://polygon-mainnet.infura.io/v3/${infuraProjectId}`,

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -345,6 +345,18 @@ export const UnpopularNetworkList = [
       imageSource: require('../../images/harmony.png'),
     },
   },
+  {
+    chainId: toHex('11297108109'),
+    nickname: 'Palm',
+    rpcUrl: `https://palm-mainnet.infura.io/v3/${infuraProjectId}`,
+    ticker: 'PALM',
+    warning: true,
+    rpcPrefs: {
+      blockExplorerUrl: 'https://palm.chainlens.com',
+      imageUrl: 'PALM',
+      imageSource: require('../../images/palm.png'),
+    },
+  },
 ];
 
 export const NETWORK_CHAIN_ID: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The Palm network is no longer active, so it should no longer surface as an option in the in-app network picker (the "Additional / Popular networks" list).

The picker is driven by the `PopularList` array in `app/util/networks/customNetworks.tsx`. This PR removes the `Palm` entry from that list and updates the unit test that enumerates expected popular-network chain IDs.

To preserve the network logo for any existing user who previously added Palm to their wallet, a matching entry was added to `UnpopularNetworkList` — per the docblock above that list, this is exactly its purpose (`RemoteImageBadgeWrapper`, `Balance`, and the confirmations network util all fall back to `UnpopularNetworkList` for the image source when a chain ID isn't in `PopularList`).

Scope was kept intentionally minimal — no migrations and no churn in unrelated places:

- `palm-mainnet.infura.io` is left in `allowedInfuraHosts` so any user who previously added/used Palm doesn't have their existing requests get blocked.
- `PALM_TESTNET` chain id and the `palm.png` image / `image-icons.js` `PALM` export are left in place: they don't drive the picker, and removing them risks breaking icon lookups for any pre-existing user state that still references Palm.
- The `NetworkToCaipChainId.PALM` enum entry in `NetworkMultiSelector.constants.ts` is currently unreferenced and could be removed in a separate cleanup; leaving it for now to keep this PR strictly scoped to the picker list.
- E2E fixtures (`tests/resources/networks.e2e.js`) and infura mocks still mention `palm-mainnet.infura.io` — these are test infrastructure, not the production picker, so out of scope here.

One small side-effect fix: removing Palm narrowed the inferred `(typeof PopularList)[number]` union (Palm was the only entry without both `failoverRpcUrls` and `warning`), which broke an existing `useAddNetwork.test.ts` mock that matched exactly that shape. Added `warning: false` to the mock so it satisfies one of the remaining union variants.

## **Changelog**

CHANGELOG entry: Removed the Palm network from the popular networks picker.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Popular networks picker

  Scenario: user opens the network picker on the Popular tab
    Given the wallet is unlocked

    When user taps the network selector and opens the "Popular" / "Additional networks" list
    Then the list does not include "Palm"
    And other popular networks (Avalanche, Arbitrum, BNB Chain, Base, OP, Polygon, zkSync Era, Sei, Monad, HyperEVM, MegaETH, Tempo) are still shown
```

## **Screenshots/Recordings**

### **Before**

<img width="375" height="247" alt="Screenshot 2026-05-19 at 15 24 14" src="https://github.com/user-attachments/assets/d4783d98-11b5-41d9-a13e-e3061de0b0d2" />

### **After**

<img width="366" height="209" alt="Screenshot 2026-05-19 at 15 17 05" src="https://github.com/user-attachments/assets/5425a9e5-7fb2-4da6-b754-a8ce3fdffec5" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead82d6f-351d-4326-bc01-ef2b4c800f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead82d6f-351d-4326-bc01-ef2b4c800f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

