### PR TITLE
fix(perps): auto-detect and clean stale CocoaPods state in preflight

### DIFF
--- a/scripts/perps/agentic/lib/compute-cache-fp.js
+++ b/scripts/perps/agentic/lib/compute-cache-fp.js
@@ -61,6 +61,19 @@ const options = {
     // extraSources entry above; ignore the generated copy so we don't
     // double-count it on rebuild.
     'android/app/src/main/assets/InpageBridgeWeb3.js',
+    // Debug preflight runs against Metro. App JS, recipes, and harness scripts
+    // are served/read live from the worktree, so changing them must not force a
+    // native rebuild. Native-affecting inputs remain covered by Expo's default
+    // fingerprint plus projectConfig.extraSources (package/yarn lock, ios/, android/,
+    // app config, patches, react-native config, build/setup scripts, etc.).
+    'app/**',
+    'scripts/perps/agentic/**',
+    'tsconfig.json',
+    // Podfile.lock can be rewritten by the pod-install step during the build.
+    // Key off the source inputs instead (yarn.lock + ios/Podfile) so a freshly
+    // built app does not invalidate itself on the next preflight.
+    'ios/Podfile.lock',
+    'ios/Pods/**',
   ],
 };
 

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -314,6 +314,19 @@ run_with_live_log() {
   return $rc
 }
 
+js_dependencies_need_install() {
+  # Worktrees often survive branch switches. If package.json / yarn.lock are
+  # newer than Yarn's node_modules state, or if a required workspace binary is
+  # missing, reconcile node_modules before invoking Expo. This preserves the
+  # normal `yarn expo ...` path while fixing stale installs at the source.
+  [ ! -d node_modules ] && return 0
+  [ ! -f node_modules/.yarn-state.yml ] && return 0
+  [ -f package.json ] && [ package.json -nt node_modules/.yarn-state.yml ] && return 0
+  [ -f yarn.lock ] && [ yarn.lock -nt node_modules/.yarn-state.yml ] && return 0
+  yarn bin expo >/dev/null 2>&1 || return 0
+  return 1
+}
+
 # ── Early fixture validation (fail fast before long pipeline) ────────
 if $DO_WALLET_SETUP; then
   if [ ! -f "$WALLET_FIXTURE" ]; then
@@ -350,6 +363,14 @@ fi
 
 mkdir -p "$LOG_DIR"
 
+JS_DEPS_STALE=false
+if ! $DO_CLEAN && js_dependencies_need_install; then
+  if $CHECK_ONLY; then
+    fail "JS dependencies are stale or missing required bins (run without --check-only to reconcile node_modules)"
+  fi
+  JS_DEPS_STALE=true
+fi
+
 # Timing
 PREFLIGHT_START=$(python3 -c "import time; print(int(time.time()))")
 STEP_START=$PREFLIGHT_START
@@ -360,6 +381,7 @@ elapsed_since() { echo $(( $(python3 -c "import time; print(int(time.time()))") 
 # Compute total steps based on flags
 TOTAL_STEPS=4  # device + app + metro + cdp
 $DO_CLEAN && TOTAL_STEPS=$((TOTAL_STEPS + 1))
+$JS_DEPS_STALE && TOTAL_STEPS=$((TOTAL_STEPS + 1))
 ($DO_WALLET_SETUP || [ -n "$WALLET_PW" ]) && TOTAL_STEPS=$((TOTAL_STEPS + 1))
 CURRENT_STEP=0
 CURRENT_STEP_NAME=""
@@ -437,6 +459,20 @@ sweep_port() {
 sweep_port "$PORT" "worktree Metro"
 # expo CLI's hardcoded default — any prior run without --port leaks here.
 [ "$PORT" != "8081" ] && sweep_port 8081 "expo default"
+
+# ── Step: reconcile stale node_modules (default/auto/fast modes) ──────
+if $JS_DEPS_STALE; then
+  step "Reconciling JS dependencies" "yarn install --immutable (package/yarn state changed or expo bin missing)"
+  stage_log "$DEPS_LOG"
+  printf '%s\n' '$ yarn install --immutable' > "$DEPS_LOG"
+  if ! run_with_live_log "$DEPS_LOG" "yarn install --immutable"; then
+    echo ""
+    echo -e "  ${RED}Dependency reconciliation failed — see $DEPS_LOG${NC}"
+    tail -20 "$DEPS_LOG" | sed 's/^/    /'
+    fail "yarn install --immutable failed"
+  fi
+  ok "node_modules reconciled"
+fi
 
 # ── Step: yarn setup (clean only) ────────────────────────────────────
 # --check-only is read-only by contract; refuse a destructive yarn setup

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -150,7 +150,7 @@ PODS_MARKER_FILE="$PODS_MARKER_DIR/pods-inputs.sha256"
 pods_input_hash() {
   # yarn.lock drives which podspecs land in node_modules; Podfile controls
   # which pods are requested. Together they determine the expected pod state.
-  cat yarn.lock ios/Podfile 2>/dev/null | shasum -a 256 | cut -d' ' -f1
+  { cat yarn.lock ios/Podfile 2>/dev/null || true; } | shasum -a 256 | cut -d' ' -f1
 }
 
 pods_are_stale() {

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -141,6 +141,44 @@ else
   BUILD_CACHE_ENABLED=false
 fi
 
+# ── Pod staleness detection ────────────────────────────────────────
+# Hash yarn.lock + ios/Podfile to detect when Pods/Podfile.lock are stale.
+# Each worktree stores its own marker so independent clones don't collide.
+PODS_MARKER_DIR=".agent/build-cache/ios"
+PODS_MARKER_FILE="$PODS_MARKER_DIR/pods-inputs.sha256"
+
+pods_input_hash() {
+  # yarn.lock drives which podspecs land in node_modules; Podfile controls
+  # which pods are requested. Together they determine the expected pod state.
+  cat yarn.lock ios/Podfile 2>/dev/null | shasum -a 256 | cut -d' ' -f1
+}
+
+pods_are_stale() {
+  [ ! -f ios/Podfile.lock ] && return 1  # no lock = nothing to be stale
+  local current saved
+  current=$(pods_input_hash)
+  if [ -f "$PODS_MARKER_FILE" ]; then
+    saved=$(cat "$PODS_MARKER_FILE")
+    [ "$current" != "$saved" ]
+  else
+    return 0  # no marker = never validated, treat as stale
+  fi
+}
+
+pods_save_marker() {
+  mkdir -p "$PODS_MARKER_DIR"
+  pods_input_hash > "$PODS_MARKER_FILE"
+}
+
+pods_clean_stale() {
+  if pods_are_stale; then
+    echo "  Pods inputs changed (yarn.lock / Podfile) — cleaning stale pod state..."
+    rm -rf ios/Pods ios/Podfile.lock
+    return 0
+  fi
+  return 1
+}
+
 # ── Platform detection ─────────────────────────────────────────────
 detect_platform() {
   if [ -n "$FORCE_PLATFORM" ]; then echo "$FORCE_PLATFORM"; return; fi
@@ -411,6 +449,12 @@ if $DO_CLEAN; then
     step "Installing dependencies" "rm ios/build → yarn setup (install deps + patches + pods)"
     echo "  Cleaning iOS build artifacts..."
     rm -rf ios/build
+    # Always clean stale pod state in --clean mode to prevent version mismatches
+    # between Podfile.lock and podspecs that changed in node_modules.
+    pods_clean_stale || {
+      echo "  Pods inputs unchanged — cleaning anyway (--clean mode)..."
+      rm -rf ios/Pods ios/Podfile.lock
+    }
   else
     step "Installing dependencies" "clean android build → yarn setup (install deps + patches)"
     echo "  Cleaning Android build artifacts..."
@@ -423,6 +467,9 @@ if $DO_CLEAN; then
     echo -e "  ${RED}Dependencies failed — see $DEPS_LOG${NC}"
     tail -20 "$DEPS_LOG" | sed 's/^/    /'
     fail "yarn setup failed"
+  fi
+  if [ "$PLAT" = "ios" ]; then
+    pods_save_marker
   fi
   ok "yarn setup complete"
 fi
@@ -544,6 +591,13 @@ if [ "$PLAT" = "ios" ]; then
     # Skip --repo-update unless --mode clean: it re-pulls every CocoaPods
     # spec (~3-5 min) on every dispatch. Plain `pod install` is sufficient
     # whenever Podfile.lock pods are already present in the local spec repo.
+    #
+    # Auto-clean stale Pods before pod install in any mode. This prevents
+    # version mismatches when yarn.lock changes bring new podspecs but
+    # Podfile.lock still pins old versions (common across independent clones).
+    if ! $DO_CLEAN; then
+      pods_clean_stale && warn "Stale pod state auto-cleaned"
+    fi
     if $DO_CLEAN; then
       POD_CMD="cd ios && bundle exec pod install --repo-update --ansi"
     else
@@ -553,12 +607,16 @@ if [ "$PLAT" = "ios" ]; then
     stage_log "$POD_INSTALL_LOG"
     printf '$ (%s)\n' "$POD_CMD" > "$POD_INSTALL_LOG"
     if run_with_live_log "$POD_INSTALL_LOG" "$POD_CMD"; then
+      pods_save_marker
       ok "pod install complete"
     else
       # On non-clean modes, the failure may be a missing spec → retry once with --repo-update.
       if ! $DO_CLEAN; then
         warn "pod install failed — retrying with --repo-update"
+        # Clean Pods before retry — the lock file may be the cause.
+        rm -rf ios/Pods ios/Podfile.lock
         if run_with_live_log "$POD_INSTALL_LOG" "cd ios && bundle exec pod install --repo-update --ansi"; then
+          pods_save_marker
           ok "pod install complete (after --repo-update retry)"
         else
           warn "pod install had issues — see $POD_INSTALL_LOG"


### PR DESCRIPTION
## **Description**

Pod install fails when `yarn.lock` changes bring new podspecs but `Podfile.lock` still pins old versions. This is common across independent repo clones on the same branch after pulling main — the `fast_float` podspec version mismatch being a frequent offender.

Adds a per-worktree staleness marker (`.agent/build-cache/ios/pods-inputs.sha256`) that hashes `yarn.lock + ios/Podfile`. Before pod install in any mode, compares against the saved marker — if mismatched, auto-cleans `ios/Pods` and `Podfile.lock` before proceeding.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A — infrastructure fix for agentic preflight reliability.

## **Manual testing steps**

```gherkin
Feature: Pod staleness auto-detection

  Scenario: preflight auto-cleans stale pods after pulling main
    Given a clone with an existing ios/Podfile.lock from a previous build
    And yarn.lock has changed since the last pod install

    When user runs yarn a:setup:ios or yarn a:ios
    Then preflight detects the staleness via marker mismatch
    And automatically cleans ios/Pods and ios/Podfile.lock
    And pod install succeeds without manual intervention
```

## **Screenshots/Recordings**

N/A — shell script change, no UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agentic preflight and local build-cache fingerprinting; no app runtime, auth, or release pipeline behavior.
> 
> **Overview**
> Agentic preflight and the native build-cache fingerprint are tuned so **Metro/debug workflows** stop paying for full native rebuilds when only JS or harness code changes, while **iOS pod state** self-heals after lockfile drift.
> 
> **`compute-cache-fp.js`** adds `ignorePaths` for `app/**`, `scripts/perps/agentic/**`, `tsconfig.json`, and generated CocoaPods outputs (`ios/Podfile.lock`, `ios/Pods/**`). Debug preflight still keys native reuse on real binary inputs (locks, native dirs, patches, etc.) without treating pod-install side effects or live-served JS as fingerprint churn.
> 
> **`preflight.sh`** introduces a per-worktree marker (`.agent/build-cache/ios/pods-inputs.sha256`) from `yarn.lock` + `ios/Podfile`. Before `pod install`, a mismatch deletes `ios/Pods` and `Podfile.lock`; successful installs (including `--repo-update` retry) refresh the marker. **`--clean`** always wipes pod state; non-clean modes auto-clean only when stale. A separate **`js_dependencies_need_install`** gate runs `yarn install --immutable` when `package.json`/`yarn.lock` beat `.yarn-state.yml` or `expo` is missing, with `--check-only` failing loud instead of mutating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fae0b4c2fc11788cf8e3ac0f341c95c3463208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->