### PR TITLE
fix(ledger): prevent Android crash when connecting Ledger or paginating accounts

### DIFF
--- a/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch
+++ b/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch
@@ -1,10 +1,10 @@
-diff --git a/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java b/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
-index 0000000..0000001 100644
---- a/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
-+++ b/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
+diff --git a/android/src/main/java/com/bleplx/utils/SafePromise.java b/android/src/main/java/com/bleplx/utils/SafePromise.java
+index 0203473c88dacf979340c324829871af83cf6d02..35c475e3c33cc882b1322ce6a9d811e6522269d2 100644
+--- a/android/src/main/java/com/bleplx/utils/SafePromise.java
++++ b/android/src/main/java/com/bleplx/utils/SafePromise.java
 @@ -7,6 +7,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
  import javax.annotation.Nullable;
-
+ 
  public class SafePromise {
 +  /**
 +   * Fallback non-null reject code used when callers (e.g. BlePlxModule) pass
@@ -17,32 +17,33 @@ index 0000000..0000001 100644
 +   */
 +  private static final String DEFAULT_REJECT_CODE = "BleError";
 +
-+  private static String safeCode(String code) {
++ private static String safeCode(String code) {
 +    return code != null ? code : DEFAULT_REJECT_CODE;
-+  }
++ }
 +
    private Promise promise;
    private AtomicBoolean isFinished = new AtomicBoolean();
-
+ 
 @@ -22,19 +37,19 @@ public class SafePromise {
-
+ 
    public void reject(String code, String message) {
      if (isFinished.compareAndSet(false, true)) {
 -      promise.reject(code, message);
 +      promise.reject(safeCode(code), message);
      }
    }
-
+ 
    public void reject(String code, Throwable e) {
      if (isFinished.compareAndSet(false, true)) {
 -      promise.reject(code, e);
 +      promise.reject(safeCode(code), e);
      }
    }
-
+ 
    public void reject(String code, String message, Throwable e) {
      if (isFinished.compareAndSet(false, true)) {
 -      promise.reject(code, message, e);
-+      promise.reject(safeCode(code), message, e);
++       promise.reject(safeCode(code), message, e);
      }
    }
+ 

--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
     "@metamask/keyring-api@npm:^22.0.0": "23.1.0",
     "@metamask/bridge-status-controller@npm:^71.0.0": "patch:@metamask/bridge-status-controller@npm%3A71.1.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-71.1.0-6140a0bdf3.patch",
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
-    "@metamask/permission-controller": "^13.1.1"
+    "@metamask/permission-controller": "^13.1.1",
+    "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -471,7 +472,7 @@
     "react-native-aes-crypto-forked": "patch:react-native-aes-crypto-forked@https%3A//github.com/MetaMask/react-native-aes-crypto-forked.git%23397d5db5250e8e7408294807965b5b9fd4ca6a25#~/.yarn/patches/react-native-aes-crypto-forked-https-9ebec3d485.patch",
     "react-native-animatable": "^1.3.3",
     "react-native-background-timer": "2.1.1",
-    "react-native-ble-plx": "3.4.0",
+    "react-native-ble-plx": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
     "react-native-blob-util": "^0.19.9",
     "react-native-branch": "^5.6.2",
     "react-native-browser-polyfill": "0.1.2",

--- a/patches/react-native-ble-plx+3.4.0.patch
+++ b/patches/react-native-ble-plx+3.4.0.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java b/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
+index 0000000..0000001 100644
+--- a/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
++++ b/node_modules/react-native-ble-plx/android/src/main/java/com/bleplx/utils/SafePromise.java
+@@ -7,6 +7,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
+ import javax.annotation.Nullable;
+
+ public class SafePromise {
++  /**
++   * Fallback non-null reject code used when callers (e.g. BlePlxModule) pass
++   * {@code null} as the code argument. React Native's PromiseImpl.reject is
++   * annotated @NonNull on its code parameter; passing null triggers a
++   * NullPointerException ("Parameter specified as non-null is null") on the
++   * native modules thread, which crashes the host app. Substituting a stable
++   * non-null string preserves the existing error-message payload (already
++   * carried in the second argument) while keeping the reject path safe.
++   */
++  private static final String DEFAULT_REJECT_CODE = "BleError";
++
++  private static String safeCode(String code) {
++    return code != null ? code : DEFAULT_REJECT_CODE;
++  }
++
+   private Promise promise;
+   private AtomicBoolean isFinished = new AtomicBoolean();
+
+@@ -22,19 +37,19 @@ public class SafePromise {
+
+   public void reject(String code, String message) {
+     if (isFinished.compareAndSet(false, true)) {
+-      promise.reject(code, message);
++      promise.reject(safeCode(code), message);
+     }
+   }
+
+   public void reject(String code, Throwable e) {
+     if (isFinished.compareAndSet(false, true)) {
+-      promise.reject(code, e);
++      promise.reject(safeCode(code), e);
+     }
+   }
+
+   public void reject(String code, String message, Throwable e) {
+     if (isFinished.compareAndSet(false, true)) {
+-      promise.reject(code, message, e);
++      promise.reject(safeCode(code), message, e);
+     }
+   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35557,7 +35557,7 @@ __metadata:
     react-native-aes-crypto-forked: "patch:react-native-aes-crypto-forked@https%3A//github.com/MetaMask/react-native-aes-crypto-forked.git%23397d5db5250e8e7408294807965b5b9fd4ca6a25#~/.yarn/patches/react-native-aes-crypto-forked-https-9ebec3d485.patch"
     react-native-animatable: "npm:^1.3.3"
     react-native-background-timer: "npm:2.1.1"
-    react-native-ble-plx: "npm:3.4.0"
+    react-native-ble-plx: "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch"
     react-native-blob-util: "npm:^0.19.9"
     react-native-branch: "npm:^5.6.2"
     react-native-browser-polyfill: "npm:0.1.2"
@@ -39952,6 +39952,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/13d5c846a92b9c7badf561e4028337a7d2fad0d2ad6b5e11071146ed98e2a433b30bd6c7ec488fc75dbb7083037ecb9620773edac0398ce8da5f14d0da78f1f9
+  languageName: node
+  linkType: hard
+
+"react-native-ble-plx@patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch":
+  version: 3.4.0
+  resolution: "react-native-ble-plx@patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch::version=3.4.0&hash=9771b9"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/36cbf29185b6b397b1f07192f2c818264e0249c94e7f37dc2b46565aadc4b43b81c2bbc5c60fa3cece014846f297b2cb9baae04002de35f1ed0a1075b4d2cb07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Patch `react-native-ble-plx` to guard against null reject codes in `SafePromise.java`. When BLE operations fail with a null error code, React Native's `@NonNull` promise reject path throws a native `NullPointerException`, crashing the app during Ledger connect or Select Account pagination on Android.
- Substitutes a stable fallback code (`BleError`) while preserving the existing error message payload.

Fixes #30491

## Test plan

- [ ] On Android (e.g. Samsung Galaxy S22, Android 16), add a hardware wallet account via Ledger
- [ ] Verify the app does not crash when connecting Ledger
- [ ] Verify pagination in the Select Account interface works without crashing
- [ ] Verify selecting an account completes successfully
- [ ] Smoke test other BLE flows (if applicable) to confirm no regressions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly scopes to Android BLE error handling by substituting a fallback reject code when `null` is passed, with minimal behavior change beyond preventing a native crash.
> 
> **Overview**
> Prevents an Android crash during BLE failures (e.g., Ledger connect/account pagination) by patching `react-native-ble-plx` so `SafePromise.reject` never passes a `null` error code into React Native's `Promise.reject`.
> 
> The app now consumes `react-native-ble-plx@3.4.0` via a Yarn patch (`.yarn/patches/...`) and updates `package.json`/`yarn.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24cbc6a202995fb19528d78a0f704c9e9c3fed6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->