### PR TITLE
refactor(analytics): PR E1 rename addTraitsToUser to identify in mobile-core-ux files

### DIFF
--- a/app/components/UI/NetworkManager/index.test.tsx
+++ b/app/components/UI/NetworkManager/index.test.tsx
@@ -122,7 +122,7 @@ jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
     trackEvent: mockTrackEvent,
     createEventBuilder: mockCreateEventBuilder,
-    addTraitsToUser: mockAddTraitsToUser,
+    identify: mockAddTraitsToUser,
   }),
 }));
 

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -83,7 +83,7 @@ const NetworkManager = () => {
   const navigation = useNavigation();
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, { colors });
-  const { trackEvent, createEventBuilder, addTraitsToUser } = useAnalytics();
+  const { trackEvent, createEventBuilder, identify } = useAnalytics();
   const { disableNetwork, enabledNetworksByNamespace } = useNetworkEnablement();
 
   const enabledNetworks = useMemo(() => {
@@ -296,11 +296,11 @@ const NetworkManager = () => {
       NetworkController.removeNetwork(chainId);
       disableNetwork(showConfirmDeleteModal.caipChainId);
 
-      addTraitsToUser(removeItemFromChainIdList(chainId));
+      identify(removeItemFromChainIdList(chainId));
 
       setShowConfirmDeleteModal(initialShowConfirmDeleteModal);
     }
-  }, [showConfirmDeleteModal, disableNetwork, addTraitsToUser]);
+  }, [showConfirmDeleteModal, disableNetwork, identify]);
 
   const cancelButtonProps: ButtonProps = useMemo(
     () => ({

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -27,7 +27,7 @@ import Logger from '../../../util/Logger';
 import { protectWalletModalVisible } from '../../../actions/user';
 import Routes from '../../../constants/navigation/Routes';
 import { AccountActionsBottomSheetSelectorsIDs } from './AccountActionsBottomSheet.testIds';
-import { useMetrics } from '../../../components/hooks/useMetrics';
+import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import {
   isHardwareAccount,
   isHDOrFirstPartySnapAccount,
@@ -64,7 +64,7 @@ const AccountActions = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const { navigate } = useNavigation();
   const dispatch = useDispatch();
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { networkSupporting7702Present } = useEIP7702Networks(
     selectedAccount.address,
   );

--- a/app/components/Views/AccountsMenu/AccountsMenu.test.tsx
+++ b/app/components/Views/AccountsMenu/AccountsMenu.test.tsx
@@ -50,29 +50,6 @@ jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
-jest.mock('../../../core/Analytics', () => ({
-  MetaMetrics: {
-    getInstance: () => ({
-      trackEvent: mockTrackEvent,
-    }),
-  },
-}));
-
-jest.mock('../../../core/Analytics/MetaMetrics.events', () => ({
-  EVENT_NAME: {
-    CARD_HOME_CLICKED: 'Card Home Clicked',
-    SETTINGS_VIEWED: 'Settings Viewed',
-    SETTINGS_ABOUT: 'About MetaMask',
-    NAVIGATION_TAPS_SEND_FEEDBACK: 'Send Feedback',
-    NAVIGATION_TAPS_GET_HELP: 'Get Help',
-    NAVIGATION_TAPS_LOGOUT: 'Logout',
-    QR_SCANNER_OPENED: 'QR Scanner Opened',
-    RAMPS_BUTTON_CLICKED: 'Ramps Button Clicked',
-    NOTIFICATIONS_MENU_OPENED: 'Notifications Menu Opened',
-    NOTIFICATIONS_ACTIVATED: 'Notifications Activated',
-  },
-}));
-
 jest.mock('../../../core/Analytics/MetricsEventBuilder', () => ({
   MetricsEventBuilder: {
     createEventBuilder: jest.fn(() => ({

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.test.ts
@@ -84,7 +84,7 @@ const mockCreateEventBuilder = jest.fn(() => ({
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
     trackEvent: mockTrackEvent,
-    addTraitsToUser: mockAddTraitsToUser,
+    identify: mockAddTraitsToUser,
     createEventBuilder: mockCreateEventBuilder,
   }),
 }));

--- a/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
+++ b/app/components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts
@@ -84,7 +84,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
   const providerConfig = useSelector(selectProviderConfig);
   const isAllNetworks = useSelector(selectIsAllNetworks);
   const tokenNetworkFilter = useSelector(selectTokenNetworkFilter);
-  const { trackEvent, addTraitsToUser, createEventBuilder } = useAnalytics();
+  const { trackEvent, identify, createEventBuilder } = useAnalytics();
 
   // ---- Handle network add/update ------------------------------------------
   const handleNetworkUpdate = useCallback(
@@ -204,7 +204,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
         await NetworkController.addNetwork({
           ...networkConfig,
         } as unknown as AddNetworkFields);
-        addTraitsToUser(addItemToChainIdList(networkConfig.chainId));
+        identify(addItemToChainIdList(networkConfig.chainId));
       }
 
       if (!skipPostSaveNavigation) {
@@ -221,7 +221,7 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       navigation,
       networkConfigurations,
       trackEvent,
-      addTraitsToUser,
+      identify,
       createEventBuilder,
     ],
   );
@@ -396,11 +396,11 @@ export const useNetworkOperations = (): UseNetworkOperationsReturn => {
       const { NetworkController } = Engine.context;
       NetworkController.removeNetwork(hexChainId);
 
-      addTraitsToUser(removeItemFromChainIdList(hexChainId));
+      identify(removeItemFromChainIdList(hexChainId));
 
       navigation.goBack();
     },
-    [navigation, networkConfigurations, providerConfig, addTraitsToUser],
+    [navigation, networkConfigurations, providerConfig, identify],
   );
 
   // ---- Navigate to edit ---------------------------------------------------

--- a/app/components/Views/Settings/AutoDetectNFTSettings/index.test.tsx
+++ b/app/components/Views/Settings/AutoDetectNFTSettings/index.test.tsx
@@ -59,7 +59,7 @@ describe('AutoDetectNFTSettings', () => {
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
         trackEvent: mockTrackEvent,
-        addTraitsToUser: mockAddTraitsToUser,
+        identify: mockAddTraitsToUser,
       }),
     );
     (useNavigation as jest.Mock).mockImplementation(() => mockNavigation);

--- a/app/components/Views/Settings/AutoDetectNFTSettings/index.tsx
+++ b/app/components/Views/Settings/AutoDetectNFTSettings/index.tsx
@@ -23,7 +23,7 @@ import createStyles from './index.styles';
 import { NFT_AUTO_DETECT_MODE_SECTION } from './index.constants';
 
 const AutoDetectNFTSettings = () => {
-  const { trackEvent, addTraitsToUser, createEventBuilder } = useAnalytics();
+  const { trackEvent, identify, createEventBuilder } = useAnalytics();
   const theme = useTheme();
   const { colors } = theme;
   const styles = createStyles();
@@ -38,7 +38,7 @@ const AutoDetectNFTSettings = () => {
       }
       PreferencesController.setUseNftDetection(value);
 
-      addTraitsToUser({
+      identify({
         ...(value && {
           [UserProfileProperty.ENABLE_OPENSEA_API]: value
             ? UserProfileProperty.ON
@@ -57,7 +57,7 @@ const AutoDetectNFTSettings = () => {
           .build(),
       );
     },
-    [addTraitsToUser, trackEvent, createEventBuilder],
+    [identify, trackEvent, createEventBuilder],
   );
 
   return (

--- a/app/components/Views/Settings/AutoDetectTokensSettings/index.test.tsx
+++ b/app/components/Views/Settings/AutoDetectTokensSettings/index.test.tsx
@@ -44,7 +44,7 @@ describe('AssetSettings', () => {
     jest
       .mocked(useAnalytics)
       .mockReturnValue(
-        createMockUseAnalyticsHook({ addTraitsToUser: mockAddTraitsToUser }),
+        createMockUseAnalyticsHook({ identify: mockAddTraitsToUser }),
       );
   });
 

--- a/app/components/Views/Settings/AutoDetectTokensSettings/index.tsx
+++ b/app/components/Views/Settings/AutoDetectTokensSettings/index.tsx
@@ -26,20 +26,20 @@ const AutoDetectTokensSettings = () => {
   const theme = useTheme();
   const { colors } = theme;
   const { styles } = useStyles(styleSheet, {});
-  const { addTraitsToUser } = useAnalytics();
+  const { identify } = useAnalytics();
 
   const isTokenDetectionEnabled = useSelector(selectUseTokenDetection);
 
   const toggleTokenDetection = useCallback(
     (value: boolean) => {
       Engine.context.PreferencesController.setUseTokenDetection(value);
-      addTraitsToUser({
+      identify({
         [UserProfileProperty.TOKEN_DETECTION]: value
           ? UserProfileProperty.ON
           : UserProfileProperty.OFF,
       });
     },
-    [addTraitsToUser],
+    [identify],
   );
 
   return (

--- a/app/components/Views/Settings/BatchAccountBalanceSettings/index.tsx
+++ b/app/components/Views/Settings/BatchAccountBalanceSettings/index.tsx
@@ -25,7 +25,7 @@ const BatchAccountBalanceSettings = () => {
   const theme = useTheme();
   const { colors } = theme;
   const { styles } = useStyles(styleSheet, {});
-  const { addTraitsToUser } = useAnalytics();
+  const { identify } = useAnalytics();
 
   const isMultiAccountBalancesEnabled = useSelector(
     selectIsMultiAccountBalancesEnabled,
@@ -36,13 +36,13 @@ const BatchAccountBalanceSettings = () => {
       PreferencesController.setIsMultiAccountBalancesEnabled(
         multiAccountBalancesEnabled,
       );
-      addTraitsToUser({
+      identify({
         [UserProfileProperty.MULTI_ACCOUNT_BALANCE]: multiAccountBalancesEnabled
           ? UserProfileProperty.ON
           : UserProfileProperty.OFF,
       });
     },
-    [PreferencesController, addTraitsToUser],
+    [PreferencesController, identify],
   );
 
   return (

--- a/app/components/Views/Settings/DisplayNFTMediaSettings/index.test.tsx
+++ b/app/components/Views/Settings/DisplayNFTMediaSettings/index.test.tsx
@@ -43,7 +43,7 @@ describe('DisplayNFTMediaSettings', () => {
     jest
       .mocked(useAnalytics)
       .mockReturnValue(
-        createMockUseAnalyticsHook({ addTraitsToUser: mockAddTraitsToUser }),
+        createMockUseAnalyticsHook({ identify: mockAddTraitsToUser }),
       );
   });
 

--- a/app/components/Views/Settings/DisplayNFTMediaSettings/index.tsx
+++ b/app/components/Views/Settings/DisplayNFTMediaSettings/index.tsx
@@ -21,7 +21,7 @@ const DisplayNFTMediaSettings = () => {
   const theme = useTheme();
   const { colors } = theme;
   const { styles } = useStyles(styleSheet, {});
-  const { addTraitsToUser } = useAnalytics();
+  const { identify } = useAnalytics();
 
   const displayNftMedia = useSelector(selectDisplayNftMedia);
 
@@ -39,7 +39,7 @@ const DisplayNFTMediaSettings = () => {
         [UserProfileProperty.NFT_AUTODETECTION]: UserProfileProperty.OFF,
       }),
     };
-    addTraitsToUser(traits);
+    identify(traits);
   };
 
   return (

--- a/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/BlockaidSettings.tsx
@@ -21,7 +21,7 @@ import { SECURITY_ALERTS_URL } from '../../../../../constants/urls';
 const BlockaidSettings = () => {
   const theme = useTheme();
   const { colors } = useTheme();
-  const { trackEvent, createEventBuilder, addTraitsToUser } = useAnalytics();
+  const { trackEvent, createEventBuilder, identify } = useAnalytics();
   const styles = createStyles();
   const securityAlertsEnabled = useSelector(selectIsSecurityAlertsEnabled);
 
@@ -41,7 +41,7 @@ const BlockaidSettings = () => {
         .build(),
     );
 
-    addTraitsToUser({
+    identify({
       [UserProfileProperty.SECURITY_PROVIDERS]: newSecurityAlertsEnabledState
         ? 'blockaid'
         : '',

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.test.ts
@@ -72,7 +72,7 @@ describe('useAddPopularNetwork', () => {
           build: jest.fn().mockReturnValue({ event: 'test' }),
         }),
       }),
-      addTraitsToUser: mockAddTraitsToUser,
+      identify: mockAddTraitsToUser,
     });
     (useNetworkEnablement as jest.Mock).mockReturnValue({
       enableNetwork: mockEnableNetwork,

--- a/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
+++ b/app/components/hooks/useAddPopularNetwork/useAddPopularNetwork.ts
@@ -36,7 +36,7 @@ interface UseAddPopularNetworkResult {
  */
 export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
   const dispatch = useDispatch();
-  const { trackEvent, createEventBuilder, addTraitsToUser } = useAnalytics();
+  const { trackEvent, createEventBuilder, identify } = useAnalytics();
   const networkConfigurationByChainId = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
@@ -116,7 +116,7 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
           ],
         });
 
-        addTraitsToUser(addItemToChainIdList(hexChainId));
+        identify(addItemToChainIdList(hexChainId));
 
         networkClientId =
           addedNetwork?.rpcEndpoints?.[addedNetwork.defaultRpcEndpointIndex]
@@ -138,7 +138,7 @@ export const useAddPopularNetwork = (): UseAddPopularNetworkResult => {
       networkConfigurationByChainId,
       trackEvent,
       createEventBuilder,
-      addTraitsToUser,
+      identify,
       enableNetwork,
       dispatch,
     ],


### PR DESCRIPTION
## **Description**

Part of the analytics cleanup workstream (#26686).

Renames `.addTraitsToUser()` → `.identify()` across all mobile-core-ux-owned Settings components and network hooks, and migrates `AccountActions.tsx` from the deprecated `useMetrics` to `useAnalytics`. Also removes stale `MetaMetrics`/`MetaMetrics.events` mocks from `AccountsMenu.test.tsx`.

Files touched:
- `BlockaidSettings.tsx`, `DisplayNFTMediaSettings`, `BatchAccountBalanceSettings`, `AutoDetectTokensSettings`, `AutoDetectNFTSettings` — rename `.addTraitsToUser` → `.identify`
- `useNetworkOperations.ts`, `useAddPopularNetwork.ts`, `NetworkManager/index.tsx` — rename `.addTraitsToUser` → `.identify`
- `AccountActions.tsx` — migrate `useMetrics` → `useAnalytics`
- Corresponding test files updated to use `identify` override in `createMockUseAnalyticsHook`
- `AccountsMenu.test.tsx` — remove stale `jest.mock('../../../core/Analytics', ...)` and `jest.mock('../../../core/Analytics/MetaMetrics.events', ...)`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: #26821
Refs: #26686

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A — no UI changes.

### **After**

N/A — no UI changes.

## **Pre-merge author checklist**

- [x] I've followed the [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, test affected areas)
- [ ] I confirm that this PR addresses what is claimed in the PR title
- [ ] I confirm that I've manually reviewed the changes if not manually tested

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to analytics hook usage and test mocks, with minimal runtime behavior change beyond calling the new `identify` alias.
> 
> **Overview**
> Updates mobile-core-ux components and network-related hooks to use `useAnalytics().identify` instead of the deprecated `addTraitsToUser` for updating analytics user traits (settings toggles and network add/remove flows).
> 
> Migrates `AccountActions` off `useMetrics` to `useAnalytics`, and cleans up related unit tests by updating mocked hook return values and removing stale `MetaMetrics`/`MetaMetrics.events` mocks in `AccountsMenu.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367f37e920fef4d5094183b647e5be47ee59d2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->