### PR TITLE
chore: Remove PR_TOKEN from build workflows

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PR_TOKEN || github.token }}
+          token: ${{ github.token }}
       - name: Delete temporary build branch
         env:
           BRANCH: ${{ needs.prepare-build-branch.outputs.build_branch }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PR_TOKEN || github.token }}
+          token: ${{ github.token }}
       - name: Delete temporary build branch
         env:
           BRANCH: ${{ needs.prepare-build-branch.outputs.build_branch }}

--- a/.github/workflows/create-build-branch.yml
+++ b/.github/workflows/create-build-branch.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.source_branch }}
-          token: ${{ secrets.PR_TOKEN || github.token }}
+          token: ${{ github.token }}
       - name: Create temporary build branch
         id: create-branch
         env:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PR_TOKEN || github.token }}
+          token: ${{ github.token }}
       - name: Delete ephemeral branches
         env:
           EXP_BRANCH: ${{ needs.android-exp-branch.outputs.build_branch }}

--- a/.github/workflows/update-latest-build-version.yml
+++ b/.github/workflows/update-latest-build-version.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.base-branch }}
-          token: ${{ secrets.PR_TOKEN || github.token }}
+          token: ${{ github.token }}
       - name: Bump build version
         id: bump-build-version
         shell: bash

--- a/.github/workflows/update-latest-build-version.yml
+++ b/.github/workflows/update-latest-build-version.yml
@@ -23,7 +23,7 @@ on:
     secrets:
       PR_TOKEN:
         description: 'GitHub token for checkout and push operations.'
-        required: true
+        required: false
     outputs:
       build-version:
         description: 'Generated build version number'
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.base-branch }}
-          token: ${{ github.token }}
+          token: ${{ secrets.PR_TOKEN || github.token }}
       - name: Bump build version
         id: bump-build-version
         shell: bash


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Since PR_TOKEN is rolled by Patroll every 30 mins, the team has been encountering step failures especially post token roll. This PR removes PR_TOKEN from workflows that do not need it, stabilizing workflows such as Nightly builds and uploading build to testflight. We'll rely on github.token instead for branch checkout + deletion steps.

Example failures-
- Nightly builds - https://github.com/MetaMask/metamask-mobile/actions/runs/26015385923/usage
- Build and upload to TestFlight -  https://github.com/MetaMask/metamask-mobile/actions/runs/26098154929
- [Patroll](https://github.com/MetaMask/patroll) rolls PR_TOKEN every 30 min, which can make the old token stale especially if workflows are taking longer than 30 mins

@Cal-L - Once this PR is merged into main, we'll verify that the workflows do not need PR_TOKEN and further remove PR_TOKEN dependencies as needed

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-613

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes authentication/permissions used by CI workflows that create and delete ephemeral build branches, which could break nightly/TestFlight pipelines if `github.token` lacks required access in some contexts.
> 
> **Overview**
> Removes reliance on the rotating `PR_TOKEN` in build-related GitHub Actions by switching checkouts in branch-creation and cleanup jobs to use `github.token` instead.
> 
> Also makes the `PR_TOKEN` secret optional in `update-latest-build-version.yml` (while still falling back to `github.token` for checkout/push), reducing required secret wiring for callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7d7a175296d6c3e73d7c86fb2420634dda5ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->