### PR TITLE
feat(Rewards): Use correct source tokens for Ondo swaps when coming from Rewards

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import OndoCampaignRwaSelectorView from './OndoCampaignRwaSelectorView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
@@ -142,12 +142,19 @@ jest.mock('../../../../core/Analytics', () => ({
 
 jest.mock('../utils/formatUtils', () => ({
   ...jest.requireActual('../utils/formatUtils'),
-  parseCaip19: jest.fn(() => ({
-    namespace: 'eip155',
-    chainId: '1',
-    assetReference: '0xabc',
-  })),
-  caipChainIdToHex: jest.fn(() => '0x1'),
+  parseCaip19: jest.fn((assetId: string) => {
+    const [chainId, assetPath] = assetId.split('/');
+    const [namespace, chainReference] = chainId.split(':');
+    const [, assetReference] = assetPath.split(':');
+    return {
+      namespace,
+      chainId: chainReference,
+      assetReference,
+    };
+  }),
+  caipChainIdToHex: jest.fn((caipChainId: string) =>
+    caipChainId === 'eip155:56' ? '0x38' : '0x1',
+  ),
 }));
 
 jest.mock(
@@ -470,22 +477,22 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
   });
 
-  describe('open_position mode — USDY source preselection', () => {
-    const USDY_HEX_ADDRESS = '0xabc';
+  describe('open_position mode — source token preselection', () => {
+    const USDY_ADDRESS = '0x96f6ef951840721adbf46ac996b59e0235cb985c';
     const ACCOUNT_ADDRESS = '0xaccount1';
 
     beforeEach(() => {
       mockRouteParams = { mode: 'open_position', campaignId: 'campaign-1' };
     });
 
-    it('passes USDY as source token when user holds a non-zero USDY balance', () => {
+    it('prefers USDY as the source token when user holds a non-zero USDY balance', () => {
       mockUseRwaTokens.mockReturnValue({
-        data: [buildToken('AAPL')],
+        data: [buildToken('AAPL', 'eip155:1/erc20:0xaapl')],
         isLoading: false,
       });
       mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
       mockAllTokenBalances = {
-        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
+        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_ADDRESS]: '0x64' } },
       };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
@@ -498,40 +505,39 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(destArg?.symbol).toBe('AAPL');
     });
 
-    it('passes undefined as source token when active group accounts are empty', () => {
+    it('falls back to USDC on mainnet as the source token for mainnet assets', () => {
       mockUseRwaTokens.mockReturnValue({
-        data: [buildToken('AAPL')],
+        data: [buildToken('AAPL', 'eip155:1/erc20:0xaapl')],
         isLoading: false,
       });
-      mockActiveGroupAccounts = [];
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
 
       expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-      const [srcArg] = mockGoToSwaps.mock.calls[0];
-      expect(srcArg).toBeUndefined();
+      const [srcArg, destArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg?.symbol).toBe('USDC');
+      expect(srcArg?.chainId).toBe('0x1');
+      expect(destArg?.symbol).toBe('AAPL');
     });
 
-    it('passes undefined as source token when USDY balance is zero', () => {
+    it('passes USDT on BNB Chain as the source token for BNB Chain assets', () => {
       mockUseRwaTokens.mockReturnValue({
-        data: [buildToken('AAPL')],
+        data: [buildToken('AAPL', 'eip155:56/erc20:0xaapl')],
         isLoading: false,
       });
-      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
-      mockAllTokenBalances = {
-        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x0' } },
-      };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
 
       expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
-      const [srcArg] = mockGoToSwaps.mock.calls[0];
-      expect(srcArg).toBeUndefined();
+      const [srcArg, destArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg?.symbol).toBe('USDT');
+      expect(srcArg?.chainId).toBe('0x38');
+      expect(destArg?.chainId).toBe('eip155:56');
     });
 
-    it('does not preset USDY as source in swap mode even when user holds balance', () => {
+    it('does not preset an open-position source in swap mode', () => {
       mockRouteParams = {
         mode: 'swap',
         campaignId: 'campaign-1',
@@ -543,10 +549,6 @@ describe('OndoCampaignRwaSelectorView', () => {
         data: [buildToken('AAPL')],
         isLoading: false,
       });
-      mockActiveGroupAccounts = [{ address: ACCOUNT_ADDRESS }];
-      mockAllTokenBalances = {
-        [ACCOUNT_ADDRESS]: { '0x1': { [USDY_HEX_ADDRESS]: '0x64' } },
-      };
 
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
@@ -580,7 +582,7 @@ describe('OndoCampaignRwaSelectorView', () => {
       const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
       fireEvent.press(getByTestId('token-row-AAPL'));
       expect(mockGoToSwaps).toHaveBeenCalledWith(
-        undefined,
+        expect.objectContaining({ symbol: 'USDC' }),
         expect.objectContaining({ name: 'Apple (Ondo Tokenized)' }),
       );
     });
@@ -709,6 +711,3 @@ describe('OndoCampaignRwaSelectorView', () => {
     });
   });
 });
-
-// keep the act import used in other test files from triggering "unused import" lint
-void act;

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -62,12 +62,34 @@ import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 
-// USDY (Ondo USD Yield) on Ethereum mainnet — used to preset the source token
-// for open_position mode. This is the only network where USDY is supported in
-// the RWA campaign feature.
+// USDY (Ondo USD Yield) on Ethereum mainnet — preferred source token for
+// open_position mode when the active account group holds a balance.
 const USDY_CAIP19 =
   'eip155:1/erc20:0x96f6ef951840721adbf46ac996b59e0235cb985c' as const;
 const USDY_DECIMALS = 18;
+
+const ONDO_OPEN_POSITION_SOURCE_TOKENS: Partial<
+  Record<CaipChainId, BridgeToken>
+> = {
+  'eip155:1': {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    chainId: '0x1',
+    image:
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+  },
+  'eip155:56': {
+    address: '0x55d398326f99059ff775485246999027b3197955',
+    symbol: 'USDT',
+    name: 'Tether USD',
+    decimals: 18,
+    chainId: '0x38',
+    image:
+      'https://static.cx.metamask.io/api/v1/tokenIcons/56/0x55d398326f99059ff775485246999027b3197955.png',
+  },
+};
 
 // ParamListBase requires an index signature, which interfaces don't support
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -213,10 +235,6 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
   );
   const allTokenBalances = useSelector(selectAllTokenBalances);
 
-  // In open_position mode, preset USDY as the source if the user holds a balance.
-  // Uses a hardcoded CAIP-19 so the preset is independent of the search state —
-  // rwaTokens is filtered by searchQuery and may not contain USDY when a user
-  // searches for another token (e.g. "AAPL").
   const ondoUsdSrcToken = useMemo((): BridgeToken | undefined => {
     if (mode !== 'open_position' || !activeGroupAccounts.length)
       return undefined;
@@ -275,15 +293,21 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
     (asset: TrendingAsset) => {
       const parsed = parseCaip19(asset.assetId);
       if (!parsed) return;
+      const destChainId =
+        `${parsed.namespace}:${parsed.chainId}` as CaipChainId;
       const destToken: BridgeToken = {
         address: parsed.assetReference,
         symbol: asset.symbol,
         name: asset.name,
         decimals: asset.decimals,
-        chainId: `${parsed.namespace}:${parsed.chainId}` as CaipChainId,
+        chainId: destChainId,
         image: getTrendingTokenImageUrl(asset.assetId),
         rwaData: asset.rwaData as BridgeToken['rwaData'],
       };
+      const openPositionSourceToken =
+        mode === 'open_position'
+          ? (ondoUsdSrcToken ?? ONDO_OPEN_POSITION_SOURCE_TOKENS[destChainId])
+          : undefined;
 
       if (!isTokenTradingOpen(destToken)) {
         const rawNextOpen = destToken.rwaData?.market?.nextOpen;
@@ -303,9 +327,10 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
           })
           .build(),
       );
-      goToSwaps(ondoUsdSrcToken, destToken);
+      goToSwaps(openPositionSourceToken, destToken);
     },
     [
+      mode,
       goToSwaps,
       isTokenTradingOpen,
       trackEvent,
@@ -454,6 +479,13 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
               setIsAfterHoursSheetOpen(false);
               setAfterHoursNextOpen(null);
               if (afterHoursPendingToken) {
+                const openPositionSourceToken =
+                  mode === 'open_position'
+                    ? (ondoUsdSrcToken ??
+                      ONDO_OPEN_POSITION_SOURCE_TOKENS[
+                        afterHoursPendingToken.chainId as CaipChainId
+                      ])
+                    : undefined;
                 trackEvent(
                   createEventBuilder(
                     MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
@@ -463,7 +495,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
                     })
                     .build(),
                 );
-                goToSwaps(ondoUsdSrcToken, afterHoursPendingToken);
+                goToSwaps(openPositionSourceToken, afterHoursPendingToken);
               }
               setAfterHoursPendingToken(null);
             }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change pre-fills the correct source token when attempting to swap into Ondo assets from the Rewards campaign.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: made it easier to get started swapping Ondo GM assets from Rewards

## **Related issues**

Fixes: n/a

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the token preselection logic passed into `goToSwaps` for Rewards-driven Ondo swaps, which can impact swap routing and user balances if chain/token mapping is wrong. Scope is contained to the Ondo RWA selector and covered by updated unit tests.
> 
> **Overview**
> Improves Rewards → Ondo *open position* flow by choosing an appropriate prefilled swap source token based on the selected destination asset’s chain: **prefer USDY on Ethereum when the user holds a balance**, otherwise fall back to a per-chain default (`USDC` on `eip155:1`, `USDT` on `eip155:56`).
> 
> Updates the selector and after-hours confirmation paths to pass this computed source into `goToSwaps`, and revises tests/mocks to validate chain-aware defaults and remove the previous “undefined source” expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1019e7acc6eaf6d41f8c02345f1ea99ec6dc5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->