### PR TITLE
test: stabilize RemoteImage load tests

### DIFF
--- a/app/components/Base/RemoteImage/index.test.tsx
+++ b/app/components/Base/RemoteImage/index.test.tsx
@@ -9,6 +9,39 @@ import { Dimensions } from 'react-native';
 import { Image } from 'expo-image';
 import { mockTheme } from '../../../util/theme';
 
+// Keep image loading explicit in these tests so the mock cannot overwrite
+// dimension assertions with a timer-driven default load.
+jest.mock('expo-image', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View: MockView } = jest.requireActual('react-native');
+
+  const MockImage = ReactActual.forwardRef(
+    (
+      props: {
+        testID?: string;
+        style?: object;
+        source?: unknown;
+        recyclingKey?: string;
+      },
+      ref: React.Ref<unknown>,
+    ) => ReactActual.createElement(MockView, { ...props, ref }),
+  );
+
+  MockImage.displayName = 'MockedExpoImage';
+
+  return {
+    __esModule: true,
+    Image: MockImage,
+    ImageContentFit: {
+      contain: 'contain',
+      cover: 'cover',
+      fill: 'fill',
+      none: 'none',
+      'scale-down': 'scale-down',
+    },
+  };
+});
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn().mockImplementation(() => 'https://dweb.link/ipfs/'),
@@ -49,11 +82,15 @@ jest.mock('./RemoteImageBadgeWrapper', () => ({
 
 const mockGetFormattedIpfsUrl = getFormattedIpfsUrl as jest.Mock;
 const mockLogger = Logger as jest.Mocked<typeof Logger>;
+const createPendingIpfsResolution = () =>
+  new Promise<false>(() => {
+    // Tests that assert IPFS behavior override this default mock.
+  });
 
 describe('RemoteImage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetFormattedIpfsUrl.mockResolvedValue(false);
+    mockGetFormattedIpfsUrl.mockImplementation(createPendingIpfsResolution);
   });
 
   it('renders svg correctly', () => {
@@ -147,11 +184,6 @@ describe('RemoteImage', () => {
   describe('Error State Reset', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
     });
 
     it('renders image when source URI changes', async () => {
@@ -161,10 +193,6 @@ describe('RemoteImage', () => {
           testID="remote-image"
         />,
       );
-
-      await act(async () => {
-        jest.runAllTimers();
-      });
 
       await waitFor(() => {
         expect(queryByTestId('remote-image')).toBeOnTheScreen();
@@ -177,7 +205,6 @@ describe('RemoteImage', () => {
             testID="remote-image"
           />,
         );
-        jest.runAllTimers();
       });
 
       await waitFor(() => {
@@ -194,10 +221,6 @@ describe('RemoteImage', () => {
         />,
       );
 
-      await act(async () => {
-        jest.runAllTimers();
-      });
-
       await waitFor(() => {
         expect(queryByTestId('remote-image')).toBeOnTheScreen();
       });
@@ -211,10 +234,6 @@ describe('RemoteImage', () => {
         />,
       );
 
-      await act(async () => {
-        jest.runAllTimers();
-      });
-
       await waitFor(() => {
         expect(queryByTestId('remote-image-1')).toBeOnTheScreen();
       });
@@ -226,7 +245,6 @@ describe('RemoteImage', () => {
             testID="remote-image-2"
           />,
         );
-        jest.runAllTimers();
       });
 
       await waitFor(() => {
@@ -248,7 +266,7 @@ describe('RemoteImage', () => {
 
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({ source: { width: 100, height: 100 } });
+        fireEvent(image, 'load', { source: { width: 100, height: 100 } });
       });
 
       await waitFor(() => {
@@ -405,7 +423,6 @@ describe('RemoteImage', () => {
     let dimensionsSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      jest.useFakeTimers();
       dimensionsSpy = jest.spyOn(Dimensions, 'get').mockReturnValue({
         width: 400,
         height: 800,
@@ -415,8 +432,6 @@ describe('RemoteImage', () => {
     });
 
     afterEach(() => {
-      jest.runOnlyPendingTimers();
-      jest.useRealTimers();
       jest.restoreAllMocks();
       dimensionsSpy.mockRestore();
     });
@@ -431,12 +446,9 @@ describe('RemoteImage', () => {
         />,
       );
 
-      // Clear any pending timers from the mock's automatic onLoad
-      jest.clearAllTimers();
-
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 800, height: 400 },
         });
       });
@@ -458,12 +470,9 @@ describe('RemoteImage', () => {
         />,
       );
 
-      // Clear any pending timers from the mock's automatic onLoad
-      jest.clearAllTimers();
-
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 400, height: 800 },
         });
       });
@@ -485,12 +494,9 @@ describe('RemoteImage', () => {
         />,
       );
 
-      // Clear any pending timers from the mock's automatic onLoad
-      jest.clearAllTimers();
-
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 500, height: 500 },
         });
       });
@@ -512,12 +518,9 @@ describe('RemoteImage', () => {
         />,
       );
 
-      // Clear any pending timers from the mock's automatic onLoad
-      jest.clearAllTimers();
-
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 500, height: 500 },
         });
       });
@@ -532,7 +535,7 @@ describe('RemoteImage', () => {
 
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 500, height: 500 },
         });
       });
@@ -558,9 +561,6 @@ describe('RemoteImage', () => {
           source={{ uri: 'https://example.com/image.png' }}
         />,
       );
-
-      // Clear any pending timers from the mock's automatic onLoad
-      jest.clearAllTimers();
 
       await act(async () => {
         const image = UNSAFE_getByType(Image);
@@ -650,7 +650,7 @@ describe('RemoteImage', () => {
 
       await act(async () => {
         const image = UNSAFE_getByType(Image);
-        image.props.onLoad({
+        fireEvent(image, 'load', {
           source: { width: 600, height: 400 },
         });
       });


### PR DESCRIPTION
## **Description**

Stabilizes the `RemoteImage` unit tests by making mocked image load events explicit in the test file.

The previous setup could let the shared `expo-image` mock fire a timer-driven default load during tests. This change uses a passive local image mock, keeps unrelated IPFS resolution pending by default, and dispatches image load events through `fireEvent`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: RemoteImage unit tests

  Scenario: RemoteImage load behavior is tested deterministically
    Given the RemoteImage unit test file
    When the targeted test suite runs
    Then image dimensions are asserted from explicit load events
```

Verification run:

```text
git diff --check
yarn eslint app/components/Base/RemoteImage/index.test.tsx
yarn lint:tsc
```

## **Screenshots/Recordings**

N/A. Test-only change.

### **Before**

N/A.

### **After**

N/A.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable. N/A: test-only change.
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android. N/A: test-only change.
- [x] I've tested with a power user scenario. N/A: test-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics. N/A: test-only change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
