### PR TITLE
fix: show fallback token icons in confirmation rows cp-7.78.0

### DIFF
--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -57,7 +57,12 @@ jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
 
 jest.mock('../../token-icon/', () => ({
   TokenIcon: (props: TokenIconProps) => (
-    <MockText>{`${props.address} ${props.chainId}`}</MockText>
+    <>
+      <MockText>{`${props.address} ${props.chainId}`}</MockText>
+      <MockText testID="token-icon-symbol">
+        {`icon-symbol:${props.symbol ?? ''}`}
+      </MockText>
+    </>
   ),
   TokenIconVariant: { Default: 'default', Row: 'row', Hero: 'hero' },
 }));
@@ -197,6 +202,13 @@ describe('PayWithRow', () => {
       const { getByText } = render();
       expect(getByText('Receive')).toBeDefined();
       expect(getByText('test')).toBeDefined();
+    });
+
+    it('passes the receive token symbol to the token icon', () => {
+      const { getByTestId } = render();
+      expect(getByTestId('token-icon-symbol')).toHaveTextContent(
+        'icon-symbol:test',
+      );
     });
 
     it('hides balance in withdraw mode', () => {

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -154,6 +154,7 @@ export function PayWithRow() {
           <TokenIcon
             address={displayToken.address}
             chainId={displayToken.chainId}
+            symbol={displayToken.symbol}
             variant={TokenIconVariant.Row}
           />
           <Text

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Hex } from '@metamask/utils';
 import { TokenIcon, TokenIconProps } from './token-icon';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { merge } from 'lodash';
@@ -9,8 +10,43 @@ import {
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 
+jest.mock('../../../../Base/TokenIcon', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text, View } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: ({
+      icon,
+      symbol,
+      testID,
+    }: {
+      icon?: string;
+      symbol?: string;
+      testID?: string;
+    }) =>
+      icon
+        ? ReactActual.createElement(View, {
+            testID,
+            accessibilityLabel: icon,
+          })
+        : ReactActual.createElement(
+            Text,
+            { testID },
+            symbol?.[0]?.toUpperCase(),
+          ),
+  };
+});
+
 const ADDRESS_MOCK = tokenAddress1Mock;
 const CHAIN_ID_MOCK = '0x1';
+const TOKEN_ICON_URL_MOCK = `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ADDRESS_MOCK}.png`;
+const SUPPORTED_CHAIN_ICON_CASES: [string, Hex, string][] = [
+  ['mainnet', '0x1', '1'],
+  ['Linea', '0xe708', '59144'],
+  ['BSC', '0x38', '56'],
+  ['Monad', '0x8f', '143'],
+];
 
 const STATE_MOCK = merge(
   {},
@@ -36,7 +72,9 @@ describe('TokenIcon', () => {
       chainId: CHAIN_ID_MOCK,
     });
 
-    expect(getByTestId('token-icon')).toHaveTextContent('T');
+    expect(getByTestId('token-icon').props.accessibilityLabel).toBe(
+      TOKEN_ICON_URL_MOCK,
+    );
   });
 
   it('renders nothing if token not found', () => {
@@ -47,4 +85,33 @@ describe('TokenIcon', () => {
 
     expect(queryByTestId('token-icon')).toBeNull();
   });
+
+  it('renders token icon URL fallback when token metadata is missing', () => {
+    const address = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef';
+    const { getByTestId } = render({
+      address,
+      chainId: CHAIN_ID_MOCK,
+      symbol: 'ABC',
+    });
+
+    expect(getByTestId('token-icon').props.accessibilityLabel).toBe(
+      `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${address}.png`,
+    );
+  });
+
+  it.each(SUPPORTED_CHAIN_ICON_CASES)(
+    'renders token icon URL fallback for %s when token metadata is missing',
+    (_networkName, chainId, decimalChainId) => {
+      const address = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef';
+      const { getByTestId } = render({
+        address,
+        chainId,
+        symbol: 'ABC',
+      });
+
+      expect(getByTestId('token-icon').props.accessibilityLabel).toBe(
+        `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/${decimalChainId}/erc20/${address}.png`,
+      );
+    },
+  );
 });

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
 import BaseTokenIcon from '../../../../Base/TokenIcon';
 import styleSheet from './token-icon.styles';
@@ -11,11 +12,13 @@ import Badge, {
 } from '../../../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { useTokenWithBalance } from '../../hooks/tokens/useTokenWithBalance';
+import { getAssetImageUrl } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 
 export interface TokenIconProps {
   address: Hex;
   chainId: Hex;
   showNetwork?: boolean;
+  symbol?: string;
   variant?: TokenIconVariant;
 }
 
@@ -29,15 +32,19 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
   address,
   chainId,
   showNetwork = true,
+  symbol: symbolProp,
   variant = TokenIconVariant.Default,
 }) => {
   const { styles } = useStyles(styleSheet, { variant });
 
   const token = useTokenWithBalance(address, chainId);
+  const symbol = token?.symbol ?? symbolProp;
 
-  if (!token) {
+  if (!token && !symbol) {
     return null;
   }
+
+  const icon = token?.image ?? getTokenIconUrl(address, chainId);
 
   const networkImageSource = getNetworkImageSource({
     chainId,
@@ -59,10 +66,18 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
     >
       <BaseTokenIcon
         testID="token-icon"
-        icon={token?.image}
-        symbol={token?.symbol}
+        icon={icon}
+        symbol={symbol}
         style={styles.tokenIcon}
       />
     </BadgeWrapper>
   );
 };
+
+function getTokenIconUrl(address: Hex, chainId: Hex) {
+  if (address.toLowerCase() === getNativeTokenAddress(chainId).toLowerCase()) {
+    return undefined;
+  }
+
+  return getAssetImageUrl(address, chainId);
+}


### PR DESCRIPTION
## **Description**

Fixes missing token icons in confirmation rows when token metadata is unavailable in local token state. The confirmation `TokenIcon` now falls back to the shared MetaMask token icon URL when it has an address, chain ID, and symbol, while still rendering nothing when neither token metadata nor a symbol is available.

This also passes the receive token symbol from `PayWithRow` into `TokenIcon`, so Perps and Predict deposit/withdraw rows can render the token icon fallback for mUSD and other supported ERC-20 tokens with missing local metadata.

## **Changelog**

CHANGELOG entry: Show fallback token icons in confirmation rows

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1411

## **Manual testing steps**

```gherkin
Feature: Confirmation token icon fallback

  Scenario: user withdraws mUSD from Perps or Predict
    Given the user has an mUSD balance
    And the user starts a Perps or Predict withdraw flow

    When the Receive row displays mUSD
    Then the mUSD token icon is shown next to the token symbol
```

## **Screenshots/Recordings**

### **Before**


### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects how token icons are resolved/rendered in confirmation rows. Main risk is incorrect fallback URL generation for some chains, but it’s covered by new unit tests.
> 
> **Overview**
> Fixes missing token icons in confirmation flows by updating `TokenIcon` to accept an optional `symbol` and, when local token metadata is absent, fall back to a MetaMask-hosted token icon URL (while still rendering nothing when neither metadata nor `symbol` is available).
> 
> Updates `PayWithRow` to pass the displayed token `symbol` into `TokenIcon` (notably for *Receive/withdraw* rows), and expands unit tests to validate symbol propagation and fallback URL generation across multiple supported chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8921cc44d9382d74ed659710e5f6f642fd6500c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->