### PR TITLE
refactor(analytics): PR E4 migrate TradeTabBarItem from useMetrics to useAnalytics

### DIFF
--- a/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
+++ b/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
@@ -16,10 +16,8 @@ import Text, { TextColor, TextVariant } from '../../Texts/Text';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
-import {
-  MetaMetricsEvents,
-  useMetrics,
-} from '../../../../components/hooks/useMetrics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { useAnalytics } from '../../../../components/hooks/useAnalytics/useAnalytics';
 import { useSelector } from 'react-redux';
 import { selectChainId } from '../../../../selectors/networkController';
 import { getDecimalChainId } from '../../../../util/networks';
@@ -39,7 +37,7 @@ function TradeTabBarItem({ label, ...props }: TradeTabBarItemProps) {
   const [buttonLayout, setButtonLayout] = useState<LayoutRectangle>();
   const fontScale = useWindowDimensions().fontScale;
 
-  const { trackEvent, createEventBuilder } = useMetrics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const chainId = useSelector(selectChainId);
 


### PR DESCRIPTION
## **Description**

Part of the analytics cleanup workstream (#26686).

Migrates `TradeTabBarItem` from the deprecated `useMetrics` to `useAnalytics`. Moves the `MetaMetricsEvents` import from the `useMetrics` barrel to `core/Analytics` directly, consistent with other already-migrated components.

Files touched:
- `TradeTabBarItem/TradeTabBarItem.tsx` — replace `useMetrics` import with `useAnalytics`, move `MetaMetricsEvents` import to `core/Analytics`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: #30514
Refs: #26686

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A — no UI changes.

### **After**

N/A — no UI changes.

## **Pre-merge author checklist**

- [x] I've followed the [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md))
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md))

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, test affected areas)
- [ ] I confirm that this PR addresses what is claimed in the PR title
- [ ] I confirm that I've manually reviewed the changes if not manually tested