### PR TITLE
feat: align unified assets hides and non-EVM import with assets-controller v8

### DIFF
--- a/app/components/UI/TokenDetails/components/useAssetVisibility.test.ts
+++ b/app/components/UI/TokenDetails/components/useAssetVisibility.test.ts
@@ -348,7 +348,7 @@ describe('useAssetVisibility', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('calls removeCustomAsset when the token is a custom asset (not hidden)', () => {
+    it('calls removeCustomAsset only when custom asset has no balance entry', () => {
       setupSelectors({
         customAssets: { [ACCOUNT_ID]: [EVM_ASSET_ID] },
       });
@@ -358,6 +358,23 @@ describe('useAssetVisibility', () => {
         Engine.context.AssetsController.removeCustomAsset,
       ).toHaveBeenCalledWith(ACCOUNT_ID, EVM_ASSET_ID);
       expect(Engine.context.AssetsController.hideAsset).not.toHaveBeenCalled();
+    });
+
+    it('calls removeCustomAsset and hideAsset when custom asset also has balance', () => {
+      setupSelectors({
+        customAssets: { [ACCOUNT_ID]: [EVM_ASSET_ID] },
+        assetsBalance: {
+          [ACCOUNT_ID]: { [EVM_ASSET_ID]: { amount: '100', unit: 'USDC' } },
+        },
+      });
+      const { result } = renderHook(() => useAssetVisibility(evmToken()));
+      act(() => result.current.handleHideToken());
+      expect(
+        Engine.context.AssetsController.removeCustomAsset,
+      ).toHaveBeenCalledWith(ACCOUNT_ID, EVM_ASSET_ID);
+      expect(Engine.context.AssetsController.hideAsset).toHaveBeenCalledWith(
+        EVM_ASSET_ID,
+      );
     });
 
     it('calls hideAsset when token has a balance entry (not hidden, not custom)', () => {

--- a/app/components/UI/TokenDetails/components/useAssetVisibility.ts
+++ b/app/components/UI/TokenDetails/components/useAssetVisibility.ts
@@ -32,8 +32,8 @@ export interface UseAssetVisibilityReturn {
   /**
    * Calls the correct AssetsController method based on the token's current state:
    * - already hidden → unhideAsset   (checked first: hideAsset keeps the balance entry)
-   * - custom asset   → removeCustomAsset
-   * - has balance    → hideAsset
+   * - not hidden + custom → removeCustomAsset
+   * - not hidden + balance entry → hideAsset (runs in addition to removeCustomAsset when both apply)
    */
   handleHideToken: () => void;
   /**
@@ -150,10 +150,16 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
         if (allIgnoredNonEvmAssets[accountId]?.includes(assetId)) {
           MultichainAssetsController.addAssets([assetId], accountId);
         }
-      } else if (isCustomAsset) {
-        AssetsController.removeCustomAsset(accountId, assetId);
-      } else if (isInAssetsBalance) {
-        AssetsController.hideAsset(assetId);
+      } else {
+        // Custom-added tokens typically also have an assetsBalance entry once
+        // unified assets state hydrated the balance; removing only from
+        // customAssets would leave a visible detected token unless we hide too.
+        if (isCustomAsset) {
+          AssetsController.removeCustomAsset(accountId, assetId);
+        }
+        if (isInAssetsBalance) {
+          AssetsController.hideAsset(assetId);
+        }
       }
     } catch (err) {
       Logger.log(err, 'useAssetVisibility: Failed to update token visibility');

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -280,6 +280,21 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
         addresses as CaipAssetType[],
         selectedNonEvmAccount.id,
       );
+      if (isAssetsUnifyStateEnabled) {
+        const caipAssetTypes = addresses
+          .map((address) =>
+            toAssetId(address, formatChainIdToCaip(selectedChainId)),
+          )
+          .filter((assetId): assetId is CaipAssetType => Boolean(assetId));
+
+        if (caipAssetTypes.length > 0) {
+          await Promise.all(
+            caipAssetTypes.map((assetId) =>
+              handleAddCustomAsset(assetId, selectedNonEvmAccount.id),
+            ),
+          );
+        }
+      }
     } else {
       const caipChainId = formatChainIdToCaip(
         selectedChainId as SupportedCaipChainId,

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -280,21 +280,6 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
         addresses as CaipAssetType[],
         selectedNonEvmAccount.id,
       );
-      if (isAssetsUnifyStateEnabled) {
-        const caipAssetTypes = addresses
-          .map((address) =>
-            toAssetId(address, formatChainIdToCaip(selectedChainId)),
-          )
-          .filter((assetId): assetId is CaipAssetType => Boolean(assetId));
-
-        if (caipAssetTypes.length > 0) {
-          await Promise.all(
-            caipAssetTypes.map((assetId) =>
-              handleAddCustomAsset(assetId, selectedNonEvmAccount.id),
-            ),
-          );
-        }
-      }
     } else {
       const caipChainId = formatChainIdToCaip(
         selectedChainId as SupportedCaipChainId,

--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
@@ -41,6 +41,7 @@ import type { PhishingControllerBulkScanTokensAction } from '@metamask/phishing-
 import type {
   SnapControllerHandleRequestAction,
   SnapControllerGetRunnableSnapsAction,
+  SnapControllerSnapInstalledEvent,
 } from '@metamask/snaps-controllers';
 import type {
   TransactionControllerTransactionConfirmedEvent,
@@ -85,7 +86,8 @@ type AssetsControllerAllowedEvents =
   | PermissionControllerStateChange
   | TransactionControllerUnapprovedTransactionAddedEvent
   | NetworkControllerNetworkRemovedEvent
-  | NetworkControllerNetworkAddedEvent;
+  | NetworkControllerNetworkAddedEvent
+  | SnapControllerSnapInstalledEvent;
 
 /** Re-export package type so init receives the type expected by AssetsController constructor. */
 export type AssetsControllerMessenger = PackageAssetsControllerMessenger;
@@ -140,6 +142,7 @@ export function getAssetsControllerMessenger(
       'TransactionController:unapprovedTransactionAdded',
       'NetworkController:networkRemoved',
       'NetworkController:networkAdded',
+      'SnapController:snapInstalled',
     ],
     messenger,
   });

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -313,6 +313,7 @@
         "0x38": true,
         "0x531": true,
         "0x89": true,
+        "0x8f": true,
         "0xa": true,
         "0xa4b1": true,
         "0xe708": true

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^7.1.2",
+    "@metamask/assets-controller": "^8.0.1",
     "@metamask/assets-controllers": "^108.0.1",
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,6 +7685,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/assets-controller@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@metamask/assets-controller@npm:8.0.1"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/account-tree-controller": "npm:^7.4.0"
+    "@metamask/accounts-controller": "npm:^38.1.1"
+    "@metamask/assets-controllers": "npm:^108.1.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/client-controller": "npm:^1.0.1"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/core-backend": "npm:^6.3.0"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-controller": "npm:^25.5.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.0.2"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.2.0"
+    "@metamask/permission-controller": "npm:^13.1.1"
+    "@metamask/phishing-controller": "npm:^17.2.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/056627318de4985ea2780f3009f8f803cba7eb4ba45f605b29dc4783146db9a8743e83e9d91ea949ad401c2018105531eef66793f09bf7822d955807446016f1
+  languageName: node
+  linkType: hard
+
 "@metamask/assets-controllers@npm:^108.0.0, @metamask/assets-controllers@npm:^108.0.1, @metamask/assets-controllers@npm:^108.1.0":
   version: 108.1.0
   resolution: "@metamask/assets-controllers@npm:108.1.0"
@@ -9263,6 +9300,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/network-enablement-controller@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@metamask/network-enablement-controller@npm:5.2.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/multichain-network-controller": "npm:^3.1.2"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/slip44": "npm:^4.3.0"
+    "@metamask/transaction-controller": "npm:^65.4.0"
+    "@metamask/utils": "npm:^11.9.0"
+    reselect: "npm:^5.1.1"
+  checksum: 10/e8565cd74d21c43aa0c80f23e82eed4b8d7151ee5f708894abf285243dc4e8f8c0b03e43250ea6c87c3d4feb677e168c348a9329944bfde4d4a1a29e4b712153
+  languageName: node
+  linkType: hard
+
 "@metamask/nonce-tracker@npm:^6.0.0":
   version: 6.0.0
   resolution: "@metamask/nonce-tracker@npm:6.0.0"
@@ -9361,6 +9416,24 @@ __metadata:
     fastest-levenshtein: "npm:^1.0.16"
     punycode: "npm:^2.1.1"
   checksum: 10/61a50a802aaaded12b452303025205a9145c59e17eb2f56014c94cbf27f71d9b8582b1cb4cf9859e665471863f4738622f80aff2f7a4881d05dff4575f4ef9eb
+  languageName: node
+  linkType: hard
+
+"@metamask/phishing-controller@npm:^17.2.0":
+  version: 17.2.0
+  resolution: "@metamask/phishing-controller@npm:17.2.0"
+  dependencies:
+    "@metamask/address-book-controller": "npm:^7.1.2"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/transaction-controller": "npm:^65.4.0"
+    "@noble/hashes": "npm:^1.8.0"
+    "@types/punycode": "npm:^2.1.0"
+    ethereum-cryptography: "npm:^2.1.2"
+    fastest-levenshtein: "npm:^1.0.16"
+    punycode: "npm:^2.1.1"
+  checksum: 10/de271d813043ca535e76cff52084ac9d4e0da762fa02e75425583dfc068c4b4bcb189266cb9cf58baf7ed79ab58f0b003a5643426780bb49192ca30212640b05
   languageName: node
   linkType: hard
 
@@ -35214,7 +35287,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^7.1.2"
+    "@metamask/assets-controller": "npm:^8.0.1"
     "@metamask/assets-controllers": "npm:^108.0.1"
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9282,25 +9282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^5.1.0, @metamask/network-enablement-controller@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@metamask/network-enablement-controller@npm:5.1.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.0.0"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/multichain-network-controller": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^31.0.0"
-    "@metamask/slip44": "npm:^4.3.0"
-    "@metamask/transaction-controller": "npm:^65.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    reselect: "npm:^5.1.1"
-  checksum: 10/bcf7443559e161e73a07dc478e89fd2e041b2c32071adb0916de49ebf5e61e630dea41c68f59d252f5bffa62b0f7b15142bb7e8799af97b28adb5cd66918a96e
-  languageName: node
-  linkType: hard
-
-"@metamask/network-enablement-controller@npm:^5.2.0":
+"@metamask/network-enablement-controller@npm:^5.1.0, @metamask/network-enablement-controller@npm:^5.1.1, @metamask/network-enablement-controller@npm:^5.2.0":
   version: 5.2.0
   resolution: "@metamask/network-enablement-controller@npm:5.2.0"
   dependencies:
@@ -9402,24 +9384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/phishing-controller@npm:^17.1.1, @metamask/phishing-controller@npm:^17.1.2":
-  version: 17.1.2
-  resolution: "@metamask/phishing-controller@npm:17.1.2"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.0.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/transaction-controller": "npm:^65.3.0"
-    "@noble/hashes": "npm:^1.8.0"
-    "@types/punycode": "npm:^2.1.0"
-    ethereum-cryptography: "npm:^2.1.2"
-    fastest-levenshtein: "npm:^1.0.16"
-    punycode: "npm:^2.1.1"
-  checksum: 10/61a50a802aaaded12b452303025205a9145c59e17eb2f56014c94cbf27f71d9b8582b1cb4cf9859e665471863f4738622f80aff2f7a4881d05dff4575f4ef9eb
-  languageName: node
-  linkType: hard
-
-"@metamask/phishing-controller@npm:^17.2.0":
+"@metamask/phishing-controller@npm:^17.1.1, @metamask/phishing-controller@npm:^17.1.2, @metamask/phishing-controller@npm:^17.2.0":
   version: 17.2.0
   resolution: "@metamask/phishing-controller@npm:17.2.0"
   dependencies:


### PR DESCRIPTION
Bump @metamask/assets-controller and subscribe AssetsControllerMessenger to SnapController:snapInstalled. Hide flow now removes custom assets and hides detected balances when both apply; add search-import path syncs non-EVM adds via addCustomAsset when unified assets flag is enabled.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: align unified assets hides and non-EVM import with assets-controller v8

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major dependency bump plus wallet token visibility logic changes; snap-install subscription affects when assets refresh after snap installs.
> 
> **Overview**
> Upgrades **`@metamask/assets-controller`** to **v8** and wires **`AssetsController`** to **`SnapController:snapInstalled`** so unified assets can react when snaps are installed.
> 
> **`useAssetVisibility`** hide behavior no longer treats custom vs balance as mutually exclusive: when a token is not hidden, it may call **`removeCustomAsset`** and **`hideAsset`** together so user-added tokens that still have a detected balance entry actually disappear from the list. Unhide paths are unchanged. Tests cover the custom-only vs custom+balance cases.
> 
> Fixture updates enable **Monad mainnet (`0x8f`)** in the default **`NetworkEnablementController`** test state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9bd67725a1218c6ed87c88ab1cb3c08c794f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->