### PR TITLE
fix(android): exclude x86_64 ABI from production AAB to resolve Play 16 KB warning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -163,7 +163,10 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  */
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
-    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+    if (value) {
+        return value.split(",").toList()
+    }
+    return ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
 
@@ -190,6 +193,15 @@ android {
         // Braze SDK credentials — names match .android.env / build.sh exports
         resValue "string", "com_braze_api_key", "${System.env.MM_BRAZE_API_KEY_ANDROID ?: ''}"
         resValue "string", "com_braze_custom_endpoint", "${System.env.MM_BRAZE_SDK_ENDPOINT ?: ''}"
+
+        ndk {
+            // Restrict packaged .so files (including those pulled from third-party AARs
+            // like Facebook Conceal and react-native-fast-crypto) to the ABIs listed in
+            // reactNativeArchitectures. Without this, AGP packages every ABI shipped in
+            // dependency AARs regardless, which is what put x86_64 libconceal.so and
+            // libsecp256k1.so into the AAB and triggered Play's 16 KB alignment warning.
+            abiFilters(*reactNativeArchitectures())
+        }
 
         // Explicitly specify supported languages for the app, ensuring the app locales are valid when uploading to the Play Store
         resourceConfigurations += ['en', 'de', 'el', 'es', 'fr', 'hi', 'id', 'ja', 'ko', 'pt', 'ru', 'tl', 'tr', 'vi', 'zh']

--- a/android/gradle.properties.release
+++ b/android/gradle.properties.release
@@ -31,8 +31,13 @@ android.enableJetifier=true
 # Enable AAPT2 PNG crunching
 android.enablePngCrunchInReleaseBuilds=true
 
-# ALL architectures for Play Store distribution (differs from E2E which uses x86_64 only)
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+# Play Store distribution architectures. x86_64 is excluded because the
+# AAR-bundled libconceal.so (react-native-keychain) and libsecp256k1.so
+# (react-native-fast-crypto) ship 4 KB-aligned x86_64 binaries that fail
+# Play's 16 KB page-size check. No real phone uses x86_64 (Chromebooks/
+# emulators only), so dropping it silences the warning without affecting
+# users. Enforced at packaging time via ndk.abiFilters in app/build.gradle.
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86
 
 # New Architecture + Hermes
 newArchEnabled=true


### PR DESCRIPTION
## **Description**

Google Play flagged two prebuilt `.so` files in our production AAB as non-compliant with Android's 16 KB page-size requirement, both in the `x86_64` ABI:

- `base/lib/x86_64/libconceal.so` — from `react-native-keychain` via `com.facebook.conceal:1.1.3` (last released in 2016, archived upstream).
- `base/lib/x86_64/libsecp256k1.so` — from `react-native-fast-crypto`, shipped as an `IMPORTED` prebuilt in its CMake config (not rebuilt from source).

Neither library can be realistically rebuilt with 16 KB alignment:

- Facebook Conceal has been unmaintained since 2018; there is no source-of-truth fork with 16 KB alignment.
- `react-native-fast-crypto` consumes `libsecp256k1.so` as a prebuilt binary; the existing yarn patch already adds `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` for the bridge code we compile, but it does not regenerate the imported `libsecp256k1.so` files.

x86_64 is only ever used by Chromebook ARC++/ARCVM and emulators — no real phone ships with an x86_64 CPU. Dropping the x86_64 ABI from production AABs silences the Play warning without affecting users.

### What this PR does

Two changes that need to land together:

1. **`android/gradle.properties.release`** — remove `x86_64` from `reactNativeArchitectures` so React Native's own native libs (Hermes, RN core) aren't built for that ABI in the production AAB.

2. **`android/app/build.gradle`** — add `ndk.abiFilters(*reactNativeArchitectures())` inside `defaultConfig`. Without this, AGP packages every ABI shipped in dependency AARs regardless of `reactNativeArchitectures`, which is what put the x86_64 `libconceal.so` and `libsecp256k1.so` into the AAB in the first place.

A small refactor of the `reactNativeArchitectures()` helper to return a `List` (via `.toList()`) makes the Groovy spread `*reactNativeArchitectures()` into `abiFilters(String...)` robust across AGP/Groovy versions.

### What this PR does NOT change

- `android/gradle.properties` (default) — local dev still gets x86_64 emulator support.
- `android/gradle.properties.github` (CI E2E, `x86_64` only) — the new `abiFilters` resolves to `["x86_64"]` in that context, so emulator tests continue to work.
- `android/gradle.properties.github.dual-versions` (`armeabi-v7a,arm64-v8a`) — already excludes x86_64.
- `scripts/build.sh` `-PreactNativeArchitectures=...` CLI overrides — still respected by the helper.

### Follow-up work (out of scope)

The same `.so` files still ship for `arm64-v8a` with 4 KB alignment. If/when Play extends the warning to arm64, or enforces the runtime 16 KB device requirement more aggressively on Android 15+ devices in 16 KB mode, these will need structural fixes:

- Replace `react-native-fast-crypto` with `react-native-quick-crypto@1.x` (we only consume `scrypt`).
- Drop the Conceal dependency from `react-native-keychain` (yarn patch or upgrade to v10) — safe because `minSdk = 24` means the Conceal cipher path is never selected at runtime.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Google Play 16 KB page-size warning for `base/lib/x86_64/libconceal.so` and `base/lib/x86_64/libsecp256k1.so`.

## **Manual testing steps**

```gherkin
Feature: Production AAB no longer contains x86_64 ABI

  Scenario: A production release build is generated
    Given a clean checkout of this branch
    When the production AAB is built via the standard release workflow
      (the same one that does `cp android/gradle.properties.release android/gradle.properties`
       before `./gradlew bundleProdRelease`)
    Then `unzip -l app-prod-release.aab | grep '/lib/'` shows only
      `lib/arm64-v8a/`, `lib/armeabi-v7a/`, and `lib/x86/` entries
    And no `lib/x86_64/` entries appear in the output
    And no `libconceal.so` or `libsecp256k1.so` files appear under any
      `lib/x86_64/` path

  Scenario: Local dev on x86_64 emulator still works
    Given a developer running `yarn android` on an Intel Mac with an x86_64 emulator
    When the debug variant is built using the default `android/gradle.properties`
    Then x86_64 native libs are still produced and the app installs and runs

  Scenario: CI E2E on x86_64 emulator still works
    Given CI overlays `android/gradle.properties.github` (reactNativeArchitectures=x86_64)
    When `./gradlew assembleProdDebug` runs
    Then the resulting APK contains a `lib/x86_64/` directory and Detox tests pass
```

## **Screenshots/Recordings**

### **Before**

Play Console flagged:
- `base/lib/x86_64/libconceal.so`
- `base/lib/x86_64/libsecp256k1.so`

### **After**

Production AAB contains no `lib/x86_64/` directory — both warnings cleared.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable — N/A (build-config change; verification is via the `unzip -l` check on the produced AAB)
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable — N/A
- [ ] I've applied the right labels on the PR — `team-mobile-platform`

#### Performance checks (if applicable)

- [x] I've tested on Android — verified locally that the abiFilters change does not break the `gradle.properties.github` (x86_64-only) path used by CI E2E.
- [ ] I've tested with a power user scenario — N/A (no JS behavior change)
- [ ] I've instrumented key operations with Sentry traces — N/A

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time ABI and packaging configuration only; no runtime app logic, auth, or data-path changes, with emulator/CI paths still driven by their gradle overlays.
> 
> **Overview**
> Production Play Store builds stop shipping **x86_64** native libraries so Google Play’s **16 KB page-size** warnings go away for prebuilt `libconceal.so` and `libsecp256k1.so` that only appeared under `lib/x86_64/`.
> 
> **`android/gradle.properties.release`** drops `x86_64` from `reactNativeArchitectures` (now `armeabi-v7a`, `arm64-v8a`, `x86`). **`android/app/build.gradle`** adds `defaultConfig.ndk.abiFilters(*reactNativeArchitectures())` so AGP does not still package every ABI from third-party AARs when RN’s arch list is narrower. The `reactNativeArchitectures()` helper now returns a Groovy `List` via `.toList()` so the spread into `abiFilters` is reliable.
> 
> Default and CI gradle property files are unchanged in this diff: local debug can still target x86_64 emulators, and CI E2E overlays that still set `x86_64` only continue to filter to that ABI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dd023f50a3ea330c882cc0a76ee8eb82563676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->