### PR TITLE
Fix Engine.hasFunds token fiat total

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -514,7 +514,7 @@ describe('Engine', () => {
     it('calculates when theres no balances', () => {
       const engine = Engine.init(TEST_ANALYTICS_ID, state);
 
-      (store.getState as jest.Mock).mockReturnValueOnce({
+      const mockedState = {
         onboarding: {
           completedOnboarding: true,
         },
@@ -533,7 +533,9 @@ describe('Engine', () => {
             },
           },
         },
-      });
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce(mockedState);
 
       const totalFiatBalance = engine.getTotalEvmFiatAccountBalance();
       expect(totalFiatBalance).toStrictEqual({
@@ -551,7 +553,7 @@ describe('Engine', () => {
 
       const engine = Engine.init(TEST_ANALYTICS_ID, state);
 
-      (store.getState as jest.Mock).mockReturnValueOnce({
+      const mockedState = {
         onboarding: {
           completedOnboarding: true,
         },
@@ -569,7 +571,9 @@ describe('Engine', () => {
             },
           },
         },
-      });
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce(mockedState);
 
       const totalFiatBalance = engine.getTotalEvmFiatAccountBalance();
 
@@ -611,7 +615,7 @@ describe('Engine', () => {
 
       const engine = Engine.init(TEST_ANALYTICS_ID, state);
 
-      (store.getState as jest.Mock).mockReturnValueOnce({
+      const mockedState = {
         onboarding: {
           completedOnboarding: true,
         },
@@ -663,7 +667,9 @@ describe('Engine', () => {
             },
           },
         },
-      });
+      };
+
+      (store.getState as jest.Mock).mockReturnValueOnce(mockedState);
 
       const totalFiatBalance = engine.getTotalEvmFiatAccountBalance();
 
@@ -802,6 +808,113 @@ describe('Engine', () => {
         ticker: 'ETH',
         totalNativeTokenBalance: '1',
       });
+    });
+  });
+
+  describe('hasFunds', () => {
+    it('returns true when token fiat is present even if tokenBalances is empty', () => {
+      const selectedAddress = '0x9DeE4BF1dE9E3b930E511Db5cEBEbC8d6F855Db0';
+      const selectedAccountId = 'test-account-id';
+      const chainId: Hex = '0x1';
+      const ticker = 'ETH';
+      const ethConversionRate = 4000;
+      const tokenAddress = '0x0001' as Hex;
+
+      const state: Partial<EngineState> = {
+        AccountsController: {
+          ...createMockAccountsControllerState(
+            [selectedAddress],
+            selectedAddress,
+          ),
+          internalAccounts: {
+            accounts: {
+              [selectedAccountId]: createMockInternalAccount(
+                selectedAddress,
+                'Test Account',
+              ),
+            },
+            selectedAccount: selectedAccountId,
+          },
+        },
+        AccountTrackerController: {
+          accountsByChainId: {
+            [chainId]: {
+              [selectedAddress]: { balance: '0', stakedBalance: '0' },
+            },
+          },
+        },
+        NetworkController: mockNetworkState({
+          chainId: '0x1',
+          id: '0x1',
+          nickname: 'mainnet',
+          ticker: 'ETH',
+        }),
+        CurrencyRateController: {
+          currencyRates: {
+            [ticker]: {
+              conversionRate: ethConversionRate,
+              conversionDate: 0,
+              usdConversionRate: ethConversionRate,
+            },
+          },
+          currentCurrency: ticker,
+        },
+      };
+
+      const engine = Engine.init(TEST_ANALYTICS_ID, state);
+
+      const mockedState = {
+        onboarding: {
+          completedOnboarding: true,
+        },
+        engine: {
+          backgroundState: {
+            ...state,
+            NftController: {
+              nfts: [],
+            },
+            TokensController: {
+              allTokens: {
+                [chainId]: {
+                  [selectedAddress]: [
+                    {
+                      address: tokenAddress,
+                      balance: '1',
+                      decimals: 18,
+                      symbol: 'TEST1',
+                    },
+                  ],
+                },
+              },
+              allIgnoredTokens: {},
+              allDetectedTokens: {},
+            },
+            TokenBalancesController: {
+              tokenBalances: {
+                [selectedAddress as Hex]: {
+                  [chainId]: {},
+                },
+              },
+            },
+            TokenRatesController: {
+              marketData: {
+                [chainId]: {
+                  [tokenAddress]: {
+                    price: 1,
+                    pricePercentChange1d: 0,
+                  } as unknown as MarketDataDetails,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      (store.getState as jest.Mock)
+        .mockReturnValueOnce(mockedState)
+        .mockReturnValueOnce(mockedState);
+
+      expect(engine.hasFunds()).toBe(true);
     });
   });
 

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1154,7 +1154,7 @@ export class Engine {
       const tokenFound = hasNonZeroTokenBalance();
 
       const fiatBalance = this.getTotalEvmFiatAccountBalance() || 0;
-      const totalFiatBalance = fiatBalance.ethFiat + fiatBalance.ethFiat;
+      const totalFiatBalance = fiatBalance.ethFiat + fiatBalance.tokenFiat;
 
       return totalFiatBalance > 0 || tokenFound || nfts.length > 0;
     } catch (e) {


### PR DESCRIPTION
## Summary
- fix `Engine.hasFunds()` to sum `ethFiat` and `tokenFiat`
- add a regression test for the token-fiat-present case when `tokenBalances` is empty
- keep the existing `getTotalEvmFiatAccountBalance()` tests readable by reusing named mocked state fixtures

## Why
`getTotalEvmFiatAccountBalance()` returns separate `ethFiat` and `tokenFiat` values, but `hasFunds()` was still summing `ethFiat + ethFiat`. That can misclassify backup/protection flows when token fiat is present even though the raw `tokenBalances` map is empty or stale.

## Impact
Backup gating that depends on `Engine.hasFunds()` now treats token fiat as funds instead of ignoring it.

## Testing
- `yarn jest app/core/Engine/Engine.test.ts --runInBand`
- `yarn eslint app/core/Engine/Engine.ts app/core/Engine/Engine.test.ts` *(existing deprecation warnings only)*

Related: #30576

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet “has funds” detection used for backup/protection gating; incorrect behavior could block or allow flows, but the fix is a one-line logic correction with targeted tests.
> 
> **Overview**
> **`Engine.hasFunds()`** now treats total fiat as **`ethFiat + tokenFiat`** instead of incorrectly doubling **`ethFiat`**. That aligns with **`getTotalEvmFiatAccountBalance()`**, so backup and other flows that gate on “has funds” count token value even when **`TokenBalancesController`** balances are empty or stale.
> 
> Tests add a **`hasFunds`** regression for token fiat with an empty **`tokenBalances`** map, and refactor existing **`getTotalEvmFiatAccountBalance`** cases to use shared **`mockedState`** fixtures before **`store.getState`** mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e934948e8fa1c07524b18e25f0dd327964fdb230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->