### PR TITLE
chore(release): Bump main version to 7.80.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -179,7 +179,7 @@ android {
         applicationId "io.metamask"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName "7.79.0"
+        versionName "7.80.0"
         versionCode 4532
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1028,7 +1028,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.79.0;
+				MARKETING_VERSION = 7.80.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1094,7 +1094,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.79.0;
+				MARKETING_VERSION = 7.80.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1163,7 +1163,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.79.0;
+				MARKETING_VERSION = 7.80.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1227,7 +1227,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.79.0;
+				MARKETING_VERSION = 7.80.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask",
-  "version": "7.79.0",
+  "version": "7.80.0",
   "private": true,
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 7.79.0 to 7.80.0 after cutting the release branch.

created manually as the automation was broken

CHANGELOG entry: null