### PR TITLE
fix: Perps withdraw back-swipe toast cp-7.78.0

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.test.ts
@@ -2,6 +2,7 @@ import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { useNavigation } from '@react-navigation/native';
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { providerErrors } from '@metamask/rpc-errors';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
@@ -191,6 +192,23 @@ describe('usePerpsWithdrawConfirmation', () => {
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledWith(mockWithdrawalStartFailedToast);
+  });
+
+  it('does not show the start failure toast when the user rejects the confirmation', async () => {
+    const error = providerErrors.userRejectedRequest();
+    mockAddTransactionBatch.mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => usePerpsWithdrawConfirmation());
+
+    await expect(
+      act(async () => {
+        await result.current.withdrawWithConfirmation();
+      }),
+    ).rejects.toThrow(error.message);
+
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockWithdrawalStartFailed).not.toHaveBeenCalled();
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 
   it('swallows retry failures after showing another retryable error toast', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts
@@ -14,7 +14,46 @@ import { ARBITRUM_USDC } from '../../../Views/confirmations/constants/perps';
 import { RootState } from '../../../../reducers';
 import Routes from '../../../../constants/navigation/Routes';
 import { ensureError } from '../../../../util/errorUtils';
+import { containsUserRejectedError } from '../../../../util/middlewares';
 import usePerpsToasts from './usePerpsToasts';
+
+interface ErrorLike {
+  code?: unknown;
+  message?: unknown;
+}
+
+function getErrorLike(error: unknown): ErrorLike | undefined {
+  return typeof error === 'object' && error !== null
+    ? (error as ErrorLike)
+    : undefined;
+}
+
+function getErrorCode(error: unknown): number | undefined {
+  const code = getErrorLike(error)?.code;
+
+  if (typeof code === 'number') {
+    return code;
+  }
+
+  if (typeof code === 'string') {
+    const numericCode = Number(code);
+    return Number.isNaN(numericCode) ? undefined : numericCode;
+  }
+
+  return undefined;
+}
+
+function getErrorMessage(error: unknown, fallbackMessage: string): string {
+  const message = getErrorLike(error)?.message;
+  return typeof message === 'string' ? message : fallbackMessage;
+}
+
+function isUserRejectedError(error: unknown, fallbackMessage: string): boolean {
+  return containsUserRejectedError(
+    getErrorMessage(error, fallbackMessage),
+    getErrorCode(error),
+  );
+}
 
 /**
  * Hook that triggers the Perps "withdraw to any token" confirmation flow.
@@ -68,6 +107,10 @@ export function usePerpsWithdrawConfirmation() {
           error,
           'usePerpsWithdrawConfirmation.withdrawWithConfirmation',
         );
+
+        if (isUserRejectedError(error, errorObj.message)) {
+          throw errorObj;
+        }
 
         navigation.goBack();
         showToast(


### PR DESCRIPTION
## Summary

Fixes the Perps withdraw confirmation flow so user-initiated confirmation rejection, including iOS back-swipe, does not show the retryable "withdrawal wasn't started" error toast.

## Root Cause

PR #30299 added an `addTransactionBatch` catch path that navigates back and shows the withdrawal-start failure toast for every rejected batch initialization. Back-swiping the confirmation rejects the approval with a user-rejected error, so that normal cancellation path was being treated as a real initialization failure.

## Changes

- Detect user-rejected errors before showing the withdrawal-start failure toast.
- Keep the existing retry toast behavior for real `addTransactionBatch` failures.
- Add regression coverage for user rejection so it does not call `goBack`, build the retry toast, or show the toast.

Fixes #30485.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to Perps withdraw error handling and adds a regression test; behavior only changes for user-rejected/cancel paths.
> 
> **Overview**
> Prevents Perps withdraw confirmation cancellations (user-rejected errors) from being treated as `addTransactionBatch` failures: on rejection, the hook now rethrows without calling `navigation.goBack()` or showing the retryable “withdrawalStartFailed” toast.
> 
> Adds a regression test covering a `providerErrors.userRejectedRequest()` rejection to ensure no back navigation or toast is triggered, while keeping the existing retry-toast behavior for real batch initialization failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23f2c36aa0469447b4cce532c4c871160c9be07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->