### PR TITLE
fix(ci): preserve release/* branches after merge into stable

### DIFF
--- a/.github/workflows/preserve-release-branch.yml
+++ b/.github/workflows/preserve-release-branch.yml
@@ -1,0 +1,57 @@
+name: Preserve release branch after merge
+
+# Re-creates `release/*` head branches that GitHub auto-deletes immediately
+# after a release PR merges into `stable`. The repo-level "Automatically delete
+# head branches" setting drops the head ref of every merged PR; for release
+# branches we want to keep them around for OTA hotfix forks (`-ota`),
+# cherry-picks, post-release audits, and tag back-references.
+#
+# The workflow is idempotent — if the branch is still present (e.g. someone
+# disables `delete_branch_on_merge` or the ruleset starts blocking the
+# auto-delete again), it no-ops.
+
+permissions:
+  contents: write
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - stable
+
+jobs:
+  preserve:
+    name: Preserve release/* head branch
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for auto-delete to settle
+        # GitHub fires HeadRefDeletedEvent ~2-5s after merge. Sleep beyond that
+        # so the existence check below reflects the post-auto-delete state.
+        run: sleep 15
+
+      - name: Re-create branch if it was auto-deleted
+        env:
+          # STABLE_SYNC_TOKEN bypasses the "Release branch" ruleset's `creation`
+          # rule, which would otherwise block re-creating `release/X.Y.Z` refs.
+          # The same token is used by stable-branch-sync.yml /
+          # release-branch-sync.yml for the same reason.
+          GH_TOKEN: ${{ secrets.STABLE_SYNC_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if gh api "repos/$REPO/git/ref/heads/$HEAD_REF" >/dev/null 2>&1; then
+            echo "Branch $HEAD_REF still exists; nothing to restore."
+            exit 0
+          fi
+
+          echo "Branch $HEAD_REF was auto-deleted; restoring at $HEAD_SHA"
+          gh api --method POST "repos/$REPO/git/refs" \
+            -f ref="refs/heads/$HEAD_REF" \
+            -f sha="$HEAD_SHA"
+          echo "Restored $HEAD_REF -> $HEAD_SHA"


### PR DESCRIPTION
## **Description**

Re-creates `release/*` head branches that GitHub auto-deletes immediately after a release PR merges into `stable`.

### What changed

Before **2026-04-08**, release branches were preserved automatically — see [#27990 (release/7.72.0)](https://github.com/MetaMask/metamask-mobile/pull/27990)'s timeline: `MergedEvent` only, no `HeadRefDeletedEvent`.

Starting with [#28679 (release/7.72.1)](https://github.com/MetaMask/metamask-mobile/pull/28679) on 2026-04-13, every release PR's head ref is auto-deleted within 2-5s of merge. Two recent examples:

| PR | Head | Merged | head_ref_deleted | head_ref_restored |
|---|---|---|---|---|
| [#29883](https://github.com/MetaMask/metamask-mobile/pull/29883) | `release/7.77.0` | 16:50:01 | 16:50:05 (auto) | 18:20:28 (manual) |
| [#30309](https://github.com/MetaMask/metamask-mobile/pull/30309) | `release/7.77.1-ota` | 17:01:40 | 17:01:42 (auto) | 17:02:13 (manual) |

The "Release branch" ruleset (id 5621068) has a `{ "type": "deletion" }` rule and was last updated `2026-04-08T18:58:08+02:00` — exactly inside the transition window — but the rule no longer prevents `delete_branch_on_merge`'s deletion path. Its include patterns also don't cover OTA branches:

```
refs/heads/release/[0-9].[0-9].[0-9]      -> matches release/7.77.0
                                            does NOT match release/7.77.1-ota
```

### Fix

Tactical workflow that:

- Triggers on `pull_request closed` for branches into `stable`
- Filters to merged PRs whose head starts with `release/` (covers both `release/X.Y.Z` and `release/X.Y.Z-ota`)
- Waits 15s for the auto-delete to settle
- If the branch is missing, recreates it at the original `head.sha`

Idempotent: if the branch is still present (e.g. once the ruleset properly blocks the auto-delete again), it no-ops, so leaving this workflow in place after the root cause is fixed is safe.

Uses `STABLE_SYNC_TOKEN` to bypass the "Release branch" ruleset's `creation` rule (the same token / same reason as `stable-branch-sync.yml` and `release-branch-sync.yml`).

### Why a workflow instead of a ruleset/setting fix

Both proper fixes — disabling repo-level `delete_branch_on_merge`, or adjusting the "Release branch" ruleset's bypass list — require **admin** permission, which I don't have. This workflow restores the pre-April-8 behavior with `write` permission only and can be removed in a single commit once an admin reverts whatever changed on 2026-04-08.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- Triggering bug example: #29883 (manual restore needed after merge)
- Same pattern: #30309
- Ruleset updated on the transition date: [Release branch ruleset](https://github.com/MetaMask/metamask-mobile/rules/5621068)

## **Manual testing steps**

```gherkin
Feature: Release branch survives merge into stable

  Scenario: a release branch is auto-deleted after merge
    Given a PR with head "release/X.Y.Z" or "release/X.Y.Z-ota" targeting stable
    And the repo has "Automatically delete head branches" enabled
    When the PR is merged
    Then GitHub fires HeadRefDeletedEvent within ~5s
    And this workflow runs after a 15s settle period
    And it recreates the branch at the original head.sha
    And the timeline shows HeadRefRestoredEvent by the workflow's actor

  Scenario: the underlying behavior is fixed
    Given the auto-delete is no longer happening
    When a release PR is merged
    Then this workflow's existence check finds the branch
    And it no-ops (logs "nothing to restore")
```

End-to-end will be exercised on the next release/OTA merge into stable.

## **Screenshots/Recordings**

N/A — workflow change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)