### PR TITLE
ci: split push-eas-update into two parallel jobs

### DIFF
--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -1,0 +1,218 @@
+name: EAS Update Platform
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform to update (ios or android)'
+        type: string
+        required: true
+      commit_sha:
+        description: 'Target commit SHA to build and push'
+        type: string
+        required: true
+      artifact_name:
+        description: 'node_modules artifact name to download'
+        type: string
+        required: true
+      channel:
+        description: 'OTA channel (exp, rc, production)'
+        type: string
+        required: true
+      message:
+        description: 'EAS update message'
+        type: string
+        required: true
+      build_name:
+        description: 'Build name from builds.yml (e.g. main-exp)'
+        type: string
+        required: true
+      github_environment:
+        description: 'GitHub environment name for secrets/approvals'
+        type: string
+        required: true
+      secrets_json:
+        description: 'JSON mapping of secret aliases from builds.yml'
+        type: string
+        required: true
+
+jobs:
+  push-update:
+    name: Push EAS Update (${{ inputs.platform }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.github_environment }}
+    env:
+      # OTA-specific vars only — build config + secrets come from builds.yml via steps below
+      TARGET_COMMIT_HASH: ${{ inputs.commit_sha }}
+      ARTIFACT_NAME: ${{ inputs.artifact_name }}
+      EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
+      UPDATE_MESSAGE: ${{ inputs.message }}
+      TARGET_CHANNEL: ${{ inputs.channel }}
+      OTA_PUSH_PLATFORM: ${{ inputs.platform }}
+      GIT_BRANCH: ${{ github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_COMMIT_HASH }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Validate artifact compatibility
+        uses: ./.github/actions/validate-artifact-compatibility
+        with:
+          artifact-name: ${{ env.ARTIFACT_NAME }}
+          artifact-prefix: node-modules-eas-update-pr
+          validation-context: artifact
+
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+
+      - name: Restore executable permissions
+        uses: ./.github/actions/restore-node-modules-permissions
+
+      - name: Verify downloaded artifacts
+        run: |
+          echo "✅ Verifying downloaded artifacts..."
+          if [ ! -d "node_modules" ]; then
+            echo "❌ node_modules directory not found"
+            exit 1
+          fi
+          if [ ! -f "app/core/InpageBridgeWeb3.js" ]; then
+            echo "❌ InpageBridgeWeb3.js not found in artifact"
+            exit 1
+          fi
+          echo "📦 node_modules size: $(du -sh node_modules | cut -f1)"
+          echo "✅ Artifacts verified"
+
+      - name: Apply build config from builds.yml
+        run: |
+          BUILD_NAME="${{ inputs.build_name }}"
+          echo "📦 Applying build config for: $BUILD_NAME"
+          eval "$(node scripts/apply-build-config.js "$BUILD_NAME" --export)"
+          node scripts/apply-build-config.js "$BUILD_NAME" --export-github-env >> "$GITHUB_ENV"
+
+      - name: Set secrets from builds.yml mapping
+        env:
+          CONFIG_SECRETS: ${{ inputs.secrets_json }}
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: node scripts/set-secrets-from-config.js
+
+      - name: Determine signing secret name
+        shell: bash
+        env:
+          TARGET: ${{ inputs.channel }}
+        run: |
+          case "$TARGET" in
+            exp)
+              SECRET_NAME="metamask-exp-expo-signer"
+              ;;
+            rc)
+              SECRET_NAME="metamask-rc-expo-signer"
+              ;;
+            production)
+              SECRET_NAME="metamask-prod-expo-signer"
+              ;;
+            *)
+              echo "❌ Unknown target: $TARGET"
+              exit 1
+              ;;
+          esac
+          echo "AWS_SIGNING_CERT_SECRET_NAME=$SECRET_NAME" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: 'us-east-2'
+
+      - name: Fetch secret and export as environment variables
+        shell: bash
+        run: |
+          echo "🔐 Fetching secret from Secrets Manager..."
+          secret_json=$(aws secretsmanager get-secret-value \
+            --region 'us-east-2' \
+            --secret-id "${AWS_SIGNING_CERT_SECRET_NAME}" \
+            --query SecretString \
+            --output text)
+
+          keys=$(echo "$secret_json" | jq -r 'keys[]')
+          for key in $keys; do
+            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k]')
+            echo "::add-mask::$value"
+            echo "$key=$(printf '%s' "$value")" >> "$GITHUB_ENV"
+            echo "✅ Set secret for key: $key"
+          done
+
+      - name: Display configuration
+        run: |
+          TARGET_RUNTIME_VERSION=$(node -p "require('./package.json').version")
+          echo "🔧 Configuration:"
+          echo "  Platform: ${{ inputs.platform }}"
+          echo "  Build: ${{ inputs.build_name }}"
+          echo "  Channel: ${EXPO_CHANNEL:-<not set>}"
+          echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
+          echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
+          echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
+
+      - name: Build & Push EAS Update via build.sh
+        env:
+          SKIP_TRANSFORM_LINT: 'true'
+          NODE_OPTIONS: '--max_old_space_size=8192'
+        run: |
+          echo "📦 Configuring EXPO key..."
+          if [[ -z "$EXPO_KEY_PRIV_B64" ]]; then
+            echo "⚠️ EXPO_KEY_PRIV_B64 is not set. Skipping keystore decoding."
+            exit 1
+          fi
+
+          # Decode the key
+          EXPO_KEY_PRIV=$(echo "$EXPO_KEY_PRIV_B64" | base64 --decode)
+          export EXPO_KEY_PRIV
+          echo "✅ Expo key decoded and exported"
+
+          echo "🚀 Pushing EAS update for channel: ${TARGET_CHANNEL}"
+          case "${TARGET_CHANNEL}" in
+            exp)
+              yarn run build:expo-update:main:exp
+              ;;
+            rc)
+              yarn run build:expo-update:main:rc
+              ;;
+            production)
+              yarn run build:expo-update:main:prod
+              ;;
+            *)
+              echo "❌ Unsupported TARGET_CHANNEL: ${TARGET_CHANNEL}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Update summary
+        if: success()
+        run: |
+          PLATFORM_LABEL=$(echo "${{ inputs.platform }}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+          {
+            echo "### ✅ EAS Update Published Successfully (${PLATFORM_LABEL})"
+            echo
+            echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
+            echo "**Message:** ${UPDATE_MESSAGE:-<not set>}"
+            echo
+            echo "${PLATFORM_LABEL} users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update summary on failure
+        if: failure()
+        run: |
+          PLATFORM_LABEL=$(echo "${{ inputs.platform }}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+          {
+            echo "### ❌ EAS Update Failed (${PLATFORM_LABEL})"
+            echo
+            echo "Check the logs above for error details."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -332,8 +332,8 @@ jobs:
           pr-number: ${{ needs.validate-pr.outputs.pr_number }}
           token: ${{ secrets.METAMASK_MOBILE_ORG_READ_TOKEN }}
 
-  push-update:
-    name: Push EAS Update
+  push-update-ios:
+    name: Push EAS Update (iOS)
     runs-on: ubuntu-latest
     environment: ${{ needs.prepare.outputs.github_environment }}
     needs:
@@ -344,7 +344,8 @@ jobs:
       - prepare
     if: >
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
-      needs.approval.result == 'success'
+      needs.approval.result == 'success' &&
+      (inputs.platform == 'all' || inputs.platform == 'ios')
     env:
       # OTA-specific vars only — build config + secrets come from builds.yml via steps below
       TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
@@ -352,7 +353,7 @@ jobs:
       EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
       UPDATE_MESSAGE: ${{ inputs.message }}
       TARGET_CHANNEL: ${{ inputs.channel }}
-      OTA_PUSH_PLATFORM: ${{ inputs.platform }}
+      OTA_PUSH_PLATFORM: ios
       GIT_BRANCH: ${{ github.ref_name }}
     steps:
       - name: Checkout repository
@@ -501,19 +502,206 @@ jobs:
         if: success()
         run: |
           {
-            echo "### ✅ EAS Update Published Successfully"
+            echo "### ✅ EAS Update Published Successfully (iOS)"
             echo
             echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
             echo "**Message:** ${UPDATE_MESSAGE:-<not set>}"
             echo
-            echo "Users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
+            echo "iOS users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update summary on failure
         if: failure()
         run: |
           {
-            echo "### ❌ EAS Update Failed"
+            echo "### ❌ EAS Update Failed (iOS)"
+            echo
+            echo "Check the logs above for error details."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  push-update-android:
+    name: Push EAS Update (Android)
+    runs-on: ubuntu-latest
+    environment: ${{ needs.prepare.outputs.github_environment }}
+    needs:
+      - fingerprint-comparison
+      - approval
+      - validate-pr
+      - setup-dependencies
+      - prepare
+    if: >
+      needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
+      needs.approval.result == 'success' &&
+      (inputs.platform == 'all' || inputs.platform == 'android')
+    env:
+      # OTA-specific vars only — build config + secrets come from builds.yml via steps below
+      TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
+      ARTIFACT_NAME: ${{ needs.setup-dependencies.outputs.artifact-name }}
+      EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
+      UPDATE_MESSAGE: ${{ inputs.message }}
+      TARGET_CHANNEL: ${{ inputs.channel }}
+      OTA_PUSH_PLATFORM: android
+      GIT_BRANCH: ${{ github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_COMMIT_HASH }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Validate artifact compatibility
+        uses: ./.github/actions/validate-artifact-compatibility
+        with:
+          artifact-name: ${{ env.ARTIFACT_NAME }}
+          artifact-prefix: node-modules-eas-update-pr
+          validation-context: artifact
+
+      - name: Download node_modules artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+
+      - name: Restore executable permissions
+        uses: ./.github/actions/restore-node-modules-permissions
+
+      - name: Verify downloaded artifacts
+        run: |
+          echo "✅ Verifying downloaded artifacts..."
+          if [ ! -d "node_modules" ]; then
+            echo "❌ node_modules directory not found"
+            exit 1
+          fi
+          if [ ! -f "app/core/InpageBridgeWeb3.js" ]; then
+            echo "❌ InpageBridgeWeb3.js not found in artifact"
+            exit 1
+          fi
+          echo "📦 node_modules size: $(du -sh node_modules | cut -f1)"
+          echo "✅ Artifacts verified"
+
+      - name: Apply build config from builds.yml
+        run: |
+          BUILD_NAME="${{ needs.prepare.outputs.build_name }}"
+          echo "📦 Applying build config for: $BUILD_NAME"
+          eval "$(node scripts/apply-build-config.js "$BUILD_NAME" --export)"
+          node scripts/apply-build-config.js "$BUILD_NAME" --export-github-env >> "$GITHUB_ENV"
+
+      - name: Set secrets from builds.yml mapping
+        env:
+          CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: node scripts/set-secrets-from-config.js
+
+      - name: Determine signing secret name
+        shell: bash
+        env:
+          TARGET: ${{ inputs.channel }}
+        run: |
+          case "$TARGET" in
+            exp)
+              SECRET_NAME="metamask-exp-expo-signer"
+              ;;
+            rc)
+              SECRET_NAME="metamask-rc-expo-signer"
+              ;;
+            production)
+              SECRET_NAME="metamask-prod-expo-signer"
+              ;;
+            *)
+              echo "❌ Unknown target: $TARGET"
+              exit 1
+              ;;
+          esac
+          echo "AWS_SIGNING_CERT_SECRET_NAME=$SECRET_NAME" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: 'us-east-2'
+
+      - name: Fetch secret and export as environment variables
+        shell: bash
+        run: |
+          echo "🔐 Fetching secret from Secrets Manager..."
+          secret_json=$(aws secretsmanager get-secret-value \
+            --region 'us-east-2' \
+            --secret-id "${AWS_SIGNING_CERT_SECRET_NAME}" \
+            --query SecretString \
+            --output text)
+
+          keys=$(echo "$secret_json" | jq -r 'keys[]')
+          for key in $keys; do
+            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k]')
+            echo "::add-mask::$value"
+            echo "$key=$(printf '%s' "$value")" >> "$GITHUB_ENV"
+            echo "✅ Set secret for key: $key"
+          done
+
+      - name: Display configuration
+        run: |
+          TARGET_RUNTIME_VERSION=$(node -p "require('./package.json').version")
+          echo "🔧 Configuration:"
+          echo "  Build: ${{ needs.prepare.outputs.build_name }}"
+          echo "  Channel: ${EXPO_CHANNEL:-<not set>}"
+          echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
+          echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
+          echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
+
+      - name: Build & Push EAS Update via build.sh
+        env:
+          SKIP_TRANSFORM_LINT: 'true'
+          NODE_OPTIONS: '--max_old_space_size=8192'
+        run: |
+          echo "📦 Configuring EXPO key..."
+          if [[ -z "$EXPO_KEY_PRIV_B64" ]]; then
+            echo "⚠️ EXPO_KEY_PRIV_B64 is not set. Skipping keystore decoding."
+            exit 1
+          fi
+
+          # Decode the key
+          EXPO_KEY_PRIV=$(echo "$EXPO_KEY_PRIV_B64" | base64 --decode)
+          export EXPO_KEY_PRIV
+          echo "✅ Expo key decoded and exported"
+
+          echo "🚀 Pushing EAS update for channel: ${TARGET_CHANNEL}"
+          case "${TARGET_CHANNEL}" in
+            exp)
+              yarn run build:expo-update:main:exp
+              ;;
+            rc)
+              yarn run build:expo-update:main:rc
+              ;;
+            production)
+              yarn run build:expo-update:main:prod
+              ;;
+            *)
+              echo "❌ Unsupported TARGET_CHANNEL: ${TARGET_CHANNEL}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Update summary
+        if: success()
+        run: |
+          {
+            echo "### ✅ EAS Update Published Successfully (Android)"
+            echo
+            echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
+            echo "**Message:** ${UPDATE_MESSAGE:-<not set>}"
+            echo
+            echo "Android users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update summary on failure
+        if: failure()
+        run: |
+          {
+            echo "### ❌ EAS Update Failed (Android)"
             echo
             echo "Check the logs above for error details."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -334,8 +334,6 @@ jobs:
 
   push-update-ios:
     name: Push EAS Update (iOS)
-    runs-on: ubuntu-latest
-    environment: ${{ needs.prepare.outputs.github_environment }}
     needs:
       - fingerprint-comparison
       - approval
@@ -346,183 +344,20 @@ jobs:
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
       needs.approval.result == 'success' &&
       (inputs.platform == 'all' || inputs.platform == 'ios')
-    env:
-      # OTA-specific vars only — build config + secrets come from builds.yml via steps below
-      TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
-      ARTIFACT_NAME: ${{ needs.setup-dependencies.outputs.artifact-name }}
-      EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
-      UPDATE_MESSAGE: ${{ inputs.message }}
-      TARGET_CHANNEL: ${{ inputs.channel }}
-      OTA_PUSH_PLATFORM: ios
-      GIT_BRANCH: ${{ github.ref_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.TARGET_COMMIT_HASH }}
-          fetch-depth: 1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Validate artifact compatibility
-        uses: ./.github/actions/validate-artifact-compatibility
-        with:
-          artifact-name: ${{ env.ARTIFACT_NAME }}
-          artifact-prefix: node-modules-eas-update-pr
-          validation-context: artifact
-
-      - name: Download node_modules artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-
-      - name: Restore executable permissions
-        uses: ./.github/actions/restore-node-modules-permissions
-
-      - name: Verify downloaded artifacts
-        run: |
-          echo "✅ Verifying downloaded artifacts..."
-          if [ ! -d "node_modules" ]; then
-            echo "❌ node_modules directory not found"
-            exit 1
-          fi
-          if [ ! -f "app/core/InpageBridgeWeb3.js" ]; then
-            echo "❌ InpageBridgeWeb3.js not found in artifact"
-            exit 1
-          fi
-          echo "📦 node_modules size: $(du -sh node_modules | cut -f1)"
-          echo "✅ Artifacts verified"
-
-      - name: Apply build config from builds.yml
-        run: |
-          BUILD_NAME="${{ needs.prepare.outputs.build_name }}"
-          echo "📦 Applying build config for: $BUILD_NAME"
-          eval "$(node scripts/apply-build-config.js "$BUILD_NAME" --export)"
-          node scripts/apply-build-config.js "$BUILD_NAME" --export-github-env >> "$GITHUB_ENV"
-
-      - name: Set secrets from builds.yml mapping
-        env:
-          CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-        run: node scripts/set-secrets-from-config.js
-
-      - name: Determine signing secret name
-        shell: bash
-        env:
-          TARGET: ${{ inputs.channel }}
-        run: |
-          case "$TARGET" in
-            exp)
-              SECRET_NAME="metamask-exp-expo-signer"
-              ;;
-            rc)
-              SECRET_NAME="metamask-rc-expo-signer"
-              ;;
-            production)
-              SECRET_NAME="metamask-prod-expo-signer"
-              ;;
-            *)
-              echo "❌ Unknown target: $TARGET"
-              exit 1
-              ;;
-          esac
-          echo "AWS_SIGNING_CERT_SECRET_NAME=$SECRET_NAME" >> "$GITHUB_ENV"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: 'us-east-2'
-
-      - name: Fetch secret and export as environment variables
-        shell: bash
-        run: |
-          echo "🔐 Fetching secret from Secrets Manager..."
-          secret_json=$(aws secretsmanager get-secret-value \
-            --region 'us-east-2' \
-            --secret-id "${AWS_SIGNING_CERT_SECRET_NAME}" \
-            --query SecretString \
-            --output text)
-
-          keys=$(echo "$secret_json" | jq -r 'keys[]')
-          for key in $keys; do
-            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k]')
-            echo "::add-mask::$value"
-            echo "$key=$(printf '%s' "$value")" >> "$GITHUB_ENV"
-            echo "✅ Set secret for key: $key"
-          done
-
-      - name: Display configuration
-        run: |
-          TARGET_RUNTIME_VERSION=$(node -p "require('./package.json').version")
-          echo "🔧 Configuration:"
-          echo "  Build: ${{ needs.prepare.outputs.build_name }}"
-          echo "  Channel: ${EXPO_CHANNEL:-<not set>}"
-          echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
-          echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
-          echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
-
-      - name: Build & Push EAS Update via build.sh
-        env:
-          SKIP_TRANSFORM_LINT: 'true'
-          NODE_OPTIONS: '--max_old_space_size=8192'
-        run: |
-          echo "📦 Configuring EXPO key..."
-          if [[ -z "$EXPO_KEY_PRIV_B64" ]]; then
-            echo "⚠️ EXPO_KEY_PRIV_B64 is not set. Skipping keystore decoding."
-            exit 1
-          fi
-
-          # Decode the key
-          EXPO_KEY_PRIV=$(echo "$EXPO_KEY_PRIV_B64" | base64 --decode)
-          export EXPO_KEY_PRIV
-          echo "✅ Expo key decoded and exported"
-
-          echo "🚀 Pushing EAS update for channel: ${TARGET_CHANNEL}"
-          case "${TARGET_CHANNEL}" in
-            exp)
-              yarn run build:expo-update:main:exp
-              ;;
-            rc)
-              yarn run build:expo-update:main:rc
-              ;;
-            production)
-              yarn run build:expo-update:main:prod
-              ;;
-            *)
-              echo "❌ Unsupported TARGET_CHANNEL: ${TARGET_CHANNEL}" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Update summary
-        if: success()
-        run: |
-          {
-            echo "### ✅ EAS Update Published Successfully (iOS)"
-            echo
-            echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
-            echo "**Message:** ${UPDATE_MESSAGE:-<not set>}"
-            echo
-            echo "iOS users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update summary on failure
-        if: failure()
-        run: |
-          {
-            echo "### ❌ EAS Update Failed (iOS)"
-            echo
-            echo "Check the logs above for error details."
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/eas-update-platform.yml
+    with:
+      platform: ios
+      commit_sha: ${{ needs.validate-pr.outputs.commit_sha }}
+      artifact_name: ${{ needs.setup-dependencies.outputs.artifact-name }}
+      channel: ${{ inputs.channel }}
+      message: ${{ inputs.message }}
+      build_name: ${{ needs.prepare.outputs.build_name }}
+      github_environment: ${{ needs.prepare.outputs.github_environment }}
+      secrets_json: ${{ needs.prepare.outputs.secrets_json }}
+    secrets: inherit
 
   push-update-android:
     name: Push EAS Update (Android)
-    runs-on: ubuntu-latest
-    environment: ${{ needs.prepare.outputs.github_environment }}
     needs:
       - fingerprint-comparison
       - approval
@@ -533,178 +368,17 @@ jobs:
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
       needs.approval.result == 'success' &&
       (inputs.platform == 'all' || inputs.platform == 'android')
-    env:
-      # OTA-specific vars only — build config + secrets come from builds.yml via steps below
-      TARGET_COMMIT_HASH: ${{ needs.validate-pr.outputs.commit_sha }}
-      ARTIFACT_NAME: ${{ needs.setup-dependencies.outputs.artifact-name }}
-      EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
-      UPDATE_MESSAGE: ${{ inputs.message }}
-      TARGET_CHANNEL: ${{ inputs.channel }}
-      OTA_PUSH_PLATFORM: android
-      GIT_BRANCH: ${{ github.ref_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.TARGET_COMMIT_HASH }}
-          fetch-depth: 1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Validate artifact compatibility
-        uses: ./.github/actions/validate-artifact-compatibility
-        with:
-          artifact-name: ${{ env.ARTIFACT_NAME }}
-          artifact-prefix: node-modules-eas-update-pr
-          validation-context: artifact
-
-      - name: Download node_modules artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-
-      - name: Restore executable permissions
-        uses: ./.github/actions/restore-node-modules-permissions
-
-      - name: Verify downloaded artifacts
-        run: |
-          echo "✅ Verifying downloaded artifacts..."
-          if [ ! -d "node_modules" ]; then
-            echo "❌ node_modules directory not found"
-            exit 1
-          fi
-          if [ ! -f "app/core/InpageBridgeWeb3.js" ]; then
-            echo "❌ InpageBridgeWeb3.js not found in artifact"
-            exit 1
-          fi
-          echo "📦 node_modules size: $(du -sh node_modules | cut -f1)"
-          echo "✅ Artifacts verified"
-
-      - name: Apply build config from builds.yml
-        run: |
-          BUILD_NAME="${{ needs.prepare.outputs.build_name }}"
-          echo "📦 Applying build config for: $BUILD_NAME"
-          eval "$(node scripts/apply-build-config.js "$BUILD_NAME" --export)"
-          node scripts/apply-build-config.js "$BUILD_NAME" --export-github-env >> "$GITHUB_ENV"
-
-      - name: Set secrets from builds.yml mapping
-        env:
-          CONFIG_SECRETS: ${{ needs.prepare.outputs.secrets_json }}
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-        run: node scripts/set-secrets-from-config.js
-
-      - name: Determine signing secret name
-        shell: bash
-        env:
-          TARGET: ${{ inputs.channel }}
-        run: |
-          case "$TARGET" in
-            exp)
-              SECRET_NAME="metamask-exp-expo-signer"
-              ;;
-            rc)
-              SECRET_NAME="metamask-rc-expo-signer"
-              ;;
-            production)
-              SECRET_NAME="metamask-prod-expo-signer"
-              ;;
-            *)
-              echo "❌ Unknown target: $TARGET"
-              exit 1
-              ;;
-          esac
-          echo "AWS_SIGNING_CERT_SECRET_NAME=$SECRET_NAME" >> "$GITHUB_ENV"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: 'us-east-2'
-
-      - name: Fetch secret and export as environment variables
-        shell: bash
-        run: |
-          echo "🔐 Fetching secret from Secrets Manager..."
-          secret_json=$(aws secretsmanager get-secret-value \
-            --region 'us-east-2' \
-            --secret-id "${AWS_SIGNING_CERT_SECRET_NAME}" \
-            --query SecretString \
-            --output text)
-
-          keys=$(echo "$secret_json" | jq -r 'keys[]')
-          for key in $keys; do
-            value=$(echo "$secret_json" | jq -r --arg k "$key" '.[$k]')
-            echo "::add-mask::$value"
-            echo "$key=$(printf '%s' "$value")" >> "$GITHUB_ENV"
-            echo "✅ Set secret for key: $key"
-          done
-
-      - name: Display configuration
-        run: |
-          TARGET_RUNTIME_VERSION=$(node -p "require('./package.json').version")
-          echo "🔧 Configuration:"
-          echo "  Build: ${{ needs.prepare.outputs.build_name }}"
-          echo "  Channel: ${EXPO_CHANNEL:-<not set>}"
-          echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
-          echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
-          echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
-
-      - name: Build & Push EAS Update via build.sh
-        env:
-          SKIP_TRANSFORM_LINT: 'true'
-          NODE_OPTIONS: '--max_old_space_size=8192'
-        run: |
-          echo "📦 Configuring EXPO key..."
-          if [[ -z "$EXPO_KEY_PRIV_B64" ]]; then
-            echo "⚠️ EXPO_KEY_PRIV_B64 is not set. Skipping keystore decoding."
-            exit 1
-          fi
-
-          # Decode the key
-          EXPO_KEY_PRIV=$(echo "$EXPO_KEY_PRIV_B64" | base64 --decode)
-          export EXPO_KEY_PRIV
-          echo "✅ Expo key decoded and exported"
-
-          echo "🚀 Pushing EAS update for channel: ${TARGET_CHANNEL}"
-          case "${TARGET_CHANNEL}" in
-            exp)
-              yarn run build:expo-update:main:exp
-              ;;
-            rc)
-              yarn run build:expo-update:main:rc
-              ;;
-            production)
-              yarn run build:expo-update:main:prod
-              ;;
-            *)
-              echo "❌ Unsupported TARGET_CHANNEL: ${TARGET_CHANNEL}" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Update summary
-        if: success()
-        run: |
-          {
-            echo "### ✅ EAS Update Published Successfully (Android)"
-            echo
-            echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
-            echo "**Message:** ${UPDATE_MESSAGE:-<not set>}"
-            echo
-            echo "Android users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update summary on failure
-        if: failure()
-        run: |
-          {
-            echo "### ❌ EAS Update Failed (Android)"
-            echo
-            echo "Check the logs above for error details."
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/eas-update-platform.yml
+    with:
+      platform: android
+      commit_sha: ${{ needs.validate-pr.outputs.commit_sha }}
+      artifact_name: ${{ needs.setup-dependencies.outputs.artifact-name }}
+      channel: ${{ inputs.channel }}
+      message: ${{ inputs.message }}
+      build_name: ${{ needs.prepare.outputs.build_name }}
+      github_environment: ${{ needs.prepare.outputs.github_environment }}
+      secrets_json: ${{ needs.prepare.outputs.secrets_json }}
+    secrets: inherit
 
   fingerprint-mismatch:
     name: Fingerprint Mismatch Guard


### PR DESCRIPTION
## **Description**

Splits the `push-eas-update` job into two parallel jobs, one per platform (iOS and Android), running on separate runners. This avoids LavaMoat serializer contention and mitigates intermittent OTA deployment failures caused by a [known GitHub Actions runner issue](https://github.com/actions/runner/issues/3819#issuecomment-3729711355).

The shared EAS update steps have been extracted into a reusable workflow.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

| Run | Platform | Result |
|-----|----------|--------|
| [iOS dry-run](https://github.com/MetaMask/metamask-mobile/actions/runs/26117723683/job/76811308433) | iOS | ✅ Passed — cancelled before EAS upload |
| [Android test](https://github.com/MetaMask/metamask-mobile/actions/runs/26119164078) | Android | ✅ Passed |
| [Both platforms in parallel](https://github.com/MetaMask/metamask-mobile/actions/runs/26120507757) | iOS + Android | ✅ Both passed |

## **Before/After**

### **Before**
Single `push-update` job — iOS bundled first, then Android sequentially on the same runner.

### **After**
Two parallel jobs (`push-update-ios`, `push-update-android`) running simultaneously on isolated runners, visible as side-by-side nodes in the Actions run graph. Verified via dry-run dispatch targeting `exp` channel.