### PR TITLE
fix: fiat payment design alignments

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -23,6 +23,7 @@ import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { AssetType } from '../../../types/token';
 import {
+  useTransactionPayFiatPayment,
   useTransactionPayRequiredTokens,
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
@@ -179,6 +180,10 @@ describe('CustomAmountInfo', () => {
   const useAccountTokensMock = jest.mocked(useAccountTokens);
   const useConfirmActionsMock = jest.mocked(useConfirmActions);
 
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
+
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
@@ -227,6 +232,7 @@ describe('CustomAmountInfo', () => {
     } as never);
 
     useTransactionAccountOverrideMock.mockReturnValue(undefined);
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
 
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: false,
@@ -581,6 +587,16 @@ describe('CustomAmountInfo', () => {
     expect(
       queryByText(strings('alert_system.account_no_funds.message')),
     ).toBeNull();
+  });
+
+  it('does not render PayAccountSelector when supportAccountSelection is true but selectedFiatPaymentMethodId exists', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'fiat-method-1',
+    } as never);
+
+    const { queryByTestId } = render({ supportAccountSelection: true });
+
+    expect(queryByTestId('pay-account-selector')).toBeNull();
   });
 
   it('renders PayAccountSelector for moneyAccountDeposit when supportAccountSelection is true', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -239,7 +239,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           <AlertMessage alertMessage={alertMessage ?? headlessBuyError} />
           {!isResultReady && (
             <>
-              {supportAccountSelection && (
+              {supportAccountSelection && !selectedFiatPaymentMethodId && (
                 <PayAccountSelector style={styles.separator} />
               )}
               {disablePay !== true && hasTokens && <PayWithRow />}
@@ -247,7 +247,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           )}
           {isResultReady && (
             <Box>
-              {supportAccountSelection && <PayAccountSelector />}
+              {supportAccountSelection && !selectedFiatPaymentMethodId && (
+                <PayAccountSelector />
+              )}
               {disablePay !== true && hasTokens && <PayWithRow />}
               {showPaymentDetails && (
                 <>

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -225,7 +225,7 @@ function PayWithFiatPaymentMethodRow({
           <PaymentMethodIcon
             paymentMethodType={paymentMethod.paymentType as PaymentType}
             size={20}
-            color={disabled ? colors.icon.muted : undefined}
+            color={disabled ? colors.icon.muted : colors.icon.default}
           />
           <Text
             variant={TextVariant.BodyMd}


### PR DESCRIPTION
## Description

This PR fixes two UI issues related to fiat payment method selection in the confirmation flow:

### 1. Hide PayAccountSelector when fiat payment method is selected
When a fiat payment method (`selectedFiatPaymentMethodId`) is active, the `PayAccountSelector` component should not be rendered in `CustomAmountInfo`. The guard was added to both the keyboard-visible and result-ready states. Test coverage added to verify the new behavior.

### 2. Fix dark mode icon color for fiat payment method row
`PaymentMethodIcon` in `PayWithFiatPaymentMethodRow` was receiving `color={undefined}` when not disabled, causing react-native-vector-icons to default to black — invisible in dark mode. Fixed by using `colors.icon.default` from the theme, which resolves to the correct color in both light and dark modes.

## Changes
- `custom-amount-info.tsx`: Added `!selectedFiatPaymentMethodId` guard to `PayAccountSelector` rendering
- `custom-amount-info.test.tsx`: Added test for PayAccountSelector hidden when fiat payment method selected
- `pay-with-row.tsx`: Changed `PaymentMethodIcon` color from `undefined` to `colors.icon.default`

## Related to

- Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1415

## Recording and screenshots

### After


https://github.com/user-attachments/assets/51e483dc-7073-4bd0-ac14-0a115323d2dd





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small confirmation UI guards and theme token for an icon; no auth, transaction, or payment logic changes.
> 
> **Overview**
> When a **fiat payment method** is selected on the custom amount confirmation screen, **`PayAccountSelector` is hidden** so users are not prompted to pick a crypto pay account alongside fiat. The same guard applies in both the in-progress (keyboard) and post-**Done** layouts.
> 
> The **Pay with** row for fiat methods now uses **`colors.icon.default`** for `PaymentMethodIcon` when enabled, fixing icons that looked wrong (e.g. black) in **dark mode**.
> 
> Tests assert the account selector stays off when `selectedPaymentMethodId` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa7eab9070c201004962414edaad3fabd28fed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->