### PR TITLE
fix: correct fiat no-quotes alert condition in useNoPayTokenQuotesAlert

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -138,6 +138,50 @@ describe('useNoPayTokenQuotesAlert', () => {
     ]);
   });
 
+  it('returns no alerts for fiat when rampsQuote is present', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '50.00',
+      rampsQuote: { id: 'quote-1' },
+    } as never);
+
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns alert for fiat when sourceAmounts is non-empty but no rampsQuote', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '50.00',
+    });
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {} as TransactionPaySourceAmount,
+    ]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        key: AlertKeys.NoPayTokenQuotes,
+        severity: Severity.Danger,
+        isBlocking: true,
+      }),
+    ]);
+  });
+
   it('returns no alerts for fiat when amount is not entered', () => {
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
       selectedPaymentMethodId: 'pm-card',

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -56,7 +56,7 @@ export function useNoPayTokenQuotesAlert() {
     hasSelectedFiatPaymentMethod &&
     hasValidFiatAmount &&
     !isQuotesLoading &&
-    sourceAmounts?.length === 0 &&
+    !fiatPayment?.rampsQuote &&
     quotes?.length === 0;
 
   // Post-quote flows (e.g. money account withdraw MUSD -> MUSD) can end up with


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

The fiat no-quotes alert in `useNoPayTokenQuotesAlert` was not firing when a fiat payment method was selected with a valid amount but no ramps quote was available.

`shouldShowFiatNoQuotesAlert` required `sourceAmounts?.length === 0`, but in fiat payment flows `sourceAmounts` can be populated (tokens the user needs) while no quote exists to fill them. This prevented the alert from ever showing.

Replaced `sourceAmounts?.length === 0` with `!fiatPayment?.rampsQuote` so the alert fires based on the actual ramps quote availability rather than the source amounts array length. Also added two test cases covering the new condition.

## **Changelog**

CHANGELOG entry: Fixed fiat no-quotes alert not showing when paying with a card and no ramps quote is available

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Fiat no-quotes alert

  Scenario: Alert shows when fiat payment has no ramps quote
    Given user is on a confirmation screen with fiat payment selected
    And a valid fiat amount is entered
    And no ramps quote is available

    When quotes finish loading
    Then a danger alert is displayed indicating no quotes are available

  Scenario: Alert does not show when ramps quote exists
    Given user is on a confirmation screen with fiat payment selected
    And a valid fiat amount is entered
    And a ramps quote is present

    When quotes finish loading
    Then no danger alert is displayed
```

## **Screenshots/Recordings**

### **Before**

<!-- Not applicable - logic-only change -->

### **After**

<!-- Not applicable - logic-only change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small confirmation-alert condition change with unit tests; no auth, payments execution, or broad refactors.
> 
> **Overview**
> Fixes the **fiat "no quotes"** blocking alert on transaction confirmation so it reflects whether a **ramps quote** exists, not whether `sourceAmounts` is empty.
> 
> `shouldShowFiatNoQuotesAlert` previously required `sourceAmounts?.length === 0`, which often failed in card/fiat flows because `sourceAmounts` can still list tokens the user must cover even when no ramps quote is available—so the danger alert never appeared. The condition now uses **`!fiatPayment?.rampsQuote`** (with quotes still empty and not loading). Tests cover **no alert when `rampsQuote` is present** and **alert when `sourceAmounts` is non-empty but `rampsQuote` is missing**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e45af666cc5787b275f6efde91a130d72d8982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->