### PR TITLE
fix: Polish Token Details sections, cards and spacing

### DIFF
--- a/app/components/UI/AssetOverview/Balance/Balance.tsx
+++ b/app/components/UI/AssetOverview/Balance/Balance.tsx
@@ -243,7 +243,7 @@ const Balance = ({
 
         <View style={styles.percentageChange}>
           <View style={styles.assetName}>
-            <Text variant={TextVariant.BodyMD}>
+            <Text variant={TextVariant.BodyMDMedium}>
               {asset.name || asset.symbol}
             </Text>
             {label && <Tag label={label} testID={ACCOUNT_TYPE_LABEL_TEST_ID} />}

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
@@ -3,6 +3,9 @@ import { StyleSheet, TextStyle } from 'react-native';
 const styleSheet = () =>
   StyleSheet.create({
     tokenDetailsContainer: {},
+    tokenDetailsContainerWithoutMarketDetails: {
+      paddingBottom: 24,
+    },
     title: {
       paddingVertical: 8,
     } as TextStyle,

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.styles.tsx
@@ -2,10 +2,7 @@ import { StyleSheet, TextStyle } from 'react-native';
 
 const styleSheet = () =>
   StyleSheet.create({
-    tokenDetailsContainer: {
-      marginTop: 16,
-      gap: 24,
-    },
+    tokenDetailsContainer: {},
     title: {
       paddingVertical: 8,
     } as TextStyle,

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
@@ -223,7 +223,14 @@ const TokenDetails: React.FC<TokenDetailsProps> = ({ asset }) => {
   const showMarketDetailsList = Boolean(marketData && marketDetails);
 
   return (
-    <View style={styles.tokenDetailsContainer}>
+    <View
+      style={[
+        styles.tokenDetailsContainer,
+        showTokenDetailsList &&
+          !showMarketDetailsList &&
+          styles.tokenDetailsContainerWithoutMarketDetails,
+      ]}
+    >
       {showTokenDetailsList && <TokenDetailsList tokenDetails={tokenDetails} />}
       {showMarketDetailsList && marketDetails && (
         <>

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
@@ -22,6 +22,7 @@ import { selectNativeCurrencyByChainId } from '../../../../selectors/networkCont
 import Logger from '../../../../util/Logger';
 import TokenDetailsList from './TokenDetailsList';
 import MarketDetailsList from './MarketDetailsList';
+import TokenDetailsSectionDivider from './TokenDetailsSectionDivider';
 import { TokenI } from '../../Tokens/types';
 import {
   isAssetFromSearch,
@@ -217,13 +218,18 @@ const TokenDetails: React.FC<TokenDetailsProps> = ({ asset }) => {
 
   const hasAddressAndDecimals =
     tokenDetails.contractAddress !== null && tokenDetails.tokenDecimal !== null;
+  const showTokenDetailsList =
+    asset.isETH || isNonEvmAsset || hasAddressAndDecimals;
+  const showMarketDetailsList = Boolean(marketData && marketDetails);
+
   return (
     <View style={styles.tokenDetailsContainer}>
-      {(asset.isETH || isNonEvmAsset || hasAddressAndDecimals) && (
-        <TokenDetailsList tokenDetails={tokenDetails} />
-      )}
-      {marketData && marketDetails && (
-        <MarketDetailsList marketDetails={marketDetails} />
+      {showTokenDetailsList && <TokenDetailsList tokenDetails={tokenDetails} />}
+      {showMarketDetailsList && marketDetails && (
+        <>
+          {showTokenDetailsList && <TokenDetailsSectionDivider />}
+          <MarketDetailsList marketDetails={marketDetails} />
+        </>
       )}
     </View>
   );

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetailsList/TokenDetailsList.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetailsList/TokenDetailsList.tsx
@@ -10,6 +10,7 @@ import { IconName } from '../../../../../component-library/components/Icons/Icon
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
+  TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import styleSheet from '../TokenDetails.styles';
@@ -65,7 +66,10 @@ const TokenDetailsList: React.FC<TokenDetailsListProps> = ({
               style={tw`flex-row items-center gap-1`}
               onPress={copyAccountToClipboard}
             >
-              <Text variant={TextVariant.BodySM}>
+              <Text
+                variant={TextVariant.BodyMDMedium}
+                color={TextColor.Default}
+              >
                 {formatAddress(tokenDetails.contractAddress, 'short')}
               </Text>
               <Icon name={DesignSystemIconName.Copy} size={IconSize.Sm} />
@@ -82,9 +86,12 @@ const TokenDetailsList: React.FC<TokenDetailsListProps> = ({
         {tokenDetails.tokenList && (
           <TokenDetailsListItem
             label={strings('token.token_list')}
-            value={tokenDetails.tokenList}
             style={[styles.listItemStacked, styles.lastChild]}
-          />
+          >
+            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+              {tokenDetails.tokenList}
+            </Text>
+          </TokenDetailsListItem>
         )}
       </View>
     </View>

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetailsListItem.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetailsListItem.tsx
@@ -23,7 +23,7 @@ const TokenDetailsListItem: React.FC<TokenDetailsListItemProps> = ({
       {label}
     </Text>
     {children || (
-      <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+      <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
         {value}
       </Text>
     )}

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetailsSectionDivider.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetailsSectionDivider.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box } from '@metamask/design-system-react-native';
+
+type BottomPadding = 'pb-2' | 'pb-6';
+
+interface TokenDetailsSectionDividerProps {
+  /** Bottom spacing below the divider line. Defaults to pb-6 (24px). */
+  bottomPadding?: BottomPadding;
+}
+
+/**
+ * Section divider with full-bleed line within a px-4 (16px) parent.
+ * pt-6 (24px) above the line; bottom padding configurable per call site.
+ */
+const TokenDetailsSectionDivider = ({
+  bottomPadding = 'pb-6',
+}: TokenDetailsSectionDividerProps) => (
+  <Box twClassName={`${bottomPadding} pt-6 self-stretch -mx-4`}>
+    <Box twClassName="h-px bg-border-muted" />
+  </Box>
+);
+
+export default TokenDetailsSectionDivider;

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/ResourceRing.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/ResourceRing.tsx
@@ -21,8 +21,8 @@ export interface ResourceRingProps {
 
 const ResourceRing: React.FC<ResourceRingProps> = ({
   icon,
-  size = 52,
-  strokeWidth = 6,
+  size = 40,
+  strokeWidth = 2,
   progress = 0,
   indeterminate = false,
 }) => {

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.tsx
@@ -8,8 +8,10 @@ import {
   BoxJustifyContent,
   IconName,
   TextColor,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
+import TokenDetailsSectionDivider from '../TokenDetails/TokenDetailsSectionDivider';
 import ResourceRing from './ResourceRing';
 import { useTronResources } from './useTronResources';
 
@@ -27,11 +29,11 @@ const TronEnergyBandwidthDetail = () => {
     (bandwidth.current || 0) / BANDWIDTH_PER_TRX_TRANSFER_BASELINE,
   );
   return (
-    <Box twClassName="w-full bg-default p-4 mt-4 mb-4">
-      <Text variant={TextVariant.BodyLg}>
+    <Box twClassName="w-full bg-default pt-6 px-4">
+      <Text variant={TextVariant.HeadingMd}>
         {strings('asset_overview.tron.daily_resource')}
       </Text>
-      <Text variant={TextVariant.BodyMd} twClassName="text-alternative mt-2">
+      <Text variant={TextVariant.BodyMd} twClassName="text-alternative mt-1">
         {strings('asset_overview.tron.daily_resource_description')}
       </Text>
 
@@ -51,17 +53,25 @@ const TronEnergyBandwidthDetail = () => {
             progress={energy.percentage / 100}
           />
           <Box>
-            <Text variant={TextVariant.BodyLg}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('asset_overview.tron.energy')}
             </Text>
             {usdtTransfersCovered === 1 ? (
-              <Text variant={TextVariant.BodySm} twClassName="text-alternative">
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                twClassName="text-alternative"
+              >
                 {strings(
                   'asset_overview.tron.sufficient_to_cover_usdt_transfer',
                 )}
               </Text>
             ) : (
-              <Text variant={TextVariant.BodySm} twClassName="text-alternative">
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                twClassName="text-alternative"
+              >
                 {strings(
                   'asset_overview.tron.sufficient_to_cover_usdt_transfers',
                   {
@@ -73,10 +83,10 @@ const TronEnergyBandwidthDetail = () => {
           </Box>
         </Box>
         <Box flexDirection={BoxFlexDirection.Row}>
-          <Text variant={TextVariant.BodyLg}>
+          <Text variant={TextVariant.BodyMd}>
             {energy.current ? energy.current.toLocaleString() : '0'}
           </Text>
-          <Text variant={TextVariant.BodyLg} color={TextColor.TextMuted}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextMuted}>
             /{energy.max.toLocaleString()}
           </Text>
         </Box>
@@ -98,17 +108,25 @@ const TronEnergyBandwidthDetail = () => {
             progress={bandwidth.percentage / 100}
           />
           <Box>
-            <Text variant={TextVariant.BodyLg}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('asset_overview.tron.bandwidth')}
             </Text>
             {trxTxsCovered === 1 ? (
-              <Text variant={TextVariant.BodySm} twClassName="text-alternative">
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                twClassName="text-alternative"
+              >
                 {strings(
                   'asset_overview.tron.sufficient_to_cover_trx_transfer',
                 )}
               </Text>
             ) : (
-              <Text variant={TextVariant.BodySm} twClassName="text-alternative">
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                twClassName="text-alternative"
+              >
                 {strings(
                   'asset_overview.tron.sufficient_to_cover_trx_transfers',
                   { amount: trxTxsCovered },
@@ -118,14 +136,15 @@ const TronEnergyBandwidthDetail = () => {
           </Box>
         </Box>
         <Box flexDirection={BoxFlexDirection.Row}>
-          <Text variant={TextVariant.BodyLg}>
+          <Text variant={TextVariant.BodyMd}>
             {bandwidth.current ? bandwidth.current.toLocaleString() : '0'}
           </Text>
-          <Text variant={TextVariant.BodyLg} color={TextColor.TextMuted}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextMuted}>
             /{bandwidth.max.toLocaleString()}
           </Text>
         </Box>
       </Box>
+      <TokenDetailsSectionDivider bottomPadding="pb-2" />
     </Box>
   );
 };

--- a/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
+++ b/app/components/UI/Earn/components/EarnLendingBalance/EarnLendingBalance.styles.ts
@@ -42,9 +42,6 @@ const styleSheet = (params: {
     EarnEmptyStateCta: {
       paddingTop: 16,
     },
-    earnings: {
-      paddingTop: 16,
-    },
   });
 };
 

--- a/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnLendingBalance/index.tsx
@@ -48,8 +48,8 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-  Text as DesignSystemText,
 } from '@metamask/design-system-react-native';
+import TokenDetailsSectionDivider from '../../../AssetOverview/TokenDetails/TokenDetailsSectionDivider';
 
 export const EARN_LENDING_BALANCE_TEST_IDS = {
   RECEIPT_TOKEN_BALANCE_ASSET_LOGO: 'receipt-token-balance-asset-logo',
@@ -298,11 +298,11 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
             <Button
               variant={ButtonVariant.Secondary}
               style={styles.button}
-              size={ButtonSize.Md}
+              size={ButtonSize.Lg}
               onPress={handleNavigateToWithdrawalInputScreen}
               testID={EARN_LENDING_BALANCE_TEST_IDS.WITHDRAW_BUTTON}
             >
-              <DesignSystemText>{strings('earn.withdraw')}</DesignSystemText>
+              {strings('earn.withdraw')}
             </Button>
           )}
           {userHasUnderlyingTokensAvailableToLend &&
@@ -311,21 +311,20 @@ const EarnLendingBalance = ({ asset }: EarnLendingBalanceProps) => {
               <Button
                 variant={ButtonVariant.Secondary}
                 style={styles.button}
-                size={ButtonSize.Md}
+                size={ButtonSize.Lg}
                 onPress={handleNavigateToDepositInputScreen}
                 testID={EARN_LENDING_BALANCE_TEST_IDS.DEPOSIT_BUTTON}
               >
-                <DesignSystemText>
-                  {strings('earn.deposit_more')}
-                </DesignSystemText>
+                {strings('earn.deposit_more')}
               </Button>
             )}
         </View>
       )}
       {isAssetReceiptToken && (
-        <View style={styles.earnings}>
+        <>
+          <TokenDetailsSectionDivider />
           <Earnings asset={asset} />
-        </View>
+        </>
       )}
     </View>
   );

--- a/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
+++ b/app/components/UI/Earn/components/Earnings/Earnings.styles.ts
@@ -12,9 +12,6 @@ const styleSheet = (params: { theme: Theme }) => {
       left: 15,
       right: 15,
     },
-    earningsContainer: {
-      paddingTop: 16,
-    },
     title: {
       paddingBottom: 8,
     } as TextStyle,

--- a/app/components/UI/Earn/components/Earnings/index.tsx
+++ b/app/components/UI/Earn/components/Earnings/index.tsx
@@ -84,7 +84,7 @@ const EarningsContent = ({ asset }: EarningsProps) => {
   if (!hasEarnings) return <></>;
 
   return (
-    <View style={styles.earningsContainer}>
+    <View>
       <Text variant={TextVariant.HeadingMD} style={styles.title}>
         {strings('stake.your_earnings')}
       </Text>

--- a/app/components/UI/Earn/components/EmptyStateCta/EmptyStateCta.styles.ts
+++ b/app/components/UI/Earn/components/EmptyStateCta/EmptyStateCta.styles.ts
@@ -7,13 +7,12 @@ const styleSheet = (params: { theme: Theme }) => {
   return StyleSheet.create({
     container: {
       alignItems: 'center',
-      marginTop: 8,
       padding: 16,
       borderRadius: 12,
       backgroundColor: colors.background.section,
     },
     heading: {
-      paddingBottom: 8,
+      paddingBottom: 4,
     },
     body: {
       textAlign: 'center',

--- a/app/components/UI/Earn/components/EmptyStateCta/index.tsx
+++ b/app/components/UI/Earn/components/EmptyStateCta/index.tsx
@@ -134,27 +134,32 @@ const EarnEmptyStateCta = ({ token }: EarnEmptyStateCta) => {
 
   return (
     <View style={styles.container} testID={EARN_EMPTY_STATE_CTA_TEST_ID}>
-      <Text variant={TextVariant.HeadingMD} style={styles.heading}>
+      <Text variant={TextVariant.BodyMDMedium} style={styles.heading}>
         {strings('earn.empty_state_cta.heading', { tokenSymbol: token.symbol })}
       </Text>
-      <Text style={styles.body}>
+      <Text
+        variant={TextVariant.BodySMMedium}
+        color={TextColor.Alternative}
+        style={styles.body}
+      >
         {strings('earn.empty_state_cta.body', {
           tokenSymbol: token.symbol,
           protocol: capitalize(earnToken?.experience.market?.protocol),
         })}{' '}
-        <Text variant={TextVariant.BodyMDBold} color={TextColor.Success}>
+        <Text variant={TextVariant.BodySMMedium} color={TextColor.Success}>
           {apr}%
         </Text>{' '}
         {strings('earn.empty_state_cta.annually')}{' '}
         <Button
           label={strings('earn.empty_state_cta.learn_more')}
           variant={ButtonVariants.Link}
+          labelTextVariant={TextVariant.BodySMMedium}
           onPress={navigateToLendingHistoricApyChart}
         />
       </Text>
       <Button
         variant={ButtonVariants.Secondary}
-        size={ButtonSize.Md}
+        size={ButtonSize.Lg}
         width={ButtonWidthTypes.Full}
         label={strings('earn.empty_state_cta.earn')}
         onPress={navigateToLendInputScreen}

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.styles.ts
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/MusdConversionAssetOverviewCta.styles.ts
@@ -9,16 +9,14 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       paddingLeft: 16,
       paddingRight: 12,
-      borderWidth: 1,
       borderRadius: 12,
-      borderColor: colors.border.muted,
-      backgroundColor: colors.background.default,
+      backgroundColor: colors.background.muted,
       alignItems: 'center',
-      gap: 16,
     },
     imageContainer: {
-      width: 78,
-      height: 78,
+      marginRight: 16,
+      width: 72,
+      height: 72,
       borderRadius: 12,
       backgroundColor: colors.background.muted,
       overflow: 'hidden',
@@ -27,20 +25,32 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     musdIcon: {
       padding: 4,
-      width: 78,
-      height: 78,
+      width: 72,
+      height: 72,
+    },
+    contentSection: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: 2,
+      minWidth: 0,
     },
     textContainer: {
       flex: 1,
-      gap: 4,
+      flexShrink: 1,
+      minWidth: 0,
       paddingVertical: 16,
     },
     title: {
       color: colors.text.default,
+      flexShrink: 1,
+    },
+    description: {
+      flexShrink: 1,
     },
     closeButton: {
-      alignSelf: 'flex-start',
-      marginTop: 16,
+      flexShrink: 0,
+      marginTop: 12,
     },
   });
 };

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx
@@ -105,35 +105,41 @@ const MusdConversionAssetOverviewCta = ({
         <Image source={musdIcon} style={styles.musdIcon} />
       </View>
 
-      {/* Text content in the center */}
-      <View style={styles.textContainer}>
-        <Text variant={TextVariant.BodySMMedium} style={styles.title}>
-          {strings('earn.musd_conversion.bonus_title', {
-            percentage: MUSD_CONVERSION_APY,
-          })}
-        </Text>
-        <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>
-          {strings('earn.musd_conversion.bonus_description', {
-            percentage: MUSD_CONVERSION_APY,
-          })}
-        </Text>
-      </View>
+      <View style={styles.contentSection}>
+        <View style={styles.textContainer}>
+          <Text variant={TextVariant.BodySMMedium} style={styles.title}>
+            {strings('earn.musd_conversion.bonus_title', {
+              percentage: MUSD_CONVERSION_APY,
+            })}
+          </Text>
+          <Text
+            variant={TextVariant.BodySMMedium}
+            color={TextColor.Alternative}
+            style={styles.description}
+          >
+            {strings('earn.musd_conversion.bonus_description', {
+              percentage: MUSD_CONVERSION_APY,
+            })}
+          </Text>
+        </View>
 
-      {/* Close button on the right */}
-      {onDismiss && (
-        <Pressable
-          testID={EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON}
-          onPress={onDismiss}
-          hitSlop={16}
-          style={styles.closeButton}
-        >
-          <Icon
-            name={IconName.Close}
-            size={IconSize.Md}
-            color={IconColor.Alternative}
-          />
-        </Pressable>
-      )}
+        {onDismiss && (
+          <Pressable
+            testID={
+              EARN_TEST_IDS.MUSD.ASSET_OVERVIEW_CONVERSION_CTA_CLOSE_BUTTON
+            }
+            onPress={onDismiss}
+            hitSlop={16}
+            style={styles.closeButton}
+          >
+            <Icon
+              name={IconName.Close}
+              size={IconSize.Md}
+              color={IconColor.Alternative}
+            />
+          </Pressable>
+        )}
+      </View>
     </Pressable>
   );
 };

--- a/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
+++ b/app/components/UI/Earn/components/Tron/TronStakingCta/TronStakingCta.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   TextVariant,
   TextColor,
+  FontWeight,
   Button,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
@@ -53,19 +54,32 @@ const TronStakingCta = ({ asset, aprText }: TronStakingCtaProps) => {
 
   return (
     <Box
-      padding={4}
+      paddingTop={4}
+      paddingBottom={4}
+      paddingHorizontal={4}
+      marginBottom={1}
       backgroundColor={BoxBackgroundColor.BackgroundSection}
       twClassName="rounded-xl"
       testID={TronStakingCtaTestIds.CONTAINER}
     >
-      <Box alignItems={BoxAlignItems.Center} marginBottom={4} gap={1}>
-        <Text variant={TextVariant.HeadingMd} twClassName="text-center">
+      <Box alignItems={BoxAlignItems.Center} marginBottom={4}>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          twClassName="text-center"
+        >
           {strings('stake.stake_your_trx_cta.title')}
         </Text>
-        <Text twClassName="text-center">
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+        >
           {strings('stake.stake_your_trx_cta.description_start')}
           {aprText ? (
-            <Text color={TextColor.SuccessDefault}>{aprText}</Text>
+            <Text variant={TextVariant.BodySm} color={TextColor.SuccessDefault}>
+              {aprText}
+            </Text>
           ) : null}
           {strings('stake.stake_your_trx_cta.description_end')}
         </Text>

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx
@@ -218,7 +218,7 @@ const MarketInsightsEntryCard: React.FC<MarketInsightsEntryCardProps> = ({
       <TouchableOpacity
         activeOpacity={0.7}
         onPress={onPress}
-        style={tw.style('px-4 mt-2 mb-4')}
+        style={tw.style('px-4 mt-2')}
         testID={testID}
       >
         <View ref={cardRef} collapsable={false} onLayout={onVisibilityLayout}>

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCardSkeleton.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCardSkeleton.tsx
@@ -12,7 +12,7 @@ const MarketInsightsEntryCardSkeleton: React.FC = () => {
 
   return (
     <Box
-      twClassName="px-4 mt-2 mb-4"
+      twClassName="px-4 mt-2"
       testID={MarketInsightsSelectorsIDs.ENTRY_CARD_SKELETON}
     >
       <Box twClassName="bg-background-muted rounded-xl" padding={4} gap={1}>

--- a/app/components/UI/Perps/components/PerpsDiscoveryBanner/PerpsDiscoveryBanner.test.tsx
+++ b/app/components/UI/Perps/components/PerpsDiscoveryBanner/PerpsDiscoveryBanner.test.tsx
@@ -5,8 +5,9 @@ import PerpsDiscoveryBanner from './PerpsDiscoveryBanner';
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: () => ({
     styles: {
-      container: {},
+      outer: {},
       banner: {},
+      logoContainer: {},
       textContainer: {},
       perpsLogo: {},
     },
@@ -58,6 +59,9 @@ describe('PerpsDiscoveryBanner', () => {
 
   it('renders logo image', () => {
     const { getByTestId } = render(<PerpsDiscoveryBanner {...defaultProps} />);
+    expect(
+      getByTestId('perps-discovery-banner-logo-container'),
+    ).toBeOnTheScreen();
     expect(getByTestId('perps-discovery-banner-logo')).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Perps/components/PerpsDiscoveryBanner/PerpsDiscoveryBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsDiscoveryBanner/PerpsDiscoveryBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Image, Pressable, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
   Box,
@@ -8,32 +9,44 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   BoxBackgroundColor,
+  FontWeight,
 } from '@metamask/design-system-react-native';
-import { Image, Pressable, StyleSheet } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import type { PerpsDiscoveryBannerProps } from './PerpsDiscoveryBanner.types';
 
 // eslint-disable-next-line import-x/no-commonjs, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const perpsLogo = require('../../../../../images/perps-home-empty-state.png');
 
+const LOGO_CONTAINER_SIZE = 72;
+
 const styleSheet = () =>
   StyleSheet.create({
-    container: {
+    outer: {
       marginTop: 8,
       paddingHorizontal: 16,
     },
     banner: {
-      borderRadius: 8,
-      paddingHorizontal: 16,
-      paddingVertical: 16,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 16,
+      borderRadius: 12,
+      padding: 16,
+    },
+    logoContainer: {
+      width: LOGO_CONTAINER_SIZE,
+      height: LOGO_CONTAINER_SIZE,
+      borderRadius: 12,
+      overflow: 'hidden',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    perpsLogo: {
+      width: LOGO_CONTAINER_SIZE,
+      height: LOGO_CONTAINER_SIZE,
     },
     textContainer: {
       flex: 1,
-      marginLeft: 12,
-    },
-    perpsLogo: {
-      width: 32,
-      height: 32,
+      gap: 4,
     },
   });
 
@@ -62,33 +75,36 @@ const PerpsDiscoveryBanner: React.FC<PerpsDiscoveryBannerProps> = ({
 
   return (
     <Pressable onPress={onPress} testID={testID}>
-      <Box style={styles.container}>
+      <Box style={styles.outer}>
         <Box
           style={styles.banner}
           backgroundColor={BoxBackgroundColor.BackgroundMuted}
         >
           <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
+            style={styles.logoContainer}
+            backgroundColor={BoxBackgroundColor.BackgroundMuted}
+            testID={`${testID}-logo-container`}
           >
             <Image
               source={perpsLogo}
               style={styles.perpsLogo}
+              resizeMode="contain"
               testID={`${testID}-logo`}
             />
-            <Box style={styles.textContainer}>
-              <Text variant={TextVariant.BodyMd}>
-                {strings('perps.discovery_banner.title', { symbol })}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('perps.discovery_banner.subtitle', {
-                  leverage: maxLeverage,
-                })}
-              </Text>
-            </Box>
+          </Box>
+          <Box style={styles.textContainer}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {strings('perps.discovery_banner.title', { symbol })}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+            >
+              {strings('perps.discovery_banner.subtitle', {
+                leverage: maxLeverage,
+              })}
+            </Text>
           </Box>
         </Box>
       </Box>

--- a/app/components/UI/SecurityTrust/components/SecurityTrustEntryCard/SecurityTrustEntryCard.tsx
+++ b/app/components/UI/SecurityTrust/components/SecurityTrustEntryCard/SecurityTrustEntryCard.tsx
@@ -97,7 +97,7 @@ const SecurityTrustEntryCard: React.FC<SecurityTrustEntryCardProps> = ({
   };
 
   const content = isLoading ? (
-    <Box gap={3}>
+    <Box gap={2}>
       <Skeleton height={22} width="100%" />
       <Skeleton height={24} width="50%" />
       <Box flexDirection={BoxFlexDirection.Row} gap={2}>
@@ -106,7 +106,7 @@ const SecurityTrustEntryCard: React.FC<SecurityTrustEntryCardProps> = ({
       </Box>
     </Box>
   ) : (
-    <Box gap={3}>
+    <Box gap={2}>
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
@@ -22,7 +22,6 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-  Text,
 } from '@metamask/design-system-react-native';
 
 interface StakingButtonsProps extends Pick<ViewProps, 'style'> {
@@ -111,9 +110,9 @@ const StakingButtons = ({
           style={styles.balanceActionButton}
           variant={ButtonVariant.Secondary}
           onPress={onUnstakePress}
-          size={ButtonSize.Md}
+          size={ButtonSize.Lg}
         >
-          <Text>{strings('stake.unstake')}</Text>
+          {strings('stake.unstake')}
         </Button>
       )}
       {isPooledStakingEnabled && isEligible && (
@@ -122,13 +121,11 @@ const StakingButtons = ({
           style={styles.balanceActionButton}
           variant={ButtonVariant.Secondary}
           onPress={onStakePress}
-          size={ButtonSize.Md}
+          size={ButtonSize.Lg}
         >
-          <Text>
-            {hasStakedPositions
-              ? strings('stake.stake_more')
-              : strings('stake.stake')}
-          </Text>
+          {hasStakedPositions
+            ? strings('stake.stake_more')
+            : strings('stake.stake')}
         </Button>
       )}
     </View>

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -32,6 +32,7 @@ import { selectPerpsEnabledFlag } from '../../Perps';
 import { usePerpsMarketForAsset } from '../../Perps/hooks/usePerpsMarketForAsset';
 import { TraceName, endTrace } from '../../../../util/trace';
 import ActivityHeader from '../../../Views/Asset/ActivityHeader';
+import TokenDetailsSectionDivider from '../../AssetOverview/TokenDetails/TokenDetailsSectionDivider';
 import Transactions from '../../Transactions';
 import MultichainTransactionsView from '../../../Views/MultichainTransactionsView/MultichainTransactionsView';
 import { TransactionDetailLocation } from '../../../../core/Analytics/events/transactions';
@@ -51,6 +52,9 @@ const styleSheet = (params: { theme: Theme }) => {
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    activitySectionDivider: {
+      paddingHorizontal: 16,
     },
   });
 };
@@ -250,12 +254,17 @@ const TokenDetails: React.FC<{
         ///: END:ONLY_INCLUDE_IF
       />
       {(txLoading || hasTransactions) && (
-        <ActivityHeader
-          asset={{
-            ...token,
-            hasBalanceError: token.hasBalanceError ?? false,
-          }}
-        />
+        <>
+          <View style={styles.activitySectionDivider}>
+            <TokenDetailsSectionDivider />
+          </View>
+          <ActivityHeader
+            asset={{
+              ...token,
+              hasBalanceError: token.hasBalanceError ?? false,
+            }}
+          />
+        </>
       )}
     </>
   );

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -584,8 +584,13 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     showMusdConvertSection ||
     Boolean(tronNativeToken);
   const showDividerBeforePerps = showPerpsPositionBlock && hasContentAbovePerps;
+  const hasBalanceSection = balance != null;
   const showDividerBeforeTokenDetails =
-    hasContentAbovePerps || showPerpsPositionBlock || showPerpsDiscoveryBlock;
+    shouldShowMarketInsights ||
+    showPerpsPositionBlock ||
+    showPerpsDiscoveryBlock ||
+    hasContentAbovePerps ||
+    !hasBalanceSection;
 
   return (
     <Box twClassName="pt-[2px]" testID={TokenOverviewSelectorsIDs.CONTAINER}>

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -42,6 +42,7 @@ import PerpsPositionCard from '../../Perps/components/PerpsPositionCard';
 import Price from '../../AssetOverview/Price';
 import Balance from '../../AssetOverview/Balance';
 import TokenDetails from '../../AssetOverview/TokenDetails';
+import TokenDetailsSectionDivider from '../../AssetOverview/TokenDetails/TokenDetailsSectionDivider';
 import { TokenDetailsActions } from './TokenDetailsActions';
 import AssetOverviewClaimBonus from '../../Earn/components/AssetOverviewClaimBonus';
 import MoneyConvertStablecoins from '../../Money/components/MoneyConvertStablecoins/MoneyConvertStablecoins';
@@ -124,22 +125,21 @@ const styleSheet = (params: { theme: Theme }) => {
       padding: 20,
     } as ViewStyle,
     tokenDetailsWrapper: {
-      marginBottom: 20,
       paddingHorizontal: 16,
     } as ViewStyle,
     marketInsightsWrapper: {
       paddingTop: 16,
     } as ViewStyle,
+    sectionDividerWrapper: {
+      paddingHorizontal: 16,
+    } as ViewStyle,
     perpsPositionCardContainer: {
       paddingHorizontal: 16,
-      paddingTop: 24,
     } as ViewStyle,
     marketClosedActionButtonContainer: {
       marginBottom: 8,
     },
     securityTrustWrapper: {
-      marginTop: 20,
-      marginBottom: 20,
       paddingHorizontal: 16,
     } as ViewStyle,
   });
@@ -575,6 +575,18 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
     Boolean(marketInsightsCaip19Id) &&
     (Boolean(marketInsightsReport) || isMarketInsightsLoading);
 
+  const showPerpsPositionBlock = showPerpsSection && Boolean(perpsPosition);
+  const showPerpsDiscoveryBlock =
+    showPerpsSection && !perpsPosition && Boolean(marketData);
+  const hasContentAbovePerps =
+    balance != null ||
+    isTokenEligibleForMerklClaim ||
+    showMusdConvertSection ||
+    Boolean(tronNativeToken);
+  const showDividerBeforePerps = showPerpsPositionBlock && hasContentAbovePerps;
+  const showDividerBeforeTokenDetails =
+    hasContentAbovePerps || showPerpsPositionBlock || showPerpsDiscoveryBlock;
+
   return (
     <Box twClassName="pt-[2px]" testID={TokenOverviewSelectorsIDs.CONTAINER}>
       {token.hasBalanceError ? (
@@ -784,7 +796,12 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
             )
             ///: END:ONLY_INCLUDE_IF
           }
-          {showPerpsSection && perpsPosition && (
+          {showDividerBeforePerps && (
+            <View style={styles.sectionDividerWrapper}>
+              <TokenDetailsSectionDivider />
+            </View>
+          )}
+          {showPerpsPositionBlock && perpsPosition && (
             <View style={styles.perpsPositionCardContainer}>
               <Text variant={TextVariant.HeadingMd} twClassName="mb-2">
                 {strings('asset_overview.perps_position')}
@@ -797,7 +814,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
               />
             </View>
           )}
-          {showPerpsSection && !perpsPosition && marketData && (
+          {showPerpsDiscoveryBlock && marketData && (
             <PerpsDiscoveryBanner
               symbol={marketData.symbol}
               maxLeverage={marketData.maxLeverage}
@@ -805,8 +822,17 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
               testID={TokenOverviewSelectorsIDs.PERPS_DISCOVERY_BANNER}
             />
           )}
+          {showDividerBeforeTokenDetails && (
+            <View style={styles.sectionDividerWrapper}>
+              <TokenDetailsSectionDivider />
+            </View>
+          )}
           <View style={styles.tokenDetailsWrapper}>
             <TokenDetails asset={token} />
+            {!hasSecurityDataError &&
+              (isSecurityDataLoading || securityData?.resultType) && (
+                <TokenDetailsSectionDivider />
+              )}
           </View>
           {!hasSecurityDataError &&
             (isSecurityDataLoading || securityData?.resultType) && (

--- a/app/components/UI/Transactions/TransactionsFooter.test.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.test.tsx
@@ -61,7 +61,8 @@ jest.mock('../../../component-library/components/Texts/Text', () => ({
     );
   },
   getFontFamily: jest.fn(() => 'System'),
-  TextVariant: { BodySM: 'BodySM' },
+  TextVariant: { BodySM: 'BodySM', BodyXS: 'BodyXS' },
+  TextColor: { Alternative: 'alternative' },
 }));
 
 import {

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { View, StyleSheet, ViewStyle, TextStyle } from 'react-native';
-import type { Theme } from '@metamask/design-tokens';
 import { strings } from '../../../../locales/i18n';
 import Button, {
   ButtonSize,
   ButtonVariants,
 } from '../../../component-library/components/Buttons/Button';
 import Text, {
-  getFontFamily,
+  TextColor,
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { NO_RPC_BLOCK_EXPLORER, RPC } from '../../../constants/network';
@@ -15,8 +14,6 @@ import {
   getBlockExplorerName,
   isMainnetByChainId,
 } from '../../../util/networks';
-import { useTheme } from '../../../util/theme';
-
 interface Styles {
   viewMoreWrapper: ViewStyle;
   viewMoreButton: ViewStyle;
@@ -24,10 +21,7 @@ interface Styles {
   disclaimerText: TextStyle;
 }
 
-const createStyles = (
-  colors: Theme['colors'],
-  typography: Theme['typography'],
-): Styles =>
+const createStyles = (): Styles =>
   StyleSheet.create({
     viewMoreWrapper: {
       padding: 16,
@@ -38,11 +32,7 @@ const createStyles = (
     disclaimerWrapper: {
       padding: 16,
     },
-    disclaimerText: {
-      color: colors.text.default,
-      ...typography.sBodySM,
-      fontFamily: getFontFamily(TextVariant.BodySM),
-    } as TextStyle,
+    disclaimerText: {} as TextStyle,
   });
 
 interface TransactionsFooterProps {
@@ -86,8 +76,7 @@ const TransactionsFooter = ({
   onViewBlockExplorer,
   showDisclaimer = true,
 }: TransactionsFooterProps) => {
-  const { colors, typography } = useTheme();
-  const styles = createStyles(colors, typography);
+  const styles = createStyles();
 
   const getBlockExplorerText = (): string | null => {
     if (isNonEvmChain) {
@@ -140,7 +129,11 @@ const TransactionsFooter = ({
       )}
       {showDisclaimer && (
         <View style={styles.disclaimerWrapper}>
-          <Text style={styles.disclaimerText}>
+          <Text
+            variant={TextVariant.BodyXS}
+            color={TextColor.Alternative}
+            style={styles.disclaimerText}
+          >
             {strings('asset_overview.disclaimer')}
           </Text>
         </View>

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsFooter.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsFooter.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { View, StyleSheet, ViewStyle, TextStyle } from 'react-native';
-import type { Theme } from '@metamask/design-tokens';
 import { strings } from '../../../../locales/i18n';
 import Button, {
   ButtonSize,
   ButtonVariants,
 } from '../../../component-library/components/Buttons/Button';
-import Text from '../../../component-library/components/Texts/Text';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../component-library/components/Texts/Text';
 import { getBlockExplorerName } from '../../../util/networks';
-import { useTheme } from '../../../util/theme';
 
 interface Styles {
   viewMoreWrapper: ViewStyle;
@@ -17,7 +18,7 @@ interface Styles {
   disclaimerText: TextStyle;
 }
 
-const createStyles = (colors: Theme['colors']): Styles =>
+const createStyles = (): Styles =>
   StyleSheet.create({
     viewMoreWrapper: {
       padding: 16,
@@ -28,9 +29,7 @@ const createStyles = (colors: Theme['colors']): Styles =>
     disclaimerWrapper: {
       padding: 16,
     },
-    disclaimerText: {
-      color: colors.text.default,
-    } as TextStyle,
+    disclaimerText: {} as TextStyle,
   });
 
 interface MultichainTransactionsFooterProps {
@@ -63,8 +62,7 @@ const MultichainTransactionsFooter = ({
   showExplorerLink = true,
   onViewMore,
 }: MultichainTransactionsFooterProps) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const styles = createStyles();
 
   return (
     <View>
@@ -83,7 +81,11 @@ const MultichainTransactionsFooter = ({
       )}
       {showDisclaimer && (
         <View style={styles.disclaimerWrapper}>
-          <Text style={styles.disclaimerText}>
+          <Text
+            variant={TextVariant.BodyXS}
+            color={TextColor.Alternative}
+            style={styles.disclaimerText}
+          >
             {strings('asset_overview.disclaimer')}
           </Text>
         </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

### What is the reason for the change?
- Old feature had inconsistent typography
- Lack of sectioning made it hard to parse and scan
- Disparate banner components across features made the UI feel sloppy

### What is the improvement/solution?
- Consistent section spacing compared to other features (Money, Perps etc.)
- Polished `Perps`, `mUSD`, `Lend` and `Earn` banners 
- Refined `Tron` components to match styles for sections 
- Refined vertical rhythm for consistency
- Consistent typography styles for list items

[See original designs](https://www.figma.com/design/iqPZeL5rVg7tWGmacjIeyH/Token-details?node-id=407-7938) for context.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: polish token details ui

## **Related issues**

Fixes:
Activity section is polished here: https://github.com/MetaMask/metamask-mobile/pull/30510

## **Manual testing steps**

```gherkin
Feature: Token details asset overview visual consistency

  Scenario: user views promotional and feature banners on token details
    Given the user is on token details for an asset with market insights, earn or lend, mUSD conversion, perps discovery, or tron resources enabled

    When the user scrolls through the asset overview below the chart and actions
    Then market insights, balance, and major feature blocks use consistent vertical spacing with section dividers where applicable
    And lend, mUSD, perps discovery, and tron CTAs use aligned section card styling, muted backgrounds, and body md or body sm medium typography with large action buttons where shown

  Scenario: user scans token details metadata and activity on token details
    Given the user is on token details with token or market metadata and transaction activity visible

    When the user scrolls through token details, security trust, and activity
    Then section dividers separate token details, market details, security trust, and activity
    And list values use body md medium typography
    And the activity disclaimer uses body xs text in alternative color
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="851" height="586" alt="Screenshot 2026-05-21 at 6 03 10 PM" src="https://github.com/user-attachments/assets/8e6d2ba9-23cb-4aac-919c-b1ef49be40a8" />
<img width="852" height="589" alt="Screenshot 2026-05-21 at 6 03 19 PM" src="https://github.com/user-attachments/assets/c6dfdb37-04ba-4ce9-a9fa-e86b5eea29eb" />
<img width="593" height="611" alt="Screenshot 2026-05-21 at 6 03 38 PM" src="https://github.com/user-attachments/assets/01293cbf-731a-455a-9af5-0dbc4e204e62" />
<img width="593" height="619" alt="Screenshot 2026-05-21 at 6 03 46 PM" src="https://github.com/user-attachments/assets/8f85efc3-9b32-448e-bd66-0dc4c59b1cf7" />


### **After**

<img width="1076" height="744" alt="Screenshot 2026-05-21 at 5 50 03 PM" src="https://github.com/user-attachments/assets/80efe5e3-3022-417f-9f55-3b9ee098ee18" />
<img width="1076" height="747" alt="Screenshot 2026-05-21 at 5 50 17 PM" src="https://github.com/user-attachments/assets/41d32cca-1898-4e3d-8c8a-2b638beb2efc" />
<img width="736" height="749" alt="Screenshot 2026-05-21 at 5 50 26 PM" src="https://github.com/user-attachments/assets/04d96964-ea34-4459-8efb-a1e0f7cd611a" />
<img width="738" height="749" alt="Screenshot 2026-05-21 at 5 50 39 PM" src="https://github.com/user-attachments/assets/55983fa4-2701-4500-87b5-0e7784662ff5" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/typography and layout adjustments across token details-related screens; low functional risk aside from potential minor spacing/regression in section visibility and footers.
> 
> **Overview**
> Improves Token Details visual hierarchy by introducing a reusable `TokenDetailsSectionDivider` and wiring it throughout token details, market details, perps blocks, Tron resources, earnings, and the activity header to create consistent section separation and spacing.
> 
> Standardizes typography and sizing across asset overview components (e.g., token name, token details list values, Earn/Stake CTAs) and updates several promotional cards/banners (Perps discovery, mUSD conversion, Earn empty state, Tron resource ring) to align padding, muted backgrounds, and button sizes.
> 
> Updates transaction footers to render the disclaimer using explicit `Text` variants/colors (removing theme-derived styling) and tweaks Market Insights/Security Trust card spacing for tighter vertical rhythm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ec57653d0c7dcb765a68769084e4ea88076f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->