### PR TITLE
feat(predict): Bottom Sheet Keyboard Fix cp-7.78.0

### DIFF
--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.test.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.test.tsx
@@ -18,12 +18,12 @@ describe('PredictKeypad', () => {
     mockOnChange = null;
   });
   const defaultProps = {
-    isInputFocused: true,
+    isKeypadOpen: true,
     currentValue: 1,
     currentValueUSDString: '1.00',
     setCurrentValue: jest.fn(),
     setCurrentValueUSDString: jest.fn(),
-    setIsInputFocused: jest.fn(),
+    setIsKeypadOpen: jest.fn(),
   };
 
   beforeEach(() => {
@@ -35,32 +35,26 @@ describe('PredictKeypad', () => {
   });
 
   describe('Rendering', () => {
-    it('renders keypad when input is focused', () => {
-      // Arrange
-      const props = { ...defaultProps, isInputFocused: true };
+    it('renders keypad when keypad is open', () => {
+      const props = { ...defaultProps, isKeypadOpen: true };
 
-      // Act
       const { getByText } = render(<PredictKeypad {...props} />);
 
-      // Assert
-      expect(getByText('$20')).toBeTruthy();
-      expect(getByText('$50')).toBeTruthy();
-      expect(getByText('$100')).toBeTruthy();
-      expect(getByText('Done')).toBeTruthy();
+      expect(getByText('$20')).toBeOnTheScreen();
+      expect(getByText('$50')).toBeOnTheScreen();
+      expect(getByText('$100')).toBeOnTheScreen();
+      expect(getByText('Done')).toBeOnTheScreen();
     });
 
-    it('does not render keypad when input is not focused', () => {
-      // Arrange
-      const props = { ...defaultProps, isInputFocused: false };
+    it('does not render keypad when keypad is closed', () => {
+      const props = { ...defaultProps, isKeypadOpen: false };
 
-      // Act
       const { queryByText } = render(<PredictKeypad {...props} />);
 
-      // Assert
-      expect(queryByText('$20')).toBeNull();
-      expect(queryByText('$50')).toBeNull();
-      expect(queryByText('$100')).toBeNull();
-      expect(queryByText('Done')).toBeNull();
+      expect(queryByText('$20')).not.toBeOnTheScreen();
+      expect(queryByText('$50')).not.toBeOnTheScreen();
+      expect(queryByText('$100')).not.toBeOnTheScreen();
+      expect(queryByText('Done')).not.toBeOnTheScreen();
     });
   });
 
@@ -117,7 +111,7 @@ describe('PredictKeypad', () => {
       fireEvent.press(getByText('Done'));
 
       // Assert
-      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+      expect(props.setIsKeypadOpen).toHaveBeenCalledWith(false);
     });
 
     it('exposes handleAmountPress handler through ref', () => {
@@ -130,7 +124,7 @@ describe('PredictKeypad', () => {
       ref.current?.handleAmountPress();
 
       // Assert
-      expect(props.setIsInputFocused).toHaveBeenCalledWith(true);
+      expect(props.setIsKeypadOpen).toHaveBeenCalledWith(true);
     });
 
     it('exposes handleKeypadAmountPress handler through ref', () => {
@@ -157,7 +151,7 @@ describe('PredictKeypad', () => {
       ref.current?.handleDonePress();
 
       // Assert
-      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+      expect(props.setIsKeypadOpen).toHaveBeenCalledWith(false);
     });
   });
 
@@ -184,7 +178,7 @@ describe('PredictKeypad', () => {
 
       expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('25');
       expect(props.setCurrentValue).toHaveBeenCalledWith(25);
-      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+      expect(props.setIsKeypadOpen).toHaveBeenCalledWith(false);
     });
 
     it('handles empty string after removing decimal point', () => {
@@ -212,7 +206,7 @@ describe('PredictKeypad', () => {
       ref.current?.handleDonePress();
 
       expect(props.setCurrentValueUSDString).not.toHaveBeenCalled();
-      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+      expect(props.setIsKeypadOpen).toHaveBeenCalledWith(false);
     });
   });
 

--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
@@ -8,12 +8,12 @@ import Button, {
 import Keypad from '../../../../Base/Keypad';
 
 interface PredictKeypadProps {
-  isInputFocused: boolean;
+  isKeypadOpen: boolean;
   currentValue: number;
   currentValueUSDString: string;
   setCurrentValue: (value: number) => void;
   setCurrentValueUSDString: (value: string) => void;
-  setIsInputFocused: (focused: boolean) => void;
+  setIsKeypadOpen: (open: boolean) => void;
   hideHeader?: boolean;
 }
 
@@ -26,12 +26,12 @@ export interface PredictKeypadHandles {
 const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
   (
     {
-      isInputFocused,
+      isKeypadOpen,
       currentValue,
       currentValueUSDString,
       setCurrentValue,
       setCurrentValueUSDString,
-      setIsInputFocused,
+      setIsKeypadOpen,
       hideHeader = false,
     },
     ref,
@@ -39,8 +39,8 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
     const tw = useTailwind();
 
     const handleAmountPress = useCallback(() => {
-      setIsInputFocused(true);
-    }, [setIsInputFocused]);
+      setIsKeypadOpen(true);
+    }, [setIsKeypadOpen]);
 
     const handleKeypadAmountPress = useCallback(
       (amount: number) => {
@@ -58,9 +58,9 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
         setCurrentValueUSDString(cleanedValue);
         setCurrentValue(parseFloat(cleanedValue) || 0);
       }
-      setIsInputFocused(false);
+      setIsKeypadOpen(false);
     }, [
-      setIsInputFocused,
+      setIsKeypadOpen,
       currentValueUSDString,
       setCurrentValueUSDString,
       setCurrentValue,
@@ -93,9 +93,9 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
           adjustedValue = value.replace('.', '');
         }
 
-        // Set focus flag immediately
-        if (!isInputFocused) {
-          setIsInputFocused(true);
+        // Open the keypad immediately on any keystroke
+        if (!isKeypadOpen) {
+          setIsKeypadOpen(true);
         }
 
         // Enforce 9-digit limit (ignoring non-digits). Block the change if exceeded.
@@ -129,14 +129,14 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
       },
       [
         currentValue,
-        isInputFocused,
+        isKeypadOpen,
         setCurrentValue,
         setCurrentValueUSDString,
-        setIsInputFocused,
+        setIsKeypadOpen,
       ],
     );
 
-    if (!isInputFocused) return null;
+    if (!isKeypadOpen) return null;
 
     return (
       <View style={tw.style('py-4')}>

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -2207,7 +2207,7 @@ describe('PredictBuyPreview', () => {
   });
 
   describe('renderBottomContent visibility', () => {
-    it('returns null when isInputFocused is true', () => {
+    it('returns null when keypad is open', () => {
       mockBalance = 1000;
       mockBalanceLoading = false;
 
@@ -2219,7 +2219,7 @@ describe('PredictBuyPreview', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('renders bottom content when isInputFocused is false', () => {
+    it('renders bottom content when keypad is closed', () => {
       mockBalance = 1000;
       mockBalanceLoading = false;
 

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -197,7 +197,7 @@ const PredictBuyPreview = (props: PredictBuyPreviewProps) => {
 
   const [currentValue, setCurrentValue] = useState(0);
   const [currentValueUSDString, setCurrentValueUSDString] = useState('');
-  const [isInputFocused, setIsInputFocused] = useState(true);
+  const [isKeypadOpen, setIsKeypadOpen] = useState(true);
   const [isUserInputChange, setIsUserInputChange] = useState(false);
   const [isFeeBreakdownVisible, setIsFeeBreakdownVisible] = useState(false);
   const previousValueRef = useRef(0);
@@ -487,7 +487,7 @@ const PredictBuyPreview = (props: PredictBuyPreviewProps) => {
           <PredictAmountDisplay
             amount={currentValueUSDString}
             onPress={() => keypadRef.current?.handleAmountPress()}
-            isActive={isInputFocused}
+            isActive={isKeypadOpen}
             hasError={isInsufficientBalance}
           />
         </Box>
@@ -605,7 +605,7 @@ const PredictBuyPreview = (props: PredictBuyPreviewProps) => {
   };
 
   const renderBottomContent = () => {
-    if (isInputFocused) {
+    if (isKeypadOpen) {
       return null;
     }
 
@@ -669,12 +669,12 @@ const PredictBuyPreview = (props: PredictBuyPreviewProps) => {
       {renderMinimumBetWarning()}
       <PredictKeypad
         ref={keypadRef}
-        isInputFocused={isInputFocused}
+        isKeypadOpen={isKeypadOpen}
         currentValue={currentValue}
         currentValueUSDString={currentValueUSDString}
         setCurrentValue={setCurrentValue}
         setCurrentValueUSDString={setCurrentValueUSDString}
-        setIsInputFocused={setIsInputFocused}
+        setIsKeypadOpen={setIsKeypadOpen}
       />
       {renderBottomContent()}
       {isFeeBreakdownVisible && (

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -14,7 +14,7 @@ const mockResetOrderNotFilled = jest.fn();
 const mockClearBuyErrorBanner = jest.fn();
 const mockSetCurrentValue = jest.fn();
 const mockSetCurrentValueUSDString = jest.fn();
-const mockSetIsInputFocused = jest.fn();
+const mockSetIsKeypadOpen = jest.fn();
 const mockSetIsUserInputChange = jest.fn();
 const mockSetIsConfirming = jest.fn();
 const mockHandleRetryWithBestPrice = jest.fn();
@@ -133,19 +133,22 @@ jest.mock('./hooks/usePredictBuyAvailableBalance', () => ({
   }),
 }));
 
+const mockUsePredictBuyInputState = jest.fn(() => ({
+  currentValue: 20,
+  setCurrentValue: mockSetCurrentValue,
+  currentValueUSDString: '$20.00',
+  setCurrentValueUSDString: mockSetCurrentValueUSDString,
+  isKeypadOpen: false,
+  setIsKeypadOpen: mockSetIsKeypadOpen,
+  isUserInputChange: true,
+  setIsUserInputChange: mockSetIsUserInputChange,
+  isConfirming: false,
+  setIsConfirming: mockSetIsConfirming,
+}));
+
 jest.mock('./hooks/usePredictBuyInputState', () => ({
-  usePredictBuyInputState: () => ({
-    currentValue: 20,
-    setCurrentValue: mockSetCurrentValue,
-    currentValueUSDString: '$20.00',
-    setCurrentValueUSDString: mockSetCurrentValueUSDString,
-    isInputFocused: false,
-    setIsInputFocused: mockSetIsInputFocused,
-    isUserInputChange: true,
-    setIsUserInputChange: mockSetIsUserInputChange,
-    isConfirming: false,
-    setIsConfirming: mockSetIsConfirming,
-  }),
+  usePredictBuyInputState: (...args: unknown[]) =>
+    mockUsePredictBuyInputState(...args),
 }));
 
 jest.mock('./hooks/usePredictBuyInfo', () => ({
@@ -323,7 +326,7 @@ jest.mock('./components/PredictPayWithAnyTokenInfo', () => {
     currentValue,
   }: {
     currentValue: number;
-    isInputFocused: boolean;
+    shouldDeferRelaySetup: boolean;
   }) {
     return <Text testID="predict-pay-with-any-token-info">{currentValue}</Text>;
   };
@@ -544,6 +547,14 @@ describe('PredictBuyWithAnyToken', () => {
       ).not.toBeOnTheScreen();
     });
 
+    it('initialises usePredictBuyInputState with initialKeypadOpen=false', () => {
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(mockUsePredictBuyInputState).toHaveBeenCalledWith({
+        initialKeypadOpen: false,
+      });
+    });
+
     it('renders PredictQuickAmounts inside bottom content', () => {
       renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
 
@@ -564,12 +575,12 @@ describe('PredictBuyWithAnyToken', () => {
       expect(screen.getByTestId('predict-keypad')).toBeOnTheScreen();
     });
 
-    it('sets isInputFocused to false when quick amount is tapped', () => {
+    it('closes the keypad when a quick amount is tapped', () => {
       renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
 
       fireEvent.press(screen.getByTestId('quick-amount-20'));
 
-      expect(mockSetIsInputFocused).toHaveBeenCalledWith(false);
+      expect(mockSetIsKeypadOpen).toHaveBeenCalledWith(false);
       expect(mockSetCurrentValue).toHaveBeenCalledWith(20);
       expect(mockSetCurrentValueUSDString).toHaveBeenCalledWith('20');
     });
@@ -640,6 +651,14 @@ describe('PredictBuyWithAnyToken', () => {
   });
 
   describe('non-sheet mode', () => {
+    it('initialises usePredictBuyInputState with initialKeypadOpen=true', () => {
+      renderWithProvider(<PredictBuyWithAnyToken />);
+
+      expect(mockUsePredictBuyInputState).toHaveBeenCalledWith({
+        initialKeypadOpen: true,
+      });
+    });
+
     it('does NOT render the banner even if buyErrorBanner is set', () => {
       mockBuyErrorBanner = {
         variant: 'order_failed',

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -133,7 +133,7 @@ jest.mock('./hooks/usePredictBuyAvailableBalance', () => ({
   }),
 }));
 
-const mockUsePredictBuyInputState = jest.fn(() => ({
+const mockUsePredictBuyInputState = jest.fn((..._args: unknown[]) => ({
   currentValue: 20,
   setCurrentValue: mockSetCurrentValue,
   currentValueUSDString: '$20.00',
@@ -320,15 +320,18 @@ jest.mock('../../components/PredictOrderRetrySheet', () => {
   ));
 });
 
+const mockPredictPayWithAnyTokenInfo = jest.fn();
+
 jest.mock('./components/PredictPayWithAnyTokenInfo', () => {
   const { Text } = jest.requireActual('react-native');
-  return function MockPredictPayWithAnyTokenInfo({
-    currentValue,
-  }: {
+  return function MockPredictPayWithAnyTokenInfo(props: {
     currentValue: number;
     shouldDeferRelaySetup: boolean;
   }) {
-    return <Text testID="predict-pay-with-any-token-info">{currentValue}</Text>;
+    mockPredictPayWithAnyTokenInfo(props);
+    return (
+      <Text testID="predict-pay-with-any-token-info">{props.currentValue}</Text>
+    );
   };
 });
 
@@ -685,6 +688,78 @@ describe('PredictBuyWithAnyToken', () => {
 
       expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
         /mode-confirm/,
+      );
+    });
+  });
+
+  describe('shouldDeferRelaySetup propagation', () => {
+    const sheetProps = {
+      mode: 'sheet' as const,
+      market: { id: 'market-1' },
+      outcome: { id: 'outcome-1' },
+      outcomeToken: { id: 'token-1', title: 'Yes', price: 0.62 },
+      entryPoint: 'market_details',
+      onClose: jest.fn(),
+    } as unknown as PredictBuyPreviewProps;
+
+    const mockHookReturnWithKeypadOpen = (isKeypadOpen: boolean) => ({
+      currentValue: 20,
+      setCurrentValue: mockSetCurrentValue,
+      currentValueUSDString: '$20.00',
+      setCurrentValueUSDString: mockSetCurrentValueUSDString,
+      isKeypadOpen,
+      setIsKeypadOpen: mockSetIsKeypadOpen,
+      isUserInputChange: true,
+      setIsUserInputChange: mockSetIsUserInputChange,
+      isConfirming: false,
+      setIsConfirming: mockSetIsConfirming,
+    });
+
+    it('passes shouldDeferRelaySetup=false in sheet mode when keypad is closed', () => {
+      mockUsePredictBuyInputState.mockReturnValueOnce(
+        mockHookReturnWithKeypadOpen(false),
+      );
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(mockPredictPayWithAnyTokenInfo).toHaveBeenLastCalledWith(
+        expect.objectContaining({ shouldDeferRelaySetup: false }),
+      );
+    });
+
+    it('passes shouldDeferRelaySetup=false in sheet mode even when keypad is open', () => {
+      mockUsePredictBuyInputState.mockReturnValueOnce(
+        mockHookReturnWithKeypadOpen(true),
+      );
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(mockPredictPayWithAnyTokenInfo).toHaveBeenLastCalledWith(
+        expect.objectContaining({ shouldDeferRelaySetup: false }),
+      );
+    });
+
+    it('passes shouldDeferRelaySetup=false in non-sheet mode when keypad is closed', () => {
+      mockUsePredictBuyInputState.mockReturnValueOnce(
+        mockHookReturnWithKeypadOpen(false),
+      );
+
+      renderWithProvider(<PredictBuyWithAnyToken />);
+
+      expect(mockPredictPayWithAnyTokenInfo).toHaveBeenLastCalledWith(
+        expect.objectContaining({ shouldDeferRelaySetup: false }),
+      );
+    });
+
+    it('passes shouldDeferRelaySetup=true in non-sheet mode when keypad is open', () => {
+      mockUsePredictBuyInputState.mockReturnValueOnce(
+        mockHookReturnWithKeypadOpen(true),
+      );
+
+      renderWithProvider(<PredictBuyWithAnyToken />);
+
+      expect(mockPredictPayWithAnyTokenInfo).toHaveBeenLastCalledWith(
+        expect.objectContaining({ shouldDeferRelaySetup: true }),
       );
     });
   });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -508,8 +508,11 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
               onPaymentSelectorOpen={lockPaymentSelectorNavigation}
             />
           )}
+          {/* Always enabled when rendered: in legacy mode the parent only
+              mounts PredictBuyBottomContent while the keypad is closed; in
+              sheet mode the fee summary is always actionable. */}
           <PredictFeeSummary
-            disabled={!isSheetMode && isKeypadOpen}
+            disabled={false}
             loading={isPayFeesLoading}
             total={total}
             rewardsFeeAmountUsd={rewardsFeeAmount}

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -165,21 +165,21 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     setCurrentValue,
     currentValueUSDString,
     setCurrentValueUSDString,
-    isInputFocused,
-    setIsInputFocused,
+    isKeypadOpen,
+    setIsKeypadOpen,
     isUserInputChange,
     setIsUserInputChange,
     isConfirming,
     setIsConfirming,
-  } = usePredictBuyInputState();
+  } = usePredictBuyInputState({ initialKeypadOpen: !isSheetMode });
 
   const handleQuickAmount = useCallback(
     (amount: number) => {
       setCurrentValue(amount);
       setCurrentValueUSDString(amount.toString());
-      setIsInputFocused(false);
+      setIsKeypadOpen(false);
     },
-    [setCurrentValue, setCurrentValueUSDString, setIsInputFocused],
+    [setCurrentValue, setCurrentValueUSDString, setIsKeypadOpen],
   );
 
   const handleFeesInfoPress = useCallback(() => {
@@ -334,14 +334,14 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     previousValueRef.current = currentValue;
   }, [currentValue, isUserInputChange, clearBuyErrorBanner]);
 
-  // When the banner appears in sheet mode, blur the amount input so the keypad
-  // collapses and the Retry CTA + banner are immediately visible without the
-  // user having to dismiss the keyboard.
+  // When the banner appears in sheet mode, close the keypad so the Retry CTA
+  // + banner are immediately visible without the user having to dismiss the
+  // keyboard.
   useEffect(() => {
-    if (isSheetMode && isBannerActive && isInputFocused) {
-      setIsInputFocused(false);
+    if (isSheetMode && isBannerActive && isKeypadOpen) {
+      setIsKeypadOpen(false);
     }
-  }, [isSheetMode, isBannerActive, isInputFocused, setIsInputFocused]);
+  }, [isSheetMode, isBannerActive, isKeypadOpen, setIsKeypadOpen]);
 
   const handleBuyButtonPress = useCallback(() => {
     if (isPaymentSelectorNavigationLocked) {
@@ -433,7 +433,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
           <PredictBuyAmountSection
             currentValueUSDString={currentValueUSDString}
             keypadRef={keypadRef}
-            isInputFocused={isInputFocused}
+            isKeypadOpen={isKeypadOpen}
             isBalanceLoading={isBalanceLoading}
             isBalancePulsing={isBalancePulsing}
             availableBalanceDisplay={availableBalanceDisplay}
@@ -458,7 +458,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
             <PredictBuyAmountSection
               currentValueUSDString={currentValueUSDString}
               keypadRef={keypadRef}
-              isInputFocused={isInputFocused}
+              isKeypadOpen={isKeypadOpen}
               isBalanceLoading={isBalanceLoading}
               isBalancePulsing={isBalancePulsing}
               availableBalanceDisplay={availableBalanceDisplay}
@@ -484,75 +484,74 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
       {!isSheetMode && (
         <PredictKeypad
           ref={keypadRef}
-          isInputFocused={isInputFocused}
+          isKeypadOpen={isKeypadOpen}
           currentValue={currentValue}
           currentValueUSDString={currentValueUSDString}
           setCurrentValue={setCurrentValue}
           setCurrentValueUSDString={setCurrentValueUSDString}
-          setIsInputFocused={setIsInputFocused}
+          setIsKeypadOpen={setIsKeypadOpen}
         />
       )}
-      <PredictBuyBottomContent
-        isInputFocused={isSheetMode ? false : isInputFocused}
-        hideBorder={isSheetMode}
-      >
-        {isSheetMode && (
-          <PredictQuickAmounts
-            onSelectAmount={handleQuickAmount}
-            disabled={isPlacingOrder}
+      {(isSheetMode || !isKeypadOpen) && (
+        <PredictBuyBottomContent hideBorder={isSheetMode}>
+          {isSheetMode && (
+            <PredictQuickAmounts
+              onSelectAmount={handleQuickAmount}
+              disabled={isPlacingOrder}
+            />
+          )}
+          {payWithAnyTokenEnabled && isSheetMode && (
+            <PredictPayWithRow
+              disabled={isPlacingOrder || isPaymentSelectorNavigationLocked}
+              variant="row"
+              availableBalance={availableBalanceDisplay}
+              onPaymentSelectorOpen={lockPaymentSelectorNavigation}
+            />
+          )}
+          <PredictFeeSummary
+            disabled={!isSheetMode && isKeypadOpen}
+            loading={isPayFeesLoading}
+            total={total}
+            rewardsFeeAmountUsd={rewardsFeeAmount}
+            rewardsLoadingOverride={isUserChangeTriggeringCalculation}
+            handleFeesInfoPress={handleFeesInfoPress}
           />
-        )}
-        {payWithAnyTokenEnabled && isSheetMode && (
-          <PredictPayWithRow
-            disabled={isPlacingOrder || isPaymentSelectorNavigationLocked}
-            variant="row"
-            availableBalance={availableBalanceDisplay}
-            onPaymentSelectorOpen={lockPaymentSelectorNavigation}
+          {isSheetMode && buyErrorBanner && (
+            <PredictBuyErrorBanner
+              variant={buyErrorBanner.variant}
+              title={buyErrorBanner.title}
+              description={buyErrorBanner.description}
+              testID={
+                buyErrorBanner.variant === 'price_changed'
+                  ? PredictBuyPreviewSelectorsIDs.PRICE_CHANGED_BANNER
+                  : PredictBuyPreviewSelectorsIDs.ORDER_FAILED_BANNER
+              }
+            />
+          )}
+          <PredictBuyActionButton
+            isLoading={isPlacingOrder || (isBannerActive && isRetrying)}
+            onPress={handleBuyButtonPress}
+            disabled={isBuyActionButtonDisabled}
+            showReducedOpacity={showBuyActionButtonReducedOpacity}
+            outcomeTokenTitle={outcomeToken?.title}
+            sharePrice={preview?.sharePrice ?? outcomeToken?.price ?? 0}
+            isSheetMode={isSheetMode}
+            isRetry={isSheetMode && isBannerActive}
+            isChangePaymentMode={!isBannerActive && isChangePaymentMode}
+            isAddFundsMode={!isBannerActive && isAddFundsMode}
+            testID={PredictBuyPreviewSelectorsIDs.PLACE_BET_BUTTON}
           />
-        )}
-        <PredictFeeSummary
-          disabled={isSheetMode ? false : isInputFocused}
-          loading={isPayFeesLoading}
-          total={total}
-          rewardsFeeAmountUsd={rewardsFeeAmount}
-          rewardsLoadingOverride={isUserChangeTriggeringCalculation}
-          handleFeesInfoPress={handleFeesInfoPress}
-        />
-        {isSheetMode && buyErrorBanner && (
-          <PredictBuyErrorBanner
-            variant={buyErrorBanner.variant}
-            title={buyErrorBanner.title}
-            description={buyErrorBanner.description}
-            testID={
-              buyErrorBanner.variant === 'price_changed'
-                ? PredictBuyPreviewSelectorsIDs.PRICE_CHANGED_BANNER
-                : PredictBuyPreviewSelectorsIDs.ORDER_FAILED_BANNER
-            }
-          />
-        )}
-        <PredictBuyActionButton
-          isLoading={isPlacingOrder || (isBannerActive && isRetrying)}
-          onPress={handleBuyButtonPress}
-          disabled={isBuyActionButtonDisabled}
-          showReducedOpacity={showBuyActionButtonReducedOpacity}
-          outcomeTokenTitle={outcomeToken?.title}
-          sharePrice={preview?.sharePrice ?? outcomeToken?.price ?? 0}
-          isSheetMode={isSheetMode}
-          isRetry={isSheetMode && isBannerActive}
-          isChangePaymentMode={!isBannerActive && isChangePaymentMode}
-          isAddFundsMode={!isBannerActive && isAddFundsMode}
-          testID={PredictBuyPreviewSelectorsIDs.PLACE_BET_BUTTON}
-        />
-      </PredictBuyBottomContent>
+        </PredictBuyBottomContent>
+      )}
       {isSheetMode && (
         <PredictKeypad
           ref={keypadRef}
-          isInputFocused={isInputFocused}
+          isKeypadOpen={isKeypadOpen}
           currentValue={currentValue}
           currentValueUSDString={currentValueUSDString}
           setCurrentValue={setCurrentValue}
           setCurrentValueUSDString={setCurrentValueUSDString}
-          setIsInputFocused={setIsInputFocused}
+          setIsKeypadOpen={setIsKeypadOpen}
           hideHeader
         />
       )}
@@ -582,7 +581,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
       <PredictPayWithAnyTokenInfo
         currentValue={currentValue}
         preview={preview}
-        isInputFocused={isSheetMode ? false : isInputFocused}
+        shouldDeferRelaySetup={!isSheetMode && isKeypadOpen}
       />
     </Wrapper>
   );

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.test.tsx
@@ -71,7 +71,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -89,7 +89,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -108,7 +108,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -128,7 +128,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$250"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$1,234.56"
@@ -148,7 +148,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -166,7 +166,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -184,7 +184,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -204,7 +204,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$250.50"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -222,7 +222,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -243,7 +243,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused
+          isKeypadOpen
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -265,7 +265,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing
           availableBalanceDisplay="$500"
@@ -283,7 +283,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -303,7 +303,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$0"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -321,7 +321,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$10000"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$50000"
@@ -339,7 +339,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString=""
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -357,7 +357,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading
           isBalancePulsing
           availableBalanceDisplay="$500"
@@ -375,7 +375,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -396,7 +396,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused
+          isKeypadOpen
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"
@@ -421,7 +421,7 @@ describe('PredictBuyAmountSection', () => {
         <PredictBuyAmountSection
           currentValueUSDString="$100"
           keypadRef={mockKeypadRef}
-          isInputFocused={false}
+          isKeypadOpen={false}
           isBalanceLoading={false}
           isBalancePulsing={false}
           availableBalanceDisplay="$500"

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx
@@ -19,7 +19,7 @@ import type { PredictKeypadHandles } from '../../../../components/PredictKeypad'
 interface PredictBuyAmountSectionProps {
   currentValueUSDString: string;
   keypadRef: React.RefObject<PredictKeypadHandles | null>;
-  isInputFocused: boolean;
+  isKeypadOpen: boolean;
   isBalanceLoading: boolean;
   isBalancePulsing: boolean;
   availableBalanceDisplay: string;
@@ -32,7 +32,7 @@ interface PredictBuyAmountSectionProps {
 const PredictBuyAmountSection = ({
   currentValueUSDString,
   keypadRef,
-  isInputFocused,
+  isKeypadOpen,
   isBalanceLoading,
   isBalancePulsing,
   availableBalanceDisplay,
@@ -75,7 +75,7 @@ const PredictBuyAmountSection = ({
           onPress={() =>
             !isPlacingOrder && keypadRef.current?.handleAmountPress()
           }
-          isActive={isInputFocused && !isPlacingOrder}
+          isActive={isKeypadOpen && !isPlacingOrder}
           hasError={false}
         />
       </Box>

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyBottomContent/PredictBuyBottomContent.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyBottomContent/PredictBuyBottomContent.test.tsx
@@ -34,25 +34,10 @@ describe('PredictBuyBottomContent', () => {
     jest.clearAllMocks();
   });
 
-  describe('when isInputFocused is true', () => {
-    it('returns null and does not render anything', () => {
-      renderWithProvider(
-        <PredictBuyBottomContent isInputFocused>
-          {mockChildren}
-        </PredictBuyBottomContent>,
-      );
-
-      expect(screen.queryByText(/Disclaimer text/)).not.toBeOnTheScreen();
-      expect(screen.queryByTestId('children-content')).not.toBeOnTheScreen();
-    });
-  });
-
-  describe('when isInputFocused is false', () => {
+  describe('rendering', () => {
     it('renders children content', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       expect(screen.getByTestId('children-content')).toBeOnTheScreen();
@@ -60,9 +45,7 @@ describe('PredictBuyBottomContent', () => {
 
     it('renders disclaimer text', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       expect(screen.getByText(/Disclaimer text/)).toBeOnTheScreen();
@@ -70,9 +53,7 @@ describe('PredictBuyBottomContent', () => {
 
     it('renders learn more link', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       expect(screen.getByText(/Learn more/)).toBeOnTheScreen();
@@ -80,9 +61,7 @@ describe('PredictBuyBottomContent', () => {
 
     it('opens Polymarket TOS URL when learn more is pressed', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       const learnMoreLink = screen.getByText(/Learn more/);
@@ -108,9 +87,7 @@ describe('PredictBuyBottomContent', () => {
       );
 
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {multipleChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{multipleChildren}</PredictBuyBottomContent>,
       );
 
       expect(screen.getByTestId('child-1')).toBeOnTheScreen();
@@ -121,9 +98,7 @@ describe('PredictBuyBottomContent', () => {
   describe('Linking behavior', () => {
     it('calls Linking.openURL with correct URL', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       const learnMoreLink = screen.getByText(/Learn more/);
@@ -137,9 +112,7 @@ describe('PredictBuyBottomContent', () => {
 
     it('opens URL only when learn more is pressed', () => {
       renderWithProvider(
-        <PredictBuyBottomContent isInputFocused={false}>
-          {mockChildren}
-        </PredictBuyBottomContent>,
+        <PredictBuyBottomContent>{mockChildren}</PredictBuyBottomContent>,
       );
 
       expect(Linking.openURL).not.toHaveBeenCalled();

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyBottomContent/PredictBuyBottomContent.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyBottomContent/PredictBuyBottomContent.tsx
@@ -12,22 +12,15 @@ import { Linking } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 
 interface PredictBuyBottomContentProps {
-  isInputFocused: boolean;
-
   hideBorder?: boolean;
   children: React.ReactNode;
 }
 
 const PredictBuyBottomContent = ({
-  isInputFocused,
   hideBorder = false,
   children,
 }: PredictBuyBottomContentProps) => {
   const tw = useTailwind();
-
-  if (isInputFocused) {
-    return null;
-  }
 
   return (
     <Box

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.test.tsx
@@ -133,7 +133,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -149,7 +149,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={1}
           preview={null}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -163,7 +163,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={1}
           preview={createMockPreview({ fees: undefined })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -177,7 +177,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={0.5}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -204,7 +204,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -229,7 +229,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -254,7 +254,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -281,7 +281,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -299,7 +299,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
           preview={createMockPreview({
             maxAmountSpent: 99.99,
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -323,7 +323,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -333,28 +333,28 @@ describe('PredictPayWithAnyTokenInfo', () => {
   });
 
   describe('deposit amount gating', () => {
-    it('does not commit deposit amount while input is focused', () => {
+    it('does not commit deposit amount while relay setup is deferred', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
 
       render(
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused
+          shouldDeferRelaySetup
         />,
       );
 
       expect(mockUpdatePendingAmount).not.toHaveBeenCalled();
     });
 
-    it('commits deposit amount when input loses focus', () => {
+    it('commits deposit amount when relay setup deferral is released', () => {
       mockActiveTransactionMeta = { id: 'tx-1' };
 
       const { rerender } = render(
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused
+          shouldDeferRelaySetup
         />,
       );
 
@@ -364,7 +364,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -378,7 +378,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -391,7 +391,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused
+          shouldDeferRelaySetup
         />,
       );
 
@@ -399,7 +399,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -414,7 +414,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -429,7 +429,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -444,7 +444,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -455,7 +455,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={200}
           preview={createMockPreview({ maxAmountSpent: 200 })}
-          isInputFocused
+          shouldDeferRelaySetup
         />,
       );
 
@@ -465,7 +465,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={200}
           preview={createMockPreview({ maxAmountSpent: 200 })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -482,7 +482,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -497,7 +497,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -512,7 +512,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={0}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -527,7 +527,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -551,7 +551,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -569,7 +569,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -594,7 +594,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
               collector: '0xCollector',
             },
           })}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -610,7 +610,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -626,7 +626,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -642,7 +642,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -658,7 +658,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -674,7 +674,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={0}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -696,7 +696,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -711,7 +711,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -729,7 +729,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -754,7 +754,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -779,7 +779,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -798,7 +798,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -813,7 +813,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -830,7 +830,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -847,7 +847,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 
@@ -865,7 +865,7 @@ describe('PredictPayWithAnyTokenInfo', () => {
         <PredictPayWithAnyTokenInfo
           currentValue={100}
           preview={defaultPreview}
-          isInputFocused={false}
+          shouldDeferRelaySetup={false}
         />,
       );
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -15,12 +15,14 @@ import { getPredictBuyAllInCost } from '../../../../utils/orders';
 interface PredictPayWithAnyTokenInfoProps {
   currentValue: number;
   preview?: OrderPreview | null;
-  // When true, defers the mm_pay relay-config side effects
-  // (`updatePendingAmount` / `setPayToken`). The legacy full-screen flow sets
-  // this while the keypad is open and only releases it on Done so the relay
-  // isn't reconfigured on every keystroke. The bottom-sheet flow keeps it
-  // false because there is no Done affordance and the user can tap Confirm
-  // while the keypad is still open.
+  /**
+   * When true, defers the mm_pay relay-config side effects
+   * (`updatePendingAmount` / `setPayToken`). The legacy full-screen flow
+   * sets this while the keypad is open and only releases it on Done so the
+   * relay isn't reconfigured on every keystroke. The bottom-sheet flow
+   * keeps it false because there is no Done affordance and the user can
+   * tap Confirm while the keypad is still open.
+   */
   shouldDeferRelaySetup: boolean;
 }
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx
@@ -15,13 +15,19 @@ import { getPredictBuyAllInCost } from '../../../../utils/orders';
 interface PredictPayWithAnyTokenInfoProps {
   currentValue: number;
   preview?: OrderPreview | null;
-  isInputFocused: boolean;
+  // When true, defers the mm_pay relay-config side effects
+  // (`updatePendingAmount` / `setPayToken`). The legacy full-screen flow sets
+  // this while the keypad is open and only releases it on Done so the relay
+  // isn't reconfigured on every keystroke. The bottom-sheet flow keeps it
+  // false because there is no Done affordance and the user can tap Confirm
+  // while the keypad is still open.
+  shouldDeferRelaySetup: boolean;
 }
 
 const PredictPayWithAnyTokenInfo = ({
   currentValue,
   preview,
-  isInputFocused,
+  shouldDeferRelaySetup,
 }: PredictPayWithAnyTokenInfoProps) => {
   const transactionMeta = useTransactionMetadataRequest();
 
@@ -33,7 +39,7 @@ const PredictPayWithAnyTokenInfo = ({
     <PredictPayWithAnyTokenInfoInner
       currentValue={currentValue}
       preview={preview}
-      isInputFocused={isInputFocused}
+      shouldDeferRelaySetup={shouldDeferRelaySetup}
     />
   );
 };
@@ -41,7 +47,7 @@ const PredictPayWithAnyTokenInfo = ({
 function PredictPayWithAnyTokenInfoInner({
   currentValue,
   preview,
-  isInputFocused,
+  shouldDeferRelaySetup,
 }: PredictPayWithAnyTokenInfoProps) {
   const [depositAmount, setDepositAmount] = useState('');
 
@@ -66,8 +72,8 @@ function PredictPayWithAnyTokenInfoInner({
       !isPredictBalanceSelected &&
       !!fees &&
       currentValue >= MINIMUM_BET &&
-      !isInputFocused,
-    [isPredictBalanceSelected, fees, currentValue, isInputFocused],
+      !shouldDeferRelaySetup,
+    [isPredictBalanceSelected, fees, currentValue, shouldDeferRelaySetup],
   );
 
   const computedDepositAmount = useMemo(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.test.ts
@@ -94,21 +94,37 @@ describe('usePredictBuyInputState', () => {
     });
   });
 
-  describe('isInputFocused', () => {
-    it('initializes to true', () => {
+  describe('isKeypadOpen', () => {
+    it('initializes to true by default', () => {
       const { result } = renderHook(() => usePredictBuyInputState());
 
-      expect(result.current.isInputFocused).toBe(true);
+      expect(result.current.isKeypadOpen).toBe(true);
     });
 
-    it('updates isInputFocused via setIsInputFocused', () => {
+    it('honours initialKeypadOpen=false from caller options', () => {
+      const { result } = renderHook(() =>
+        usePredictBuyInputState({ initialKeypadOpen: false }),
+      );
+
+      expect(result.current.isKeypadOpen).toBe(false);
+    });
+
+    it('honours initialKeypadOpen=true from caller options', () => {
+      const { result } = renderHook(() =>
+        usePredictBuyInputState({ initialKeypadOpen: true }),
+      );
+
+      expect(result.current.isKeypadOpen).toBe(true);
+    });
+
+    it('updates isKeypadOpen via setIsKeypadOpen', () => {
       const { result } = renderHook(() => usePredictBuyInputState());
 
       act(() => {
-        result.current.setIsInputFocused(false);
+        result.current.setIsKeypadOpen(false);
       });
 
-      expect(result.current.isInputFocused).toBe(false);
+      expect(result.current.isKeypadOpen).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.ts
@@ -1,7 +1,13 @@
 import { SetStateAction, useCallback, useRef, useState } from 'react';
 import { usePredictActiveOrder } from '../../../hooks/usePredictActiveOrder';
 
-export const usePredictBuyInputState = () => {
+interface UsePredictBuyInputStateOptions {
+  initialKeypadOpen?: boolean;
+}
+
+export const usePredictBuyInputState = ({
+  initialKeypadOpen = true,
+}: UsePredictBuyInputStateOptions = {}) => {
   const { clearOrderError } = usePredictActiveOrder();
 
   const [currentValue, setCurrentValueState] = useState(0);
@@ -13,14 +19,14 @@ export const usePredictBuyInputState = () => {
     currentValue ? currentValue.toString() : '',
   );
 
-  const [isInputFocused, setIsInputFocusedState] = useState(true);
+  const [isKeypadOpen, setIsKeypadOpenState] = useState(initialKeypadOpen);
   const shouldSyncCurrentValueRef = useRef(false);
   const shouldClearAmountErrorRef = useRef(false);
-  const shouldSyncInputFocusRef = useRef(false);
+  const shouldSyncKeypadOpenRef = useRef(false);
 
-  const setIsInputFocused = useCallback((nextIsInputFocused: boolean) => {
-    shouldSyncInputFocusRef.current = true;
-    setIsInputFocusedState(nextIsInputFocused);
+  const setIsKeypadOpen = useCallback((nextIsKeypadOpen: boolean) => {
+    shouldSyncKeypadOpenRef.current = true;
+    setIsKeypadOpenState(nextIsKeypadOpen);
   }, []);
 
   const [isUserInputChange, setIsUserInputChange] = useState(false);
@@ -56,8 +62,8 @@ export const usePredictBuyInputState = () => {
     setCurrentValue,
     currentValueUSDString,
     setCurrentValueUSDString,
-    isInputFocused,
-    setIsInputFocused,
+    isKeypadOpen,
+    setIsKeypadOpen,
     isUserInputChange,
     setIsUserInputChange,
     isConfirming,


### PR DESCRIPTION
## **Description**

The Predict Buy bottom-sheet introduced in [#28779](https://github.com/MetaMask/metamask-mobile/pull/28779) opened with the custom keypad already rendered behind the rest of the sheet content. The root cause was a single `isInputFocused` boolean inside `usePredictBuyInputState` that was hard-coded to `true` on first render and overloaded across **five** unrelated behaviours:

1. Mounting `PredictKeypad`.
2. Highlighting the amount-display "active" state.
3. Hiding `PredictBuyBottomContent` while the keypad is up.
4. Disabling `PredictFeeSummary`.
5. Deferring the mm_pay relay-config side effects (`updatePendingAmount` / `setPayToken`) inside `PredictPayWithAnyTokenInfo`.

Because the only "off switch" was `setIsInputFocused(false)` (driven from a `Done` button that doesn't exist in sheet mode) the previous PR worked around the issue with three `isSheetMode ? false : isInputFocused` ternaries — Bugbot flagged this on #28779. The workarounds also produced a confusing situation where bottom content and keypad rendered simultaneously on first sheet open.

This PR separates the conflated meanings, parameterises the initial state, and removes the workarounds. No behaviour change for the legacy full-screen flow.

### What changed

**`usePredictBuyInputState` ([hooks/usePredictBuyInputState.ts](app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.ts))**
- Accepts an options object: `{ initialKeypadOpen = true }`.
- Renamed state + setter: `isInputFocused` → `isKeypadOpen`, `setIsInputFocused` → `setIsKeypadOpen`.
- Default value preserves legacy behaviour; sheet mode opts out.

**`PredictBuyWithAnyToken` ([PredictBuyWithAnyToken.tsx](app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx))**
- Calls the hook as `usePredictBuyInputState({ initialKeypadOpen: !isSheetMode })` so the sheet opens with the keypad collapsed.
- Removed the three `isSheetMode ? false : isInputFocused` patches.
- Renders `PredictBuyBottomContent` at the call site via `{(isSheetMode || !isKeypadOpen) && <PredictBuyBottomContent ... />}` instead of relying on the component to bail internally. Keeps the legacy "hide while typing" behaviour while letting the sheet show the bottom content (and Confirm) at all times.
- Passes the new self-documenting `shouldDeferRelaySetup={!isSheetMode && isKeypadOpen}` prop to `PredictPayWithAnyTokenInfo`. Same effective value as before, but the prop name now describes its actual purpose.

**`PredictPayWithAnyTokenInfo` ([components/PredictPayWithAnyTokenInfo](app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithAnyTokenInfo/PredictPayWithAnyTokenInfo.tsx))**
- Renamed prop: `isInputFocused` → `shouldDeferRelaySetup`. This is the genuine separation: the prop is **not** about UI keypad state, it's about pausing `updatePendingAmount` / `setPayToken` calls. Legacy mode still defers until the user taps Done; sheet mode never defers (relay must update on every keystroke since there's no Done and the user can tap Confirm with the keypad still open — preventing underfunded deposits).
- Added a JSDoc comment explaining the contract.

**`PredictBuyBottomContent` ([components/PredictBuyBottomContent](app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyBottomContent/PredictBuyBottomContent.tsx))**
- Removed the `isInputFocused` prop and the `if (isInputFocused) return null` early return. Component is now purely structural; visibility is the parent's responsibility.

**`PredictKeypad` and `PredictBuyAmountSection`**
- Mechanical prop renames: `isInputFocused` → `isKeypadOpen`, `setIsInputFocused` → `setIsKeypadOpen`.

**Legacy `PredictBuyPreview` ([views/PredictBuyPreview](app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx))**
- Local `useState(true)` renamed to `isKeypadOpen` for consistency with the rest of the tree. No behaviour change (still initialises `true`, still gates `renderBottomContent`).

**Tests**
- All prop/state references renamed.
- New coverage on `usePredictBuyInputState` for `initialKeypadOpen: false` and `initialKeypadOpen: true`.
- New assertions in `PredictBuyWithAnyToken.test.tsx` that the hook is called with `initialKeypadOpen: false` in sheet mode and `initialKeypadOpen: true` in non-sheet mode.
- `PredictBuyBottomContent.test.tsx`: removed the now-irrelevant `isInputFocused is true / false` describe blocks since visibility is caller-controlled.
- `PredictPayWithAnyTokenInfo.test.tsx`: updated 43 prop references and renamed two test descriptions to reflect the new "relay deferral" intent.
- `PredictBuyPreview.test.tsx`: updated `renderBottomContent` describe block descriptions.

### Net behavioural effect (sheet mode)

- Sheet opens → keypad hidden, amount display shows `$0` (inactive), quick amounts + pay-with row + fee summary + Confirm button visible (Confirm disabled until amount > 0).
- Tap amount display → keypad opens at the bottom of the sheet, stacked **below** the Confirm button (does not overlap).
- Tap a quick amount → value set, keypad closes.
- Tap Confirm with keypad still open → places order (relay setup is up-to-date because `shouldDeferRelaySetup` is `false` in sheet mode).
- Auto-blur on banner display still works.

Legacy full-screen flow: unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: PRED-707 (follow-up to [#28779](https://github.com/MetaMask/metamask-mobile/pull/28779))

## **Manual testing steps**

```gherkin
Feature: Predict buy bottom-sheet keypad initial state

  Scenario: Sheet opens with keypad collapsed (flag ON)
    Given the predictBottomSheet feature flag is enabled
    And the user is on a prediction market details page

    When user taps a "Yes" or "No" outcome button
    Then a bottom sheet opens with the buy preview content
    And the custom numeric keypad is NOT visible
    And the amount display shows "$0"
    And the quick amount buttons ($20 / $50 / $100 / $250) are visible
    And the Pay with row, fee summary and Confirm button are visible
    And the Confirm button is disabled

  Scenario: Tapping the amount opens the keypad
    Given the buy bottom sheet is open with no amount entered
    And the keypad is hidden

    When user taps the amount display
    Then the custom keypad becomes visible at the bottom of the sheet
    And the keypad does NOT cover the Confirm button
    And the amount display shows the active highlight

  Scenario: Tapping a quick amount sets value and closes the keypad
    Given the keypad is open
    And the user has typed "$73"

    When user taps the "$50" quick amount button
    Then the amount becomes "$50"
    And the keypad closes
    And haptic feedback fires (Light impact)
    And the Confirm button is enabled

  Scenario: Confirming with keypad still open
    Given the keypad is open
    And the user has typed "$25"

    When user taps the Confirm button
    Then the order is placed successfully
    And the relay was configured for $25 (no underfunded deposit)
    And the sheet closes

  Scenario: Banner display auto-blurs the keypad in sheet mode
    Given the buy bottom sheet is open
    And the keypad is open

    When an order_failed or price_changed banner appears
    Then the keypad auto-closes
    And the banner + Retry CTA are visible without needing to tap Done

  Scenario: Legacy full-screen flow is unchanged (flag OFF)
    Given the predictBottomSheet feature flag is disabled
    And the user navigates to the BuyPreview screen

    When the screen mounts
    Then the keypad is open by default (matching previous behaviour)
    And tapping Done closes the keypad and reveals the bottom content
    And the relay is configured once on Done (deferred during typing)
```

## **Screenshots/Recordings**

### **Before**

Sheet opens with the keypad rendered behind the bottom content; bottom content and keypad are both visible simultaneously on first paint. (See screenshot in PR comments — keypad sits below `Confirm` even though the user has not yet tapped the amount display.)

### **After**

Sheet opens with the keypad hidden; bottom content (quick amounts, pay with row, fee summary, Confirm) is the only thing visible. Tapping the amount display reveals the keypad; tapping a quick amount or Confirm collapses it.


https://github.com/user-attachments/assets/af89b78a-5103-48eb-b2c9-346ea64cd463


<!-- TODO: attach .mov / screenshots once recorded against the branch -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

> N/A — pure refactor of UI state semantics, no new code paths.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Predict buy keypad state is tracked and used to gate bottom content and mm_pay relay setup; mistakes could surface as incorrect UI visibility or misconfigured deposit/payment amounts during checkout. Scope is mostly contained to Predict buy views and covered by updated tests.
> 
> **Overview**
> Fixes the Predict buy bottom-sheet keypad initial state by splitting the previously overloaded `isInputFocused` flag into a dedicated `isKeypadOpen` state, including a new `initialKeypadOpen` option in `usePredictBuyInputState` so sheet mode can start closed.
> 
> Updates `PredictBuyWithAnyToken`/`PredictKeypad`/`PredictBuyAmountSection` to use `isKeypadOpen` for keypad mounting and active styling, moves bottom-content visibility control to the parent (removing `PredictBuyBottomContent`’s internal early-return), and introduces `shouldDeferRelaySetup` (replacing `isInputFocused`) to explicitly gate `PredictPayWithAnyTokenInfo`’s relay-configuration side effects.
> 
> Refactors legacy `PredictBuyPreview` to the same `isKeypadOpen` naming and updates/adds tests to assert the new initialization, visibility behavior, and relay deferral propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d3d4dd1fb15c581bbb92472bf951513f646b60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->