### PR TITLE
chore: replace assets legacy state direct access

### DIFF
--- a/app/components/UI/Earn/utils/musdConversionTransaction.test.ts
+++ b/app/components/UI/Earn/utils/musdConversionTransaction.test.ts
@@ -1,5 +1,6 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { providerErrors } from '@metamask/rpc-errors';
+import { TokensControllerState } from '@metamask/assets-controllers';
 import {
   TransactionType,
   type TransactionMeta,
@@ -19,7 +20,6 @@ import {
   ensureMusdTokenRegistered,
   replaceMusdConversionTransactionForPayToken,
 } from './musdConversionTransaction';
-import { TokensControllerState } from '@metamask/assets-controllers';
 
 jest.mock('@metamask/rpc-errors', () => ({
   providerErrors: {

--- a/app/components/UI/Earn/utils/musdConversionTransaction.test.ts
+++ b/app/components/UI/Earn/utils/musdConversionTransaction.test.ts
@@ -12,11 +12,14 @@ import { generateTransferData } from '../../../../util/transactions';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
+import { getTokensControllerAllTokens } from '../../../../selectors/assets/assets-migration';
+import { store } from '../../../../store';
 import {
   createMusdConversionTransaction,
   ensureMusdTokenRegistered,
   replaceMusdConversionTransactionForPayToken,
 } from './musdConversionTransaction';
+import { TokensControllerState } from '@metamask/assets-controllers';
 
 jest.mock('@metamask/rpc-errors', () => ({
   providerErrors: {
@@ -48,6 +51,16 @@ jest.mock('../../../Views/confirmations/utils/transaction-pay', () => ({
 
 jest.mock('../../../Views/confirmations/utils/transaction', () => ({
   parseStandardTokenTransactionData: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/assets/assets-migration', () => ({
+  getTokensControllerAllTokens: jest.fn(),
+}));
+
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
 }));
 
 jest.mock('../constants/musd', () => ({
@@ -98,9 +111,6 @@ interface MockedEngineContext {
     rejectRequest: jest.Mock<void, [string, unknown]>;
   };
   TokensController?: {
-    state: {
-      allTokens: Record<string, Record<string, { address: string }[]>>;
-    };
     addToken: jest.Mock<
       Promise<void>,
       [
@@ -121,6 +131,11 @@ const mockedProviderErrors = providerErrors as jest.Mocked<
 >;
 const mockedEngineService = EngineService as jest.Mocked<typeof EngineService>;
 const mockedEngine = Engine as unknown as { context: MockedEngineContext };
+const mockedGetTokensControllerAllTokens =
+  getTokensControllerAllTokens as jest.MockedFunction<
+    typeof getTokensControllerAllTokens
+  >;
+const mockedStore = store as jest.Mocked<typeof store>;
 
 const mockedGenerateTransferData = generateTransferData as jest.MockedFunction<
   typeof generateTransferData
@@ -219,13 +234,17 @@ describe('musdConversionTransaction', () => {
         rejectRequest: approvalControllerReject,
       },
       TokensController: {
-        state: { allTokens: {} },
         addToken: tokensControllerAddToken,
       },
     };
 
     (MUSD_TOKEN_ADDRESS_BY_CHAIN as Record<string, Hex>)['0x1'] =
       '0xmusdTokenAddress';
+
+    mockedStore.getState.mockReturnValue(
+      {} as ReturnType<typeof store.getState>,
+    );
+    mockedGetTokensControllerAllTokens.mockReturnValue({});
 
     networkControllerFindNetworkClientIdByChainId.mockReturnValue(
       'networkClientId',
@@ -787,16 +806,11 @@ describe('musdConversionTransaction', () => {
 
     describe('when mUSD token is already registered for the chain', () => {
       it('does not call addToken when the token exists for one account', async () => {
-        mockedEngine.context.TokensController = {
-          state: {
-            allTokens: {
-              [CHAIN_ID]: {
-                '0xaccountAddress': [{ address: MUSD_ADDRESS }],
-              },
-            },
+        mockedGetTokensControllerAllTokens.mockReturnValue({
+          [CHAIN_ID]: {
+            '0xaccountAddress': [{ address: MUSD_ADDRESS }],
           },
-          addToken: tokensControllerAddToken,
-        };
+        } as unknown as TokensControllerState['allTokens']);
 
         await ensureMusdTokenRegistered({
           chainId: CHAIN_ID,
@@ -809,10 +823,7 @@ describe('musdConversionTransaction', () => {
 
     describe('when mUSD token is not yet registered', () => {
       it('calls addToken with the correct token metadata and networkClientId', async () => {
-        mockedEngine.context.TokensController = {
-          state: { allTokens: {} },
-          addToken: tokensControllerAddToken,
-        };
+        mockedGetTokensControllerAllTokens.mockReturnValue({});
         tokensControllerAddToken.mockResolvedValue(undefined);
 
         await ensureMusdTokenRegistered({
@@ -831,16 +842,11 @@ describe('musdConversionTransaction', () => {
       });
 
       it('calls addToken when the chain entry exists but no accounts hold mUSD', async () => {
-        mockedEngine.context.TokensController = {
-          state: {
-            allTokens: {
-              [CHAIN_ID]: {
-                '0xaccountAddress': [{ address: '0xdifferentTokenAddress' }],
-              },
-            },
+        mockedGetTokensControllerAllTokens.mockReturnValue({
+          [CHAIN_ID]: {
+            '0xaccountAddress': [{ address: '0xdifferentTokenAddress' }],
           },
-          addToken: tokensControllerAddToken,
-        };
+        } as unknown as TokensControllerState['allTokens']);
         tokensControllerAddToken.mockResolvedValue(undefined);
 
         await ensureMusdTokenRegistered({
@@ -859,10 +865,7 @@ describe('musdConversionTransaction', () => {
       });
 
       it('calls addToken when allTokens has no entry for the chain', async () => {
-        mockedEngine.context.TokensController = {
-          state: { allTokens: { '0xe708': {} } },
-          addToken: tokensControllerAddToken,
-        };
+        mockedGetTokensControllerAllTokens.mockReturnValue({ '0xe708': {} });
         tokensControllerAddToken.mockResolvedValue(undefined);
 
         await ensureMusdTokenRegistered({

--- a/app/components/UI/Earn/utils/musdConversionTransaction.ts
+++ b/app/components/UI/Earn/utils/musdConversionTransaction.ts
@@ -12,6 +12,8 @@ import { generateTransferData } from '../../../../util/transactions';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants/musd';
+import { getTokensControllerAllTokens } from '../../../../selectors/assets/assets-migration';
+import { store } from '../../../../store';
 
 interface PayTokenSelection {
   address: Hex;
@@ -167,7 +169,7 @@ export async function ensureMusdTokenRegistered({
     return;
   }
 
-  const { allTokens } = Engine.context.TokensController.state;
+  const allTokens = getTokensControllerAllTokens(store.getState());
   const accountTokens = Object.values(allTokens[chainId] ?? {}).flat();
   const hasMusdToken = accountTokens.some(
     (t) => t.address.toLowerCase() === musdTokenAddress.toLowerCase(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Remove direct reference to assets legacy state and replace it with a call to a selector that manages whether the access is done to the legacy state or the new state based on a remote feature flag.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3249

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `ensureMusdTokenRegistered` reads token registry state (now via Redux `store.getState()` + migration selector), which could affect mUSD registration behavior if selector/state wiring differs in some runtimes.
> 
> **Overview**
> Refactors `ensureMusdTokenRegistered` to stop reading `Engine.context.TokensController.state.allTokens` directly and instead fetch tokens via the migration-aware selector `getTokensControllerAllTokens(store.getState())`, enabling the remote-flagged assets state unification path.
> 
> Updates the associated unit tests to mock the Redux `store` and selector output (and adjust types) rather than mutating `TokensController.state`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f552206ec1fefb37cec3e9737ec3e5555bb557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->