### PR TITLE
test(snaps): Re-enable BIP-44 test

### DIFF
--- a/tests/smoke/snaps/test-snap-bip-44.spec.ts
+++ b/tests/smoke/snaps/test-snap-bip-44.spec.ts
@@ -8,7 +8,7 @@ import Assertions from '../../framework/Assertions';
 
 jest.setTimeout(150_000);
 
-describe.skip(SmokeSnaps('BIP-44 Snap Tests'), () => {
+describe(SmokeSnaps('BIP-44 Snap Tests'), () => {
   it('can connect to BIP-44 snap', async () => {
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Re-enable the BIP-44 test after disabling device synchronization across all Snaps tests.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test execution by re-enabling an existing smoke spec, with no production code impact.
> 
> **Overview**
> Re-enables the `BIP-44 Snap Tests` smoke suite by removing `describe.skip`, so the BIP-44 Snap connection/signing/entropy tests run again in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20422fbcd3455091d826890e4e5971a04339e585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->