### PR TITLE
fix: avoid Add funds eligibility failure without geolocation

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts
@@ -359,7 +359,7 @@ describe('useRampsSmartRouting', () => {
       );
     });
 
-    it('routes to ERROR when geolocation is not detected', async () => {
+    it('keeps routing unresolved when geolocation is not detected', async () => {
       mockDetectedGeolocation = undefined;
       mockOrders = [];
 
@@ -368,7 +368,7 @@ describe('useRampsSmartRouting', () => {
       await waitFor(() =>
         expect(mockDispatch).toHaveBeenCalledWith({
           type: 'FIAT_SET_RAMP_ROUTING_DECISION',
-          payload: UnifiedRampRoutingType.ERROR,
+          payload: null,
         }),
       );
 

--- a/app/components/UI/Ramp/hooks/useRampsSmartRouting.ts
+++ b/app/components/UI/Ramp/hooks/useRampsSmartRouting.ts
@@ -73,7 +73,10 @@ export default function useRampsSmartRouting() {
 
     const initializeRampRoutingDecision = async () => {
       if (!rampGeodetectedRegion) {
-        dispatch(setRampRoutingDecision(UnifiedRampRoutingType.ERROR));
+        // Geolocation can still be hydrating when wallet home renders. Keep
+        // routing unresolved so entry points can open token selection instead
+        // of treating a transient UNKNOWN location as an eligibility failure.
+        dispatch(setRampRoutingDecision(null));
         return;
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep unified ramps routing unresolved while geolocation is missing/UNKNOWN instead of marking it as an eligibility ERROR
- Preserve ERROR routing for actual region eligibility API failures after a region is available
- Update smart-routing unit coverage for the no-geolocation case

## Testing
- `NODE_OPTIONS='--max-old-space-size=4096' yarn eslint "app/components/UI/Ramp/hooks/useRampsSmartRouting.ts" "app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts"` (passes with existing no-shadow warning in test helper)
- `yarn jest app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts` reported PASS for all assertions, then the Jest process OOMed during shutdown
- `NODE_OPTIONS="--max-old-space-size=8192" yarn jest app/components/UI/Ramp/hooks/useRampsSmartRouting.test.ts --runInBand` reported PASS for all assertions, then remained open after completion and was stopped
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C09AYKX30P3/p1779291181105479?thread_ts=1779291181.105479&cid=C09AYKX30P3)

<div><a href="https://cursor.com/agents/bc-3d82f9f4-ed36-5388-8d8c-5b2f264858d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d82f9f4-ed36-5388-8d8c-5b2f264858d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

