### PR TITLE
fix: Refactor sites search for consistency

### DIFF
--- a/app/components/Views/SitesFullView/SitesFullView.test.tsx
+++ b/app/components/Views/SitesFullView/SitesFullView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, act, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../util/test/renderWithProvider';
+import { strings } from '../../../../locales/i18n';
 import SitesFullView from './SitesFullView';
 import { useSitesData } from '../../UI/Sites/hooks/useSiteData/useSitesData';
 import type { SiteData } from '../../UI/Sites/components/SiteRowItem/SiteRowItem';
@@ -36,55 +37,17 @@ jest.mock('../../../util/theme', () => {
   };
 });
 
-jest.mock('../../UI/shared/ListHeaderWithSearch/ListHeaderWithSearch', () => {
-  const ReactNative = jest.requireActual('react-native');
-  return jest.fn(
-    ({
-      defaultTitle,
-      isSearchVisible,
-      searchQuery,
-      onSearchQueryChange,
-      onBack,
-      onSearchToggle,
-      testID,
-    }) => (
-      <ReactNative.View testID={testID}>
-        {!isSearchVisible ? (
-          <>
-            <ReactNative.TouchableOpacity
-              testID={`${testID}-back-button`}
-              onPress={onBack}
-            >
-              <ReactNative.Text>Back</ReactNative.Text>
-            </ReactNative.TouchableOpacity>
-            <ReactNative.Text testID={`${testID}-title`}>
-              {defaultTitle}
-            </ReactNative.Text>
-            <ReactNative.TouchableOpacity
-              testID={`${testID}-search-toggle`}
-              onPress={onSearchToggle}
-            >
-              <ReactNative.Text>Search</ReactNative.Text>
-            </ReactNative.TouchableOpacity>
-          </>
-        ) : (
-          <>
-            <ReactNative.TextInput
-              testID={`${testID}-search-bar`}
-              value={searchQuery}
-              onChangeText={onSearchQueryChange}
-            />
-            <ReactNative.TouchableOpacity
-              testID={`${testID}-search-close`}
-              onPress={onSearchToggle}
-            >
-              <ReactNative.Text>Cancel</ReactNative.Text>
-            </ReactNative.TouchableOpacity>
-          </>
-        )}
-      </ReactNative.View>
-    ),
-  );
+jest.mock('@metamask/design-system-twrnc-preset', () => {
+  const { Theme } = jest.requireActual('@metamask/design-system-twrnc-preset');
+  const tw = Object.assign((..._args: unknown[]) => ({}), {
+    style: (..._args: unknown[]) => ({}),
+  });
+
+  return {
+    Theme,
+    useTailwind: () => tw,
+    useTheme: () => Theme.Light,
+  };
 });
 
 jest.mock('../../UI/Sites/components/SitesList/SitesList', () => {
@@ -197,13 +160,13 @@ describe('SitesFullView', () => {
         refetch: mockRefetch,
       });
 
-      const { getByTestId } = renderWithProvider(<SitesFullView />);
+      const { getByTestId, getByText } = renderWithProvider(<SitesFullView />);
 
       expect(getByTestId('sites-full-view-header')).toBeOnTheScreen();
       expect(
         getByTestId('sites-full-view-header-back-button'),
       ).toBeOnTheScreen();
-      expect(getByTestId('sites-full-view-header-title')).toBeOnTheScreen();
+      expect(getByText(strings('trending.popular_sites'))).toBeOnTheScreen();
       expect(
         getByTestId('sites-full-view-header-search-toggle'),
       ).toBeOnTheScreen();
@@ -271,13 +234,14 @@ describe('SitesFullView', () => {
     it('filters sites by name, URL, and display URL', () => {
       setupMockWithSearchFilter();
 
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <SitesFullView />,
-      );
+      const { getByTestId, getByPlaceholderText, queryByTestId } =
+        renderWithProvider(<SitesFullView />);
 
       // Activate search
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
-      const searchInput = getByTestId('sites-full-view-header-search-bar');
+      const searchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
 
       // Search by name
       fireEvent.changeText(searchInput, 'Meta');
@@ -298,11 +262,15 @@ describe('SitesFullView', () => {
     it('shows all sites when search query is empty', () => {
       setupMockWithSearchFilter();
 
-      const { getByTestId } = renderWithProvider(<SitesFullView />);
+      const { getByTestId, getByPlaceholderText } = renderWithProvider(
+        <SitesFullView />,
+      );
 
       // Activate search
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
-      const searchInput = getByTestId('sites-full-view-header-search-bar');
+      const searchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
 
       // Empty search
       fireEvent.changeText(searchInput, '');
@@ -320,11 +288,15 @@ describe('SitesFullView', () => {
         refetch: mockRefetch,
       });
 
-      const { getByTestId } = renderWithProvider(<SitesFullView />);
+      const { getByTestId, getByPlaceholderText } = renderWithProvider(
+        <SitesFullView />,
+      );
 
       // Activate search
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
-      const searchInput = getByTestId('sites-full-view-header-search-bar');
+      const searchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
 
       // Type search query
       fireEvent.changeText(searchInput, 'test');
@@ -336,7 +308,9 @@ describe('SitesFullView', () => {
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
 
       // Search input should be empty
-      const newSearchInput = getByTestId('sites-full-view-header-search-bar');
+      const newSearchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
       expect(newSearchInput.props.value).toBe('');
     });
 
@@ -347,16 +321,17 @@ describe('SitesFullView', () => {
         refetch: mockRefetch,
       });
 
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <SitesFullView />,
-      );
+      const { getByTestId, getByPlaceholderText, queryByTestId } =
+        renderWithProvider(<SitesFullView />);
 
       // Initially no footer
       expect(queryByTestId('sites-search-footer')).toBeNull();
 
       // Activate search
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
-      const searchInput = getByTestId('sites-full-view-header-search-bar');
+      const searchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
 
       // Type search query
       fireEvent.changeText(searchInput, 'test');
@@ -470,13 +445,14 @@ describe('SitesFullView', () => {
     it('performs case-insensitive search', () => {
       setupMockWithSearchFilter();
 
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <SitesFullView />,
-      );
+      const { getByTestId, getByPlaceholderText, queryByTestId } =
+        renderWithProvider(<SitesFullView />);
 
       // Activate search
       fireEvent.press(getByTestId('sites-full-view-header-search-toggle'));
-      const searchInput = getByTestId('sites-full-view-header-search-bar');
+      const searchInput = getByPlaceholderText(
+        strings('trending.search_sites'),
+      );
 
       // Search with different case
       fireEvent.changeText(searchInput, 'METAMASK');

--- a/app/components/Views/SitesFullView/SitesFullView.tsx
+++ b/app/components/Views/SitesFullView/SitesFullView.tsx
@@ -18,8 +18,13 @@ import {
   bookmarkUrlForRemoval,
   type SiteData,
 } from '../../UI/Sites/components/SiteRowItem/SiteRowItem';
+import {
+  HeaderSearch,
+  HeaderSearchVariant,
+  HeaderStandard,
+  IconName as DSIconName,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
-import ListHeaderWithSearch from '../../UI/shared/ListHeaderWithSearch/ListHeaderWithSearch';
 
 type SitesFullViewParams = { mode?: 'favorites' } | undefined;
 
@@ -36,6 +41,7 @@ const createStyles = (theme: Theme) =>
       flex: 1,
       paddingLeft: 16,
       paddingRight: 16,
+      marginTop: 8,
     },
   });
 
@@ -84,6 +90,10 @@ const SitesFullView: React.FC = () => {
     });
   }, []);
 
+  const handleSearchClear = useCallback(() => {
+    setSearchQuery('');
+  }, []);
+
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
@@ -123,17 +133,47 @@ const SitesFullView: React.FC = () => {
           },
         ]}
       >
-        <ListHeaderWithSearch
-          defaultTitle={title}
-          isSearchVisible={isSearchActive}
-          searchQuery={searchQuery}
-          searchPlaceholder={strings('trending.search_sites')}
-          cancelText={strings('browser.cancel')}
-          onSearchQueryChange={setSearchQuery}
-          onBack={handleBackPress}
-          onSearchToggle={handleSearchToggle}
-          testID="sites-full-view-header"
-        />
+        {isSearchActive ? (
+          <HeaderSearch
+            variant={HeaderSearchVariant.Inline}
+            textFieldSearchProps={{
+              value: searchQuery,
+              onChangeText: setSearchQuery,
+              placeholder: strings('trending.search_sites'),
+              onPressClearButton: handleSearchClear,
+              autoFocus: true,
+              testID: 'sites-full-view-header-search-bar',
+              clearButtonProps: {
+                testID: 'sites-full-view-header-search-field-clear',
+              },
+            }}
+            onPressCancelButton={handleSearchToggle}
+            cancelButtonProps={{
+              testID: 'sites-full-view-header-search-close',
+              twClassName: 'self-center',
+              textProps: {
+                twClassName: 'text-default',
+              },
+            }}
+            twClassName="mr-0 mb-0"
+          />
+        ) : (
+          <HeaderStandard
+            title={title}
+            onBack={handleBackPress}
+            backButtonProps={{
+              testID: 'sites-full-view-header-back-button',
+            }}
+            endButtonIconProps={[
+              {
+                iconName: DSIconName.Search,
+                onPress: handleSearchToggle,
+                testID: 'sites-full-view-header-search-toggle',
+              },
+            ]}
+            testID="sites-full-view-header"
+          />
+        )}
       </View>
 
       {isLoading ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

What is the reason for the change?
- The search component is stylistically inconsistent with other search experiences in the app.
- Header height differences cause content to shift during navigation and interaction.

What is the improvement/solution?
- Updated the search component to align with the Explore home search pattern and other search components across the app.
- Standardized header sizing to prevent content shifting.

This work is part of a wider initiative to standardize our design patterns.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: update search for sites

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/pull/29404
https://github.com/MetaMask/metamask-mobile/pull/29400

## **Manual testing steps**

```gherkin
Feature: Explore - Sites

Scenario: user searches popular sites from the full list screen
  Given the user is on the Popular sites screen with the standard header visible and the popular sites list loaded

  When the user taps the search icon in the header
  Then the header displays the inline search field with placeholder "Search sites" and a Cancel button, matches the Explore home search pattern, and the site list does not shift due to a header height change
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/4b6bbd12-ac6e-4882-a5e1-df979b4714d9




### **After**

https://github.com/user-attachments/assets/c505815a-4d69-4a0b-9d4b-fd289d5f3e37




## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: replaces the Sites list header/search implementation with design-system headers, which can affect navigation/search interactions and testIDs, but doesn’t change backend/data logic.
> 
> **Overview**
> Refactors `SitesFullView` to replace `ListHeaderWithSearch` with design-system `HeaderStandard` + inline `HeaderSearch`, adding explicit clear handling and tweaking list top spacing to avoid layout shifts.
> 
> Updates `SitesFullView` tests to stop mocking the old header component, mock Tailwind/theme for the design-system header, and assert header title/search input via localized text and placeholder rather than header title test IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0d332fb4300e9ee19b5c3be732b1e3ae3cdc9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->