### PR TITLE
feat: add money account option to payment bottom sheet

### DIFF
--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
@@ -3,6 +3,7 @@ import { ReactElement, ReactNode } from 'react';
 export type PayWithSectionId =
   | 'perps'
   | 'predict'
+  | 'money-account'
   | 'bank-card'
   | 'crypto'
   | (string & {});

--- a/app/components/Views/confirmations/hooks/pay/sections/index.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/index.ts
@@ -1,3 +1,4 @@
 export { usePayWithCryptoSection } from './usePayWithCryptoSection';
 export { usePayWithFiatSection } from './usePayWithFiatSection';
+export { usePayWithMoneyAccountSection } from './usePayWithMoneyAccountSection';
 export { usePayWithPerpsSection } from './usePayWithPerpsSection';

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -173,7 +173,9 @@ describe('usePayWithMoneyAccountSection', () => {
   it('renders an Image icon with the MUSD token image URI', () => {
     const { result } = renderHook(() => usePayWithMoneyAccountSection());
 
-    const icon = result.current?.rows[0].icon as React.ReactElement;
+    const icon = result.current?.rows[0].icon as React.ReactElement<{
+      source: { uri: string };
+    }>;
     expect(icon).toBeDefined();
     expect(icon.props.source.uri).toContain('tokenIcons');
   });

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -1,0 +1,191 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionType } from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+import { selectPrimaryMoneyAccount } from '../../../../../../selectors/moneyAccountController';
+import { selectMetaMaskPayFlags } from '../../../../../../selectors/featureFlagController/confirmations';
+import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { useTransactionMetadataRequest } from '../../transactions/useTransactionMetadataRequest';
+import {
+  usePayWithMoneyAccountSection,
+  PAY_WITH_MONEY_ACCOUNT_SECTION_TEST_ID,
+  PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
+} from './usePayWithMoneyAccountSection';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: { balance?: string }) => {
+    const translations: Record<string, string> = {
+      'confirm.pay_with_bottom_sheet.available_balance': `${
+        params?.balance ?? ''
+      } available`,
+      'confirm.pay_with_bottom_sheet.money_account': 'Money account',
+    };
+    return translations[key] ?? key;
+  },
+}));
+jest.mock('../../../../../UI/Money/hooks/useMoneyAccountBalance');
+jest.mock('../../transactions/useTransactionMetadataRequest');
+
+describe('usePayWithMoneyAccountSection', () => {
+  const useSelectorMock = jest.mocked(useSelector);
+  const useMoneyAccountBalanceMock = jest.mocked(useMoneyAccountBalance);
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
+  const moneyAccountMock = { id: 'ma-1', balance: '100' };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx-1',
+      type: TransactionType.perpsDeposit,
+      txParams: {},
+    } as never);
+
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectPrimaryMoneyAccount) {
+        return moneyAccountMock;
+      }
+      if (selector === selectMetaMaskPayFlags) {
+        return { enablePerpsMoneyAccountTransactions: true };
+      }
+      return undefined;
+    });
+
+    useMoneyAccountBalanceMock.mockReturnValue({
+      totalFiatFormatted: '$100.00',
+    } as never);
+  });
+
+  it('returns null when enablePerpsMoneyAccountTransactions is false', () => {
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectPrimaryMoneyAccount) {
+        return moneyAccountMock;
+      }
+      if (selector === selectMetaMaskPayFlags) {
+        return { enablePerpsMoneyAccountTransactions: false };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when transaction type is not supported', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx-1',
+      type: TransactionType.simpleSend,
+      txParams: {},
+    } as never);
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when there is no money account', () => {
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === selectPrimaryMoneyAccount) {
+        return null;
+      }
+      if (selector === selectMetaMaskPayFlags) {
+        return { enablePerpsMoneyAccountTransactions: true };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when there is no transaction metadata', () => {
+    useTransactionMetadataRequestMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current).toBeNull();
+  });
+
+  it.each([
+    TransactionType.perpsDeposit,
+    TransactionType.perpsWithdraw,
+    TransactionType.predictDeposit,
+    TransactionType.predictDepositAndOrder,
+    TransactionType.predictWithdraw,
+  ])('returns section config for supported transaction type %s', (txType) => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx-1',
+      type: txType,
+      txParams: {},
+    } as never);
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        id: 'money-account',
+        title: 'Money account',
+        testID: PAY_WITH_MONEY_ACCOUNT_SECTION_TEST_ID,
+      }),
+    );
+    expect(result.current?.rows).toHaveLength(1);
+    expect(result.current?.rows[0]).toEqual(
+      expect.objectContaining({
+        id: 'money-account-musd',
+        title: 'mUSD',
+        subtitle: '$100.00 available',
+        isSelected: false,
+        isLastUsed: false,
+        trailingElement: 'none',
+        testID: PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
+      }),
+    );
+  });
+
+  it('renders subtitle with formatted balance', () => {
+    useMoneyAccountBalanceMock.mockReturnValue({
+      totalFiatFormatted: '$250.50',
+    } as never);
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current?.rows[0].subtitle).toBe('$250.50 available');
+  });
+
+  it('renders undefined subtitle when totalFiatFormatted is falsy', () => {
+    useMoneyAccountBalanceMock.mockReturnValue({
+      totalFiatFormatted: '',
+    } as never);
+
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    expect(result.current?.rows[0].subtitle).toBeUndefined();
+  });
+
+  it('renders an Image icon with the MUSD token image URI', () => {
+    const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+    const icon = result.current?.rows[0].icon as React.ReactElement;
+    expect(icon).toBeDefined();
+    expect(icon.props.source.uri).toContain('tokenIcons');
+  });
+
+  it('keeps the result reference stable across renders when nothing changes', () => {
+    const { result, rerender } = renderHook(() =>
+      usePayWithMoneyAccountSection(),
+    );
+    const firstResult = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(firstResult);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { Image } from 'react-native';
+import { useSelector } from 'react-redux';
+import { TransactionType } from '@metamask/transaction-controller';
+import { strings } from '../../../../../../../locales/i18n';
+import { selectPrimaryMoneyAccount } from '../../../../../../selectors/moneyAccountController';
+import { selectMetaMaskPayFlags } from '../../../../../../selectors/featureFlagController/confirmations';
+import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { MUSD_TOKEN } from '../../../../../UI/Earn/constants/musd';
+import { useTransactionMetadataRequest } from '../../transactions/useTransactionMetadataRequest';
+import { hasTransactionType } from '../../../utils/transaction';
+import {
+  PayWithRowConfig,
+  PayWithSectionConfig,
+} from '../../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
+
+export const PAY_WITH_MONEY_ACCOUNT_SECTION_TEST_ID =
+  'pay-with-section-money-account';
+export const PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID = 'pay-with-money-account-row';
+
+const SUPPORTED_TRANSACTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
+  TransactionType.predictDeposit,
+  TransactionType.predictDepositAndOrder,
+  TransactionType.predictWithdraw,
+] as const;
+
+export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
+  const transactionMeta = useTransactionMetadataRequest();
+  const moneyAccount = useSelector(selectPrimaryMoneyAccount);
+  const { enablePerpsMoneyAccountTransactions } = useSelector(
+    selectMetaMaskPayFlags,
+  );
+  const { totalFiatFormatted } = useMoneyAccountBalance();
+
+  const isSupported = hasTransactionType(
+    transactionMeta,
+    SUPPORTED_TRANSACTION_TYPES as unknown as TransactionType[],
+  );
+
+  return useMemo(() => {
+    if (!enablePerpsMoneyAccountTransactions || !isSupported || !moneyAccount) {
+      return null;
+    }
+
+    const subtitle = totalFiatFormatted
+      ? strings('confirm.pay_with_bottom_sheet.available_balance', {
+          balance: totalFiatFormatted,
+        })
+      : undefined;
+
+    const row: PayWithRowConfig = {
+      id: 'money-account-musd',
+      icon: React.createElement(Image, {
+        source: { uri: MUSD_TOKEN.image },
+        style: { width: 24, height: 24 },
+      }),
+      title: MUSD_TOKEN.symbol,
+      subtitle,
+      isSelected: false,
+      isLastUsed: false,
+      trailingElement: 'none',
+      testID: PAY_WITH_MONEY_ACCOUNT_ROW_TEST_ID,
+    };
+
+    return {
+      id: 'money-account',
+      title: strings('confirm.pay_with_bottom_sheet.money_account'),
+      testID: PAY_WITH_MONEY_ACCOUNT_SECTION_TEST_ID,
+      rows: [row],
+    };
+  }, [
+    enablePerpsMoneyAccountTransactions,
+    isSupported,
+    moneyAccount,
+    totalFiatFormatted,
+  ]);
+}

--- a/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
@@ -2,11 +2,13 @@ import { renderHook } from '@testing-library/react-hooks';
 import { PayWithSectionConfig } from '../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
 import { usePayWithCryptoSection } from './sections/usePayWithCryptoSection';
 import { usePayWithFiatSection } from './sections/usePayWithFiatSection';
+import { usePayWithMoneyAccountSection } from './sections/usePayWithMoneyAccountSection';
 import { usePayWithPerpsSection } from './sections/usePayWithPerpsSection';
 import { usePayWithSections } from './usePayWithSections';
 
 jest.mock('./sections/usePayWithCryptoSection');
 jest.mock('./sections/usePayWithFiatSection');
+jest.mock('./sections/usePayWithMoneyAccountSection');
 jest.mock('./sections/usePayWithPerpsSection');
 
 const CRYPTO_SECTION_MOCK: PayWithSectionConfig = {
@@ -33,6 +35,18 @@ const PERPS_SECTION_MOCK: PayWithSectionConfig = {
   ],
 };
 
+const MONEY_ACCOUNT_SECTION_MOCK: PayWithSectionConfig = {
+  id: 'money-account',
+  title: 'Money account',
+  rows: [
+    {
+      id: 'money-account-musd',
+      icon: 'mUSD',
+      title: 'mUSD',
+    },
+  ],
+};
+
 const BANK_CARD_SECTION_MOCK: PayWithSectionConfig = {
   id: 'bank-card',
   title: 'Bank and card',
@@ -48,6 +62,9 @@ const BANK_CARD_SECTION_MOCK: PayWithSectionConfig = {
 describe('usePayWithSections', () => {
   const usePayWithCryptoSectionMock = jest.mocked(usePayWithCryptoSection);
   const usePayWithFiatSectionMock = jest.mocked(usePayWithFiatSection);
+  const usePayWithMoneyAccountSectionMock = jest.mocked(
+    usePayWithMoneyAccountSection,
+  );
   const usePayWithPerpsSectionMock = jest.mocked(usePayWithPerpsSection);
 
   beforeEach(() => {
@@ -55,6 +72,7 @@ describe('usePayWithSections', () => {
 
     usePayWithCryptoSectionMock.mockReturnValue(null);
     usePayWithFiatSectionMock.mockReturnValue(null);
+    usePayWithMoneyAccountSectionMock.mockReturnValue(null);
     usePayWithPerpsSectionMock.mockReturnValue(null);
   });
 
@@ -112,6 +130,30 @@ describe('usePayWithSections', () => {
     ]);
   });
 
+  it('returns the visible money-account section when only money-account is available', () => {
+    usePayWithMoneyAccountSectionMock.mockReturnValue(
+      MONEY_ACCOUNT_SECTION_MOCK,
+    );
+
+    const { result } = renderHook(() => usePayWithSections());
+
+    expect(result.current.sections).toEqual([MONEY_ACCOUNT_SECTION_MOCK]);
+  });
+
+  it('renders money-account before perps when both are visible', () => {
+    usePayWithMoneyAccountSectionMock.mockReturnValue(
+      MONEY_ACCOUNT_SECTION_MOCK,
+    );
+    usePayWithPerpsSectionMock.mockReturnValue(PERPS_SECTION_MOCK);
+
+    const { result } = renderHook(() => usePayWithSections());
+
+    expect(result.current.sections).toEqual([
+      MONEY_ACCOUNT_SECTION_MOCK,
+      PERPS_SECTION_MOCK,
+    ]);
+  });
+
   it('renders perps, bank-card, then crypto when all three sections are visible', () => {
     usePayWithCryptoSectionMock.mockReturnValue(CRYPTO_SECTION_MOCK);
     usePayWithFiatSectionMock.mockReturnValue(BANK_CARD_SECTION_MOCK);
@@ -120,6 +162,24 @@ describe('usePayWithSections', () => {
     const { result } = renderHook(() => usePayWithSections());
 
     expect(result.current.sections).toEqual([
+      PERPS_SECTION_MOCK,
+      BANK_CARD_SECTION_MOCK,
+      CRYPTO_SECTION_MOCK,
+    ]);
+  });
+
+  it('renders money-account, perps, bank-card, then crypto when all four sections are visible', () => {
+    usePayWithMoneyAccountSectionMock.mockReturnValue(
+      MONEY_ACCOUNT_SECTION_MOCK,
+    );
+    usePayWithCryptoSectionMock.mockReturnValue(CRYPTO_SECTION_MOCK);
+    usePayWithFiatSectionMock.mockReturnValue(BANK_CARD_SECTION_MOCK);
+    usePayWithPerpsSectionMock.mockReturnValue(PERPS_SECTION_MOCK);
+
+    const { result } = renderHook(() => usePayWithSections());
+
+    expect(result.current.sections).toEqual([
+      MONEY_ACCOUNT_SECTION_MOCK,
       PERPS_SECTION_MOCK,
       BANK_CARD_SECTION_MOCK,
       CRYPTO_SECTION_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/usePayWithSections.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithSections.ts
@@ -3,6 +3,7 @@ import { PayWithSectionConfig } from '../../components/modals/pay-with-bottom-sh
 import {
   usePayWithCryptoSection,
   usePayWithFiatSection,
+  usePayWithMoneyAccountSection,
   usePayWithPerpsSection,
 } from './sections';
 
@@ -11,17 +12,21 @@ export interface UsePayWithSectionsResult {
 }
 
 export function usePayWithSections(): UsePayWithSectionsResult {
+  const moneyAccountSection = usePayWithMoneyAccountSection();
   const perpsSection = usePayWithPerpsSection();
   const bankCardSection = usePayWithFiatSection();
   const cryptoSection = usePayWithCryptoSection();
 
   return useMemo<UsePayWithSectionsResult>(
     () => ({
-      sections: [perpsSection, bankCardSection, cryptoSection].filter(
-        isPayWithSectionConfig,
-      ),
+      sections: [
+        moneyAccountSection,
+        perpsSection,
+        bankCardSection,
+        cryptoSection,
+      ].filter(isPayWithSectionConfig),
     }),
-    [bankCardSection, cryptoSection, perpsSection],
+    [bankCardSection, cryptoSection, moneyAccountSection, perpsSection],
   );
 }
 

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -236,6 +236,7 @@ describe('Transaction Controller Init', () => {
       slippage: 0.005,
       stxDisabled: false,
       enableDepositWalletWithdraw: false,
+      enablePerpsMoneyAccountTransactions: false,
     });
 
     payHookClassMock.mockReturnValue({

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -457,6 +457,7 @@ describe('Transaction Controller Init', () => {
         slippage: 0.005,
         stxDisabled: true,
         enableDepositWalletWithdraw: false,
+        enablePerpsMoneyAccountTransactions: false,
       });
 
       const hooks = testConstructorOption('hooks');
@@ -475,6 +476,7 @@ describe('Transaction Controller Init', () => {
         slippage: 0.005,
         stxDisabled: false,
         enableDepositWalletWithdraw: false,
+        enablePerpsMoneyAccountTransactions: false,
       });
 
       const hooks = testConstructorOption('hooks');

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -17,6 +17,7 @@ import {
   PAY_FIAT_MAX_DELAY_MINUTES_FOR_PAYMENT_METHODS,
   selectMetaMaskPayHardwareFlags,
   PAY_ENABLE_DEPOSIT_WALLET_WITHDRAW_DEFAULT,
+  PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT,
   PAY_HARDWARE_ENABLED_DEFAULT,
   PreferredToken,
   getPreferredTokensForTransactionType,
@@ -582,5 +583,75 @@ describe('selectMetaMaskPayFlags extended flags', () => {
     expect(selectMetaMaskPayFlags(state).enableDepositWalletWithdraw).toEqual(
       true,
     );
+  });
+
+  describe('enablePerpsMoneyAccountTransactions', () => {
+    afterEach(() => {
+      delete process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED;
+    });
+
+    it('returns default (false) when flag is absent and env var is unset', () => {
+      const state = cloneDeep(mockedEmptyFlagsState);
+
+      expect(
+        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+      ).toEqual(PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
+    });
+
+    it('returns false when remote flag is true but env var is unset', () => {
+      const state = cloneDeep(mockedEmptyFlagsState);
+      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+        {
+          confirmations_pay_extended: {
+            enablePerpsMoneyAccountTransactions: true,
+          },
+        };
+
+      expect(
+        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+      ).toBe(false);
+    });
+
+    it('returns false when env var is true but remote flag is absent', () => {
+      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
+
+      const state = cloneDeep(mockedEmptyFlagsState);
+
+      expect(
+        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+      ).toBe(false);
+    });
+
+    it('returns true when both env var and remote flag are true', () => {
+      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
+
+      const state = cloneDeep(mockedEmptyFlagsState);
+      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+        {
+          confirmations_pay_extended: {
+            enablePerpsMoneyAccountTransactions: true,
+          },
+        };
+
+      expect(
+        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+      ).toBe(true);
+    });
+
+    it('returns false when env var is set to a non-true value', () => {
+      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'false';
+
+      const state = cloneDeep(mockedEmptyFlagsState);
+      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+        {
+          confirmations_pay_extended: {
+            enablePerpsMoneyAccountTransactions: true,
+          },
+        };
+
+      expect(
+        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+      ).toBe(false);
+    });
   });
 });

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -12,6 +12,7 @@ export const PAY_FIAT_ENABLED_TRANSACTION_TYPES = [];
 export const PAY_FIAT_MAX_DELAY_MINUTES_FOR_PAYMENT_METHODS = 10;
 export const PAY_HARDWARE_ENABLED_DEFAULT = false;
 export const PAY_ENABLE_DEPOSIT_WALLET_WITHDRAW_DEFAULT = false;
+export const PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT = false;
 export const SLIPPAGE_DEFAULT = 0.005;
 export const STX_DISABLED_DEFAULT = false;
 
@@ -52,6 +53,7 @@ export interface MetaMaskPayFlags {
 
 export interface MetaMaskPayExtendedFlags {
   enableDepositWalletWithdraw: boolean;
+  enablePerpsMoneyAccountTransactions: boolean;
 }
 
 export interface MetaMaskPayTokensFlags {
@@ -125,6 +127,11 @@ export const selectMetaMaskPayFlags = createSelector(
       (metaMaskPayExtendedFlags?.enableDepositWalletWithdraw as boolean) ??
       PAY_ENABLE_DEPOSIT_WALLET_WITHDRAW_DEFAULT;
 
+    const enablePerpsMoneyAccountTransactions =
+      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED === 'true' &&
+      ((metaMaskPayExtendedFlags?.enablePerpsMoneyAccountTransactions as boolean) ??
+        PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
+
     return {
       attemptsMax,
       bufferInitial,
@@ -133,6 +140,7 @@ export const selectMetaMaskPayFlags = createSelector(
       slippage,
       stxDisabled,
       enableDepositWalletWithdraw,
+      enablePerpsMoneyAccountTransactions,
     };
   },
 );

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -51,6 +51,8 @@ const newOverrides = [
       'app/selectors/featureFlagController/legacyIosGoogleConfig/index.test.ts',
       'app/selectors/featureFlagController/googleLoginIosUnsupportedBlocking/index.ts',
       'app/selectors/featureFlagController/googleLoginIosUnsupportedBlocking/index.test.ts',
+      'app/selectors/featureFlagController/confirmations/index.ts',
+      'app/selectors/featureFlagController/confirmations/index.test.ts',
       'app/selectors/featureFlagController/seedlessTelegramLogin/index.ts',
       'app/selectors/featureFlagController/seedlessTelegramLogin/index.test.ts',
       'app/util/environment.ts',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7201,7 +7201,8 @@
       "add": "Add",
       "available_balance": "{{balance}} available",
       "other_assets": "Other assets",
-      "other_assets_description": "Select from your tokens"
+      "other_assets_description": "Select from your tokens",
+      "money_account": "Money account"
     },
     "staking_footer": {
       "part1": "By continuing, you agree to our ",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adding money account option on perps / predict deposit and withdraw pages. It is currently behind feature flag and env variable.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1405

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<img width="396" height="848" alt="Screenshot 2026-05-26 at 12 17 27 AM" src="https://github.com/user-attachments/assets/25ea4fdb-d131-44e7-8d79-b0bb81476e63" />
<img width="393" height="849" alt="Screenshot 2026-05-26 at 12 04 44 AM" src="https://github.com/user-attachments/assets/293e5aa2-f41b-475a-ad8d-f92be3d4bb27" />
<img width="395" height="852" alt="Screenshot 2026-05-26 at 12 04 12 AM" src="https://github.com/user-attachments/assets/12f4df55-e7ad-4a2f-9c3d-99fc86561597" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-method UI and dual gating (remote flag + env) for money-account funding on deposit/withdraw confirmations; row selection handlers are not wired in this diff.
> 
> **Overview**
> Adds a **Money account** payment option to the confirmation **Pay with** bottom sheet for perps and predict deposit/withdraw flows, shown as an **mUSD** row with available fiat balance.
> 
> Visibility is gated by **`enablePerpsMoneyAccountTransactions`**, which requires both the remote `confirmations_pay_extended` flag and **`MONEY_ACCOUNT_PERPS_PREDICT_ENABLED=true`**. The new section is ordered **first** (before perps, bank/card, and crypto). Includes hook tests, selector tests, i18n, and babel test config so env-based flag logic is not inlined at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf962e34a6142b226c01d461d5d2bf6a84c23ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->