### PR TITLE
ci: filter push and scheduled runs for QA metrics

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -83,30 +83,50 @@ let _runId = null;
 let _artifactList = null;
 
 /**
- * Fetches the ID of the latest successful CI workflow run on `main`.
+ * Fetches the ID of the latest successful CI workflow run on `main` triggered
+ * by a `push` (merge-queue merge) or `schedule` event.
+ *
+ * These two event types always upload artifacts to standard GitHub storage.
+ * `workflow_dispatch` runs with runner_provider=namespace upload to Namespace's
+ * own storage instead, which is invisible to the standard GitHub artifacts API
+ * and would cause all artifact-based metrics to silently drop from the output.
+ * `workflow_call` runs are PR shadow runs — also not useful here.
+ *
+ * The GitHub API only supports a single `event` filter per request, so both
+ * event types are fetched in parallel and the most recently created run wins.
  *
  * @returns {Promise<string>}
  */
 async function getLatestCiRunId() {
-  const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&status=success&per_page=1`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${GITHUB_TOKEN}`,
-      Accept: 'application/vnd.github+json',
-    },
-  });
+  const headers = {
+    Authorization: `Bearer ${GITHUB_TOKEN}`,
+    Accept: 'application/vnd.github+json',
+  };
 
-  if (!res.ok) {
-    throw new Error(`Failed to fetch CI workflow runs: ${res.status} ${res.statusText}`);
-  }
+  const fetchLatestForEvent = async (event) => {
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&status=success&event=${event}&per_page=1`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch CI workflow runs (event=${event}): ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    return data.workflow_runs?.[0] ?? null;
+  };
 
-  const data = await res.json();
-  const run = data.workflow_runs?.[0];
+  const [pushRun, scheduleRun] = await Promise.all([
+    fetchLatestForEvent('push'),
+    fetchLatestForEvent('schedule'),
+  ]);
+
+  const run = [pushRun, scheduleRun]
+    .filter(Boolean)
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
   if (!run) {
-    throw new Error('No successful CI workflow runs found on main');
+    throw new Error('No successful CI workflow runs found on main (push or schedule)');
   }
 
-  console.log(`[run] Using latest successful ci run #${run.run_number} (id=${run.id}, ${run.created_at})`);
+  console.log(`[run] Using latest successful ci run #${run.run_number} (id=${run.id}, event=${run.event}, ${run.created_at})`);
   return String(run.id);
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the QA stats script selects the source CI run; if the GitHub Actions API filtering differs from expectations, metrics collection could fail or target an unintended run.
> 
> **Overview**
> QA metrics collection now **only targets artifacts from `main` CI runs triggered by `push` or `schedule`**, avoiding `workflow_dispatch`/`workflow_call` runs that don’t publish artifacts to the standard GitHub artifacts API.
> 
> `collect-qa-stats.mjs` fetches the latest successful run for both events in parallel, selects the newest by `created_at`, and improves logging/error messages to include the chosen run’s `event`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276ea5c3d0e8c7757f36d78f9d83972ac5c1f5a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->