### PR TITLE
ci: re-run CI on finished runs when e2e labels are modified in the PR…

### DIFF
--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -49,6 +49,7 @@ jobs:
             --repo "$REPO" \
             --branch "$HEAD_REF" \
             --workflow "ci.yml" \
+            --event pull_request \
             --limit 1 \
             --json databaseId \
             --jq '.[0].databaseId')
@@ -61,26 +62,20 @@ jobs:
           echo "run_id=$LATEST_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Wait for cancellation to complete
-        if: steps.cancel.outputs.cancelled == 'true'
+        if: steps.cancel.outputs.cancelled == 'true' && steps.find.outputs.run_id
         run: |
+          RUN_ID="${{ steps.find.outputs.run_id }}"
           MAX_WAIT=600
           ELAPSED=0
-          IN_PROGRESS=1
 
-          echo "Waiting up to ${MAX_WAIT}s for all CI runs to finish cancelling..."
+          echo "Waiting up to ${MAX_WAIT}s for workflow to finish cancelling..."
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do
-            IN_PROGRESS=$(gh run list \
-              --repo "$REPO" \
-              --branch "$HEAD_REF" \
-              --workflow "ci.yml" \
-              --json databaseId,status \
-              --jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+            STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
+            echo "Status: $STATUS (${ELAPSED}s elapsed)"
 
-            echo "In-progress/queued runs: $IN_PROGRESS (${ELAPSED}s elapsed)"
-
-            if [ "$IN_PROGRESS" -eq 0 ]; then
-              echo "No active runs remaining — ready to rerun"
+            if [ "$STATUS" != "in_progress" ] && [ "$STATUS" != "queued" ]; then
+              echo "Workflow ready for rerun"
               break
             fi
 
@@ -88,15 +83,19 @@ jobs:
             ELAPSED=$((ELAPSED + 15))
           done
 
-          if [ "$IN_PROGRESS" -gt 0 ]; then
-            echo "Timeout: $IN_PROGRESS run(s) still active after ${MAX_WAIT}s"
+          FINAL_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
+          if [ "$FINAL_STATUS" = "in_progress" ] || [ "$FINAL_STATUS" = "queued" ]; then
+            echo "Timeout: workflow still $FINAL_STATUS after ${MAX_WAIT}s"
             exit 1
           fi
 
       - name: Rerun CI workflow
-        if: github.event.pull_request.state == 'open' && steps.find.outputs.run_id
+        if: steps.find.outputs.run_id
         run: |
           RUN_ID="${{ steps.find.outputs.run_id }}"
-          echo "Re-running CI workflow run $RUN_ID..."
-          gh run rerun "$RUN_ID" --repo "$REPO"
-          echo "CI workflow re-triggered successfully"
+          echo "Re-running workflow $RUN_ID..."
+          if gh run rerun "$RUN_ID" --repo "$REPO"; then
+            echo "CI workflow re-triggered successfully"
+          else
+            echo "Rerun not possible (run may not be in a retriable state)"
+          fi

--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -12,11 +12,12 @@ env:
 jobs:
   rerun-ci:
     if: >-
-      github.event.label.name == 'skip-smart-e2e-selection' ||
-      github.event.label.name == 'skip-e2e' ||
-      github.event.label.name == 'skip-e2e-flakiness-detection' ||
-      github.event.label.name == 'pr-not-ready-for-e2e' ||
-      github.event.label.name == 'force-builds'
+      github.event.pull_request.state == 'open' &&
+      (github.event.label.name == 'skip-smart-e2e-selection' ||
+       github.event.label.name == 'skip-e2e' ||
+       github.event.label.name == 'skip-e2e-flakiness-detection' ||
+       github.event.label.name == 'pr-not-ready-for-e2e' ||
+       github.event.label.name == 'force-builds')
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fix re-run CI on finished runs when e2e labels are modified in the PR

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a GitHub Actions helper workflow; no app runtime, auth, or data paths.
> 
> **Overview**
> Tightens the **Rerun CI on skipped E2E labels** workflow so label changes can re-trigger CI even when the latest run has already finished, not only while runs are still active.
> 
> The job now runs only on **open** PRs (that guard moved from the rerun step into the job `if`). Finding the run to rerun filters `ci.yml` runs with **`--event pull_request`**. After cancel, the wait step polls **that run’s** status via `gh run view` instead of counting every in-progress/queued run on the branch. The rerun step treats a failed `gh run rerun` as a soft outcome when the run isn’t retriable, instead of failing the workflow outright.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c620e90cbdf3a126f5234ac010737e961ce48866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->