### PR TITLE
fix: add BTC swap reserve enforcement with quote-aware fee handling

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -286,6 +286,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     token: sourceToken,
     latestAtomicBalance: latestSourceBalance?.atomicBalance,
     walletAddress,
+    activeQuote,
   });
 
   const isGasFeesSponsoredNetworkEnabled = useSelector(

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -79,17 +79,6 @@ export const SwapsConfirmButton = ({
     latestAtomicBalance: latestSourceBalance?.atomicBalance,
   });
 
-  const insufficientNativeReserveError = useInsufficientNativeReserveError({
-    amount: sourceAmount,
-    token: sourceToken,
-    latestAtomicBalance: latestSourceBalance?.atomicBalance,
-    walletAddress,
-  });
-
-  const hasInsufficientNativeReserveError = Boolean(
-    insufficientNativeReserveError,
-  );
-
   const {
     activeQuote,
     isLoading,
@@ -99,6 +88,18 @@ export const SwapsConfirmButton = ({
     isNoQuotesAvailable,
     isActiveQuoteForCurrentTokenPair,
   } = useBridgeQuoteDataContext();
+
+  const insufficientNativeReserveError = useInsufficientNativeReserveError({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceBalance?.atomicBalance,
+    walletAddress,
+    activeQuote,
+  });
+
+  const hasInsufficientNativeReserveError = Boolean(
+    insufficientNativeReserveError,
+  );
 
   const handleConfirm = useBridgeConfirm({
     activeQuote,

--- a/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
@@ -1,9 +1,14 @@
 import {
+  ChainId,
+  formatChainIdToCaip,
   formatChainIdToHex,
+  isBitcoinChainId,
   isNativeAddress,
   isNonEvmChainId,
+  type QuoteMetadata,
+  type QuoteResponse,
 } from '@metamask/bridge-controller';
-import { Hex } from '@metamask/utils';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import { BridgeToken } from '../../types';
 import { useSelector } from 'react-redux';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
@@ -12,21 +17,45 @@ import { BigNumber as BigNumberJS } from 'bignumber.js';
 import { formatUnits, parseUnits } from 'ethers/lib/utils';
 import { isHardwareAccount } from '../../../../../util/address';
 
-const MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN: { [key: Hex]: string } = {
+type ChainIdWithNativeReserve = Hex | CaipChainId;
+type ActiveQuote = (QuoteResponse & QuoteMetadata) | null | undefined;
+
+const BTC_MAINNET_CHAIN_ID = formatChainIdToCaip(ChainId.BTC);
+
+const MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN: {
+  [key in ChainIdWithNativeReserve]?: string;
+} = {
   '0x8f': '10',
+  [BTC_MAINNET_CHAIN_ID]: '0.00003',
 };
 
 const getMinimumReserveBalanceForTokenChainAndAddress = ({
-  chainIdHex,
+  chainId,
   tokenAddress,
 }: {
-  chainIdHex: Hex;
-  tokenAddress: Hex;
+  chainId: ChainIdWithNativeReserve;
+  tokenAddress: string;
 }): string => {
   if (!tokenAddress || !isNativeAddress(tokenAddress)) {
     return '0';
   }
-  return MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN[chainIdHex] ?? '0';
+  return MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN[chainId] ?? '0';
+};
+
+const toBaseUnitBigNumber = (value: string, decimals: number) => {
+  const decimalValue = BigNumberJS(value);
+  if (!decimalValue.isFinite()) {
+    return undefined;
+  }
+
+  const fixedValue = decimalValue.toFixed();
+  const decimalIndex = fixedValue.indexOf('.');
+  const tokenDecimalValue =
+    decimalIndex === -1
+      ? fixedValue
+      : fixedValue.slice(0, decimalIndex + 1 + decimals);
+
+  return BigNumberJS(parseUnits(tokenDecimalValue, decimals).toString());
 };
 
 interface UseInsufficientNativeReserveErrorParams {
@@ -34,20 +63,26 @@ interface UseInsufficientNativeReserveErrorParams {
   token?: BridgeToken;
   latestAtomicBalance?: BigNumber;
   walletAddress?: string;
+  activeQuote?: ActiveQuote;
 }
 
 /**
- * Initially for gas-sponsored networks with a native reserve balance
- * logic, such as for Monad that needs 10 MON at all times.
+ * For networks with a native reserve balance requirement:
+ * - gas-sponsored EVM networks, such as Monad which needs 10 MON at all times
+ * - BTC mainnet swaps, which keep a buffer for network fees
  */
 export const useInsufficientNativeReserveError = ({
   amount,
   token,
   latestAtomicBalance,
   walletAddress,
+  activeQuote,
 }: UseInsufficientNativeReserveErrorParams) => {
   const isGasFeesSponsoredNetworkEnabled = useSelector(
     getGasFeesSponsoredNetworkEnabled,
+  );
+  const isBitcoinReserveChain = Boolean(
+    token?.chainId && isBitcoinChainId(token.chainId),
   );
 
   if (
@@ -56,8 +91,13 @@ export const useInsufficientNativeReserveError = ({
     !token?.chainId ||
     !latestAtomicBalance ||
     !walletAddress ||
-    isNonEvmChainId(token.chainId)
+    (isNonEvmChainId(token.chainId) && !isBitcoinReserveChain)
   ) {
+    return undefined;
+  }
+
+  const inputAmount = BigNumberJS(amount);
+  if (!inputAmount.isFinite()) {
     return undefined;
   }
 
@@ -65,27 +105,80 @@ export const useInsufficientNativeReserveError = ({
     walletAddress && isHardwareAccount(walletAddress),
   );
 
-  const chainIdHex = formatChainIdToHex(token.chainId);
-  const isNetworkGasSponsored = isNonEvmChainId(token.chainId)
-    ? false
-    : !isHardwareWalletAccount && isGasFeesSponsoredNetworkEnabled(chainIdHex);
+  const chainIdWithNativeReserve = isNonEvmChainId(token.chainId)
+    ? token.chainId
+    : formatChainIdToHex(token.chainId);
+  const chainIdHex = isNonEvmChainId(token.chainId)
+    ? undefined
+    : formatChainIdToHex(token.chainId);
+  const isNetworkGasSponsored = Boolean(
+    chainIdHex &&
+      !isHardwareWalletAccount &&
+      isGasFeesSponsoredNetworkEnabled(chainIdHex),
+  );
 
-  const minimumNativeBalanceToBeKeptInAccount = isNetworkGasSponsored
-    ? getMinimumReserveBalanceForTokenChainAndAddress({
-        chainIdHex,
-        tokenAddress: token.address as Hex,
-      })
-    : '0';
+  const minimumNativeBalanceToBeKeptInAccount =
+    isNetworkGasSponsored || isBitcoinReserveChain
+      ? getMinimumReserveBalanceForTokenChainAndAddress({
+          chainId: chainIdWithNativeReserve,
+          tokenAddress: token.address,
+        })
+      : '0';
 
-  const maxSwappableNativeBalanceBaseUnits = BigNumberJS.max(
-    new BigNumberJS(latestAtomicBalance.toString() ?? '0').minus(
-      BigNumberJS(
-        parseUnits(
+  const minimumNativeBalanceToBeKeptInAccountBaseUnits =
+    minimumNativeBalanceToBeKeptInAccount !== '0'
+      ? toBaseUnitBigNumber(
           minimumNativeBalanceToBeKeptInAccount,
           token.decimals,
-        ).toString(),
-      ),
-    ),
+        )
+      : BigNumberJS(0);
+
+  if (!minimumNativeBalanceToBeKeptInAccountBaseUnits) {
+    return undefined;
+  }
+
+  let btcQuoteNetworkFeeBaseUnits = BigNumberJS(0);
+  let btcQuoteSourceOverheadBaseUnits = BigNumberJS(0);
+  if (isBitcoinReserveChain && activeQuote) {
+    const networkFeeAmount = activeQuote.totalNetworkFee?.amount;
+    const sentAmount = activeQuote.sentAmount?.amount;
+    const networkFeeBaseUnits = networkFeeAmount
+      ? toBaseUnitBigNumber(networkFeeAmount, token.decimals)
+      : undefined;
+    const sentAmountBaseUnits = sentAmount
+      ? toBaseUnitBigNumber(sentAmount, token.decimals)
+      : undefined;
+    const inputAmountBaseUnits = toBaseUnitBigNumber(amount, token.decimals);
+
+    if (
+      !networkFeeBaseUnits ||
+      !sentAmountBaseUnits ||
+      !inputAmountBaseUnits ||
+      networkFeeBaseUnits.lte(0)
+    ) {
+      return undefined;
+    }
+
+    if (
+      networkFeeBaseUnits
+        .plus(sentAmountBaseUnits)
+        .gte(BigNumberJS(latestAtomicBalance.toString()))
+    ) {
+      return undefined;
+    }
+
+    btcQuoteNetworkFeeBaseUnits = networkFeeBaseUnits;
+    btcQuoteSourceOverheadBaseUnits = BigNumberJS.max(
+      sentAmountBaseUnits.minus(inputAmountBaseUnits),
+      0,
+    );
+  }
+
+  const maxSwappableNativeBalanceBaseUnits = BigNumberJS.max(
+    new BigNumberJS(latestAtomicBalance.toString() ?? '0')
+      .minus(minimumNativeBalanceToBeKeptInAccountBaseUnits)
+      .minus(btcQuoteNetworkFeeBaseUnits)
+      .minus(btcQuoteSourceOverheadBaseUnits),
     0,
   );
 
@@ -94,7 +187,7 @@ export const useInsufficientNativeReserveError = ({
   );
 
   return minimumNativeBalanceToBeKeptInAccount !== '0' &&
-    maxSwappableNativeBalance.lt(amount)
+    maxSwappableNativeBalance.lt(inputAmount)
     ? {
         minimumNativeBalanceToBeKeptInAccount,
         maxSwappableNativeBalance: maxSwappableNativeBalance.toString(),

--- a/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
@@ -17,13 +17,13 @@ import { BigNumber as BigNumberJS } from 'bignumber.js';
 import { formatUnits, parseUnits } from 'ethers/lib/utils';
 import { isHardwareAccount } from '../../../../../util/address';
 
-type ChainIdWithNativeReserve = Hex | CaipChainId;
+type ChainIdHexOrCaip = Hex | CaipChainId;
 type ActiveQuote = (QuoteResponse & QuoteMetadata) | null | undefined;
 
 const BTC_MAINNET_CHAIN_ID = formatChainIdToCaip(ChainId.BTC);
 
 const MINIMUM_NATIVE_RESERVE_BALANCE_PER_CHAIN: {
-  [key in ChainIdWithNativeReserve]?: string;
+  [key in ChainIdHexOrCaip]?: string;
 } = {
   '0x8f': '10',
   [BTC_MAINNET_CHAIN_ID]: '0.00003',
@@ -33,7 +33,7 @@ const getMinimumReserveBalanceForTokenChainAndAddress = ({
   chainId,
   tokenAddress,
 }: {
-  chainId: ChainIdWithNativeReserve;
+  chainId: ChainIdHexOrCaip;
   tokenAddress: string;
 }): string => {
   if (!tokenAddress || !isNativeAddress(tokenAddress)) {

--- a/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/index.ts
@@ -48,12 +48,9 @@ const toBaseUnitBigNumber = (value: string, decimals: number) => {
     return undefined;
   }
 
-  const fixedValue = decimalValue.toFixed();
-  const decimalIndex = fixedValue.indexOf('.');
-  const tokenDecimalValue =
-    decimalIndex === -1
-      ? fixedValue
-      : fixedValue.slice(0, decimalIndex + 1 + decimals);
+  const tokenDecimalValue = decimalValue
+    .decimalPlaces(decimals, BigNumberJS.ROUND_DOWN)
+    .toFixed();
 
   return BigNumberJS(parseUnits(tokenDecimalValue, decimals).toString());
 };

--- a/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/useInsufficientNativeReserveError.test.tsx
+++ b/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/useInsufficientNativeReserveError.test.tsx
@@ -6,10 +6,16 @@ import { legacy_createStore as createStore, Store } from 'redux';
 import { BridgeToken } from '../../types';
 import { BigNumber } from 'ethers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  ChainId,
+  type QuoteMetadata,
+  type QuoteResponse,
+} from '@metamask/bridge-controller';
 import { initialState } from '../../_mocks_/initialState';
 import { useInsufficientNativeReserveError } from './index';
 import { ZERO_ADDRESS } from '../../../../Views/confirmations/constants/address';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
+import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 
 jest.mock('../../../../../selectors/featureFlagController/gasFeesSponsored');
 jest.mock('../../../../../util/address', () => ({
@@ -58,18 +64,19 @@ const ethTokenOnMainnet: BridgeToken = {
   chainId: CHAIN_IDS.MAINNET as `0x${string}`,
 };
 
+const btcTokenOnBitcoin: BridgeToken = {
+  address: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  symbol: 'BTC',
+  decimals: 8,
+  chainId: 'bip122:000000000019d6689c085ae165831e93',
+};
+
 const nonEvmNativeTokens: BridgeToken[] = [
   {
     address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
     symbol: 'SOL',
     decimals: 9,
     chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-  },
-  {
-    address: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
-    symbol: 'BTC',
-    decimals: 8,
-    chainId: 'bip122:000000000019d6689c085ae165831e93',
   },
   {
     address: 'tron:728126428/slip44:195',
@@ -87,6 +94,29 @@ function renderHookWithWrapper<
 >(callback: RenderHookCallback<TProps, TResult>) {
   return renderHook(callback, { wrapper: wrapper(createMockStore()) });
 }
+
+const createBtcQuote = ({
+  networkFeeAmount = '0.00000001',
+  sentAmount = '0.99997',
+}: {
+  networkFeeAmount?: string;
+  sentAmount?: string;
+} = {}): QuoteResponse & QuoteMetadata =>
+  ({
+    ...mockQuoteWithMetadata,
+    quote: {
+      ...mockQuoteWithMetadata.quote,
+      srcChainId: ChainId.BTC,
+    },
+    sentAmount: {
+      ...mockQuoteWithMetadata.sentAmount,
+      amount: sentAmount,
+    },
+    totalNetworkFee: {
+      ...mockQuoteWithMetadata.totalNetworkFee,
+      amount: networkFeeAmount,
+    },
+  }) as QuoteResponse & QuoteMetadata;
 
 describe('useInsufficientNativeReserveError', () => {
   beforeEach(() => {
@@ -178,6 +208,92 @@ describe('useInsufficientNativeReserveError', () => {
         walletAddress: '0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8',
       }),
     );
+    expect(result.current).toStrictEqual(undefined);
+  });
+
+  it('returns a insufficientNativeReserveError when BTC amount goes beyond reserve', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.999995',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      maxSwappableNativeBalance: '0.99997',
+      minimumNativeBalanceToBeKeptInAccount: '0.00003',
+    });
+  });
+
+  it('returns insufficientNativeReserveError=undefined when BTC amount covers exactly the reserve', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.99997',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+      }),
+    );
+
+    expect(result.current).toStrictEqual(undefined);
+  });
+
+  it('returns a quote-aware insufficientNativeReserveError for BTC when quote fees consume the reserve', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.99997',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+        activeQuote: createBtcQuote({
+          networkFeeAmount: '0.00000001',
+          sentAmount: '0.99997',
+        }),
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      maxSwappableNativeBalance: '0.99996999',
+      minimumNativeBalanceToBeKeptInAccount: '0.00003',
+    });
+  });
+
+  it('includes BTC source-side quote overhead in the max swappable amount', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.99997',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+        activeQuote: createBtcQuote({
+          networkFeeAmount: '0.00000001',
+          sentAmount: '0.999971',
+        }),
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      maxSwappableNativeBalance: '0.99996899',
+      minimumNativeBalanceToBeKeptInAccount: '0.00003',
+    });
+  });
+
+  it('returns insufficientNativeReserveError=undefined for BTC when gas validation should own the failure', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.99997',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+        activeQuote: createBtcQuote({
+          networkFeeAmount: '0.000031',
+          sentAmount: '0.99997',
+        }),
+      }),
+    );
+
     expect(result.current).toStrictEqual(undefined);
   });
 

--- a/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/useInsufficientNativeReserveError.test.tsx
+++ b/app/components/UI/Bridge/hooks/useInsufficientNativeReserveError/useInsufficientNativeReserveError.test.tsx
@@ -260,6 +260,26 @@ describe('useInsufficientNativeReserveError', () => {
     });
   });
 
+  it('truncates BTC quote amounts to token decimals before parsing', () => {
+    const { result } = renderHookWithWrapper(() =>
+      useInsufficientNativeReserveError({
+        amount: '0.999970009',
+        token: btcTokenOnBitcoin,
+        latestAtomicBalance: BigNumber.from('100000000'), // 1 BTC
+        walletAddress: 'bc1q7m7cq86p5fnz29s3e0nl8g5ep3p5d4rz2f3duz',
+        activeQuote: createBtcQuote({
+          networkFeeAmount: '0.000000019',
+          sentAmount: '0.999970009',
+        }),
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      maxSwappableNativeBalance: '0.99996999',
+      minimumNativeBalanceToBeKeptInAccount: '0.00003',
+    });
+  });
+
   it('includes BTC source-side quote overhead in the max swappable amount', () => {
     const { result } = renderHookWithWrapper(() =>
       useInsufficientNativeReserveError({


### PR DESCRIPTION
## **Description**
This pull request enhances the `useInsufficientNativeReserveError` hook to support Bitcoin (BTC) native reserve logic, ensuring accurate handling of minimum reserve requirements and quote-aware calculations for BTC swaps. It also improves test coverage for these scenarios and refactors related code for better clarity and extensibility.

**BTC Native Reserve Support and Logic Improvements:**

* Added BTC mainnet support to the minimum native reserve calculation, introducing a specific reserve threshold for BTC and handling BTC chain IDs using CAIP format. The hook now accounts for BTC-specific requirements when determining if a swap would violate the minimum reserve.

**Testing Enhancements:**

* Added comprehensive test cases for BTC reserve logic, including scenarios for reserve breaches, quote-aware calculations, and edge cases where reserve or fees restrict swaps. Introduced BTC token and quote mocks for robust test coverage.

**Refactoring and Type Improvements:**

* Refactored types and utility functions to support both EVM and non-EVM (CAIP) chain IDs, improving maintainability and future extensibility.

**Integration Updates:**

* Updated `BridgeViewContent` and `SwapsConfirmButton` components to pass the `activeQuote` prop to the hook, enabling quote-aware reserve checks in the UI flow.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added BTC swap reserve enforcement with quote-aware fee handling

## **Related issues**

Fixes: Bridging BTC is failing at the transaction crafting in certain cases

## **Manual testing steps**

BTC max amount / reserve validation
1. Use a BTC account with a small balance.
2. Select BTC as source and ETH as destination.
3. Enter an amount that would leave less than 0.00003 BTC after the swap.
4. Confirm the warning banner says Minimum BTC reserve balance is required.
5. Confirm the message displays a reserve of 0.00003 BTC.
6. Confirm the CTA shows Insufficient funds.
7. Click Use max allowed.
8. Confirm the input is reduced to the max amount shown in the banner.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="400" height="800" alt="BTC-swap" src="https://github.com/user-attachments/assets/b0990cdc-d0a3-4903-a544-eed08bc60ac8" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates swap/bridge validation for BTC to enforce a minimum native reserve using quote-provided network fees/overhead, which can block transactions if miscomputed. Changes are localized and covered by new unit tests, but affect user-facing amount limits and submit eligibility.
> 
> **Overview**
> **Adds BTC native reserve enforcement to swap/bridge submit validation.** `useInsufficientNativeReserveError` now supports CAIP chain IDs, defines a BTC mainnet minimum reserve (`0.00003`), and for BTC uses `activeQuote` to subtract quoted network fees and source-side overhead when computing the max swappable amount.
> 
> **Integrates quote-aware checks in the UI flow.** `BridgeView` and `SwapsConfirmButton` now pass `activeQuote` into the hook so banners/CTAs and the confirm button correctly reflect BTC reserve + fee constraints.
> 
> **Expands test coverage.** Adds BTC-specific unit tests covering reserve boundary conditions, quote fee consumption, decimal truncation, and cases where gas validation should own the failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0093c0c0106683d74b1bb957cb273553cb3557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->