### PR TITLE
ci: reduce scheduled CI frequency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ on:
       - synchronize
   merge_group:
   schedule:
-    # Run the full suite "overnight," once every hour from 2:00am UTC until 6:00am UTC.
-    # This helps to identy the flaky and failed tests on main branch
-    - cron: '0 2-6 * * *'
+    # Run the full suite overnight twice, spaced apart to sample main-branch
+    # flakes while reducing duplicate failures on the same broken SHA.
+    - cron: '0 3,6 * * *'
   workflow_call:
     inputs:
       runner_provider:


### PR DESCRIPTION
## **Description**

Reduce scheduled `ci.yml` runs from five configured overnight slots to two spaced overnight samples.

The intent is to keep main-branch flaky-test signal while reducing duplicate scheduled failures on the same broken SHA.

Evidence checked on 2026-05-19 with `gh run list --workflow ci.yml --event schedule --limit 80`: 80 recent scheduled runs had 72 failures and 8 successes, usually completing 3 scheduled runs per day with an average wall-clock duration of about 46 minutes. Sample run `26082287514` had 94 jobs, including unit shards, component-view shards, iOS E2E, Android E2E, merge coverage, and Sonar.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Scheduled CI cadence

  Scenario: overnight scheduled CI runs
    Given the ci workflow schedule is evaluated by GitHub Actions
    When the daily schedule reaches 03:00 UTC and 06:00 UTC
    Then the full ci workflow is eligible to run for main
```

## **Screenshots/Recordings**

N/A - CI workflow schedule change only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
