### PR TITLE
fix: preserve Transak-native order asset label

### DIFF
--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -420,10 +420,19 @@ describe('useTransakRouting', () => {
         id: 'order-123',
         providerOrderId: 'order-123',
         walletAddress: '0xabc',
+        cryptoCurrency: {
+          assetId: 'eip155:42161/slip44:60',
+          chainId: 'eip155:42161',
+          symbol: 'ETH',
+        },
       });
       mockRefreshOrder.mockResolvedValue({
         providerOrderId: 'order-123',
-        cryptoCurrency: { symbol: 'ETH' },
+        cryptoCurrency: {
+          assetId: 'eip155:42161/slip44:60',
+          chainId: 'eip155:42161',
+          symbol: 'ARB',
+        },
         cryptoAmount: '0.05',
         status: 'Pending',
       });
@@ -450,6 +459,16 @@ describe('useTransakRouting', () => {
               params: expect.objectContaining({ orderId: 'order-123' }),
             }),
           ],
+        }),
+      );
+      expect(mockAddOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerOrderId: 'order-123',
+          cryptoCurrency: expect.objectContaining({
+            assetId: 'eip155:42161/slip44:60',
+            chainId: 'eip155:42161',
+            symbol: 'ETH',
+          }),
         }),
       );
     });
@@ -1325,11 +1344,20 @@ describe('useTransakRouting', () => {
         provider: 'transak-native',
         walletAddress: MOCK_WALLET_ADDRESS,
         paymentDetails: { instructions: 'Wire transfer' },
+        cryptoCurrency: {
+          assetId: 'eip155:42161/slip44:60',
+          chainId: 'eip155:42161',
+          symbol: 'ETH',
+        },
       };
       mockGetOrder.mockResolvedValue(depositOrder);
       mockRefreshOrder.mockResolvedValue({
         providerOrderId: 'order-123',
-        cryptoCurrency: { symbol: 'ETH' },
+        cryptoCurrency: {
+          assetId: 'eip155:42161/slip44:60',
+          chainId: 'eip155:42161',
+          symbol: 'ARB',
+        },
         cryptoAmount: '0.05',
         status: 'Pending',
         fiatAmount: 100,
@@ -1361,6 +1389,11 @@ describe('useTransakRouting', () => {
         expect.objectContaining({
           providerOrderId: 'order-123',
           paymentDetails: { instructions: 'Wire transfer' },
+          cryptoCurrency: expect.objectContaining({
+            assetId: 'eip155:42161/slip44:60',
+            chainId: 'eip155:42161',
+            symbol: 'ETH',
+          }),
         }),
       );
       expect(mockShowV2OrderToast).toHaveBeenCalledWith({

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -7,7 +7,9 @@ import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
 import {
   normalizeProviderCode,
+  type RampsOrder,
   type TransakBuyQuote,
+  type TransakDepositOrder,
 } from '@metamask/ramps-controller';
 import { REDIRECTION_URL } from '../Deposit/constants';
 import { generateThemeParameters } from '../Deposit/utils';
@@ -106,6 +108,23 @@ interface UseTransakRoutingConfig {
    */
   baseRouteParams?: Record<string, unknown>;
 }
+
+const reconcileOrderWithTransakAsset = (
+  rampsOrder: RampsOrder,
+  transakOrder: TransakDepositOrder,
+): RampsOrder => {
+  if (!transakOrder.cryptoCurrency?.symbol) {
+    return rampsOrder;
+  }
+
+  return {
+    ...rampsOrder,
+    cryptoCurrency: {
+      ...rampsOrder.cryptoCurrency,
+      ...transakOrder.cryptoCurrency,
+    },
+  };
+};
 
 export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const baseRoute = config?.baseRoute;
@@ -423,10 +442,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         const providerCode = normalizeProviderCode(
           String(depositOrder.provider ?? 'transak-native'),
         );
-        const rampsOrder = await refreshOrder(
+        const refreshedOrder = await refreshOrder(
           providerCode,
           depositOrder.providerOrderId,
           walletAddress || depositOrder.walletAddress,
+        );
+        const rampsOrder = reconcileOrderWithTransakAsset(
+          refreshedOrder,
+          depositOrder,
         );
 
         addOrder({
@@ -602,10 +625,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
                 const providerCode = normalizeProviderCode(
                   String(depositOrder.provider ?? 'transak-native'),
                 );
-                const rampsOrder = await refreshOrder(
+                const refreshedOrder = await refreshOrder(
                   providerCode,
                   depositOrder.providerOrderId,
                   walletAddress || depositOrder.walletAddress,
+                );
+                const rampsOrder = reconcileOrderWithTransakAsset(
+                  refreshedOrder,
+                  depositOrder,
                 );
 
                 addOrder({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Preserve direct Transak order crypto metadata when storing refreshed unified ramp orders.
- Covers both Transak widget redirect and manual bank transfer success paths.
- Adds regression coverage for ETH on Arbitrum being overwritten by ARB in the refreshed order response.

## Validation
- `bash -lc 'source "$HOME/.nvm/nvm.sh" && nvm use 20.18.0 >/dev/null && corepack yarn eslint app/components/UI/Ramp/hooks/useTransakRouting.ts app/components/UI/Ramp/hooks/useTransakRouting.test.ts'` ✅
- `yarn jest app/components/UI/Ramp/hooks/useTransakRouting.test.ts` printed PASS for all tests, then the local Jest/Node process exited non-zero after a heap OOM during post-run teardown.
- `bash -lc 'source "$HOME/.nvm/nvm.sh" && nvm use 20.18.0 >/dev/null && NODE_OPTIONS="--max-old-space-size=8192" corepack yarn jest --runTestsByPath app/components/UI/Ramp/hooks/useTransakRouting.test.ts -t "navigates to bank details|adds order" --runInBand --forceExit --watchman=false'` printed PASS for the targeted regression tests, then hung in teardown and was stopped manually.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C04G8UGLL4R/p1778836558395549?thread_ts=1778836558.395549&cid=C04G8UGLL4R)

<div><a href="https://cursor.com/agents/bc-7d1ac731-2a6c-5173-8951-7f8e29d4547f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d1ac731-2a6c-5173-8951-7f8e29d4547f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

