### PR TITLE
fix(confirmations): preserve Predict claim navigation state

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -16,6 +16,7 @@ import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import useConfirmationAlerts from '../../hooks/alerts/useConfirmationAlerts';
 import { useFullScreenConfirmation } from '../../hooks/ui/useFullScreenConfirmation';
+import Routes from '../../../../../constants/navigation/Routes';
 
 jest.mock('../../hooks/useConfirmActions');
 
@@ -486,6 +487,30 @@ describe('Confirm', () => {
 
     expect(mockSetOptions).toHaveBeenCalledWith({
       headerShown: true,
+      gestureEnabled: true,
+    });
+  });
+
+  it('keeps navigation header hidden for no-header full screen confirmations', () => {
+    jest.mocked(useFullScreenConfirmation).mockReturnValue({
+      isFullScreenConfirmation: true,
+    });
+
+    renderWithProvider(
+      <Confirm
+        route={
+          {
+            name: Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER,
+          } as never
+        }
+      />,
+      {
+        state: stakingDepositConfirmationState,
+      },
+    );
+
+    expect(mockSetOptions).toHaveBeenCalledWith({
+      headerShown: false,
       gestureEnabled: true,
     });
   });

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -35,6 +35,7 @@ import { useTransactionMetadataRequest } from '../../hooks/transactions/useTrans
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
 import { TransferInfoSkeleton } from '../info/transfer/transfer';
+import Routes from '../../../../../constants/navigation/Routes';
 
 const TRANSACTION_TYPES_DISABLE_SCROLL = [TransactionType.predictClaim];
 
@@ -120,6 +121,9 @@ export const Confirm = ({
     isFullScreenConfirmation,
     disableSafeArea,
   });
+  const shouldHideHeader =
+    (route as { name?: string } | undefined)?.name ===
+    Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER;
 
   useEffect(() => {
     if (approvalRequest) {
@@ -129,13 +133,13 @@ export const Confirm = ({
         gestureEnabled: true,
       };
 
-      if (isFullScreenConfirmation) {
+      if (isFullScreenConfirmation && !shouldHideHeader) {
         // If the confirmation is full screen, we need to show the header
         options.headerShown = true;
       }
       navigation.setOptions(options);
     }
-  }, [approvalRequest, isFullScreenConfirmation, navigation]);
+  }, [approvalRequest, isFullScreenConfirmation, navigation, shouldHideHeader]);
 
   useEffect(() => {
     if (!approvalRequest) {

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { useModalNavbar } from '../../../hooks/ui/useNavbar';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
+import { usePredictClaimConfirmationMetrics } from '../../../hooks/metrics/usePredictClaimConfirmationMetrics';
+import { PredictClaimInfo } from './predict-claim-info';
+
+jest.mock('../../../hooks/ui/useNavbar', () => ({
+  useModalNavbar: jest.fn(),
+}));
+
+jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../hooks/metrics/usePredictClaimConfirmationMetrics', () => ({
+  usePredictClaimConfirmationMetrics: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useConfirmActions', () => ({
+  useConfirmActions: jest.fn(() => ({
+    onReject: jest.fn(),
+  })),
+}));
+
+jest.mock('../../predict-confirmations/predict-claim-amount', () => ({
+  PredictClaimAmount: () => null,
+  PredictClaimAmountSkeleton: () => null,
+}));
+
+jest.mock('../../predict-confirmations/predict-claim-background', () => ({
+  PredictClaimBackground: () => null,
+}));
+
+jest.mock(
+  '../../../../../../component-library/components/Buttons/ButtonIcon',
+  () => ({
+    __esModule: true,
+    default: () => null,
+    ButtonIconSizes: {
+      Lg: 'Lg',
+    },
+  }),
+);
+
+jest.mock('../../../../../../component-library/components/Icons/Icon', () => ({
+  IconName: {
+    Close: 'Close',
+  },
+}));
+
+jest.mock('../../../../../../component-library/hooks', () => ({
+  useStyles: () => ({
+    styles: {
+      backButton: {},
+    },
+  }),
+}));
+
+describe('PredictClaimInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears pending confirmation when leaving through native navigation', () => {
+    render(<PredictClaimInfo />);
+
+    expect(useModalNavbar).toHaveBeenCalled();
+    expect(useClearConfirmationOnBackSwipe).toHaveBeenCalled();
+    expect(usePredictClaimConfirmationMetrics).toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
@@ -13,9 +13,11 @@ import { IconName } from '../../../../../../component-library/components/Icons/I
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './predict-claim-info.styles';
+import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 
 export function PredictClaimInfo() {
   useModalNavbar();
+  useClearConfirmationOnBackSwipe();
   usePredictClaimConfirmationMetrics();
 
   return (


### PR DESCRIPTION
## Summary
- keep the fullscreen no-header confirmation route from re-enabling the nav header
- clear pending Predict claim confirmations on native back-swipe/exit
- add focused regression coverage

## Testing
- yarn jest app/components/Views/confirmations/components/confirm/confirm-component.test.tsx app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
- yarn eslint app/components/Views/confirmations/components/confirm/confirm-component.tsx app/components/Views/confirmations/components/confirm/confirm-component.test.tsx app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation navigation options and rejection handling on native gestures/back presses, which could affect confirmation UX and dismissal behavior if mis-triggered.
> 
> **Overview**
> **Preserves no-header fullscreen confirmations.** `Confirm` now detects `Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER` and keeps `headerShown: false` even when `useFullScreenConfirmation` is true.
> 
> **Clears Predict claim confirmations on native exits.** `PredictClaimInfo` now calls `useClearConfirmationOnBackSwipe()` so a back-swipe/hardware back triggers `onReject` to clear the pending approval, with new targeted Jest coverage for both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c0877f18c2053c03f23ca021ccfd75eead1c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->