### PR TITLE
ci: skip Smart E2E comment on locked PRs

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -236,5 +236,11 @@ runs:
 
         FULL_COMMENT="${TITLE}"$'\n'"${COMMENT_BODY}"$'\n\n'"${FOOTER}"$'\n'"${MARKER}"
 
+        IS_LOCKED=$(gh api "repos/${{ inputs.repository }}/issues/${{ inputs.pr-number }}" --jq '.locked')
+        if [[ "$IS_LOCKED" == "true" ]]; then
+          echo "⏭️ PR conversation is locked; skipping Smart E2E selection comment"
+          exit 0
+        fi
+
         gh pr comment ${{ inputs.pr-number }} --repo ${{ inputs.repository }} --body "$FULL_COMMENT"
         echo "✅ Successfully created comment"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Skip posting the Smart E2E selection PR comment when the target PR conversation is locked. This prevents the selector job from failing after it has already produced outputs because `gh pr comment` cannot add comments to locked PR conversations with `GITHUB_TOKEN`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Smart E2E selection comment posting

  Scenario: PR conversation is locked
    Given the Smart E2E selection action has produced outputs
    When the action detects that the PR conversation is locked
    Then it skips posting the comment and exits successfully
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Testing

- `git diff --check`
- `python3` YAML parse for `.github/actions/smart-e2e-selection/action.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b26b674-96bc-4105-9871-41251b98cfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b26b674-96bc-4105-9871-41251b98cfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

