### PR TITLE
feat: add pagination on Explore token search

### DIFF
--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -101,6 +101,7 @@ const arrangeMocks = () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
   };
 

--- a/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.test.ts
+++ b/app/components/UI/Trending/hooks/useRwaTokens/useRwaTokens.test.ts
@@ -44,6 +44,7 @@ const arrangeMocks = (options?: {
     loadMore: jest.fn(),
     isLoadingMore: false,
     hasNextPage: false,
+    totalCount: undefined,
   });
   mockSortTrendingTokens.mockImplementation((tokens) => tokens);
 };

--- a/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts
+++ b/app/components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts
@@ -69,6 +69,7 @@ export const useSearchRequest = (options: {
   const [endCursor, setEndCursor] = useState<string | undefined>();
   const [hasNextPage, setHasNextPage] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [totalCount, setTotalCount] = useState<number | undefined>();
 
   // Track the current request ID to prevent stale results from overwriting current ones
   const requestIdRef = useRef(0);
@@ -86,6 +87,7 @@ export const useSearchRequest = (options: {
       setIsFetching(false);
       setEndCursor(undefined);
       setHasNextPage(false);
+      setTotalCount(undefined);
       return;
     }
 
@@ -95,6 +97,7 @@ export const useSearchRequest = (options: {
     setError(null);
     setEndCursor(undefined);
     setHasNextPage(false);
+    setTotalCount(undefined);
 
     try {
       const searchResults = await searchTokens(stableChainIds, debouncedQuery, {
@@ -107,6 +110,11 @@ export const useSearchRequest = (options: {
         setResults((searchResults?.data as SearchResult[]) || []);
         setEndCursor(searchResults?.pageInfo?.endCursor ?? undefined);
         setHasNextPage(searchResults?.pageInfo?.hasNextPage ?? false);
+        setTotalCount(
+          typeof searchResults?.totalCount === 'number'
+            ? searchResults.totalCount
+            : undefined,
+        );
         if (searchResults?.error) {
           setError({ message: searchResults.error, name: 'SearchError' });
         }
@@ -186,5 +194,6 @@ export const useSearchRequest = (options: {
     loadMore,
     isLoadingMore,
     hasNextPage,
+    totalCount,
   };
 };

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -76,6 +76,7 @@ describe('useTrendingSearch', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
 
     mockUseTrendingRequest.mockReturnValue({
@@ -145,6 +146,7 @@ describe('useTrendingSearch', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
 
     const { result } = renderHookWithProvider(() =>
@@ -185,6 +187,7 @@ describe('useTrendingSearch', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
 
     const { result } = renderHookWithProvider(() =>
@@ -232,6 +235,7 @@ describe('useTrendingSearch', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
 
     const { result } = renderHookWithProvider(() =>
@@ -351,6 +355,7 @@ describe('useTrendingSearch', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { result } = renderHookWithProvider(() =>
@@ -378,6 +383,7 @@ describe('useTrendingSearch', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { result } = renderHookWithProvider(() =>
@@ -406,6 +412,7 @@ describe('useTrendingSearch', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
 
     const { result } = renderHookWithProvider(() =>

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -76,6 +76,7 @@ export const useTrendingSearch = (opts?: {
     loadMore,
     isLoadingMore,
     hasNextPage,
+    totalCount,
   } = useSearchRequest({
     query: debouncedQuery || '',
     limit: 20,
@@ -163,5 +164,6 @@ export const useTrendingSearch = (opts?: {
     loadMore,
     isLoadingMore,
     hasNextPage,
+    totalCount: debouncedQuery?.trim() ? totalCount : undefined,
   };
 };

--- a/app/components/Views/AddAsset/AddAsset.test.tsx
+++ b/app/components/Views/AddAsset/AddAsset.test.tsx
@@ -135,6 +135,7 @@ describe('AddAsset', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
   });
 
@@ -166,6 +167,7 @@ describe('AddAsset', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { getByTestId, queryByTestId } = renderComponent();
@@ -191,6 +193,7 @@ describe('AddAsset', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { getByTestId, queryByTestId } = renderComponent();

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
@@ -199,6 +199,7 @@ const setupWithTokenResults = () => {
     loadMore: jest.fn(),
     isLoadingMore: false,
     hasNextPage: false,
+    totalCount: undefined,
   } as ReturnType<typeof useTrendingSearch>);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockConvertTokens.mockReturnValue([mockImportAset as any]);
@@ -251,6 +252,7 @@ describe('SearchTokenAutocomplete', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     } as ReturnType<typeof useTrendingSearch>);
     mockConvertTokens.mockReturnValue([]);
     (Engine.context.TokensController.addTokens as jest.Mock).mockResolvedValue(
@@ -477,6 +479,7 @@ describe('SearchTokenAutocomplete', () => {
       loadMore: jest.fn(),
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     } as ReturnType<typeof useTrendingSearch>);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockConvertTokens.mockReturnValue([mockNonEvmToken as any]);
@@ -577,6 +580,7 @@ describe('SearchTokenAutocomplete', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       } as ReturnType<typeof useTrendingSearch>);
 
       mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
@@ -706,6 +710,7 @@ describe('SearchTokenAutocomplete', () => {
         loadMore: jest.fn(),
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       } as ReturnType<typeof useTrendingSearch>);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockConvertTokens.mockReturnValue([mockNonEvmToken as any]);

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -47,6 +47,7 @@ describe('useTokensFeed', () => {
       loadMore: mockLoadMore,
       isLoadingMore: false,
       hasNextPage: false,
+      totalCount: undefined,
     });
   });
 
@@ -111,6 +112,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: true,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() => useTokensFeed({ query: 'eth' }));
@@ -128,6 +130,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: true,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() => useTokensFeed({ query: undefined }));
@@ -145,11 +148,44 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: true,
         hasNextPage: true,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() => useTokensFeed({ query: 'eth' }));
 
       expect(result.current.isLoadingMore).toBe(true);
+    });
+
+    it('forwards totalCount from useTrendingSearch when query is present', () => {
+      mockUseTrendingSearch.mockReturnValue({
+        data: sampleTokens,
+        isLoading: false,
+        refetch: mockRefetch,
+        loadMore: mockLoadMore,
+        isLoadingMore: false,
+        hasNextPage: true,
+        totalCount: 2101,
+      });
+
+      const { result } = renderHook(() => useTokensFeed({ query: 'eth' }));
+
+      expect(result.current.totalCount).toBe(2101);
+    });
+
+    it('suppresses totalCount when query is absent', () => {
+      mockUseTrendingSearch.mockReturnValue({
+        data: sampleTokens,
+        isLoading: false,
+        refetch: mockRefetch,
+        loadMore: mockLoadMore,
+        isLoadingMore: false,
+        hasNextPage: true,
+        totalCount: 2101,
+      });
+
+      const { result } = renderHook(() => useTokensFeed({ query: undefined }));
+
+      expect(result.current.totalCount).toBeUndefined();
     });
   });
 
@@ -206,6 +242,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
     });
 
@@ -242,6 +279,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() =>
@@ -259,6 +297,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() =>
@@ -276,6 +315,7 @@ describe('useTokensFeed', () => {
         loadMore: mockLoadMore,
         isLoadingMore: false,
         hasNextPage: false,
+        totalCount: undefined,
       });
 
       const { result } = renderHook(() =>

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
@@ -23,6 +23,7 @@ export interface UseTokensFeedResult {
   loadMore?: () => void;
   isLoadingMore?: boolean;
   hasMore?: boolean;
+  totalCount?: number;
 }
 
 /** Trending tokens feed; same source for the home list, "crypto movers" pills, and search. */
@@ -31,25 +32,62 @@ export const useTokensFeed = ({
   refresh,
   hideRiskyTokens = false,
 }: UseTokensFeedOptions = {}): UseTokensFeedResult => {
-  const { data, isLoading, refetch, loadMore, isLoadingMore, hasNextPage } =
-    useTrendingSearch({
-      searchQuery: query,
-      enableDebounce: false,
-    });
+  const {
+    data,
+    isLoading,
+    refetch,
+    loadMore,
+    isLoadingMore,
+    hasNextPage,
+    totalCount,
+  } = useTrendingSearch({
+    searchQuery: query,
+    enableDebounce: false,
+  });
 
   useFeedRefresh(refresh, refetch);
 
+  /**
+   * firstPageSizeRef records how many items were in the first page response so
+   * that subsequent pages can be appended without resorting. A single effect
+   * handles both concerns: reset on query change (and bail out immediately so
+   * a stale data.length is never captured on the same render), then capture the
+   * boundary once the initial load settles.
+   */
+  const firstPageSizeRef = useRef<number | null>(null);
+  const prevQueryRef = useRef(query);
+
+  useEffect(() => {
+    if (prevQueryRef.current !== query) {
+      firstPageSizeRef.current = null;
+      prevQueryRef.current = query;
+      return;
+    }
+    if (!isLoading && !isLoadingMore && firstPageSizeRef.current === null) {
+      firstPageSizeRef.current = data.length;
+    }
+  }, [query, isLoading, isLoadingMore, data.length]);
+
   const filteredData = useMemo(() => {
-    // Skip Fuse when a query is active: useTrendingSearch already merges API
-    // search results, and re-filtering would silently drop paginated items.
-    const searched = query?.trim()
-      ? data.sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0))
-      : fuseSearch(
-          data,
-          query,
-          TOKEN_FUSE_OPTIONS,
-          (a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0),
-        );
+    let searched: TrendingAsset[];
+
+    if (query?.trim()) {
+      // Sort only the first-page slice; subsequent pages are appended as-is so
+      // that pagination order is preserved rather than interleaved by market cap.
+      const boundary = firstPageSizeRef.current ?? data.length;
+      const firstPage = data
+        .slice(0, boundary)
+        .sort((a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0));
+      const rest = data.slice(boundary);
+      searched = [...firstPage, ...rest];
+    } else {
+      searched = fuseSearch(
+        data,
+        query,
+        TOKEN_FUSE_OPTIONS,
+        (a, b) => (b.marketCap ?? 0) - (a.marketCap ?? 0),
+      );
+    }
 
     if (!hideRiskyTokens) return searched;
 
@@ -59,6 +97,9 @@ export const useTokensFeed = ({
         !resultType || resultType === 'Verified' || resultType === 'Benign'
       );
     });
+    // firstPageSizeRef is a ref — intentionally excluded from deps so that
+    // boundary captures the snapshot set by the effect, not a stale closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, query, hideRiskyTokens]);
 
   return {
@@ -68,5 +109,6 @@ export const useTokensFeed = ({
     loadMore: query ? loadMore : undefined,
     isLoadingMore: query ? isLoadingMore : undefined,
     hasMore: query ? hasNextPage : undefined,
+    totalCount: query ? totalCount : undefined,
   };
 };

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -129,7 +129,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
           onPress={() => handleViewMore(section)}
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel={`${getViewMoreLabel(section.feedId, section.items.length, searchQuery, section.hasMore)} ${item.title}`}
+          accessibilityLabel={`${getViewMoreLabel(section.feedId, section.items.length, searchQuery, section.hasMore, section.totalCount)} ${item.title}`}
           style={({ pressed }) =>
             tw.style(
               'flex-row items-center gap-1 rounded px-1',
@@ -143,6 +143,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
               section.items.length,
               searchQuery,
               section.hasMore,
+              section.totalCount,
             )}
           </Text>
           <Icon

--- a/app/components/Views/TrendingView/search/useExploreSearch.ts
+++ b/app/components/Views/TrendingView/search/useExploreSearch.ts
@@ -39,6 +39,7 @@ export interface SearchFeedSection<T = unknown> {
   fetchMore?: () => void;
   isFetchingMore?: boolean;
   hasMore?: boolean;
+  totalCount?: number;
 }
 
 export interface ExploreSearchResult {

--- a/app/components/Views/TrendingView/search/useExploreSearchV2.test.ts
+++ b/app/components/Views/TrendingView/search/useExploreSearchV2.test.ts
@@ -22,9 +22,16 @@ const mockStocksData = [{ assetId: 'stock-1' }];
 const mockPredictionsData = [{ id: 'pred-1' }];
 const mockSitesData = [{ url: 'https://example.com' }];
 const mockFetchMore = jest.fn();
+const mockTokensLoadMore = jest.fn();
 
 jest.mock('../feeds/tokens/useTokensFeed', () => ({
-  useTokensFeed: jest.fn(() => ({ data: mockTokensData, isLoading: false })),
+  useTokensFeed: jest.fn(() => ({
+    data: mockTokensData,
+    isLoading: false,
+    loadMore: mockTokensLoadMore,
+    isLoadingMore: false,
+    hasMore: true,
+  })),
 }));
 
 jest.mock('../feeds/perps/usePerpsFeed', () => ({
@@ -94,6 +101,14 @@ describe('useExploreSearchV2', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsPerpsEnabled = true;
+    (useTokensFeed as jest.Mock).mockReturnValue({
+      data: mockTokensData,
+      isLoading: false,
+      loadMore: mockTokensLoadMore,
+      isLoadingMore: false,
+      hasMore: true,
+      totalCount: undefined,
+    });
   });
 
   describe('section order', () => {
@@ -214,8 +229,62 @@ describe('useExploreSearchV2', () => {
     });
   });
 
-  describe('non-predictions sections have no pagination fields', () => {
-    it.each(['tokens', 'perps', 'stocks', 'sites'] as const)(
+  describe('tokens pagination fields', () => {
+    it('exposes fetchMore (loadMore), isFetchingMore, and hasMore on the tokens section', () => {
+      const { result } = renderV2();
+      const tokensSection = result.current.sections.find(
+        (s) => s.feedId === 'tokens',
+      );
+      expect(tokensSection?.fetchMore).toBe(mockTokensLoadMore);
+      expect(tokensSection?.isFetchingMore).toBe(false);
+      expect(tokensSection?.hasMore).toBe(true);
+    });
+
+    it('reflects updated hasMore from the tokens feed', () => {
+      (useTokensFeed as jest.Mock).mockReturnValue({
+        data: mockTokensData,
+        isLoading: false,
+        loadMore: mockTokensLoadMore,
+        isLoadingMore: false,
+        hasMore: false,
+        totalCount: undefined,
+      });
+
+      const { result } = renderV2();
+      const tokensSection = result.current.sections.find(
+        (s) => s.feedId === 'tokens',
+      );
+      expect(tokensSection?.hasMore).toBe(false);
+    });
+
+    it('forwards totalCount from the tokens feed to the tokens section', () => {
+      (useTokensFeed as jest.Mock).mockReturnValue({
+        data: mockTokensData,
+        isLoading: false,
+        loadMore: mockTokensLoadMore,
+        isLoadingMore: false,
+        hasMore: true,
+        totalCount: 2101,
+      });
+
+      const { result } = renderV2();
+      const tokensSection = result.current.sections.find(
+        (s) => s.feedId === 'tokens',
+      );
+      expect(tokensSection?.totalCount).toBe(2101);
+    });
+
+    it('passes undefined totalCount when the feed has no totalCount', () => {
+      const { result } = renderV2();
+      const tokensSection = result.current.sections.find(
+        (s) => s.feedId === 'tokens',
+      );
+      expect(tokensSection?.totalCount).toBeUndefined();
+    });
+  });
+
+  describe('sections without pagination fields', () => {
+    it.each(['perps', 'stocks', 'sites'] as const)(
       '%s section does not carry fetchMore or hasMore',
       (feedId) => {
         const { result } = renderV2();

--- a/app/components/Views/TrendingView/search/useExploreSearchV2.ts
+++ b/app/components/Views/TrendingView/search/useExploreSearchV2.ts
@@ -50,6 +50,10 @@ export const useExploreSearchV2 = (query: string): ExploreSearchResult => {
         title: strings('trending.search_tabs.crypto'),
         items: tokens.data,
         isLoading: isDebouncing || tokens.isLoading,
+        fetchMore: tokens.loadMore,
+        isFetchingMore: tokens.isLoadingMore,
+        hasMore: tokens.hasMore,
+        totalCount: tokens.totalCount,
       },
     ];
 
@@ -92,6 +96,10 @@ export const useExploreSearchV2 = (query: string): ExploreSearchResult => {
     isPerpsEnabled,
     tokens.data,
     tokens.isLoading,
+    tokens.loadMore,
+    tokens.isLoadingMore,
+    tokens.hasMore,
+    tokens.totalCount,
     perps.data,
     perps.isLoading,
     stocks.data,

--- a/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
@@ -1,0 +1,105 @@
+import { getViewMoreLabel, MAX_ITEMS_PER_SECTION } from './viewMoreLabel';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string, params?: Record<string, unknown>) => {
+    if (params) return `${key}:${JSON.stringify(params)}`;
+    return key;
+  }),
+}));
+
+describe('getViewMoreLabel', () => {
+  describe('no query (empty or whitespace)', () => {
+    it.each(['', '  '])('returns "view_all" when searchQuery is %p', (q) => {
+      expect(getViewMoreLabel('tokens', 10, q)).toBe('trending.view_all');
+      expect(getViewMoreLabel('stocks', 10, q)).toBe('trending.view_all');
+    });
+  });
+
+  describe('local-search feeds (perps, stocks, sites)', () => {
+    it('returns "view_x_more" when items exceed MAX_ITEMS_PER_SECTION', () => {
+      const extra = 5;
+      const total = MAX_ITEMS_PER_SECTION + extra;
+      expect(getViewMoreLabel('stocks', total, 'eth')).toBe(
+        `trending.view_x_more:{"count":${extra}}`,
+      );
+    });
+
+    it('returns "view_all" when items equal MAX_ITEMS_PER_SECTION', () => {
+      expect(getViewMoreLabel('perps', MAX_ITEMS_PER_SECTION, 'eth')).toBe(
+        'trending.view_all',
+      );
+    });
+
+    it('returns "view_all" when items are fewer than MAX_ITEMS_PER_SECTION', () => {
+      expect(getViewMoreLabel('sites', MAX_ITEMS_PER_SECTION - 1, 'eth')).toBe(
+        'trending.view_all',
+      );
+    });
+  });
+
+  describe('predictions (local feed with hasMore fallback)', () => {
+    it('returns "view_x_more" when items exceed MAX_ITEMS_PER_SECTION', () => {
+      expect(
+        getViewMoreLabel('predictions', MAX_ITEMS_PER_SECTION + 2, 'eth', true),
+      ).toBe(`trending.view_x_more:{"count":2}`);
+    });
+
+    it('returns "view_more" when items fit preview but hasMore is true', () => {
+      expect(
+        getViewMoreLabel('predictions', MAX_ITEMS_PER_SECTION, 'eth', true),
+      ).toBe('trending.view_more');
+    });
+
+    it('returns "view_all" when items fit preview and hasMore is false', () => {
+      expect(
+        getViewMoreLabel('predictions', MAX_ITEMS_PER_SECTION, 'eth', false),
+      ).toBe('trending.view_all');
+    });
+  });
+
+  describe('tokens feed (remote search with totalCount)', () => {
+    it('returns "view_x_more" using totalCount when there are remaining results', () => {
+      // totalCount: 2101, visible: 3 → extra = 2101 - 3 = 2098
+      expect(getViewMoreLabel('tokens', 20, 'eth', true, 2101)).toBe(
+        `trending.view_x_more:{"count":2098}`,
+      );
+    });
+
+    it('caps visible items at MAX_ITEMS_PER_SECTION when computing extra', () => {
+      // totalItems=20 is capped to MAX_ITEMS_PER_SECTION=3 → extra = 100 - 3 = 97
+      expect(getViewMoreLabel('tokens', 20, 'eth', true, 100)).toBe(
+        `trending.view_x_more:{"count":97}`,
+      );
+    });
+
+    it('returns "view_all" when totalCount equals MAX_ITEMS_PER_SECTION', () => {
+      expect(
+        getViewMoreLabel(
+          'tokens',
+          MAX_ITEMS_PER_SECTION,
+          'eth',
+          false,
+          MAX_ITEMS_PER_SECTION,
+        ),
+      ).toBe('trending.view_all');
+    });
+
+    it('returns "view_all" when totalCount is less than visible items', () => {
+      expect(getViewMoreLabel('tokens', 3, 'eth', false, 2)).toBe(
+        'trending.view_all',
+      );
+    });
+
+    it('returns "view_all" when totalCount is undefined (no API response yet)', () => {
+      expect(getViewMoreLabel('tokens', 0, 'eth', true, undefined)).toBe(
+        'trending.view_all',
+      );
+    });
+
+    it('returns "view_all" when query is empty regardless of totalCount', () => {
+      expect(getViewMoreLabel('tokens', 20, '', true, 2101)).toBe(
+        'trending.view_all',
+      );
+    });
+  });
+});

--- a/app/components/Views/TrendingView/search/viewMoreLabel.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.ts
@@ -23,22 +23,34 @@ export const LOCAL_SEARCH_FEEDS: ReadonlySet<SearchFeedId> = new Set([
  * when the active query produces more than MAX_ITEMS_PER_SECTION hits.
  * For predictions, falls back to "View more" when the server signals there are
  * additional pages (hasMore) but the loaded slice fits in the preview.
- * Remote-search feeds (tokens) and the no-query state always show "View all".
+ * Tokens use totalCount from the search API to compute the remaining count
+ * across all pages not yet loaded.
+ * The no-query state always shows "View all".
  */
 export function getViewMoreLabel(
   feedId: SearchFeedId,
   totalItems: number,
   searchQuery: string,
   hasMore?: boolean,
+  totalCount?: number,
 ): string {
-  if (LOCAL_SEARCH_FEEDS.has(feedId) && searchQuery.trim()) {
-    const extra = totalItems - MAX_ITEMS_PER_SECTION;
-    if (extra > 0) {
-      return strings('trending.view_x_more', { count: extra });
-    }
-    // Predictions: loaded page fits within the preview but server has more pages
-    if (hasMore) {
-      return strings('trending.view_more');
+  if (searchQuery.trim()) {
+    if (LOCAL_SEARCH_FEEDS.has(feedId)) {
+      const extra = totalItems - MAX_ITEMS_PER_SECTION;
+      if (extra > 0) {
+        return strings('trending.view_x_more', { count: extra });
+      }
+      // Predictions: loaded page fits within the preview but server has more pages
+      if (hasMore) {
+        return strings('trending.view_more');
+      }
+    } else if (feedId === 'tokens' && totalCount !== undefined) {
+      // totalCount covers all pages from the API; subtract what is already
+      // visible (capped at the preview limit) to get the remaining count.
+      const extra = totalCount - Math.min(totalItems, MAX_ITEMS_PER_SECTION);
+      if (extra > 0) {
+        return strings('trending.view_x_more', { count: extra });
+      }
     }
   }
   return strings('trending.view_all');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Added pagination on Explore token search plus the "View X more" support

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add pagination on Explore token search

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3239

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/11289fe6-b074-49e8-92d2-3fe3c5778436


<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/ea31deec-3fe4-418d-9582-89d8bdfdd440



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token search pagination and ordering in the Explore search flow by threading API `totalCount` through multiple hooks and UI labels; mistakes could lead to incorrect counts, ordering, or pagination behavior. Impact is limited to Explore/trending token search surfaces and is covered by added unit tests.
> 
> **Overview**
> Adds end-to-end support for *paginated Explore token search* by propagating the search API’s `totalCount` through `useSearchRequest` → `useTrendingSearch` → `useTokensFeed` → `useExploreSearchV2` sections.
> 
> Updates Explore search section headers to show **"View X more"** for tokens using `totalCount` (new `getViewMoreLabel` logic + tests), and exposes tokens pagination controls (`fetchMore`/`hasMore`/`isFetchingMore`) in V2 search sections.
> 
> Adjusts `useTokensFeed` sorting for active queries to **only sort the first page by market cap** and append subsequent pages without re-sorting, preserving pagination order; adds/updates tests and mocks across affected components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ebfae590126bba642c67a1bd6dd58fd7862d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->