### PR TITLE
fix: cp-7.78.0 add `isAtomicBatchSupported` action to `TransactionPayController` init messenger

### DIFF
--- a/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
@@ -11,6 +11,7 @@ import {
   KeyringControllerSignPersonalMessageAction,
   KeyringControllerSignTypedMessageAction,
 } from '@metamask/keyring-controller';
+import { TransactionControllerIsAtomicBatchSupportedAction } from '@metamask/transaction-controller';
 
 export function getTransactionPayControllerMessenger(
   rootMessenger: RootMessenger,
@@ -65,7 +66,8 @@ type InitMessengerActions =
   | DelegationControllerSignDelegationAction
   | KeyringControllerSignEip7702AuthorizationAction
   | KeyringControllerSignPersonalMessageAction
-  | KeyringControllerSignTypedMessageAction;
+  | KeyringControllerSignTypedMessageAction
+  | TransactionControllerIsAtomicBatchSupportedAction;
 type InitMessengerEvents = never;
 
 export type TransactionPayControllerInitMessenger = ReturnType<
@@ -91,6 +93,7 @@ export function getTransactionPayControllerInitMessenger(
       'KeyringController:signEip7702Authorization',
       'KeyringController:signPersonalMessage',
       'KeyringController:signTypedMessage',
+      'TransactionController:isAtomicBatchSupported',
     ],
     events: [],
     messenger,


### PR DESCRIPTION
## **Description**

Add `TransactionControllerIsAtomicBatchSupportedAction` to the `TransactionPayControllerInit` messenger. This enables the init messenger to delegate the `TransactionController:isAtomicBatchSupported` action, which is needed during controller initialization to check atomic batch support.

Companion to MetaMask/metamask-extension#42809.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #42781

## **Manual testing steps**

1. Build the app with `yarn start:ios` or `yarn start:android`
2. Verify the app loads without errors
3. Verify transaction pay functionality works as expected

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single delegated messenger action used during initialization, with no changes to transaction execution or signing behavior.
> 
> **Overview**
> Allows `TransactionPayController` initialization to query atomic batch capability by **adding delegation for** `TransactionController:isAtomicBatchSupported`.
> 
> This extends `TransactionPayControllerInit` messenger types/imports to include `TransactionControllerIsAtomicBatchSupportedAction` and delegates the new action via `rootMessenger.delegate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81e10b7d15eaac8642fb3e9c3595dee5bdf8467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->