### PR TITLE
fix: reject `predictDepositAndOrder` before opening Add Funds flow

### DIFF
--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -61,14 +61,21 @@ import { parseAnalyticsProperties } from '../utils/analytics';
 interface SheetModeProviderEntry {
   id: number;
   hasBuyParams: () => boolean;
+  dismissPreviewSheet: () => void;
 }
 
 let _sheetModeProviders: SheetModeProviderEntry[] = [];
 let _nextSheetModeProviderId = 0;
 
-function registerSheetModeProvider(hasBuyParams: () => boolean): number {
+function registerSheetModeProvider(
+  hasBuyParams: () => boolean,
+  dismissPreviewSheet: () => void,
+): number {
   const id = ++_nextSheetModeProviderId;
-  _sheetModeProviders = [..._sheetModeProviders, { id, hasBuyParams }];
+  _sheetModeProviders = [
+    ..._sheetModeProviders,
+    { id, hasBuyParams, dismissPreviewSheet },
+  ];
   return id;
 }
 
@@ -78,6 +85,11 @@ function unregisterSheetModeProvider(id: number): void {
 
 function isActiveSheetModeProvider(id: number): boolean {
   return _sheetModeProviders[_sheetModeProviders.length - 1]?.id === id;
+}
+
+export function dismissActivePreviewSheet(): void {
+  const active = _sheetModeProviders[_sheetModeProviders.length - 1];
+  active?.dismissPreviewSheet();
 }
 
 /**
@@ -154,6 +166,7 @@ const SellSheetHeader: React.FC<{ params: PredictSellPreviewParams }> = ({
 interface PredictPreviewSheetContextValue {
   openBuySheet: (params: PredictBuyPreviewParams) => void;
   openSellSheet: (params: PredictSellPreviewParams) => void;
+  dismissPreviewSheet: () => void;
 }
 
 const PredictPreviewSheetContext = createContext<
@@ -183,6 +196,7 @@ export const usePredictPreviewSheet = (): PredictPreviewSheetContextValue => {
           params,
         });
       },
+      dismissPreviewSheet: () => undefined,
     }),
     [navigation],
   );
@@ -264,7 +278,9 @@ export const PredictPreviewSheetProvider: React.FC<
 
   useEffect(() => {
     if (!disableBottomSheet) {
-      providerIdRef.current = registerSheetModeProvider(hasBuyParams);
+      providerIdRef.current = registerSheetModeProvider(hasBuyParams, () =>
+        setBuyParams(null),
+      );
     }
     return () => {
       if (providerIdRef.current !== null) {
@@ -314,6 +330,10 @@ export const PredictPreviewSheetProvider: React.FC<
     },
     [bottomSheetEnabled, disableBottomSheet, navigation],
   );
+
+  const dismissPreviewSheet = useCallback(() => {
+    setBuyParams(null);
+  }, []);
 
   useEffect(() => {
     if (buyParams) {
@@ -465,8 +485,8 @@ export const PredictPreviewSheetProvider: React.FC<
   const onSellDismiss = useCallback(() => setSellParams(null), []);
 
   const contextValue = React.useMemo(
-    () => ({ openBuySheet, openSellSheet }),
-    [openBuySheet, openSellSheet],
+    () => ({ openBuySheet, openSellSheet, dismissPreviewSheet }),
+    [openBuySheet, openSellSheet, dismissPreviewSheet],
   );
 
   return (

--- a/app/components/UI/Predict/contexts/index.ts
+++ b/app/components/UI/Predict/contexts/index.ts
@@ -7,4 +7,5 @@ export {
   shouldSuppressLegacyOrderFailureToast,
   PredictPreviewSheetProvider,
   usePredictPreviewSheet,
+  dismissActivePreviewSheet,
 } from './PredictPreviewSheetContext';

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../Views/confirmations/types/token';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { usePredictBalanceTokenFilter } from './usePredictBalanceTokenFilter';
+import { dismissActivePreviewSheet } from '../contexts';
 import Routes from '../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
@@ -52,6 +53,16 @@ jest.mock('../../../Views/confirmations/utils/transaction', () => ({
   hasTransactionType: jest.fn(),
 }));
 
+const mockOnReject = jest.fn();
+jest.mock('../../../Views/confirmations/hooks/useApprovalRequest', () => ({
+  __esModule: true,
+  default: () => ({ onReject: mockOnReject, approvalRequest: { id: 'test' } }),
+}));
+
+jest.mock('../contexts', () => ({
+  dismissActivePreviewSheet: jest.fn(),
+}));
+
 const mockHasTransactionType = hasTransactionType as jest.MockedFunction<
   typeof hasTransactionType
 >;
@@ -83,6 +94,7 @@ describe('usePredictBalanceTokenFilter', () => {
     mockHasTransactionType.mockReturnValue(false);
     mockUseSelector.mockReturnValue({ image: 'pusd-token-image' });
     mockNavigate.mockReset();
+    mockOnReject.mockReset();
   });
 
   it('returns original tokens when transaction type does not match and forceEnabled is false', () => {
@@ -196,7 +208,7 @@ describe('usePredictBalanceTokenFilter', () => {
     expect(item.actions?.[0].buttonLabel).toBeTruthy();
   });
 
-  it('navigates to ADD_FUNDS_SHEET with autoDeposit when the Add action is pressed', () => {
+  it('rejects the current approval and navigates to ADD_FUNDS_SHEET when the Add action is pressed', () => {
     mockHasTransactionType.mockReturnValue(true);
     const tokens = [createMockToken()];
 
@@ -206,6 +218,8 @@ describe('usePredictBalanceTokenFilter', () => {
     const item = filteredTokens[0] as HighlightedItem;
     item.actions?.[0].onPress();
 
+    expect(dismissActivePreviewSheet).toHaveBeenCalledTimes(1);
+    expect(mockOnReject).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
       screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       params: { autoDeposit: true },

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
@@ -16,9 +16,11 @@ import {
   TokenListItem,
 } from '../../../Views/confirmations/types/token';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
+import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import { PREDICT_BALANCE_CHAIN_ID } from '../constants/transactions';
 import { usePredictBalance } from './usePredictBalance';
 import { usePredictPaymentToken } from './usePredictPaymentToken';
+import { dismissActivePreviewSheet } from '../contexts';
 
 export function usePredictBalanceTokenFilter(
   forceEnabled = false,
@@ -27,6 +29,7 @@ export function usePredictBalanceTokenFilter(
   const navigation = useNavigation();
   const transactionMeta = useTransactionMetadataRequest();
   const { isPredictBalanceSelected } = usePredictPaymentToken();
+  const { onReject } = useApprovalRequest();
   const { data: predictBalance = 0 } = usePredictBalance();
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const pusdToken = useSelector((state: RootState) =>
@@ -38,11 +41,13 @@ export function usePredictBalanceTokenFilter(
   );
 
   const handleAddFunds = useCallback(() => {
+    onReject();
+    dismissActivePreviewSheet();
     navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
       screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       params: { autoDeposit: true },
     });
-  }, [navigation]);
+  }, [navigation, onReject]);
 
   return useCallback(
     (tokens: AssetType[]): TokenListItem[] => {


### PR DESCRIPTION
## **Description**

When the user taps "Add" on the Predict balance row in the pay-with picker during a `predictDepositAndOrder` confirmation, the existing flow creates a `predictDeposit` transaction **on top of** the active `predictDepositAndOrder` confirmation. This causes two issues:

1. Stacking confirmations is unsafe - we assume a single active transaction at a time
2. The pay-with modal doesn't work on the second confirmation because it's on the wrong navigation stack

### Fix

Mirror the Perps pattern (`usePerpsBalanceTokenFilter`):

1. **`dismissActivePreviewSheet()`** - instantly removes the `PredictPreviewSheet` overlay (module-level function that calls `setBuyParams(null)` on the active provider)
2. **`onReject()`** - rejects the existing `predictDepositAndOrder` approval
3. **`navigation.navigate(ADD_FUNDS_SHEET)`** - opens the deposit flow cleanly

### Changes

- **`usePredictBalanceTokenFilter.ts`** - `handleAddFunds` now calls `dismissActivePreviewSheet()` + `onReject()` before navigating to Add Funds
- **`PredictPreviewSheetContext.tsx`** - Extended `SheetModeProviderEntry` with `dismissPreviewSheet` callback; added exported `dismissActivePreviewSheet()` function that dismisses the active provider's sheet from anywhere (including outside the context tree)
- **`contexts/index.ts`** - Export `dismissActivePreviewSheet`
- **`usePredictBalanceTokenFilter.test.ts`** - Updated test to mock `useApprovalRequest`, `usePredictDeposit`, and assert `onReject` is called

## **Manual testing steps**

1. Open a prediction market and tap a bet outcome
2. In the buy sheet, tap "Pay with" to open the token picker
3. Tap "Add" next to "Predict balance"
4. Verify: the buy sheet and `predictDepositAndOrder` confirmation are dismissed
5. Verify: the Add Prediction Funds flow opens cleanly on top

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f5b3bce0-324b-4f47-aaaa-6568d8258433


### **After**

https://github.com/user-attachments/assets/0862c578-d0bb-464c-b380-d6401fc41997


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR
- [x] I've properly set the title of this PR
- [x] If applicable, I've included the `Run Smoke E2E` and/or `Run Full E2E` label to run smoke/full E2E tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Predict confirmation flow by programmatically dismissing the active preview sheet and rejecting the current approval before starting the Add Funds navigation; mistakes could interrupt user order/confirmation state or leave UI in an inconsistent dismissal state.
> 
> **Overview**
> Prevents stacking a new Add Funds deposit flow on top of an active `predictDepositAndOrder` confirmation when users tap **Add** on the Predict balance row.
> 
> Introduces a module-level `dismissActivePreviewSheet()` in `PredictPreviewSheetContext` (tracked per active provider) and updates `usePredictBalanceTokenFilter` to call `onReject()` + `dismissActivePreviewSheet()` before navigating to `ADD_FUNDS_SHEET`; associated unit test now mocks `useApprovalRequest` and asserts both calls occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d9f81628ce9c654fff9e0fd46013277e87e68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->