### PR TITLE
fix(perps): incorrect decimals on limit price for open orders

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.test.tsx
@@ -96,6 +96,9 @@ jest.mock('../../utils/formatUtils', () => ({
   formatPerpsFiat: jest.fn((value) => `$${value.toFixed(2)}`),
   formatPositionSize: jest.fn((value) => value.toFixed(4)),
   formatOrderCardDate: jest.fn(() => 'Nov 25, 2025'),
+  PRICE_RANGES_UNIVERSAL: [
+    { min: 0, max: Infinity, decimals: 2, threshold: 0.000001 },
+  ],
 }));
 
 // Mock component-library Button to be testable
@@ -278,6 +281,24 @@ describe('PerpsOrderDetailsView', () => {
     render(<PerpsOrderDetailsView />);
 
     expect(screen.getByText('perps.order_details.price')).toBeOnTheScreen();
+  });
+
+  it('formats order price with adaptive sig-dig ranges', () => {
+    // Arrange
+    const { formatPerpsFiat: mockFormatPerpsFiat } = jest.requireMock(
+      '../../utils/formatUtils',
+    ) as { formatPerpsFiat: jest.Mock };
+
+    // Act
+    render(<PerpsOrderDetailsView />);
+
+    // Assert — the price call (50000) must pass a ranges option
+    const priceCall = mockFormatPerpsFiat.mock.calls.find(
+      (call: unknown[]) => call[0] === 50000,
+    );
+    expect(priceCall).toBeDefined();
+    expect(priceCall[1]).toBeDefined();
+    expect(priceCall[1].ranges).toBeDefined();
   });
 
   it('renders original size, order value and reduce-only rows', () => {

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
@@ -33,6 +33,7 @@ import {
   formatPerpsFiat,
   formatPositionSize,
   formatOrderCardDate,
+  PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import {
   formatOrderLabel,
@@ -131,11 +132,15 @@ const PerpsOrderDetailsView: React.FC = () => {
     const priceText =
       isMarketExecution || validOrderPrice === null
         ? strings('perps.order_details.market')
-        : formatPerpsFiat(validOrderPrice);
+        : formatPerpsFiat(validOrderPrice, {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          });
 
     let triggerCondition: string | undefined;
     if (order.isTrigger && validTriggerPrice !== null) {
-      const formattedTriggerPrice = formatPerpsFiat(validTriggerPrice);
+      const formattedTriggerPrice = formatPerpsFiat(validTriggerPrice, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+      });
       const conditionKey = inferTriggerConditionKey({
         detailedOrderType: order.detailedOrderType,
         side: order.side,
@@ -175,10 +180,14 @@ const PerpsOrderDetailsView: React.FC = () => {
         ? strings('perps.order_details.yes')
         : strings('perps.order_details.no'),
       takeProfitPriceText: hasTakeProfitPrice
-        ? formatPerpsFiat(parsedTakeProfitPrice)
+        ? formatPerpsFiat(parsedTakeProfitPrice, {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          })
         : undefined,
       stopLossPriceText: hasStopLossPrice
-        ? formatPerpsFiat(parsedStopLossPrice)
+        ? formatPerpsFiat(parsedStopLossPrice, {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          })
         : undefined,
     };
   }, [order, priceMetrics]);

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -305,6 +305,24 @@ describe('PerpsCard', () => {
       expect(getByText('Limit short')).toBeDefined();
     });
 
+    it('formats low-price order with adaptive sig-dig instead of threshold', () => {
+      // Arrange
+      const lowPriceOrder = {
+        ...mockOrder,
+        symbol: 'PUMP',
+        price: '0.001',
+      };
+
+      // Act
+      const { getByText, queryByText } = render(
+        <PerpsCard order={lowPriceOrder} testID="test-card" />,
+      );
+
+      // Assert — must show actual price, not <$0.01
+      expect(getByText('$0.001')).toBeOnTheScreen();
+      expect(queryByText('<$0.01')).toBeNull();
+    });
+
     it('uses trigger price label for trigger orders', () => {
       const triggerOrder = {
         ...mockOrder,

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -38,7 +38,6 @@ import {
 } from '../../utils/orderUtils';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import PerpsTokenLogo from '../PerpsTokenLogo';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import type { PerpsCardProps } from './PerpsCard.types';
 import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
@@ -81,10 +80,6 @@ const getOrderDisplayData = (order: Order): CardDisplayData => {
           ranges: PRICE_RANGES_MINIMAL_VIEW,
         })
       : strings('perps.order.market');
-  DevLogger.log(
-    '[TAT-3178] BUG_MARKER: PerpsCard order price formatted with MINIMAL_VIEW',
-    { priceValue, valueText, symbol: order.symbol },
-  );
   const labelText = strings(labelKey);
 
   return {

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -31,6 +31,7 @@ import {
   formatPnl,
   formatPercentage,
   PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import {
   formatOrderLabel,
@@ -77,7 +78,7 @@ const getOrderDisplayData = (order: Order): CardDisplayData => {
   const valueText =
     priceValue !== null
       ? formatPerpsFiat(priceValue, {
-          ranges: PRICE_RANGES_MINIMAL_VIEW,
+          ranges: PRICE_RANGES_UNIVERSAL,
         })
       : strings('perps.order.market');
   const labelText = strings(labelKey);

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../utils/orderUtils';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import PerpsTokenLogo from '../PerpsTokenLogo';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import type { PerpsCardProps } from './PerpsCard.types';
 import { HOME_SCREEN_CONFIG } from '../../constants/perpsConfig';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
@@ -80,6 +81,10 @@ const getOrderDisplayData = (order: Order): CardDisplayData => {
           ranges: PRICE_RANGES_MINIMAL_VIEW,
         })
       : strings('perps.order.market');
+  DevLogger.log(
+    '[TAT-3178] BUG_MARKER: PerpsCard order price formatted with MINIMAL_VIEW',
+    { priceValue, valueText, symbol: order.symbol },
+  );
   const labelText = strings(labelKey);
 
   return {


### PR DESCRIPTION
## **Description**

Fix limit order price formatting on Perps home order card, order detail screen, and wallet home. These screens used `PRICE_RANGES_MINIMAL_VIEW` (threshold-based, max 2 decimals) instead of `PRICE_RANGES_UNIVERSAL` (adaptive significant digits), causing low-price assets like PUMP to display `<$0.01` instead of the actual price `$0.001`.

## **Changelog**

CHANGELOG entry: Fixed limit order price displaying `<$0.01` instead of actual price on order cards and detail screens

## **Related issues**

Fixes: [TAT-3178](https://consensyssoftware.atlassian.net/browse/TAT-3178)

## **Manual testing steps**

```gherkin
Feature: Limit order price formatting

  Scenario: user views limit order price on low-price asset
    Given wallet is unlocked and Perps is ready to trade

    When user places a limit order on PUMP at $0.001
    Then Perps home order card shows $0.001 (not <$0.01)
    And order detail screen shows Price: $0.001
    And wallet home shows $0.001 for the order
```

## **Screenshots/Recordings**

Limit order price now shows adaptive sig-dig ($0.001) instead of threshold (<$0.01) on all 3 screens.

<table>
<tr><td colspan="2"><strong>AC1: Perps home order card price (&lt;$0.01 → $0.001)</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/before-evidence-ac1-perps-home-order-card.png?sha=3ffbf4d" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/after-ac1-perps-home-order-card.png?sha=3ffbf4d" alt="after" width="400" /></td>
</tr>
<tr><td colspan="2"><strong>AC2: Order detail screen price (&lt;$0.01 → $0.001)</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/before-evidence-ac2-order-details-price.png?sha=3ffbf4d" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/after-ac2-order-details-price.png?sha=3ffbf4d" alt="after" width="400" /></td>
</tr>
<tr><td colspan="2"><strong>AC3: Wallet home order price (&lt;$0.01 → $0.001)</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/before-evidence-ac3-wallet-home-order-price.png?sha=3ffbf4d" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/30615/after-ac3-wallet-home-order-price.png?sha=3ffbf4d" alt="after" width="400" /></td>
</tr>
</table>


**Video evidence** — drag-and-drop into PR if needed:
- Before: `.task/fix/tat-3178-0526-095542/artifacts/before.mp4`
- After: `.task/fix/tat-3178-0526-095542/artifacts/after.mp4`
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "title": "Verify limit order price uses adaptive sig-dig on all screens",
  "jira": "TAT-3178",
  "acceptance_criteria": [
    "AC1: Perps home order card displays limit price with adaptive sig-dig (not <$0.01)",
    "AC2: Order detail screen displays limit price with adaptive sig-dig",
    "AC3: Wallet home displays limit order price with adaptive sig-dig"
  ],
  "initial_conditions": { "testnet": false },
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.ready_to_trade"],
      "entry": "setup-place-order",
      "nodes": {
        "setup-place-order": {
          "action": "call",
          "ref": "perps/order-limit-place",
          "params": { "symbol": "PUMP", "side": "long", "usdAmount": "11", "limitPrice": "0.001" },
          "next": "setup-wait"
        },
        "setup-wait": { "action": "wait", "ms": 4000, "next": "ac1-nav-perps-home" },
        "ac1-nav-perps-home": { "action": "navigate", "target": "PerpsMarketListView", "next": "ac1-wait-orders-loaded" },
        "ac1-wait-orders-loaded": { "action": "wait_for", "expression": "...wait for '11000' in fiber tree...", "timeout_ms": 20000, "next": "ac1-scroll-to-orders" },
        "ac1-scroll-to-orders": { "action": "eval_sync", "expression": "...scrollTo({y:350})...", "next": "ac1-scroll-settle" },
        "ac1-scroll-settle": { "action": "wait", "ms": 500, "next": "ac1-eval-no-bug" },
        "ac1-eval-no-bug": { "action": "eval_sync", "expression": "...assert <$0.01 absent...", "assert": { "operator": "eq", "field": "buggy", "value": false }, "next": "ac1-screenshot" },
        "ac1-screenshot": { "action": "screenshot", "filename": "evidence-ac1-perps-home-order-card.png", "next": "ac2-nav-market" },
        "ac2-nav-market": { "action": "navigate", "target": "PerpsMarketDetails", "next": "ac2-wait-market" },
        "ac2-wait-market": { "action": "wait_for", "test_id": "perps-compact-order-row-first", "next": "ac2-press-order" },
        "ac2-press-order": { "action": "press", "test_id": "perps-compact-order-row-first", "next": "ac2-wait-details" },
        "ac2-wait-details": { "action": "wait_for", "route": "PerpsOrderDetailsView", "next": "ac2-eval-no-bug" },
        "ac2-eval-no-bug": { "action": "eval_sync", "expression": "...assert <$0.01 absent...", "assert": { "operator": "eq", "field": "buggy", "value": false }, "next": "ac2-screenshot" },
        "ac2-screenshot": { "action": "screenshot", "filename": "evidence-ac2-order-details-price.png", "next": "ac3-nav-wallet" },
        "ac3-nav-wallet": { "action": "navigate", "target": "WalletView", "next": "ac3-wait-orders-loaded" },
        "ac3-wait-orders-loaded": { "action": "wait_for", "expression": "...wait for '11000' in fiber tree...", "timeout_ms": 20000, "next": "ac3-scroll-to-orders" },
        "ac3-scroll-to-orders": { "action": "eval_sync", "expression": "...scrollTo({y:600})...", "next": "ac3-scroll-settle" },
        "ac3-scroll-settle": { "action": "wait", "ms": 500, "next": "ac3-eval-no-bug" },
        "ac3-eval-no-bug": { "action": "eval_sync", "expression": "...assert <$0.01 absent...", "assert": { "operator": "eq", "field": "buggy", "value": false }, "next": "ac3-screenshot" },
        "ac3-screenshot": { "action": "screenshot", "filename": "evidence-ac3-wallet-home-order-price.png", "next": "teardown-cancel-order" },
        "teardown-cancel-order": { "action": "call", "ref": "perps/order-limit-cancel", "params": { "symbol": "PUMP" }, "next": "teardown-done" },
        "teardown-done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  %% Verify limit order price uses adaptive sig-dig on all screens
  __entry__(["ENTRY"]) --> node_setup_place_order
  node_setup_place_order[["setup-place-order<br/>perps/order-limit-place"]]
  node_setup_wait["setup-wait<br/>wait"]
  node_ac1_nav_perps_home["ac1-nav-perps-home<br/>navigate"]
  node_ac1_wait_orders_loaded["ac1-wait-orders-loaded<br/>wait_for"]
  node_ac1_eval_no_bug["ac1-eval-no-bug<br/>eval_sync"]
  node_ac1_screenshot["ac1-screenshot<br/>screenshot"]
  node_ac2_nav_market["ac2-nav-market<br/>navigate"]
  node_ac2_wait_market["ac2-wait-market<br/>wait_for"]
  node_ac2_press_order["ac2-press-order<br/>press"]
  node_ac2_wait_details["ac2-wait-details<br/>wait_for"]
  node_ac2_eval_no_bug["ac2-eval-no-bug<br/>eval_sync"]
  node_ac2_screenshot["ac2-screenshot<br/>screenshot"]
  node_ac3_nav_wallet["ac3-nav-wallet<br/>navigate"]
  node_ac3_wait_orders_loaded["ac3-wait-orders-loaded<br/>wait_for"]
  node_ac3_eval_no_bug["ac3-eval-no-bug<br/>eval_sync"]
  node_ac3_screenshot["ac3-screenshot<br/>screenshot"]
  node_teardown_cancel_order[["teardown-cancel-order<br/>perps/order-limit-cancel"]]
  node_teardown_done(["teardown-done<br/>PASS"])
  node_setup_place_order --> node_setup_wait
  node_setup_wait --> node_ac1_nav_perps_home
  node_ac1_nav_perps_home --> node_ac1_wait_orders_loaded
  node_ac1_wait_orders_loaded --> node_ac1_eval_no_bug
  node_ac1_eval_no_bug --> node_ac1_screenshot
  node_ac1_screenshot --> node_ac2_nav_market
  node_ac2_nav_market --> node_ac2_wait_market
  node_ac2_wait_market --> node_ac2_press_order
  node_ac2_press_order --> node_ac2_wait_details
  node_ac2_wait_details --> node_ac2_eval_no_bug
  node_ac2_eval_no_bug --> node_ac2_screenshot
  node_ac2_screenshot --> node_ac3_nav_wallet
  node_ac3_nav_wallet --> node_ac3_wait_orders_loaded
  node_ac3_wait_orders_loaded --> node_ac3_eval_no_bug
  node_ac3_eval_no_bug --> node_ac3_screenshot
  node_ac3_screenshot --> node_teardown_cancel_order
  node_teardown_cancel_order --> node_teardown_done
```

</details>


[TAT-3178]: https://consensyssoftware.atlassian.net/browse/TAT-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting change in Perps UI with targeted tests; no trading, auth, or data-path changes.
> 
> **Overview**
> **Limit order prices** on Perps order cards and the order details screen now use **`PRICE_RANGES_UNIVERSAL`** (adaptive significant digits) instead of **`PRICE_RANGES_MINIMAL_VIEW`**, so low-priced assets (e.g. PUMP at `$0.001`) show the real price instead of a threshold like `<$0.01`.
> 
> **`PerpsOrderDetailsView`** passes universal ranges to **`formatPerpsFiat`** for limit price, trigger price, take profit, and stop loss. **`PerpsCard`** does the same for the order card’s displayed price. Tests assert the new formatting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b32f0bb8bd457ccb72d2cf36aa3376072bfa838a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
