### PR TITLE
chore: Add a required source branch input to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,11 @@ on:
         value: ${{ jobs.emit-build-metadata.outputs.ios_version_code }}
   workflow_dispatch:
     inputs:
+      source_branch:
+        description: 'Branch, tag, or SHA to build'
+        required: true
+        type: string
+        default: 'main'
       build_name:
         required: true
         type: choice
@@ -79,11 +84,6 @@ on:
         required: true
         type: choice
         options: [android, ios, both]
-      source_branch:
-        description: 'Branch, tag, or SHA to build'
-        required: true
-        type: string
-        default: 'main'
       upload_to_sentry:
         description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,9 @@ on:
         required: true
         type: string # android, ios, or both
       source_branch:
-        description: >-
-          Branch, tag, or SHA for prepare, node-modules setup, and build checkout (empty uses the default triggering ref).
-          When build_number is set, the bump is applied locally on each build runner after checkout.
-        required: false
+        description: 'Branch, tag, or SHA to build'
+        required: true
         type: string
-        default: ''
       build_number:
         description: >-
           Optional (workflow_call only). From generate-build-version.yml. When non-empty, each matrix
@@ -43,10 +40,10 @@ on:
         description: 'platform input (android, ios, or both)'
         value: ${{ inputs.platform }}
       source_branch_input:
-        description: 'source_branch input (empty means default ref was used)'
+        description: 'source_branch input passed to this workflow'
         value: ${{ inputs.source_branch }}
       checkout_ref:
-        description: 'Git ref used for checkout (source_branch or triggering ref)'
+        description: 'Git ref used for checkout (same as source_branch)'
         value: ${{ jobs.emit-build-metadata.outputs.checkout_ref }}
       built_commit_sha:
         description: 'Resolved commit SHA at checkout_ref after build succeeded'
@@ -82,6 +79,11 @@ on:
         required: true
         type: choice
         options: [android, ios, both]
+      source_branch:
+        description: 'Branch, tag, or SHA to build'
+        required: true
+        type: string
+        default: 'main'
       upload_to_sentry:
         description: 'Upload JS source maps and native debug symbols to Sentry during the build (requires Sentry auth in the build environment)'
         required: false
@@ -113,18 +115,18 @@ jobs:
       signing_aws_secret: ${{ steps.config.outputs.signing_aws_secret }}
       signing_android_keystore_path: ${{ steps.config.outputs.signing_android_keystore_path }}
       script_name: ${{ steps.config.outputs.script_name }}
-      checkout_ref_for_setup: ${{ inputs.source_branch || github.ref_name }}
+      checkout_ref_for_setup: ${{ inputs.source_branch }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
         with:
           fetch-depth: 1
-          ref: ${{ inputs.source_branch || github.ref_name }}
+          ref: ${{ inputs.source_branch }}
       - uses: actions/checkout@v4
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
-          ref: ${{ inputs.source_branch || github.ref_name }}
+          ref: ${{ inputs.source_branch }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -191,12 +193,12 @@ jobs:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
         with:
-          ref: ${{ inputs.source_branch || github.ref_name }}
+          ref: ${{ inputs.source_branch }}
           submodules: recursive
       - uses: actions/checkout@v4
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
-          ref: ${{ inputs.source_branch || github.ref_name }}
+          ref: ${{ inputs.source_branch }}
           submodules: recursive
 
       - name: Apply build number locally
@@ -434,7 +436,7 @@ jobs:
           # Must match Apply build config / artifact naming so build.sh loads the same
           # builds.yml entry (e.g. main-e2e-bs-with-srp), not generic main-e2e (sim-only).
           BUILD_CONFIG_NAME: ${{ inputs.build_name }}
-          GIT_BRANCH: ${{ inputs.source_branch || github.ref_name }}
+          GIT_BRANCH: ${{ inputs.source_branch }}
           # React Native 0.81's ReactAndroid/build.gradle.kts requests CMake 3.30.5
           # via `System.getenv("CMAKE_VERSION") ?: "3.30.5"`. The self-hosted runner
           # only ships CMake 3.22.1 in /opt/android-sdk/cmake/ and AGP cannot auto-

--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -40,5 +40,6 @@ jobs:
     with:
       build_name: main-dev-expo
       platform: both
+      source_branch: ${{ github.ref_name }}
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some of our workflows such as `build.yml` relies on the `main` workflow file being run. This is to allow other branches to build while still locking down the workflow from the main branch. This adds a source branch input to the `build.yml` workflow to allow building from source branches

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

With source input
<img width="267" height="427" alt="image" src="https://github.com/user-attachments/assets/905d085d-f4dd-4374-bd28-cdf030e80e48" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `build.yml` resolves the git ref for checkout and build metadata, which can break callers if they don’t pass `source_branch` or if the value differs from the triggering ref.
> 
> **Overview**
> Makes `source_branch` a **required** input for `.github/workflows/build.yml` and uses it consistently for all checkouts/metadata (removing fallbacks to `github.ref_name`).
> 
> Adds `source_branch` to manual `workflow_dispatch` runs (defaulting to `main`) and updates `expo-dev-build.yml` to pass the current ref name into the reusable build workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd6417ff6e5e56424464ff0127fd9199572c8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->