### PR TITLE
fix(perps): apply safe area top inset directly to TPSL header cp-7.78.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -6,7 +6,10 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -75,6 +78,7 @@ const PerpsTPSLView: React.FC = () => {
   const [isUpdating, setIsUpdating] = useState(false);
   const { colors } = useTheme();
   const styles = createStyles(colors);
+  const { top: topInset } = useSafeAreaInsets();
 
   const scrollViewRef = useRef<ScrollView>(null);
 
@@ -447,11 +451,16 @@ const PerpsTPSLView: React.FC = () => {
   return (
     <SafeAreaView
       style={styles.container}
-      edges={['top', 'bottom']}
+      edges={['bottom']}
       testID={PerpsTPSLViewSelectorsIDs.BOTTOM_SHEET}
     >
       {/* Simple header with back button and title */}
-      <View style={styles.header}>
+      <View
+        style={[
+          styles.header,
+          topInset > 0 ? { paddingTop: 16 + topInset } : undefined,
+        ]}
+      >
         <View style={styles.headerBackButton}>
           <ButtonIcon
             iconName={IconName.ArrowLeft}


### PR DESCRIPTION
## **Description**

The TPSL (Take Profit / Stop Loss) page header was intermittently positioned too high, overlapping the status bar / notch area. This occurred both when creating a TPSL from the order screen and when editing a TPSL for an open position.

**Root cause:** The screen relied on the shimmed `SafeAreaView` with `edges={['top', 'bottom']}` to apply the top safe area inset. The shim (`SafeAreaViewWithHookTopInset`) turns off the native top inset and re-applies it via a hook-based `paddingTop`. With the `transparentModal` presentation mode used by this screen, the hook-based top inset was intermittently not applied, causing the header to render too high.

**Fix:** Follow the same proven pattern used by `PerpsOrderHeader` — apply the top inset directly to the header view using `useSafeAreaInsets()`, and only use `SafeAreaView` for the bottom edge. This is deterministic and does not depend on the shimmed SafeAreaView lifecycle for transparent modals.

## **Changelog**

CHANGELOG entry: Fixed TPSL page header overlapping the status bar area

## **Related issues**

Fixes: TAT-3213

## **Manual testing steps**

```gherkin
Feature: TPSL page header alignment

  Scenario: user creates a TPSL from the order screen
    Given the user is on the Perps order screen with an asset selected

    When user taps the TPSL / Auto close button
    Then the TPSL page opens with the header properly below the status bar / notch area

  Scenario: user edits a TPSL for an open position
    Given the user has an open Perps position with or without existing TP/SL values

    When user taps the Auto close / Edit TPSL button on the position
    Then the TPSL page opens with the header properly below the status bar / notch area

  Scenario: user repeatedly opens and closes the TPSL page
    Given the user is on the Perps order screen

    When user opens and closes the TPSL page multiple times
    Then the header is consistently aligned below the safe area every time
```

## **Screenshots/Recordings**

### **Before**

https://consensys.slack.com/archives/C092T3GPHQD/p1779353500168619

### **After**
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-21 at 11 40 56" src="https://github.com/user-attachments/assets/71ea9e56-f7d6-43ea-8e22-d00c4ca78c5a" />


Header is consistently positioned below the safe area.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI layout change limited to safe-area handling in the Perps TPSL screen; no business logic or data flow changes.
> 
> **Overview**
> Fixes an intermittent layout issue where the Perps TPSL header could render under the status bar/notch.
> 
> `PerpsTPSLView` now uses `useSafeAreaInsets()` to add top padding directly on the header, and updates `SafeAreaView` to only apply the bottom safe area (`edges={['bottom']}`) so top inset behavior is deterministic in modal presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dd563a409ac90ae220955bc0e08fc155b21c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->