### PR TITLE
fix: Polish activity list item component

### DIFF
--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -159,7 +159,7 @@ const MultichainBridgeTransactionListItem = ({
           </ListItem.Date>
           <ListItem.Content style={style.listItemContent}>
             <ListItem.Icon>{renderTxElementIcon()}</ListItem.Icon>
-            <ListItem.Body>
+            <ListItem.Body style={style.listItemBody}>
               <ListItem.Title
                 numberOfLines={1}
                 style={style.listItemTitle as TextStyle}

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.styles.ts
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.styles.ts
@@ -26,8 +26,8 @@ const createStyles = (colors: ThemeColors, typography: ThemeTypography) =>
       paddingHorizontal: 10,
     },
     icon: {
-      width: 32,
-      height: 32,
+      width: 40,
+      height: 40,
     } as ImageStyle,
     summaryWrapper: {
       padding: 15,
@@ -50,22 +50,35 @@ const createStyles = (colors: ThemeColors, typography: ThemeTypography) =>
       paddingTop: 10,
     },
     listItemDate: {
-      marginBottom: 10,
+      ...(typography.sBodyXSMedium as TextStyle),
+      fontFamily: getFontFamily(TextVariant.BodyXSMedium),
+      color: colors.text.alternative,
+      marginVertical: 0,
+      marginBottom: 8,
       paddingBottom: 0,
     },
     listItemContent: {
-      alignItems: 'flex-start',
+      alignItems: 'center',
       marginTop: 0,
       paddingTop: 0,
+    },
+    listItemBody: {
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 16,
     },
     listItemTitle: {
       ...typography.sBodyLGMedium,
       fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      marginVertical: 0,
       marginTop: 0,
     },
     listItemStatus: {
-      ...(typography.sBodyMDBold as TextStyle),
-      fontFamily: getFontFamily(TextVariant.BodyMDBold),
+      ...(typography.sBodySMMedium as TextStyle),
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
+      marginVertical: 0,
+      marginTop: 0,
     },
     listItemFiatAmount: {
       ...(typography.sBodyLGMedium as TextStyle),
@@ -73,9 +86,10 @@ const createStyles = (colors: ThemeColors, typography: ThemeTypography) =>
       marginTop: 0,
     },
     listItemAmount: {
-      ...(typography.sBodyMD as TextStyle),
-      fontFamily: getFontFamily(TextVariant.BodyMD),
+      ...(typography.sBodySMMedium as TextStyle),
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
       color: colors.text.alternative,
+      flexShrink: 0,
     },
     itemContainer: {
       padding: 0,

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -136,7 +136,7 @@ const MultichainTransactionListItem = ({
           <ListItem.Icon>
             {renderTxElementIcon(isRedeposit ? 'redeposit' : transaction.type)}
           </ListItem.Icon>
-          <ListItem.Body>
+          <ListItem.Body style={style.listItemBody}>
             <ListItem.Title
               numberOfLines={1}
               style={style.listItemTitle as TextStyle}

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -99,49 +99,102 @@ const createStyles = (colors, typography) =>
       paddingHorizontal: 10,
     },
     icon: {
-      width: 32,
-      height: 32,
+      width: 40,
+      height: 40,
     },
     iconBadgePosition: {
       bottom: -4,
       right: -4,
     },
     importText: {
+      ...typography.sBodyXSMedium,
+      fontFamily: getFontFamily(TextVariant.BodyXSMedium),
       color: colors.text.alternative,
-      fontSize: 14,
-      ...fontStyles.bold,
-      alignContent: 'center',
+      textAlign: 'left',
+    },
+    infoIcon: {
+      color: colors.text.alternative,
+      fontSize: 12,
+    },
+    importRow: {
+      backgroundColor: colors.background.default,
+    },
+    importRowBorder: {
+      marginHorizontal: 16,
+      borderTopWidth: 1,
+      borderBottomWidth: 1,
+      borderTopColor: colors.border.muted,
+      borderBottomColor: colors.border.muted,
+      paddingVertical: 12,
     },
     importRowBody: {
+      flexDirection: 'row',
       alignItems: 'center',
-      paddingTop: 10,
+      justifyContent: 'space-between',
+      alignSelf: 'stretch',
+    },
+    importLabel: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 8,
+    },
+    importDate: {
+      ...typography.sBodyXSMedium,
+      fontFamily: getFontFamily(TextVariant.BodyXSMedium),
+      color: colors.text.alternative,
+      flexShrink: 0,
+      marginVertical: 0,
+      marginBottom: 0,
     },
     listItemDate: {
-      marginBottom: 10,
+      ...typography.sBodyXSMedium,
+      fontFamily: getFontFamily(TextVariant.BodyXSMedium),
+      color: colors.text.alternative,
+      marginVertical: 0,
+      marginBottom: 8,
       paddingBottom: 0,
     },
     listItemContent: {
-      alignItems: 'flex-start',
+      alignItems: 'center',
       marginTop: 0,
       paddingTop: 0,
     },
+    listItemBody: {
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+      marginRight: 16,
+    },
+    listItemAmounts: {
+      flex: 0,
+      flexGrow: 0,
+      flexShrink: 0,
+      alignItems: 'flex-end',
+    },
     listItemTitle: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      ...typography.sBodyMDMedium,
+      fontFamily: getFontFamily(TextVariant.BodyMDMedium),
+      marginVertical: 0,
       marginTop: 0,
     },
     listItemStatus: {
-      ...typography.sBodyMDBold,
-      fontFamily: getFontFamily(TextVariant.BodyMDBold),
+      ...typography.sBodySMMedium,
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
+      marginVertical: 0,
+      marginTop: 0,
     },
     listItemFiatAmount: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      ...typography.sBodyMDMedium,
+      fontFamily: getFontFamily(TextVariant.BodyMDMedium),
+      color: colors.text.default,
       marginTop: 0,
     },
     listItemAmount: {
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
+      ...typography.sBodySMMedium,
+      fontFamily: getFontFamily(TextVariant.BodySMMedium),
       color: colors.text.alternative,
     },
   });
@@ -393,17 +446,23 @@ class TransactionElement extends PureComponent {
     const accountImportTime = selectedInternalAccount?.metadata.importTime;
     if (tx.insertImportTime && accountImportTime) {
       return (
-        <View style={styles.row}>
-          <TouchableOpacity
-            onPress={this.onPressImportWalletTip}
-            style={styles.importRowBody}
-          >
-            <Text style={styles.importText}>
-              {`${strings('transactions.import_wallet_row')} `}
-              <FAIcon name="info-circle" style={styles.infoIcon} />
-            </Text>
-            <ListItem.Date>{toDateFormat(accountImportTime)}</ListItem.Date>
-          </TouchableOpacity>
+        <View style={styles.importRow}>
+          <View style={styles.importRowBorder}>
+            <TouchableOpacity
+              onPress={this.onPressImportWalletTip}
+              style={styles.importRowBody}
+            >
+              <View style={styles.importLabel}>
+                <Text style={styles.importText}>
+                  {`${strings('transactions.import_wallet_row')} `}
+                  <FAIcon name="info-circle" style={styles.infoIcon} />
+                </Text>
+              </View>
+              <Text style={styles.importDate}>
+                {toDateFormat(accountImportTime)}
+              </Text>
+            </TouchableOpacity>
+          </View>
         </View>
       );
     }
@@ -559,7 +618,7 @@ class TransactionElement extends PureComponent {
           <ListItem.Icon>
             {this.renderTxElementIcon(transactionElement, tx)}
           </ListItem.Icon>
-          <ListItem.Body>
+          <ListItem.Body style={styles.listItemBody}>
             <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
               {title}
             </ListItem.Title>
@@ -579,7 +638,7 @@ class TransactionElement extends PureComponent {
             )}
           </ListItem.Body>
           {Boolean(value) && (
-            <ListItem.Amounts>
+            <ListItem.Amounts style={styles.listItemAmounts}>
               {!isTestNet(chainId) && (
                 <ListItem.FiatAmount style={styles.listItemFiatAmount}>
                   {fiatValue}
@@ -737,7 +796,7 @@ class TransactionElement extends PureComponent {
           <ListItem.Icon>
             <View style={styles.icon} />
           </ListItem.Icon>
-          <ListItem.Body>
+          <ListItem.Body style={styles.listItemBody}>
             <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
               ...
             </ListItem.Title>

--- a/app/components/UI/Transactions/TransactionsFooter.test.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../../../component-library/components/Buttons/Button', () => ({
       </TouchableOpacity>
     );
   },
-  ButtonVariants: { Link: 'link' },
+  ButtonVariants: { Secondary: 'secondary' },
   ButtonSize: { Lg: 'lg' },
 }));
 

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -30,7 +30,8 @@ const createStyles = (
 ): Styles =>
   StyleSheet.create({
     viewMoreWrapper: {
-      padding: 16,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
     },
     viewMoreButton: {
       width: '100%',
@@ -130,7 +131,7 @@ const TransactionsFooter = ({
       {blockExplorerText && rpcBlockExplorer && (
         <View style={styles.viewMoreWrapper}>
           <Button
-            variant={ButtonVariants.Link}
+            variant={ButtonVariants.Secondary}
             size={ButtonSize.Lg}
             label={blockExplorerText}
             style={styles.viewMoreButton}

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsFooter.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsFooter.tsx
@@ -20,7 +20,9 @@ interface Styles {
 const createStyles = (colors: Theme['colors']): Styles =>
   StyleSheet.create({
     viewMoreWrapper: {
-      padding: 16,
+      paddingHorizontal: 16,
+      paddingTop: 16,
+      paddingBottom: 0,
     },
     viewMoreButton: {
       width: '100%',
@@ -71,7 +73,7 @@ const MultichainTransactionsFooter = ({
       {hasTransactions && showExplorerLink && (
         <View style={styles.viewMoreWrapper}>
           <Button
-            variant={ButtonVariants.Link}
+            variant={ButtonVariants.Secondary}
             size={ButtonSize.Lg}
             label={`${strings(
               'transactions.view_full_history_on',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

What is the reason for the change?
- Typography was inconsistent with all other list styles
- Title text is cut off, making some transactions unreadable

What is the improvement/solution?
- Consistent title and description font color, size and weight
- Improved vertical rhythm and spacing

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: update activity list ui component

## **Related issues**

This is associated with another PR to polish Token Details:
https://github.com/MetaMask/metamask-mobile/pull/30505

## **Manual testing steps**

```gherkin
Feature: Activity transactions list visual consistency

  Scenario: user views the updated Activity transactions list
    Given I am logged into MetaMask Mobile
    And I have transaction history on an EVM network
    And I am on the Activity screen with the Transactions tab selected

    When I scroll through the transaction list to the bottom
    Then transaction rows show updated typography, 40px centered icons, and a 16px gap between title and amounts so long titles are not truncated early
    And date headers use body xs medium alternative text with 40px bottom spacing
    And the "Account added to this device" row shows label and date on one line with inset top and bottom borders and alternative xs medium text
    And the block explorer action is a secondary button with 16px horizontal and top padding and no bottom padding above the market data disclaimer
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1063" height="727" alt="Screenshot 2026-05-21 at 7 03 17 PM" src="https://github.com/user-attachments/assets/86f712e6-8555-4f20-9776-f10da984ce0b" />


### **After**

<img width="1066" height="753" alt="Screenshot 2026-05-21 at 6 58 34 PM" src="https://github.com/user-attachments/assets/128da69c-274e-4bda-87d6-11d49899244e" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only changes to list styles and footer button variants; no transaction logic, networking, or auth changes.
> 
> **Overview**
> Aligns **Activity** transaction rows with the app’s list typography and spacing so long titles stay readable and amounts stay visible.
> 
> **List rows** (`TransactionElement`, multichain/bridge list items): transaction icons grow from **32px to 40px**; row content is **vertically centered**. **`ListItem.Body`** gets **`listItemBody`** (`flex: 1`, `flexShrink: 1`, `minWidth: 0`, **16px** right margin) so titles truncate less aggressively; fiat/crypto amounts use **`listItemAmounts`** with **`flexShrink: 0`**. Dates and secondary text use **Body XS/SM** tokens with **alternative** color; titles and status lines use updated **MD/LG** and **SM** weights (EVM title moves to **Body MD Medium**).
> 
> The **“Account added to this device”** row is restyled: inset **muted** top/bottom borders, label and date on one **space-between** row, and typography via design tokens instead of ad-hoc font sizes.
> 
> **Footers** (`TransactionsFooter`, `MultichainTransactionsFooter`): block-explorer actions switch from **link** to **secondary** full-width buttons, with tighter vertical padding above the disclaimer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea103dbe544ee24786a5287d0354787e8b8f3097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->