### PR TITLE
feat: disable smart account on gas fees sponsored network

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
@@ -3,6 +3,7 @@ import { BridgeTransactionDetails } from './TransactionDetails';
 import {
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import Routes from '../../../../../constants/navigation/Routes';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
@@ -272,5 +273,29 @@ describe('BridgeTransactionDetails', () => {
     );
 
     expect(getByTestId('paid-by-metamask')).toBeOnTheScreen();
+  });
+
+  it('does not show "Paid by MetaMask" for a sponsored revoke delegation transaction', () => {
+    mockIsHardwareAccount.mockReturnValue(false);
+
+    const sponsoredRevokeDelegationTx = {
+      ...mockEVMTx,
+      isGasFeeSponsored: true,
+      type: TransactionType.revokeDelegation,
+    } as TransactionMeta;
+
+    const { queryByTestId } = renderScreen(
+      () => (
+        <BridgeTransactionDetails
+          route={{ params: { evmTxMeta: sponsoredRevokeDelegationTx } }}
+        />
+      ),
+      {
+        name: Routes.BRIDGE.BRIDGE_TRANSACTION_DETAILS,
+      },
+      { state: mockState },
+    );
+
+    expect(queryByTestId('paid-by-metamask')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -45,6 +45,7 @@ import TagColored, {
 } from '../../../../../component-library/components-temp/TagColored';
 // import { renderShortAddress } from '../../../../../util/address';
 import { isHardwareAccount } from '../../../../../util/address';
+import { isTransactionMarkedAsGasFeeSponsored } from '../../../../Views/confirmations/utils/transaction';
 
 const styles = StyleSheet.create({
   detailRow: {
@@ -401,7 +402,8 @@ export const BridgeTransactionDetails = (
           <Text variant={TextVariant.BodyMDMedium}>
             {strings('bridge_transaction_details.total_gas_fee')}
           </Text>
-          {evmTxMeta?.isGasFeeSponsored && !isHardwareWallet ? (
+          {isTransactionMarkedAsGasFeeSponsored(evmTxMeta) &&
+          !isHardwareWallet ? (
             <PaidByMetaMask />
           ) : (
             <>

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -51,7 +51,7 @@ import {
 import { getGlobalEthQuery } from '../../../../util/networks/global-network';
 import {
   hasGasFeeTokenSelected,
-  isGasFeeActuallySponsored,
+  isTransactionMarkedAsGasFeeSponsored,
 } from '../../../Views/confirmations/utils/transaction';
 import Avatar, {
   AvatarSize,
@@ -483,7 +483,8 @@ class TransactionDetails extends PureComponent {
             transactionType={updatedTransactionDetails.transactionType}
             chainId={chainId}
             isGasFeeSponsored={
-              isGasFeeActuallySponsored(transactionObject) && !isHardwareWallet
+              isTransactionMarkedAsGasFeeSponsored(transactionObject) &&
+              !isHardwareWallet
             }
           />
         </View>

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -49,7 +49,10 @@ import {
   selectTransactions,
 } from '../../../../selectors/transactionController';
 import { getGlobalEthQuery } from '../../../../util/networks/global-network';
-import { hasGasFeeTokenSelected } from '../../../Views/confirmations/utils/transaction';
+import {
+  hasGasFeeTokenSelected,
+  isGasFeeActuallySponsored,
+} from '../../../Views/confirmations/utils/transaction';
 import Avatar, {
   AvatarSize,
   AvatarVariant,
@@ -480,7 +483,7 @@ class TransactionDetails extends PureComponent {
             transactionType={updatedTransactionDetails.transactionType}
             chainId={chainId}
             isGasFeeSponsored={
-              transactionObject.isGasFeeSponsored && !isHardwareWallet
+              isGasFeeActuallySponsored(transactionObject) && !isHardwareWallet
             }
           />
         </View>

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -9,6 +9,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { mockNetworkState } from '../../../../util/test/network';
 import type { NetworkState } from '@metamask/network-controller';
 import { isHardwareAccount } from '../../../../util/address';
+import { TransactionType } from '@metamask/transaction-controller';
 
 const Stack = createStackNavigator();
 const mockEthQuery = {
@@ -526,6 +527,19 @@ describe('TransactionDetails', () => {
       transactionObj: {
         isGasFeeSponsored: true,
         txParams: { from: '0xHardwareAddress' },
+      },
+    });
+
+    expect(screen.queryByTestId('paid-by-metamask')).not.toBeOnTheScreen();
+    expect(screen.queryByText('Paid by MetaMask')).not.toBeOnTheScreen();
+  });
+
+  it('does not show "Paid by MetaMask" for revoke delegation even when isGasFeeSponsored is true', () => {
+    renderComponent({
+      state: initialState,
+      transactionObj: {
+        isGasFeeSponsored: true,
+        type: TransactionType.revokeDelegation,
       },
     });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
@@ -76,4 +76,16 @@ describe('TransactionDetailsNetworkFeeRow', () => {
     const { getByText } = render();
     expect(getByText(`$${CALCULATED_FEE_MOCK}`)).toBeDefined();
   });
+
+  it('renders calculated network fee for revoke delegation fallback', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        type: TransactionType.revokeDelegation,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+
+    expect(getByText(`$${CALCULATED_FEE_MOCK}`)).toBeDefined();
+  });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -16,6 +16,7 @@ const FALLBACK_TYPES = [
   TransactionType.predictClaim,
   TransactionType.predictWithdraw,
   TransactionType.musdClaim,
+  TransactionType.revokeDelegation,
 ];
 
 export function TransactionDetailsNetworkFeeRow() {

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
@@ -15,6 +15,7 @@ import {
   GasFeeEstimateType,
   SimulationData,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { useSelectedGasFeeToken } from '../../../../hooks/gas/useGasFeeToken';
 import { useIsGaslessSupported } from '../../../../hooks/gas/useIsGaslessSupported';
@@ -339,6 +340,25 @@ describe('GasFeesDetailsRow', () => {
 
     expect(getByText('Paid by MetaMask')).toBeDefined();
     expect(queryByText('ETH')).toBeNull();
+  });
+
+  it('shows network fee when sponsored transaction is revoke delegation', async () => {
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
+    clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].isGasFeeSponsored = true;
+    clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].type =
+      TransactionType.revokeDelegation;
+
+    const { getByText, queryByTestId } = renderWithProvider(
+      <GasFeesDetailsRow />,
+      {
+        state: clonedStakingDepositConfirmationState,
+      },
+    );
+
+    expect(queryByTestId('paid-by-metamask')).toBeNull();
+    expect(getByText('$0.34')).toBeDefined();
+    expect(getByText('ETH')).toBeDefined();
   });
 
   it('does not show MetaMask fee info when metaMaskFee is 0x0', () => {

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -45,7 +45,7 @@ import useNetworkInfo from '../../../../hooks/useNetworkInfo';
 import TagColored, {
   TagColor,
 } from '../../../../../../../component-library/components-temp/TagColored';
-import { isGasFeeActuallySponsored } from '../../../../utils/transaction';
+import { shouldApplyGasFeeSponsorship } from '../../../../utils/transaction';
 
 const PaidByMetaMask = () => (
   <TagColored
@@ -272,10 +272,10 @@ const GasFeesDetailsRow = ({
 
   // Gasless support (including HW check) is centralized in useIsGaslessSupported.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
-  const isGasFeeSponsored = isGasFeeActuallySponsored(
-    transactionMetadata as TransactionMeta | undefined,
+  const isGasFeeSponsored = shouldApplyGasFeeSponsorship({
+    transactionMeta: transactionMetadata as TransactionMeta | undefined,
     isGaslessSupported,
-  );
+  });
 
   const handleNetworkFeeTooltipClickedEvent = () => {
     trackTooltipClickedEvent({

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -45,6 +45,7 @@ import useNetworkInfo from '../../../../hooks/useNetworkInfo';
 import TagColored, {
   TagColor,
 } from '../../../../../../../component-library/components-temp/TagColored';
+import { isGasFeeActuallySponsored } from '../../../../utils/transaction';
 
 const PaidByMetaMask = () => (
   <TagColored
@@ -262,10 +263,7 @@ const GasFeesDetailsRow = ({
   const transactionBatchesMetadata = useTransactionBatchesMetadata();
   const gasFeeToken = useSelectedGasFeeToken();
   const metamaskFeeFiat = gasFeeToken?.metamaskFeeFiat;
-  const {
-    userFeeLevel: isUserFeeLevelExists,
-    isGasFeeSponsored: doesSentinelAllowSponsorship,
-  } = transactionMetadata ?? {};
+  const { userFeeLevel: isUserFeeLevelExists } = transactionMetadata ?? {};
 
   const hideFiatForTestnet = useHideFiatForTestnet(
     transactionMetadata?.chainId,
@@ -274,7 +272,10 @@ const GasFeesDetailsRow = ({
 
   // Gasless support (including HW check) is centralized in useIsGaslessSupported.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
-  const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
+  const isGasFeeSponsored = isGasFeeActuallySponsored(
+    transactionMetadata as TransactionMeta | undefined,
+    isGaslessSupported,
+  );
 
   const handleNetworkFeeTooltipClickedEvent = () => {
     trackTooltipClickedEvent({

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -273,7 +273,7 @@ const GasFeesDetailsRow = ({
   // Gasless support (including HW check) is centralized in useIsGaslessSupported.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored = shouldApplyGasFeeSponsorship({
-    transactionMeta: transactionMetadata as TransactionMeta | undefined,
+    transactionMeta: transactionMetadata,
     isGaslessSupported,
   });
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -381,6 +381,38 @@ describe('useInsufficientBalanceAlert', () => {
       const { result } = renderHook(() => useInsufficientBalanceAlert());
       expect(result.current).toEqual([]);
     });
+
+    it('returns alert when transaction is revoke delegation', () => {
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+      const txWithGasFeeSponsored = {
+        ...mockTransaction,
+        isGasFeeSponsored: true,
+        type: TransactionType.revokeDelegation,
+      };
+      mockUseTransactionMetadataRequest.mockReturnValue(txWithGasFeeSponsored);
+
+      const { result } = renderHook(() => useInsufficientBalanceAlert());
+
+      expect(result.current).toEqual([
+        {
+          action: {
+            label: `Buy ${mockNativeCurrency}`,
+            callback: expect.any(Function),
+          },
+          isBlocking: true,
+          field: RowAlertKey.EstimatedFee,
+          key: AlertKeys.InsufficientBalance,
+          message: `Insufficient ${mockNativeCurrency} balance`,
+          title: 'Insufficient Balance',
+          severity: Severity.Danger,
+          skipConfirmation: true,
+        },
+      ]);
+    });
   });
 
   describe('isQuotesLoading', () => {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -12,7 +12,7 @@ import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { TransactionType } from '@metamask/transaction-controller';
 import {
   hasTransactionType,
-  isGasFeeActuallySponsored,
+  shouldApplyGasFeeSponsorship,
 } from '../../utils/transaction';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
@@ -66,10 +66,10 @@ export const useInsufficientBalanceAlert = ({
     const isGaslessCheckComplete = !isGaslessCheckPending;
 
     // Transaction is sponsored only if it's marked as sponsored AND gasless is supported
-    const isSponsoredTransaction = isGasFeeActuallySponsored(
-      transactionMetadata,
+    const isSponsoredTransaction = shouldApplyGasFeeSponsorship({
+      transactionMeta: transactionMetadata,
       isGaslessSupported,
-    );
+    });
 
     // Simulation is complete if it's disabled, or if enabled and gasFeeTokens is loaded
     const isSimulationComplete = !isSimulationEnabled || Boolean(gasFeeTokens);

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -10,7 +10,10 @@ import { useConfirmActions } from '../useConfirmActions';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../utils/transaction';
+import {
+  hasTransactionType,
+  isGasFeeActuallySponsored,
+} from '../../utils/transaction';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
@@ -54,12 +57,8 @@ export const useInsufficientBalanceAlert = ({
       return [];
     }
 
-    const {
-      selectedGasFeeToken,
-      isGasFeeSponsored,
-      gasFeeTokens,
-      excludeNativeTokenForFee,
-    } = transactionMetadata;
+    const { selectedGasFeeToken, gasFeeTokens, excludeNativeTokenForFee } =
+      transactionMetadata;
 
     const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
 
@@ -67,7 +66,10 @@ export const useInsufficientBalanceAlert = ({
     const isGaslessCheckComplete = !isGaslessCheckPending;
 
     // Transaction is sponsored only if it's marked as sponsored AND gasless is supported
-    const isSponsoredTransaction = isGasFeeSponsored && isGaslessSupported;
+    const isSponsoredTransaction = isGasFeeActuallySponsored(
+      transactionMetadata,
+      isGaslessSupported,
+    );
 
     // Simulation is complete if it's disabled, or if enabled and gasFeeTokens is loaded
     const isSimulationComplete = !isSimulationEnabled || Boolean(gasFeeTokens);

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -92,6 +92,12 @@ describe('useFeeCalculations', () => {
   });
 
   it('returns fee calculations when sponsored transaction is revoke delegation', () => {
+    mockUseIsGaslessSupported.mockReturnValue({
+      isSupported: true,
+      isSmartTransaction: false,
+      pending: false,
+    });
+
     const { result } = renderHookWithProvider(
       () =>
         useFeeCalculations({

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -1,4 +1,5 @@
 import { Hex } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
 import { cloneDeep } from 'lodash';
 import { decimalToHex } from '../../../../../util/conversions';
 import { isTestNet } from '../../../../../util/networks';
@@ -87,6 +88,28 @@ describe('useFeeCalculations', () => {
     expect(result.current.preciseNativeFeeInHex).toBe('0x0');
     expect(result.current.maxFeeFiat).toBe('$0');
     expect(result.current.maxFeeNative).toBe('0');
+    expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returns fee calculations when sponsored transaction is revoke delegation', () => {
+    const { result } = renderHookWithProvider(
+      () =>
+        useFeeCalculations({
+          ...transactionMeta,
+          isGasFeeSponsored: true,
+          type: TransactionType.revokeDelegation,
+        }),
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(result.current.estimatedFeeFiat).toBe('$0.34');
+    expect(result.current.estimatedFeeNative).toBe('0.0001');
+    expect(result.current.estimatedFeeFiatPrecise).toBe('0.337875011');
+    expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
+    expect(result.current.maxFeeFiat).toBe('$0.86');
+    expect(result.current.maxFeeNative).toBe('0.0002');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
 

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -11,6 +11,7 @@ import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
 import { isTestNet } from '../../../../../util/networks';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { calculateGasEstimate, getFeesFromHex } from '../../utils/gas';
+import { isGasFeeActuallySponsored } from '../../utils/transaction';
 import {
   addHexes,
   decimalToHex,
@@ -79,7 +80,6 @@ export const useFeeCalculations = (
   const { maxFeePerGas, maxPriorityFeePerGas } =
     useEIP1559TxFees(transactionMeta);
   const { gasFeeEstimates } = useGasFeeEstimates(networkClientId);
-  const isGasFeeSponsored = isGasFeeActuallySponsored(transactionMeta);
   const shouldHideFiat =
     (isTestNet(chainId as Hex) && !showFiatOnTestnets) ||
     nativeConversionRate === null ||
@@ -102,6 +102,10 @@ export const useFeeCalculations = (
     ?.estimatedBaseFee;
 
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
+  const isGasFeeSponsored = isGasFeeActuallySponsored(
+    transactionMeta,
+    isGaslessSupported,
+  );
   const txParamsGasPrice = transactionMeta.txParams?.gasPrice ?? HEX_ZERO;
   const receiptGasPriceHex = txReceipt?.effectiveGasPrice;
 
@@ -147,13 +151,9 @@ export const useFeeCalculations = (
     [estimatedBaseFee, layer1GasFee, getFeesFromHexCallback],
   );
 
-  const isSponsorshipEnabledForTx = Boolean(
-    transactionMeta?.isGasFeeSponsored && isGaslessSupported,
-  );
-
   // Estimated fee
   const estimatedFees = useMemo(() => {
-    if (isSponsorshipEnabledForTx) {
+    if (isGasFeeSponsored) {
       return {
         currentCurrencyFee: fiatFormatter(new BigNumber('0')),
         preciseCurrentCurrencyFee: '0',
@@ -177,13 +177,13 @@ export const useFeeCalculations = (
     supportsEIP1559,
     txParamsGasPrice,
     receiptGasPriceHex,
-    isSponsorshipEnabledForTx,
+    isGasFeeSponsored,
     fiatFormatter,
   ]);
 
   // Max fee
   const maxFee = useMemo(() => {
-    if (isSponsorshipEnabledForTx) {
+    if (isGasFeeSponsored) {
       return HEX_ZERO;
     }
     return addHexes(
@@ -201,7 +201,7 @@ export const useFeeCalculations = (
     txParamsGasPrice,
     transactionMeta.txParams.gas,
     transactionMeta.layer1GasFee,
-    isSponsorshipEnabledForTx,
+    isGasFeeSponsored,
   ]);
 
   const {

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -79,6 +79,7 @@ export const useFeeCalculations = (
   const { maxFeePerGas, maxPriorityFeePerGas } =
     useEIP1559TxFees(transactionMeta);
   const { gasFeeEstimates } = useGasFeeEstimates(networkClientId);
+  const isGasFeeSponsored = isGasFeeActuallySponsored(transactionMeta);
   const shouldHideFiat =
     (isTestNet(chainId as Hex) && !showFiatOnTestnets) ||
     nativeConversionRate === null ||

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -11,7 +11,7 @@ import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
 import { isTestNet } from '../../../../../util/networks';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { calculateGasEstimate, getFeesFromHex } from '../../utils/gas';
-import { isGasFeeActuallySponsored } from '../../utils/transaction';
+import { shouldApplyGasFeeSponsorship } from '../../utils/transaction';
 import {
   addHexes,
   decimalToHex,
@@ -102,10 +102,10 @@ export const useFeeCalculations = (
     ?.estimatedBaseFee;
 
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
-  const isGasFeeSponsored = isGasFeeActuallySponsored(
+  const isGasFeeSponsored = shouldApplyGasFeeSponsorship({
     transactionMeta,
     isGaslessSupported,
-  );
+  });
   const txParamsGasPrice = transactionMeta.txParams?.gasPrice ?? HEX_ZERO;
   const receiptGasPriceHex = txReceipt?.effectiveGasPrice;
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -464,6 +464,35 @@ describe('useTransactionConfirm', () => {
       });
     });
 
+    it('clears isGasFeeSponsored for revoke delegation when gasless is supported', async () => {
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        chainId: CHAIN_ID_MOCK,
+        origin: ORIGIN_METAMASK,
+        txParams: {},
+        type: TransactionType.revokeDelegation,
+        isGasFeeSponsored: true,
+      } as unknown as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.objectContaining({
+          isGasFeeSponsored: false,
+        }),
+      });
+    });
+
     it('clears isGasFeeSponsored even without selectedGasFeeToken', async () => {
       useIsGaslessSupportedMock.mockReturnValue({
         isSmartTransaction: false,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -12,7 +12,10 @@ import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/use
 import { isHardwareAccount } from '../../../../../util/address';
 import { createProjectLogger } from '@metamask/utils';
 import { useSelectedGasFeeToken } from '../gas/useGasFeeToken';
-import { hasTransactionType } from '../../utils/transaction';
+import {
+  hasTransactionType,
+  isGasFeeActuallySponsored,
+} from '../../utils/transaction';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
 import { cloneDeep } from 'lodash';
@@ -109,8 +112,10 @@ export function useTransactionConfirm() {
       // Ensure the persisted `isGasFeeSponsored` flag reflects whether gasless
       // is actually supported (e.g. HW wallets don't support gasless, so the
       // flag must be cleared so the activity list does not show "Paid by MetaMask").
-      updatedMetadata.isGasFeeSponsored =
-        isGaslessSupported && transactionMetadata?.isGasFeeSponsored;
+      updatedMetadata.isGasFeeSponsored = isGasFeeActuallySponsored(
+        transactionMetadata,
+        isGaslessSupported,
+      );
 
       if (isGaslessSupportedSTX) {
         handleSmartTransaction(updatedMetadata);

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -14,7 +14,7 @@ import { createProjectLogger } from '@metamask/utils';
 import { useSelectedGasFeeToken } from '../gas/useGasFeeToken';
 import {
   hasTransactionType,
-  isGasFeeActuallySponsored,
+  shouldApplyGasFeeSponsorship,
 } from '../../utils/transaction';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
@@ -112,10 +112,10 @@ export function useTransactionConfirm() {
       // Ensure the persisted `isGasFeeSponsored` flag reflects whether gasless
       // is actually supported (e.g. HW wallets don't support gasless, so the
       // flag must be cleared so the activity list does not show "Paid by MetaMask").
-      updatedMetadata.isGasFeeSponsored = isGasFeeActuallySponsored(
-        transactionMetadata,
+      updatedMetadata.isGasFeeSponsored = shouldApplyGasFeeSponsorship({
+        transactionMeta: transactionMetadata,
         isGaslessSupported,
-      );
+      });
 
       if (isGaslessSupportedSTX) {
         handleSmartTransaction(updatedMetadata);

--- a/app/components/Views/confirmations/utils/transaction.test.ts
+++ b/app/components/Views/confirmations/utils/transaction.test.ts
@@ -11,6 +11,8 @@ import {
   getSeverity,
   hasGasFeeTokenSelected,
   hasTransactionType,
+  isGasFeeActuallySponsored,
+  isRevokeDelegationTransaction,
   isTransactionPayWithdraw,
   parseStandardTokenTransactionData,
 } from './transaction';
@@ -244,6 +246,49 @@ describe('hasGasFeeTokenSelected', () => {
         selectedGasFeeToken: '0xabc123',
       } as unknown as TransactionMeta),
     ).toBe(true);
+  });
+});
+
+describe('isRevokeDelegationTransaction', () => {
+  it('returns true for revoke delegation transaction', () => {
+    const txMeta = {
+      type: TransactionType.revokeDelegation,
+    } as TransactionMeta;
+
+    expect(isRevokeDelegationTransaction(txMeta)).toBe(true);
+  });
+
+  it('returns false for undefined transaction', () => {
+    expect(isRevokeDelegationTransaction(undefined)).toBe(false);
+  });
+});
+
+describe('isGasFeeActuallySponsored', () => {
+  it('returns true when gas sponsorship is supported and transaction is sponsored', () => {
+    const txMeta = {
+      isGasFeeSponsored: true,
+      type: TransactionType.simpleSend,
+    } as TransactionMeta;
+
+    expect(isGasFeeActuallySponsored(txMeta, true)).toBe(true);
+  });
+
+  it('returns false when gasless is not supported', () => {
+    const txMeta = {
+      isGasFeeSponsored: true,
+      type: TransactionType.simpleSend,
+    } as TransactionMeta;
+
+    expect(isGasFeeActuallySponsored(txMeta, false)).toBe(false);
+  });
+
+  it('returns false for sponsored revoke delegation transaction', () => {
+    const txMeta = {
+      isGasFeeSponsored: true,
+      type: TransactionType.revokeDelegation,
+    } as TransactionMeta;
+
+    expect(isGasFeeActuallySponsored(txMeta, true)).toBe(false);
   });
 });
 

--- a/app/components/Views/confirmations/utils/transaction.test.ts
+++ b/app/components/Views/confirmations/utils/transaction.test.ts
@@ -11,10 +11,11 @@ import {
   getSeverity,
   hasGasFeeTokenSelected,
   hasTransactionType,
-  isGasFeeActuallySponsored,
   isRevokeDelegationTransaction,
+  isTransactionMarkedAsGasFeeSponsored,
   isTransactionPayWithdraw,
   parseStandardTokenTransactionData,
+  shouldApplyGasFeeSponsorship,
 } from './transaction';
 import {
   abiERC721,
@@ -263,14 +264,19 @@ describe('isRevokeDelegationTransaction', () => {
   });
 });
 
-describe('isGasFeeActuallySponsored', () => {
+describe('shouldApplyGasFeeSponsorship', () => {
   it('returns true when gas sponsorship is supported and transaction is sponsored', () => {
     const txMeta = {
       isGasFeeSponsored: true,
       type: TransactionType.simpleSend,
     } as TransactionMeta;
 
-    expect(isGasFeeActuallySponsored(txMeta, true)).toBe(true);
+    expect(
+      shouldApplyGasFeeSponsorship({
+        transactionMeta: txMeta,
+        isGaslessSupported: true,
+      }),
+    ).toBe(true);
   });
 
   it('returns false when gasless is not supported', () => {
@@ -279,7 +285,12 @@ describe('isGasFeeActuallySponsored', () => {
       type: TransactionType.simpleSend,
     } as TransactionMeta;
 
-    expect(isGasFeeActuallySponsored(txMeta, false)).toBe(false);
+    expect(
+      shouldApplyGasFeeSponsorship({
+        transactionMeta: txMeta,
+        isGaslessSupported: false,
+      }),
+    ).toBe(false);
   });
 
   it('returns false for sponsored revoke delegation transaction', () => {
@@ -288,7 +299,32 @@ describe('isGasFeeActuallySponsored', () => {
       type: TransactionType.revokeDelegation,
     } as TransactionMeta;
 
-    expect(isGasFeeActuallySponsored(txMeta, true)).toBe(false);
+    expect(
+      shouldApplyGasFeeSponsorship({
+        transactionMeta: txMeta,
+        isGaslessSupported: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isTransactionMarkedAsGasFeeSponsored', () => {
+  it('returns true when a transaction is marked as gas fee sponsored', () => {
+    const txMeta = {
+      isGasFeeSponsored: true,
+      type: TransactionType.simpleSend,
+    } as TransactionMeta;
+
+    expect(isTransactionMarkedAsGasFeeSponsored(txMeta)).toBe(true);
+  });
+
+  it('returns false for a revoke delegation transaction', () => {
+    const txMeta = {
+      isGasFeeSponsored: true,
+      type: TransactionType.revokeDelegation,
+    } as TransactionMeta;
+
+    expect(isTransactionMarkedAsGasFeeSponsored(txMeta)).toBe(false);
   });
 });
 

--- a/app/components/Views/confirmations/utils/transaction.ts
+++ b/app/components/Views/confirmations/utils/transaction.ts
@@ -170,14 +170,24 @@ export function isRevokeDelegationTransaction(
   return transactionMeta?.type === TransactionType.revokeDelegation;
 }
 
-export function isGasFeeActuallySponsored(
+export function isTransactionMarkedAsGasFeeSponsored(
   transactionMeta: TransactionMeta | undefined,
-  isGaslessSupported = true,
 ): boolean {
   return Boolean(
-    isGaslessSupported &&
-      transactionMeta?.isGasFeeSponsored &&
+    transactionMeta?.isGasFeeSponsored &&
       !isRevokeDelegationTransaction(transactionMeta),
+  );
+}
+
+export function shouldApplyGasFeeSponsorship({
+  transactionMeta,
+  isGaslessSupported,
+}: {
+  transactionMeta: TransactionMeta | undefined;
+  isGaslessSupported: boolean;
+}): boolean {
+  return (
+    isGaslessSupported && isTransactionMarkedAsGasFeeSponsored(transactionMeta)
   );
 }
 

--- a/app/components/Views/confirmations/utils/transaction.ts
+++ b/app/components/Views/confirmations/utils/transaction.ts
@@ -164,6 +164,23 @@ export function hasGasFeeTokenSelected(
   return Boolean(transactionMeta?.selectedGasFeeToken);
 }
 
+export function isRevokeDelegationTransaction(
+  transactionMeta: TransactionMeta | undefined,
+): boolean {
+  return transactionMeta?.type === TransactionType.revokeDelegation;
+}
+
+export function isGasFeeActuallySponsored(
+  transactionMeta: TransactionMeta | undefined,
+  isGaslessSupported = true,
+): boolean {
+  return Boolean(
+    isGaslessSupported &&
+      transactionMeta?.isGasFeeSponsored &&
+      !isRevokeDelegationTransaction(transactionMeta),
+  );
+}
+
 export function getSeverity(status: TransactionStatus): Severity {
   switch (status) {
     case TransactionStatus.confirmed:

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -685,6 +685,48 @@ describe('Transaction Controller Init', () => {
         expect(mockDelegation7702Hook).not.toHaveBeenCalled();
       });
 
+      it('skips Delegation7702PublishHook for revoke delegation transactions', async () => {
+        selectShouldUseSmartTransactionMock.mockReturnValue(false);
+        isSendBundleSupportedMock.mockResolvedValue(false);
+
+        const hooks = testConstructorOption('hooks');
+        const result = await hooks?.publish?.({
+          ...MOCK_TRANSACTION_META,
+          chainId: '0x13',
+          type: TransactionType.revokeDelegation,
+          isGasFeeSponsored: true,
+        });
+
+        expect(Delegation7702PublishHookMock).not.toHaveBeenCalled();
+        expect(mockDelegation7702Hook).not.toHaveBeenCalled();
+        expect(result).toEqual({ transactionHash: undefined });
+      });
+
+      it('keeps Smart Transactions eligible for revoke delegation transactions', async () => {
+        submitSmartTransactionHookMock.mockResolvedValue({
+          transactionHash: '0xsmarthash',
+        });
+
+        const hooks = testConstructorOption('hooks');
+        const result = await hooks?.publish?.({
+          ...MOCK_TRANSACTION_META,
+          chainId: '0x13',
+          type: TransactionType.revokeDelegation,
+          isGasFeeSponsored: true,
+        });
+
+        expect(Delegation7702PublishHookMock).not.toHaveBeenCalled();
+        expect(mockDelegation7702Hook).not.toHaveBeenCalled();
+        expect(submitSmartTransactionHookMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            transactionMeta: expect.objectContaining({
+              type: TransactionType.revokeDelegation,
+            }),
+          }),
+        );
+        expect(result?.transactionHash).toBe('0xsmarthash');
+      });
+
       it('falls back to Delegation7702PublishHook when smart transactions are disabled', async () => {
         selectShouldUseSmartTransactionMock.mockReturnValue(false);
         const hooks = testConstructorOption('hooks');

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -257,6 +257,8 @@ async function publishHook({
   }
 
   const { isExternalSign } = transactionMeta;
+  const isRevokeDelegation =
+    transactionMeta.type === TransactionType.revokeDelegation;
 
   const keyringSupports7702 = await accountSupports7702(
     transactionMeta.txParams?.from,
@@ -265,6 +267,7 @@ async function publishHook({
 
   if (
     keyringSupports7702 &&
+    !isRevokeDelegation &&
     (!shouldUseSmartTransaction || !sendBundleSupport || isExternalSign)
   ) {
     const hook = new Delegation7702PublishHook({

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -194,6 +194,25 @@ describe('Delegation 7702 Publish Hook', () => {
   });
 
   describe('returns empty result if', () => {
+    it('transaction type is revokeDelegation', async () => {
+      const result = await hookClass.getHook()(
+        {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.revokeDelegation,
+          isGasFeeSponsored: true,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        },
+        SIGNED_TX_MOCK,
+      );
+
+      expect(result).toEqual({
+        transactionHash: undefined,
+      });
+      expect(isAtomicBatchSupportedMock).not.toHaveBeenCalled();
+      expect(submitRelayTransactionMock).not.toHaveBeenCalled();
+    });
+
     it('atomic batch is not supported', async () => {
       const result = await hookClass.getHook()(
         TRANSACTION_META_MOCK,

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -8,6 +8,7 @@ import {
   PublishHook,
   PublishHookResult,
   TransactionMeta,
+  TransactionType,
   decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger } from '@metamask/utils';
@@ -107,6 +108,11 @@ export class Delegation7702PublishHook {
     transactionMeta: TransactionMeta,
     _signedTx: string,
   ): Promise<PublishHookResult> {
+    if (transactionMeta.type === TransactionType.revokeDelegation) {
+      log('Skipping: revokeDelegation must publish as top-level setCode');
+      return EMPTY_RESULT;
+    }
+
     const { chainId, gasFeeTokens, selectedGasFeeToken, txParams } =
       transactionMeta;
 


### PR DESCRIPTION
## **Description**
This pull request refines how the application handles "revoke delegation" transactions, particularly in the context of gas fee sponsorship. The changes ensure that "revoke delegation" transactions are not incorrectly marked as gas-fee sponsored and that UI components, fee calculations, and alerts reflect this logic accurately. Additionally, the logic for determining gas fee sponsorship is centralized for consistency across the codebase.

**Gas Fee Sponsorship Logic Updates:**

* Introduced and used a centralized `shouldApplyGasFeeSponsorship` utility function to determine if a transaction should be treated as gas-fee sponsored, replacing scattered checks throughout the codebase. This ensures that "revoke delegation" transactions are never considered sponsored, even if the flag is set.

* Updated the import and usage of sponsorship-related helpers in `TransactionDetails` and related components to use the new centralized logic.

**UI and Fee Calculation Adjustments:**

* Modified UI components (e.g., `GasFeesDetailsRow`, `TransactionDetailsNetworkFeeRow`) and their tests to ensure that "Paid by MetaMask" is not shown for "revoke delegation" transactions, and that network fee calculations display correctly for these transactions.

* Updated fee calculation hooks and their tests to use the new sponsorship logic, ensuring correct fee calculation for "revoke delegation" transactions.

**Alert and Confirmation Flow Enhancements:**

* Enhanced the insufficient balance alert logic to properly handle "revoke delegation" transactions, ensuring users are notified when they have insufficient funds for these transactions, even if sponsorship flags are set.

* Updated the transaction confirmation flow to clear the `isGasFeeSponsored` flag for "revoke delegation" transactions when gasless is supported, preventing incorrect UI indications post-confirmation.

**Testing and Utility Improvements:**

* Added and updated tests throughout the codebase to verify the new logic for "revoke delegation" transactions, including utility function tests and component behavior.

These changes collectively ensure that "revoke delegation" transactions are handled consistently and correctly with respect to gas fee sponsorship across the application.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disabled smart account on gas fees sponsored network

## **Related issues**

Fixes: user not able to disable Smart Account on gas fees sponsored networks

## **Manual testing steps**

1. Go to the Smart Account properties of an account which has his 7702 delegation enabled on a gas fees sponsored network
2. Toggle off the flag regarding the network to disable the delegation
3. The transaction "Account update" dialog pops up, confirm, the transaction is executed and the delegation is disabled
4. The flag for this network is disabled in the Smart Account properties of the account.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="400" height="600" alt="smart account toggle on" src="https://github.com/user-attachments/assets/b0e91a60-6422-472b-b624-53cb69e087f2" />


### **After**
<img width="400" height="700" alt="Disable trx" src="https://github.com/user-attachments/assets/36f1306e-7c1a-4ff8-8263-74ee5e2158c0" />
<img width="400" height="600" alt="Smart account toggle off" src="https://github.com/user-attachments/assets/6e7c5f0d-a4cd-4385-a704-d84122cf9b1e" />



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirm, publish hooks, and fee/sponsorship logic for a security-adjacent flow (7702 delegation); behavior is well-tested but spans UI and Engine publish paths.
> 
> **Overview**
> **Revoke delegation** transactions are excluded from gas-fee sponsorship even when `isGasFeeSponsored` is set, so users can turn off Smart Account (7702) on sponsored networks without misleading “Paid by MetaMask” UI or wrong zero-fee behavior.
> 
> New helpers in `transaction.ts` (`isRevokeDelegationTransaction`, `isTransactionMarkedAsGasFeeSponsored`, `shouldApplyGasFeeSponsorship`) replace scattered `isGasFeeSponsored && isGaslessSupported` checks in confirmation hooks, fee rows, and activity/bridge transaction details. Confirm clears the sponsored flag on submit for revoke delegation; insufficient-balance alerts still apply for those txs.
> 
> **Publish path:** `Delegation7702PublishHook` and transaction-controller init skip the 7702 relay hook for `revokeDelegation` (must publish as top-level `setCode`), while smart transactions can still run for that type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2793a8424382dda8b0fd25fcc3f505a8950f4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->