### PR TITLE
fix: handle headless ramp callback load errors

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -817,6 +817,61 @@ describe('Checkout', () => {
       expect(mockParentPop).toHaveBeenCalledTimes(1);
     });
 
+    it('processes callback URL HTTP errors as successful provider callbacks when headless', async () => {
+      const onOrderCreated = jest.fn();
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-http-error-callback'));
+      });
+
+      await waitFor(() => {
+        expect(onOrderCreated).toHaveBeenCalledWith('headless-order-1');
+      });
+      expect(mockFailSession).not.toHaveBeenCalled();
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      expect(mockGetOrderFromCallback).toHaveBeenCalledWith(
+        'moonpay',
+        `${callbackBaseUrl}?orderId=123`,
+        '0xdeadbeef',
+      );
+    });
+
+    it('forwards callback URL HTTP errors to custom navigation handlers when headless checkout has no callback flow', async () => {
+      const onNavigationStateChange = jest.fn();
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test Provider',
+        onNavigationStateChange,
+        headlessSessionId: 'hs-1',
+      });
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-http-error-callback'));
+      });
+
+      expect(onNavigationStateChange).toHaveBeenCalledWith({
+        url: `${callbackBaseUrl}?orderId=123`,
+      });
+      expect(mockFailSession).not.toHaveBeenCalled();
+    });
+
     it('treats an empty provider callback as user dismissal when headless', async () => {
       mockUseParams.mockReturnValue(callbackFlowParams);
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -466,10 +466,15 @@ const Checkout = () => {
   const handleCallbackUrlHttpError = useCallback(
     (callbackUrl: string): boolean => {
       if (hasCallbackFlow) {
-        void handleNavigationStateChange({
+        handleNavigationStateChange({
           url: callbackUrl,
           loading: false,
-        } as WebViewNavigation);
+        } as WebViewNavigation).catch((callbackError: unknown) => {
+          Logger.error(
+            callbackError as Error,
+            'UnifiedCheckout: error handling callback URL HTTP error',
+          );
+        });
         return true;
       }
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -463,6 +463,31 @@ const Checkout = () => {
     [onNavigationStateChange, recordUrlChange],
   );
 
+  const handleCallbackUrlHttpError = useCallback(
+    (callbackUrl: string): boolean => {
+      if (hasCallbackFlow) {
+        void handleNavigationStateChange({
+          url: callbackUrl,
+          loading: false,
+        } as WebViewNavigation);
+        return true;
+      }
+
+      if (onNavigationStateChange) {
+        handleNavigationStateChangeWithDedup({ url: callbackUrl });
+        return true;
+      }
+
+      return false;
+    },
+    [
+      handleNavigationStateChange,
+      handleNavigationStateChangeWithDedup,
+      hasCallbackFlow,
+      onNavigationStateChange,
+    ],
+  );
+
   const handleLoadStart = useCallback(() => {
     loadStartTimeRef.current = Date.now();
   }, []);
@@ -629,8 +654,8 @@ const Checkout = () => {
             const { nativeEvent } = syntheticEvent;
             const errorUrl = nativeEvent.url;
             const isInitialUrl = errorUrl === initialUriRef.current;
-            const isTerminal =
-              isInitialUrl || errorUrl.startsWith(callbackBaseUrl);
+            const isCallbackUrl = errorUrl.startsWith(callbackBaseUrl);
+            const isTerminal = isInitialUrl || isCallbackUrl;
 
             loadUrlErrorsRef.current.add(errorUrl);
             trackEvent(
@@ -649,6 +674,10 @@ const Checkout = () => {
                 })
                 .build(),
             );
+
+            if (isCallbackUrl && handleCallbackUrlHttpError(errorUrl)) {
+              return;
+            }
 
             if (isTerminal) {
               closeSourceRef.current = 'http_error';

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -216,8 +216,8 @@ jest.mock('@metamask/ramps-controller', () => ({
   normalizeProviderCode: (code: string) => code.replace(/^\/providers\//, ''),
 }));
 
-jest.mock('../Deposit/constants', () => ({
-  REDIRECTION_URL: 'https://redirect.example.com',
+jest.mock('../utils/getRampCallbackBaseUrl', () => ({
+  getRampCallbackBaseUrl: () => 'https://redirect.example.com',
 }));
 
 const mockQuote = {
@@ -1207,7 +1207,7 @@ describe('useTransakRouting', () => {
       return capturedHandleNavigationStateChange;
     };
 
-    it('returns early when url does not start with REDIRECTION_URL', async () => {
+    it('returns early when url does not start with the ramp callback base URL', async () => {
       const handler = await runApprovedFlowToCaptureCallback();
       expect(handler).not.toBeNull();
       if (!handler) return;

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -9,7 +9,6 @@ import {
   normalizeProviderCode,
   type TransakBuyQuote,
 } from '@metamask/ramps-controller';
-import { REDIRECTION_URL } from '../Deposit/constants';
 import { generateThemeParameters } from '../Deposit/utils';
 import { BasicInfoFormData } from '../Deposit/Views/BasicInfo/BasicInfo';
 import { AddressFormData } from '../Deposit/Views/EnterAddress/EnterAddress';
@@ -34,6 +33,7 @@ import {
   getSession,
 } from '../headless/sessionRegistry';
 import { dismissHeadlessFlow } from '../headless/headlessEntryNavigation';
+import { getRampCallbackBaseUrl } from '../utils/getRampCallbackBaseUrl';
 
 interface RampStackParamList {
   /** `baseRouteParams` (e.g. `headlessSessionId`) are merged onto this route in resets — see `navigateToVerifyIdentityCallback`. */
@@ -387,7 +387,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
 
   const handleNavigationStateChange = useCallback(
     async ({ url }: { url: string }) => {
-      if (!url.startsWith(REDIRECTION_URL)) return;
+      if (!url.startsWith(getRampCallbackBaseUrl())) return;
 
       let orderId: string | null = null;
       try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route callback URL WebView HTTP errors through the existing callback success handlers instead of failing headless Checkout sessions immediately.
- Forward callback URL HTTP errors to custom Checkout navigation handlers used by Transak native/headless flows.
- Align Transak native redirect detection with the environment-specific ramp callback base URL.

## Context
When a provider redirects to the fake ramp callback URL, the WebView can emit an HTTP error for that sentinel URL (especially after the user backgrounds the app for bank approval) before the normal navigation-state success path completes. In headless mode, Checkout treated that callback URL load error as terminal and fired `onError`, even though the provider had already created the order.

## Verification
- `NODE_OPTIONS='--max-old-space-size=12288' yarn jest --runInBand --forceExit app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx -t "callback URL HTTP errors"`
- `NODE_OPTIONS='--max-old-space-size=12288' yarn jest --runInBand --forceExit app/components/UI/Ramp/hooks/useTransakRouting.test.ts -t "handleNavigationStateChange"`
- `NODE_OPTIONS='--max-old-space-size=12288' yarn eslint app/components/UI/Ramp/Views/Checkout/Checkout.tsx app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx app/components/UI/Ramp/hooks/useTransakRouting.ts app/components/UI/Ramp/hooks/useTransakRouting.test.ts` (passes with pre-existing `customOrderId` deprecation warning)

## Notes
- Full focused files reported all tests as PASS, but the Jest processes hit/hung near the Node heap/open-handle limit in this cloud environment after test completion. The targeted regression/redirect subsets above exit cleanly with `--forceExit`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0A8Q7P0SCX/p1779128172734549?thread_ts=1779128172.734549&cid=C0A8Q7P0SCX)

<div><a href="https://cursor.com/agents/bc-79027084-d5e5-5284-a415-5f89ae044e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79027084-d5e5-5284-a415-5f89ae044e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

