### PR TITLE
fix(predict): pause details price refresh during buy flow

### DIFF
--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -195,10 +195,12 @@ const sellParams: PredictSellPreviewParams = {
 };
 
 const TestConsumer: React.FC = () => {
-  const { openBuySheet, openSellSheet } = usePredictPreviewSheet();
+  const { openBuySheet, openSellSheet, isBuySheetOpen } =
+    usePredictPreviewSheet();
 
   return (
     <View>
+      <Text testID="buy-sheet-open">{String(isBuySheetOpen)}</Text>
       <TouchableOpacity
         testID="open-buy"
         onPress={() => openBuySheet(buyParams)}
@@ -258,6 +260,24 @@ describe('PredictPreviewSheetContext', () => {
 
     expect(screen.getByTestId('predict-buy-preview-sheet')).toBeOnTheScreen();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('exposes buy sheet open state while sheet is mounted', () => {
+    render(
+      <PredictPreviewSheetProvider>
+        <TestConsumer />
+      </PredictPreviewSheetProvider>,
+    );
+
+    expect(screen.getByTestId('buy-sheet-open')).toHaveTextContent('false');
+
+    fireEvent.press(screen.getByTestId('open-buy'));
+
+    expect(screen.getByTestId('buy-sheet-open')).toHaveTextContent('true');
+
+    fireEvent.press(screen.getByTestId('dismiss-sheet'));
+
+    expect(screen.getByTestId('buy-sheet-open')).toHaveTextContent('false');
   });
 
   it('renders sell preview sheet when openSellSheet is called and flag is ON', () => {

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -167,6 +167,7 @@ interface PredictPreviewSheetContextValue {
   openBuySheet: (params: PredictBuyPreviewParams) => void;
   openSellSheet: (params: PredictSellPreviewParams) => void;
   dismissPreviewSheet: () => void;
+  isBuySheetOpen: boolean;
 }
 
 const PredictPreviewSheetContext = createContext<
@@ -197,6 +198,7 @@ export const usePredictPreviewSheet = (): PredictPreviewSheetContextValue => {
         });
       },
       dismissPreviewSheet: () => undefined,
+      isBuySheetOpen: false,
     }),
     [navigation],
   );
@@ -485,8 +487,13 @@ export const PredictPreviewSheetProvider: React.FC<
   const onSellDismiss = useCallback(() => setSellParams(null), []);
 
   const contextValue = React.useMemo(
-    () => ({ openBuySheet, openSellSheet, dismissPreviewSheet }),
-    [openBuySheet, openSellSheet, dismissPreviewSheet],
+    () => ({
+      openBuySheet,
+      openSellSheet,
+      dismissPreviewSheet,
+      isBuySheetOpen: Boolean(buyParams),
+    }),
+    [openBuySheet, openSellSheet, dismissPreviewSheet, buyParams],
   );
 
   return (

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -3544,14 +3544,13 @@ describe('PredictMarketDetails', () => {
       );
     });
 
-    it('pauses broad outcome price updates while buy sheet is open', () => {
+    it('pauses and resumes broad outcome price updates as buy sheet visibility changes', () => {
       const { usePredictPrices } = jest.requireMock(
         '../../hooks/usePredictPrices',
       );
       const { useLiveMarketPrices } = jest.requireMock(
         '../../hooks/useLiveMarketPrices',
       );
-      mockIsBuySheetOpen = true;
       const worldCupWinnerMarket = createMockMarket({
         status: 'open',
         outcomes: Array.from({ length: 64 }, (_, index) => ({
@@ -3567,7 +3566,21 @@ describe('PredictMarketDetails', () => {
         })),
       });
 
-      setupPredictMarketDetailsTest(worldCupWinnerMarket);
+      mockIsBuySheetOpen = false;
+      const { rerender } = setupPredictMarketDetailsTest(worldCupWinnerMarket);
+
+      expect(usePredictPrices).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          pollingInterval: 2000,
+        }),
+      );
+      expect(useLiveMarketPrices).toHaveBeenLastCalledWith(expect.any(Array), {
+        enabled: true,
+      });
+
+      mockIsBuySheetOpen = true;
+      rerender(<PredictMarketDetails />);
 
       expect(usePredictPrices).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -3578,6 +3591,19 @@ describe('PredictMarketDetails', () => {
       );
       expect(useLiveMarketPrices).toHaveBeenLastCalledWith([], {
         enabled: false,
+      });
+
+      mockIsBuySheetOpen = false;
+      rerender(<PredictMarketDetails />);
+
+      expect(usePredictPrices).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          pollingInterval: 2000,
+        }),
+      );
+      expect(useLiveMarketPrices).toHaveBeenLastCalledWith(expect.any(Array), {
+        enabled: true,
       });
     });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -128,10 +128,12 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => {
 
 const mockOpenBuySheet = jest.fn();
 const mockOpenSellSheet = jest.fn();
+let mockIsBuySheetOpen = false;
 jest.mock('../../contexts', () => ({
   usePredictPreviewSheet: () => ({
     openBuySheet: mockOpenBuySheet,
     openSellSheet: mockOpenSellSheet,
+    isBuySheetOpen: mockIsBuySheetOpen,
   }),
 }));
 
@@ -774,6 +776,7 @@ describe('PredictMarketDetails', () => {
   afterEach(() => {
     jest.clearAllMocks();
     mockRunAfterInteractions.mockReset();
+    mockIsBuySheetOpen = false;
   });
 
   afterAll(() => {
@@ -3539,6 +3542,43 @@ describe('PredictMarketDetails', () => {
           queries: expect.any(Array),
         }),
       );
+    });
+
+    it('pauses broad outcome price updates while buy sheet is open', () => {
+      const { usePredictPrices } = jest.requireMock(
+        '../../hooks/usePredictPrices',
+      );
+      const { useLiveMarketPrices } = jest.requireMock(
+        '../../hooks/useLiveMarketPrices',
+      );
+      mockIsBuySheetOpen = true;
+      const worldCupWinnerMarket = createMockMarket({
+        status: 'open',
+        outcomes: Array.from({ length: 64 }, (_, index) => ({
+          id: `outcome-${index + 1}`,
+          title: `Team ${index + 1}`,
+          groupItemTitle: `Team ${index + 1}`,
+          status: 'open',
+          tokens: [
+            { id: `token-${index + 1}-yes`, title: 'Yes', price: 0.5 },
+            { id: `token-${index + 1}-no`, title: 'No', price: 0.5 },
+          ],
+          volume: 1000000,
+        })),
+      });
+
+      setupPredictMarketDetailsTest(worldCupWinnerMarket);
+
+      expect(usePredictPrices).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          enabled: false,
+          queries: [],
+          pollingInterval: undefined,
+        }),
+      );
+      expect(useLiveMarketPrices).toHaveBeenLastCalledWith([], {
+        enabled: false,
+      });
     });
 
     it('handles price fetching errors gracefully', () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -68,7 +68,7 @@ interface PredictMarketDetailsProps {}
 const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
-  const { openBuySheet } = usePredictPreviewSheet();
+  const { openBuySheet, isBuySheetOpen } = usePredictPreviewSheet();
   const { colors } = useTheme();
   const { claim, isClaimPending } = usePredictClaim();
   const route =
@@ -226,8 +226,12 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     timeframes,
   } = useChartData({ market, hasAnyOutcomeToken });
 
+  const shouldRefreshOpenOutcomePrices =
+    market?.status === PredictMarketStatus.OPEN && !isBuySheetOpen;
+
   const { closedOutcomes, openOutcomes, yesPercentage } = useOpenOutcomes({
     market,
+    enabled: shouldRefreshOpenOutcomePrices,
   });
 
   const handleBackPress = () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts
+++ b/app/components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts
@@ -10,6 +10,7 @@ import {
 
 interface UseOpenOutcomesParams {
   market: PredictMarket | null;
+  enabled?: boolean;
 }
 
 interface UseOpenOutcomesResult {
@@ -18,8 +19,11 @@ interface UseOpenOutcomesResult {
   yesPercentage: number;
 }
 
+const EMPTY_PRICE_QUERIES: PriceQuery[] = [];
+
 export const useOpenOutcomes = ({
   market,
+  enabled = true,
 }: UseOpenOutcomesParams): UseOpenOutcomesResult => {
   const closedOutcomes = useMemo(
     () =>
@@ -46,18 +50,23 @@ export const useOpenOutcomes = ({
     [openOutcomesBase],
   );
 
+  const shouldFetchPrices = enabled && priceQueries.length > 0;
+  const activePriceQueries = shouldFetchPrices
+    ? priceQueries
+    : EMPTY_PRICE_QUERIES;
+
   const { prices } = usePredictPrices({
-    queries: priceQueries,
-    enabled: priceQueries.length > 0,
-    pollingInterval: 2000,
+    queries: activePriceQueries,
+    enabled: shouldFetchPrices,
+    pollingInterval: shouldFetchPrices ? 2000 : undefined,
   });
 
   const tokenIds = useMemo(
-    () => priceQueries.map((q) => q.outcomeTokenId),
-    [priceQueries],
+    () => activePriceQueries.map((q) => q.outcomeTokenId),
+    [activePriceQueries],
   );
   const { getPrice: getLivePrice } = useLiveMarketPrices(tokenIds, {
-    enabled: tokenIds.length > 0,
+    enabled: shouldFetchPrices,
   });
 
   // Price precedence: live WebSocket bestAsk > REST entry.sell > base market price.


### PR DESCRIPTION
## **Description**

Fixes a Predict market details issue where placing a bet from a large multi-outcome market, such as the World Cup winner market with 64 outcomes, could stall before the transaction-added event appeared.

The details screen was keeping broad outcome price work active behind the buy sheet. For 64 outcomes, that meant REST price polling and live price subscriptions for every YES/NO token while the buy flow was also initializing transaction setup. This change exposes buy sheet open state from the preview sheet context and pauses the market details open-outcome price refresh while the buy sheet is mounted.

Changes included:

- Add `isBuySheetOpen` to `PredictPreviewSheetContext`.
- Disable broad open-outcome REST polling and live subscriptions from `PredictMarketDetails` while the buy sheet is open.
- Keep existing outcome data available so the selected buy flow still has its market/outcome context.
- Add regression coverage for the buy sheet open state and the 64-outcome paused-refresh behavior.

## **Changelog**

CHANGELOG entry: Fixed a bug that could delay prediction bet placement from large market details screens.

## **Related issues**

Fixes: [PRED-930](https://consensyssoftware.atlassian.net/browse/PRED-930)

## **Manual testing steps**

```gherkin
Feature: Predict large market bet placement

  Scenario: user places a bet from a 64-outcome market details screen
    Given Predict is enabled
    And the user opens the World Cup winner market details screen
    And the market has many open outcomes

    When the user taps Buy on an outcome
    And the buy sheet opens
    Then the market details screen pauses broad open-outcome price polling and live subscriptions

    When the user proceeds with the bet
    Then transaction setup should continue without the details screen generating repeated RPC degraded logs from broad outcome refresh work
```

Automated testing run:

```bash
node .yarn/releases/yarn-4.14.1.cjs jest app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx --runInBand
node .yarn/releases/yarn-4.14.1.cjs jest app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx --runInBand
git diff --check
```

## **Screenshots/Recordings**

### **Before**

Reporter-provided recording showed bet placement from the World Cup winner market details screen getting stuck before transaction-added logs appeared, followed by repeated RPC degraded logs.

### **After**

No after recording captured in this session. Behavior is covered by targeted unit tests for pausing the broad details price refresh while the buy sheet is open.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-930]: https://consensyssoftware.atlassian.net/browse/PRED-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted performance fix: toggles existing price hooks off during buy sheet only; no auth, payment, or order logic changes.
> 
> **Overview**
> Fixes stalls when placing bets from **large multi-outcome** Predict market details (e.g. 64 teams) by stopping background price work while the buy sheet is open.
> 
> **`PredictPreviewSheetContext`** now exposes **`isBuySheetOpen`** (true while buy preview params are mounted; **`false`** in the navigation fallback outside the provider). **`PredictMarketDetails`** uses it to gate **`useOpenOutcomes`**: broad **REST polling** (~2s) and **live price subscriptions** for every open outcome token pause when the buy sheet is visible and resume on dismiss. **`useOpenOutcomes`** accepts an optional **`enabled`** flag and passes empty queries with polling disabled when off, while still returning cached outcome structure for the buy flow.
> 
> Tests cover buy-sheet open/close state and the 64-outcome pause/resume behavior for **`usePredictPrices`** / **`useLiveMarketPrices`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55989d7a9ea5306e4d6cebd35cedeb28a106e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->