### PR TITLE
feat: Add dev auto-unlock password support

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -54,6 +54,10 @@ export METAMASK_ENVIRONMENT="dev"
 # Build type: "main" or "flask" or "beta"
 export METAMASK_BUILD_TYPE="main"
 
+# Optional: automatically unlock an existing wallet after app/Metro refresh in dev.
+# Only used when METAMASK_ENVIRONMENT="dev"; must match the wallet password.
+# export DEV_AUTO_UNLOCK_PASSWORD=""
+
 # Optional: enable Ramps debug dashboard bridge in __DEV__ (WebSocket + fetch instrumentation).
 # See app/components/UI/Ramp/debug/README.md
 # export RAMPS_DEBUG_DASHBOARD="true"

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -41,6 +41,7 @@ import {
   watchMarketingAttributionOnClearOnboarding,
   watchMarketingAttributionOnConsentChange,
 } from './marketingAttribution';
+import { getDevAutoUnlockPassword } from '../../util/environment';
 
 /**
  * Creates a channel to listen to app state changes.
@@ -147,6 +148,17 @@ export function* appLockStateMachine() {
  */
 export function* requestAuthOnAppStart() {
   try {
+    const devAutoUnlockPassword = getDevAutoUnlockPassword();
+    if (devAutoUnlockPassword) {
+      const { KeyringController } = Engine.context;
+      if (!KeyringController.isUnlocked() && KeyringController.state?.vault) {
+        yield call(Authentication.unlockWallet, {
+          password: devAutoUnlockPassword,
+        });
+        return;
+      }
+    }
+
     yield call(tryBiometricUnlock);
   } catch (_) {
     // If authentication fails, navigate to login screen

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -26,6 +26,7 @@ import Authentication from '../../core/Authentication';
 import AppConstants from '../../core/AppConstants';
 import trackErrorAsAnalytics from '../../util/metrics/TrackError/trackErrorAsAnalytics';
 import { providerErrors } from '@metamask/rpc-errors';
+import { getDevAutoUnlockPassword } from '../../util/environment';
 
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
@@ -91,6 +92,9 @@ jest.mock('../../core/Engine', () => ({
     },
     KeyringController: {
       isUnlocked: jest.fn().mockReturnValue(false),
+      state: {
+        vault: undefined,
+      },
     },
     SnapController: {
       updateRegistry: jest.fn(),
@@ -147,6 +151,10 @@ jest.mock('../../core/Authentication', () => ({
   },
 }));
 
+jest.mock('../../util/environment', () => ({
+  getDevAutoUnlockPassword: jest.fn(),
+}));
+
 jest.mock('../../core/LockManagerService', () => ({
   __esModule: true,
   default: {
@@ -178,6 +186,16 @@ const defaultMockState = {
   bridge: {},
   banners: {},
 };
+
+beforeEach(() => {
+  (getDevAutoUnlockPassword as jest.Mock).mockReturnValue(undefined);
+  (Engine.context.KeyringController.isUnlocked as jest.Mock).mockReturnValue(
+    false,
+  );
+  Engine.context.KeyringController.state = {
+    vault: undefined,
+  };
+});
 
 describe('requestAuthOnAppStart', () => {
   beforeEach(() => {
@@ -218,6 +236,46 @@ describe('requestAuthOnAppStart', () => {
     await expectSaga(requestAuthOnAppStart).run();
     expect(mockReset).toHaveBeenCalledWith({
       routes: [{ name: Routes.ONBOARDING.LOGIN }],
+    });
+  });
+
+  it('uses dev auto-unlock password in dev when the wallet has a vault and is locked', async () => {
+    (getDevAutoUnlockPassword as jest.Mock).mockReturnValue('test-password');
+    Engine.context.KeyringController.state = {
+      vault: 'mock-vault',
+    };
+
+    await expectSaga(requestAuthOnAppStart).run();
+
+    expect(Authentication.unlockWallet).toHaveBeenCalledWith({
+      password: 'test-password',
+    });
+    expect(
+      Authentication.checkIsSeedlessPasswordOutdated,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('falls back to normal app-start authentication when dev auto-unlock is not configured', async () => {
+    Engine.context.KeyringController.state = {
+      vault: 'mock-vault',
+    };
+
+    await expectSaga(requestAuthOnAppStart).run();
+
+    expect(Authentication.unlockWallet).toHaveBeenCalledWith();
+    expect(Authentication.unlockWallet).not.toHaveBeenCalledWith({
+      password: 'test-password',
+    });
+  });
+
+  it('falls back to normal app-start authentication when no vault exists', async () => {
+    (getDevAutoUnlockPassword as jest.Mock).mockReturnValue('test-password');
+
+    await expectSaga(requestAuthOnAppStart).run();
+
+    expect(Authentication.unlockWallet).toHaveBeenCalledWith();
+    expect(Authentication.unlockWallet).not.toHaveBeenCalledWith({
+      password: 'test-password',
     });
   });
 });

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -94,6 +94,8 @@ jest.mock('../../core/Engine', () => ({
       isUnlocked: jest.fn().mockReturnValue(false),
       state: {
         vault: undefined,
+        keyrings: [],
+        isUnlocked: false,
       },
     },
     SnapController: {
@@ -194,6 +196,8 @@ beforeEach(() => {
   );
   Engine.context.KeyringController.state = {
     vault: undefined,
+    keyrings: [],
+    isUnlocked: false,
   };
 });
 
@@ -243,6 +247,8 @@ describe('requestAuthOnAppStart', () => {
     (getDevAutoUnlockPassword as jest.Mock).mockReturnValue('test-password');
     Engine.context.KeyringController.state = {
       vault: 'mock-vault',
+      keyrings: [],
+      isUnlocked: false,
     };
 
     await expectSaga(requestAuthOnAppStart).run();
@@ -258,6 +264,8 @@ describe('requestAuthOnAppStart', () => {
   it('falls back to normal app-start authentication when dev auto-unlock is not configured', async () => {
     Engine.context.KeyringController.state = {
       vault: 'mock-vault',
+      keyrings: [],
+      isUnlocked: false,
     };
 
     await expectSaga(requestAuthOnAppStart).run();

--- a/app/util/environment.test.ts
+++ b/app/util/environment.test.ts
@@ -1,4 +1,4 @@
-import { isProduction } from './environment';
+import { getDevAutoUnlockPassword, isProduction } from './environment';
 
 const originalMetamaskEnvironment = process.env.METAMASK_ENVIRONMENT;
 
@@ -40,5 +40,75 @@ describe('isProduction', () => {
       configurable: true,
     });
     expect(isProduction()).toBe(false);
+  });
+});
+
+describe('getDevAutoUnlockPassword', () => {
+  const originalDevAutoUnlockPassword = process.env.DEV_AUTO_UNLOCK_PASSWORD;
+
+  afterEach(() => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: originalMetamaskEnvironment,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'DEV_AUTO_UNLOCK_PASSWORD', {
+      value: originalDevAutoUnlockPassword,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  it('returns the password in dev', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'dev',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'DEV_AUTO_UNLOCK_PASSWORD', {
+      value: 'test-password',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(getDevAutoUnlockPassword()).toBe('test-password');
+  });
+
+  it('returns undefined outside dev', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'production',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'DEV_AUTO_UNLOCK_PASSWORD', {
+      value: 'test-password',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(getDevAutoUnlockPassword()).toBeUndefined();
+  });
+
+  it('returns undefined when password is empty', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'dev',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'DEV_AUTO_UNLOCK_PASSWORD', {
+      value: '',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect(getDevAutoUnlockPassword()).toBeUndefined();
   });
 });

--- a/app/util/environment.ts
+++ b/app/util/environment.ts
@@ -18,3 +18,14 @@ export const getE2EMockOAuthEmailForQaMock = (): string | undefined => {
   const email = process.env.E2E_MOCK_OAUTH_EMAIL;
   return typeof email === 'string' && email.length > 0 ? email : undefined;
 };
+
+export const getDevAutoUnlockPassword = (): string | undefined => {
+  const password = process.env.DEV_AUTO_UNLOCK_PASSWORD;
+  if (process.env.METAMASK_ENVIRONMENT !== 'dev') {
+    return undefined;
+  }
+
+  return typeof password === 'string' && password.length > 0
+    ? password
+    : undefined;
+};


### PR DESCRIPTION


## **Description**

This PR introduces a developer feature that automatically unlocks an existing wallet after app or Metro refresh in development mode, eliminating the need to manually enter the password on every refresh.


## Changes
### Core Implementation
- **New environment variable**: `DEV_AUTO_UNLOCK_PASSWORD` - Optional password for auto-unlock in dev mode
- **Modified**: `app/store/sagas/index.ts`
  - Added `tryDevAutoUnlock()` function that attempts to unlock the wallet using the configured password
  - Modified `requestAuthOnAppStart` saga to try dev auto-unlock before falling back to biometric authentication
  - Auto-unlock only activates when:
    - `METAMASK_ENVIRONMENT` is set to `"dev"`
    - `DEV_AUTO_UNLOCK_PASSWORD` is configured
    - A vault exists (wallet was previously created)
    - The wallet is currently locked
### Utility Function
- **New**: `app/util/environment.ts::getDevAutoUnlockPassword()`
  - Safely retrieves the dev auto-unlock password
  - Returns `undefined` in non-dev environments for security
  - Returns `undefined` if password is empty or not set
### Documentation
- **Updated**: `.js.env.example` - Added documentation for the new `DEV_AUTO_UNLOCK_PASSWORD` variable
### Testing
- **Updated**: `app/store/sagas/sagas.test.ts`
  - Added tests for dev auto-unlock success path
  - Added tests for fallback to normal authentication when password not configured
  - Added tests for fallback when no vault exists
  - Added proper mocking and cleanup for the new functionality
- **Updated**: `app/util/environment.test.ts`
  - Added comprehensive tests for `getDevAutoUnlockPassword()`
  - Tests cover dev environment, non-dev environment, and empty password scenarios
## How to Use
1. Set `METAMASK_ENVIRONMENT="dev"` in your `.js.env` (typically already set for dev)
2. Add `export DEV_AUTO_UNLOCK_PASSWORD="your-wallet-password"` to your `.js.env`
3. Restart Metro bundler
4. The app will now automatically unlock after refresh
**Note**: The password must match your actual wallet password for this to work.
## Security Considerations
- ✅ Only works when `METAMASK_ENVIRONMENT="dev"`
- ✅ Returns `undefined` in all non-dev environments
- ✅ The `.js.env` file is gitignored and never committed
- ✅ `.js.env.example` shows the variable commented out by default
- ✅ Does not skip biometric authentication in production builds


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-start wallet unlock behavior, but only when `METAMASK_ENVIRONMENT` is dev and a local env password is set; misconfiguration could weaken dev machines if secrets leak from `.js.env`.
> 
> **Overview**
> Adds an optional **dev-only** auto-unlock path so engineers can skip re-entering the wallet password after Metro or app refresh when a vault already exists.
> 
> Developers can set `DEV_AUTO_UNLOCK_PASSWORD` in local `.js.env` (documented in `.js.env.example`). `getDevAutoUnlockPassword()` only returns that value when `METAMASK_ENVIRONMENT` is `"dev"` and the password is non-empty; otherwise it is ignored.
> 
> On startup, `requestAuthOnAppStart` checks that password first: if configured and `KeyringController` is locked but has a vault, it calls `Authentication.unlockWallet` with the password and **skips** the usual seedless/biometric `tryBiometricUnlock` path. If auto-unlock is not configured, there is no vault, or unlock fails, behavior stays the same (biometric flow or login reset). Foreground/lock-screen auth is unchanged.
> 
> Unit tests cover the env helper and saga branches (success, missing password, no vault).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5afd84ed8d3cbe932c2fd8b9ab272a469cd7b7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->