### PR TITLE
fix: gate Social AI notification settings & bump notification-services-controller to 24.1.1

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.view.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.view.test.tsx
@@ -110,7 +110,7 @@ describeForPlatforms('Notifications settings (toggles + visibility)', () => {
 
   it('renders notification sections when notifications are enabled', async () => {
     const { getByTestId, getByText, findAllByText, findByText } =
-      renderSettings();
+      renderSettings({ socialLeaderboardEnabled: true });
 
     expect(
       getByTestId(NotificationSettingsViewSelectorsIDs.NOTIFICATIONS_TOGGLE),
@@ -122,6 +122,17 @@ describeForPlatforms('Notifications settings (toggles + visibility)', () => {
     expect(getByText(SECTION_TITLES.marketing)).toBeOnTheScreen();
     expect(await findAllByText('Push, In app')).toHaveLength(3);
     expect(getByText('Off')).toBeOnTheScreen();
+  });
+
+  it('hides social AI section when social leaderboard feature flag is disabled', async () => {
+    const { getByText, queryByText, findAllByText, findByText } =
+      renderSettings({ socialLeaderboardEnabled: false });
+
+    expect(await findByText(SECTION_TITLES.walletActivity)).toBeOnTheScreen();
+    expect(getByText(SECTION_TITLES.perps)).toBeOnTheScreen();
+    expect(queryByText(SECTION_TITLES.socialAI)).toBeNull();
+    expect(getByText(SECTION_TITLES.marketing)).toBeOnTheScreen();
+    expect(await findAllByText('Push, In app')).toHaveLength(2);
   });
 
   it('hides notification sections when main toggle is off', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.test.tsx
@@ -6,12 +6,20 @@ import { Props } from './NotificationsSettings.types';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsControllerTestUtils';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar';
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
+import { strings } from '../../../../../locales/i18n';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('7.72.0'),
+}));
 
 jest.mock('../../../UI/Perps/selectors/featureFlags', () => ({
   selectPerpsEnabledFlag: jest.fn().mockReturnValue(true),
 }));
 
-const mockInitialState = {
+const createMockState = ({
+  notificationsEnabled = false,
+  socialLeaderboardEnabled = false,
+} = {}) => ({
   settings: {
     avatarAccountType: AvatarAccountType.Maskicon,
   },
@@ -19,9 +27,43 @@ const mockInitialState = {
     backgroundState: {
       ...backgroundState,
       AccountsController: MOCK_ACCOUNTS_CONTROLLER_STATE,
+      NotificationServicesController: {
+        ...backgroundState.NotificationServicesController,
+        isNotificationServicesEnabled: notificationsEnabled,
+      },
+      RemoteFeatureFlagController: {
+        ...backgroundState.RemoteFeatureFlagController,
+        remoteFeatureFlags: {
+          ...backgroundState.RemoteFeatureFlagController.remoteFeatureFlags,
+          aiSocialLeaderboardEnabled: {
+            enabled: socialLeaderboardEnabled,
+            minimumVersion: '0.0.1',
+          },
+        },
+      },
     },
   },
-};
+});
+
+const setOptions = jest.fn();
+
+const renderNotificationsSettings = (
+  state = createMockState(),
+  navigation = {
+    setOptions,
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+  } as unknown as Props['navigation'],
+) =>
+  renderWithProvider(
+    <NotificationsSettings
+      navigation={navigation}
+      route={{} as unknown as Props['route']}
+    />,
+    {
+      state,
+    },
+  );
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -76,25 +118,42 @@ jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   }),
 }));
 
-const setOptions = jest.fn();
+const socialAISectionTitle = strings(
+  'app_settings.notifications_opts.social_ai_title',
+);
 
 describe('NotificationsSettings', () => {
-  it('renders correctly', () => {
-    const { getByTestId } = renderWithProvider(
-      <NotificationsSettings
-        navigation={
-          {
-            setOptions,
-          } as unknown as Props['navigation']
-        }
-        route={{} as unknown as Props['route']}
-      />,
-      {
-        state: mockInitialState,
-      },
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders main notifications toggle', () => {
+    const { getByTestId } = renderNotificationsSettings();
+
     expect(
       getByTestId(NotificationSettingsViewSelectorsIDs.NOTIFICATIONS_TOGGLE),
     ).toBeOnTheScreen();
+  });
+
+  it('renders social AI section when social leaderboard feature flag is enabled', () => {
+    const state = createMockState({
+      notificationsEnabled: true,
+      socialLeaderboardEnabled: true,
+    });
+
+    const { getByText } = renderNotificationsSettings(state);
+
+    expect(getByText(socialAISectionTitle)).toBeOnTheScreen();
+  });
+
+  it('hides social AI section when social leaderboard feature flag is disabled', () => {
+    const state = createMockState({
+      notificationsEnabled: true,
+      socialLeaderboardEnabled: false,
+    });
+
+    const { queryByText } = renderNotificationsSettings(state);
+
+    expect(queryByText(socialAISectionTitle)).toBeNull();
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -12,6 +12,7 @@ import SwitchLoadingModal from '../../../UI/Notification/SwitchLoadingModal';
 import { Props } from './NotificationsSettings.types';
 
 import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/notifications';
+import { selectSocialLeaderboardEnabled } from '../../../../selectors/featureFlagController/socialLeaderboard';
 
 import Routes from '../../../../constants/navigation/Routes';
 
@@ -96,6 +97,9 @@ const NotificationsSettings = ({ navigation }: Props) => {
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
+  const isSocialLeaderboardEnabled = useSelector(
+    selectSocialLeaderboardEnabled,
+  );
 
   const loadingText = useSwitchNotificationLoadingText();
   const { preferences } = useNotificationStoragePreferences();
@@ -155,18 +159,20 @@ const NotificationsSettings = ({ navigation }: Props) => {
               }
             />
 
-            <NotificationRow
-              title={strings('app_settings.notifications_opts.social_ai_title')}
-              status={getStatusText(preferences?.socialAI)}
-              iconName={IconName.Ai}
-              onPress={() =>
-                navigateToSection(
-                  'socialAI',
-                  strings('app_settings.notifications_opts.social_ai_title'),
-                  strings('app_settings.notifications_opts.social_ai_desc'),
-                )
-              }
-            />
+            {isSocialLeaderboardEnabled && (
+              <NotificationRow
+                title={strings('app_settings.notifications_opts.social_ai_title')}
+                status={getStatusText(preferences?.socialAI)}
+                iconName={IconName.Ai}
+                onPress={() =>
+                  navigateToSection(
+                    'socialAI',
+                    strings('app_settings.notifications_opts.social_ai_title'),
+                    strings('app_settings.notifications_opts.social_ai_desc'),
+                  )
+                }
+              />
+            )}
 
             <NotificationRow
               title={strings('app_settings.notifications_opts.marketing_title')}

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -161,7 +161,9 @@ const NotificationsSettings = ({ navigation }: Props) => {
 
             {isSocialLeaderboardEnabled && (
               <NotificationRow
-                title={strings('app_settings.notifications_opts.social_ai_title')}
+                title={strings(
+                  'app_settings.notifications_opts.social_ai_title',
+                )}
                 status={getStatusText(preferences?.socialAI)}
                 iconName={IconName.Ai}
                 onPress={() =>

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@metamask/native-utils": "^0.8.0",
     "@metamask/network-controller": "^31.0.0",
     "@metamask/network-enablement-controller": "^5.1.0",
-    "@metamask/notification-services-controller": "^24.0.0",
+    "@metamask/notification-services-controller": "24.1.1",
     "@metamask/permission-controller": "^13.1.1",
     "@metamask/phishing-controller": "^17.1.1",
     "@metamask/post-message-stream": "^10.0.0",

--- a/tests/api-mocking/mock-responses/defaults/user-storage.ts
+++ b/tests/api-mocking/mock-responses/defaults/user-storage.ts
@@ -28,8 +28,9 @@ const notificationPreferences = {
       },
     ],
   },
+  // Feature announcements are controlled by marketing in-app preferences.
   marketing: {
-    inAppNotificationsEnabled: false,
+    inAppNotificationsEnabled: true,
     pushNotificationsEnabled: false,
   },
   perps: {

--- a/tests/component-view/presets/notifications.ts
+++ b/tests/component-view/presets/notifications.ts
@@ -42,6 +42,7 @@ interface NotificationsPresetOptions {
   notificationsEnabled?: boolean;
   featureAnnouncementsEnabled?: boolean;
   pushEnabled?: boolean;
+  socialLeaderboardEnabled?: boolean;
   notifications?: typeof MOCK_NOTIFICATIONS;
 }
 
@@ -62,6 +63,7 @@ export function buildNotificationsState(
     notificationsEnabled = true,
     featureAnnouncementsEnabled = true,
     pushEnabled = true,
+    socialLeaderboardEnabled = false,
     notifications = MOCK_NOTIFICATIONS,
   } = options;
 
@@ -93,6 +95,10 @@ export function buildNotificationsState(
         RemoteFeatureFlagController: {
           remoteFeatureFlags: {
             assetsNotificationsEnabled: true,
+            aiSocialLeaderboardEnabled: {
+              enabled: socialLeaderboardEnabled,
+              minimumVersion: '0.0.1',
+            },
           },
         },
         AccountsController: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9275,9 +9275,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/notification-services-controller@npm:^24.0.0":
-  version: 24.1.0
-  resolution: "@metamask/notification-services-controller@npm:24.1.0"
+"@metamask/notification-services-controller@npm:24.1.1":
+  version: 24.1.1
+  resolution: "@metamask/notification-services-controller@npm:24.1.1"
   dependencies:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
@@ -9293,7 +9293,7 @@ __metadata:
     loglevel: "npm:^1.8.1"
     semver: "npm:^7.6.3"
     uuid: "npm:^8.3.2"
-  checksum: 10/c8bcfcc7e9178eee8789ef4417636ac583e597639596c85eac82e5703c5d59fb8e4762e0d1fe71005320bedb11ea5893431ee540f0d268bcecf10bb226d7af33
+  checksum: 10/8f5249dea67dc7168c9254fde1de81e24483f9b054ba1ac282c36849e2090515f0cff0ed7cd4beaf6aefed6382f966277e02d3259f69aea67dee1c84c2ec7400
   languageName: node
   linkType: hard
 
@@ -35288,7 +35288,7 @@ __metadata:
     "@metamask/native-utils": "npm:^0.8.0"
     "@metamask/network-controller": "npm:^31.0.0"
     "@metamask/network-enablement-controller": "npm:^5.1.0"
-    "@metamask/notification-services-controller": "npm:^24.0.0"
+    "@metamask/notification-services-controller": "npm:24.1.1"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
     "@metamask/phishing-controller": "npm:^17.1.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Ensure the project uses the newer `@metamask/notification-services-controller` version and prevent Social AI notification controls from showing when the Social Leaderboard feature is disabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-244
Related to https://github.com/MetaMask/core/pull/8861

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI visibility is now controlled by an existing remote feature flag and changes are covered by updated tests; dependency bump may have minor integration fallout but is limited in scope.
> 
> **Overview**
> **Gates the Social AI notification settings section** so it only appears when the `aiSocialLeaderboardEnabled` remote feature flag is enabled (via `selectSocialLeaderboardEnabled`).
> 
> Updates unit/component-view tests and notification-state presets to cover both flag states, and adjusts the user-storage mock defaults for `marketing.inAppNotificationsEnabled`.
> 
> Bumps `@metamask/notification-services-controller` to `24.1.1` (and updates lockfile accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445bca50c42702577f97243691874b69ae51beca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->