### PR TITLE
feat(rewards): allow vanity referral codes

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
@@ -276,7 +276,11 @@ const OnboardingMainStep: React.FC = () => {
         />
       );
     }
-    if (referralCode.length >= 6) {
+    if (
+      referralCode.length >= 1 &&
+      !isValidatingReferralCode &&
+      !referralCodeIsValid
+    ) {
       return (
         <Icon
           name={IconName.Error}
@@ -332,18 +336,17 @@ const OnboardingMainStep: React.FC = () => {
             isDisabled={optinLoading}
             endAccessory={renderReferralIcon()}
             isError={
-              referralCode.length >= 6 &&
+              referralCode.length >= 1 &&
               !referralCodeIsValid &&
               !isValidatingReferralCode &&
               !isUnknownErrorReferralCode
             }
             inputProps={{
               autoCapitalize: 'characters',
-              maxLength: 6,
               testID: 'referral-input',
             }}
           />
-          {referralCode.length >= 6 &&
+          {referralCode.length >= 1 &&
             !referralCodeIsValid &&
             !isValidatingReferralCode &&
             !isUnknownErrorReferralCode && (

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
@@ -29,7 +29,10 @@ import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
 import { strings } from '../../../../../../locales/i18n';
 import { useGeoRewardsMetadata } from '../../hooks/useGeoRewardsMetadata';
 import { useOptin } from '../../hooks/useOptIn';
-import { useValidateReferralCode } from '../../hooks/useValidateReferralCode';
+import {
+  REFERRAL_CODE_MIN_LENGTH,
+  useValidateReferralCode,
+} from '../../hooks/useValidateReferralCode';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { isHardwareAccount } from '../../../../../util/address';
 import Engine from '../../../../../core/Engine';
@@ -78,6 +81,8 @@ const OnboardingMainStep: React.FC = () => {
   const isPrefilledReferral = Boolean(onboardingReferralCode);
   const [showReferralInput, setShowReferralInput] =
     useState(isPrefilledReferral);
+  const referralCodeReadyForValidation =
+    referralCode.length >= REFERRAL_CODE_MIN_LENGTH;
 
   // Candidate subscription ID state
   const candidateSubscriptionIdLoading =
@@ -277,7 +282,7 @@ const OnboardingMainStep: React.FC = () => {
       );
     }
     if (
-      referralCode.length >= 1 &&
+      referralCodeReadyForValidation &&
       !isValidatingReferralCode &&
       !referralCodeIsValid
     ) {
@@ -336,7 +341,7 @@ const OnboardingMainStep: React.FC = () => {
             isDisabled={optinLoading}
             endAccessory={renderReferralIcon()}
             isError={
-              referralCode.length >= 1 &&
+              referralCodeReadyForValidation &&
               !referralCodeIsValid &&
               !isValidatingReferralCode &&
               !isUnknownErrorReferralCode
@@ -346,7 +351,7 @@ const OnboardingMainStep: React.FC = () => {
               testID: 'referral-input',
             }}
           />
-          {referralCode.length >= 1 &&
+          {referralCodeReadyForValidation &&
             !referralCodeIsValid &&
             !isValidatingReferralCode &&
             !isUnknownErrorReferralCode && (

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
@@ -283,6 +283,7 @@ const mockUseValidateReferralCode = {
 };
 
 jest.mock('../../../hooks/useValidateReferralCode', () => ({
+  REFERRAL_CODE_MIN_LENGTH: 3,
   useValidateReferralCode: () => mockUseValidateReferralCode,
 }));
 

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
@@ -621,6 +621,58 @@ describe('OnboardingMainStep', () => {
           nextButton.props.disabled,
       ).toBe(true);
     });
+
+    it('shows error text after validation completes and code is invalid', () => {
+      mockUseValidateReferralCode.referralCode = 'BANKLESS';
+      mockUseValidateReferralCode.isValid = false;
+      mockUseValidateReferralCode.isValidating = false;
+      mockUseValidateReferralCode.isUnknownError = false;
+
+      renderWithProviders(<OnboardingMainStep />);
+
+      // Reveal the input so the input + error gating render
+      fireEvent.press(screen.getAllByTestId('referral-prompt')[0]);
+
+      expect(
+        screen.getByText(
+          'mocked_rewards.onboarding.step4_referral_input_error',
+        ),
+      ).toBeDefined();
+    });
+
+    it('does not show error text while validation is in flight', () => {
+      mockUseValidateReferralCode.referralCode = 'BANKLESS';
+      mockUseValidateReferralCode.isValid = false;
+      mockUseValidateReferralCode.isValidating = true;
+      mockUseValidateReferralCode.isUnknownError = false;
+
+      renderWithProviders(<OnboardingMainStep />);
+
+      fireEvent.press(screen.getAllByTestId('referral-prompt')[0]);
+
+      expect(
+        screen.queryByText(
+          'mocked_rewards.onboarding.step4_referral_input_error',
+        ),
+      ).toBeNull();
+    });
+
+    it('does not show error text when input is empty', () => {
+      mockUseValidateReferralCode.referralCode = '';
+      mockUseValidateReferralCode.isValid = false;
+      mockUseValidateReferralCode.isValidating = false;
+      mockUseValidateReferralCode.isUnknownError = false;
+
+      renderWithProviders(<OnboardingMainStep />);
+
+      fireEvent.press(screen.getAllByTestId('referral-prompt')[0]);
+
+      expect(
+        screen.queryByText(
+          'mocked_rewards.onboarding.step4_referral_input_error',
+        ),
+      ).toBeNull();
+    });
   });
 
   describe('legal disclaimer', () => {

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
@@ -67,6 +67,7 @@ const mockUseValidateReferralCode = {
 };
 
 jest.mock('../../../hooks/useValidateReferralCode', () => ({
+  REFERRAL_CODE_MIN_LENGTH: 3,
   useValidateReferralCode: () => mockUseValidateReferralCode,
 }));
 

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
@@ -212,6 +212,7 @@ jest.mock('../../hooks/useReferralDetails', () => ({
 }));
 
 jest.mock('../../hooks/useValidateReferralCode', () => ({
+  REFERRAL_CODE_MIN_LENGTH: 3,
   useValidateReferralCode: jest.fn(),
 }));
 

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
@@ -501,7 +501,7 @@ describe('ReferredByCodeSection', () => {
       expect(endAccessory).toBeOnTheScreen();
     });
 
-    it('renders error icon when code is 6+ chars and invalid', () => {
+    it('renders error icon when code is non-empty and invalid', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'INVALID',
         setReferralCode: mockSetInputCode,
@@ -547,9 +547,9 @@ describe('ReferredByCodeSection', () => {
       expect(queryByTestId('referred-by-code-invalid-code')).toBeNull();
     });
 
-    it('does not render error text when code is less than 6 chars', () => {
+    it('does not render error text when code is empty', () => {
       mockUseValidateReferralCode.mockReturnValue({
-        referralCode: 'ABC',
+        referralCode: '',
         setReferralCode: mockSetInputCode,
         validateCode: jest.fn().mockResolvedValue(''),
         isValidating: false,
@@ -665,7 +665,7 @@ describe('ReferredByCodeSection', () => {
   });
 
   describe('Apply Referral Code Error', () => {
-    it('renders error message when applyReferralCodeError exists and code is 6+ chars', () => {
+    it('renders error message when applyReferralCodeError exists and code is non-empty', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'VALID1',
         setReferralCode: mockSetInputCode,
@@ -724,9 +724,9 @@ describe('ReferredByCodeSection', () => {
       expect(queryByTestId('apply-referral-code-error')).toBeNull();
     });
 
-    it('does not render error message when input code is less than 6 chars', () => {
+    it('does not render error message when input code is empty', () => {
       mockUseValidateReferralCode.mockReturnValue({
-        referralCode: 'ABC',
+        referralCode: '',
         setReferralCode: mockSetInputCode,
         validateCode: jest.fn().mockResolvedValue(''),
         isValidating: false,

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
@@ -18,10 +18,7 @@ import {
 } from '../../../../../reducers/rewards/selectors';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import { useReferralDetails } from '../../hooks/useReferralDetails';
-import {
-  useValidateReferralCode,
-  REFERRAL_CODE_LENGTH,
-} from '../../hooks/useValidateReferralCode';
+import { useValidateReferralCode } from '../../hooks/useValidateReferralCode';
 import { useApplyReferralCode } from '../../hooks/useApplyReferralCode';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useTheme } from '../../../../../util/theme';
@@ -102,7 +99,7 @@ const ReferredByCodeSection: React.FC = () => {
     }
 
     if (
-      (inputCode.length >= 6 && !clientCheckValid) ||
+      (inputCode.length >= 1 && !clientCheckValid) ||
       applyReferralCodeError
     ) {
       return (
@@ -118,7 +115,7 @@ const ReferredByCodeSection: React.FC = () => {
   };
 
   const showClientValidationError =
-    inputCode.length >= 6 &&
+    inputCode.length >= 1 &&
     !clientCheckValid &&
     !isValidating &&
     !isUnknownError &&
@@ -197,7 +194,6 @@ const ReferredByCodeSection: React.FC = () => {
             placeholder={strings('rewards.referred_by_code.input_placeholder')}
             value={hasReferredByCode ? (referredByCode ?? '') : inputCode}
             onChangeText={hasReferredByCode ? undefined : handleInputChange}
-            maxLength={REFERRAL_CODE_LENGTH}
             isDisabled={hasReferredByCode}
             autoCapitalize="characters"
             endAccessory={renderIcon()}
@@ -218,7 +214,7 @@ const ReferredByCodeSection: React.FC = () => {
             !isApplyingReferralCode &&
             !showClientValidationError &&
             !applyReferralCodeSuccess &&
-            inputCode.length >= 6 && (
+            inputCode.length >= 1 && (
               <Text
                 variant={TextVariant.BodySm}
                 twClassName="text-error-default mt-1"

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
@@ -18,7 +18,10 @@ import {
 } from '../../../../../reducers/rewards/selectors';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import { useReferralDetails } from '../../hooks/useReferralDetails';
-import { useValidateReferralCode } from '../../hooks/useValidateReferralCode';
+import {
+  REFERRAL_CODE_MIN_LENGTH,
+  useValidateReferralCode,
+} from '../../hooks/useValidateReferralCode';
 import { useApplyReferralCode } from '../../hooks/useApplyReferralCode';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useTheme } from '../../../../../util/theme';
@@ -49,6 +52,8 @@ const ReferredByCodeSection: React.FC = () => {
   const { fetchReferralDetails } = useReferralDetails({ fetchOnMount: false });
 
   const hasReferredByCode = Boolean(referredByCode);
+  const inputCodeReadyForValidation =
+    inputCode.length >= REFERRAL_CODE_MIN_LENGTH;
 
   const isApplyingRef = useRef(false);
 
@@ -99,7 +104,7 @@ const ReferredByCodeSection: React.FC = () => {
     }
 
     if (
-      (inputCode.length >= 1 && !clientCheckValid) ||
+      (inputCodeReadyForValidation && !clientCheckValid) ||
       applyReferralCodeError
     ) {
       return (
@@ -115,7 +120,7 @@ const ReferredByCodeSection: React.FC = () => {
   };
 
   const showClientValidationError =
-    inputCode.length >= 1 &&
+    inputCodeReadyForValidation &&
     !clientCheckValid &&
     !isValidating &&
     !isUnknownError &&
@@ -214,7 +219,7 @@ const ReferredByCodeSection: React.FC = () => {
             !isApplyingReferralCode &&
             !showClientValidationError &&
             !applyReferralCodeSuccess &&
-            inputCode.length >= 1 && (
+            inputCodeReadyForValidation && (
               <Text
                 variant={TextVariant.BodySm}
                 twClassName="text-error-default mt-1"

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
@@ -131,6 +131,58 @@ describe('useValidateReferralCode', () => {
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
+  it('does not validate locally invalid referral code formats', async () => {
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    act(() => {
+      result.current.setReferralCode('AB');
+    });
+
+    expect(result.current.referralCode).toBe('AB');
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+
+    await advanceReferralCodeDebounce();
+
+    act(() => {
+      result.current.setReferralCode('ABCDEFGHIJKLM');
+    });
+
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+
+    await advanceReferralCodeDebounce();
+
+    act(() => {
+      result.current.setReferralCode('ABC_123');
+    });
+
+    expect(result.current.isValidating).toBe(false);
+    expect(result.current.isValid).toBe(false);
+
+    await advanceReferralCodeDebounce();
+
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('does not call validateCode backend for locally invalid referral code formats', async () => {
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    await act(async () => {
+      const tooShortError = await result.current.validateCode('AB');
+      expect(tooShortError).toBe(
+        'Invalid referral code. Please check and try again.',
+      );
+
+      const badCharacterError = await result.current.validateCode('ABC_123');
+      expect(badCharacterError).toBe(
+        'Invalid referral code. Please check and try again.',
+      );
+    });
+
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
   it('validates after debounce for a short non-empty code', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
@@ -79,29 +79,46 @@ describe('useValidateReferralCode', () => {
     );
   });
 
-  it('does not validate when code is shorter than 6 characters', () => {
+  it('does not validate for empty input', () => {
     const { result } = renderHook(() => useValidateReferralCode());
 
     act(() => {
-      result.current.setReferralCode('ABC');
+      result.current.setReferralCode('');
     });
 
-    expect(result.current.referralCode).toBe('ABC');
+    expect(result.current.referralCode).toBe('');
     expect(result.current.isValid).toBe(false);
     expect(result.current.isValidating).toBe(false);
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
-  it('does not validate when code is longer than 6 characters', () => {
+  it('does not validate for whitespace-only input', () => {
     const { result } = renderHook(() => useValidateReferralCode());
 
     act(() => {
-      result.current.setReferralCode('ABCDEFG');
+      result.current.setReferralCode('   ');
     });
 
+    expect(result.current.referralCode).toBe('');
     expect(result.current.isValid).toBe(false);
     expect(result.current.isValidating).toBe(false);
     expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('validates immediately for a short non-empty code', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    await act(async () => {
+      result.current.setReferralCode('ABC');
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateReferralCode',
+      'ABC',
+    );
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.isValidating).toBe(false);
   });
 
   it('validates immediately for valid 6-char code', async () => {
@@ -116,6 +133,24 @@ describe('useValidateReferralCode', () => {
       'RewardsController:validateReferralCode',
       'ABCDEF',
     );
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('validates immediately for a vanity code (happy path)', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    await act(async () => {
+      result.current.setReferralCode('bankless');
+    });
+
+    // Code is normalized to uppercase before being forwarded
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateReferralCode',
+      'BANKLESS',
+    );
+    expect(result.current.referralCode).toBe('BANKLESS');
     expect(result.current.isValid).toBe(true);
     expect(result.current.isValidating).toBe(false);
   });
@@ -180,7 +215,7 @@ describe('useValidateReferralCode', () => {
     expect(result.current.referralCode).toBe('GHJKMN');
   });
 
-  it('invalidates in-flight request when code length changes away from 6', async () => {
+  it('invalidates in-flight request when code is cleared to empty', async () => {
     let resolveValidation: (value: boolean) => void;
     const validationPromise = new Promise<boolean>((resolve) => {
       resolveValidation = resolve;
@@ -196,7 +231,7 @@ describe('useValidateReferralCode', () => {
     expect(result.current.isValidating).toBe(true);
 
     act(() => {
-      result.current.setReferralCode('ABCDE');
+      result.current.setReferralCode('');
     });
 
     expect(result.current.isValidating).toBe(false);
@@ -207,6 +242,6 @@ describe('useValidateReferralCode', () => {
     });
 
     expect(result.current.isValid).toBe(false);
-    expect(result.current.referralCode).toBe('ABCDE');
+    expect(result.current.referralCode).toBe('');
   });
 });

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.test.ts
@@ -1,5 +1,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { useValidateReferralCode } from './useValidateReferralCode';
+import {
+  REFERRAL_CODE_DEBOUNCE_MS,
+  useValidateReferralCode,
+} from './useValidateReferralCode';
 import Engine from '../../../../core/Engine';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -8,13 +11,27 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.useFakeTimers();
+
 describe('useValidateReferralCode', () => {
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
 
+  const advanceReferralCodeDebounce = async (
+    ms = REFERRAL_CODE_DEBOUNCE_MS,
+  ) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
   });
 
   it('initializes with correct default values', () => {
@@ -28,10 +45,15 @@ describe('useValidateReferralCode', () => {
     expect(typeof result.current.validateCode).toBe('function');
   });
 
-  it('initializes with custom initial value and validates immediately', async () => {
+  it('initializes with custom initial value and validates after debounce', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
 
     const { result } = renderHook(() => useValidateReferralCode('ABCDEF'));
+
+    expect(result.current.isValidating).toBe(true);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
 
     await waitFor(() => {
       expect(result.current.isValid).toBe(true);
@@ -64,15 +86,19 @@ describe('useValidateReferralCode', () => {
     });
   });
 
-  it('converts code to uppercase and trims whitespace', async () => {
+  it('converts code to uppercase, trims whitespace, and validates after debounce', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('  abcdef  ');
     });
 
     expect(result.current.referralCode).toBe('ABCDEF');
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
+
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:validateReferralCode',
       'ABCDEF',
@@ -105,13 +131,18 @@ describe('useValidateReferralCode', () => {
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
-  it('validates immediately for a short non-empty code', async () => {
+  it('validates after debounce for a short non-empty code', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('ABC');
     });
+
+    expect(result.current.isValidating).toBe(true);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
 
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:validateReferralCode',
@@ -121,13 +152,17 @@ describe('useValidateReferralCode', () => {
     expect(result.current.isValidating).toBe(false);
   });
 
-  it('validates immediately for valid 6-char code', async () => {
+  it('validates after debounce for valid 6-char code', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('ABCDEF');
     });
+
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
 
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:validateReferralCode',
@@ -137,13 +172,17 @@ describe('useValidateReferralCode', () => {
     expect(result.current.isValidating).toBe(false);
   });
 
-  it('validates immediately for a vanity code (happy path)', async () => {
+  it('validates after debounce for a vanity code (happy path)', async () => {
     mockEngineCall.mockResolvedValueOnce(true);
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('bankless');
     });
+
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
 
     // Code is normalized to uppercase before being forwarded
     expect(mockEngineCall).toHaveBeenCalledWith(
@@ -159,12 +198,38 @@ describe('useValidateReferralCode', () => {
     mockEngineCall.mockRejectedValueOnce(new Error('Network error'));
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('ABCDEF');
     });
 
+    await advanceReferralCodeDebounce();
+
     expect(result.current.isUnknownError).toBe(true);
     expect(result.current.isValid).toBe(false);
+  });
+
+  it('debounces rapid input changes and only validates the last value', async () => {
+    mockEngineCall.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useValidateReferralCode());
+
+    act(() => {
+      result.current.setReferralCode('A');
+      result.current.setReferralCode('AB');
+      result.current.setReferralCode('ABC');
+    });
+
+    expect(result.current.referralCode).toBe('ABC');
+    expect(result.current.isValidating).toBe(true);
+    expect(mockEngineCall).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce();
+
+    expect(mockEngineCall).toHaveBeenCalledTimes(1);
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:validateReferralCode',
+      'ABC',
+    );
+    expect(result.current.isValid).toBe(true);
   });
 
   it('clears isUnknownError on subsequent successful validation', async () => {
@@ -174,15 +239,19 @@ describe('useValidateReferralCode', () => {
 
     const { result } = renderHook(() => useValidateReferralCode());
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('ABCDEF');
     });
 
+    await advanceReferralCodeDebounce();
+
     expect(result.current.isUnknownError).toBe(true);
 
-    await act(async () => {
+    act(() => {
       result.current.setReferralCode('GHJKMN');
     });
+
+    await advanceReferralCodeDebounce();
 
     expect(result.current.isUnknownError).toBe(false);
     expect(result.current.isValid).toBe(true);
@@ -203,9 +272,13 @@ describe('useValidateReferralCode', () => {
       result.current.setReferralCode('ABCDEF');
     });
 
-    await act(async () => {
+    await advanceReferralCodeDebounce();
+
+    act(() => {
       result.current.setReferralCode('GHJKMN');
     });
+
+    await advanceReferralCodeDebounce();
 
     await act(async () => {
       resolveFirst?.(false);
@@ -227,6 +300,8 @@ describe('useValidateReferralCode', () => {
     act(() => {
       result.current.setReferralCode('ABCDEF');
     });
+
+    await advanceReferralCodeDebounce();
 
     expect(result.current.isValidating).toBe(true);
 

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
@@ -3,9 +3,16 @@ import Engine from '../../../../core/Engine';
 import { strings } from '../../../../../locales/i18n';
 
 export const REFERRAL_CODE_DEBOUNCE_MS = 1000;
+export const REFERRAL_CODE_MIN_LENGTH = 3;
+export const REFERRAL_CODE_MAX_LENGTH = 12;
 const REFERRAL_CODE_UNKNOWN_ERROR = 'Unknown error';
+const REFERRAL_CODE_PATTERN = /^[A-Z0-9-]+$/;
 
 const normalizeReferralCode = (code: string) => code.trim().toUpperCase();
+const isReferralCodeFormatValid = (code: string) =>
+  code.length >= REFERRAL_CODE_MIN_LENGTH &&
+  code.length <= REFERRAL_CODE_MAX_LENGTH &&
+  REFERRAL_CODE_PATTERN.test(code);
 
 export interface UseValidateReferralCodeResult {
   /**
@@ -37,9 +44,9 @@ export interface UseValidateReferralCodeResult {
 
 /**
  * Custom hook for validating referral codes.
- * Debounces validation for any non-empty input — backend lookup is the source
- * of truth for whether the code exists. Stale responses from older requests
- * are automatically discarded.
+ * Debounces backend validation for referral codes that pass the backend format
+ * constraints: 3-12 uppercase letters, numbers, or hyphens. Stale responses
+ * from older requests are automatically discarded.
  *
  * @param initialValue - Initial referral code value (default: '')
  * @param debounceMs - Debounce delay in milliseconds
@@ -53,7 +60,7 @@ export const useValidateReferralCode = (
   const [referralCode, setReferralCodeState] = useState(initialReferralCode);
   const [error, setError] = useState('');
   const [isValidating, setIsValidating] = useState(
-    initialReferralCode.length >= 1,
+    isReferralCodeFormatValid(initialReferralCode),
   );
   const hasInitialized = useRef(false);
   const requestIdRef = useRef(0);
@@ -67,10 +74,16 @@ export const useValidateReferralCode = (
   }, []);
 
   const validateCode = useCallback(async (code: string): Promise<string> => {
+    const refinedCode = normalizeReferralCode(code);
+
+    if (!isReferralCodeFormatValid(refinedCode)) {
+      return strings('rewards.error_messages.invalid_referral_code');
+    }
+
     try {
       const valid = await Engine.controllerMessenger.call(
         'RewardsController:validateReferralCode',
-        code,
+        refinedCode,
       );
       if (!valid) {
         return strings('rewards.error_messages.invalid_referral_code');
@@ -115,6 +128,14 @@ export const useValidateReferralCode = (
         return;
       }
 
+      if (!isReferralCodeFormatValid(refinedCode)) {
+        requestIdRef.current += 1;
+        clearDebounceTimer();
+        setIsValidating(false);
+        setError(strings('rewards.error_messages.invalid_referral_code'));
+        return;
+      }
+
       triggerValidation(refinedCode);
     },
     [clearDebounceTimer, triggerValidation],
@@ -138,7 +159,8 @@ export const useValidateReferralCode = (
     [clearDebounceTimer],
   );
 
-  const isValid = referralCode.length >= 1 && !error && !isValidating;
+  const isValid =
+    isReferralCodeFormatValid(referralCode) && !error && !isValidating;
   const isUnknownError = error === REFERRAL_CODE_UNKNOWN_ERROR;
 
   return {

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
@@ -120,7 +120,7 @@ export const useValidateReferralCode = (
       const refinedCode = normalizeReferralCode(code);
       setReferralCodeState(refinedCode);
 
-      if (refinedCode.length < 1) {
+      if (refinedCode.length < REFERRAL_CODE_MIN_LENGTH) {
         requestIdRef.current += 1;
         clearDebounceTimer();
         setIsValidating(false);

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
@@ -2,8 +2,6 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import Engine from '../../../../core/Engine';
 import { strings } from '../../../../../locales/i18n';
 
-export const REFERRAL_CODE_LENGTH = 6;
-
 export interface UseValidateReferralCodeResult {
   /**
    * Current referral code value
@@ -34,8 +32,9 @@ export interface UseValidateReferralCodeResult {
 
 /**
  * Custom hook for validating referral codes.
- * Validates immediately when the code is exactly 6 Base32 characters.
- * Stale responses from older requests are automatically discarded.
+ * Validates immediately for any non-empty input — backend lookup is the source of
+ * truth for whether the code exists. Stale responses from older requests are
+ * automatically discarded.
  *
  * @param initialValue - Initial referral code value (default: '')
  * @returns UseValidateReferralCodeResult object with validation state and methods
@@ -91,7 +90,7 @@ export const useValidateReferralCode = (
       const refinedCode = code.trim().toUpperCase();
       setReferralCodeState(refinedCode);
 
-      if (refinedCode.length !== REFERRAL_CODE_LENGTH) {
+      if (refinedCode.length < 1) {
         ++requestIdRef.current;
         setIsValidating(false);
         setError(strings('rewards.error_messages.invalid_referral_code'));
@@ -113,8 +112,7 @@ export const useValidateReferralCode = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialValue]);
 
-  const isValid =
-    referralCode.length === REFERRAL_CODE_LENGTH && !error && !isValidating;
+  const isValid = referralCode.length >= 1 && !error && !isValidating;
 
   return {
     referralCode,

--- a/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
+++ b/app/components/UI/Rewards/hooks/useValidateReferralCode.ts
@@ -2,6 +2,11 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import Engine from '../../../../core/Engine';
 import { strings } from '../../../../../locales/i18n';
 
+export const REFERRAL_CODE_DEBOUNCE_MS = 1000;
+const REFERRAL_CODE_UNKNOWN_ERROR = 'Unknown error';
+
+const normalizeReferralCode = (code: string) => code.trim().toUpperCase();
+
 export interface UseValidateReferralCodeResult {
   /**
    * Current referral code value
@@ -32,22 +37,34 @@ export interface UseValidateReferralCodeResult {
 
 /**
  * Custom hook for validating referral codes.
- * Validates immediately for any non-empty input — backend lookup is the source of
- * truth for whether the code exists. Stale responses from older requests are
- * automatically discarded.
+ * Debounces validation for any non-empty input — backend lookup is the source
+ * of truth for whether the code exists. Stale responses from older requests
+ * are automatically discarded.
  *
  * @param initialValue - Initial referral code value (default: '')
+ * @param debounceMs - Debounce delay in milliseconds
  * @returns UseValidateReferralCodeResult object with validation state and methods
  */
 export const useValidateReferralCode = (
   initialValue: string = '',
+  debounceMs: number = REFERRAL_CODE_DEBOUNCE_MS,
 ): UseValidateReferralCodeResult => {
-  const [referralCode, setReferralCodeState] = useState(initialValue);
+  const initialReferralCode = normalizeReferralCode(initialValue);
+  const [referralCode, setReferralCodeState] = useState(initialReferralCode);
   const [error, setError] = useState('');
-  const [isValidating, setIsValidating] = useState(false);
-  const [unknownError, setUnknownError] = useState(false);
+  const [isValidating, setIsValidating] = useState(
+    initialReferralCode.length >= 1,
+  );
   const hasInitialized = useRef(false);
   const requestIdRef = useRef(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearDebounceTimer = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, []);
 
   const validateCode = useCallback(async (code: string): Promise<string> => {
     try {
@@ -60,46 +77,47 @@ export const useValidateReferralCode = (
       }
       return '';
     } catch {
-      return 'Unknown error';
+      return REFERRAL_CODE_UNKNOWN_ERROR;
     }
   }, []);
 
   const triggerValidation = useCallback(
-    async (code: string) => {
-      const currentRequestId = ++requestIdRef.current;
+    (code: string) => {
+      requestIdRef.current += 1;
+      const currentRequestId = requestIdRef.current;
 
-      setUnknownError(false);
+      clearDebounceTimer();
       setError('');
       setIsValidating(true);
 
-      const validationError = await validateCode(code);
+      debounceTimerRef.current = setTimeout(async () => {
+        const validationError = await validateCode(code);
 
-      if (currentRequestId !== requestIdRef.current) return;
+        if (currentRequestId !== requestIdRef.current) return;
 
-      if (validationError === 'Unknown error') {
-        setUnknownError(true);
-      }
-      setError(validationError);
-      setIsValidating(false);
+        setError(validationError);
+        setIsValidating(false);
+      }, debounceMs);
     },
-    [validateCode],
+    [clearDebounceTimer, debounceMs, validateCode],
   );
 
   const setReferralCode = useCallback(
     (code: string) => {
-      const refinedCode = code.trim().toUpperCase();
+      const refinedCode = normalizeReferralCode(code);
       setReferralCodeState(refinedCode);
 
       if (refinedCode.length < 1) {
-        ++requestIdRef.current;
+        requestIdRef.current += 1;
+        clearDebounceTimer();
         setIsValidating(false);
-        setError(strings('rewards.error_messages.invalid_referral_code'));
+        setError('');
         return;
       }
 
       triggerValidation(refinedCode);
     },
-    [triggerValidation],
+    [clearDebounceTimer, triggerValidation],
   );
 
   useEffect(() => {
@@ -112,7 +130,16 @@ export const useValidateReferralCode = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialValue]);
 
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      clearDebounceTimer();
+    },
+    [clearDebounceTimer],
+  );
+
   const isValid = referralCode.length >= 1 && !error && !isValidating;
+  const isUnknownError = error === REFERRAL_CODE_UNKNOWN_ERROR;
 
   return {
     referralCode,
@@ -120,7 +147,7 @@ export const useValidateReferralCode = (
     validateCode,
     isValidating,
     isValid,
-    isUnknownError: unknownError,
+    isUnknownError,
   };
 };
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -8668,29 +8668,54 @@ describe('RewardsController', () => {
       );
     });
 
-    it('returns false for empty or whitespace-only codes', async () => {
+    it('returns false for empty or whitespace-only codes and does not call data service', async () => {
       // Act & Assert
       expect(await controller.validateReferralCode('')).toBe(false);
       expect(await controller.validateReferralCode('   ')).toBe(false);
       expect(await controller.validateReferralCode('\t\n')).toBe(false);
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:validateReferralCode',
+        expect.anything(),
+      );
     });
 
-    it('returns false for codes with incorrect length', async () => {
+    it('forwards non-empty vanity codes to the data service', async () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:validateReferralCode') {
+          return Promise.resolve({ valid: true });
+        }
+        return Promise.resolve();
+      });
+
+      // Act
+      const result = await controller.validateReferralCode('BANKLESS');
+
+      // Assert: vanity code is forwarded regardless of length or charset
+      expect(result).toBe(true);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:validateReferralCode',
+        'BANKLESS',
+      );
+    });
+
+    it('forwards codes with characters outside Base32 alphabet to the data service', async () => {
+      // Arrange — backend decides validity, not the client
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockMessenger.call.mockImplementation((action, ..._args): any => {
+        if (action === 'RewardsDataService:validateReferralCode') {
+          return Promise.resolve({ valid: false });
+        }
+        return Promise.resolve();
+      });
+
       // Act & Assert
-      expect(await controller.validateReferralCode('ABC12')).toBe(false); // Too short
-      expect(await controller.validateReferralCode('ABC1234')).toBe(false); // Too long
-    });
-
-    it('returns false for codes with characters outside Base32 alphabet', async () => {
-      // I, L, O, U are excluded from the Base32 alphabet
       expect(await controller.validateReferralCode('ABCIOU')).toBe(false);
-      expect(await controller.validateReferralCode('LIONER')).toBe(false);
-    });
-
-    it('returns false for codes with special characters', async () => {
-      // Act & Assert
-      expect(await controller.validateReferralCode('AB-C!D')).toBe(false);
-      expect(await controller.validateReferralCode('CO@E12')).toBe(false);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:validateReferralCode',
+        'ABCIOU',
+      );
     });
 
     it('returns true for valid referral codes from service', async () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -53,7 +53,6 @@ import {
   type VipDashboardState,
   type VipFeesResponseDto,
   type VipPerpsFeesState,
-  BASE32_REGEX,
   CampaignType,
 } from './types';
 import {
@@ -2927,14 +2926,6 @@ export class RewardsController extends BaseController<
     }
 
     if (!code.trim()) {
-      return false;
-    }
-
-    if (code.length !== 6) {
-      return false;
-    }
-
-    if (!BASE32_REGEX.test(code)) {
       return false;
     }
 

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -6,11 +6,6 @@ import { CaipAccountId, CaipAssetType, type Json } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import type { RewardsControllerMethodActions } from './RewardsController-method-action-types';
 
-/**
- * Crockford's Base32 alphabet — excludes I, L, O, U to avoid ambiguity.
- */
-export const BASE32_REGEX = /^[0-9A-HJKMNP-TV-Z]+$/i;
-
 export interface LoginResponseDto {
   sessionId: string;
   subscription: SubscriptionDto;


### PR DESCRIPTION
## **Description**

Relaxes client-side referral-code validation in the Rewards onboarding/opt-in path so any non-empty string is accepted. The backend's DB lookup (`getSubscriptionByReferralCode`) remains the source of truth for whether a code exists, so vanity codes like `BANKLESS`, `ALICE`, or `MM2026` can now be used end-to-end once seeded by the backend.

**What changed**
- `RewardsController.validateReferralCode` no longer rejects codes for length or Base32 charset — only empty/whitespace input is short-circuited client-side. Anything else is forwarded to `RewardsDataService:validateReferralCode`.
- `BASE32_REGEX` is removed from `rewards-controller/types.ts` (sole importer was the controller).
- `useValidateReferralCode` fires validation for any non-empty input rather than gating on `length === 6`. `REFERRAL_CODE_LENGTH` is removed.
- `OnboardingMainStep` now shows the error icon / error styling / error message only after validation has completed and the code came back invalid — no more length-based pre-emption. The `maxLength: 6` cap on the input is removed so vanity codes longer than 6 chars can actually be typed.

**Out of scope**
- Auto-generation of new referral codes (still 6-char Crockford Base32 on the backend).
- Self-referral / "already-referred" checks (unchanged in `applyReferralCode`).

This is PR 2 of 3 in a coordinated change across `va-mmcx-rewards` (backend), `metamask-mobile`, and `metamask-extension`. The three PRs can ship independently — the backend already tolerates the relaxed input shape after its own PR lands.

## **Changelog**

CHANGELOG entry: Allowed vanity referral codes (any non-empty string) to be entered during Rewards onboarding; the backend decides whether the code exists.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Vanity referral codes in Rewards onboarding

  Scenario: User enters a valid vanity code
    Given the user is on the Rewards onboarding screen
    And the backend has a subscription with referral code "BANKLESS"

    When the user reveals the referral input and types "BANKLESS"
    Then after validation, no error icon or error message is shown
    And the next button is enabled
    And opting in successfully creates the referral relationship

  Scenario: User enters an unknown vanity code
    Given the user is on the Rewards onboarding screen

    When the user types "NOTACODE12345"
    Then after validation completes (not before), the error icon and message appear

  Scenario: User enters an existing 6-char code
    Given the user is on the Rewards onboarding screen
    And the backend has a subscription with referral code "ABC234"

    When the user types "abc234"
    Then the input is normalized to "ABC234"
    And after validation, the success icon is shown
    And opting in succeeds

  Scenario: User clears the input
    Given the user has typed a referral code

    When the user clears the input
    Then no error icon or error message is shown
    And the next button reverts to enabled (no code submitted)
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — non-visual relaxation of validation rules. -->

### **After**

<!-- N/A — non-visual relaxation of validation rules. -->

## **Test plan**

- [x] Vanity-code happy path: `BANKLESS` (8 chars) is forwarded to the backend and validates green.
- [x] Empty / whitespace input is short-circuited client-side and the data service is NOT called.
- [x] Existing 6-char Base32 codes (`ABC234`, `XYZ567`) still work.
- [x] Error UI appears only after validation completes and returns invalid — no length-based pre-emption.
- [x] Error UI is hidden while validation is in flight.
- [x] Referral-code generation path (backend) is untouched — out of scope for this PR.
- [x] (Manual, after backend PR lands) End-to-end opt-in on DEV with a seeded vanity code.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client/server referral-code validation rules and debounced backend calls, which can affect onboarding opt-in gating and service load/UX timing. Risk is moderated by expanded unit test coverage but still touches a core enrollment flow.
> 
> **Overview**
> **Enables vanity referral codes in Rewards flows.** `RewardsController.validateReferralCode` no longer enforces 6-char Base32 checks and now forwards any non-empty code to the data service (removing `BASE32_REGEX`).
> 
> **Refactors client validation to be length/pattern-based and debounced.** `useValidateReferralCode` adds normalization, local format checks (3–12 chars, `[A-Z0-9-]`), a 1s debounce, and improved stale-request cleanup; `REFERRAL_CODE_LENGTH` is removed in favor of `REFERRAL_CODE_MIN_LENGTH/MAX_LENGTH`.
> 
> **Aligns UI gating and tests.** Onboarding and settings referral inputs remove the 6-char `maxLength` and switch error icon/styling/messages to show only once validation is complete (not just based on length), with updated/added unit tests for in-flight, empty, invalid, and vanity-code cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a27c0627bc40112ef7da4dfb6ec199d2745415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->