### PR TITLE
chore(release): release-changelog/7.77.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.77.1]
+
+### Added
+
+- Added support for cross-chain withdrawals through MetaMask Pay in Predict for users with a Polymarket Deposit Wallet, while keeping the existing "withdrawals unavailable" sheet for users who do not have the feature enabled. (#29953)
+
+### Fixed
+
+- Fixed a bug that caused a user's first Predict deposit to fail while their Polymarket Deposit Wallet was still being registered. (#30267)
+
 ## [7.77.0]
 
 ### Added
@@ -11494,7 +11504,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.77.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v7.77.1...HEAD
+[7.77.1]: https://github.com/MetaMask/metamask-mobile/compare/v7.77.0...v7.77.1
 [7.77.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.76.3...v7.77.0
 [7.76.3]: https://github.com/MetaMask/metamask-mobile/compare/v7.76.0...v7.76.3
 [7.76.0]: https://github.com/MetaMask/metamask-mobile/compare/v7.75.1...v7.76.0


### PR DESCRIPTION
## What

`release/7.77.1-ota` is an OTA hotfix line carrying two cherry-picks.

CHANGELOG entry: null


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update to `CHANGELOG.md` with no runtime code changes.
> 
> **Overview**
> Adds a new `7.77.1` section to `CHANGELOG.md`, documenting **Predict** support for MetaMask Pay cross-chain withdrawals (when Polymarket Deposit Wallet is enabled) and a fix for first-deposit failures during wallet registration.
> 
> Updates the changelog footer links so `[Unreleased]` now compares from `v7.77.1` and adds the new `[7.77.1]` compare URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0d13b484e14c7faf9a1181bbf0397678765448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->