### PR TITLE
fix: predict claim back dismissal cleanup

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cloneDeep } from 'lodash';
-import { ScrollView } from 'react-native';
+import { BackHandler, ScrollView } from 'react-native';
 import {
   generateContractInteractionState,
   personalSignatureConfirmationState,
@@ -294,6 +294,40 @@ describe('Confirm', () => {
     });
 
     expect(getByTestId('confirm-loader-default')).toBeDefined();
+  });
+
+  it('prevents dismissing the loading state before an approval request exists', () => {
+    const removeBackHandler = jest.fn();
+    jest.spyOn(BackHandler, 'addEventListener').mockReturnValue({
+      remove: removeBackHandler,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    renderWithProvider(<Confirm />, {
+      state: stateWithoutRequest,
+    });
+
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      headerShown: false,
+      gestureEnabled: false,
+    });
+
+    expect(BackHandler.addEventListener).toHaveBeenCalledWith(
+      'hardwareBackPress',
+      expect.any(Function),
+    );
+
+    const backHandlerCallback = jest.mocked(BackHandler.addEventListener).mock
+      .calls[0][1];
+
+    expect(backHandlerCallback()).toBe(true);
   });
 
   it('displays alternate loader if specified', () => {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -122,27 +122,27 @@ export const Confirm = ({
   });
 
   useEffect(() => {
-    if (approvalRequest) {
-      const options = {
-        headerShown: false,
-        // If there is an approvalRequest, we need to allow the user to swipe to reject the confirmation
-        gestureEnabled: true,
-      };
+    const options = {
+      headerShown: false,
+      // If there is an approvalRequest, we need to allow the user to swipe to reject the confirmation.
+      // If not, keep the loading state in place until there is a request that can be rejected.
+      gestureEnabled: Boolean(approvalRequest),
+    };
 
-      if (isFullScreenConfirmation) {
-        // If the confirmation is full screen, we need to show the header
-        options.headerShown = true;
-      }
-      navigation.setOptions(options);
+    if (approvalRequest && isFullScreenConfirmation) {
+      // If the confirmation is full screen, we need to show the header
+      options.headerShown = true;
     }
+
+    navigation.setOptions(options);
   }, [approvalRequest, isFullScreenConfirmation, navigation]);
 
   useEffect(() => {
     if (!approvalRequest) {
       const backHandlerSubscription = BackHandler.addEventListener(
         'hardwareBackPress',
-        // Do nothing if back button is pressed for Android in case of no approvalRequest (loading state)
-        () => undefined,
+        // Keep users on the loading state until there is an approval request that can be rejected.
+        () => true,
       );
 
       return () => {

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PredictClaimInfo } from './predict-claim-info';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
+
+jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
+
+jest.mock('../../../hooks/ui/useNavbar', () => ({
+  useModalNavbar: jest.fn(),
+}));
+
+jest.mock('../../../hooks/metrics/usePredictClaimConfirmationMetrics', () => ({
+  usePredictClaimConfirmationMetrics: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useConfirmActions', () => ({
+  useConfirmActions: () => ({
+    onReject: jest.fn(),
+  }),
+}));
+
+jest.mock('../../predict-confirmations/predict-claim-amount', () => ({
+  PredictClaimAmount: () => null,
+  PredictClaimAmountSkeleton: () => null,
+}));
+
+jest.mock('../../predict-confirmations/predict-claim-background', () => ({
+  PredictClaimBackground: () => null,
+}));
+
+jest.mock(
+  '../../../../../../component-library/components/Buttons/ButtonIcon',
+  () => ({
+    __esModule: true,
+    default: () => null,
+    ButtonIconSizes: {
+      Lg: 'lg',
+    },
+  }),
+);
+
+jest.mock('../../../../../../component-library/hooks', () => ({
+  useStyles: () => ({
+    styles: {
+      backButton: {},
+    },
+  }),
+}));
+
+describe('PredictClaimInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears the confirmation when dismissed with a back gesture', () => {
+    render(<PredictClaimInfo />);
+
+    expect(useClearConfirmationOnBackSwipe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
@@ -13,10 +13,12 @@ import { IconName } from '../../../../../../component-library/components/Icons/I
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './predict-claim-info.styles';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 
 export function PredictClaimInfo() {
   useModalNavbar();
   usePredictClaimConfirmationMetrics();
+  useClearConfirmationOnBackSwipe();
 
   return (
     <>

--- a/tests/framework/fixtures/fixture-validation.ts
+++ b/tests/framework/fixtures/fixture-validation.ts
@@ -219,6 +219,7 @@ export function getMobileFixtureIgnoredKeys(): string[] {
     'engine.backgroundState.AccountTreeController.selectedAccountGroup',
     'engine.backgroundState.AccountTreeController.accountGroupsMetadata',
     'engine.backgroundState.AccountTreeController.accountWalletsMetadata',
+    'engine.backgroundState.MoneyAccountController.moneyAccounts',
     'engine.backgroundState.TokenBalancesController.tokenBalances',
     'engine.backgroundState.MultichainNetworkController.networksWithTransactionActivity',
     'browser.activeTab',


### PR DESCRIPTION
## Summary

This PR prevents Predict claim confirmations from being stranded when the user dismisses the full-screen confirmation with a back gesture instead of the close button.

The Predict claim screen now opts into the existing full-screen confirmation back-swipe cleanup hook, so gesture and Android hardware-back dismissals reject the active confirmation instead of only removing the route. The shared confirmation loader also disables gestures and consumes Android back presses while there is no approval request yet, so users cannot leave the loading screen before there is a request that can be rejected.

## Root Cause

Predict claim used a custom close button that called the normal reject path, but the screen did not install the existing back-swipe cleanup hook used by other full-screen confirmations. A route-level back dismissal could therefore remove the confirmation UI while leaving the approval and unapproved transaction in controller state. In the real claim flow, that can leave the Predict pending claim entry active, causing later claim attempts to be treated as already in progress.

Original ticket: https://consensyssoftware.atlassian.net/browse/CONF-1375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation gesture/back-button handling in the confirmations flow, which could affect user ability to exit confirmations if conditions are wrong. Main behavioral change is gated to the pre-`approvalRequest` loading state and full-screen Predict claim dismissals, with added tests to reduce regressions.
> 
> **Overview**
> Prevents users from dismissing the `Confirm` loading state before an `approvalRequest` exists by **disabling navigation gestures** and **consuming Android hardware back presses** until there’s something to reject.
> 
> Updates the Predict claim confirmation info screen to opt into the shared `useClearConfirmationOnBackSwipe` cleanup so back-swipe/hardware-back dismissals trigger the normal reject path, and adds focused unit tests for both behaviors. Also updates fixture validation ignore lists to exclude `engine.backgroundState.MoneyAccountController.moneyAccounts` from schema comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86388d27e10c799bc4b4b73215bb82f63d0e873b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->