### PR TITLE
chore: update Crowdin translation workflow and add Turkish placeholder fix script

### DIFF
--- a/.github/workflows/crowdin_download_translations.yml
+++ b/.github/workflows/crowdin_download_translations.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   download-translations:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -24,6 +24,7 @@ jobs:
           upload_translations: false # disabled to prevent translations overwriting Blends translations
           download_translations: true # created separate action to pull down completed translations
           export_only_approved: true
+          localization_branch_name: l10n_crowdin_action
           pull_request_title: 'chore: New Crowdin Translations by GitHub Action'
           github_user_name: metamaskbot
           github_user_email: metamaskbot@users.noreply.github.com
@@ -32,3 +33,36 @@ jobs:
           GITHUB_ACTOR: metamaskbot
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Fix Turkish percentage placeholders on Crowdin branch
+        env:
+          BRANCH_NAME: l10n_crowdin_action
+          FIX_SCRIPT_PATH: scripts/fix-turkish-percentage-placeholders.js
+        run: |
+          if ! git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null; then
+            echo "Crowdin localization branch was not created or updated; nothing to fix."
+            exit 0
+          fi
+
+          git fetch origin "$BRANCH_NAME"
+          git checkout -B "$BRANCH_NAME" "origin/$BRANCH_NAME"
+
+          FIX_SCRIPT="$FIX_SCRIPT_PATH"
+          if [ ! -f "$FIX_SCRIPT" ]; then
+            FIX_SCRIPT="/tmp/fix-turkish-percentage-placeholders.js"
+            git show "${GITHUB_SHA}:${FIX_SCRIPT_PATH}" > "$FIX_SCRIPT"
+          fi
+
+          node "$FIX_SCRIPT"
+          node "$FIX_SCRIPT" --check
+
+          if git diff --quiet -- locales/languages/tr.json; then
+            echo "No Turkish placeholder fixes needed."
+            exit 0
+          fi
+
+          git config user.name "metamaskbot"
+          git config user.email "metamaskbot@users.noreply.github.com"
+          git add locales/languages/tr.json
+          git commit -m "fix: normalize Turkish percentage placeholders"
+          git push origin "$BRANCH_NAME"

--- a/locales/tr.placeholders.test.js
+++ b/locales/tr.placeholders.test.js
@@ -1,5 +1,10 @@
 import tr from './languages/tr.json';
 
+const INVALID_PERCENT_BEFORE_DOUBLE_BRACE_PLACEHOLDER =
+  /(?<!\}\})%\{\{/u;
+const INVALID_LITERAL_PERCENT_BEFORE_SINGLE_BRACE_PLACEHOLDER =
+  /(?<!\}\})%%\{/u;
+
 /**
  * Recursively collects leaf string values from nested locale objects.
  *
@@ -35,9 +40,9 @@ describe('Turkish locale (tr.json)', () => {
     return strings;
   }
 
-  it('contains no %{{ substrings in any translation value', () => {
+  it('does not use % before a double-brace placeholder', () => {
     const offenders = getAllLeafStrings().filter(({ value }) =>
-      value.includes('%{{'),
+      INVALID_PERCENT_BEFORE_DOUBLE_BRACE_PLACEHOLDER.test(value),
     );
 
     expect(offenders).toEqual([]);
@@ -45,7 +50,7 @@ describe('Turkish locale (tr.json)', () => {
 
   it('does not use %%{…} (literal % before placeholder); use {{…}}% like other locales', () => {
     const offenders = getAllLeafStrings().filter(({ value }) =>
-      value.includes('%%{'),
+      INVALID_LITERAL_PERCENT_BEFORE_SINGLE_BRACE_PLACEHOLDER.test(value),
     );
 
     expect(offenders).toEqual([]);

--- a/locales/tr.placeholders.test.js
+++ b/locales/tr.placeholders.test.js
@@ -3,7 +3,7 @@ import tr from './languages/tr.json';
 const INVALID_PERCENT_BEFORE_DOUBLE_BRACE_PLACEHOLDER =
   /(?<!\}\})%\{\{/u;
 const INVALID_LITERAL_PERCENT_BEFORE_SINGLE_BRACE_PLACEHOLDER =
-  /(?<!\}\})%%\{/u;
+  /%%\{/u;
 
 /**
  * Recursively collects leaf string values from nested locale objects.

--- a/scripts/fix-turkish-percentage-placeholders.js
+++ b/scripts/fix-turkish-percentage-placeholders.js
@@ -1,0 +1,93 @@
+/* eslint-disable no-console */
+/* eslint-disable import-x/no-nodejs-modules */
+/* eslint-disable import-x/no-commonjs */
+
+const fs = require('fs');
+const path = require('path');
+
+const localePath = path.resolve(
+  process.cwd(),
+  'locales',
+  'languages',
+  'tr.json',
+);
+const checkOnly = process.argv.includes('--check');
+
+function fixPercentagePlaceholders(value) {
+  return value
+    .replace(/%\{\{\s*([^}]+?)\s*\}\}/gu, '{{$1}}%')
+    .replace(/%%\{\s*([^}]+?)\s*\}/gu, '{{$1}}%');
+}
+
+function collectOffenders(node, pathSegments = [], offenders = []) {
+  if (typeof node === 'string') {
+    if (node.includes('%{{') || node.includes('%%{')) {
+      offenders.push({
+        path: pathSegments.join('.'),
+        value: node,
+      });
+    }
+    return offenders;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((item, index) => {
+      collectOffenders(item, [...pathSegments, `[${index}]`], offenders);
+    });
+    return offenders;
+  }
+
+  if (node !== null && typeof node === 'object') {
+    Object.entries(node).forEach(([key, value]) => {
+      collectOffenders(value, [...pathSegments, key], offenders);
+    });
+  }
+
+  return offenders;
+}
+
+function fixNode(node) {
+  if (typeof node === 'string') {
+    return fixPercentagePlaceholders(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(fixNode);
+  }
+
+  if (node !== null && typeof node === 'object') {
+    return Object.fromEntries(
+      Object.entries(node).map(([key, value]) => [key, fixNode(value)]),
+    );
+  }
+
+  return node;
+}
+
+const original = fs.readFileSync(localePath, 'utf8');
+const locale = JSON.parse(original);
+
+if (checkOnly) {
+  const offenders = collectOffenders(locale);
+
+  if (offenders.length > 0) {
+    console.error('Turkish locale contains invalid percentage placeholders:');
+    offenders.forEach(({ path: offenderPath, value }) => {
+      console.error(`- ${offenderPath}: ${value}`);
+    });
+    process.exit(1);
+  }
+
+  console.log('Turkish percentage placeholders are valid.');
+  process.exit(0);
+}
+
+const fixed = `${JSON.stringify(fixNode(locale), null, 2)}\n`;
+
+if (fixed === original) {
+  console.log('No Turkish percentage placeholder fixes needed.');
+  process.exit(0);
+}
+
+fs.writeFileSync(localePath, fixed);
+console.log('Fixed Turkish percentage placeholders.');

--- a/scripts/fix-turkish-percentage-placeholders.js
+++ b/scripts/fix-turkish-percentage-placeholders.js
@@ -13,7 +13,7 @@ const localePath = path.resolve(
 );
 const checkOnly = process.argv.includes('--check');
 const INVALID_PERCENTAGE_PLACEHOLDER_REGEX =
-  /(?<!\}\})%\{\{\s*([^}]+?)\s*\}\}|(?<!\}\})%%\{\s*([^}]+?)\s*\}/gu;
+  /(?<!\}\})%\{\{\s*([^}]+?)\s*\}\}|%%\{\s*([^}]+?)\s*\}/gu;
 
 function fixPercentagePlaceholders(value) {
   return value.replace(

--- a/scripts/fix-turkish-percentage-placeholders.js
+++ b/scripts/fix-turkish-percentage-placeholders.js
@@ -12,21 +12,26 @@ const localePath = path.resolve(
   'tr.json',
 );
 const checkOnly = process.argv.includes('--check');
+const INVALID_PERCENTAGE_PLACEHOLDER_REGEX =
+  /(?<!\}\})%\{\{\s*([^}]+?)\s*\}\}|(?<!\}\})%%\{\s*([^}]+?)\s*\}/gu;
 
 function fixPercentagePlaceholders(value) {
-  return value
-    .replace(/%\{\{\s*([^}]+?)\s*\}\}/gu, '{{$1}}%')
-    .replace(/%%\{\s*([^}]+?)\s*\}/gu, '{{$1}}%');
+  return value.replace(
+    INVALID_PERCENTAGE_PLACEHOLDER_REGEX,
+    (_match, doubleBracePlaceholder, singleBracePlaceholder) =>
+      `{{${doubleBracePlaceholder ?? singleBracePlaceholder}}}%`,
+  );
 }
 
 function collectOffenders(node, pathSegments = [], offenders = []) {
   if (typeof node === 'string') {
-    if (node.includes('%{{') || node.includes('%%{')) {
+    if (INVALID_PERCENTAGE_PLACEHOLDER_REGEX.test(node)) {
       offenders.push({
         path: pathSegments.join('.'),
         value: node,
       });
     }
+    INVALID_PERCENTAGE_PLACEHOLDER_REGEX.lastIndex = 0;
     return offenders;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR updates the Crowdin download workflow to automatically normalize Turkish percentage placeholders after Crowdin creates or updates the localization branch.

Crowdin can occasionally produce Turkish translations with malformed percentage placeholders such as `%{{fee}}` or `%%{fee}`. These fail the Turkish locale placeholder test because the app expects the percentage sign after the placeholder, like `{{fee}}%`.

The workflow now:
- Uses an explicit Crowdin localization branch name: `l10n_crowdin_action`
- Checks out that branch after the Crowdin action runs
- Runs a new script to fix Turkish percentage placeholders in `locales/languages/tr.json`
- Verifies the placeholders with the script’s `--check` mode
- Commits and pushes a `metamaskbot` fix commit only if `tr.json` changed

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
Ref: https://consensyssoftware.atlassian.net/browse/TMCU-848

## **Manual testing steps**

```gherkin
Feature: Crowdin Turkish placeholder normalization

  Scenario: Turkish locale contains malformed percentage placeholders
    Given the Turkish locale contains values like "%{{fee}}" or "%%{fee}"

    When the Turkish percentage placeholder fix script runs
    Then those values are normalized to "{{fee}}%"
    And the Turkish placeholder validation passes
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Crowdin GitHub Actions and Turkish locale JSON validation/fixes; no runtime app, auth, or payment logic is touched.
> 
> **Overview**
> The scheduled **Crowdin download** workflow now pins the localization branch to `l10n_crowdin_action`, allows a bit more runtime, and adds a follow-up step on that branch: run a Node script to rewrite malformed Turkish percent placeholders in `locales/languages/tr.json` (e.g. `%{{fee}}` / `%%{fee}` → `{{fee}}%`), verify with `--check`, and push a bot commit only when the file changes.
> 
> A new **`scripts/fix-turkish-percentage-placeholders.js`** implements that rewrite and validation. **`locales/tr.placeholders.test.js`** is tightened to use the same style of regex checks instead of naive substring matches, staying aligned with what the script enforces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b33268b7180cb72cb5d997130d71cb8b1f1dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->