### PR TITLE
feat(perps): add vip_tier and vip_discount tracking to trading events

### DIFF
--- a/app/controllers/perps/PerpsController.ts
+++ b/app/controllers/perps/PerpsController.ts
@@ -2181,6 +2181,7 @@ export class PerpsController extends BaseController<
     return this.#tradingService.flipPosition({
       provider,
       position: params.position,
+      trackingData: params.trackingData,
       context: this.#createServiceContext('flipPosition'),
     });
   }

--- a/app/controllers/perps/constants/eventNames.ts
+++ b/app/controllers/perps/constants/eventNames.ts
@@ -110,6 +110,10 @@ export const PERPS_EVENT_PROPERTY = {
   IMAGE_SELECTED: 'image_selected',
   TAB_NUMBER: 'tab_number',
 
+  // VIP rewards properties
+  VIP_TIER: 'vip_tier',
+  VIP_DISCOUNT: 'vip_discount',
+
   // A/B testing properties (flat per test for multiple concurrent tests)
   // Only include AB test properties when test is enabled (event not sent when disabled)
   // Button color test (TAT-1937)

--- a/app/controllers/perps/services/TradingService.test.ts
+++ b/app/controllers/perps/services/TradingService.test.ts
@@ -365,6 +365,89 @@ describe('TradingService', () => {
       );
     });
 
+    it('includes vip_tier and vip_discount in analytics when provided in trackingData', async () => {
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+        leverage: 10,
+        trackingData: {
+          totalFee: 5,
+          marketPrice: 50000,
+          vipTier: 3,
+          vipDiscount: 15,
+        },
+      };
+      const mockOrderResult: OrderResult = {
+        success: true,
+        orderId: 'order-vip',
+        filledSize: '0.1',
+        averagePrice: '50000',
+      };
+
+      mockProvider.placeOrder.mockResolvedValue(mockOrderResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.placeOrder({
+        provider: mockProvider,
+        params: orderParams,
+        context: mockContext,
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.objectContaining({
+          status: 'executed',
+          vip_tier: 3,
+          vip_discount: 15,
+        }),
+      );
+    });
+
+    it('omits vip_tier and vip_discount from analytics when not provided', async () => {
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+        leverage: 10,
+        trackingData: {
+          totalFee: 5,
+          marketPrice: 50000,
+        },
+      };
+      const mockOrderResult: OrderResult = {
+        success: true,
+        orderId: 'order-no-vip',
+        filledSize: '0.1',
+        averagePrice: '50000',
+      };
+
+      mockProvider.placeOrder.mockResolvedValue(mockOrderResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.placeOrder({
+        provider: mockProvider,
+        params: orderParams,
+        context: mockContext,
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.not.objectContaining({
+          vip_tier: expect.anything(),
+          vip_discount: expect.anything(),
+        }),
+      );
+    });
+
     it('tracks analytics event when order fails', async () => {
       const orderParams: OrderParams = {
         symbol: 'BTC',
@@ -1470,6 +1553,83 @@ describe('TradingService', () => {
       );
     });
 
+    it('includes vip_tier and vip_discount in close analytics when provided', async () => {
+      const params: ClosePositionParams = {
+        symbol: 'BTC',
+        trackingData: {
+          totalFee: 2,
+          marketPrice: 55000,
+          vipTier: 2,
+          vipDiscount: 10,
+        },
+      };
+      const mockResult: OrderResult = {
+        success: true,
+        orderId: 'close-vip',
+        filledSize: '0.5',
+        averagePrice: '55000',
+      };
+
+      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockProvider.closePosition.mockResolvedValue(mockResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.closePosition({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getPositions: mockGetPositions },
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.PositionCloseTransaction,
+        expect.objectContaining({
+          status: 'executed',
+          vip_tier: 2,
+          vip_discount: 10,
+        }),
+      );
+    });
+
+    it('omits vip_tier and vip_discount from close analytics when not provided', async () => {
+      const params: ClosePositionParams = {
+        symbol: 'BTC',
+        trackingData: {
+          totalFee: 2,
+          marketPrice: 55000,
+        },
+      };
+      const mockResult: OrderResult = {
+        success: true,
+        orderId: 'close-no-vip',
+        filledSize: '0.5',
+        averagePrice: '55000',
+      };
+
+      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockProvider.closePosition.mockResolvedValue(mockResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.closePosition({
+        provider: mockProvider,
+        params,
+        context: { ...mockContext, getPositions: mockGetPositions },
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.PositionCloseTransaction,
+        expect.not.objectContaining({
+          vip_tier: expect.anything(),
+          vip_discount: expect.anything(),
+        }),
+      );
+    });
+
     it('reports order to data lake on successful close', async () => {
       const params: ClosePositionParams = {
         symbol: 'BTC',
@@ -2408,6 +2568,86 @@ describe('TradingService', () => {
         orderType: 'market',
         leverage: 10,
       });
+    });
+
+    it('includes vip_tier and vip_discount in flip analytics on success', async () => {
+      const mockResult: OrderResult = {
+        success: true,
+        orderId: 'flip-vip',
+        averagePrice: '60000',
+      };
+      mockProvider.placeOrder.mockResolvedValue(mockResult);
+
+      await tradingService.flipPosition({
+        provider: mockProvider,
+        position: mockPosition,
+        trackingData: {
+          totalFee: 3,
+          marketPrice: 60000,
+          vipTier: 5,
+          vipDiscount: 25,
+        },
+        context: mockContext,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.objectContaining({
+          status: 'executed',
+          vip_tier: 5,
+          vip_discount: 25,
+        }),
+      );
+    });
+
+    it('includes vip_tier and vip_discount in flip analytics on failure', async () => {
+      mockProvider.placeOrder.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        tradingService.flipPosition({
+          provider: mockProvider,
+          position: mockPosition,
+          trackingData: {
+            totalFee: 0,
+            marketPrice: 50000,
+            vipTier: 1,
+            vipDiscount: 5,
+          },
+          context: mockContext,
+        }),
+      ).rejects.toThrow('Network error');
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.objectContaining({
+          status: 'failed',
+          vip_tier: 1,
+          vip_discount: 5,
+        }),
+      );
+    });
+
+    it('omits vip_tier and vip_discount from flip analytics when not provided', async () => {
+      const mockResult: OrderResult = {
+        success: true,
+        orderId: 'flip-no-vip',
+        averagePrice: '60000',
+      };
+      mockProvider.placeOrder.mockResolvedValue(mockResult);
+
+      await tradingService.flipPosition({
+        provider: mockProvider,
+        position: mockPosition,
+        context: mockContext,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.not.objectContaining({
+          vip_tier: expect.anything(),
+          vip_discount: expect.anything(),
+        }),
+      );
     });
   });
 });

--- a/app/controllers/perps/services/TradingService.ts
+++ b/app/controllers/perps/services/TradingService.ts
@@ -27,6 +27,7 @@ import type {
   ClosePositionsParams,
   ClosePositionsResult,
   Position,
+  TrackingData,
   UpdatePositionTPSLParams,
   PerpsAnalyticsProperties,
   PerpsPlatformDependencies,
@@ -221,6 +222,14 @@ export class TradingService {
       // Add failure-specific properties
       properties[PERPS_EVENT_PROPERTY.ERROR_MESSAGE] =
         error?.message ?? result?.error ?? 'Unknown error';
+    }
+
+    if (params.trackingData?.vipTier !== undefined) {
+      properties[PERPS_EVENT_PROPERTY.VIP_TIER] = params.trackingData.vipTier;
+    }
+    if (params.trackingData?.vipDiscount !== undefined) {
+      properties[PERPS_EVENT_PROPERTY.VIP_DISCOUNT] =
+        params.trackingData.vipDiscount;
     }
 
     if (
@@ -684,6 +693,12 @@ export class TradingService {
       }),
       ...(params.trackingData?.source && {
         [PERPS_EVENT_PROPERTY.SOURCE]: params.trackingData.source,
+      }),
+      ...(params.trackingData?.vipTier !== undefined && {
+        [PERPS_EVENT_PROPERTY.VIP_TIER]: params.trackingData.vipTier,
+      }),
+      ...(params.trackingData?.vipDiscount !== undefined && {
+        [PERPS_EVENT_PROPERTY.VIP_DISCOUNT]: params.trackingData.vipDiscount,
       }),
     };
 
@@ -1989,15 +2004,17 @@ export class TradingService {
    * @param options - The configuration options.
    * @param options.provider - The perps provider instance.
    * @param options.position - The position data.
+   * @param options.trackingData - Optional tracking data for analytics events.
    * @param options.context - The service context for dependencies.
    * @returns The result of the operation.
    */
   async flipPosition(options: {
     provider: PerpsProvider;
     position: Position;
+    trackingData?: TrackingData;
     context: ServiceContext;
   }): Promise<OrderResult> {
-    const { provider, position, context } = options;
+    const { provider, position, trackingData, context } = options;
     const traceId = uuidv4();
     const startTime = this.#deps.performance.now();
 
@@ -2068,6 +2085,12 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
             [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
             [PERPS_EVENT_PROPERTY.ORDER_VALUE]: positionSize * executedPrice,
+            ...(trackingData?.vipTier !== undefined && {
+              [PERPS_EVENT_PROPERTY.VIP_TIER]: trackingData.vipTier,
+            }),
+            ...(trackingData?.vipDiscount !== undefined && {
+              [PERPS_EVENT_PROPERTY.VIP_DISCOUNT]: trackingData.vipDiscount,
+            }),
           },
         );
 
@@ -2105,6 +2128,12 @@ export class TradingService {
         [PERPS_EVENT_PROPERTY.ACTION]: failFlipAction,
         [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
         [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
+        ...(trackingData?.vipTier !== undefined && {
+          [PERPS_EVENT_PROPERTY.VIP_TIER]: trackingData.vipTier,
+        }),
+        ...(trackingData?.vipDiscount !== undefined && {
+          [PERPS_EVENT_PROPERTY.VIP_DISCOUNT]: trackingData.vipDiscount,
+        }),
       });
 
       this.#deps.tracer.endTrace({

--- a/app/controllers/perps/types/index.ts
+++ b/app/controllers/perps/types/index.ts
@@ -125,6 +125,10 @@ export type TrackingData = {
   mmPayTokenSelected?: string; // Token symbol when tradeWithToken is true
   mmPayNetworkSelected?: string; // chainId when tradeWithToken is true
 
+  // VIP tier and discount for rewards tracking
+  vipTier?: number; // User's VIP tier level
+  vipDiscount?: number; // VIP discount percentage applied
+
   // A/B test context to attribute trade events to specific experiments
   abTests?: Record<string, string>;
 };
@@ -319,6 +323,9 @@ export type MarginResult = {
 export type FlipPositionParams = {
   symbol: string; // Asset identifier to flip (e.g., 'BTC', 'ETH', 'xyz:TSLA')
   position: Position; // Current position to flip
+
+  // Optional tracking data for MetaMetrics events
+  trackingData?: TrackingData;
 };
 
 export type InitializeResult = {


### PR DESCRIPTION
## **Description**

Adds `vip_tier` and `vip_discount` as optional tracking properties to perps trading analytics events. These fields allow downstream dashboards to attribute trades to specific VIP reward tiers and measure the discount applied.

**Changes:**
- Added `vipTier` and `vipDiscount` to the `TrackingData` type so callers can pass them through the existing tracking data pattern.
- Added `VIP_TIER` and `VIP_DISCOUNT` event property constants.
- Emits `vip_tier` / `vip_discount` in analytics events for:
  - **Order submission** (`#trackOrderResult` → `TradeTransaction`)
  - **Position close** (`#buildCloseEventProperties` → `PositionCloseTransaction`)
  - **Position flip/reverse** (`flipPosition` → `TradeTransaction`, both success and failure)
- Added `trackingData` to `FlipPositionParams` and threaded it through `PerpsController.flipPosition` → `TradingService.flipPosition`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to: https://consensyssoftware.atlassian.net/browse/TAT-3161

## **Manual testing steps**

```gherkin
Feature: VIP tracking in perps trade events

  Scenario: vip_tier and vip_discount are included in order submission analytics
    Given the user has a VIP tier and discount from the rewards system

    When user submits a perps order with trackingData containing vipTier and vipDiscount
    Then the TradeTransaction analytics event includes vip_tier and vip_discount properties

  Scenario: vip_tier and vip_discount are included in position close analytics
    Given the user has an open perps position

    When user closes the position with trackingData containing vipTier and vipDiscount
    Then the PositionCloseTransaction analytics event includes vip_tier and vip_discount properties

  Scenario: vip_tier and vip_discount are included in position flip analytics
    Given the user has an open perps position

    When user flips the position with trackingData containing vipTier and vipDiscount
    Then the TradeTransaction analytics event for the flip includes vip_tier and vip_discount properties
```

## **Screenshots/Recordings**

N/A — no UI changes, analytics-only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional analytics properties and threads `trackingData` through `flipPosition` without changing trading execution logic.
> 
> **Overview**
> Adds VIP rewards analytics support by introducing `PERPS_EVENT_PROPERTY.VIP_TIER`/`VIP_DISCOUNT` and extending `TrackingData` with `vipTier`/`vipDiscount`.
> 
> Threads optional `trackingData` through `PerpsController.flipPosition`/`TradingService.flipPosition`, and conditionally emits `vip_tier`/`vip_discount` on `TradeTransaction` and `PositionCloseTransaction` events (including flip success/failure). Updates unit tests to verify the properties are included only when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b9ca4d461720be974778776476f6d92c8e26cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->